### PR TITLE
style: compact metric cards in header

### DIFF
--- a/web/console/src/components/ui/MetricCard.tsx
+++ b/web/console/src/components/ui/MetricCard.tsx
@@ -1,8 +1,8 @@
 export function MetricCard(props: { label: string; value: string; tone?: "accent" }) {
   return (
-    <article className={`metric-card ${props.tone === "accent" ? "metric-card-accent" : ""}`}>
-      <p>{props.label}</p>
-      <strong>{props.value}</strong>
+    <article className={`metric-card flex flex-col justify-center ${props.tone === "accent" ? "metric-card-accent" : ""}`}>
+      <p className="opacity-70">{props.label}</p>
+      <strong className="truncate">{props.value}</strong>
     </article>
   );
 }

--- a/web/console/src/components/ui/MetricCard.tsx
+++ b/web/console/src/components/ui/MetricCard.tsx
@@ -2,7 +2,7 @@ export function MetricCard(props: { label: string; value: string; tone?: "accent
   return (
     <article className={`metric-card flex flex-col justify-center ${props.tone === "accent" ? "metric-card-accent" : ""}`}>
       <p className="opacity-70">{props.label}</p>
-      <strong className="truncate">{props.value}</strong>
+      <strong title={props.value}>{props.value}</strong>
     </article>
   );
 }

--- a/web/console/src/main.tsx
+++ b/web/console/src/main.tsx
@@ -1398,7 +1398,7 @@ function App() {
       dockTab={dockTab}
       onDockTabChange={setDockTab}
       headerMetrics={
-        <div className="flex space-x-6">
+        <div className="flex space-x-2">
           <MetricCard label="账户" value={monitorMode} />
           <MetricCard label="策略" value={String(highlightedLiveSession?.session?.strategyId ?? "--")} />
           <MetricCard label="实盘状态" value={highlightedLiveSession?.health.status ?? "--"} tone={highlightedLiveSession?.health.status === "ready" ? "accent" : undefined} />

--- a/web/console/src/styles.css
+++ b/web/console/src/styles.css
@@ -335,20 +335,24 @@ a {
 }
 
 .metric-card {
-  padding: 12px;
+  padding: 6px 14px;
+  border-radius: 12px;
+  min-width: 100px;
 }
 
 .metric-card p {
   margin: 0;
   color: var(--muted);
-  font-size: 0.82rem;
+  font-size: 0.72rem;
+  font-family: inherit;
 }
 
 .metric-card strong {
   display: block;
-  margin-top: 8px;
-  font-size: 1.3rem;
-  line-height: 1.05;
+  margin-top: 2px;
+  font-size: 0.95rem;
+  line-height: 1.1;
+  font-family: inherit;
 }
 
 .metric-card-accent {


### PR DESCRIPTION
优化顶部栏指标卡片布局，使其更紧凑并在一行内显示。主要修改了 MetricCard 组件样式和 header 容器间距。