### PR TITLE
  Add frontend static deploy workflow and docs

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -49,6 +49,7 @@ jobs:
 
   frontend:
     name: Build and deploy frontend
+    needs: deploy
     if: github.ref == 'refs/heads/main'
     runs-on: [self-hosted, macOS, ARM64]
     defaults:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -47,6 +47,40 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
+  frontend:
+    name: Build and deploy frontend
+    if: github.ref == 'refs/heads/main'
+    runs-on: [self-hosted, macOS, ARM64]
+    defaults:
+      run:
+        working-directory: web/console
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: web/console/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build frontend
+        env:
+          VITE_API_BASE: ""
+        run: npm run build
+
+      - name: Validate remote frontend directory
+        run: |
+          ssh root@1.95.71.247 'mkdir -p /var/www/bktrader'
+
+      - name: Deploy frontend assets
+        run: |
+          rsync -av --delete dist/ root@1.95.71.247:/var/www/bktrader/
+
   deploy:
     name: Deploy on Macmini runner
     needs: docker

--- a/README.md
+++ b/README.md
@@ -218,6 +218,46 @@ export VITE_API_BASE=http://127.0.0.1:8080
 npm run dev
 ```
 
+前端开发环境默认通过 `VITE_API_BASE` 直连本地后端，例如：
+
+- `VITE_API_BASE=http://127.0.0.1:8080`
+
+生产环境推荐改为同域部署，不显式配置 `VITE_API_BASE`，让前端直接请求当前域名下的 `/api/...`。这样可以避免跨域，并通过反向代理统一前后端入口。
+
+### 前端生产发布
+
+当前推荐的前端生产部署方式不是 Docker，而是：
+
+1. GitHub Actions 在 `web/console` 下执行 `npm ci` 和 `npm run build`
+2. 产出静态文件 `web/console/dist`
+3. 通过 `rsync` 直接覆盖远端 Nginx 静态目录，例如 `/var/www/bktrader`
+4. 由 Nginx 提供前端页面，并把 `/api/` 和 `/healthz` 反代到后端
+
+推荐的 Nginx 路由结构如下：
+
+- `/`：前端静态文件目录，例如 `/var/www/bktrader`
+- `/api/`：反代到后端 API
+- `/healthz`：反代到后端健康检查
+
+当前一套可工作的线上结构示例：
+
+- 前端静态目录：`/var/www/bktrader`
+- 前端站点：`https://trade.sunnywifi.cn:3088`
+- 后端公网入口：由 FRP 暴露到远端 `127.0.0.1:3081`
+- Nginx 反代：`/api/` -> `http://127.0.0.1:3081`
+
+如果沿用仓库里的 `cd.yml`，前端发布链路是：
+
+1. 在 self-hosted macOS runner 上构建 `web/console/dist`
+2. 通过 `ssh root@1.95.71.247 'mkdir -p /var/www/bktrader'` 确保目录存在
+3. 通过 `rsync -av --delete dist/ root@1.95.71.247:/var/www/bktrader/` 覆盖远端静态目录
+
+这种模式适合当前项目，因为：
+
+- 前端是 Vite 静态站点，没有必要再套一层容器
+- 回滚和排障更直接，核心就是 `dist/` 目录内容
+- Nginx 可以同时处理静态资源、TLS 和 `/api` 反代
+
 ## 回测执行数据源
 
 平台将策略信号周期与执行层数据源分开管理，回测模块支持可选执行测试源：
@@ -324,10 +364,10 @@ python3 scripts/check_1d_1min_parity.py
 
 ## CI/CD
 
-仓库已提供一套最小可用的 Docker 化 CI/CD 骨架：
+仓库已提供一套最小可用的 CI/CD 骨架：
 
 - `.github/workflows/ci.yml`：后端 `go test/build`、前端 `npm run build`、Docker 构建校验
-- `.github/workflows/cd.yml`：构建镜像并推送到 GHCR，然后通过 SSH 到目标主机执行部署脚本
+- `.github/workflows/cd.yml`：构建后端镜像并推送到 GHCR，在 self-hosted runner 上部署后端 Docker，同时构建并发布前端静态文件
 - `Dockerfile`：多阶段构建，产出 `platform-api` 运行镜像
 - `deployments/docker-compose.prod.yml`：生产环境 Compose 编排
 - `scripts/deploy.sh`：远程部署脚本
@@ -354,10 +394,23 @@ python3 scripts/check_1d_1min_parity.py
 
 ### 推荐的部署机准备
 
-目标机器至少安装：
+后端部署节点至少安装：
 
 - Docker
 - Docker Compose Plugin
+
+前端静态发布目标机至少需要：
+
+- Nginx
+- 可写的静态目录，例如 `/var/www/bktrader`
+- GitHub Actions runner 到目标机的 SSH 可达性
+- `rsync`
+
+如果前端和 Nginx 在同一台机器，建议额外确认：
+
+- 防火墙已放行站点监听端口，例如 `3088`
+- 站点证书和 `server_name` 已配置
+- `/api/` 和 `/healthz` 已反代到后端入口
 
 并准备好 `.env` 文件，例如：
 

--- a/docs/cicd-maintenance.md
+++ b/docs/cicd-maintenance.md
@@ -6,7 +6,7 @@
 
 项目目前包含两个主要的 GitHub Actions 工作流：
 - **CI (`ci.yml`)**: 自动执行后端 (Go) 格式检查、编译、前端 (Vite) 构建以及 Docker 镜像构建验证。
-- **CD (`cd.yml`)**: 自动构建并推送 Docker 镜像，随后在自托管 (Self-hosted) 的 Macmini 节点上执行部署脚本。
+- **CD (`cd.yml`)**: 自动构建并推送后端 Docker 镜像，在自托管 (Self-hosted) 的 Macmini 节点上执行后端部署脚本，并构建前端静态文件后同步到远端 Nginx 目录。
 
 ---
 
@@ -26,7 +26,7 @@ gofmt -w .
 ### 2. Macmini 部署节点处于 Queued 状态
 
 **现象**：CD 任务的 `Deploy on Macmini runner` 环节显示 `Queued` (排队中)，长时间不执行。
-**原因**：自托管的 Runner 服务掉线或由于权限问题无法启动。
+**原因**：自托管的 Runner 服务掉线或由于权限问题无法启动。这会同时影响后端部署和前端静态发布。
 **维护注意事项**：
 - **目录位置**：不要将 Runner 目录放在 `~/Downloads` 或 `~/Desktop` 文件夹下。受 macOS 系统权限限制（TCC），后台服务（LaunchAgent）无法静默访问这些隐私目录。建议放在 `~/actions-runner/` 下。
 - **查看状态**：
@@ -44,6 +44,50 @@ gofmt -w .
   ```bash
   nohup ./run.sh &
   ```
+
+### 3. 前端静态发布失败
+
+**现象**：CD 中 `Build and deploy frontend` 失败，通常出现在 `npm ci`、`npm run build`、`ssh` 或 `rsync` 步骤。
+
+**排查顺序**：
+
+1. 确认 Runner 上 Node.js 版本正常，且能访问 npm registry。
+2. 确认 `web/console/package-lock.json` 与依赖没有漂移，必要时本地重新生成并提交。
+3. 确认 Runner 到目标机的 SSH 免密是通的：
+   ```bash
+   ssh root@1.95.71.247 'echo ok'
+   ```
+4. 确认目标机发布目录存在且可写：
+   ```bash
+   ssh root@1.95.71.247 'mkdir -p /var/www/bktrader && test -w /var/www/bktrader'
+   ```
+5. 确认目标机安装了 `rsync`，并且 Runner 本机也能执行 `rsync`。
+
+**当前前端发布约定**：
+
+- 构建目录：`web/console/dist`
+- 远端目录：`/var/www/bktrader`
+- 发布方式：`rsync -av --delete`
+- 线上访问：由 Nginx 提供静态资源，`/api/` 和 `/healthz` 反代到后端
+
+**常见原因**：
+
+- Runner SSH key 没有权限登录远端机器
+- 远端目录权限不对
+- `rsync --delete` 删除了手工放置但未纳入构建产物的文件
+- 前端构建时仍把 `VITE_API_BASE` 写死到本地地址，导致线上页面请求错地址
+
+### 4. 前端页面能打开，但接口报错
+
+**现象**：`trade.sunnywifi.cn` 页面能加载，但数据接口返回 401、404、502 或超时。
+
+**排查顺序**：
+
+1. 确认 Nginx 的 `/api/` 和 `/healthz` 已反代到正确后端端口。
+2. 确认 FRP 隧道已建立，远端反代目标端口可访问。
+3. 确认后端容器内 `/healthz` 返回 200。
+4. 确认前端生产构建没有把 API 地址写死成 `http://127.0.0.1:8080`。
+5. 如果开启了鉴权，确认浏览器请求带上了正确的登录态或 Bearer token。
 
 ---
 

--- a/web/console/src/main.tsx
+++ b/web/console/src/main.tsx
@@ -406,7 +406,7 @@ type SessionMarker = {
   text: string;
 };
 
-const API_BASE = (import.meta.env.VITE_API_BASE as string | undefined) ?? "http://127.0.0.1:8080";
+const API_BASE = ((import.meta.env.VITE_API_BASE as string | undefined) ?? "").replace(/\/$/, "");
 
 function App() {
   const [loading, setLoading] = useState(true);


### PR DESCRIPTION

  This PR adds a production-ready static deployment path for the frontend and documents the full release flow.

  ## Changes

  - add a frontend deploy job to `.github/workflows/cd.yml`
  - build `web/console` on the self-hosted macOS runner
  - publish `web/console/dist` to `root@1.95.71.247:/var/www/bktrader/` via `rsync`
  - switch the frontend production API default to same-origin relative paths instead of hardcoded `http://127.0.0.1:8080`
  - document the frontend static deployment flow in `README.md`
  - document CI/CD maintenance and troubleshooting for frontend static deploy in `docs/cicd-maintenance.md`

  ## Deployment Model

  Production frontend is deployed as static files, not Docker:

  - frontend static assets are served by Nginx from `/var/www/bktrader`
  - `/api/` and `/healthz` are proxied by Nginx to the backend
  - backend remains on the existing Docker + FRP path
  - production site example: `https://trade.sunnywifi.cn:3088`

  ## Why

  This keeps frontend deployment simpler and more operationally stable for the current architecture:

  - Vite frontend only needs static hosting in production
  - no extra frontend container or port management
  - same-origin API access avoids cross-origin issues
  - rollback/debugging is simpler because deployment output is just `dist/`

  ## Notes

  - frontend deploy in CD currently targets `root@1.95.71.247:/var/www/bktrader/`
  - Nginx is expected to serve `/` from `/var/www/bktrader`
  - Nginx is expected to proxy `/api/` and `/healthz` to `127.0.0.1:3081`
  - this PR does not change backend runtime behavior outside the existing deploy flow么验_

## 是否影响 main 默认行为
- [x] 否
- [ ] 是，已在上述“风险点”说明
