### PR TITLE
[codex] add inline Codex PR review

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -1,0 +1,150 @@
+name: AI PR Review
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: ai-review-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    name: Codex inline review
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false
+    runs-on: [self-hosted, macOS, ARM64]
+    timeout-minutes: 45
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
+          path: pr
+
+      - name: Checkout trusted review tools
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.base_ref || github.ref_name }}
+          fetch-depth: 1
+          path: review-tools
+
+      - name: Fetch base branch
+        working-directory: pr
+        run: |
+          git fetch origin "${{ github.base_ref || 'main' }}:refs/remotes/origin/${{ github.base_ref || 'main' }}"
+
+      - name: Verify Codex login
+        working-directory: pr
+        run: |
+          codex --version
+          codex login status
+
+      - name: Run AI review
+        working-directory: pr
+        env:
+          AI_REVIEW_MAX_WORKERS: "1"
+          AI_REVIEW_MAX_FILES: "30"
+          AI_REVIEW_MAX_TOTAL_COMMENTS: "20"
+          AI_REVIEW_CODEX_TIMEOUT: "240"
+        run: |
+          python3 ../review-tools/scripts/ai_review_pr.py \
+            --repo-root "$PWD" \
+            --base "origin/${{ github.base_ref || 'main' }}" \
+            --output .ai-review/review-comments.json \
+            --summary .ai-review/summary.md
+
+      - name: Upload review artifacts
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: ai-review
+          path: pr/.ai-review/
+
+      - name: Publish inline comments
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- bktrader-ai-review -->';
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const pull_number = context.payload.pull_request.number;
+            const commit_id = context.payload.pull_request.head.sha;
+            const payload = JSON.parse(fs.readFileSync('pr/.ai-review/review-comments.json', 'utf8'));
+            const summary = fs.existsSync('pr/.ai-review/summary.md')
+              ? fs.readFileSync('pr/.ai-review/summary.md', 'utf8')
+              : 'AI review finished.';
+
+            const existing = await github.paginate(github.rest.pulls.listReviewComments, {
+              owner,
+              repo,
+              pull_number,
+              per_page: 100,
+            });
+            const duplicateKeys = new Set(
+              existing
+                .filter(comment => comment.commit_id === commit_id && comment.body.includes(marker))
+                .map(comment => `${comment.path}:${comment.line}:${comment.body}`)
+            );
+
+            const comments = [];
+            for (const item of payload.comments || []) {
+              const body = `${marker}\n**AI Review / ${item.severity}**\n\n${item.message}`;
+              const key = `${item.path}:${item.line}:${body}`;
+              if (duplicateKeys.has(key)) {
+                continue;
+              }
+              comments.push({
+                path: item.path,
+                line: item.line,
+                side: item.side || 'RIGHT',
+                body,
+              });
+            }
+
+            if (comments.length > 0) {
+              await github.rest.pulls.createReview({
+                owner,
+                repo,
+                pull_number,
+                commit_id,
+                event: 'COMMENT',
+                body: `${marker}\n${summary}`,
+                comments,
+              });
+            } else {
+              const body = `${marker}\n${summary}`;
+              const { data: issueComments } = await github.rest.issues.listComments({
+                owner,
+                repo,
+                issue_number: pull_number,
+                per_page: 100,
+              });
+              const previous = issueComments.find(comment =>
+                comment.user.type === 'Bot' && comment.body.includes(marker)
+              );
+              if (previous) {
+                await github.rest.issues.updateComment({
+                  owner,
+                  repo,
+                  comment_id: previous.id,
+                  body,
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number: pull_number,
+                  body,
+                });
+              }
+            }

--- a/docs/cicd-maintenance.md
+++ b/docs/cicd-maintenance.md
@@ -7,10 +7,37 @@
 项目目前包含两个主要的 GitHub Actions 工作流：
 - **CI (`ci.yml`)**: 自动执行后端 (Go) 格式检查、编译、前端 (Vite) 构建以及 Docker 镜像构建验证。
 - **CD (`cd.yml`)**: 自动构建并推送后端 Docker 镜像，在自托管 (Self-hosted) 的 Macmini 节点上执行后端部署脚本，并构建前端静态文件后同步到远端 Nginx 目录。
+- **AI PR Review (`ai-review.yml`)**: 在自托管 Macmini runner 上调用已登录的 Codex CLI，按文件审查 PR diff，并把通过校验的结果写成 PR 行级评论。
 
 ---
 
 ## 常见问题与解决方法
+
+### 0. AI PR Review 没有评论或启动失败
+
+**现象**：`AI PR Review` 工作流失败，或只留下 summary，没有行级评论。
+
+**排查顺序**：
+
+1. 在 self-hosted runner 使用的 macOS 用户下确认 Codex 已登录：
+   ```bash
+   codex login status
+   ```
+2. 确认非交互模式能工作：
+   ```bash
+   printf '只回复 OK\n' | codex exec --ephemeral --sandbox read-only --color never -
+   ```
+3. 确认 runner 能执行 Python 脚本：
+   ```bash
+   python3 --version
+   ```
+4. 下载 Actions 中的 `ai-review` artifact，查看 `.ai-review/summary.md` 和 `.ai-review/review-comments.json`。
+
+**设计约定**：
+
+- 工作流会把 PR checkout 到 `pr/`，把 base 分支上的审查工具 checkout 到 `review-tools/`，避免直接执行 PR 自己修改过的审查脚本。
+- Codex 只允许返回 JSON；脚本会丢弃不在新增 diff 行中的评论。
+- 默认并发数是 `1`，优先稳定，不追求马上出结果。
 
 ### 1. 后端格式检查失败 (Verify formatting)
 

--- a/scripts/ai_review_pr.py
+++ b/scripts/ai_review_pr.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+import argparse
+import concurrent.futures
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+
+SCRIPT_REPO_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = SCRIPT_REPO_ROOT
+PROMPT_PATH = SCRIPT_REPO_ROOT / "scripts" / "ai_review_prompt.md"
+SCHEMA_PATH = SCRIPT_REPO_ROOT / "scripts" / "ai_review_schema.json"
+
+REVIEW_EXTENSIONS = {
+    ".go",
+    ".sql",
+    ".ts",
+    ".tsx",
+    ".js",
+    ".jsx",
+    ".py",
+    ".sh",
+    ".yml",
+    ".yaml",
+}
+REVIEW_NAMES = {
+    "Dockerfile",
+    ".dockerignore",
+    ".gitignore",
+    "go.mod",
+    "package.json",
+    "package-lock.json",
+}
+SKIP_PATH_PARTS = {
+    "node_modules",
+    "dist",
+    "build",
+    "coverage",
+    ".git",
+}
+SKIP_SUFFIXES = (
+    ".sum",
+    ".lock",
+    ".csv",
+    ".parquet",
+    ".zip",
+    ".gz",
+    ".png",
+    ".jpg",
+    ".jpeg",
+    ".gif",
+    ".webp",
+    ".ico",
+    ".pdf",
+)
+
+
+@dataclass(frozen=True)
+class AddedLine:
+    line: int
+    code: str
+
+
+@dataclass(frozen=True)
+class FileDiff:
+    path: str
+    diff: str
+    added_lines: tuple[AddedLine, ...]
+
+
+def run(cmd, *, input_text=None, timeout=120):
+    return subprocess.run(
+        cmd,
+        cwd=REPO_ROOT,
+        input=input_text,
+        text=True,
+        capture_output=True,
+        timeout=timeout,
+        check=False,
+    )
+
+
+def load_diff(base):
+    result = run(["git", "diff", "--no-ext-diff", "--unified=20", f"{base}...HEAD"], timeout=60)
+    if result.returncode != 0:
+        raise RuntimeError(f"git diff failed: {result.stderr.strip()}")
+    return result.stdout
+
+
+def parse_diff(diff_text):
+    files = []
+    current_path = None
+    buffer = []
+    added = []
+    new_line = None
+
+    def flush():
+        if current_path and buffer:
+            files.append(FileDiff(current_path, "\n".join(buffer) + "\n", tuple(added)))
+
+    for raw_line in diff_text.splitlines():
+        if raw_line.startswith("diff --git "):
+            flush()
+            current_path = raw_line.split(" b/", 1)[-1]
+            buffer = [raw_line]
+            added = []
+            new_line = None
+            continue
+
+        if current_path is None:
+            continue
+
+        buffer.append(raw_line)
+
+        if raw_line.startswith("+++ ") or raw_line.startswith("--- "):
+            continue
+
+        if raw_line.startswith("@@ "):
+            # Example: @@ -10,6 +20,9 @@ func name() {
+            header_parts = raw_line.split(" ")
+            new_range = next((part for part in header_parts if part.startswith("+")), None)
+            if not new_range:
+                new_line = None
+                continue
+            start = new_range[1:].split(",", 1)[0]
+            new_line = int(start)
+            continue
+
+        if new_line is None:
+            continue
+
+        if raw_line.startswith("+"):
+            added.append(AddedLine(new_line, raw_line[1:]))
+            new_line += 1
+        elif raw_line.startswith("-"):
+            continue
+        else:
+            new_line += 1
+
+    flush()
+    return files
+
+
+def should_review(file_diff):
+    path = file_diff.path
+    parts = set(Path(path).parts)
+    name = Path(path).name
+    suffix = Path(path).suffix
+
+    if not file_diff.added_lines:
+        return False
+    if parts & SKIP_PATH_PARTS:
+        return False
+    if path.startswith("data/") or path.startswith("research/dataset/"):
+        return False
+    if path.endswith(SKIP_SUFFIXES) and name not in REVIEW_NAMES:
+        return False
+    return suffix in REVIEW_EXTENSIONS or name in REVIEW_NAMES or path.startswith(".github/workflows/")
+
+
+def trim_diff(text, max_chars):
+    if len(text) <= max_chars:
+        return text
+    return text[:max_chars] + "\n\n[diff truncated by ai_review_pr.py]\n"
+
+
+def build_review_prompt(file_diff, max_diff_chars):
+    base_prompt = PROMPT_PATH.read_text(encoding="utf-8")
+    candidate_lines = "\n".join(
+        f"ADD line={line.line}: {line.code}" for line in file_diff.added_lines
+    )
+    return (
+        f"{base_prompt}\n\n"
+        f"Current file: {file_diff.path}\n\n"
+        f"ADD candidate lines:\n{candidate_lines}\n\n"
+        f"Full file diff:\n```diff\n{trim_diff(file_diff.diff, max_diff_chars)}```\n"
+    )
+
+
+def call_codex(file_diff, args):
+    prompt = build_review_prompt(file_diff, args.max_diff_chars)
+    allowed_lines = {line.line for line in file_diff.added_lines}
+
+    with tempfile.TemporaryDirectory(prefix="ai-review-") as tmpdir:
+        output_path = Path(tmpdir) / "last-message.json"
+        cmd = [
+            "codex",
+            "exec",
+            "--ephemeral",
+            "--sandbox",
+            "read-only",
+            "--color",
+            "never",
+            "--output-schema",
+            str(SCHEMA_PATH),
+            "--output-last-message",
+            str(output_path),
+            "-",
+        ]
+        result = run(cmd, input_text=prompt, timeout=args.codex_timeout)
+        if result.returncode != 0:
+            return [], f"{file_diff.path}: codex failed: {result.stderr.strip() or result.stdout.strip()}"
+        if not output_path.exists():
+            return [], f"{file_diff.path}: codex did not write an output message"
+
+        try:
+            payload = json.loads(output_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            return [], f"{file_diff.path}: invalid JSON from codex: {exc}"
+
+    comments = []
+    for item in payload.get("comments", []):
+        line = item.get("line")
+        message = str(item.get("message", "")).strip()
+        severity = str(item.get("severity", "warning")).strip().lower()
+        if line not in allowed_lines:
+            continue
+        if not message:
+            continue
+        if severity not in {"critical", "warning", "suggestion"}:
+            severity = "warning"
+        comments.append(
+            {
+                "path": file_diff.path,
+                "line": line,
+                "side": "RIGHT",
+                "severity": severity,
+                "message": message,
+            }
+        )
+    return comments[: args.max_comments_per_file], None
+
+
+def review_file(file_diff, args):
+    if args.dry_run:
+        return [], None
+    return call_codex(file_diff, args)
+
+
+def write_json(path, payload):
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
+    Path(path).write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def write_summary(path, reviewed, skipped, comments, warnings):
+    lines = [
+        "## AI Review Summary",
+        "",
+        f"- Reviewed files: {reviewed}",
+        f"- Skipped files: {skipped}",
+        f"- Inline comments: {len(comments)}",
+    ]
+    if warnings:
+        lines.append("")
+        lines.append("### Warnings")
+        lines.extend(f"- {warning}" for warning in warnings[:10])
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
+    Path(path).write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Run project-specific Codex inline review for a PR.")
+    parser.add_argument("--repo-root", default=os.environ.get("AI_REVIEW_REPO_ROOT", str(REPO_ROOT)))
+    parser.add_argument("--base", default=os.environ.get("AI_REVIEW_BASE", "origin/main"))
+    parser.add_argument("--output", default=".ai-review/review-comments.json")
+    parser.add_argument("--summary", default=".ai-review/summary.md")
+    parser.add_argument("--max-workers", type=int, default=int(os.environ.get("AI_REVIEW_MAX_WORKERS", "1")))
+    parser.add_argument("--max-files", type=int, default=int(os.environ.get("AI_REVIEW_MAX_FILES", "30")))
+    parser.add_argument("--max-total-comments", type=int, default=int(os.environ.get("AI_REVIEW_MAX_TOTAL_COMMENTS", "20")))
+    parser.add_argument("--max-comments-per-file", type=int, default=int(os.environ.get("AI_REVIEW_MAX_COMMENTS_PER_FILE", "5")))
+    parser.add_argument("--max-diff-chars", type=int, default=int(os.environ.get("AI_REVIEW_MAX_DIFF_CHARS", "18000")))
+    parser.add_argument("--codex-timeout", type=int, default=int(os.environ.get("AI_REVIEW_CODEX_TIMEOUT", "240")))
+    parser.add_argument("--dry-run", action="store_true")
+    return parser.parse_args()
+
+
+def main():
+    global REPO_ROOT
+    args = parse_args()
+    REPO_ROOT = Path(args.repo_root).resolve()
+    args.max_workers = max(1, min(args.max_workers, 2))
+
+    diff_text = load_diff(args.base)
+    all_file_diffs = parse_diff(diff_text)
+    reviewable = [file for file in all_file_diffs if should_review(file)]
+    reviewable = reviewable[: args.max_files]
+
+    comments = []
+    warnings = []
+    with concurrent.futures.ThreadPoolExecutor(max_workers=args.max_workers) as executor:
+        future_map = {executor.submit(review_file, file_diff, args): file_diff for file_diff in reviewable}
+        for future in concurrent.futures.as_completed(future_map):
+            file_comments, warning = future.result()
+            comments.extend(file_comments)
+            if warning:
+                warnings.append(warning)
+
+    comments = sorted(comments, key=lambda item: (item["path"], item["line"]))[: args.max_total_comments]
+    skipped = max(0, len(all_file_diffs) - len(reviewable))
+
+    write_json(args.output, {"comments": comments, "warnings": warnings})
+    write_summary(args.summary, len(reviewable), skipped, comments, warnings)
+
+    print(f"reviewed_files={len(reviewable)}")
+    print(f"skipped_files={skipped}")
+    print(f"comments={len(comments)}")
+    print(f"warnings={len(warnings)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ai_review_prompt.md
+++ b/scripts/ai_review_prompt.md
@@ -1,0 +1,31 @@
+You are reviewing a pull request for bktrader, a Go trading platform with a Vite/TypeScript console, PostgreSQL migrations, Docker/GitHub Actions deployment, and Python research/check scripts.
+
+Review only the diff provided in this prompt. Return JSON only.
+
+Project-specific risk model:
+- Trading safety matters more than style. Flag changes that can dispatch real orders unexpectedly, change dispatchMode from manual-review, switch mock/testnet paths toward real/mainnet, mis-size orders, skip risk exits, lose stop-loss/profit-protection behavior, corrupt positions, or advance a live plan incorrectly.
+- Live execution, order state, session recovery, paper/live parity, fills, positions, equity snapshots, notification/ack state, and reconciliation must stay consistent and idempotent.
+- SQL migrations and Postgres queries must be compatible with existing data, safe to rerun where expected, and not create unbounded scans on hot paths.
+- GitHub Actions, Docker, deploy scripts, secrets, GHCR auth, SSH/rsync deploy, macOS self-hosted runner behavior, and production env handling must remain non-interactive and non-leaky.
+- Frontend changes must preserve the API contract, auth behavior, live-session safety affordances, and user intent before sending execution/dispatch actions.
+- Python data/research/check scripts should avoid loading very large tick archives into memory unless intentionally bounded.
+
+Comment policy:
+- Report only concrete defects, security issues, production/deploy breakages, data corruption risks, trading/资金 risks, or test gaps that can hide those problems.
+- Do not report style, naming, formatting, broad best-practice advice, or speculative problems.
+- If the change is OK, return an empty comments array.
+- Comment only on ADD candidate lines supplied below.
+- The line field must exactly match a line number from ADD candidate lines.
+- Prefer one concise comment per root cause. Maximum 5 comments for this file.
+- Message language: Chinese. Keep it direct and actionable. Include why it matters for this project.
+
+Return this JSON shape:
+{
+  "comments": [
+    {
+      "line": 123,
+      "severity": "critical|warning|suggestion",
+      "message": "..."
+    }
+  ]
+}

--- a/scripts/ai_review_schema.json
+++ b/scripts/ai_review_schema.json
@@ -1,0 +1,31 @@
+{
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["comments"],
+  "properties": {
+    "comments": {
+      "type": "array",
+      "maxItems": 5,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["line", "severity", "message"],
+        "properties": {
+          "line": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "severity": {
+            "type": "string",
+            "enum": ["critical", "warning", "suggestion"]
+          },
+          "message": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 1200
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What changed
- Add an `AI PR Review` GitHub Actions workflow for PR-triggered Codex review on the macOS self-hosted runner.
- Add `scripts/ai_review_pr.py` to split PR diffs by file, send review prompts through `codex exec`, validate returned line numbers against added diff lines, and emit GitHub-ready inline comments JSON.
- Add a bktrader-specific review prompt and JSON schema.
- Document the runner/Codex login troubleshooting path.

## Why
The project already has a local authenticated Codex CLI and a self-hosted Macmini runner. This keeps AI review inside that environment instead of exposing a Flask gateway.

## Safety notes
- Default AI review concurrency is 1.
- The workflow checks out PR code into `pr/` and trusted review tooling into `review-tools/`.
- The publisher de-duplicates inline comments for the same head SHA and updates a summary comment when there are no inline findings.
- The Python script drops AI comments whose `line` is not an added line in the parsed PR diff.

## Validation
- `python3 -m py_compile scripts/ai_review_pr.py`
- `python3 -m json.tool scripts/ai_review_schema.json`
- `python3 scripts/ai_review_pr.py --repo-root "$PWD" --base origin/main --dry-run --output /tmp/ai-review-comments.json --summary /tmp/ai-review-summary.md`
- Controlled `codex exec --output-schema ... --output-last-message ...` probe
- Live script probe: reviewed 1 changed file via Codex and produced valid empty JSON
- Ruby YAML parse of `.github/workflows/ai-review.yml`
- `git diff --check HEAD`
