### PR TITLE
Follow up execution normalization, SL protection, and watermark boundaries

### DIFF
--- a/docs/20260403改进计划_plan.md
+++ b/docs/20260403改进计划_plan.md
@@ -1,5 +1,76 @@
 # bkTrader 项目 Review 与 README 中文化
 
+## 2026-04 Execution Engine Follow-up
+
+这部分是基于 PR #17 reviewer 最终 `APPROVED` 后保留下来的后续优化方向。它们已经不属于当前必须阻塞合并的问题，但建议作为下一阶段核心执行链路优化来跟进。
+
+### 1. volatility-adjusted sizing 与交易所约束统一落地
+
+当前 `volatility_adjusted` 仓位已经按 ATR 和真实止损距离计算目标数量，但后续仍建议继续明确“理论 quantity -> 交易所可提交 quantity”的归一化链路。
+
+建议收口为一条显式路径：
+- 先计算 `rawQuantity`
+- 再统一经过 `stepSize / minQty / minNotional / tickSize` 归一化
+- 在 execution telemetry 中同时记录：
+  - `rawQuantity`
+  - `normalizedQuantity`
+  - `normalizationReason`
+  - `minNotionalAdjusted`
+
+目标：
+- 避免 reviewer 提到的“理论仓位正确，但最终交易所拒单”的灰区
+- 让 testnet / 实盘复盘时能看清楚到底是 sizing 决策问题，还是交易所规则裁剪问题
+
+### 2. SL 保护限价进一步结合 depth
+
+当前 `resolveAggressiveSLProtectionPrice()` 已经从“单边 quote 偏移”改成了基于 `bid/ask` 整段 spread 的保护定价，这一版已经足够安全上线。
+
+后续建议继续升级成 depth-aware 版本，而不是只看 top-of-book：
+- 结合前几档 depth 估算可成交覆盖量
+- 识别极端薄盘口 / quote gap / 虚假 top-of-book
+- 让 SL 保护限价可以根据订单目标数量动态选择更合理的保护区间
+
+建议新增 telemetry：
+- `topDepthNotional`
+- `expectedFillCoverage`
+- `quoteGapBps`
+- `slProtectionDepthMode`
+
+目标：
+- 提高薄盘口和跳价场景下的 SL 保护可靠性
+- 给后续 order book execution 策略优化提供分析数据
+
+### 3. trailing stop / watermark 副作用边界继续收敛
+
+当前 `evaluateLivePositionState(...)` 的副作用风险已经通过 clone 和 `watermarkPositionKey` 重置降低了，但 reviewer 提的方向仍然值得继续推进。
+
+建议后续重构成两段式：
+- `updateLivePositionWatermarks(...)`
+- `evaluateLivePositionState(...)`
+
+其中：
+- 前者只负责刷新持仓上下文相关的 `hwm / lwm / watermarkPositionKey`
+- 后者只负责基于当前 position + signal bar + watermarks 计算保护状态、止损线、PT/SL readiness
+
+目标：
+- 减少 signal evaluation / recovery / replay 之间的状态副作用耦合
+- 让 trailing stop 行为更容易写单元测试和恢复测试
+
+### 建议执行顺序
+
+1. 先做 `volatility_adjusted` 的最终归一化链路和 telemetry
+2. 再做 `SL protection` 的 depth-aware 定价增强
+3. 最后整理 trailing stop / watermark 的副作用边界
+
+### 上线前可接受状态
+
+如果短期目标是先合并并继续 testnet / 实盘观察，那么当前实现已经满足：
+- 可以合并
+- 可以继续监控
+- 不需要为以上 3 项继续阻塞当前 PR
+
+但后续如果要继续提升 execution quality 和 order book 策略迭代效率，建议把这 3 项列为同一阶段的连续任务。
+
 ## 项目总览
 
 bkTrader 是一个 **BTCUSDT 量化交易平台**，包含两部分：

--- a/internal/service/execution_strategy.go
+++ b/internal/service/execution_strategy.go
@@ -618,7 +618,7 @@ func resolveAggressiveSLProtectionDecision(side string, quantity, bestBid, bestA
 						decision.DepthMode = "top-book-cover"
 						return decision
 					}
-					decision.Price = bestBid + (spreadCapped-bestBid)*coverage
+					decision.Price = spreadCapped + (bestBid-spreadCapped)*coverage
 					decision.DepthMode = "coverage-weighted-cap"
 					return decision
 				}
@@ -636,7 +636,7 @@ func resolveAggressiveSLProtectionDecision(side string, quantity, bestBid, bestA
 						decision.DepthMode = "top-book-cover"
 						return decision
 					}
-					decision.Price = bestAsk - (bestAsk-spreadCapped)*coverage
+					decision.Price = spreadCapped + (bestAsk-spreadCapped)*(1-coverage)
 					decision.DepthMode = "coverage-weighted-cap"
 					return decision
 				}

--- a/internal/service/execution_strategy.go
+++ b/internal/service/execution_strategy.go
@@ -613,16 +613,17 @@ func resolveAggressiveSLProtectionDecision(side string, quantity, bestBid, bestA
 				if quantity > 0 && bestBidQty > 0 {
 					coverage := math.Min(bestBidQty/quantity, 1)
 					decision.ExpectedCoverage = coverage
-					if coverage >= 1 {
+					if bestBid < spreadCapped {
 						decision.Price = spreadCapped
-						if spreadCapped == bestBid {
-							decision.DepthMode = "top-book-cover"
-						} else {
-							decision.DepthMode = "top-book-outside-cap"
-						}
+						decision.DepthMode = "top-book-outside-cap"
 						return decision
 					}
-					decision.Price = math.Max(spreadCapped+(bestBid-spreadCapped)*coverage, spreadCapped)
+					if coverage >= 1 {
+						decision.Price = bestBid
+						decision.DepthMode = "top-book-cover"
+						return decision
+					}
+					decision.Price = spreadCapped + (bestBid-spreadCapped)*coverage
 					decision.DepthMode = "coverage-weighted-cap"
 					return decision
 				}
@@ -635,16 +636,17 @@ func resolveAggressiveSLProtectionDecision(side string, quantity, bestBid, bestA
 				if quantity > 0 && bestAskQty > 0 {
 					coverage := math.Min(bestAskQty/quantity, 1)
 					decision.ExpectedCoverage = coverage
-					if coverage >= 1 {
+					if bestAsk > spreadCapped {
 						decision.Price = spreadCapped
-						if spreadCapped == bestAsk {
-							decision.DepthMode = "top-book-cover"
-						} else {
-							decision.DepthMode = "top-book-outside-cap"
-						}
+						decision.DepthMode = "top-book-outside-cap"
 						return decision
 					}
-					decision.Price = math.Min(spreadCapped+(bestAsk-spreadCapped)*coverage, spreadCapped)
+					if coverage >= 1 {
+						decision.Price = bestAsk
+						decision.DepthMode = "top-book-cover"
+						return decision
+					}
+					decision.Price = spreadCapped + (bestAsk-spreadCapped)*coverage
 					decision.DepthMode = "coverage-weighted-cap"
 					return decision
 				}

--- a/internal/service/execution_strategy.go
+++ b/internal/service/execution_strategy.go
@@ -112,6 +112,15 @@ type executionProfile struct {
 	SLMaxSlippageBps      float64
 }
 
+type slProtectionDecision struct {
+	Price            float64
+	TopDepthQty      float64
+	TopDepthNotional float64
+	ExpectedCoverage float64
+	QuoteGapBps      float64
+	DepthMode        string
+}
+
 func (bookAwareExecutionStrategy) Key() string {
 	return "book-aware-v1"
 }
@@ -248,7 +257,8 @@ func (bookAwareExecutionStrategy) BuildProposal(ctx ExecutionPlanningContext) (E
 	if profile.ReduceOnly && reasonTag == "sl" {
 		slMaxSlippageBps := firstPositive(profile.SLMaxSlippageBps, 50)
 		if spreadBps > 0 && slMaxSlippageBps > 0 && spreadBps > slMaxSlippageBps {
-			cappedPrice := resolveAggressiveSLProtectionPrice(intent.Side, bestBid, bestAsk, priceHint, slMaxSlippageBps)
+			slProtection := resolveAggressiveSLProtectionDecision(intent.Side, proposal.Quantity, bestBid, bestAsk, bestBidQty, bestAskQty, priceHint, slMaxSlippageBps)
+			cappedPrice := slProtection.Price
 			proposal.Type = "LIMIT"
 			proposal.LimitPrice = cappedPrice
 			proposal.TimeInForce = "GTC"
@@ -263,12 +273,21 @@ func (bookAwareExecutionStrategy) BuildProposal(ctx ExecutionPlanningContext) (E
 			proposal.Metadata["slCappedPrice"] = cappedPrice
 			proposal.Metadata["slOriginalSpreadBps"] = spreadBps
 			proposal.Metadata["slMaxSlippageBps"] = slMaxSlippageBps
+			proposal.Metadata["topDepthNotional"] = slProtection.TopDepthNotional
+			proposal.Metadata["expectedFillCoverage"] = slProtection.ExpectedCoverage
+			proposal.Metadata["quoteGapBps"] = slProtection.QuoteGapBps
+			proposal.Metadata["slProtectionDepthMode"] = slProtection.DepthMode
 			proposal.Metadata["executionDecision"] = "sl-slippage-protected"
 			proposal.Metadata["executionDecisionContext"] = mergeExecutionDecisionContext(
 				mapValue(proposal.Metadata["executionDecisionContext"]),
 				map[string]any{
-					"slProtectionBranch": true,
-					"slProtectionMode":   "spread-capped-limit",
+					"slProtectionBranch":    true,
+					"slProtectionMode":      "spread-capped-limit",
+					"slProtectionDepthMode": slProtection.DepthMode,
+					"topDepthQty":           slProtection.TopDepthQty,
+					"topDepthNotional":      slProtection.TopDepthNotional,
+					"expectedFillCoverage":  slProtection.ExpectedCoverage,
+					"quoteGapBps":           slProtection.QuoteGapBps,
 				},
 			)
 			return proposal, nil
@@ -571,31 +590,72 @@ func resolvePassiveBookPrice(side string, bestBid, bestAsk, fallback float64) fl
 	}
 }
 
-// resolveAggressiveSLProtectionPrice 基于整段盘口 spread 计算 SL 保护限价。
-// 当 spread 已经大于容忍阈值时，不再基于单边 quote 继续偏移，而是从盘口两侧推导一个
-// “最多跨越 maxSlippageBps 对应价格宽度”的保护限价。这样触发条件和控制手段都围绕同一段 spread。
-func resolveAggressiveSLProtectionPrice(side string, bestBid, bestAsk, fallback, maxSlippageBps float64) float64 {
+// resolveAggressiveSLProtectionDecision 基于 spread 与 top-of-book 深度估算 SL 保护限价。
+// 当前先使用最靠近成交的 top-of-book 数量作为一阶 depth 代理：
+// - 若顶档覆盖目标数量，则直接用顶档价；
+// - 若顶档不足，则在顶档价与 spread-capped 保护价之间按覆盖率插值；
+// - 若盘口信息不完整，则回退到 spread-capped 保护价。
+func resolveAggressiveSLProtectionDecision(side string, quantity, bestBid, bestAsk, bestBidQty, bestAskQty, fallback, maxSlippageBps float64) slProtectionDecision {
+	decision := slProtectionDecision{
+		Price:     fallback,
+		DepthMode: "spread-capped-fallback",
+	}
 	if bestBid > 0 && bestAsk > 0 && bestAsk >= bestBid {
 		mid := (bestBid + bestAsk) / 2
 		if mid > 0 {
 			allowedCross := mid * maxSlippageBps / 10000
+			decision.QuoteGapBps = (bestAsk - bestBid) / mid * 10000
 			switch strings.ToUpper(strings.TrimSpace(side)) {
 			case "SELL", "SHORT":
-				return math.Max(bestBid, bestAsk-allowedCross)
+				decision.TopDepthQty = bestBidQty
+				decision.TopDepthNotional = bestBidQty * bestBid
+				spreadCapped := math.Max(bestBid, bestAsk-allowedCross)
+				if quantity > 0 && bestBidQty > 0 {
+					coverage := math.Min(bestBidQty/quantity, 1)
+					decision.ExpectedCoverage = coverage
+					if coverage >= 1 {
+						decision.Price = bestBid
+						decision.DepthMode = "top-book-cover"
+						return decision
+					}
+					decision.Price = bestBid + (spreadCapped-bestBid)*coverage
+					decision.DepthMode = "coverage-weighted-cap"
+					return decision
+				}
+				decision.Price = spreadCapped
+				return decision
 			case "BUY":
-				return math.Min(bestAsk, bestBid+allowedCross)
+				decision.TopDepthQty = bestAskQty
+				decision.TopDepthNotional = bestAskQty * bestAsk
+				spreadCapped := math.Min(bestAsk, bestBid+allowedCross)
+				if quantity > 0 && bestAskQty > 0 {
+					coverage := math.Min(bestAskQty/quantity, 1)
+					decision.ExpectedCoverage = coverage
+					if coverage >= 1 {
+						decision.Price = bestAsk
+						decision.DepthMode = "top-book-cover"
+						return decision
+					}
+					decision.Price = bestAsk - (bestAsk-spreadCapped)*coverage
+					decision.DepthMode = "coverage-weighted-cap"
+					return decision
+				}
+				decision.Price = spreadCapped
+				return decision
 			}
 		}
 	}
+	decision.QuoteGapBps = 0
 	tolerance := maxSlippageBps / 10000
 	switch strings.ToUpper(strings.TrimSpace(side)) {
 	case "SELL", "SHORT":
-		return fallback * (1 - tolerance)
+		decision.Price = fallback * (1 - tolerance)
 	case "BUY":
-		return fallback * (1 + tolerance)
+		decision.Price = fallback * (1 + tolerance)
 	default:
-		return fallback
+		decision.Price = fallback
 	}
+	return decision
 }
 
 func signalIntentToMap(intent SignalIntent) map[string]any {

--- a/internal/service/execution_strategy.go
+++ b/internal/service/execution_strategy.go
@@ -614,11 +614,15 @@ func resolveAggressiveSLProtectionDecision(side string, quantity, bestBid, bestA
 					coverage := math.Min(bestBidQty/quantity, 1)
 					decision.ExpectedCoverage = coverage
 					if coverage >= 1 {
-						decision.Price = bestBid
-						decision.DepthMode = "top-book-cover"
+						decision.Price = spreadCapped
+						if spreadCapped == bestBid {
+							decision.DepthMode = "top-book-cover"
+						} else {
+							decision.DepthMode = "top-book-outside-cap"
+						}
 						return decision
 					}
-					decision.Price = spreadCapped + (bestBid-spreadCapped)*coverage
+					decision.Price = math.Max(spreadCapped+(bestBid-spreadCapped)*coverage, spreadCapped)
 					decision.DepthMode = "coverage-weighted-cap"
 					return decision
 				}
@@ -632,11 +636,15 @@ func resolveAggressiveSLProtectionDecision(side string, quantity, bestBid, bestA
 					coverage := math.Min(bestAskQty/quantity, 1)
 					decision.ExpectedCoverage = coverage
 					if coverage >= 1 {
-						decision.Price = bestAsk
-						decision.DepthMode = "top-book-cover"
+						decision.Price = spreadCapped
+						if spreadCapped == bestAsk {
+							decision.DepthMode = "top-book-cover"
+						} else {
+							decision.DepthMode = "top-book-outside-cap"
+						}
 						return decision
 					}
-					decision.Price = spreadCapped + (bestAsk-spreadCapped)*coverage
+					decision.Price = math.Min(spreadCapped+(bestAsk-spreadCapped)*coverage, spreadCapped)
 					decision.DepthMode = "coverage-weighted-cap"
 					return decision
 				}

--- a/internal/service/execution_strategy.go
+++ b/internal/service/execution_strategy.go
@@ -590,11 +590,9 @@ func resolvePassiveBookPrice(side string, bestBid, bestAsk, fallback float64) fl
 	}
 }
 
-// resolveAggressiveSLProtectionDecision 基于 spread 与 top-of-book 深度估算 SL 保护限价。
-// 当前先使用最靠近成交的 top-of-book 数量作为一阶 depth 代理：
-// - 若顶档覆盖目标数量，则直接用顶档价；
-// - 若顶档不足，则在顶档价与 spread-capped 保护价之间按覆盖率插值；
-// - 若盘口信息不完整，则回退到 spread-capped 保护价。
+// resolveAggressiveSLProtectionDecision 仅为“宽点差 SL 保护”分支计算一个不越过滑点 cap 的保护限价。
+// 当前调用方只会在 spread 已经超过 maxSlippageBps 时进入这里，因此最终价格始终收敛到 spread-capped，
+// top-of-book depth 仅用于记录覆盖率和盘口质量，不再假装把报价改善到 cap 之外。
 func resolveAggressiveSLProtectionDecision(side string, quantity, bestBid, bestAsk, bestBidQty, bestAskQty, fallback, maxSlippageBps float64) slProtectionDecision {
 	decision := slProtectionDecision{
 		Price:     fallback,
@@ -610,47 +608,41 @@ func resolveAggressiveSLProtectionDecision(side string, quantity, bestBid, bestA
 				decision.TopDepthQty = bestBidQty
 				decision.TopDepthNotional = bestBidQty * bestBid
 				spreadCapped := math.Max(bestBid, bestAsk-allowedCross)
+				decision.Price = spreadCapped
 				if quantity > 0 && bestBidQty > 0 {
 					coverage := math.Min(bestBidQty/quantity, 1)
 					decision.ExpectedCoverage = coverage
 					if bestBid < spreadCapped {
-						decision.Price = spreadCapped
 						decision.DepthMode = "top-book-outside-cap"
 						return decision
 					}
 					if coverage >= 1 {
-						decision.Price = bestBid
-						decision.DepthMode = "top-book-cover"
+						decision.DepthMode = "top-book-cover-within-cap"
 						return decision
 					}
-					decision.Price = spreadCapped + (bestBid-spreadCapped)*coverage
-					decision.DepthMode = "coverage-weighted-cap"
+					decision.DepthMode = "top-book-partial-within-cap"
 					return decision
 				}
-				decision.Price = spreadCapped
 				return decision
 			case "BUY":
 				decision.TopDepthQty = bestAskQty
 				decision.TopDepthNotional = bestAskQty * bestAsk
 				spreadCapped := math.Min(bestAsk, bestBid+allowedCross)
+				decision.Price = spreadCapped
 				if quantity > 0 && bestAskQty > 0 {
 					coverage := math.Min(bestAskQty/quantity, 1)
 					decision.ExpectedCoverage = coverage
 					if bestAsk > spreadCapped {
-						decision.Price = spreadCapped
 						decision.DepthMode = "top-book-outside-cap"
 						return decision
 					}
 					if coverage >= 1 {
-						decision.Price = bestAsk
-						decision.DepthMode = "top-book-cover"
+						decision.DepthMode = "top-book-cover-within-cap"
 						return decision
 					}
-					decision.Price = spreadCapped + (bestAsk-spreadCapped)*coverage
-					decision.DepthMode = "coverage-weighted-cap"
+					decision.DepthMode = "top-book-partial-within-cap"
 					return decision
 				}
-				decision.Price = spreadCapped
 				return decision
 			}
 		}

--- a/internal/service/execution_strategy.go
+++ b/internal/service/execution_strategy.go
@@ -636,7 +636,7 @@ func resolveAggressiveSLProtectionDecision(side string, quantity, bestBid, bestA
 						decision.DepthMode = "top-book-cover"
 						return decision
 					}
-					decision.Price = spreadCapped + (bestAsk-spreadCapped)*(1-coverage)
+					decision.Price = spreadCapped + (bestAsk-spreadCapped)*coverage
 					decision.DepthMode = "coverage-weighted-cap"
 					return decision
 				}

--- a/internal/service/live_execution.go
+++ b/internal/service/live_execution.go
@@ -602,11 +602,13 @@ func firstNonEmptyMapValue(values ...any) map[string]any {
 }
 
 func withExecutionSubmissionFallback(order domain.Order, fallback domain.Order) domain.Order {
-	if len(mapValue(order.Metadata["adapterSubmission"])) > 0 {
+	currentSubmission := cloneMetadata(mapValue(order.Metadata["adapterSubmission"]))
+	fallbackSubmission := cloneMetadata(mapValue(fallback.Metadata["adapterSubmission"]))
+	if len(currentSubmission) > 0 && len(fallbackSubmission) == 0 {
 		return order
 	}
-	fallbackSubmission := cloneMetadata(mapValue(fallback.Metadata["adapterSubmission"]))
-	if len(fallbackSubmission) == 0 {
+	mergedSubmission := mergeExecutionSubmissionFallback(currentSubmission, fallbackSubmission)
+	if len(mergedSubmission) == 0 {
 		return order
 	}
 	enriched := order
@@ -614,8 +616,28 @@ func withExecutionSubmissionFallback(order domain.Order, fallback domain.Order) 
 	if enriched.Metadata == nil {
 		enriched.Metadata = map[string]any{}
 	}
-	enriched.Metadata["adapterSubmission"] = fallbackSubmission
+	enriched.Metadata["adapterSubmission"] = mergedSubmission
 	return enriched
+}
+
+func mergeExecutionSubmissionFallback(current map[string]any, fallback map[string]any) map[string]any {
+	if len(current) == 0 {
+		return cloneMetadata(fallback)
+	}
+	if len(fallback) == 0 {
+		return cloneMetadata(current)
+	}
+	merged := cloneMetadata(fallback)
+	for key, value := range current {
+		currentMap := mapValue(value)
+		fallbackMap := mapValue(merged[key])
+		if len(currentMap) > 0 && len(fallbackMap) > 0 {
+			merged[key] = mergeExecutionSubmissionFallback(currentMap, fallbackMap)
+			continue
+		}
+		merged[key] = value
+	}
+	return merged
 }
 
 func executionDispatchSummary(proposalMap map[string]any, order domain.Order, failed bool) map[string]any {

--- a/internal/service/live_execution.go
+++ b/internal/service/live_execution.go
@@ -635,9 +635,36 @@ func mergeExecutionSubmissionFallback(current map[string]any, fallback map[strin
 			merged[key] = mergeExecutionSubmissionFallback(currentMap, fallbackMap)
 			continue
 		}
-		merged[key] = value
+		if executionSubmissionValuePresent(value) {
+			merged[key] = value
+		}
 	}
 	return merged
+}
+
+func executionSubmissionValuePresent(value any) bool {
+	switch typed := value.(type) {
+	case nil:
+		return false
+	case string:
+		return strings.TrimSpace(typed) != ""
+	case bool:
+		return typed
+	case int:
+		return typed != 0
+	case int64:
+		return typed != 0
+	case float64:
+		return typed != 0
+	case []any:
+		return len(typed) > 0
+	case []string:
+		return len(typed) > 0
+	case map[string]any:
+		return len(typed) > 0
+	default:
+		return true
+	}
 }
 
 func executionDispatchSummary(proposalMap map[string]any, order domain.Order, failed bool) map[string]any {

--- a/internal/service/live_execution.go
+++ b/internal/service/live_execution.go
@@ -686,6 +686,15 @@ func executionSubmissionNumericValuePresent(path string, value float64) bool {
 		return true
 	}
 	switch path {
+	case "rawQuantity",
+		"normalizedQuantity",
+		"rawPriceReference",
+		"normalizedPrice",
+		"normalization.rawQuantity",
+		"normalization.normalizedQuantity",
+		"normalization.rawPriceReference",
+		"normalization.normalizedPrice":
+		return false
 	case "symbolRules.minQty",
 		"symbolRules.stepSize",
 		"symbolRules.tickSize",

--- a/internal/service/live_execution.go
+++ b/internal/service/live_execution.go
@@ -332,6 +332,7 @@ func (p *Platform) applyLiveVirtualInitialEvent(session domain.LiveSession, prop
 	proposal := executionProposalFromMap(proposalMap)
 	state := cloneMetadata(session.State)
 	intentSignature := buildLiveIntentSignature(proposalMap)
+	virtualPositionID := fmt.Sprintf("virtual|%s|%s|%s", session.ID, eventTime.UTC().Format(time.RFC3339Nano), intentSignature)
 	entryPrice := firstPositive(
 		parseFloatValue(proposalMap["plannedPrice"]),
 		firstPositive(
@@ -363,6 +364,7 @@ func (p *Platform) applyLiveVirtualInitialEvent(session domain.LiveSession, prop
 	state["lastVirtualSignalAt"] = eventTime.UTC().Format(time.RFC3339)
 	state["lastVirtualSignalType"] = "initial"
 	state["virtualPosition"] = map[string]any{
+		"id":         virtualPositionID,
 		"found":      true,
 		"virtual":    true,
 		"symbol":     NormalizeSymbol(proposal.Symbol),

--- a/internal/service/live_execution.go
+++ b/internal/service/live_execution.go
@@ -678,15 +678,7 @@ func executionSubmissionValuePresent(path string, value any) bool {
 }
 
 func executionSubmissionBooleanValuePresent(path string, value bool) bool {
-	if value {
-		return true
-	}
-	switch path {
-	case "postOnly", "reduceOnly", "closePosition", "slProtectionActive":
-		return false
-	default:
-		return true
-	}
+	return true
 }
 
 func executionSubmissionNumericValuePresent(path string, value float64) bool {
@@ -694,19 +686,12 @@ func executionSubmissionNumericValuePresent(path string, value float64) bool {
 		return true
 	}
 	switch path {
-	case "rawQuantity",
-		"normalizedQuantity",
-		"rawPriceReference",
-		"normalizedPrice",
-		"normalization.rawQuantity",
-		"normalization.normalizedQuantity",
-		"normalization.rawPriceReference",
-		"normalization.normalizedPrice":
+	case "symbolRules.minQty",
+		"symbolRules.stepSize",
+		"symbolRules.tickSize",
+		"symbolRules.minNotional":
 		return false
 	default:
-		if strings.HasPrefix(path, "symbolRules.") {
-			return false
-		}
 		return true
 	}
 }

--- a/internal/service/live_execution.go
+++ b/internal/service/live_execution.go
@@ -649,13 +649,13 @@ func executionSubmissionValuePresent(value any) bool {
 	case string:
 		return strings.TrimSpace(typed) != ""
 	case bool:
-		return typed
+		return true
 	case int:
-		return typed != 0
+		return true
 	case int64:
-		return typed != 0
+		return true
 	case float64:
-		return typed != 0
+		return true
 	case []any:
 		return len(typed) > 0
 	case []string:

--- a/internal/service/live_execution.go
+++ b/internal/service/live_execution.go
@@ -485,7 +485,8 @@ func (p *Platform) syncLatestLiveSessionOrder(session domain.LiveSession, eventT
 		state["lastSyncedAt"] = eventTime.UTC().Format(time.RFC3339)
 		state["lastExecutionTimeoutAt"] = eventTime.UTC().Format(time.RFC3339)
 		state["lastExecutionTimeoutReason"] = "resting-order-expired"
-		state["lastExecutionDispatch"] = executionDispatchSummary(mapValue(order.Metadata["executionProposal"]), cancelledOrder, false)
+		timeoutOrder := withExecutionSubmissionFallback(cancelledOrder, order)
+		state["lastExecutionDispatch"] = executionDispatchSummary(mapValue(order.Metadata["executionProposal"]), timeoutOrder, false)
 		updateExecutionEventStats(state, mapValue(order.Metadata["executionProposal"]), mapValue(state["lastExecutionDispatch"]))
 		timeoutSignature := buildLiveIntentSignature(mapValue(order.Metadata["executionProposal"]))
 		if timeoutSignature == "" {
@@ -494,7 +495,7 @@ func (p *Platform) syncLatestLiveSessionOrder(session domain.LiveSession, eventT
 		if timeoutSignature != "" {
 			state["lastExecutionTimeoutIntentSignature"] = timeoutSignature
 		}
-		appendTimelineEvent(state, "order", eventTime, "live-order-cancelled-timeout", executionTimeoutTimelineMetadata(order, cancelledOrder))
+		appendTimelineEvent(state, "order", eventTime, "live-order-cancelled-timeout", executionTimeoutTimelineMetadata(order, timeoutOrder))
 		return p.store.UpdateLiveSessionState(session.ID, state)
 	}
 	syncedOrder, err := p.SyncLiveOrder(order.ID)
@@ -600,6 +601,23 @@ func firstNonEmptyMapValue(values ...any) map[string]any {
 	return nil
 }
 
+func withExecutionSubmissionFallback(order domain.Order, fallback domain.Order) domain.Order {
+	if len(mapValue(order.Metadata["adapterSubmission"])) > 0 {
+		return order
+	}
+	fallbackSubmission := cloneMetadata(mapValue(fallback.Metadata["adapterSubmission"]))
+	if len(fallbackSubmission) == 0 {
+		return order
+	}
+	enriched := order
+	enriched.Metadata = cloneMetadata(order.Metadata)
+	if enriched.Metadata == nil {
+		enriched.Metadata = map[string]any{}
+	}
+	enriched.Metadata["adapterSubmission"] = fallbackSubmission
+	return enriched
+}
+
 func executionDispatchSummary(proposalMap map[string]any, order domain.Order, failed bool) map[string]any {
 	proposalMeta := cloneMetadata(mapValue(proposalMap["metadata"]))
 	adapterSubmission := cloneMetadata(mapValue(order.Metadata["adapterSubmission"]))
@@ -640,10 +658,13 @@ func executionDispatchSummary(proposalMap map[string]any, order domain.Order, fa
 			parseFloatValue(adapterSubmission["rawPriceReference"]),
 			parseFloatValue(mapValue(adapterSubmission["normalization"])["rawPriceReference"]),
 		),
-		"normalizedPrice": parseFloatValue(adapterSubmission["normalizedPrice"]),
-		"normalization":   cloneMetadata(mapValue(adapterSubmission["normalization"])),
-		"symbolRules":     cloneMetadata(mapValue(adapterSubmission["symbolRules"])),
-		"failed":          failed,
+		"normalizedPrice": firstPositive(
+			parseFloatValue(adapterSubmission["normalizedPrice"]),
+			parseFloatValue(mapValue(adapterSubmission["normalization"])["normalizedPrice"]),
+		),
+		"normalization": cloneMetadata(mapValue(adapterSubmission["normalization"])),
+		"symbolRules":   cloneMetadata(mapValue(adapterSubmission["symbolRules"])),
+		"failed":        failed,
 	}
 }
 

--- a/internal/service/live_execution.go
+++ b/internal/service/live_execution.go
@@ -602,6 +602,7 @@ func firstNonEmptyMapValue(values ...any) map[string]any {
 
 func executionDispatchSummary(proposalMap map[string]any, order domain.Order, failed bool) map[string]any {
 	proposalMeta := cloneMetadata(mapValue(proposalMap["metadata"]))
+	adapterSubmission := cloneMetadata(mapValue(order.Metadata["adapterSubmission"]))
 	expectedPrice := firstPositive(parseFloatValue(proposalMap["limitPrice"]), parseFloatValue(proposalMap["priceHint"]))
 	actualPrice := firstPositive(order.Price, expectedPrice)
 	priceDriftBps := 0.0
@@ -630,7 +631,19 @@ func executionDispatchSummary(proposalMap map[string]any, order domain.Order, fa
 		"priceDriftBps":     priceDriftBps,
 		"decisionContext":   cloneMetadata(mapValue(proposalMeta["executionDecisionContext"])),
 		"book":              cloneMetadata(mapValue(proposalMeta["orderBookSnapshot"])),
-		"failed":            failed,
+		"rawQuantity":       firstPositive(parseFloatValue(adapterSubmission["rawQuantity"]), parseFloatValue(mapValue(adapterSubmission["normalization"])["rawQuantity"])),
+		"normalizedQuantity": firstPositive(
+			parseFloatValue(adapterSubmission["normalizedQuantity"]),
+			parseFloatValue(mapValue(adapterSubmission["normalization"])["normalizedQuantity"]),
+		),
+		"rawPriceReference": firstPositive(
+			parseFloatValue(adapterSubmission["rawPriceReference"]),
+			parseFloatValue(mapValue(adapterSubmission["normalization"])["rawPriceReference"]),
+		),
+		"normalizedPrice": parseFloatValue(adapterSubmission["normalizedPrice"]),
+		"normalization":   cloneMetadata(mapValue(adapterSubmission["normalization"])),
+		"symbolRules":     cloneMetadata(mapValue(adapterSubmission["symbolRules"])),
+		"failed":          failed,
 	}
 }
 

--- a/internal/service/live_execution.go
+++ b/internal/service/live_execution.go
@@ -678,15 +678,7 @@ func executionSubmissionValuePresent(path string, value any) bool {
 }
 
 func executionSubmissionBooleanValuePresent(path string, value bool) bool {
-	if value {
-		return true
-	}
-	switch path {
-	case "postOnly", "reduceOnly", "closePosition", "slProtectionActive":
-		return false
-	default:
-		return true
-	}
+	return true
 }
 
 func executionSubmissionNumericValuePresent(path string, value float64) bool {
@@ -696,13 +688,14 @@ func executionSubmissionNumericValuePresent(path string, value float64) bool {
 	switch path {
 	case "rawQuantity",
 		"normalizedQuantity",
-		"rawPriceReference",
-		"normalizedPrice",
 		"normalization.rawQuantity",
-		"normalization.normalizedQuantity",
+		"normalization.normalizedQuantity":
+		return false
+	case "rawPriceReference",
+		"normalizedPrice",
 		"normalization.rawPriceReference",
 		"normalization.normalizedPrice":
-		return false
+		return true
 	case "symbolRules.minQty",
 		"symbolRules.stepSize",
 		"symbolRules.tickSize",

--- a/internal/service/live_execution.go
+++ b/internal/service/live_execution.go
@@ -678,7 +678,15 @@ func executionSubmissionValuePresent(path string, value any) bool {
 }
 
 func executionSubmissionBooleanValuePresent(path string, value bool) bool {
-	return true
+	if value {
+		return true
+	}
+	switch path {
+	case "postOnly", "reduceOnly", "closePosition", "slProtectionActive":
+		return false
+	default:
+		return true
+	}
 }
 
 func executionSubmissionNumericValuePresent(path string, value float64) bool {

--- a/internal/service/live_execution.go
+++ b/internal/service/live_execution.go
@@ -332,7 +332,7 @@ func (p *Platform) applyLiveVirtualInitialEvent(session domain.LiveSession, prop
 	proposal := executionProposalFromMap(proposalMap)
 	state := cloneMetadata(session.State)
 	intentSignature := buildLiveIntentSignature(proposalMap)
-	virtualPositionID := fmt.Sprintf("virtual|%s|%s|%s", session.ID, eventTime.UTC().Format(time.RFC3339Nano), intentSignature)
+	virtualPositionID := fmt.Sprintf("virtual|%s|%s", session.ID, intentSignature)
 	entryPrice := firstPositive(
 		parseFloatValue(proposalMap["plannedPrice"]),
 		firstPositive(
@@ -623,6 +623,10 @@ func withExecutionSubmissionFallback(order domain.Order, fallback domain.Order) 
 }
 
 func mergeExecutionSubmissionFallback(current map[string]any, fallback map[string]any) map[string]any {
+	return mergeExecutionSubmissionFallbackWithPath(current, fallback, "")
+}
+
+func mergeExecutionSubmissionFallbackWithPath(current map[string]any, fallback map[string]any, path string) map[string]any {
 	if len(current) == 0 {
 		return cloneMetadata(fallback)
 	}
@@ -631,20 +635,24 @@ func mergeExecutionSubmissionFallback(current map[string]any, fallback map[strin
 	}
 	merged := cloneMetadata(fallback)
 	for key, value := range current {
+		childPath := key
+		if path != "" {
+			childPath = path + "." + key
+		}
 		currentMap := mapValue(value)
 		fallbackMap := mapValue(merged[key])
 		if len(currentMap) > 0 && len(fallbackMap) > 0 {
-			merged[key] = mergeExecutionSubmissionFallback(currentMap, fallbackMap)
+			merged[key] = mergeExecutionSubmissionFallbackWithPath(currentMap, fallbackMap, childPath)
 			continue
 		}
-		if executionSubmissionValuePresent(value) {
+		if executionSubmissionValuePresent(childPath, value) {
 			merged[key] = value
 		}
 	}
 	return merged
 }
 
-func executionSubmissionValuePresent(value any) bool {
+func executionSubmissionValuePresent(path string, value any) bool {
 	switch typed := value.(type) {
 	case nil:
 		return false
@@ -653,17 +661,36 @@ func executionSubmissionValuePresent(value any) bool {
 	case bool:
 		return true
 	case int:
-		return true
+		return executionSubmissionNumericValuePresent(path, float64(typed))
 	case int64:
-		return true
+		return executionSubmissionNumericValuePresent(path, float64(typed))
 	case float64:
-		return true
+		return executionSubmissionNumericValuePresent(path, typed)
 	case []any:
 		return len(typed) > 0
 	case []string:
 		return len(typed) > 0
 	case map[string]any:
 		return len(typed) > 0
+	default:
+		return true
+	}
+}
+
+func executionSubmissionNumericValuePresent(path string, value float64) bool {
+	if value != 0 {
+		return true
+	}
+	switch path {
+	case "rawQuantity",
+		"normalizedQuantity",
+		"rawPriceReference",
+		"normalizedPrice",
+		"normalization.rawQuantity",
+		"normalization.normalizedQuantity",
+		"normalization.rawPriceReference",
+		"normalization.normalizedPrice":
+		return false
 	default:
 		return true
 	}

--- a/internal/service/live_execution.go
+++ b/internal/service/live_execution.go
@@ -659,7 +659,7 @@ func executionSubmissionValuePresent(path string, value any) bool {
 	case string:
 		return strings.TrimSpace(typed) != ""
 	case bool:
-		return true
+		return executionSubmissionBooleanValuePresent(path, typed)
 	case int:
 		return executionSubmissionNumericValuePresent(path, float64(typed))
 	case int64:
@@ -672,6 +672,18 @@ func executionSubmissionValuePresent(path string, value any) bool {
 		return len(typed) > 0
 	case map[string]any:
 		return len(typed) > 0
+	default:
+		return true
+	}
+}
+
+func executionSubmissionBooleanValuePresent(path string, value bool) bool {
+	if value {
+		return true
+	}
+	switch path {
+	case "postOnly", "reduceOnly", "closePosition", "slProtectionActive":
+		return false
 	default:
 		return true
 	}
@@ -692,6 +704,9 @@ func executionSubmissionNumericValuePresent(path string, value float64) bool {
 		"normalization.normalizedPrice":
 		return false
 	default:
+		if strings.HasPrefix(path, "symbolRules.") {
+			return false
+		}
 		return true
 	}
 }

--- a/internal/service/live_recovery.go
+++ b/internal/service/live_recovery.go
@@ -126,11 +126,7 @@ func (p *Platform) refreshLiveSessionPositionContext(session domain.LiveSession,
 		return p.store.UpdateLiveSessionState(refreshed.ID, state)
 	}
 	marketPrice := firstPositive(parseFloatValue(positionSnapshot["markPrice"]), parseFloatValue(mapValue(signalBarState["current"])["close"]))
-	var watermarks livePositionWatermarks
-	if hasActiveLivePositionSnapshot(positionSnapshot) {
-		watermarks = refreshLivePositionWatermarks(state, positionSnapshot, marketPrice)
-	}
-	livePositionState := deriveLivePositionState(parameters, positionSnapshot, signalBarState, marketPrice, watermarks)
+	livePositionState := evaluateLivePositionState(parameters, positionSnapshot, signalBarState, marketPrice, state)
 	if len(livePositionState) == 0 {
 		return p.store.UpdateLiveSessionState(refreshed.ID, state)
 	}

--- a/internal/service/live_recovery.go
+++ b/internal/service/live_recovery.go
@@ -126,7 +126,10 @@ func (p *Platform) refreshLiveSessionPositionContext(session domain.LiveSession,
 		return p.store.UpdateLiveSessionState(refreshed.ID, state)
 	}
 	marketPrice := firstPositive(parseFloatValue(positionSnapshot["markPrice"]), parseFloatValue(mapValue(signalBarState["current"])["close"]))
-	watermarks := refreshLivePositionWatermarks(state, positionSnapshot, marketPrice)
+	var watermarks livePositionWatermarks
+	if hasActiveLivePositionSnapshot(positionSnapshot) {
+		watermarks = refreshLivePositionWatermarks(state, positionSnapshot, marketPrice)
+	}
 	livePositionState := deriveLivePositionState(parameters, positionSnapshot, signalBarState, marketPrice, watermarks)
 	if len(livePositionState) == 0 {
 		return p.store.UpdateLiveSessionState(refreshed.ID, state)

--- a/internal/service/live_recovery.go
+++ b/internal/service/live_recovery.go
@@ -126,7 +126,8 @@ func (p *Platform) refreshLiveSessionPositionContext(session domain.LiveSession,
 		return p.store.UpdateLiveSessionState(refreshed.ID, state)
 	}
 	marketPrice := firstPositive(parseFloatValue(positionSnapshot["markPrice"]), parseFloatValue(mapValue(signalBarState["current"])["close"]))
-	livePositionState := evaluateLivePositionState(parameters, positionSnapshot, signalBarState, marketPrice, state)
+	watermarks := refreshLivePositionWatermarks(state, positionSnapshot, marketPrice)
+	livePositionState := deriveLivePositionState(parameters, positionSnapshot, signalBarState, marketPrice, watermarks)
 	if len(livePositionState) == 0 {
 		return p.store.UpdateLiveSessionState(refreshed.ID, state)
 	}

--- a/internal/service/live_registry.go
+++ b/internal/service/live_registry.go
@@ -419,8 +419,11 @@ func (a binanceFuturesLiveAdapter) submitRESTOrder(account domain.Account, order
 			"origType":           stringValue(payload["origType"]),
 			"timeInForce":        stringValue(payload["timeInForce"]),
 			"updateTime":         acceptedAt,
+			"rawQuantity":        order.Quantity,
+			"rawPriceReference":  firstPositive(order.Price, parseFloatValue(order.Metadata["priceHint"])),
 			"normalizedQuantity": normalizedOrder.Quantity,
 			"normalizedPrice":    normalizedOrder.Price,
+			"normalization":      cloneMetadata(mapValue(normalizedOrder.Metadata["normalization"])),
 			"symbolRules": map[string]any{
 				"tickSize":    rules.TickSize,
 				"stepSize":    rules.StepSize,
@@ -720,26 +723,55 @@ func (a binanceFuturesLiveAdapter) normalizeRESTOrder(order domain.Order, creds 
 		return domain.Order{}, binanceSymbolRules{}, err
 	}
 	orderType := strings.ToUpper(strings.TrimSpace(firstNonEmpty(order.Type, "MARKET")))
-	normalized.Quantity = normalizeBinanceQuantity(order.Quantity, rules)
+	rawQuantity := order.Quantity
+	rawPriceReference := firstPositive(order.Price, parseFloatValue(order.Metadata["priceHint"]))
+	quantityAdjustments := make([]string, 0)
+	baseQuantity := normalizeBinanceQuantity(rawQuantity, rules)
+	if rules.StepSize > 0 && baseQuantity != rawQuantity {
+		quantityAdjustments = append(quantityAdjustments, "step_size")
+	}
+	if rules.MinQty > 0 && rawQuantity > 0 && rawQuantity < rules.MinQty {
+		quantityAdjustments = append(quantityAdjustments, "min_qty")
+	}
+	normalized.Quantity = baseQuantity
 	if normalized.Quantity <= 0 {
 		return domain.Order{}, binanceSymbolRules{}, fmt.Errorf("normalized order quantity is invalid for %s", rules.Symbol)
 	}
 	if rules.MaxQty > 0 && normalized.Quantity > rules.MaxQty {
 		return domain.Order{}, binanceSymbolRules{}, fmt.Errorf("normalized order quantity %.12f exceeds maxQty %.12f for %s", normalized.Quantity, rules.MaxQty, rules.Symbol)
 	}
-	priceReference := firstPositive(order.Price, parseFloatValue(order.Metadata["priceHint"]))
+	priceReference := rawPriceReference
+	priceAdjustments := make([]string, 0)
 	if orderType != "MARKET" {
 		normalized.Price = normalizeBinancePrice(priceReference, rules)
 		if normalized.Price <= 0 {
 			return domain.Order{}, binanceSymbolRules{}, fmt.Errorf("normalized order price is invalid for %s", rules.Symbol)
 		}
+		if rules.TickSize > 0 && normalized.Price != priceReference {
+			priceAdjustments = append(priceAdjustments, "tick_size")
+		}
 	}
 	if adjustedQty := normalizeBinanceQuantityForMinNotional(normalized.Quantity, firstPositive(normalized.Price, priceReference), rules); adjustedQty > normalized.Quantity {
 		normalized.Quantity = adjustedQty
+		quantityAdjustments = append(quantityAdjustments, "min_notional")
 	}
 	normalized.Metadata["normalizedQuantity"] = normalized.Quantity
 	if normalized.Price > 0 {
 		normalized.Metadata["normalizedPrice"] = normalized.Price
+	}
+	normalized.Metadata["normalization"] = map[string]any{
+		"rawQuantity":              rawQuantity,
+		"rawPriceReference":        rawPriceReference,
+		"normalizedQuantity":       normalized.Quantity,
+		"normalizedPrice":          normalized.Price,
+		"quantityAdjustments":      quantityAdjustments,
+		"priceAdjustments":         priceAdjustments,
+		"normalizationApplied":     rawQuantity != normalized.Quantity || (orderType != "MARKET" && rawPriceReference != normalized.Price),
+		"minNotionalAdjusted":      containsString(quantityAdjustments, "min_notional"),
+		"stepSizeAdjusted":         containsString(quantityAdjustments, "step_size"),
+		"minQtyAdjusted":           containsString(quantityAdjustments, "min_qty"),
+		"tickSizeAdjusted":         containsString(priceAdjustments, "tick_size"),
+		"normalizationReasonCount": len(quantityAdjustments) + len(priceAdjustments),
 	}
 	normalized.Metadata["symbolRules"] = map[string]any{
 		"tickSize":    rules.TickSize,
@@ -749,6 +781,15 @@ func (a binanceFuturesLiveAdapter) normalizeRESTOrder(order domain.Order, creds 
 		"minNotional": rules.MinNotional,
 	}
 	return normalized, rules, nil
+}
+
+func containsString(items []string, target string) bool {
+	for _, item := range items {
+		if strings.EqualFold(strings.TrimSpace(item), strings.TrimSpace(target)) {
+			return true
+		}
+	}
+	return false
 }
 
 func fetchBinanceSymbolRules(creds binanceRESTCredentials, symbol string) (binanceSymbolRules, error) {

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -693,11 +693,11 @@ func TestBookAwareExecutionStrategySetsExpiryForSLProtectionWhenConfigured(t *te
 
 func TestResolveAggressiveSLProtectionDecisionUsesTopBookWhenDepthCoversOrder(t *testing.T) {
 	decision := resolveAggressiveSLProtectionDecision("SELL", 0.5, 68000, 68150, 1.2, 0, 68000, 20)
-	if got := decision.Price; got != 68000 {
-		t.Fatalf("expected top-book bid price, got %v", got)
+	if got := decision.Price; got != 68013.85 {
+		t.Fatalf("expected capped protection price 68013.85, got %v", got)
 	}
-	if got := decision.DepthMode; got != "top-book-cover" {
-		t.Fatalf("expected top-book-cover mode, got %s", got)
+	if got := decision.DepthMode; got != "top-book-outside-cap" {
+		t.Fatalf("expected top-book-outside-cap mode, got %s", got)
 	}
 	if got := decision.TopDepthNotional; got != 81600 {
 		t.Fatalf("expected top depth notional 81600, got %v", got)
@@ -715,8 +715,8 @@ func TestResolveAggressiveSLProtectionDecisionUsesCoverageWeightedCap(t *testing
 	if got := decision.ExpectedCoverage; got != 0.5 {
 		t.Fatalf("expected 50%% coverage, got %v", got)
 	}
-	if got := decision.Price; got != 68006.925 {
-		t.Fatalf("expected weighted protection price 68006.925, got %v", got)
+	if got := decision.Price; got != 68013.85 {
+		t.Fatalf("expected capped protection price 68013.85, got %v", got)
 	}
 	if got := decision.QuoteGapBps; got <= 0 {
 		t.Fatalf("expected positive quote gap bps, got %v", got)
@@ -731,11 +731,21 @@ func TestResolveAggressiveSLProtectionDecisionUsesCoverageWeightedCapForBuy(t *t
 	if got := decision.ExpectedCoverage; got != 0.5 {
 		t.Fatalf("expected 50%% coverage, got %v", got)
 	}
-	if got := decision.Price; got != 68143.075 {
-		t.Fatalf("expected weighted protection price 68143.075, got %v", got)
+	if got := decision.Price; got != 68136.15 {
+		t.Fatalf("expected capped protection price 68136.15, got %v", got)
 	}
 	if got := decision.QuoteGapBps; got <= 0 {
 		t.Fatalf("expected positive quote gap bps, got %v", got)
+	}
+}
+
+func TestResolveAggressiveSLProtectionDecisionUsesCappedPriceWhenTopBookOutsideCap(t *testing.T) {
+	decision := resolveAggressiveSLProtectionDecision("SELL", 0.5, 68000, 68150, 1.2, 0, 68000, 20)
+	if got := decision.DepthMode; got != "top-book-outside-cap" {
+		t.Fatalf("expected top-book-outside-cap mode, got %s", got)
+	}
+	if got := decision.Price; got != 68013.85 {
+		t.Fatalf("expected top-book cover to stay capped at 68013.85, got %v", got)
 	}
 }
 
@@ -1571,6 +1581,51 @@ func TestExecutionTimeoutTimelineMetadataUsesOriginalSubmissionNormalization(t *
 	metadata := executionTimeoutTimelineMetadata(order, withExecutionSubmissionFallback(cancelledOrder, order))
 	if got := parseFloatValue(metadata["normalizedPrice"]); got != 68643.6 {
 		t.Fatalf("expected timeout metadata to preserve normalized price, got %v", got)
+	}
+}
+
+func TestWithExecutionSubmissionFallbackMergesPartialSubmissionFields(t *testing.T) {
+	order := domain.Order{
+		Metadata: map[string]any{
+			"adapterSubmission": map[string]any{
+				"normalizedPrice": 68643.6,
+				"normalization": map[string]any{
+					"normalizedPrice": 68643.6,
+				},
+			},
+		},
+	}
+	fallback := domain.Order{
+		Metadata: map[string]any{
+			"adapterSubmission": map[string]any{
+				"rawQuantity":        0.0019,
+				"normalizedQuantity": 0.002,
+				"rawPriceReference":  68643.67,
+				"normalization": map[string]any{
+					"normalizedPrice":    68643.6,
+					"normalizedQuantity": 0.002,
+					"rawPriceReference":  68643.67,
+					"rawQuantity":        0.0019,
+				},
+				"symbolRules": map[string]any{
+					"stepSize": 0.001,
+				},
+			},
+		},
+	}
+	merged := withExecutionSubmissionFallback(order, fallback)
+	submission := mapValue(merged.Metadata["adapterSubmission"])
+	if got := parseFloatValue(submission["normalizedPrice"]); got != 68643.6 {
+		t.Fatalf("expected existing normalized price to survive merge, got %v", got)
+	}
+	if got := parseFloatValue(submission["normalizedQuantity"]); got != 0.002 {
+		t.Fatalf("expected normalized quantity fallback, got %v", got)
+	}
+	if got := parseFloatValue(mapValue(submission["normalization"])["rawQuantity"]); got != 0.0019 {
+		t.Fatalf("expected nested raw quantity fallback, got %v", got)
+	}
+	if got := parseFloatValue(mapValue(submission["symbolRules"])["stepSize"]); got != 0.001 {
+		t.Fatalf("expected symbol rules fallback, got %v", got)
 	}
 }
 

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -695,7 +695,7 @@ func TestBookAwareExecutionStrategySetsExpiryForSLProtectionWhenConfigured(t *te
 	}
 }
 
-func TestResolveAggressiveSLProtectionDecisionUsesTopBookWhenDepthCoversOrder(t *testing.T) {
+func TestResolveAggressiveSLProtectionDecisionUsesCappedPriceWhenTopBookOutsideCap(t *testing.T) {
 	decision := resolveAggressiveSLProtectionDecision("SELL", 0.5, 68000, 68150, 1.2, 0, 68000, 20)
 	if got := decision.Price; got != 68013.85 {
 		t.Fatalf("expected capped protection price 68013.85, got %v", got)
@@ -711,7 +711,7 @@ func TestResolveAggressiveSLProtectionDecisionUsesTopBookWhenDepthCoversOrder(t 
 	}
 }
 
-func TestResolveAggressiveSLProtectionDecisionUsesCoverageWeightedCap(t *testing.T) {
+func TestResolveAggressiveSLProtectionDecisionRecordsPartialCoverageWhenTopBookOutsideCap(t *testing.T) {
 	decision := resolveAggressiveSLProtectionDecision("SELL", 2.0, 68000, 68150, 1.0, 0, 68000, 20)
 	if got := decision.DepthMode; got != "top-book-outside-cap" {
 		t.Fatalf("expected top-book-outside-cap mode, got %s", got)
@@ -727,7 +727,7 @@ func TestResolveAggressiveSLProtectionDecisionUsesCoverageWeightedCap(t *testing
 	}
 }
 
-func TestResolveAggressiveSLProtectionDecisionUsesCoverageWeightedCapForBuy(t *testing.T) {
+func TestResolveAggressiveSLProtectionDecisionRecordsPartialCoverageWhenTopBookOutsideCapForBuy(t *testing.T) {
 	decision := resolveAggressiveSLProtectionDecision("BUY", 2.0, 68000, 68150, 0, 1.0, 68150, 20)
 	if got := decision.DepthMode; got != "top-book-outside-cap" {
 		t.Fatalf("expected top-book-outside-cap mode, got %s", got)
@@ -743,23 +743,26 @@ func TestResolveAggressiveSLProtectionDecisionUsesCoverageWeightedCapForBuy(t *t
 	}
 }
 
-func TestResolveAggressiveSLProtectionDecisionUsesCappedPriceWhenTopBookOutsideCap(t *testing.T) {
-	decision := resolveAggressiveSLProtectionDecision("SELL", 0.5, 68000, 68150, 1.2, 0, 68000, 20)
-	if got := decision.DepthMode; got != "top-book-outside-cap" {
-		t.Fatalf("expected top-book-outside-cap mode, got %s", got)
-	}
-	if got := decision.Price; got != 68013.85 {
-		t.Fatalf("expected top-book cover to stay capped at 68013.85, got %v", got)
-	}
-}
-
 func TestResolveAggressiveSLProtectionDecisionUsesTopBookWhenWithinCap(t *testing.T) {
 	decision := resolveAggressiveSLProtectionDecision("SELL", 0.5, 68000, 68010, 1.2, 0, 68000, 20)
-	if got := decision.DepthMode; got != "top-book-cover" {
-		t.Fatalf("expected top-book-cover mode, got %s", got)
+	if got := decision.DepthMode; got != "top-book-cover-within-cap" {
+		t.Fatalf("expected top-book-cover-within-cap mode, got %s", got)
 	}
 	if got := decision.Price; got != 68000 {
 		t.Fatalf("expected top-book bid price 68000, got %v", got)
+	}
+}
+
+func TestResolveAggressiveSLProtectionDecisionRecordsPartialCoverageWhenWithinCap(t *testing.T) {
+	decision := resolveAggressiveSLProtectionDecision("SELL", 2.0, 68000, 68010, 1.0, 0, 68000, 20)
+	if got := decision.DepthMode; got != "top-book-partial-within-cap" {
+		t.Fatalf("expected top-book-partial-within-cap mode, got %s", got)
+	}
+	if got := decision.Price; got != 68000 {
+		t.Fatalf("expected capped price to remain at 68000, got %v", got)
+	}
+	if got := decision.ExpectedCoverage; got != 0.5 {
+		t.Fatalf("expected 50%% coverage, got %v", got)
 	}
 }
 
@@ -1649,7 +1652,7 @@ func TestWithExecutionSubmissionFallbackMergesPartialSubmissionFields(t *testing
 	}
 }
 
-func TestWithExecutionSubmissionFallbackPreservesExplicitScalarOverrides(t *testing.T) {
+func TestWithExecutionSubmissionFallbackRestoresZeroNormalizationFields(t *testing.T) {
 	order := domain.Order{
 		Metadata: map[string]any{
 			"adapterSubmission": map[string]any{
@@ -1670,11 +1673,11 @@ func TestWithExecutionSubmissionFallbackPreservesExplicitScalarOverrides(t *test
 	}
 	merged := withExecutionSubmissionFallback(order, fallback)
 	submission := mapValue(merged.Metadata["adapterSubmission"])
-	if got := parseFloatValue(submission["normalizedPrice"]); got != 0 {
-		t.Fatalf("expected explicit zero normalized price to be preserved, got %v", got)
+	if got := parseFloatValue(submission["normalizedPrice"]); got != 68643.6 {
+		t.Fatalf("expected zero normalized price to fall back, got %v", got)
 	}
-	if got := parseFloatValue(submission["rawQuantity"]); got != 0 {
-		t.Fatalf("expected explicit zero raw quantity to be preserved, got %v", got)
+	if got := parseFloatValue(submission["rawQuantity"]); got != 0.0019 {
+		t.Fatalf("expected zero raw quantity to fall back, got %v", got)
 	}
 	if got := boolValue(submission["reduceOnly"]); got {
 		t.Fatal("expected explicit false reduceOnly to be preserved")

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -686,6 +686,41 @@ func TestBookAwareExecutionStrategySetsExpiryForSLProtectionWhenConfigured(t *te
 	if !boolValue(mapValue(proposal.Metadata["executionDecisionContext"])["slProtectionBranch"]) {
 		t.Fatal("expected explicit SL protection branch marker")
 	}
+	if got := stringValue(mapValue(proposal.Metadata["executionDecisionContext"])["slProtectionDepthMode"]); got != "spread-capped-fallback" {
+		t.Fatalf("expected fallback SL depth mode without qty data, got %s", got)
+	}
+}
+
+func TestResolveAggressiveSLProtectionDecisionUsesTopBookWhenDepthCoversOrder(t *testing.T) {
+	decision := resolveAggressiveSLProtectionDecision("SELL", 0.5, 68000, 68150, 1.2, 0, 68000, 20)
+	if got := decision.Price; got != 68000 {
+		t.Fatalf("expected top-book bid price, got %v", got)
+	}
+	if got := decision.DepthMode; got != "top-book-cover" {
+		t.Fatalf("expected top-book-cover mode, got %s", got)
+	}
+	if got := decision.TopDepthNotional; got != 81600 {
+		t.Fatalf("expected top depth notional 81600, got %v", got)
+	}
+	if got := decision.ExpectedCoverage; got != 1 {
+		t.Fatalf("expected full coverage, got %v", got)
+	}
+}
+
+func TestResolveAggressiveSLProtectionDecisionUsesCoverageWeightedCap(t *testing.T) {
+	decision := resolveAggressiveSLProtectionDecision("SELL", 2.0, 68000, 68150, 1.0, 0, 68000, 20)
+	if got := decision.DepthMode; got != "coverage-weighted-cap" {
+		t.Fatalf("expected coverage-weighted-cap mode, got %s", got)
+	}
+	if got := decision.ExpectedCoverage; got != 0.5 {
+		t.Fatalf("expected 50%% coverage, got %v", got)
+	}
+	if got := decision.Price; got != 68006.925 {
+		t.Fatalf("expected weighted protection price 68006.925, got %v", got)
+	}
+	if got := decision.QuoteGapBps; got <= 0 {
+		t.Fatalf("expected positive quote gap bps, got %v", got)
+	}
 }
 
 func TestBookAwareExecutionStrategyUsesFallbackOrderAfterTimeoutMatch(t *testing.T) {

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -1708,8 +1708,8 @@ func TestWithExecutionSubmissionFallbackRestoresZeroNormalizationFields(t *testi
 	if got := parseFloatValue(submission["rawQuantity"]); got != 0.0019 {
 		t.Fatalf("expected zero raw quantity to fall back, got %v", got)
 	}
-	if got := boolValue(submission["reduceOnly"]); got {
-		t.Fatal("expected explicit false reduceOnly to be preserved")
+	if got := boolValue(submission["reduceOnly"]); !got {
+		t.Fatal("expected zero-value reduceOnly to fall back to original true")
 	}
 }
 

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -1689,14 +1689,14 @@ func TestWithExecutionSubmissionFallbackRestoresZeroNormalizationFields(t *testi
 	}
 	merged := withExecutionSubmissionFallback(order, fallback)
 	submission := mapValue(merged.Metadata["adapterSubmission"])
-	if got := parseFloatValue(submission["normalizedPrice"]); got != 68643.6 {
-		t.Fatalf("expected zero normalized price to fall back, got %v", got)
+	if got := parseFloatValue(submission["normalizedPrice"]); got != 0 {
+		t.Fatalf("expected explicit zero normalized price to be preserved, got %v", got)
 	}
-	if got := parseFloatValue(submission["rawQuantity"]); got != 0.0019 {
-		t.Fatalf("expected zero raw quantity to fall back, got %v", got)
+	if got := parseFloatValue(submission["rawQuantity"]); got != 0 {
+		t.Fatalf("expected explicit zero raw quantity to be preserved, got %v", got)
 	}
-	if got := boolValue(submission["reduceOnly"]); !got {
-		t.Fatal("expected zero-value reduceOnly to fall back to original true")
+	if got := boolValue(submission["reduceOnly"]); got {
+		t.Fatal("expected explicit false reduceOnly to be preserved")
 	}
 }
 

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -1355,6 +1355,112 @@ func TestNormalizeBinanceQuantityForMinNotional(t *testing.T) {
 	}
 }
 
+func TestNormalizeRESTOrderRecordsNormalizationTelemetry(t *testing.T) {
+	adapter := binanceFuturesLiveAdapter{}
+	creds := binanceRESTCredentials{BaseURL: "https://example.test"}
+	cacheKey := creds.BaseURL + "|BTCUSDT"
+	binanceSymbolRulesCacheMu.Lock()
+	binanceSymbolRulesCache[cacheKey] = binanceSymbolRules{
+		Symbol:      "BTCUSDT",
+		TickSize:    0.1,
+		StepSize:    0.001,
+		MinQty:      0.001,
+		MaxQty:      1000,
+		MinNotional: 100,
+		UpdatedAt:   time.Now().UTC(),
+	}
+	binanceSymbolRulesCacheMu.Unlock()
+
+	normalized, _, err := adapter.normalizeRESTOrder(domain.Order{
+		Symbol:   "BTCUSDT",
+		Type:     "LIMIT",
+		Quantity: 0.0019,
+		Price:    68643.67,
+	}, creds)
+	if err != nil {
+		t.Fatalf("normalize REST order failed: %v", err)
+	}
+	norm := mapValue(normalized.Metadata["normalization"])
+	if got := parseFloatValue(norm["rawQuantity"]); got != 0.0019 {
+		t.Fatalf("expected raw quantity 0.0019, got %v", got)
+	}
+	if got := parseFloatValue(norm["normalizedQuantity"]); got != 0.002 {
+		t.Fatalf("expected normalized quantity 0.002, got %v", got)
+	}
+	if got := parseFloatValue(norm["normalizedPrice"]); got != 68643.6 {
+		t.Fatalf("expected normalized price 68643.6, got %v", got)
+	}
+	quantityAdjustmentCount := normalizationItemCount(norm["quantityAdjustments"])
+	if quantityAdjustmentCount != 2 {
+		t.Fatalf("expected 2 quantity adjustments, got %v", norm["quantityAdjustments"])
+	}
+	if !boolValue(norm["stepSizeAdjusted"]) || !boolValue(norm["minNotionalAdjusted"]) {
+		t.Fatalf("expected step size and min notional adjustments, got %+v", norm)
+	}
+	if !boolValue(norm["tickSizeAdjusted"]) {
+		t.Fatalf("expected tick size adjustment, got %+v", norm)
+	}
+}
+
+func TestExecutionDispatchSummaryIncludesNormalizationTelemetry(t *testing.T) {
+	summary := executionDispatchSummary(map[string]any{
+		"type":       "LIMIT",
+		"quantity":   0.0019,
+		"limitPrice": 68643.6,
+		"priceHint":  68643.67,
+		"metadata": map[string]any{
+			"executionDecision": "direct-dispatch",
+		},
+	}, domain.Order{
+		Status:   "NEW",
+		Symbol:   "BTCUSDT",
+		Side:     "BUY",
+		Type:     "LIMIT",
+		Quantity: 0.002,
+		Price:    68643.6,
+		Metadata: map[string]any{
+			"adapterSubmission": map[string]any{
+				"rawQuantity":        0.0019,
+				"rawPriceReference":  68643.67,
+				"normalizedQuantity": 0.002,
+				"normalizedPrice":    68643.6,
+				"normalization": map[string]any{
+					"quantityAdjustments": []any{"step_size", "min_notional"},
+					"priceAdjustments":    []any{"tick_size"},
+				},
+				"symbolRules": map[string]any{
+					"stepSize":    0.001,
+					"tickSize":    0.1,
+					"minNotional": 100.0,
+				},
+			},
+		},
+	}, false)
+	if got := parseFloatValue(summary["rawQuantity"]); got != 0.0019 {
+		t.Fatalf("expected raw quantity in dispatch summary, got %v", got)
+	}
+	if got := parseFloatValue(summary["normalizedQuantity"]); got != 0.002 {
+		t.Fatalf("expected normalized quantity in dispatch summary, got %v", got)
+	}
+	if got := parseFloatValue(summary["normalizedPrice"]); got != 68643.6 {
+		t.Fatalf("expected normalized price in dispatch summary, got %v", got)
+	}
+	if normalizationItemCount(mapValue(summary["normalization"])["quantityAdjustments"]) != 2 {
+		t.Fatalf("expected quantity adjustment details in dispatch summary, got %+v", summary["normalization"])
+	}
+}
+
+func normalizationItemCount(raw any) int {
+	switch value := raw.(type) {
+	case []string:
+		return len(value)
+	case []any:
+		return len(value)
+	default:
+		return 0
+	}
+}
+
 func TestShouldMarkLiveExecutionFallback(t *testing.T) {
 	order := domain.Order{
 		Status: "REJECTED",

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -723,6 +723,22 @@ func TestResolveAggressiveSLProtectionDecisionUsesCoverageWeightedCap(t *testing
 	}
 }
 
+func TestResolveAggressiveSLProtectionDecisionUsesCoverageWeightedCapForBuy(t *testing.T) {
+	decision := resolveAggressiveSLProtectionDecision("BUY", 2.0, 68000, 68150, 0, 1.0, 68150, 20)
+	if got := decision.DepthMode; got != "coverage-weighted-cap" {
+		t.Fatalf("expected coverage-weighted-cap mode, got %s", got)
+	}
+	if got := decision.ExpectedCoverage; got != 0.5 {
+		t.Fatalf("expected 50%% coverage, got %v", got)
+	}
+	if got := decision.Price; got != 68143.075 {
+		t.Fatalf("expected weighted protection price 68143.075, got %v", got)
+	}
+	if got := decision.QuoteGapBps; got <= 0 {
+		t.Fatalf("expected positive quote gap bps, got %v", got)
+	}
+}
+
 func TestBookAwareExecutionStrategyUsesFallbackOrderAfterTimeoutMatch(t *testing.T) {
 	strategy := bookAwareExecutionStrategy{}
 	intent := SignalIntent{

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -1395,6 +1395,18 @@ func TestNormalizeRESTOrderRecordsNormalizationTelemetry(t *testing.T) {
 	creds := binanceRESTCredentials{BaseURL: "https://example.test"}
 	cacheKey := creds.BaseURL + "|BTCUSDT"
 	binanceSymbolRulesCacheMu.Lock()
+	previous, existed := binanceSymbolRulesCache[cacheKey]
+	binanceSymbolRulesCacheMu.Unlock()
+	t.Cleanup(func() {
+		binanceSymbolRulesCacheMu.Lock()
+		defer binanceSymbolRulesCacheMu.Unlock()
+		if existed {
+			binanceSymbolRulesCache[cacheKey] = previous
+		} else {
+			delete(binanceSymbolRulesCache, cacheKey)
+		}
+	})
+	binanceSymbolRulesCacheMu.Lock()
 	binanceSymbolRulesCache[cacheKey] = binanceSymbolRules{
 		Symbol:      "BTCUSDT",
 		TickSize:    0.1,
@@ -1482,6 +1494,67 @@ func TestExecutionDispatchSummaryIncludesNormalizationTelemetry(t *testing.T) {
 	}
 	if normalizationItemCount(mapValue(summary["normalization"])["quantityAdjustments"]) != 2 {
 		t.Fatalf("expected quantity adjustment details in dispatch summary, got %+v", summary["normalization"])
+	}
+}
+
+func TestExecutionDispatchSummaryFallsBackToNestedNormalizedPrice(t *testing.T) {
+	summary := executionDispatchSummary(map[string]any{
+		"type":       "LIMIT",
+		"quantity":   0.0019,
+		"limitPrice": 68643.6,
+		"priceHint":  68643.67,
+	}, domain.Order{
+		Status:   "NEW",
+		Symbol:   "BTCUSDT",
+		Side:     "BUY",
+		Type:     "LIMIT",
+		Quantity: 0.002,
+		Price:    68643.6,
+		Metadata: map[string]any{
+			"adapterSubmission": map[string]any{
+				"normalization": map[string]any{
+					"normalizedPrice":    68643.6,
+					"normalizedQuantity": 0.002,
+					"rawPriceReference":  68643.67,
+					"rawQuantity":        0.0019,
+				},
+			},
+		},
+	}, false)
+	if got := parseFloatValue(summary["normalizedPrice"]); got != 68643.6 {
+		t.Fatalf("expected normalized price fallback from normalization payload, got %v", got)
+	}
+}
+
+func TestExecutionTimeoutTimelineMetadataUsesOriginalSubmissionNormalization(t *testing.T) {
+	order := domain.Order{
+		ID: "order-1",
+		Metadata: map[string]any{
+			"executionExpiresAt": "2026-04-10T01:00:00Z",
+			"executionProposal": map[string]any{
+				"type":       "LIMIT",
+				"quantity":   0.0019,
+				"limitPrice": 68643.6,
+				"priceHint":  68643.67,
+			},
+			"adapterSubmission": map[string]any{
+				"normalizedPrice": 68643.6,
+				"normalization": map[string]any{
+					"normalizedPrice":    68643.6,
+					"normalizedQuantity": 0.002,
+					"rawPriceReference":  68643.67,
+					"rawQuantity":        0.0019,
+				},
+			},
+		},
+	}
+	cancelledOrder := domain.Order{
+		ID:     "order-1",
+		Status: "CANCELLED",
+	}
+	metadata := executionTimeoutTimelineMetadata(order, withExecutionSubmissionFallback(cancelledOrder, order))
+	if got := parseFloatValue(metadata["normalizedPrice"]); got != 68643.6 {
+		t.Fatalf("expected timeout metadata to preserve normalized price, got %v", got)
 	}
 }
 

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -709,8 +709,8 @@ func TestResolveAggressiveSLProtectionDecisionUsesTopBookWhenDepthCoversOrder(t 
 
 func TestResolveAggressiveSLProtectionDecisionUsesCoverageWeightedCap(t *testing.T) {
 	decision := resolveAggressiveSLProtectionDecision("SELL", 2.0, 68000, 68150, 1.0, 0, 68000, 20)
-	if got := decision.DepthMode; got != "coverage-weighted-cap" {
-		t.Fatalf("expected coverage-weighted-cap mode, got %s", got)
+	if got := decision.DepthMode; got != "top-book-outside-cap" {
+		t.Fatalf("expected top-book-outside-cap mode, got %s", got)
 	}
 	if got := decision.ExpectedCoverage; got != 0.5 {
 		t.Fatalf("expected 50%% coverage, got %v", got)
@@ -725,8 +725,8 @@ func TestResolveAggressiveSLProtectionDecisionUsesCoverageWeightedCap(t *testing
 
 func TestResolveAggressiveSLProtectionDecisionUsesCoverageWeightedCapForBuy(t *testing.T) {
 	decision := resolveAggressiveSLProtectionDecision("BUY", 2.0, 68000, 68150, 0, 1.0, 68150, 20)
-	if got := decision.DepthMode; got != "coverage-weighted-cap" {
-		t.Fatalf("expected coverage-weighted-cap mode, got %s", got)
+	if got := decision.DepthMode; got != "top-book-outside-cap" {
+		t.Fatalf("expected top-book-outside-cap mode, got %s", got)
 	}
 	if got := decision.ExpectedCoverage; got != 0.5 {
 		t.Fatalf("expected 50%% coverage, got %v", got)
@@ -746,6 +746,16 @@ func TestResolveAggressiveSLProtectionDecisionUsesCappedPriceWhenTopBookOutsideC
 	}
 	if got := decision.Price; got != 68013.85 {
 		t.Fatalf("expected top-book cover to stay capped at 68013.85, got %v", got)
+	}
+}
+
+func TestResolveAggressiveSLProtectionDecisionUsesTopBookWhenWithinCap(t *testing.T) {
+	decision := resolveAggressiveSLProtectionDecision("SELL", 0.5, 68000, 68010, 1.2, 0, 68000, 20)
+	if got := decision.DepthMode; got != "top-book-cover" {
+		t.Fatalf("expected top-book-cover mode, got %s", got)
+	}
+	if got := decision.Price; got != 68000 {
+		t.Fatalf("expected top-book bid price 68000, got %v", got)
 	}
 }
 
@@ -1626,6 +1636,37 @@ func TestWithExecutionSubmissionFallbackMergesPartialSubmissionFields(t *testing
 	}
 	if got := parseFloatValue(mapValue(submission["symbolRules"])["stepSize"]); got != 0.001 {
 		t.Fatalf("expected symbol rules fallback, got %v", got)
+	}
+}
+
+func TestWithExecutionSubmissionFallbackIgnoresEmptyScalarOverrides(t *testing.T) {
+	order := domain.Order{
+		Metadata: map[string]any{
+			"adapterSubmission": map[string]any{
+				"normalizedPrice": 0.0,
+				"rawQuantity":     0.0,
+				"symbolRules":     map[string]any{},
+			},
+		},
+	}
+	fallback := domain.Order{
+		Metadata: map[string]any{
+			"adapterSubmission": map[string]any{
+				"normalizedPrice": 68643.6,
+				"rawQuantity":     0.0019,
+				"symbolRules": map[string]any{
+					"stepSize": 0.001,
+				},
+			},
+		},
+	}
+	merged := withExecutionSubmissionFallback(order, fallback)
+	submission := mapValue(merged.Metadata["adapterSubmission"])
+	if got := parseFloatValue(submission["normalizedPrice"]); got != 68643.6 {
+		t.Fatalf("expected fallback normalized price to survive empty override, got %v", got)
+	}
+	if got := parseFloatValue(submission["rawQuantity"]); got != 0.0019 {
+		t.Fatalf("expected fallback raw quantity to survive empty override, got %v", got)
 	}
 }
 

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -1702,14 +1702,14 @@ func TestWithExecutionSubmissionFallbackRestoresZeroNormalizationFields(t *testi
 	}
 	merged := withExecutionSubmissionFallback(order, fallback)
 	submission := mapValue(merged.Metadata["adapterSubmission"])
-	if got := parseFloatValue(submission["normalizedPrice"]); got != 68643.6 {
-		t.Fatalf("expected zero normalized price to fall back, got %v", got)
+	if got := parseFloatValue(submission["normalizedPrice"]); got != 0 {
+		t.Fatalf("expected explicit zero normalized price to be preserved, got %v", got)
 	}
 	if got := parseFloatValue(submission["rawQuantity"]); got != 0.0019 {
 		t.Fatalf("expected zero raw quantity to fall back, got %v", got)
 	}
-	if got := boolValue(submission["reduceOnly"]); !got {
-		t.Fatal("expected zero-value reduceOnly to fall back to original true")
+	if got := boolValue(submission["reduceOnly"]); got {
+		t.Fatal("expected explicit false reduceOnly to be preserved")
 	}
 }
 

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -1473,6 +1473,12 @@ func TestNormalizeRESTOrderRecordsNormalizationTelemetry(t *testing.T) {
 	if got := parseFloatValue(norm["normalizedPrice"]); got != 68643.6 {
 		t.Fatalf("expected normalized price 68643.6, got %v", got)
 	}
+	if got := normalized.Quantity; got != 0.002 {
+		t.Fatalf("expected normalized order quantity 0.002, got %v", got)
+	}
+	if got := normalized.Price; got != 68643.6 {
+		t.Fatalf("expected normalized order price 68643.6, got %v", got)
+	}
 	quantityAdjustmentCount := normalizationItemCount(norm["quantityAdjustments"])
 	if quantityAdjustmentCount != 2 {
 		t.Fatalf("expected 2 quantity adjustments, got %v", norm["quantityAdjustments"])
@@ -1639,13 +1645,13 @@ func TestWithExecutionSubmissionFallbackMergesPartialSubmissionFields(t *testing
 	}
 }
 
-func TestWithExecutionSubmissionFallbackIgnoresEmptyScalarOverrides(t *testing.T) {
+func TestWithExecutionSubmissionFallbackPreservesExplicitScalarOverrides(t *testing.T) {
 	order := domain.Order{
 		Metadata: map[string]any{
 			"adapterSubmission": map[string]any{
 				"normalizedPrice": 0.0,
 				"rawQuantity":     0.0,
-				"symbolRules":     map[string]any{},
+				"reduceOnly":      false,
 			},
 		},
 	}
@@ -1654,19 +1660,20 @@ func TestWithExecutionSubmissionFallbackIgnoresEmptyScalarOverrides(t *testing.T
 			"adapterSubmission": map[string]any{
 				"normalizedPrice": 68643.6,
 				"rawQuantity":     0.0019,
-				"symbolRules": map[string]any{
-					"stepSize": 0.001,
-				},
+				"reduceOnly":      true,
 			},
 		},
 	}
 	merged := withExecutionSubmissionFallback(order, fallback)
 	submission := mapValue(merged.Metadata["adapterSubmission"])
-	if got := parseFloatValue(submission["normalizedPrice"]); got != 68643.6 {
-		t.Fatalf("expected fallback normalized price to survive empty override, got %v", got)
+	if got := parseFloatValue(submission["normalizedPrice"]); got != 0 {
+		t.Fatalf("expected explicit zero normalized price to be preserved, got %v", got)
 	}
-	if got := parseFloatValue(submission["rawQuantity"]); got != 0.0019 {
-		t.Fatalf("expected fallback raw quantity to survive empty override, got %v", got)
+	if got := parseFloatValue(submission["rawQuantity"]); got != 0 {
+		t.Fatalf("expected explicit zero raw quantity to be preserved, got %v", got)
+	}
+	if got := boolValue(submission["reduceOnly"]); got {
+		t.Fatal("expected explicit false reduceOnly to be preserved")
 	}
 }
 

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -291,6 +291,7 @@ func TestResolveLiveSessionPositionSnapshotUsesVirtualPosition(t *testing.T) {
 		AccountID: "live-main",
 		State: map[string]any{
 			"virtualPosition": map[string]any{
+				"id":         "virtual|session-1|signal-1",
 				"symbol":     "BTCUSDT",
 				"side":       "LONG",
 				"quantity":   0.0,
@@ -311,6 +312,9 @@ func TestResolveLiveSessionPositionSnapshotUsesVirtualPosition(t *testing.T) {
 	}
 	if !boolValue(position["hasVirtualPosition"]) {
 		t.Fatal("expected returned position snapshot to expose virtual position explicitly")
+	}
+	if got := stringValue(position["id"]); got != "virtual|session-1|signal-1" {
+		t.Fatalf("expected virtual position id to be preserved, got %s", got)
 	}
 }
 
@@ -1837,6 +1841,9 @@ func TestEvaluateLiveSessionOnSignalRecordsVirtualInitialForZeroInitialStrategy(
 	}
 	if !boolValue(mapValue(updated.State["virtualPosition"])["virtual"]) {
 		t.Fatal("expected virtualPosition to be recorded in live session state")
+	}
+	if got := stringValue(mapValue(updated.State["virtualPosition"])["id"]); got == "" {
+		t.Fatal("expected virtualPosition to carry a stable id")
 	}
 	if got := maxIntValue(updated.State["planIndex"], -1); got != 1 {
 		t.Fatalf("expected planIndex to advance after virtual initial, got %d", got)

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -753,6 +753,19 @@ func TestResolveAggressiveSLProtectionDecisionUsesTopBookWhenWithinCapForBuy(t *
 	}
 }
 
+func TestResolveAggressiveSLProtectionDecisionRecordsPartialCoverageWhenWithinCapForBuy(t *testing.T) {
+	decision := resolveAggressiveSLProtectionDecision("BUY", 2.0, 68000, 68010, 0, 1.0, 68010, 20)
+	if got := decision.DepthMode; got != "top-book-partial-within-cap" {
+		t.Fatalf("expected top-book-partial-within-cap mode, got %s", got)
+	}
+	if got := decision.ExpectedCoverage; got != 0.5 {
+		t.Fatalf("expected 50%% coverage, got %v", got)
+	}
+	if got := decision.Price; got != 68010 {
+		t.Fatalf("expected within-cap BUY price to remain at ask 68010, got %v", got)
+	}
+}
+
 func TestResolveAggressiveSLProtectionDecisionUsesTopBookWhenWithinCap(t *testing.T) {
 	decision := resolveAggressiveSLProtectionDecision("SELL", 0.5, 68000, 68010, 1.2, 0, 68000, 20)
 	if got := decision.DepthMode; got != "top-book-cover-within-cap" {
@@ -1689,11 +1702,11 @@ func TestWithExecutionSubmissionFallbackRestoresZeroNormalizationFields(t *testi
 	}
 	merged := withExecutionSubmissionFallback(order, fallback)
 	submission := mapValue(merged.Metadata["adapterSubmission"])
-	if got := parseFloatValue(submission["normalizedPrice"]); got != 0 {
-		t.Fatalf("expected explicit zero normalized price to be preserved, got %v", got)
+	if got := parseFloatValue(submission["normalizedPrice"]); got != 68643.6 {
+		t.Fatalf("expected zero normalized price to fall back, got %v", got)
 	}
-	if got := parseFloatValue(submission["rawQuantity"]); got != 0 {
-		t.Fatalf("expected explicit zero raw quantity to be preserved, got %v", got)
+	if got := parseFloatValue(submission["rawQuantity"]); got != 0.0019 {
+		t.Fatalf("expected zero raw quantity to fall back, got %v", got)
 	}
 	if got := boolValue(submission["reduceOnly"]); got {
 		t.Fatal("expected explicit false reduceOnly to be preserved")

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -743,6 +743,16 @@ func TestResolveAggressiveSLProtectionDecisionRecordsPartialCoverageWhenTopBookO
 	}
 }
 
+func TestResolveAggressiveSLProtectionDecisionUsesTopBookWhenWithinCapForBuy(t *testing.T) {
+	decision := resolveAggressiveSLProtectionDecision("BUY", 0.5, 68000, 68010, 0, 1.2, 68010, 20)
+	if got := decision.DepthMode; got != "top-book-cover-within-cap" {
+		t.Fatalf("expected top-book-cover-within-cap mode, got %s", got)
+	}
+	if got := decision.Price; got != 68010 {
+		t.Fatalf("expected top-book ask price 68010, got %v", got)
+	}
+}
+
 func TestResolveAggressiveSLProtectionDecisionUsesTopBookWhenWithinCap(t *testing.T) {
 	decision := resolveAggressiveSLProtectionDecision("SELL", 0.5, 68000, 68010, 1.2, 0, 68000, 20)
 	if got := decision.DepthMode; got != "top-book-cover-within-cap" {
@@ -1541,8 +1551,14 @@ func TestExecutionDispatchSummaryIncludesNormalizationTelemetry(t *testing.T) {
 	if got := parseFloatValue(summary["normalizedPrice"]); got != 68643.6 {
 		t.Fatalf("expected normalized price in dispatch summary, got %v", got)
 	}
+	if got := parseFloatValue(summary["rawPriceReference"]); got != 68643.67 {
+		t.Fatalf("expected raw price reference in dispatch summary, got %v", got)
+	}
 	if normalizationItemCount(mapValue(summary["normalization"])["quantityAdjustments"]) != 2 {
 		t.Fatalf("expected quantity adjustment details in dispatch summary, got %+v", summary["normalization"])
+	}
+	if normalizationItemCount(mapValue(summary["normalization"])["priceAdjustments"]) != 1 {
+		t.Fatalf("expected price adjustment details in dispatch summary, got %+v", summary["normalization"])
 	}
 }
 
@@ -1679,8 +1695,35 @@ func TestWithExecutionSubmissionFallbackRestoresZeroNormalizationFields(t *testi
 	if got := parseFloatValue(submission["rawQuantity"]); got != 0.0019 {
 		t.Fatalf("expected zero raw quantity to fall back, got %v", got)
 	}
-	if got := boolValue(submission["reduceOnly"]); got {
-		t.Fatal("expected explicit false reduceOnly to be preserved")
+	if got := boolValue(submission["reduceOnly"]); !got {
+		t.Fatal("expected zero-value reduceOnly to fall back to original true")
+	}
+}
+
+func TestWithExecutionSubmissionFallbackPreservesExplicitZeroForUnknownFields(t *testing.T) {
+	order := domain.Order{
+		Metadata: map[string]any{
+			"adapterSubmission": map[string]any{
+				"queueIndex": 0.0,
+				"auditFlag":  false,
+			},
+		},
+	}
+	fallback := domain.Order{
+		Metadata: map[string]any{
+			"adapterSubmission": map[string]any{
+				"queueIndex": 7.0,
+				"auditFlag":  true,
+			},
+		},
+	}
+	merged := withExecutionSubmissionFallback(order, fallback)
+	submission := mapValue(merged.Metadata["adapterSubmission"])
+	if got := parseFloatValue(submission["queueIndex"]); got != 0 {
+		t.Fatalf("expected explicit zero queueIndex to be preserved, got %v", got)
+	}
+	if got := boolValue(submission["auditFlag"]); got {
+		t.Fatal("expected explicit false auditFlag to be preserved")
 	}
 }
 

--- a/internal/service/strategy_optimization_test.go
+++ b/internal/service/strategy_optimization_test.go
@@ -171,7 +171,7 @@ func TestUpdateLivePositionWatermarksResetsWhenPositionChanges(t *testing.T) {
 	if lwm != 47900.0 {
 		t.Fatalf("expected lwm to update from new position context, got %v", lwm)
 	}
-	if got := stringValue(sessionState["watermarkPositionKey"]); got != "SHORT|48000.00000000" {
+	if got := stringValue(sessionState["watermarkPositionKey"]); got != "BTCUSDT|SHORT|48000.00000000" {
 		t.Fatalf("expected watermark key to reset, got %s", got)
 	}
 }
@@ -180,18 +180,23 @@ func TestResolveAndApplyLivePositionWatermarksAreSeparated(t *testing.T) {
 	sessionState := map[string]any{
 		"hwm":                  52000.0,
 		"lwm":                  50000.0,
-		"watermarkPositionKey": "LONG|50000.00000000",
+		"watermarkPositionKey": "BTCUSDT|LONG|50000.00000000",
 	}
 	currentPosition := map[string]any{
+		"symbol":     "BTCUSDT",
 		"side":       "LONG",
 		"entryPrice": 50000.0,
 	}
+	expectedKey := "BTCUSDT|LONG|50000.00000000"
 	watermarks := resolveLivePositionWatermarks(currentPosition, sessionState)
 	if watermarks.HWM != 52000.0 || watermarks.LWM != 50000.0 {
 		t.Fatalf("expected resolved watermarks from session state, got %+v", watermarks)
 	}
-	if got := stringValue(sessionState["watermarkPositionKey"]); got != "LONG|50000.00000000" {
+	if got := stringValue(sessionState["watermarkPositionKey"]); got != expectedKey {
 		t.Fatalf("expected resolve to stay side-effect free, got %s", got)
+	}
+	if watermarks.PositionKey != expectedKey {
+		t.Fatalf("expected resolved position key %s, got %s", expectedKey, watermarks.PositionKey)
 	}
 	advanced := advanceLivePositionWatermarks(watermarks, 52500.0)
 	if advanced.HWM != 52500.0 {
@@ -207,8 +212,29 @@ func TestResolveAndApplyLivePositionWatermarksAreSeparated(t *testing.T) {
 	if parseFloatValue(sessionState["lwm"]) != 50000.0 {
 		t.Fatalf("expected apply to preserve LWM, got %v", sessionState["lwm"])
 	}
-	if got := stringValue(sessionState["watermarkPositionKey"]); got != "LONG|50000.00000000" {
+	if got := stringValue(sessionState["watermarkPositionKey"]); got != expectedKey {
 		t.Fatalf("expected apply to persist watermark key, got %s", got)
+	}
+}
+
+func TestResolveLivePositionWatermarksUsesExpandedPositionContextKey(t *testing.T) {
+	sessionState := map[string]any{
+		"hwm":                  52000.0,
+		"lwm":                  50000.0,
+		"watermarkPositionKey": "BTCUSDT|LONG|50000.00000000|2026-04-10T00:00:00Z",
+	}
+	currentPosition := map[string]any{
+		"symbol":     "BTCUSDT",
+		"side":       "LONG",
+		"entryPrice": 50000.0,
+		"updatedAt":  "2026-04-11T00:00:00Z",
+	}
+	watermarks := resolveLivePositionWatermarks(currentPosition, sessionState)
+	if got := watermarks.PositionKey; got != "BTCUSDT|LONG|50000.00000000|2026-04-11T00:00:00Z" {
+		t.Fatalf("expected expanded position key, got %s", got)
+	}
+	if watermarks.HWM != 50000.0 || watermarks.LWM != 50000.0 {
+		t.Fatalf("expected watermarks to reset for new position context, got %+v", watermarks)
 	}
 }
 

--- a/internal/service/strategy_optimization_test.go
+++ b/internal/service/strategy_optimization_test.go
@@ -178,7 +178,7 @@ func TestUpdateLivePositionWatermarksResetsWhenPositionChanges(t *testing.T) {
 	if lwm != 47900.0 {
 		t.Fatalf("expected lwm to update from new position context, got %v", lwm)
 	}
-	if got := stringValue(sessionState["watermarkPositionKey"]); got != "position-new|ETHUSDT|SHORT|48000.00000000" {
+	if got := stringValue(sessionState["watermarkPositionKey"]); got != "position-new|ETHUSDT|SHORT" {
 		t.Fatalf("expected watermark key to reset, got %s", got)
 	}
 }
@@ -187,7 +187,7 @@ func TestResolveAndApplyLivePositionWatermarksAreSeparated(t *testing.T) {
 	sessionState := map[string]any{
 		"hwm":                  52000.0,
 		"lwm":                  50000.0,
-		"watermarkPositionKey": "position-1|BTCUSDT|LONG|50000.00000000",
+		"watermarkPositionKey": "position-1|BTCUSDT|LONG",
 	}
 	currentPosition := map[string]any{
 		"id":         "position-1",
@@ -197,7 +197,7 @@ func TestResolveAndApplyLivePositionWatermarksAreSeparated(t *testing.T) {
 		"quantity":   1.0,
 		"found":      true,
 	}
-	expectedKey := "position-1|BTCUSDT|LONG|50000.00000000"
+	expectedKey := "position-1|BTCUSDT|LONG"
 	watermarks := resolveLivePositionWatermarks(currentPosition, sessionState)
 	if watermarks.HWM != 52000.0 || watermarks.LWM != 50000.0 {
 		t.Fatalf("expected resolved watermarks from session state, got %+v", watermarks)
@@ -231,7 +231,7 @@ func TestResolveLivePositionWatermarksUsesExpandedPositionContextKey(t *testing.
 	sessionState := map[string]any{
 		"hwm":                  52000.0,
 		"lwm":                  50000.0,
-		"watermarkPositionKey": "position-1|BTCUSDT|LONG|50000.00000000",
+		"watermarkPositionKey": "position-1|BTCUSDT|LONG",
 	}
 	currentPosition := map[string]any{
 		"id":         "position-2",
@@ -242,11 +242,11 @@ func TestResolveLivePositionWatermarksUsesExpandedPositionContextKey(t *testing.
 		"found":      true,
 	}
 	watermarks := resolveLivePositionWatermarks(currentPosition, sessionState)
-	if got := watermarks.PositionKey; got != "position-1|BTCUSDT|LONG|50000.00000000" {
-		t.Fatalf("expected stable watermark key for same position context, got %s", got)
+	if got := watermarks.PositionKey; got != "position-2|BTCUSDT|LONG" {
+		t.Fatalf("expected new position id to reset watermark key, got %s", got)
 	}
-	if watermarks.HWM != 52000.0 || watermarks.LWM != 50000.0 {
-		t.Fatalf("expected watermarks to be preserved for same position context, got %+v", watermarks)
+	if watermarks.HWM != 50000.0 || watermarks.LWM != 50000.0 {
+		t.Fatalf("expected watermarks to reset for new position id, got %+v", watermarks)
 	}
 }
 
@@ -265,7 +265,7 @@ func TestResolveLivePositionWatermarksUsesVirtualPositionID(t *testing.T) {
 		"virtual":    true,
 	}
 	watermarks := resolveLivePositionWatermarks(currentPosition, sessionState)
-	if got := watermarks.PositionKey; got != "virtual|session-1|signal-2|BTCUSDT|LONG|50000.00000000" {
+	if got := watermarks.PositionKey; got != "virtual|session-1|signal-2|BTCUSDT|LONG" {
 		t.Fatalf("expected virtual position id to drive watermark key, got %s", got)
 	}
 	if watermarks.HWM != 50000.0 || watermarks.LWM != 50000.0 {
@@ -288,8 +288,8 @@ func TestResolveLivePositionWatermarksSupportsLegacyVirtualKey(t *testing.T) {
 		"virtual":    true,
 	}
 	watermarks := resolveLivePositionWatermarks(currentPosition, sessionState)
-	if got := watermarks.PositionKey; got != "virtual|session-1|signal-2" {
-		t.Fatalf("expected legacy virtual watermark key to remain stable, got %s", got)
+	if got := watermarks.PositionKey; got != "virtual|session-1|signal-2|BTCUSDT|LONG" {
+		t.Fatalf("expected legacy virtual watermark key to upgrade to canonical key, got %s", got)
 	}
 	if watermarks.HWM != 52000.0 || watermarks.LWM != 50000.0 {
 		t.Fatalf("expected legacy virtual key to preserve watermarks, got %+v", watermarks)
@@ -300,7 +300,7 @@ func TestResolveLivePositionWatermarksPreservesPreviousKeyWhenIDTemporarilyMissi
 	sessionState := map[string]any{
 		"hwm":                  52000.0,
 		"lwm":                  50000.0,
-		"watermarkPositionKey": "position-1|BTCUSDT|LONG|50000.00000000",
+		"watermarkPositionKey": "position-1|BTCUSDT|LONG",
 	}
 	currentPosition := map[string]any{
 		"symbol":     "BTCUSDT",
@@ -310,11 +310,36 @@ func TestResolveLivePositionWatermarksPreservesPreviousKeyWhenIDTemporarilyMissi
 		"found":      true,
 	}
 	watermarks := resolveLivePositionWatermarks(currentPosition, sessionState)
-	if got := watermarks.PositionKey; got != "position-1|BTCUSDT|LONG|50000.00000000" {
+	if got := watermarks.PositionKey; got != "position-1|BTCUSDT|LONG" {
 		t.Fatalf("expected missing id to preserve previous stable watermark key, got %s", got)
 	}
 	if watermarks.HWM != 52000.0 || watermarks.LWM != 50000.0 {
 		t.Fatalf("expected missing id to preserve existing watermarks, got %+v", watermarks)
+	}
+}
+
+func TestRefreshLivePositionWatermarksClearsStateWhenPositionIsInactive(t *testing.T) {
+	sessionState := map[string]any{
+		"hwm":                  52000.0,
+		"lwm":                  50000.0,
+		"watermarkPositionKey": "position-1|BTCUSDT|LONG",
+	}
+	watermarks := refreshLivePositionWatermarks(sessionState, map[string]any{
+		"symbol":   "BTCUSDT",
+		"quantity": 0.0,
+		"found":    false,
+	}, 0)
+	if watermarks.PositionKey != "" || watermarks.HWM != 0 || watermarks.LWM != 0 {
+		t.Fatalf("expected empty watermarks for inactive position, got %+v", watermarks)
+	}
+	if _, ok := sessionState["watermarkPositionKey"]; ok {
+		t.Fatal("expected watermarkPositionKey to be cleared when position becomes inactive")
+	}
+	if _, ok := sessionState["hwm"]; ok {
+		t.Fatal("expected hwm to be cleared when position becomes inactive")
+	}
+	if _, ok := sessionState["lwm"]; ok {
+		t.Fatal("expected lwm to be cleared when position becomes inactive")
 	}
 }
 
@@ -345,7 +370,7 @@ func TestDeriveLivePositionStateUsesProvidedWatermarks(t *testing.T) {
 		"quantity":   1.0,
 	}
 	watermarks := livePositionWatermarks{
-		PositionKey: "position-1|BTCUSDT|LONG|50000.00000000",
+		PositionKey: "position-1|BTCUSDT|LONG",
 		HWM:         50600.0,
 		LWM:         50000.0,
 	}
@@ -379,7 +404,7 @@ func TestDeriveLivePositionStateUsesProvidedWatermarksForShort(t *testing.T) {
 		"quantity":   1.0,
 	}
 	watermarks := livePositionWatermarks{
-		PositionKey: "position-2|BTCUSDT|SHORT|50000.00000000",
+		PositionKey: "position-2|BTCUSDT|SHORT",
 		HWM:         50000.0,
 		LWM:         49400.0,
 	}
@@ -396,7 +421,7 @@ func TestResolveLivePositionWatermarksIgnoresInactiveSnapshot(t *testing.T) {
 	sessionState := map[string]any{
 		"hwm":                  52000.0,
 		"lwm":                  50000.0,
-		"watermarkPositionKey": "position-1|BTCUSDT|LONG|50000.00000000",
+		"watermarkPositionKey": "position-1|BTCUSDT|LONG",
 	}
 	currentPosition := map[string]any{
 		"symbol":     "BTCUSDT",
@@ -409,7 +434,7 @@ func TestResolveLivePositionWatermarksIgnoresInactiveSnapshot(t *testing.T) {
 	if watermarks.PositionKey != "" || watermarks.HWM != 0 || watermarks.LWM != 0 {
 		t.Fatalf("expected inactive snapshot to skip watermark refresh, got %+v", watermarks)
 	}
-	if got := stringValue(sessionState["watermarkPositionKey"]); got != "position-1|BTCUSDT|LONG|50000.00000000" {
+	if got := stringValue(sessionState["watermarkPositionKey"]); got != "position-1|BTCUSDT|LONG" {
 		t.Fatalf("expected inactive snapshot to preserve persisted watermark key, got %s", got)
 	}
 	if got := parseFloatValue(sessionState["hwm"]); got != 52000.0 {
@@ -424,7 +449,7 @@ func TestResolveLivePositionWatermarksIgnoresQuantityChangesWithinSamePosition(t
 	sessionState := map[string]any{
 		"hwm":                  52000.0,
 		"lwm":                  50000.0,
-		"watermarkPositionKey": "position-1|BTCUSDT|LONG|50000.00000000",
+		"watermarkPositionKey": "position-1|BTCUSDT|LONG",
 	}
 	currentPosition := map[string]any{
 		"id":         "position-1",
@@ -435,7 +460,7 @@ func TestResolveLivePositionWatermarksIgnoresQuantityChangesWithinSamePosition(t
 		"found":      true,
 	}
 	watermarks := resolveLivePositionWatermarks(currentPosition, sessionState)
-	if got := watermarks.PositionKey; got != "position-1|BTCUSDT|LONG|50000.00000000" {
+	if got := watermarks.PositionKey; got != "position-1|BTCUSDT|LONG" {
 		t.Fatalf("expected quantity changes to keep the same watermark key, got %s", got)
 	}
 	if watermarks.HWM != 52000.0 || watermarks.LWM != 50000.0 {

--- a/internal/service/strategy_optimization_test.go
+++ b/internal/service/strategy_optimization_test.go
@@ -332,14 +332,14 @@ func TestRefreshLivePositionWatermarksClearsStateWhenPositionIsInactive(t *testi
 	if watermarks.PositionKey != "" || watermarks.HWM != 0 || watermarks.LWM != 0 {
 		t.Fatalf("expected empty watermarks for inactive position, got %+v", watermarks)
 	}
-	if _, ok := sessionState["watermarkPositionKey"]; ok {
-		t.Fatal("expected watermarkPositionKey to be cleared when position becomes inactive")
+	if got := stringValue(sessionState["watermarkPositionKey"]); got != "position-1|BTCUSDT|LONG|50000.00000000" {
+		t.Fatalf("expected inactive refresh to preserve existing watermark key, got %s", got)
 	}
-	if _, ok := sessionState["hwm"]; ok {
-		t.Fatal("expected hwm to be cleared when position becomes inactive")
+	if got := parseFloatValue(sessionState["hwm"]); got != 52000.0 {
+		t.Fatalf("expected inactive refresh to preserve HWM, got %v", got)
 	}
-	if _, ok := sessionState["lwm"]; ok {
-		t.Fatal("expected lwm to be cleared when position becomes inactive")
+	if got := parseFloatValue(sessionState["lwm"]); got != 50000.0 {
+		t.Fatalf("expected inactive refresh to preserve LWM, got %v", got)
 	}
 }
 

--- a/internal/service/strategy_optimization_test.go
+++ b/internal/service/strategy_optimization_test.go
@@ -175,3 +175,67 @@ func TestUpdateLivePositionWatermarksResetsWhenPositionChanges(t *testing.T) {
 		t.Fatalf("expected watermark key to reset, got %s", got)
 	}
 }
+
+func TestResolveAndApplyLivePositionWatermarksAreSeparated(t *testing.T) {
+	sessionState := map[string]any{
+		"hwm":                  52000.0,
+		"lwm":                  50000.0,
+		"watermarkPositionKey": "LONG|50000.00000000",
+	}
+	currentPosition := map[string]any{
+		"side":       "LONG",
+		"entryPrice": 50000.0,
+	}
+	watermarks := resolveLivePositionWatermarks(currentPosition, sessionState)
+	if watermarks.HWM != 52000.0 || watermarks.LWM != 50000.0 {
+		t.Fatalf("expected resolved watermarks from session state, got %+v", watermarks)
+	}
+	if got := stringValue(sessionState["watermarkPositionKey"]); got != "LONG|50000.00000000" {
+		t.Fatalf("expected resolve to stay side-effect free, got %s", got)
+	}
+	advanced := advanceLivePositionWatermarks(watermarks, 52500.0)
+	if advanced.HWM != 52500.0 {
+		t.Fatalf("expected advanced HWM 52500, got %v", advanced.HWM)
+	}
+	if parseFloatValue(sessionState["hwm"]) != 52000.0 {
+		t.Fatalf("expected advance to stay side-effect free, got %v", sessionState["hwm"])
+	}
+	applyLivePositionWatermarks(sessionState, advanced)
+	if parseFloatValue(sessionState["hwm"]) != 52500.0 {
+		t.Fatalf("expected apply to persist advanced HWM, got %v", sessionState["hwm"])
+	}
+}
+
+func TestDeriveLivePositionStateUsesProvidedWatermarks(t *testing.T) {
+	parameters := map[string]any{
+		"trailing_stop_atr":               0.3,
+		"delayed_trailing_activation_atr": 0.5,
+		"stop_loss_atr":                   0.05,
+		"stop_mode":                       "atr",
+	}
+	signalBarState := map[string]any{
+		"atr14":    1000.0,
+		"current":  map[string]any{"close": 50600.0},
+		"prevBar1": map[string]any{"high": 50500.0, "low": 49500.0},
+		"prevBar2": map[string]any{"high": 50600.0, "low": 49400.0},
+	}
+	currentPosition := map[string]any{
+		"found":      true,
+		"side":       "LONG",
+		"entryPrice": 50000.0,
+		"stopLoss":   49950.0,
+		"quantity":   1.0,
+	}
+	watermarks := livePositionWatermarks{
+		PositionKey: "LONG|50000.00000000",
+		HWM:         50600.0,
+		LWM:         50000.0,
+	}
+	state := deriveLivePositionState(parameters, currentPosition, signalBarState, 50600.0, watermarks)
+	if got := parseFloatValue(state["stopLoss"]); got != 50300.0 {
+		t.Fatalf("expected trailing SL 50300 from provided watermarks, got %v", got)
+	}
+	if got := parseFloatValue(state["hwm"]); got != 50600.0 {
+		t.Fatalf("expected returned HWM 50600, got %v", got)
+	}
+}

--- a/internal/service/strategy_optimization_test.go
+++ b/internal/service/strategy_optimization_test.go
@@ -244,6 +244,28 @@ func TestResolveLivePositionWatermarksUsesExpandedPositionContextKey(t *testing.
 	}
 }
 
+func TestResolveLivePositionWatermarksUsesVirtualPositionID(t *testing.T) {
+	sessionState := map[string]any{
+		"hwm":                  52000.0,
+		"lwm":                  50000.0,
+		"watermarkPositionKey": "virtual|session-1|signal-1",
+	}
+	currentPosition := map[string]any{
+		"id":         "virtual|session-1|signal-2",
+		"symbol":     "BTCUSDT",
+		"side":       "LONG",
+		"entryPrice": 50000.0,
+		"virtual":    true,
+	}
+	watermarks := resolveLivePositionWatermarks(currentPosition, sessionState)
+	if got := watermarks.PositionKey; got != "virtual|session-1|signal-2" {
+		t.Fatalf("expected virtual position id to drive watermark key, got %s", got)
+	}
+	if watermarks.HWM != 50000.0 || watermarks.LWM != 50000.0 {
+		t.Fatalf("expected watermarks to reset for a new virtual position identity, got %+v", watermarks)
+	}
+}
+
 func TestDeriveLivePositionStateUsesProvidedWatermarks(t *testing.T) {
 	parameters := map[string]any{
 		"trailing_stop_atr":               0.3,

--- a/internal/service/strategy_optimization_test.go
+++ b/internal/service/strategy_optimization_test.go
@@ -242,11 +242,11 @@ func TestResolveLivePositionWatermarksUsesExpandedPositionContextKey(t *testing.
 		"found":      true,
 	}
 	watermarks := resolveLivePositionWatermarks(currentPosition, sessionState)
-	if got := watermarks.PositionKey; got != "position-2|BTCUSDT|LONG|50000.00000000" {
-		t.Fatalf("expected expanded position key, got %s", got)
+	if got := watermarks.PositionKey; got != "position-1|BTCUSDT|LONG|50000.00000000" {
+		t.Fatalf("expected stable watermark key for same position context, got %s", got)
 	}
-	if watermarks.HWM != 50000.0 || watermarks.LWM != 50000.0 {
-		t.Fatalf("expected watermarks to reset for new position context, got %+v", watermarks)
+	if watermarks.HWM != 52000.0 || watermarks.LWM != 50000.0 {
+		t.Fatalf("expected watermarks to be preserved for same position context, got %+v", watermarks)
 	}
 }
 
@@ -270,6 +270,29 @@ func TestResolveLivePositionWatermarksUsesVirtualPositionID(t *testing.T) {
 	}
 	if watermarks.HWM != 50000.0 || watermarks.LWM != 50000.0 {
 		t.Fatalf("expected watermarks to reset for a new virtual position identity, got %+v", watermarks)
+	}
+}
+
+func TestResolveLivePositionWatermarksSupportsLegacyVirtualKey(t *testing.T) {
+	sessionState := map[string]any{
+		"hwm":                  52000.0,
+		"lwm":                  50000.0,
+		"watermarkPositionKey": "virtual|session-1|signal-2",
+	}
+	currentPosition := map[string]any{
+		"id":         "virtual|session-1|signal-2",
+		"symbol":     "BTCUSDT",
+		"side":       "LONG",
+		"entryPrice": 50000.0,
+		"quantity":   1.0,
+		"virtual":    true,
+	}
+	watermarks := resolveLivePositionWatermarks(currentPosition, sessionState)
+	if got := watermarks.PositionKey; got != "virtual|session-1|signal-2" {
+		t.Fatalf("expected legacy virtual watermark key to remain stable, got %s", got)
+	}
+	if watermarks.HWM != 52000.0 || watermarks.LWM != 50000.0 {
+		t.Fatalf("expected legacy virtual key to preserve watermarks, got %+v", watermarks)
 	}
 }
 

--- a/internal/service/strategy_optimization_test.go
+++ b/internal/service/strategy_optimization_test.go
@@ -162,16 +162,21 @@ func TestUpdateLivePositionWatermarksResetsWhenPositionChanges(t *testing.T) {
 	sessionState := map[string]any{
 		"hwm":                  52000.0,
 		"lwm":                  50000.0,
-		"watermarkPositionKey": "LONG|50000.00000000",
+		"watermarkPositionKey": "position-old",
 	}
-	hwm, lwm := updateLivePositionWatermarks(sessionState, "short", 48000.0, 47900.0)
+	hwm, lwm := updateLivePositionWatermarks(sessionState, map[string]any{
+		"id":         "position-new",
+		"symbol":     "ETHUSDT",
+		"side":       "short",
+		"entryPrice": 48000.0,
+	}, 47900.0)
 	if hwm != 48000.0 {
 		t.Fatalf("expected hwm to reset to new entry price, got %v", hwm)
 	}
 	if lwm != 47900.0 {
 		t.Fatalf("expected lwm to update from new position context, got %v", lwm)
 	}
-	if got := stringValue(sessionState["watermarkPositionKey"]); got != "BTCUSDT|SHORT|48000.00000000" {
+	if got := stringValue(sessionState["watermarkPositionKey"]); got != "position-new" {
 		t.Fatalf("expected watermark key to reset, got %s", got)
 	}
 }
@@ -180,14 +185,15 @@ func TestResolveAndApplyLivePositionWatermarksAreSeparated(t *testing.T) {
 	sessionState := map[string]any{
 		"hwm":                  52000.0,
 		"lwm":                  50000.0,
-		"watermarkPositionKey": "BTCUSDT|LONG|50000.00000000",
+		"watermarkPositionKey": "position-1",
 	}
 	currentPosition := map[string]any{
+		"id":         "position-1",
 		"symbol":     "BTCUSDT",
 		"side":       "LONG",
 		"entryPrice": 50000.0,
 	}
-	expectedKey := "BTCUSDT|LONG|50000.00000000"
+	expectedKey := "position-1"
 	watermarks := resolveLivePositionWatermarks(currentPosition, sessionState)
 	if watermarks.HWM != 52000.0 || watermarks.LWM != 50000.0 {
 		t.Fatalf("expected resolved watermarks from session state, got %+v", watermarks)
@@ -221,16 +227,16 @@ func TestResolveLivePositionWatermarksUsesExpandedPositionContextKey(t *testing.
 	sessionState := map[string]any{
 		"hwm":                  52000.0,
 		"lwm":                  50000.0,
-		"watermarkPositionKey": "BTCUSDT|LONG|50000.00000000|2026-04-10T00:00:00Z",
+		"watermarkPositionKey": "position-1",
 	}
 	currentPosition := map[string]any{
+		"id":         "position-2",
 		"symbol":     "BTCUSDT",
 		"side":       "LONG",
 		"entryPrice": 50000.0,
-		"updatedAt":  "2026-04-11T00:00:00Z",
 	}
 	watermarks := resolveLivePositionWatermarks(currentPosition, sessionState)
-	if got := watermarks.PositionKey; got != "BTCUSDT|LONG|50000.00000000|2026-04-11T00:00:00Z" {
+	if got := watermarks.PositionKey; got != "position-2" {
 		t.Fatalf("expected expanded position key, got %s", got)
 	}
 	if watermarks.HWM != 50000.0 || watermarks.LWM != 50000.0 {

--- a/internal/service/strategy_optimization_test.go
+++ b/internal/service/strategy_optimization_test.go
@@ -169,6 +169,8 @@ func TestUpdateLivePositionWatermarksResetsWhenPositionChanges(t *testing.T) {
 		"symbol":     "ETHUSDT",
 		"side":       "short",
 		"entryPrice": 48000.0,
+		"quantity":   1.0,
+		"found":      true,
 	}, 47900.0)
 	if hwm != 48000.0 {
 		t.Fatalf("expected hwm to reset to new entry price, got %v", hwm)
@@ -176,7 +178,7 @@ func TestUpdateLivePositionWatermarksResetsWhenPositionChanges(t *testing.T) {
 	if lwm != 47900.0 {
 		t.Fatalf("expected lwm to update from new position context, got %v", lwm)
 	}
-	if got := stringValue(sessionState["watermarkPositionKey"]); got != "position-new" {
+	if got := stringValue(sessionState["watermarkPositionKey"]); got != "position-new|ETHUSDT|SHORT|48000.00000000|1.00000000" {
 		t.Fatalf("expected watermark key to reset, got %s", got)
 	}
 }
@@ -185,15 +187,17 @@ func TestResolveAndApplyLivePositionWatermarksAreSeparated(t *testing.T) {
 	sessionState := map[string]any{
 		"hwm":                  52000.0,
 		"lwm":                  50000.0,
-		"watermarkPositionKey": "position-1",
+		"watermarkPositionKey": "position-1|BTCUSDT|LONG|50000.00000000|1.00000000",
 	}
 	currentPosition := map[string]any{
 		"id":         "position-1",
 		"symbol":     "BTCUSDT",
 		"side":       "LONG",
 		"entryPrice": 50000.0,
+		"quantity":   1.0,
+		"found":      true,
 	}
-	expectedKey := "position-1"
+	expectedKey := "position-1|BTCUSDT|LONG|50000.00000000|1.00000000"
 	watermarks := resolveLivePositionWatermarks(currentPosition, sessionState)
 	if watermarks.HWM != 52000.0 || watermarks.LWM != 50000.0 {
 		t.Fatalf("expected resolved watermarks from session state, got %+v", watermarks)
@@ -227,16 +231,18 @@ func TestResolveLivePositionWatermarksUsesExpandedPositionContextKey(t *testing.
 	sessionState := map[string]any{
 		"hwm":                  52000.0,
 		"lwm":                  50000.0,
-		"watermarkPositionKey": "position-1",
+		"watermarkPositionKey": "position-1|BTCUSDT|LONG|50000.00000000|1.00000000",
 	}
 	currentPosition := map[string]any{
 		"id":         "position-2",
 		"symbol":     "BTCUSDT",
 		"side":       "LONG",
 		"entryPrice": 50000.0,
+		"quantity":   1.0,
+		"found":      true,
 	}
 	watermarks := resolveLivePositionWatermarks(currentPosition, sessionState)
-	if got := watermarks.PositionKey; got != "position-2" {
+	if got := watermarks.PositionKey; got != "position-2|BTCUSDT|LONG|50000.00000000|1.00000000" {
 		t.Fatalf("expected expanded position key, got %s", got)
 	}
 	if watermarks.HWM != 50000.0 || watermarks.LWM != 50000.0 {
@@ -255,10 +261,11 @@ func TestResolveLivePositionWatermarksUsesVirtualPositionID(t *testing.T) {
 		"symbol":     "BTCUSDT",
 		"side":       "LONG",
 		"entryPrice": 50000.0,
+		"quantity":   1.0,
 		"virtual":    true,
 	}
 	watermarks := resolveLivePositionWatermarks(currentPosition, sessionState)
-	if got := watermarks.PositionKey; got != "virtual|session-1|signal-2" {
+	if got := watermarks.PositionKey; got != "virtual|session-1|signal-2|BTCUSDT|LONG|50000.00000000|1.00000000" {
 		t.Fatalf("expected virtual position id to drive watermark key, got %s", got)
 	}
 	if watermarks.HWM != 50000.0 || watermarks.LWM != 50000.0 {
@@ -287,7 +294,7 @@ func TestDeriveLivePositionStateUsesProvidedWatermarks(t *testing.T) {
 		"quantity":   1.0,
 	}
 	watermarks := livePositionWatermarks{
-		PositionKey: "LONG|50000.00000000",
+		PositionKey: "position-1|BTCUSDT|LONG|50000.00000000|1.00000000",
 		HWM:         50600.0,
 		LWM:         50000.0,
 	}
@@ -321,7 +328,7 @@ func TestDeriveLivePositionStateUsesProvidedWatermarksForShort(t *testing.T) {
 		"quantity":   1.0,
 	}
 	watermarks := livePositionWatermarks{
-		PositionKey: "SHORT|50000.00000000",
+		PositionKey: "position-2|BTCUSDT|SHORT|50000.00000000|1.00000000",
 		HWM:         50000.0,
 		LWM:         49400.0,
 	}
@@ -331,5 +338,24 @@ func TestDeriveLivePositionStateUsesProvidedWatermarksForShort(t *testing.T) {
 	}
 	if got := parseFloatValue(state["lwm"]); got != 49400.0 {
 		t.Fatalf("expected returned LWM 49400, got %v", got)
+	}
+}
+
+func TestResolveLivePositionWatermarksIgnoresInactiveSnapshot(t *testing.T) {
+	sessionState := map[string]any{
+		"hwm":                  52000.0,
+		"lwm":                  50000.0,
+		"watermarkPositionKey": "position-1|BTCUSDT|LONG|50000.00000000|1.00000000",
+	}
+	currentPosition := map[string]any{
+		"symbol":     "BTCUSDT",
+		"side":       "LONG",
+		"entryPrice": 50000.0,
+		"quantity":   0.0,
+		"found":      false,
+	}
+	watermarks := resolveLivePositionWatermarks(currentPosition, sessionState)
+	if watermarks.PositionKey != "" || watermarks.HWM != 0 || watermarks.LWM != 0 {
+		t.Fatalf("expected inactive snapshot to skip watermark refresh, got %+v", watermarks)
 	}
 }

--- a/internal/service/strategy_optimization_test.go
+++ b/internal/service/strategy_optimization_test.go
@@ -178,7 +178,7 @@ func TestUpdateLivePositionWatermarksResetsWhenPositionChanges(t *testing.T) {
 	if lwm != 47900.0 {
 		t.Fatalf("expected lwm to update from new position context, got %v", lwm)
 	}
-	if got := stringValue(sessionState["watermarkPositionKey"]); got != "position-new|ETHUSDT|SHORT|48000.00000000|1.00000000" {
+	if got := stringValue(sessionState["watermarkPositionKey"]); got != "position-new|ETHUSDT|SHORT|48000.00000000" {
 		t.Fatalf("expected watermark key to reset, got %s", got)
 	}
 }
@@ -187,7 +187,7 @@ func TestResolveAndApplyLivePositionWatermarksAreSeparated(t *testing.T) {
 	sessionState := map[string]any{
 		"hwm":                  52000.0,
 		"lwm":                  50000.0,
-		"watermarkPositionKey": "position-1|BTCUSDT|LONG|50000.00000000|1.00000000",
+		"watermarkPositionKey": "position-1|BTCUSDT|LONG|50000.00000000",
 	}
 	currentPosition := map[string]any{
 		"id":         "position-1",
@@ -197,7 +197,7 @@ func TestResolveAndApplyLivePositionWatermarksAreSeparated(t *testing.T) {
 		"quantity":   1.0,
 		"found":      true,
 	}
-	expectedKey := "position-1|BTCUSDT|LONG|50000.00000000|1.00000000"
+	expectedKey := "position-1|BTCUSDT|LONG|50000.00000000"
 	watermarks := resolveLivePositionWatermarks(currentPosition, sessionState)
 	if watermarks.HWM != 52000.0 || watermarks.LWM != 50000.0 {
 		t.Fatalf("expected resolved watermarks from session state, got %+v", watermarks)
@@ -231,7 +231,7 @@ func TestResolveLivePositionWatermarksUsesExpandedPositionContextKey(t *testing.
 	sessionState := map[string]any{
 		"hwm":                  52000.0,
 		"lwm":                  50000.0,
-		"watermarkPositionKey": "position-1|BTCUSDT|LONG|50000.00000000|1.00000000",
+		"watermarkPositionKey": "position-1|BTCUSDT|LONG|50000.00000000",
 	}
 	currentPosition := map[string]any{
 		"id":         "position-2",
@@ -242,7 +242,7 @@ func TestResolveLivePositionWatermarksUsesExpandedPositionContextKey(t *testing.
 		"found":      true,
 	}
 	watermarks := resolveLivePositionWatermarks(currentPosition, sessionState)
-	if got := watermarks.PositionKey; got != "position-2|BTCUSDT|LONG|50000.00000000|1.00000000" {
+	if got := watermarks.PositionKey; got != "position-2|BTCUSDT|LONG|50000.00000000" {
 		t.Fatalf("expected expanded position key, got %s", got)
 	}
 	if watermarks.HWM != 50000.0 || watermarks.LWM != 50000.0 {
@@ -265,7 +265,7 @@ func TestResolveLivePositionWatermarksUsesVirtualPositionID(t *testing.T) {
 		"virtual":    true,
 	}
 	watermarks := resolveLivePositionWatermarks(currentPosition, sessionState)
-	if got := watermarks.PositionKey; got != "virtual|session-1|signal-2|BTCUSDT|LONG|50000.00000000|1.00000000" {
+	if got := watermarks.PositionKey; got != "virtual|session-1|signal-2|BTCUSDT|LONG|50000.00000000" {
 		t.Fatalf("expected virtual position id to drive watermark key, got %s", got)
 	}
 	if watermarks.HWM != 50000.0 || watermarks.LWM != 50000.0 {
@@ -294,7 +294,7 @@ func TestDeriveLivePositionStateUsesProvidedWatermarks(t *testing.T) {
 		"quantity":   1.0,
 	}
 	watermarks := livePositionWatermarks{
-		PositionKey: "position-1|BTCUSDT|LONG|50000.00000000|1.00000000",
+		PositionKey: "position-1|BTCUSDT|LONG|50000.00000000",
 		HWM:         50600.0,
 		LWM:         50000.0,
 	}
@@ -328,7 +328,7 @@ func TestDeriveLivePositionStateUsesProvidedWatermarksForShort(t *testing.T) {
 		"quantity":   1.0,
 	}
 	watermarks := livePositionWatermarks{
-		PositionKey: "position-2|BTCUSDT|SHORT|50000.00000000|1.00000000",
+		PositionKey: "position-2|BTCUSDT|SHORT|50000.00000000",
 		HWM:         50000.0,
 		LWM:         49400.0,
 	}
@@ -345,7 +345,7 @@ func TestResolveLivePositionWatermarksIgnoresInactiveSnapshot(t *testing.T) {
 	sessionState := map[string]any{
 		"hwm":                  52000.0,
 		"lwm":                  50000.0,
-		"watermarkPositionKey": "position-1|BTCUSDT|LONG|50000.00000000|1.00000000",
+		"watermarkPositionKey": "position-1|BTCUSDT|LONG|50000.00000000",
 	}
 	currentPosition := map[string]any{
 		"symbol":     "BTCUSDT",
@@ -357,5 +357,37 @@ func TestResolveLivePositionWatermarksIgnoresInactiveSnapshot(t *testing.T) {
 	watermarks := resolveLivePositionWatermarks(currentPosition, sessionState)
 	if watermarks.PositionKey != "" || watermarks.HWM != 0 || watermarks.LWM != 0 {
 		t.Fatalf("expected inactive snapshot to skip watermark refresh, got %+v", watermarks)
+	}
+	if got := stringValue(sessionState["watermarkPositionKey"]); got != "position-1|BTCUSDT|LONG|50000.00000000" {
+		t.Fatalf("expected inactive snapshot to preserve persisted watermark key, got %s", got)
+	}
+	if got := parseFloatValue(sessionState["hwm"]); got != 52000.0 {
+		t.Fatalf("expected inactive snapshot to preserve persisted HWM, got %v", got)
+	}
+	if got := parseFloatValue(sessionState["lwm"]); got != 50000.0 {
+		t.Fatalf("expected inactive snapshot to preserve persisted LWM, got %v", got)
+	}
+}
+
+func TestResolveLivePositionWatermarksIgnoresQuantityChangesWithinSamePosition(t *testing.T) {
+	sessionState := map[string]any{
+		"hwm":                  52000.0,
+		"lwm":                  50000.0,
+		"watermarkPositionKey": "position-1|BTCUSDT|LONG|50000.00000000",
+	}
+	currentPosition := map[string]any{
+		"id":         "position-1",
+		"symbol":     "BTCUSDT",
+		"side":       "LONG",
+		"entryPrice": 50000.0,
+		"quantity":   0.6,
+		"found":      true,
+	}
+	watermarks := resolveLivePositionWatermarks(currentPosition, sessionState)
+	if got := watermarks.PositionKey; got != "position-1|BTCUSDT|LONG|50000.00000000" {
+		t.Fatalf("expected quantity changes to keep the same watermark key, got %s", got)
+	}
+	if watermarks.HWM != 52000.0 || watermarks.LWM != 50000.0 {
+		t.Fatalf("expected quantity changes to preserve watermarks, got %+v", watermarks)
 	}
 }

--- a/internal/service/strategy_optimization_test.go
+++ b/internal/service/strategy_optimization_test.go
@@ -204,6 +204,12 @@ func TestResolveAndApplyLivePositionWatermarksAreSeparated(t *testing.T) {
 	if parseFloatValue(sessionState["hwm"]) != 52500.0 {
 		t.Fatalf("expected apply to persist advanced HWM, got %v", sessionState["hwm"])
 	}
+	if parseFloatValue(sessionState["lwm"]) != 50000.0 {
+		t.Fatalf("expected apply to preserve LWM, got %v", sessionState["lwm"])
+	}
+	if got := stringValue(sessionState["watermarkPositionKey"]); got != "LONG|50000.00000000" {
+		t.Fatalf("expected apply to persist watermark key, got %s", got)
+	}
 }
 
 func TestDeriveLivePositionStateUsesProvidedWatermarks(t *testing.T) {
@@ -237,5 +243,39 @@ func TestDeriveLivePositionStateUsesProvidedWatermarks(t *testing.T) {
 	}
 	if got := parseFloatValue(state["hwm"]); got != 50600.0 {
 		t.Fatalf("expected returned HWM 50600, got %v", got)
+	}
+}
+
+func TestDeriveLivePositionStateUsesProvidedWatermarksForShort(t *testing.T) {
+	parameters := map[string]any{
+		"trailing_stop_atr":               0.3,
+		"delayed_trailing_activation_atr": 0.5,
+		"stop_loss_atr":                   0.05,
+		"stop_mode":                       "atr",
+	}
+	signalBarState := map[string]any{
+		"atr14":    1000.0,
+		"current":  map[string]any{"close": 49400.0},
+		"prevBar1": map[string]any{"high": 50500.0, "low": 49500.0},
+		"prevBar2": map[string]any{"high": 50600.0, "low": 49400.0},
+	}
+	currentPosition := map[string]any{
+		"found":      true,
+		"side":       "SHORT",
+		"entryPrice": 50000.0,
+		"stopLoss":   50050.0,
+		"quantity":   1.0,
+	}
+	watermarks := livePositionWatermarks{
+		PositionKey: "SHORT|50000.00000000",
+		HWM:         50000.0,
+		LWM:         49400.0,
+	}
+	state := deriveLivePositionState(parameters, currentPosition, signalBarState, 49400.0, watermarks)
+	if got := parseFloatValue(state["stopLoss"]); got != 49700.0 {
+		t.Fatalf("expected trailing SL 49700 from provided short watermarks, got %v", got)
+	}
+	if got := parseFloatValue(state["lwm"]); got != 49400.0 {
+		t.Fatalf("expected returned LWM 49400, got %v", got)
 	}
 }

--- a/internal/service/strategy_optimization_test.go
+++ b/internal/service/strategy_optimization_test.go
@@ -178,7 +178,7 @@ func TestUpdateLivePositionWatermarksResetsWhenPositionChanges(t *testing.T) {
 	if lwm != 47900.0 {
 		t.Fatalf("expected lwm to update from new position context, got %v", lwm)
 	}
-	if got := stringValue(sessionState["watermarkPositionKey"]); got != "position-new|ETHUSDT|SHORT" {
+	if got := stringValue(sessionState["watermarkPositionKey"]); got != "position-new|ETHUSDT|SHORT|48000.00000000" {
 		t.Fatalf("expected watermark key to reset, got %s", got)
 	}
 }
@@ -187,7 +187,7 @@ func TestResolveAndApplyLivePositionWatermarksAreSeparated(t *testing.T) {
 	sessionState := map[string]any{
 		"hwm":                  52000.0,
 		"lwm":                  50000.0,
-		"watermarkPositionKey": "position-1|BTCUSDT|LONG",
+		"watermarkPositionKey": "position-1|BTCUSDT|LONG|50000.00000000",
 	}
 	currentPosition := map[string]any{
 		"id":         "position-1",
@@ -197,7 +197,7 @@ func TestResolveAndApplyLivePositionWatermarksAreSeparated(t *testing.T) {
 		"quantity":   1.0,
 		"found":      true,
 	}
-	expectedKey := "position-1|BTCUSDT|LONG"
+	expectedKey := "position-1|BTCUSDT|LONG|50000.00000000"
 	watermarks := resolveLivePositionWatermarks(currentPosition, sessionState)
 	if watermarks.HWM != 52000.0 || watermarks.LWM != 50000.0 {
 		t.Fatalf("expected resolved watermarks from session state, got %+v", watermarks)
@@ -231,7 +231,7 @@ func TestResolveLivePositionWatermarksUsesExpandedPositionContextKey(t *testing.
 	sessionState := map[string]any{
 		"hwm":                  52000.0,
 		"lwm":                  50000.0,
-		"watermarkPositionKey": "position-1|BTCUSDT|LONG",
+		"watermarkPositionKey": "position-1|BTCUSDT|LONG|50000.00000000",
 	}
 	currentPosition := map[string]any{
 		"id":         "position-2",
@@ -242,7 +242,7 @@ func TestResolveLivePositionWatermarksUsesExpandedPositionContextKey(t *testing.
 		"found":      true,
 	}
 	watermarks := resolveLivePositionWatermarks(currentPosition, sessionState)
-	if got := watermarks.PositionKey; got != "position-2|BTCUSDT|LONG" {
+	if got := watermarks.PositionKey; got != "position-2|BTCUSDT|LONG|50000.00000000" {
 		t.Fatalf("expected new position id to reset watermark key, got %s", got)
 	}
 	if watermarks.HWM != 50000.0 || watermarks.LWM != 50000.0 {
@@ -265,7 +265,7 @@ func TestResolveLivePositionWatermarksUsesVirtualPositionID(t *testing.T) {
 		"virtual":    true,
 	}
 	watermarks := resolveLivePositionWatermarks(currentPosition, sessionState)
-	if got := watermarks.PositionKey; got != "virtual|session-1|signal-2|BTCUSDT|LONG" {
+	if got := watermarks.PositionKey; got != "virtual|session-1|signal-2|BTCUSDT|LONG|50000.00000000" {
 		t.Fatalf("expected virtual position id to drive watermark key, got %s", got)
 	}
 	if watermarks.HWM != 50000.0 || watermarks.LWM != 50000.0 {
@@ -288,8 +288,8 @@ func TestResolveLivePositionWatermarksSupportsLegacyVirtualKey(t *testing.T) {
 		"virtual":    true,
 	}
 	watermarks := resolveLivePositionWatermarks(currentPosition, sessionState)
-	if got := watermarks.PositionKey; got != "virtual|session-1|signal-2|BTCUSDT|LONG" {
-		t.Fatalf("expected legacy virtual watermark key to upgrade to canonical key, got %s", got)
+	if got := watermarks.PositionKey; got != "virtual|session-1|signal-2" {
+		t.Fatalf("expected legacy virtual watermark key to remain stable, got %s", got)
 	}
 	if watermarks.HWM != 52000.0 || watermarks.LWM != 50000.0 {
 		t.Fatalf("expected legacy virtual key to preserve watermarks, got %+v", watermarks)
@@ -300,7 +300,7 @@ func TestResolveLivePositionWatermarksPreservesPreviousKeyWhenIDTemporarilyMissi
 	sessionState := map[string]any{
 		"hwm":                  52000.0,
 		"lwm":                  50000.0,
-		"watermarkPositionKey": "position-1|BTCUSDT|LONG",
+		"watermarkPositionKey": "position-1|BTCUSDT|LONG|50000.00000000",
 	}
 	currentPosition := map[string]any{
 		"symbol":     "BTCUSDT",
@@ -310,7 +310,7 @@ func TestResolveLivePositionWatermarksPreservesPreviousKeyWhenIDTemporarilyMissi
 		"found":      true,
 	}
 	watermarks := resolveLivePositionWatermarks(currentPosition, sessionState)
-	if got := watermarks.PositionKey; got != "position-1|BTCUSDT|LONG" {
+	if got := watermarks.PositionKey; got != "position-1|BTCUSDT|LONG|50000.00000000" {
 		t.Fatalf("expected missing id to preserve previous stable watermark key, got %s", got)
 	}
 	if watermarks.HWM != 52000.0 || watermarks.LWM != 50000.0 {
@@ -322,7 +322,7 @@ func TestRefreshLivePositionWatermarksClearsStateWhenPositionIsInactive(t *testi
 	sessionState := map[string]any{
 		"hwm":                  52000.0,
 		"lwm":                  50000.0,
-		"watermarkPositionKey": "position-1|BTCUSDT|LONG",
+		"watermarkPositionKey": "position-1|BTCUSDT|LONG|50000.00000000",
 	}
 	watermarks := refreshLivePositionWatermarks(sessionState, map[string]any{
 		"symbol":   "BTCUSDT",
@@ -340,6 +340,29 @@ func TestRefreshLivePositionWatermarksClearsStateWhenPositionIsInactive(t *testi
 	}
 	if _, ok := sessionState["lwm"]; ok {
 		t.Fatal("expected lwm to be cleared when position becomes inactive")
+	}
+}
+
+func TestResolveLivePositionWatermarksSupportsLegacyRealPositionKey(t *testing.T) {
+	sessionState := map[string]any{
+		"hwm":                  52000.0,
+		"lwm":                  50000.0,
+		"watermarkPositionKey": "LONG|50000.00000000",
+	}
+	currentPosition := map[string]any{
+		"id":         "position-1",
+		"symbol":     "BTCUSDT",
+		"side":       "LONG",
+		"entryPrice": 50000.0,
+		"quantity":   1.0,
+		"found":      true,
+	}
+	watermarks := resolveLivePositionWatermarks(currentPosition, sessionState)
+	if got := watermarks.PositionKey; got != "LONG|50000.00000000" {
+		t.Fatalf("expected legacy real-position watermark key to remain stable during migration, got %s", got)
+	}
+	if watermarks.HWM != 52000.0 || watermarks.LWM != 50000.0 {
+		t.Fatalf("expected legacy real-position key to preserve watermarks, got %+v", watermarks)
 	}
 }
 

--- a/internal/service/strategy_optimization_test.go
+++ b/internal/service/strategy_optimization_test.go
@@ -273,6 +273,34 @@ func TestResolveLivePositionWatermarksUsesVirtualPositionID(t *testing.T) {
 	}
 }
 
+func TestResolveLivePositionWatermarksPreservesPreviousKeyWhenIDTemporarilyMissing(t *testing.T) {
+	sessionState := map[string]any{
+		"hwm":                  52000.0,
+		"lwm":                  50000.0,
+		"watermarkPositionKey": "position-1|BTCUSDT|LONG|50000.00000000",
+	}
+	currentPosition := map[string]any{
+		"symbol":     "BTCUSDT",
+		"side":       "LONG",
+		"entryPrice": 50000.0,
+		"quantity":   1.0,
+		"found":      true,
+	}
+	watermarks := resolveLivePositionWatermarks(currentPosition, sessionState)
+	if got := watermarks.PositionKey; got != "position-1|BTCUSDT|LONG|50000.00000000" {
+		t.Fatalf("expected missing id to preserve previous stable watermark key, got %s", got)
+	}
+	if watermarks.HWM != 52000.0 || watermarks.LWM != 50000.0 {
+		t.Fatalf("expected missing id to preserve existing watermarks, got %+v", watermarks)
+	}
+}
+
+func TestHasActiveLivePositionSnapshotUsesAbsoluteQuantity(t *testing.T) {
+	if !hasActiveLivePositionSnapshot(map[string]any{"quantity": -1.0}) {
+		t.Fatal("expected negative quantity snapshot to count as active")
+	}
+}
+
 func TestDeriveLivePositionStateUsesProvidedWatermarks(t *testing.T) {
 	parameters := map[string]any{
 		"trailing_stop_atr":               0.3,

--- a/internal/service/strategy_optimization_test.go
+++ b/internal/service/strategy_optimization_test.go
@@ -288,11 +288,11 @@ func TestResolveLivePositionWatermarksSupportsLegacyVirtualKey(t *testing.T) {
 		"virtual":    true,
 	}
 	watermarks := resolveLivePositionWatermarks(currentPosition, sessionState)
-	if got := watermarks.PositionKey; got != "virtual|session-1|signal-2" {
-		t.Fatalf("expected legacy virtual watermark key to remain stable, got %s", got)
+	if got := watermarks.PositionKey; got != "virtual|session-1|signal-2|BTCUSDT|LONG|50000.00000000" {
+		t.Fatalf("expected legacy virtual watermark key to migrate to canonical key, got %s", got)
 	}
 	if watermarks.HWM != 52000.0 || watermarks.LWM != 50000.0 {
-		t.Fatalf("expected legacy virtual key to preserve watermarks, got %+v", watermarks)
+		t.Fatalf("expected legacy virtual key migration to preserve watermarks, got %+v", watermarks)
 	}
 }
 
@@ -333,13 +333,13 @@ func TestRefreshLivePositionWatermarksClearsStateWhenPositionIsInactive(t *testi
 		t.Fatalf("expected empty watermarks for inactive position, got %+v", watermarks)
 	}
 	if got := stringValue(sessionState["watermarkPositionKey"]); got != "position-1|BTCUSDT|LONG|50000.00000000" {
-		t.Fatalf("expected inactive refresh to preserve existing watermark key, got %s", got)
+		t.Fatalf("expected generic inactive refresh to preserve existing watermark key, got %s", got)
 	}
 	if got := parseFloatValue(sessionState["hwm"]); got != 52000.0 {
-		t.Fatalf("expected inactive refresh to preserve HWM, got %v", got)
+		t.Fatalf("expected generic inactive refresh to preserve HWM, got %v", got)
 	}
 	if got := parseFloatValue(sessionState["lwm"]); got != 50000.0 {
-		t.Fatalf("expected inactive refresh to preserve LWM, got %v", got)
+		t.Fatalf("expected generic inactive refresh to preserve LWM, got %v", got)
 	}
 }
 
@@ -358,11 +358,65 @@ func TestResolveLivePositionWatermarksSupportsLegacyRealPositionKey(t *testing.T
 		"found":      true,
 	}
 	watermarks := resolveLivePositionWatermarks(currentPosition, sessionState)
-	if got := watermarks.PositionKey; got != "LONG|50000.00000000" {
-		t.Fatalf("expected legacy real-position watermark key to remain stable during migration, got %s", got)
+	if got := watermarks.PositionKey; got != "position-1|BTCUSDT|LONG|50000.00000000" {
+		t.Fatalf("expected legacy real-position watermark key to migrate to canonical key, got %s", got)
 	}
-	if watermarks.HWM != 52000.0 || watermarks.LWM != 50000.0 {
-		t.Fatalf("expected legacy real-position key to preserve watermarks, got %+v", watermarks)
+	if watermarks.HWM != 50000.0 || watermarks.LWM != 50000.0 {
+		t.Fatalf("expected legacy real-position key migration to reset watermarks, got %+v", watermarks)
+	}
+}
+
+func TestEvaluateLiveSignalDecisionClearsWatermarksWhenPositionInactive(t *testing.T) {
+	engine := bkStrategyEngine{}
+	context := StrategySignalEvaluationContext{
+		SessionState: map[string]any{
+			"hwm":                  52000.0,
+			"lwm":                  50000.0,
+			"watermarkPositionKey": "position-1|BTCUSDT|LONG|50000.00000000",
+		},
+		ExecutionContext: StrategyExecutionContext{
+			Parameters: map[string]any{
+				"symbol":                     "BTCUSDT",
+				"signalTimeframe":            "1d",
+				"stop_loss_atr":              0.05,
+				"profit_protect_atr":         0.5,
+				"trailing_stop_atr":          0.3,
+				"signalDecisionMaxSpreadBps": 8.0,
+			},
+		},
+		NextPlannedRole: "entry",
+		NextPlannedSide: "BUY",
+	}
+	sourceStates := map[string]any{}
+	trigger := map[string]any{"price": 50000.0, "role": "trigger", "symbol": "BTCUSDT"}
+	signalBarState := map[string]any{
+		"atr14":    1000.0,
+		"current":  map[string]any{"close": 50000.0},
+		"prevBar1": map[string]any{"high": 50500.0, "low": 49500.0},
+		"prevBar2": map[string]any{"high": 50600.0, "low": 49400.0},
+	}
+	currentPosition := map[string]any{
+		"symbol":   "BTCUSDT",
+		"quantity": 0.0,
+		"found":    false,
+	}
+	context.TriggerSummary = trigger
+	context.SourceStates = sourceStates
+	context.SignalBarStates = map[string]any{
+		signalBindingMatchKey("binance-kline", "signal", "BTCUSDT"): signalBarState,
+	}
+	context.CurrentPosition = currentPosition
+	if _, err := engine.EvaluateSignal(context); err != nil {
+		t.Fatalf("evaluate signal failed: %v", err)
+	}
+	if _, ok := context.SessionState["watermarkPositionKey"]; ok {
+		t.Fatal("expected inactive strategy evaluation to clear watermarkPositionKey")
+	}
+	if _, ok := context.SessionState["hwm"]; ok {
+		t.Fatal("expected inactive strategy evaluation to clear hwm")
+	}
+	if _, ok := context.SessionState["lwm"]; ok {
+		t.Fatal("expected inactive strategy evaluation to clear lwm")
 	}
 }
 
@@ -472,7 +526,7 @@ func TestResolveLivePositionWatermarksIgnoresQuantityChangesWithinSamePosition(t
 	sessionState := map[string]any{
 		"hwm":                  52000.0,
 		"lwm":                  50000.0,
-		"watermarkPositionKey": "position-1|BTCUSDT|LONG",
+		"watermarkPositionKey": "position-1|BTCUSDT|LONG|50000.00000000",
 	}
 	currentPosition := map[string]any{
 		"id":         "position-1",
@@ -483,7 +537,7 @@ func TestResolveLivePositionWatermarksIgnoresQuantityChangesWithinSamePosition(t
 		"found":      true,
 	}
 	watermarks := resolveLivePositionWatermarks(currentPosition, sessionState)
-	if got := watermarks.PositionKey; got != "position-1|BTCUSDT|LONG" {
+	if got := watermarks.PositionKey; got != "position-1|BTCUSDT|LONG|50000.00000000" {
 		t.Fatalf("expected quantity changes to keep the same watermark key, got %s", got)
 	}
 	if watermarks.HWM != 52000.0 || watermarks.LWM != 50000.0 {

--- a/internal/service/strategy_registry.go
+++ b/internal/service/strategy_registry.go
@@ -745,21 +745,19 @@ type livePositionWatermarks struct {
 }
 
 func buildLivePositionWatermarkKey(currentPosition map[string]any) string {
+	if positionID := strings.TrimSpace(stringValue(currentPosition["id"])); positionID != "" {
+		return positionID
+	}
 	entryPrice := parseFloatValue(currentPosition["entryPrice"])
 	side := strings.ToUpper(strings.TrimSpace(stringValue(currentPosition["side"])))
 	if entryPrice <= 0 || side == "" {
 		return ""
 	}
-	parts := make([]string, 0, 5)
+	parts := make([]string, 0, 3)
 	if symbol := NormalizeSymbol(stringValue(currentPosition["symbol"])); symbol != "" {
 		parts = append(parts, symbol)
 	}
 	parts = append(parts, side, fmt.Sprintf("%.8f", entryPrice))
-	if updatedAt := strings.TrimSpace(stringValue(currentPosition["updatedAt"])); updatedAt != "" {
-		parts = append(parts, updatedAt)
-	} else if qty := parseFloatValue(currentPosition["quantity"]); qty > 0 {
-		parts = append(parts, fmt.Sprintf("%.8f", qty))
-	}
 	return strings.Join(parts, "|")
 }
 
@@ -936,11 +934,8 @@ func deriveLivePositionState(parameters map[string]any, currentPosition map[stri
 	}
 }
 
-func updateLivePositionWatermarks(sessionState map[string]any, side string, entryPrice, marketPrice float64) (float64, float64) {
-	watermarks := refreshLivePositionWatermarks(sessionState, map[string]any{
-		"side":       side,
-		"entryPrice": entryPrice,
-	}, marketPrice)
+func updateLivePositionWatermarks(sessionState map[string]any, currentPosition map[string]any, marketPrice float64) (float64, float64) {
+	watermarks := refreshLivePositionWatermarks(sessionState, currentPosition, marketPrice)
 	return watermarks.HWM, watermarks.LWM
 }
 

--- a/internal/service/strategy_registry.go
+++ b/internal/service/strategy_registry.go
@@ -744,13 +744,35 @@ type livePositionWatermarks struct {
 	LWM         float64
 }
 
+func buildLivePositionWatermarkKey(currentPosition map[string]any) string {
+	entryPrice := parseFloatValue(currentPosition["entryPrice"])
+	side := strings.ToUpper(strings.TrimSpace(stringValue(currentPosition["side"])))
+	if entryPrice <= 0 || side == "" {
+		return ""
+	}
+	parts := make([]string, 0, 5)
+	if symbol := NormalizeSymbol(stringValue(currentPosition["symbol"])); symbol != "" {
+		parts = append(parts, symbol)
+	}
+	parts = append(parts, side, fmt.Sprintf("%.8f", entryPrice))
+	if updatedAt := strings.TrimSpace(stringValue(currentPosition["updatedAt"])); updatedAt != "" {
+		parts = append(parts, updatedAt)
+	} else if qty := parseFloatValue(currentPosition["quantity"]); qty > 0 {
+		parts = append(parts, fmt.Sprintf("%.8f", qty))
+	}
+	return strings.Join(parts, "|")
+}
+
 func resolveLivePositionWatermarks(currentPosition map[string]any, sessionState map[string]any) livePositionWatermarks {
 	entryPrice := parseFloatValue(currentPosition["entryPrice"])
 	side := strings.ToUpper(strings.TrimSpace(stringValue(currentPosition["side"])))
 	if entryPrice <= 0 || side == "" {
 		return livePositionWatermarks{}
 	}
-	positionKey := fmt.Sprintf("%s|%.8f", side, entryPrice)
+	positionKey := buildLivePositionWatermarkKey(currentPosition)
+	if positionKey == "" {
+		return livePositionWatermarks{}
+	}
 	hwm := parseFloatValue(sessionState["hwm"])
 	if hwm == 0 {
 		hwm = entryPrice

--- a/internal/service/strategy_registry.go
+++ b/internal/service/strategy_registry.go
@@ -230,6 +230,8 @@ func (e bkStrategyEngine) EvaluateSignal(context StrategySignalEvaluationContext
 		var watermarks livePositionWatermarks
 		if hasActiveLivePositionSnapshot(currentPosition) {
 			watermarks = refreshLivePositionWatermarks(context.SessionState, currentPosition, marketPrice)
+		} else {
+			clearLivePositionWatermarks(context.SessionState)
 		}
 		livePositionState = deriveLivePositionState(context.ExecutionContext.Parameters, currentPosition, signalBarState, marketPrice, watermarks)
 		if strings.EqualFold(strings.TrimSpace(context.NextPlannedRole), "exit") {
@@ -782,10 +784,11 @@ func buildLivePositionWatermarkKey(currentPosition map[string]any, sessionState 
 	lastKey := stringValue(sessionState["watermarkPositionKey"])
 	legacyBaseKey := buildLegacyLivePositionWatermarkKey(currentPosition)
 	if positionID := strings.TrimSpace(stringValue(currentPosition["id"])); positionID != "" {
-		if lastKey == positionID || strings.HasPrefix(lastKey, positionID+"|") || lastKey == baseKey || lastKey == legacyBaseKey {
-			return lastKey
+		currentKey := positionID + "|" + baseKey
+		if lastKey == positionID || strings.HasPrefix(lastKey, positionID+"|") {
+			return currentKey
 		}
-		return positionID + "|" + baseKey
+		return currentKey
 	}
 	if lastKey != "" {
 		if lastKey == baseKey || lastKey == legacyBaseKey || strings.HasSuffix(lastKey, "|"+baseKey) || strings.HasSuffix(lastKey, "|"+legacyBaseKey) {

--- a/internal/service/strategy_registry.go
+++ b/internal/service/strategy_registry.go
@@ -748,24 +748,39 @@ type livePositionWatermarks struct {
 }
 
 func hasActiveLivePositionSnapshot(currentPosition map[string]any) bool {
-	return boolValue(currentPosition["found"]) || parseFloatValue(currentPosition["quantity"]) > 0 || boolValue(currentPosition["virtual"])
+	return boolValue(currentPosition["found"]) || math.Abs(parseFloatValue(currentPosition["quantity"])) > 0 || boolValue(currentPosition["virtual"])
 }
 
-func buildLivePositionWatermarkKey(currentPosition map[string]any) string {
+func buildLivePositionWatermarkBaseKey(currentPosition map[string]any) string {
 	entryPrice := parseFloatValue(currentPosition["entryPrice"])
 	side := strings.ToUpper(strings.TrimSpace(stringValue(currentPosition["side"])))
 	if entryPrice <= 0 || side == "" {
 		return ""
 	}
-	parts := make([]string, 0, 4)
-	if positionID := strings.TrimSpace(stringValue(currentPosition["id"])); positionID != "" {
-		parts = append(parts, positionID)
-	}
+	parts := make([]string, 0, 3)
 	if symbol := NormalizeSymbol(stringValue(currentPosition["symbol"])); symbol != "" {
 		parts = append(parts, symbol)
 	}
 	parts = append(parts, side, fmt.Sprintf("%.8f", entryPrice))
 	return strings.Join(parts, "|")
+}
+
+func buildLivePositionWatermarkKey(currentPosition map[string]any, sessionState map[string]any) string {
+	baseKey := buildLivePositionWatermarkBaseKey(currentPosition)
+	if baseKey == "" {
+		return ""
+	}
+	if positionID := strings.TrimSpace(stringValue(currentPosition["id"])); positionID != "" {
+		return positionID + "|" + baseKey
+	}
+	lastKey := stringValue(sessionState["watermarkPositionKey"])
+	if lastKey == "" {
+		return baseKey
+	}
+	if lastKey == baseKey || strings.HasSuffix(lastKey, "|"+baseKey) {
+		return lastKey
+	}
+	return baseKey
 }
 
 func resolveLivePositionWatermarks(currentPosition map[string]any, sessionState map[string]any) livePositionWatermarks {
@@ -777,7 +792,7 @@ func resolveLivePositionWatermarks(currentPosition map[string]any, sessionState 
 	if entryPrice <= 0 || side == "" {
 		return livePositionWatermarks{}
 	}
-	positionKey := buildLivePositionWatermarkKey(currentPosition)
+	positionKey := buildLivePositionWatermarkKey(currentPosition, sessionState)
 	if positionKey == "" {
 		return livePositionWatermarks{}
 	}

--- a/internal/service/strategy_registry.go
+++ b/internal/service/strategy_registry.go
@@ -230,6 +230,8 @@ func (e bkStrategyEngine) EvaluateSignal(context StrategySignalEvaluationContext
 		var watermarks livePositionWatermarks
 		if hasActiveLivePositionSnapshot(currentPosition) {
 			watermarks = refreshLivePositionWatermarks(context.SessionState, currentPosition, marketPrice)
+		} else {
+			clearLivePositionWatermarks(context.SessionState)
 		}
 		livePositionState = deriveLivePositionState(context.ExecutionContext.Parameters, currentPosition, signalBarState, marketPrice, watermarks)
 		if strings.EqualFold(strings.TrimSpace(context.NextPlannedRole), "exit") {
@@ -752,16 +754,26 @@ func hasActiveLivePositionSnapshot(currentPosition map[string]any) bool {
 }
 
 func buildLivePositionWatermarkBaseKey(currentPosition map[string]any) string {
+	entryPrice := parseFloatValue(currentPosition["entryPrice"])
 	side := strings.ToUpper(strings.TrimSpace(stringValue(currentPosition["side"])))
-	if side == "" {
+	if entryPrice <= 0 || side == "" {
 		return ""
 	}
-	parts := make([]string, 0, 2)
+	parts := make([]string, 0, 3)
 	if symbol := NormalizeSymbol(stringValue(currentPosition["symbol"])); symbol != "" {
 		parts = append(parts, symbol)
 	}
-	parts = append(parts, side)
+	parts = append(parts, side, fmt.Sprintf("%.8f", entryPrice))
 	return strings.Join(parts, "|")
+}
+
+func buildLegacyLivePositionWatermarkKey(currentPosition map[string]any) string {
+	entryPrice := parseFloatValue(currentPosition["entryPrice"])
+	side := strings.ToUpper(strings.TrimSpace(stringValue(currentPosition["side"])))
+	if entryPrice <= 0 || side == "" {
+		return ""
+	}
+	return strings.Join([]string{side, fmt.Sprintf("%.8f", entryPrice)}, "|")
 }
 
 func buildLivePositionWatermarkKey(currentPosition map[string]any, sessionState map[string]any) string {
@@ -770,11 +782,15 @@ func buildLivePositionWatermarkKey(currentPosition map[string]any, sessionState 
 		return ""
 	}
 	lastKey := stringValue(sessionState["watermarkPositionKey"])
+	legacyBaseKey := buildLegacyLivePositionWatermarkKey(currentPosition)
 	if positionID := strings.TrimSpace(stringValue(currentPosition["id"])); positionID != "" {
+		if lastKey == positionID || strings.HasPrefix(lastKey, positionID+"|") || lastKey == baseKey || lastKey == legacyBaseKey {
+			return lastKey
+		}
 		return positionID + "|" + baseKey
 	}
 	if lastKey != "" {
-		if lastKey == baseKey || strings.HasSuffix(lastKey, "|"+baseKey) {
+		if lastKey == baseKey || lastKey == legacyBaseKey || strings.HasSuffix(lastKey, "|"+baseKey) || strings.HasSuffix(lastKey, "|"+legacyBaseKey) {
 			return lastKey
 		}
 	}

--- a/internal/service/strategy_registry.go
+++ b/internal/service/strategy_registry.go
@@ -227,9 +227,10 @@ func (e bkStrategyEngine) EvaluateSignal(context StrategySignalEvaluationContext
 	effectivePlannedPrice := context.NextPlannedPrice
 	livePositionState := map[string]any{}
 	if signalBarState != nil {
-		livePositionState = evaluateLivePositionState(context.ExecutionContext.Parameters, currentPosition, signalBarState, marketPrice, context.SessionState)
+		watermarks := refreshLivePositionWatermarks(context.SessionState, currentPosition, marketPrice)
+		livePositionState = deriveLivePositionState(context.ExecutionContext.Parameters, currentPosition, signalBarState, marketPrice, watermarks)
 		if strings.EqualFold(strings.TrimSpace(context.NextPlannedRole), "exit") {
-			livePositionState = evaluateLiveExitState(context.ExecutionContext.Parameters, currentPosition, signalBarState, marketPrice, context.SessionState, context.NextPlannedReason)
+			livePositionState = deriveLiveExitState(context.ExecutionContext.Parameters, currentPosition, livePositionState, marketPrice, context.NextPlannedReason)
 		}
 		if len(livePositionState) > 0 {
 			mergedPosition := cloneMetadata(currentPosition)
@@ -737,10 +738,82 @@ func computePriceProximityBps(plannedPrice, marketPrice float64) float64 {
 	return math.Abs(marketPrice/plannedPrice-1) * 10000
 }
 
+type livePositionWatermarks struct {
+	PositionKey string
+	HWM         float64
+	LWM         float64
+}
+
+func resolveLivePositionWatermarks(currentPosition map[string]any, sessionState map[string]any) livePositionWatermarks {
+	entryPrice := parseFloatValue(currentPosition["entryPrice"])
+	side := strings.ToUpper(strings.TrimSpace(stringValue(currentPosition["side"])))
+	if entryPrice <= 0 || side == "" {
+		return livePositionWatermarks{}
+	}
+	positionKey := fmt.Sprintf("%s|%.8f", side, entryPrice)
+	hwm := parseFloatValue(sessionState["hwm"])
+	if hwm == 0 {
+		hwm = entryPrice
+	}
+	lwm := parseFloatValue(sessionState["lwm"])
+	if lwm == 0 {
+		lwm = entryPrice
+	}
+	if lastKey := stringValue(sessionState["watermarkPositionKey"]); lastKey != positionKey {
+		hwm = entryPrice
+		lwm = entryPrice
+	}
+	return livePositionWatermarks{
+		PositionKey: positionKey,
+		HWM:         hwm,
+		LWM:         lwm,
+	}
+}
+
+func advanceLivePositionWatermarks(watermarks livePositionWatermarks, marketPrice float64) livePositionWatermarks {
+	if marketPrice <= 0 {
+		return watermarks
+	}
+	if watermarks.HWM == 0 {
+		watermarks.HWM = marketPrice
+	}
+	if watermarks.LWM == 0 {
+		watermarks.LWM = marketPrice
+	}
+	if marketPrice > watermarks.HWM {
+		watermarks.HWM = marketPrice
+	}
+	if marketPrice < watermarks.LWM {
+		watermarks.LWM = marketPrice
+	}
+	return watermarks
+}
+
+func applyLivePositionWatermarks(sessionState map[string]any, watermarks livePositionWatermarks) {
+	if sessionState == nil || watermarks.PositionKey == "" {
+		return
+	}
+	sessionState["watermarkPositionKey"] = watermarks.PositionKey
+	sessionState["hwm"] = watermarks.HWM
+	sessionState["lwm"] = watermarks.LWM
+}
+
+func refreshLivePositionWatermarks(sessionState map[string]any, currentPosition map[string]any, marketPrice float64) livePositionWatermarks {
+	watermarks := resolveLivePositionWatermarks(currentPosition, sessionState)
+	watermarks = advanceLivePositionWatermarks(watermarks, marketPrice)
+	applyLivePositionWatermarks(sessionState, watermarks)
+	return watermarks
+}
+
 // evaluateLivePositionState derives the current live position risk state.
 // When sessionState is provided, it also refreshes HWM/LWM watermarks used by
 // trailing-stop logic so callers do not need to duplicate watermark handling.
 func evaluateLivePositionState(parameters map[string]any, currentPosition map[string]any, signalBarState map[string]any, marketPrice float64, sessionState map[string]any) map[string]any {
+	watermarks := refreshLivePositionWatermarks(sessionState, currentPosition, marketPrice)
+	return deriveLivePositionState(parameters, currentPosition, signalBarState, marketPrice, watermarks)
+}
+
+func deriveLivePositionState(parameters map[string]any, currentPosition map[string]any, signalBarState map[string]any, marketPrice float64, watermarks livePositionWatermarks) map[string]any {
 	if !boolValue(currentPosition["found"]) && parseFloatValue(currentPosition["quantity"]) <= 0 && !boolValue(currentPosition["virtual"]) {
 		return nil
 	}
@@ -774,8 +847,8 @@ func evaluateLivePositionState(parameters map[string]any, currentPosition map[st
 	if stopLoss <= 0 {
 		stopLoss = resolveStopPrice(side, entryPrice, sig, stopMode, stopLossATR)
 	}
-
-	hwm, lwm := updateLivePositionWatermarks(sessionState, side, entryPrice, marketPrice)
+	hwm := firstPositive(watermarks.HWM, entryPrice)
+	lwm := firstPositive(watermarks.LWM, entryPrice)
 
 	// Calculate Trailing Stop Loss
 	if trailingStopATR := parseFloatValue(parameters["trailing_stop_atr"]); trailingStopATR > 0 {
@@ -824,54 +897,38 @@ func evaluateLivePositionState(parameters map[string]any, currentPosition map[st
 		}
 	}
 	return map[string]any{
-		"found":             true,
-		"symbol":            NormalizeSymbol(stringValue(currentPosition["symbol"])),
-		"side":              strings.ToUpper(side),
-		"entryPrice":        entryPrice,
-		"stopLoss":          stopLoss,
-		"protected":         protected,
-		"protectionTrigger": protectionPrice,
-		"prevHigh1":         sig.PrevHigh1,
-		"prevLow1":          sig.PrevLow1,
-		"atr14":             sig.ATR,
-		"profitProtectATR":  profitProtectATR,
+		"found":                true,
+		"symbol":               NormalizeSymbol(stringValue(currentPosition["symbol"])),
+		"side":                 strings.ToUpper(side),
+		"entryPrice":           entryPrice,
+		"stopLoss":             stopLoss,
+		"protected":            protected,
+		"protectionTrigger":    protectionPrice,
+		"prevHigh1":            sig.PrevHigh1,
+		"prevLow1":             sig.PrevLow1,
+		"atr14":                sig.ATR,
+		"profitProtectATR":     profitProtectATR,
+		"hwm":                  hwm,
+		"lwm":                  lwm,
+		"watermarkPositionKey": watermarks.PositionKey,
 	}
 }
 
 func updateLivePositionWatermarks(sessionState map[string]any, side string, entryPrice, marketPrice float64) (float64, float64) {
-	positionKey := fmt.Sprintf("%s|%.8f", strings.ToUpper(strings.TrimSpace(side)), entryPrice)
-	if sessionState != nil {
-		if lastKey := stringValue(sessionState["watermarkPositionKey"]); lastKey != positionKey {
-			sessionState["hwm"] = entryPrice
-			sessionState["lwm"] = entryPrice
-			sessionState["watermarkPositionKey"] = positionKey
-		}
-	}
-	hwm := parseFloatValue(sessionState["hwm"])
-	if hwm == 0 {
-		hwm = entryPrice
-	}
-	lwm := parseFloatValue(sessionState["lwm"])
-	if lwm == 0 {
-		lwm = entryPrice
-	}
-	if marketPrice > 0 {
-		if marketPrice > hwm {
-			hwm = marketPrice
-		}
-		if marketPrice < lwm {
-			lwm = marketPrice
-		}
-		if sessionState != nil {
-			sessionState["hwm"] = hwm
-			sessionState["lwm"] = lwm
-		}
-	}
-	return hwm, lwm
+	watermarks := refreshLivePositionWatermarks(sessionState, map[string]any{
+		"side":       side,
+		"entryPrice": entryPrice,
+	}, marketPrice)
+	return watermarks.HWM, watermarks.LWM
 }
 
 func evaluateLiveExitState(parameters map[string]any, currentPosition map[string]any, signalBarState map[string]any, marketPrice float64, sessionState map[string]any, nextReason string) map[string]any {
-	positionState := evaluateLivePositionState(parameters, currentPosition, signalBarState, marketPrice, sessionState)
+	watermarks := refreshLivePositionWatermarks(sessionState, currentPosition, marketPrice)
+	positionState := deriveLivePositionState(parameters, currentPosition, signalBarState, marketPrice, watermarks)
+	return deriveLiveExitState(parameters, currentPosition, positionState, marketPrice, nextReason)
+}
+
+func deriveLiveExitState(parameters map[string]any, currentPosition map[string]any, positionState map[string]any, marketPrice float64, nextReason string) map[string]any {
 	if len(positionState) == 0 {
 		return map[string]any{
 			"ready":      false,

--- a/internal/service/strategy_registry.go
+++ b/internal/service/strategy_registry.go
@@ -753,12 +753,11 @@ func hasActiveLivePositionSnapshot(currentPosition map[string]any) bool {
 
 func buildLivePositionWatermarkKey(currentPosition map[string]any) string {
 	entryPrice := parseFloatValue(currentPosition["entryPrice"])
-	quantity := parseFloatValue(currentPosition["quantity"])
 	side := strings.ToUpper(strings.TrimSpace(stringValue(currentPosition["side"])))
 	if entryPrice <= 0 || side == "" {
 		return ""
 	}
-	parts := make([]string, 0, 6)
+	parts := make([]string, 0, 4)
 	if positionID := strings.TrimSpace(stringValue(currentPosition["id"])); positionID != "" {
 		parts = append(parts, positionID)
 	}
@@ -766,12 +765,6 @@ func buildLivePositionWatermarkKey(currentPosition map[string]any) string {
 		parts = append(parts, symbol)
 	}
 	parts = append(parts, side, fmt.Sprintf("%.8f", entryPrice))
-	if quantity > 0 {
-		parts = append(parts, fmt.Sprintf("%.8f", quantity))
-	}
-	if recordedAt := firstNonEmpty(stringValue(currentPosition["recordedAt"]), stringValue(currentPosition["openedAt"])); recordedAt != "" {
-		parts = append(parts, recordedAt)
-	}
 	return strings.Join(parts, "|")
 }
 

--- a/internal/service/strategy_registry.go
+++ b/internal/service/strategy_registry.go
@@ -227,7 +227,10 @@ func (e bkStrategyEngine) EvaluateSignal(context StrategySignalEvaluationContext
 	effectivePlannedPrice := context.NextPlannedPrice
 	livePositionState := map[string]any{}
 	if signalBarState != nil {
-		watermarks := refreshLivePositionWatermarks(context.SessionState, currentPosition, marketPrice)
+		var watermarks livePositionWatermarks
+		if hasActiveLivePositionSnapshot(currentPosition) {
+			watermarks = refreshLivePositionWatermarks(context.SessionState, currentPosition, marketPrice)
+		}
 		livePositionState = deriveLivePositionState(context.ExecutionContext.Parameters, currentPosition, signalBarState, marketPrice, watermarks)
 		if strings.EqualFold(strings.TrimSpace(context.NextPlannedRole), "exit") {
 			livePositionState = deriveLiveExitState(context.ExecutionContext.Parameters, currentPosition, livePositionState, marketPrice, context.NextPlannedReason)
@@ -744,24 +747,38 @@ type livePositionWatermarks struct {
 	LWM         float64
 }
 
+func hasActiveLivePositionSnapshot(currentPosition map[string]any) bool {
+	return boolValue(currentPosition["found"]) || parseFloatValue(currentPosition["quantity"]) > 0 || boolValue(currentPosition["virtual"])
+}
+
 func buildLivePositionWatermarkKey(currentPosition map[string]any) string {
-	if positionID := strings.TrimSpace(stringValue(currentPosition["id"])); positionID != "" {
-		return positionID
-	}
 	entryPrice := parseFloatValue(currentPosition["entryPrice"])
+	quantity := parseFloatValue(currentPosition["quantity"])
 	side := strings.ToUpper(strings.TrimSpace(stringValue(currentPosition["side"])))
 	if entryPrice <= 0 || side == "" {
 		return ""
 	}
-	parts := make([]string, 0, 3)
+	parts := make([]string, 0, 6)
+	if positionID := strings.TrimSpace(stringValue(currentPosition["id"])); positionID != "" {
+		parts = append(parts, positionID)
+	}
 	if symbol := NormalizeSymbol(stringValue(currentPosition["symbol"])); symbol != "" {
 		parts = append(parts, symbol)
 	}
 	parts = append(parts, side, fmt.Sprintf("%.8f", entryPrice))
+	if quantity > 0 {
+		parts = append(parts, fmt.Sprintf("%.8f", quantity))
+	}
+	if recordedAt := firstNonEmpty(stringValue(currentPosition["recordedAt"]), stringValue(currentPosition["openedAt"])); recordedAt != "" {
+		parts = append(parts, recordedAt)
+	}
 	return strings.Join(parts, "|")
 }
 
 func resolveLivePositionWatermarks(currentPosition map[string]any, sessionState map[string]any) livePositionWatermarks {
+	if !hasActiveLivePositionSnapshot(currentPosition) {
+		return livePositionWatermarks{}
+	}
 	entryPrice := parseFloatValue(currentPosition["entryPrice"])
 	side := strings.ToUpper(strings.TrimSpace(stringValue(currentPosition["side"])))
 	if entryPrice <= 0 || side == "" {
@@ -829,7 +846,10 @@ func refreshLivePositionWatermarks(sessionState map[string]any, currentPosition 
 // When sessionState is provided, it also refreshes HWM/LWM watermarks used by
 // trailing-stop logic so callers do not need to duplicate watermark handling.
 func evaluateLivePositionState(parameters map[string]any, currentPosition map[string]any, signalBarState map[string]any, marketPrice float64, sessionState map[string]any) map[string]any {
-	watermarks := refreshLivePositionWatermarks(sessionState, currentPosition, marketPrice)
+	var watermarks livePositionWatermarks
+	if hasActiveLivePositionSnapshot(currentPosition) {
+		watermarks = refreshLivePositionWatermarks(sessionState, currentPosition, marketPrice)
+	}
 	return deriveLivePositionState(parameters, currentPosition, signalBarState, marketPrice, watermarks)
 }
 

--- a/internal/service/strategy_registry.go
+++ b/internal/service/strategy_registry.go
@@ -230,8 +230,6 @@ func (e bkStrategyEngine) EvaluateSignal(context StrategySignalEvaluationContext
 		var watermarks livePositionWatermarks
 		if hasActiveLivePositionSnapshot(currentPosition) {
 			watermarks = refreshLivePositionWatermarks(context.SessionState, currentPosition, marketPrice)
-		} else {
-			clearLivePositionWatermarks(context.SessionState)
 		}
 		livePositionState = deriveLivePositionState(context.ExecutionContext.Parameters, currentPosition, signalBarState, marketPrice, watermarks)
 		if strings.EqualFold(strings.TrimSpace(context.NextPlannedRole), "exit") {
@@ -875,7 +873,6 @@ func applyLivePositionWatermarks(sessionState map[string]any, watermarks livePos
 
 func refreshLivePositionWatermarks(sessionState map[string]any, currentPosition map[string]any, marketPrice float64) livePositionWatermarks {
 	if !hasActiveLivePositionSnapshot(currentPosition) {
-		clearLivePositionWatermarks(sessionState)
 		return livePositionWatermarks{}
 	}
 	watermarks := resolveLivePositionWatermarks(currentPosition, sessionState)

--- a/internal/service/strategy_registry.go
+++ b/internal/service/strategy_registry.go
@@ -770,15 +770,17 @@ func buildLivePositionWatermarkKey(currentPosition map[string]any, sessionState 
 	if baseKey == "" {
 		return ""
 	}
+	lastKey := stringValue(sessionState["watermarkPositionKey"])
+	if lastKey != "" {
+		if lastKey == baseKey || strings.HasSuffix(lastKey, "|"+baseKey) {
+			return lastKey
+		}
+		if positionID := strings.TrimSpace(stringValue(currentPosition["id"])); positionID != "" && lastKey == positionID {
+			return lastKey
+		}
+	}
 	if positionID := strings.TrimSpace(stringValue(currentPosition["id"])); positionID != "" {
 		return positionID + "|" + baseKey
-	}
-	lastKey := stringValue(sessionState["watermarkPositionKey"])
-	if lastKey == "" {
-		return baseKey
-	}
-	if lastKey == baseKey || strings.HasSuffix(lastKey, "|"+baseKey) {
-		return lastKey
 	}
 	return baseKey
 }

--- a/internal/service/strategy_registry.go
+++ b/internal/service/strategy_registry.go
@@ -752,16 +752,15 @@ func hasActiveLivePositionSnapshot(currentPosition map[string]any) bool {
 }
 
 func buildLivePositionWatermarkBaseKey(currentPosition map[string]any) string {
-	entryPrice := parseFloatValue(currentPosition["entryPrice"])
 	side := strings.ToUpper(strings.TrimSpace(stringValue(currentPosition["side"])))
-	if entryPrice <= 0 || side == "" {
+	if side == "" {
 		return ""
 	}
-	parts := make([]string, 0, 3)
+	parts := make([]string, 0, 2)
 	if symbol := NormalizeSymbol(stringValue(currentPosition["symbol"])); symbol != "" {
 		parts = append(parts, symbol)
 	}
-	parts = append(parts, side, fmt.Sprintf("%.8f", entryPrice))
+	parts = append(parts, side)
 	return strings.Join(parts, "|")
 }
 
@@ -771,18 +770,24 @@ func buildLivePositionWatermarkKey(currentPosition map[string]any, sessionState 
 		return ""
 	}
 	lastKey := stringValue(sessionState["watermarkPositionKey"])
+	if positionID := strings.TrimSpace(stringValue(currentPosition["id"])); positionID != "" {
+		return positionID + "|" + baseKey
+	}
 	if lastKey != "" {
 		if lastKey == baseKey || strings.HasSuffix(lastKey, "|"+baseKey) {
 			return lastKey
 		}
-		if positionID := strings.TrimSpace(stringValue(currentPosition["id"])); positionID != "" && lastKey == positionID {
-			return lastKey
-		}
-	}
-	if positionID := strings.TrimSpace(stringValue(currentPosition["id"])); positionID != "" {
-		return positionID + "|" + baseKey
 	}
 	return baseKey
+}
+
+func clearLivePositionWatermarks(sessionState map[string]any) {
+	if sessionState == nil {
+		return
+	}
+	delete(sessionState, "watermarkPositionKey")
+	delete(sessionState, "hwm")
+	delete(sessionState, "lwm")
 }
 
 func resolveLivePositionWatermarks(currentPosition map[string]any, sessionState map[string]any) livePositionWatermarks {
@@ -807,6 +812,13 @@ func resolveLivePositionWatermarks(currentPosition map[string]any, sessionState 
 		lwm = entryPrice
 	}
 	if lastKey := stringValue(sessionState["watermarkPositionKey"]); lastKey != positionKey {
+		if currentID := strings.TrimSpace(stringValue(currentPosition["id"])); currentID != "" && lastKey == currentID {
+			return livePositionWatermarks{
+				PositionKey: positionKey,
+				HWM:         hwm,
+				LWM:         lwm,
+			}
+		}
 		hwm = entryPrice
 		lwm = entryPrice
 	}
@@ -846,6 +858,10 @@ func applyLivePositionWatermarks(sessionState map[string]any, watermarks livePos
 }
 
 func refreshLivePositionWatermarks(sessionState map[string]any, currentPosition map[string]any, marketPrice float64) livePositionWatermarks {
+	if !hasActiveLivePositionSnapshot(currentPosition) {
+		clearLivePositionWatermarks(sessionState)
+		return livePositionWatermarks{}
+	}
 	watermarks := resolveLivePositionWatermarks(currentPosition, sessionState)
 	watermarks = advanceLivePositionWatermarks(watermarks, marketPrice)
 	applyLivePositionWatermarks(sessionState, watermarks)
@@ -859,6 +875,8 @@ func evaluateLivePositionState(parameters map[string]any, currentPosition map[st
 	var watermarks livePositionWatermarks
 	if hasActiveLivePositionSnapshot(currentPosition) {
 		watermarks = refreshLivePositionWatermarks(sessionState, currentPosition, marketPrice)
+	} else {
+		clearLivePositionWatermarks(sessionState)
 	}
 	return deriveLivePositionState(parameters, currentPosition, signalBarState, marketPrice, watermarks)
 }


### PR DESCRIPTION
## Summary
- add execution normalization telemetry so raw sizing vs normalized exchange order parameters are observable
- make SL protection pricing depth-aware with top-of-book coverage telemetry
- separate watermark refresh from live position/exit state derivation for cleaner trailing-stop boundaries

## Testing
- go test ./internal/service/...
- go test ./...