### PR TITLE
feat: support dynamic frontend api base via env and CD variables

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Build frontend
         env:
-          VITE_API_BASE: ""
+          VITE_API_BASE: ${{ vars.VITE_API_BASE || secrets.VITE_API_BASE }}
         run: npm run build
 
       - name: Validate remote frontend directory

--- a/web/console/vite.config.ts
+++ b/web/console/vite.config.ts
@@ -4,6 +4,7 @@ import tailwindcss from '@tailwindcss/vite';
 
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  envDir: '../../',
   server: {
     proxy: {
       '/api': {


### PR DESCRIPTION
This PR enables the frontend to read the API base URL from the root .env file (using Vite's envDir) and allows the CD process to inject the API base URL via GitHub variables or secrets.