### PR TITLE
[codex] AI review 评论改为中文

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -82,7 +82,7 @@ jobs:
             const payload = JSON.parse(fs.readFileSync('pr/.ai-review/review-comments.json', 'utf8'));
             const summary = fs.existsSync('pr/.ai-review/summary.md')
               ? fs.readFileSync('pr/.ai-review/summary.md', 'utf8')
-              : 'AI review finished.';
+              : 'AI 代码审查已完成。';
 
             const existing = await github.paginate(github.rest.pulls.listReviewComments, {
               owner,
@@ -98,7 +98,13 @@ jobs:
 
             const comments = [];
             for (const item of payload.comments || []) {
-              const body = `${marker}\n**AI Review / ${item.severity}**\n\n${item.message}`;
+              const severityLabels = {
+                critical: '严重',
+                warning: '警告',
+                suggestion: '建议',
+              };
+              const severityLabel = severityLabels[item.severity] || item.severity || '警告';
+              const body = `${marker}\n**AI 代码审查 / ${severityLabel}**\n\n${item.message}`;
               const key = `${item.path}:${item.line}:${body}`;
               if (duplicateKeys.has(key)) {
                 continue;

--- a/scripts/ai_review_pr.py
+++ b/scripts/ai_review_pr.py
@@ -248,15 +248,15 @@ def write_json(path, payload):
 
 def write_summary(path, reviewed, skipped, comments, warnings):
     lines = [
-        "## AI Review Summary",
+        "## AI 代码审查摘要",
         "",
-        f"- Reviewed files: {reviewed}",
-        f"- Skipped files: {skipped}",
-        f"- Inline comments: {len(comments)}",
+        f"- 已审查文件：{reviewed}",
+        f"- 已跳过文件：{skipped}",
+        f"- 行级评论：{len(comments)}",
     ]
     if warnings:
         lines.append("")
-        lines.append("### Warnings")
+        lines.append("### 审查器警告")
         lines.extend(f"- {warning}" for warning in warnings[:10])
     Path(path).parent.mkdir(parents=True, exist_ok=True)
     Path(path).write_text("\n".join(lines) + "\n", encoding="utf-8")


### PR DESCRIPTION
## 改了什么
- 把 AI Review 的 PR summary 改成中文。
- 把行级评论标题从 `AI Review / warning` 改成 `AI 代码审查 / 警告` 这类中文标签。
- 把 workflow 里的兜底完成提示改成中文。

## 为什么
PR 页面主要给项目协作者看。固定提示、摘要和严重级别用中文，审查结果更容易快速理解。

## 验证
- `python3 -m py_compile scripts/ai_review_pr.py`
- `python3 scripts/ai_review_pr.py --repo-root "$PWD" --base origin/main --dry-run --output /tmp/chinese-ai-comments.json --summary /tmp/chinese-ai-summary.md`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ai-review.yml"); puts "yaml_ok"'`
- `git diff --check`

## 测试点
这个 PR 是非 Draft，应该触发刚合入的 `AI PR Review / Codex inline review`。
