### PR TITLE
Follow up execution normalization, SL protection, and watermark boundaries

### DIFF
--- a/docs/20260403改进计划_plan.md
+++ b/docs/20260403改进计划_plan.md
@@ -1,5 +1,76 @@
 # bkTrader 项目 Review 与 README 中文化
 
+## 2026-04 Execution Engine Follow-up
+
+这部分是基于 PR #17 reviewer 最终 `APPROVED` 后保留下来的后续优化方向。它们已经不属于当前必须阻塞合并的问题，但建议作为下一阶段核心执行链路优化来跟进。
+
+### 1. volatility-adjusted sizing 与交易所约束统一落地
+
+当前 `volatility_adjusted` 仓位已经按 ATR 和真实止损距离计算目标数量，但后续仍建议继续明确“理论 quantity -> 交易所可提交 quantity”的归一化链路。
+
+建议收口为一条显式路径：
+- 先计算 `rawQuantity`
+- 再统一经过 `stepSize / minQty / minNotional / tickSize` 归一化
+- 在 execution telemetry 中同时记录：
+  - `rawQuantity`
+  - `normalizedQuantity`
+  - `normalizationReason`
+  - `minNotionalAdjusted`
+
+目标：
+- 避免 reviewer 提到的“理论仓位正确，但最终交易所拒单”的灰区
+- 让 testnet / 实盘复盘时能看清楚到底是 sizing 决策问题，还是交易所规则裁剪问题
+
+### 2. SL 保护限价进一步结合 depth
+
+当前 `resolveAggressiveSLProtectionPrice()` 已经从“单边 quote 偏移”改成了基于 `bid/ask` 整段 spread 的保护定价，这一版已经足够安全上线。
+
+后续建议继续升级成 depth-aware 版本，而不是只看 top-of-book：
+- 结合前几档 depth 估算可成交覆盖量
+- 识别极端薄盘口 / quote gap / 虚假 top-of-book
+- 让 SL 保护限价可以根据订单目标数量动态选择更合理的保护区间
+
+建议新增 telemetry：
+- `topDepthNotional`
+- `expectedFillCoverage`
+- `quoteGapBps`
+- `slProtectionDepthMode`
+
+目标：
+- 提高薄盘口和跳价场景下的 SL 保护可靠性
+- 给后续 order book execution 策略优化提供分析数据
+
+### 3. trailing stop / watermark 副作用边界继续收敛
+
+当前 `evaluateLivePositionState(...)` 的副作用风险已经通过 clone 和 `watermarkPositionKey` 重置降低了，但 reviewer 提的方向仍然值得继续推进。
+
+建议后续重构成两段式：
+- `updateLivePositionWatermarks(...)`
+- `evaluateLivePositionState(...)`
+
+其中：
+- 前者只负责刷新持仓上下文相关的 `hwm / lwm / watermarkPositionKey`
+- 后者只负责基于当前 position + signal bar + watermarks 计算保护状态、止损线、PT/SL readiness
+
+目标：
+- 减少 signal evaluation / recovery / replay 之间的状态副作用耦合
+- 让 trailing stop 行为更容易写单元测试和恢复测试
+
+### 建议执行顺序
+
+1. 先做 `volatility_adjusted` 的最终归一化链路和 telemetry
+2. 再做 `SL protection` 的 depth-aware 定价增强
+3. 最后整理 trailing stop / watermark 的副作用边界
+
+### 上线前可接受状态
+
+如果短期目标是先合并并继续 testnet / 实盘观察，那么当前实现已经满足：
+- 可以合并
+- 可以继续监控
+- 不需要为以上 3 项继续阻塞当前 PR
+
+但后续如果要继续提升 execution quality 和 order book 策略迭代效率，建议把这 3 项列为同一阶段的连续任务。
+
 ## 项目总览
 
 bkTrader 是一个 **BTCUSDT 量化交易平台**，包含两部分：

--- a/internal/service/execution_strategy.go
+++ b/internal/service/execution_strategy.go
@@ -112,6 +112,15 @@ type executionProfile struct {
 	SLMaxSlippageBps      float64
 }
 
+type slProtectionDecision struct {
+	Price            float64
+	TopDepthQty      float64
+	TopDepthNotional float64
+	ExpectedCoverage float64
+	QuoteGapBps      float64
+	DepthMode        string
+}
+
 func (bookAwareExecutionStrategy) Key() string {
 	return "book-aware-v1"
 }
@@ -248,7 +257,8 @@ func (bookAwareExecutionStrategy) BuildProposal(ctx ExecutionPlanningContext) (E
 	if profile.ReduceOnly && reasonTag == "sl" {
 		slMaxSlippageBps := firstPositive(profile.SLMaxSlippageBps, 50)
 		if spreadBps > 0 && slMaxSlippageBps > 0 && spreadBps > slMaxSlippageBps {
-			cappedPrice := resolveAggressiveSLProtectionPrice(intent.Side, bestBid, bestAsk, priceHint, slMaxSlippageBps)
+			slProtection := resolveAggressiveSLProtectionDecision(intent.Side, proposal.Quantity, bestBid, bestAsk, bestBidQty, bestAskQty, priceHint, slMaxSlippageBps)
+			cappedPrice := slProtection.Price
 			proposal.Type = "LIMIT"
 			proposal.LimitPrice = cappedPrice
 			proposal.TimeInForce = "GTC"
@@ -263,12 +273,21 @@ func (bookAwareExecutionStrategy) BuildProposal(ctx ExecutionPlanningContext) (E
 			proposal.Metadata["slCappedPrice"] = cappedPrice
 			proposal.Metadata["slOriginalSpreadBps"] = spreadBps
 			proposal.Metadata["slMaxSlippageBps"] = slMaxSlippageBps
+			proposal.Metadata["topDepthNotional"] = slProtection.TopDepthNotional
+			proposal.Metadata["expectedFillCoverage"] = slProtection.ExpectedCoverage
+			proposal.Metadata["quoteGapBps"] = slProtection.QuoteGapBps
+			proposal.Metadata["slProtectionDepthMode"] = slProtection.DepthMode
 			proposal.Metadata["executionDecision"] = "sl-slippage-protected"
 			proposal.Metadata["executionDecisionContext"] = mergeExecutionDecisionContext(
 				mapValue(proposal.Metadata["executionDecisionContext"]),
 				map[string]any{
-					"slProtectionBranch": true,
-					"slProtectionMode":   "spread-capped-limit",
+					"slProtectionBranch":    true,
+					"slProtectionMode":      "spread-capped-limit",
+					"slProtectionDepthMode": slProtection.DepthMode,
+					"topDepthQty":           slProtection.TopDepthQty,
+					"topDepthNotional":      slProtection.TopDepthNotional,
+					"expectedFillCoverage":  slProtection.ExpectedCoverage,
+					"quoteGapBps":           slProtection.QuoteGapBps,
 				},
 			)
 			return proposal, nil
@@ -571,31 +590,74 @@ func resolvePassiveBookPrice(side string, bestBid, bestAsk, fallback float64) fl
 	}
 }
 
-// resolveAggressiveSLProtectionPrice 基于整段盘口 spread 计算 SL 保护限价。
-// 当 spread 已经大于容忍阈值时，不再基于单边 quote 继续偏移，而是从盘口两侧推导一个
-// “最多跨越 maxSlippageBps 对应价格宽度”的保护限价。这样触发条件和控制手段都围绕同一段 spread。
-func resolveAggressiveSLProtectionPrice(side string, bestBid, bestAsk, fallback, maxSlippageBps float64) float64 {
+// resolveAggressiveSLProtectionDecision 仅为“宽点差 SL 保护”分支计算一个不越过滑点 cap 的保护限价。
+// 当前调用方只会在 spread 已经超过 maxSlippageBps 时进入这里，因此最终价格始终收敛到 spread-capped，
+// top-of-book depth 仅用于记录覆盖率和盘口质量，不再假装把报价改善到 cap 之外。
+func resolveAggressiveSLProtectionDecision(side string, quantity, bestBid, bestAsk, bestBidQty, bestAskQty, fallback, maxSlippageBps float64) slProtectionDecision {
+	decision := slProtectionDecision{
+		Price:     fallback,
+		DepthMode: "spread-capped-fallback",
+	}
 	if bestBid > 0 && bestAsk > 0 && bestAsk >= bestBid {
 		mid := (bestBid + bestAsk) / 2
 		if mid > 0 {
 			allowedCross := mid * maxSlippageBps / 10000
+			decision.QuoteGapBps = (bestAsk - bestBid) / mid * 10000
 			switch strings.ToUpper(strings.TrimSpace(side)) {
 			case "SELL", "SHORT":
-				return math.Max(bestBid, bestAsk-allowedCross)
+				decision.TopDepthQty = bestBidQty
+				decision.TopDepthNotional = bestBidQty * bestBid
+				spreadCapped := math.Max(bestBid, bestAsk-allowedCross)
+				decision.Price = spreadCapped
+				if quantity > 0 && bestBidQty > 0 {
+					coverage := math.Min(bestBidQty/quantity, 1)
+					decision.ExpectedCoverage = coverage
+					if bestBid < spreadCapped {
+						decision.DepthMode = "top-book-outside-cap"
+						return decision
+					}
+					if coverage >= 1 {
+						decision.DepthMode = "top-book-cover-within-cap"
+						return decision
+					}
+					decision.DepthMode = "top-book-partial-within-cap"
+					return decision
+				}
+				return decision
 			case "BUY":
-				return math.Min(bestAsk, bestBid+allowedCross)
+				decision.TopDepthQty = bestAskQty
+				decision.TopDepthNotional = bestAskQty * bestAsk
+				spreadCapped := math.Min(bestAsk, bestBid+allowedCross)
+				decision.Price = spreadCapped
+				if quantity > 0 && bestAskQty > 0 {
+					coverage := math.Min(bestAskQty/quantity, 1)
+					decision.ExpectedCoverage = coverage
+					if bestAsk > spreadCapped {
+						decision.DepthMode = "top-book-outside-cap"
+						return decision
+					}
+					if coverage >= 1 {
+						decision.DepthMode = "top-book-cover-within-cap"
+						return decision
+					}
+					decision.DepthMode = "top-book-partial-within-cap"
+					return decision
+				}
+				return decision
 			}
 		}
 	}
+	decision.QuoteGapBps = 0
 	tolerance := maxSlippageBps / 10000
 	switch strings.ToUpper(strings.TrimSpace(side)) {
 	case "SELL", "SHORT":
-		return fallback * (1 - tolerance)
+		decision.Price = fallback * (1 - tolerance)
 	case "BUY":
-		return fallback * (1 + tolerance)
+		decision.Price = fallback * (1 + tolerance)
 	default:
-		return fallback
+		decision.Price = fallback
 	}
+	return decision
 }
 
 func signalIntentToMap(intent SignalIntent) map[string]any {

--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -1380,8 +1380,9 @@ func (p *Platform) resolveLiveSessionPositionSnapshot(session domain.LiveSession
 	if err != nil {
 		return nil, false, err
 	}
+	hasRealPosition := foundPosition || math.Abs(parseFloatValue(positionSnapshot["quantity"])) > 0
 	livePositionState := cloneMetadata(mapValue(session.State["livePositionState"]))
-	if len(livePositionState) > 0 {
+	if len(livePositionState) > 0 && hasRealPosition {
 		liveSymbol := NormalizeSymbol(firstNonEmpty(stringValue(livePositionState["symbol"]), symbol))
 		if liveSymbol == NormalizeSymbol(symbol) {
 			mergedPosition := cloneMetadata(positionSnapshot)
@@ -1391,7 +1392,7 @@ func (p *Platform) resolveLiveSessionPositionSnapshot(session domain.LiveSession
 			positionSnapshot = mergedPosition
 		}
 	}
-	if foundPosition || parseFloatValue(positionSnapshot["quantity"]) > 0 {
+	if hasRealPosition {
 		return positionSnapshot, foundPosition, nil
 	}
 	virtualPosition := cloneMetadata(mapValue(session.State["virtualPosition"]))

--- a/internal/service/live_execution.go
+++ b/internal/service/live_execution.go
@@ -332,6 +332,7 @@ func (p *Platform) applyLiveVirtualInitialEvent(session domain.LiveSession, prop
 	proposal := executionProposalFromMap(proposalMap)
 	state := cloneMetadata(session.State)
 	intentSignature := buildLiveIntentSignature(proposalMap)
+	virtualPositionID := fmt.Sprintf("virtual|%s|%s", session.ID, intentSignature)
 	entryPrice := firstPositive(
 		parseFloatValue(proposalMap["plannedPrice"]),
 		firstPositive(
@@ -363,6 +364,7 @@ func (p *Platform) applyLiveVirtualInitialEvent(session domain.LiveSession, prop
 	state["lastVirtualSignalAt"] = eventTime.UTC().Format(time.RFC3339)
 	state["lastVirtualSignalType"] = "initial"
 	state["virtualPosition"] = map[string]any{
+		"id":         virtualPositionID,
 		"found":      true,
 		"virtual":    true,
 		"symbol":     NormalizeSymbol(proposal.Symbol),
@@ -485,7 +487,8 @@ func (p *Platform) syncLatestLiveSessionOrder(session domain.LiveSession, eventT
 		state["lastSyncedAt"] = eventTime.UTC().Format(time.RFC3339)
 		state["lastExecutionTimeoutAt"] = eventTime.UTC().Format(time.RFC3339)
 		state["lastExecutionTimeoutReason"] = "resting-order-expired"
-		state["lastExecutionDispatch"] = executionDispatchSummary(mapValue(order.Metadata["executionProposal"]), cancelledOrder, false)
+		timeoutOrder := withExecutionSubmissionFallback(cancelledOrder, order)
+		state["lastExecutionDispatch"] = executionDispatchSummary(mapValue(order.Metadata["executionProposal"]), timeoutOrder, false)
 		updateExecutionEventStats(state, mapValue(order.Metadata["executionProposal"]), mapValue(state["lastExecutionDispatch"]))
 		timeoutSignature := buildLiveIntentSignature(mapValue(order.Metadata["executionProposal"]))
 		if timeoutSignature == "" {
@@ -494,7 +497,7 @@ func (p *Platform) syncLatestLiveSessionOrder(session domain.LiveSession, eventT
 		if timeoutSignature != "" {
 			state["lastExecutionTimeoutIntentSignature"] = timeoutSignature
 		}
-		appendTimelineEvent(state, "order", eventTime, "live-order-cancelled-timeout", executionTimeoutTimelineMetadata(order, cancelledOrder))
+		appendTimelineEvent(state, "order", eventTime, "live-order-cancelled-timeout", executionTimeoutTimelineMetadata(order, timeoutOrder))
 		return p.store.UpdateLiveSessionState(session.ID, state)
 	}
 	syncedOrder, err := p.SyncLiveOrder(order.ID)
@@ -600,8 +603,112 @@ func firstNonEmptyMapValue(values ...any) map[string]any {
 	return nil
 }
 
+func withExecutionSubmissionFallback(order domain.Order, fallback domain.Order) domain.Order {
+	currentSubmission := cloneMetadata(mapValue(order.Metadata["adapterSubmission"]))
+	fallbackSubmission := cloneMetadata(mapValue(fallback.Metadata["adapterSubmission"]))
+	if len(currentSubmission) > 0 && len(fallbackSubmission) == 0 {
+		return order
+	}
+	mergedSubmission := mergeExecutionSubmissionFallback(currentSubmission, fallbackSubmission)
+	if len(mergedSubmission) == 0 {
+		return order
+	}
+	enriched := order
+	enriched.Metadata = cloneMetadata(order.Metadata)
+	if enriched.Metadata == nil {
+		enriched.Metadata = map[string]any{}
+	}
+	enriched.Metadata["adapterSubmission"] = mergedSubmission
+	return enriched
+}
+
+func mergeExecutionSubmissionFallback(current map[string]any, fallback map[string]any) map[string]any {
+	return mergeExecutionSubmissionFallbackWithPath(current, fallback, "")
+}
+
+func mergeExecutionSubmissionFallbackWithPath(current map[string]any, fallback map[string]any, path string) map[string]any {
+	if len(current) == 0 {
+		return cloneMetadata(fallback)
+	}
+	if len(fallback) == 0 {
+		return cloneMetadata(current)
+	}
+	merged := cloneMetadata(fallback)
+	for key, value := range current {
+		childPath := key
+		if path != "" {
+			childPath = path + "." + key
+		}
+		currentMap := mapValue(value)
+		fallbackMap := mapValue(merged[key])
+		if len(currentMap) > 0 && len(fallbackMap) > 0 {
+			merged[key] = mergeExecutionSubmissionFallbackWithPath(currentMap, fallbackMap, childPath)
+			continue
+		}
+		if executionSubmissionValuePresent(childPath, value) {
+			merged[key] = value
+		}
+	}
+	return merged
+}
+
+func executionSubmissionValuePresent(path string, value any) bool {
+	switch typed := value.(type) {
+	case nil:
+		return false
+	case string:
+		return strings.TrimSpace(typed) != ""
+	case bool:
+		return executionSubmissionBooleanValuePresent(path, typed)
+	case int:
+		return executionSubmissionNumericValuePresent(path, float64(typed))
+	case int64:
+		return executionSubmissionNumericValuePresent(path, float64(typed))
+	case float64:
+		return executionSubmissionNumericValuePresent(path, typed)
+	case []any:
+		return len(typed) > 0
+	case []string:
+		return len(typed) > 0
+	case map[string]any:
+		return len(typed) > 0
+	default:
+		return true
+	}
+}
+
+func executionSubmissionBooleanValuePresent(path string, value bool) bool {
+	return true
+}
+
+func executionSubmissionNumericValuePresent(path string, value float64) bool {
+	if value != 0 {
+		return true
+	}
+	switch path {
+	case "rawQuantity",
+		"normalizedQuantity",
+		"normalization.rawQuantity",
+		"normalization.normalizedQuantity":
+		return false
+	case "rawPriceReference",
+		"normalizedPrice",
+		"normalization.rawPriceReference",
+		"normalization.normalizedPrice":
+		return true
+	case "symbolRules.minQty",
+		"symbolRules.stepSize",
+		"symbolRules.tickSize",
+		"symbolRules.minNotional":
+		return false
+	default:
+		return true
+	}
+}
+
 func executionDispatchSummary(proposalMap map[string]any, order domain.Order, failed bool) map[string]any {
 	proposalMeta := cloneMetadata(mapValue(proposalMap["metadata"]))
+	adapterSubmission := cloneMetadata(mapValue(order.Metadata["adapterSubmission"]))
 	expectedPrice := firstPositive(parseFloatValue(proposalMap["limitPrice"]), parseFloatValue(proposalMap["priceHint"]))
 	actualPrice := firstPositive(order.Price, expectedPrice)
 	priceDriftBps := 0.0
@@ -630,7 +737,22 @@ func executionDispatchSummary(proposalMap map[string]any, order domain.Order, fa
 		"priceDriftBps":     priceDriftBps,
 		"decisionContext":   cloneMetadata(mapValue(proposalMeta["executionDecisionContext"])),
 		"book":              cloneMetadata(mapValue(proposalMeta["orderBookSnapshot"])),
-		"failed":            failed,
+		"rawQuantity":       firstPositive(parseFloatValue(adapterSubmission["rawQuantity"]), parseFloatValue(mapValue(adapterSubmission["normalization"])["rawQuantity"])),
+		"normalizedQuantity": firstPositive(
+			parseFloatValue(adapterSubmission["normalizedQuantity"]),
+			parseFloatValue(mapValue(adapterSubmission["normalization"])["normalizedQuantity"]),
+		),
+		"rawPriceReference": firstPositive(
+			parseFloatValue(adapterSubmission["rawPriceReference"]),
+			parseFloatValue(mapValue(adapterSubmission["normalization"])["rawPriceReference"]),
+		),
+		"normalizedPrice": firstPositive(
+			parseFloatValue(adapterSubmission["normalizedPrice"]),
+			parseFloatValue(mapValue(adapterSubmission["normalization"])["normalizedPrice"]),
+		),
+		"normalization": cloneMetadata(mapValue(adapterSubmission["normalization"])),
+		"symbolRules":   cloneMetadata(mapValue(adapterSubmission["symbolRules"])),
+		"failed":        failed,
 	}
 }
 

--- a/internal/service/live_execution.go
+++ b/internal/service/live_execution.go
@@ -333,12 +333,7 @@ func (p *Platform) applyLiveVirtualInitialEvent(session domain.LiveSession, prop
 	state := cloneMetadata(session.State)
 	intentSignature := buildLiveIntentSignature(proposalMap)
 	if strings.TrimSpace(intentSignature) == "" {
-		intentSignature = strings.Join([]string{
-			firstNonEmpty(strings.TrimSpace(stringValue(proposalMap["reason"])), "virtual-initial"),
-			strings.ToUpper(strings.TrimSpace(firstNonEmpty(stringValue(proposalMap["side"]), proposal.Side))),
-			NormalizeSymbol(firstNonEmpty(stringValue(proposalMap["symbol"]), proposal.Symbol)),
-			firstNonEmpty(strings.TrimSpace(stringValue(proposalMap["signalBarStateKey"])), eventTime.UTC().Format(time.RFC3339Nano)),
-		}, "|")
+		intentSignature = buildFallbackLiveIntentSignature(proposalMap, proposal, eventTime)
 	}
 	virtualPositionID := fmt.Sprintf("virtual|%s|%s", session.ID, intentSignature)
 	entryPrice := firstPositive(
@@ -400,6 +395,34 @@ func (p *Platform) applyLiveVirtualInitialEvent(session domain.LiveSession, prop
 		Status:   liveOrderStatusVirtualInitial,
 	}, false))
 	return p.store.UpdateLiveSessionState(session.ID, state)
+}
+
+func buildFallbackLiveIntentSignature(proposalMap map[string]any, proposal ExecutionProposal, eventTime time.Time) string {
+	anchor := firstNonEmpty(
+		strings.TrimSpace(stringValue(proposalMap["signalBarStateKey"])),
+		strings.TrimSpace(stringValue(proposalMap["plannedEventAt"])),
+		eventTime.UTC().Format(time.RFC3339Nano),
+	)
+	return strings.Join([]string{
+		firstNonEmpty(strings.TrimSpace(firstNonEmpty(stringValue(proposalMap["action"]), proposal.Action)), "virtual"),
+		strings.TrimSpace(firstNonEmpty(stringValue(proposalMap["role"]), proposal.Role)),
+		firstNonEmpty(strings.TrimSpace(firstNonEmpty(stringValue(proposalMap["reason"]), proposal.Reason)), "virtual-initial"),
+		strings.ToUpper(strings.TrimSpace(firstNonEmpty(stringValue(proposalMap["side"]), proposal.Side))),
+		NormalizeSymbol(firstNonEmpty(stringValue(proposalMap["symbol"]), proposal.Symbol)),
+		strings.ToUpper(strings.TrimSpace(firstNonEmpty(stringValue(proposalMap["type"]), proposal.Type, "MARKET"))),
+		strings.TrimSpace(firstNonEmpty(stringValue(proposalMap["signalKind"]), proposal.SignalKind)),
+		anchor,
+		fmt.Sprintf("%.8f", firstPositive(parseFloatValue(proposalMap["quantity"]), proposal.Quantity)),
+		fmt.Sprintf("%.8f", firstPositive(parseFloatValue(proposalMap["plannedPrice"]), 0)),
+		fmt.Sprintf("%.8f", firstPositive(parseFloatValue(proposalMap["limitPrice"]), proposal.LimitPrice)),
+		fmt.Sprintf("%.8f", firstPositive(parseFloatValue(proposalMap["priceHint"]), proposal.PriceHint)),
+		strings.TrimSpace(firstNonEmpty(stringValue(proposalMap["priceSource"]), proposal.PriceSource)),
+		strings.ToUpper(strings.TrimSpace(firstNonEmpty(stringValue(proposalMap["timeInForce"]), proposal.TimeInForce))),
+		normalizeExecutionStrategyKey(firstNonEmpty(stringValue(proposalMap["executionStrategy"]), proposal.ExecutionStrategy)),
+		fmt.Sprintf("%t", boolValue(proposalMap["postOnly"]) || proposal.PostOnly),
+		fmt.Sprintf("%t", boolValue(proposalMap["reduceOnly"]) || proposal.ReduceOnly),
+		fmt.Sprintf("%t", boolValue(proposalMap["closePosition"])),
+	}, "|")
 }
 
 func (p *Platform) applyLiveVirtualExitEvent(session domain.LiveSession, proposalMap map[string]any, eventTime time.Time) (domain.LiveSession, error) {
@@ -686,15 +709,7 @@ func executionSubmissionValuePresent(path string, value any) bool {
 }
 
 func executionSubmissionBooleanValuePresent(path string, value bool) bool {
-	if value {
-		return true
-	}
-	switch path {
-	case "postOnly", "reduceOnly", "closePosition", "slProtectionActive":
-		return false
-	default:
-		return true
-	}
+	return true
 }
 
 func executionSubmissionNumericValuePresent(path string, value float64) bool {

--- a/internal/service/live_execution.go
+++ b/internal/service/live_execution.go
@@ -332,6 +332,14 @@ func (p *Platform) applyLiveVirtualInitialEvent(session domain.LiveSession, prop
 	proposal := executionProposalFromMap(proposalMap)
 	state := cloneMetadata(session.State)
 	intentSignature := buildLiveIntentSignature(proposalMap)
+	if strings.TrimSpace(intentSignature) == "" {
+		intentSignature = strings.Join([]string{
+			firstNonEmpty(strings.TrimSpace(stringValue(proposalMap["reason"])), "virtual-initial"),
+			strings.ToUpper(strings.TrimSpace(firstNonEmpty(stringValue(proposalMap["side"]), proposal.Side))),
+			NormalizeSymbol(firstNonEmpty(stringValue(proposalMap["symbol"]), proposal.Symbol)),
+			firstNonEmpty(strings.TrimSpace(stringValue(proposalMap["signalBarStateKey"])), eventTime.UTC().Format(time.RFC3339Nano)),
+		}, "|")
+	}
 	virtualPositionID := fmt.Sprintf("virtual|%s|%s", session.ID, intentSignature)
 	entryPrice := firstPositive(
 		parseFloatValue(proposalMap["plannedPrice"]),
@@ -678,7 +686,15 @@ func executionSubmissionValuePresent(path string, value any) bool {
 }
 
 func executionSubmissionBooleanValuePresent(path string, value bool) bool {
-	return true
+	if value {
+		return true
+	}
+	switch path {
+	case "postOnly", "reduceOnly", "closePosition", "slProtectionActive":
+		return false
+	default:
+		return true
+	}
 }
 
 func executionSubmissionNumericValuePresent(path string, value float64) bool {
@@ -695,7 +711,7 @@ func executionSubmissionNumericValuePresent(path string, value float64) bool {
 		"normalizedPrice",
 		"normalization.rawPriceReference",
 		"normalization.normalizedPrice":
-		return true
+		return false
 	case "symbolRules.minQty",
 		"symbolRules.stepSize",
 		"symbolRules.tickSize",

--- a/internal/service/live_execution.go
+++ b/internal/service/live_execution.go
@@ -333,7 +333,7 @@ func (p *Platform) applyLiveVirtualInitialEvent(session domain.LiveSession, prop
 	state := cloneMetadata(session.State)
 	intentSignature := buildLiveIntentSignature(proposalMap)
 	if strings.TrimSpace(intentSignature) == "" {
-		intentSignature = buildFallbackLiveIntentSignature(proposalMap, proposal, eventTime)
+		intentSignature = buildFallbackLiveIntentSignature(proposalMap, proposal)
 	}
 	virtualPositionID := fmt.Sprintf("virtual|%s|%s", session.ID, intentSignature)
 	entryPrice := firstPositive(
@@ -397,11 +397,11 @@ func (p *Platform) applyLiveVirtualInitialEvent(session domain.LiveSession, prop
 	return p.store.UpdateLiveSessionState(session.ID, state)
 }
 
-func buildFallbackLiveIntentSignature(proposalMap map[string]any, proposal ExecutionProposal, eventTime time.Time) string {
+func buildFallbackLiveIntentSignature(proposalMap map[string]any, proposal ExecutionProposal) string {
 	anchor := firstNonEmpty(
 		strings.TrimSpace(stringValue(proposalMap["signalBarStateKey"])),
 		strings.TrimSpace(stringValue(proposalMap["plannedEventAt"])),
-		eventTime.UTC().Format(time.RFC3339Nano),
+		strings.TrimSpace(firstNonEmpty(stringValue(proposalMap["decisionState"]), proposal.DecisionState)),
 	)
 	return strings.Join([]string{
 		firstNonEmpty(strings.TrimSpace(firstNonEmpty(stringValue(proposalMap["action"]), proposal.Action)), "virtual"),

--- a/internal/service/live_execution.go
+++ b/internal/service/live_execution.go
@@ -332,7 +332,7 @@ func (p *Platform) applyLiveVirtualInitialEvent(session domain.LiveSession, prop
 	proposal := executionProposalFromMap(proposalMap)
 	state := cloneMetadata(session.State)
 	intentSignature := buildLiveIntentSignature(proposalMap)
-	if strings.TrimSpace(intentSignature) == "" {
+	if !hasInformativeLiveIntentSignature(intentSignature) {
 		intentSignature = buildFallbackLiveIntentSignature(proposalMap, proposal)
 	}
 	virtualPositionID := fmt.Sprintf("virtual|%s|%s", session.ID, intentSignature)
@@ -397,6 +397,27 @@ func (p *Platform) applyLiveVirtualInitialEvent(session domain.LiveSession, prop
 	return p.store.UpdateLiveSessionState(session.ID, state)
 }
 
+func hasInformativeLiveIntentSignature(signature string) bool {
+	nonEmpty := 0
+	for _, part := range strings.Split(signature, "|") {
+		if strings.TrimSpace(part) != "" {
+			nonEmpty++
+		}
+	}
+	return nonEmpty >= 3
+}
+
+func proposalBooleanValue(proposalMap map[string]any, key string, fallback bool) bool {
+	value, ok := proposalMap[key]
+	if !ok {
+		return fallback
+	}
+	if typed, ok := value.(bool); ok {
+		return typed
+	}
+	return boolValue(value)
+}
+
 func buildFallbackLiveIntentSignature(proposalMap map[string]any, proposal ExecutionProposal) string {
 	anchor := firstNonEmpty(
 		strings.TrimSpace(stringValue(proposalMap["signalBarStateKey"])),
@@ -419,9 +440,9 @@ func buildFallbackLiveIntentSignature(proposalMap map[string]any, proposal Execu
 		strings.TrimSpace(firstNonEmpty(stringValue(proposalMap["priceSource"]), proposal.PriceSource)),
 		strings.ToUpper(strings.TrimSpace(firstNonEmpty(stringValue(proposalMap["timeInForce"]), proposal.TimeInForce))),
 		normalizeExecutionStrategyKey(firstNonEmpty(stringValue(proposalMap["executionStrategy"]), proposal.ExecutionStrategy)),
-		fmt.Sprintf("%t", boolValue(proposalMap["postOnly"]) || proposal.PostOnly),
-		fmt.Sprintf("%t", boolValue(proposalMap["reduceOnly"]) || proposal.ReduceOnly),
-		fmt.Sprintf("%t", boolValue(proposalMap["closePosition"])),
+		fmt.Sprintf("%t", proposalBooleanValue(proposalMap, "postOnly", proposal.PostOnly)),
+		fmt.Sprintf("%t", proposalBooleanValue(proposalMap, "reduceOnly", proposal.ReduceOnly)),
+		fmt.Sprintf("%t", proposalBooleanValue(proposalMap, "closePosition", false)),
 	}, "|")
 }
 
@@ -709,7 +730,15 @@ func executionSubmissionValuePresent(path string, value any) bool {
 }
 
 func executionSubmissionBooleanValuePresent(path string, value bool) bool {
-	return true
+	if value {
+		return true
+	}
+	switch path {
+	case "postOnly", "reduceOnly", "closePosition", "slProtectionActive":
+		return false
+	default:
+		return true
+	}
 }
 
 func executionSubmissionNumericValuePresent(path string, value float64) bool {

--- a/internal/service/live_recovery.go
+++ b/internal/service/live_recovery.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"math"
 	"strings"
 	"time"
 
@@ -88,15 +89,16 @@ func (p *Platform) refreshLiveSessionPositionContext(session domain.LiveSession,
 	if err != nil {
 		return domain.LiveSession{}, err
 	}
-	hasActivePositionContext := hasActiveLivePositionSnapshot(positionSnapshot)
+	hasRealPositionContext := foundPosition || math.Abs(parseFloatValue(positionSnapshot["quantity"])) > 0
 	state["recoveredPosition"] = positionSnapshot
 	state["hasRecoveredPosition"] = foundPosition
 	state["hasRecoveredRealPosition"] = foundPosition
-	hasVirtualPosition := boolValue(positionSnapshot["virtual"]) && !foundPosition
+	virtualPosition := cloneMetadata(mapValue(state["virtualPosition"]))
+	hasVirtualPosition := !hasRealPositionContext && hasActiveVirtualPositionSnapshot(virtualPosition)
 	state["hasRecoveredVirtualPosition"] = hasVirtualPosition
 	state["lastRecoveredPositionAt"] = eventTime.UTC().Format(time.RFC3339)
 	state["positionRecoverySource"] = firstNonEmpty(source, "live-position-refresh")
-	if !hasActivePositionContext {
+	if !hasRealPositionContext && !hasVirtualPosition {
 		clearLivePositionWatermarks(state)
 		delete(state, "livePositionState")
 		state["lastLivePositionState"] = map[string]any{}
@@ -127,7 +129,7 @@ func (p *Platform) refreshLiveSessionPositionContext(session domain.LiveSession,
 	}
 	signalBarState, _ := pickSignalBarState(signalBarStates, symbol, timeframe)
 	if signalBarState == nil {
-		if hasActivePositionContext {
+		if hasRealPositionContext || hasVirtualPosition {
 			watermarks := resolveLivePositionWatermarks(positionSnapshot, state)
 			if watermarks.PositionKey == "" {
 				clearLivePositionWatermarks(state)

--- a/internal/service/live_recovery.go
+++ b/internal/service/live_recovery.go
@@ -95,6 +95,7 @@ func (p *Platform) refreshLiveSessionPositionContext(session domain.LiveSession,
 	state["lastRecoveredPositionAt"] = eventTime.UTC().Format(time.RFC3339)
 	state["positionRecoverySource"] = firstNonEmpty(source, "live-position-refresh")
 	if !foundPosition {
+		clearLivePositionWatermarks(state)
 		delete(state, "livePositionState")
 		state["lastLivePositionState"] = map[string]any{}
 		if !boolValue(mapValue(state["virtualPosition"])["virtual"]) {

--- a/internal/service/live_recovery.go
+++ b/internal/service/live_recovery.go
@@ -84,29 +84,27 @@ func (p *Platform) refreshLiveSessionPositionContext(session domain.LiveSession,
 	if symbol == "" {
 		return refreshed, nil
 	}
-	positionSnapshot, foundPosition, err := p.resolvePaperSessionPositionSnapshot(refreshed.AccountID, symbol)
+	positionSnapshot, foundPosition, err := p.resolveLiveSessionPositionSnapshot(refreshed, symbol)
 	if err != nil {
 		return domain.LiveSession{}, err
 	}
+	hasActivePositionContext := hasActiveLivePositionSnapshot(positionSnapshot)
 	state["recoveredPosition"] = positionSnapshot
 	state["hasRecoveredPosition"] = foundPosition
 	state["hasRecoveredRealPosition"] = foundPosition
-	hasVirtualPosition := boolValue(mapValue(state["virtualPosition"])["virtual"]) && !foundPosition
+	hasVirtualPosition := boolValue(positionSnapshot["virtual"]) && !foundPosition
 	state["hasRecoveredVirtualPosition"] = hasVirtualPosition
 	state["lastRecoveredPositionAt"] = eventTime.UTC().Format(time.RFC3339)
 	state["positionRecoverySource"] = firstNonEmpty(source, "live-position-refresh")
-	if !foundPosition {
-		if !hasVirtualPosition {
-			clearLivePositionWatermarks(state)
-		}
+	if !hasActivePositionContext {
+		clearLivePositionWatermarks(state)
 		delete(state, "livePositionState")
 		state["lastLivePositionState"] = map[string]any{}
-		if hasVirtualPosition {
-			state["positionRecoveryStatus"] = "monitoring-virtual-position"
-		} else {
-			state["positionRecoveryStatus"] = "flat"
-		}
+		state["positionRecoveryStatus"] = "flat"
 		return p.store.UpdateLiveSessionState(refreshed.ID, state)
+	}
+	if hasVirtualPosition {
+		state["positionRecoveryStatus"] = "monitoring-virtual-position"
 	}
 
 	version, err := p.resolveCurrentStrategyVersion(refreshed.StrategyID)
@@ -129,6 +127,14 @@ func (p *Platform) refreshLiveSessionPositionContext(session domain.LiveSession,
 	}
 	signalBarState, _ := pickSignalBarState(signalBarStates, symbol, timeframe)
 	if signalBarState == nil {
+		if hasActivePositionContext {
+			watermarks := resolveLivePositionWatermarks(positionSnapshot, state)
+			if watermarks.PositionKey == "" {
+				clearLivePositionWatermarks(state)
+			} else {
+				applyLivePositionWatermarks(state, watermarks)
+			}
+		}
 		return p.store.UpdateLiveSessionState(refreshed.ID, state)
 	}
 	marketPrice := firstPositive(parseFloatValue(positionSnapshot["markPrice"]), parseFloatValue(mapValue(signalBarState["current"])["close"]))

--- a/internal/service/live_recovery.go
+++ b/internal/service/live_recovery.go
@@ -91,14 +91,19 @@ func (p *Platform) refreshLiveSessionPositionContext(session domain.LiveSession,
 	state["recoveredPosition"] = positionSnapshot
 	state["hasRecoveredPosition"] = foundPosition
 	state["hasRecoveredRealPosition"] = foundPosition
-	state["hasRecoveredVirtualPosition"] = boolValue(mapValue(state["virtualPosition"])["virtual"]) && !foundPosition
+	hasVirtualPosition := boolValue(mapValue(state["virtualPosition"])["virtual"]) && !foundPosition
+	state["hasRecoveredVirtualPosition"] = hasVirtualPosition
 	state["lastRecoveredPositionAt"] = eventTime.UTC().Format(time.RFC3339)
 	state["positionRecoverySource"] = firstNonEmpty(source, "live-position-refresh")
 	if !foundPosition {
-		clearLivePositionWatermarks(state)
+		if !hasVirtualPosition {
+			clearLivePositionWatermarks(state)
+		}
 		delete(state, "livePositionState")
 		state["lastLivePositionState"] = map[string]any{}
-		if !boolValue(mapValue(state["virtualPosition"])["virtual"]) {
+		if hasVirtualPosition {
+			state["positionRecoveryStatus"] = "monitoring-virtual-position"
+		} else {
 			state["positionRecoveryStatus"] = "flat"
 		}
 		return p.store.UpdateLiveSessionState(refreshed.ID, state)

--- a/internal/service/live_registry.go
+++ b/internal/service/live_registry.go
@@ -752,14 +752,8 @@ func (a binanceFuturesLiveAdapter) normalizeRESTOrder(order domain.Order, creds 
 		}
 	}
 	if requiredQty := requiredBinanceQuantityForMinNotional(normalized.Quantity, firstPositive(normalized.Price, priceReference), rules); requiredQty > normalized.Quantity {
-		return domain.Order{}, binanceSymbolRules{}, fmt.Errorf(
-			"normalized order quantity %.12f below minNotional %.12f for %s at price %.12f (requires >= %.12f)",
-			normalized.Quantity,
-			rules.MinNotional,
-			rules.Symbol,
-			firstPositive(normalized.Price, priceReference),
-			requiredQty,
-		)
+		normalized.Quantity = requiredQty
+		quantityAdjustments = append(quantityAdjustments, "min_notional")
 	}
 	normalized.Metadata["normalizedQuantity"] = normalized.Quantity
 	if normalized.Price > 0 {

--- a/internal/service/live_registry.go
+++ b/internal/service/live_registry.go
@@ -751,9 +751,15 @@ func (a binanceFuturesLiveAdapter) normalizeRESTOrder(order domain.Order, creds 
 			priceAdjustments = append(priceAdjustments, "tick_size")
 		}
 	}
-	if adjustedQty := normalizeBinanceQuantityForMinNotional(normalized.Quantity, firstPositive(normalized.Price, priceReference), rules); adjustedQty > normalized.Quantity {
-		normalized.Quantity = adjustedQty
-		quantityAdjustments = append(quantityAdjustments, "min_notional")
+	if requiredQty := requiredBinanceQuantityForMinNotional(normalized.Quantity, firstPositive(normalized.Price, priceReference), rules); requiredQty > normalized.Quantity {
+		return domain.Order{}, binanceSymbolRules{}, fmt.Errorf(
+			"normalized order quantity %.12f below minNotional %.12f for %s at price %.12f (requires >= %.12f)",
+			normalized.Quantity,
+			rules.MinNotional,
+			rules.Symbol,
+			firstPositive(normalized.Price, priceReference),
+			requiredQty,
+		)
 	}
 	normalized.Metadata["normalizedQuantity"] = normalized.Quantity
 	if normalized.Price > 0 {
@@ -893,7 +899,7 @@ func normalizeBinancePrice(price float64, rules binanceSymbolRules) float64 {
 	return roundToStep(price, rules.TickSize)
 }
 
-func normalizeBinanceQuantityForMinNotional(quantity, price float64, rules binanceSymbolRules) float64 {
+func requiredBinanceQuantityForMinNotional(quantity, price float64, rules binanceSymbolRules) float64 {
 	if quantity <= 0 || price <= 0 || rules.MinNotional <= 0 {
 		return quantity
 	}

--- a/internal/service/live_registry.go
+++ b/internal/service/live_registry.go
@@ -419,8 +419,11 @@ func (a binanceFuturesLiveAdapter) submitRESTOrder(account domain.Account, order
 			"origType":           stringValue(payload["origType"]),
 			"timeInForce":        stringValue(payload["timeInForce"]),
 			"updateTime":         acceptedAt,
+			"rawQuantity":        order.Quantity,
+			"rawPriceReference":  firstPositive(order.Price, parseFloatValue(order.Metadata["priceHint"])),
 			"normalizedQuantity": normalizedOrder.Quantity,
 			"normalizedPrice":    normalizedOrder.Price,
+			"normalization":      cloneMetadata(mapValue(normalizedOrder.Metadata["normalization"])),
 			"symbolRules": map[string]any{
 				"tickSize":    rules.TickSize,
 				"stepSize":    rules.StepSize,
@@ -720,26 +723,55 @@ func (a binanceFuturesLiveAdapter) normalizeRESTOrder(order domain.Order, creds 
 		return domain.Order{}, binanceSymbolRules{}, err
 	}
 	orderType := strings.ToUpper(strings.TrimSpace(firstNonEmpty(order.Type, "MARKET")))
-	normalized.Quantity = normalizeBinanceQuantity(order.Quantity, rules)
+	rawQuantity := order.Quantity
+	rawPriceReference := firstPositive(order.Price, parseFloatValue(order.Metadata["priceHint"]))
+	quantityAdjustments := make([]string, 0)
+	baseQuantity := normalizeBinanceQuantity(rawQuantity, rules)
+	if rules.StepSize > 0 && baseQuantity != rawQuantity {
+		quantityAdjustments = append(quantityAdjustments, "step_size")
+	}
+	if rules.MinQty > 0 && rawQuantity > 0 && rawQuantity < rules.MinQty {
+		quantityAdjustments = append(quantityAdjustments, "min_qty")
+	}
+	normalized.Quantity = baseQuantity
 	if normalized.Quantity <= 0 {
 		return domain.Order{}, binanceSymbolRules{}, fmt.Errorf("normalized order quantity is invalid for %s", rules.Symbol)
 	}
 	if rules.MaxQty > 0 && normalized.Quantity > rules.MaxQty {
 		return domain.Order{}, binanceSymbolRules{}, fmt.Errorf("normalized order quantity %.12f exceeds maxQty %.12f for %s", normalized.Quantity, rules.MaxQty, rules.Symbol)
 	}
-	priceReference := firstPositive(order.Price, parseFloatValue(order.Metadata["priceHint"]))
+	priceReference := rawPriceReference
+	priceAdjustments := make([]string, 0)
 	if orderType != "MARKET" {
 		normalized.Price = normalizeBinancePrice(priceReference, rules)
 		if normalized.Price <= 0 {
 			return domain.Order{}, binanceSymbolRules{}, fmt.Errorf("normalized order price is invalid for %s", rules.Symbol)
 		}
+		if rules.TickSize > 0 && normalized.Price != priceReference {
+			priceAdjustments = append(priceAdjustments, "tick_size")
+		}
 	}
 	if adjustedQty := normalizeBinanceQuantityForMinNotional(normalized.Quantity, firstPositive(normalized.Price, priceReference), rules); adjustedQty > normalized.Quantity {
 		normalized.Quantity = adjustedQty
+		quantityAdjustments = append(quantityAdjustments, "min_notional")
 	}
 	normalized.Metadata["normalizedQuantity"] = normalized.Quantity
 	if normalized.Price > 0 {
 		normalized.Metadata["normalizedPrice"] = normalized.Price
+	}
+	normalized.Metadata["normalization"] = map[string]any{
+		"rawQuantity":              rawQuantity,
+		"rawPriceReference":        rawPriceReference,
+		"normalizedQuantity":       normalized.Quantity,
+		"normalizedPrice":          normalized.Price,
+		"quantityAdjustments":      quantityAdjustments,
+		"priceAdjustments":         priceAdjustments,
+		"normalizationApplied":     rawQuantity != normalized.Quantity || (orderType != "MARKET" && rawPriceReference != normalized.Price),
+		"minNotionalAdjusted":      containsString(quantityAdjustments, "min_notional"),
+		"stepSizeAdjusted":         containsString(quantityAdjustments, "step_size"),
+		"minQtyAdjusted":           containsString(quantityAdjustments, "min_qty"),
+		"tickSizeAdjusted":         containsString(priceAdjustments, "tick_size"),
+		"normalizationReasonCount": len(quantityAdjustments) + len(priceAdjustments),
 	}
 	normalized.Metadata["symbolRules"] = map[string]any{
 		"tickSize":    rules.TickSize,
@@ -749,6 +781,15 @@ func (a binanceFuturesLiveAdapter) normalizeRESTOrder(order domain.Order, creds 
 		"minNotional": rules.MinNotional,
 	}
 	return normalized, rules, nil
+}
+
+func containsString(items []string, target string) bool {
+	for _, item := range items {
+		if strings.EqualFold(strings.TrimSpace(item), strings.TrimSpace(target)) {
+			return true
+		}
+	}
+	return false
 }
 
 func fetchBinanceSymbolRules(creds binanceRESTCredentials, symbol string) (binanceSymbolRules, error) {

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -1702,14 +1702,39 @@ func TestWithExecutionSubmissionFallbackRestoresZeroNormalizationFields(t *testi
 	}
 	merged := withExecutionSubmissionFallback(order, fallback)
 	submission := mapValue(merged.Metadata["adapterSubmission"])
-	if got := parseFloatValue(submission["normalizedPrice"]); got != 0 {
-		t.Fatalf("expected explicit zero normalized price to be preserved, got %v", got)
+	if got := parseFloatValue(submission["normalizedPrice"]); got != 68643.6 {
+		t.Fatalf("expected zero normalized price to fall back, got %v", got)
 	}
 	if got := parseFloatValue(submission["rawQuantity"]); got != 0.0019 {
 		t.Fatalf("expected zero raw quantity to fall back, got %v", got)
 	}
-	if got := boolValue(submission["reduceOnly"]); got {
-		t.Fatal("expected explicit false reduceOnly to be preserved")
+	if got := boolValue(submission["reduceOnly"]); !got {
+		t.Fatal("expected zero-value reduceOnly to fall back to original true")
+	}
+}
+
+func TestApplyLiveVirtualInitialEventUsesFallbackVirtualPositionIDWhenIntentSignatureEmpty(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	session, err := platform.store.GetLiveSession("live-session-main")
+	if err != nil {
+		t.Fatalf("get live session failed: %v", err)
+	}
+	session.State = cloneMetadata(session.State)
+	proposalMap := map[string]any{
+		"side":   "BUY",
+		"symbol": "BTCUSDT",
+		"reason": "Initial",
+	}
+	updated, err := platform.applyLiveVirtualInitialEvent(session, proposalMap, time.Date(2026, 4, 10, 9, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("apply virtual initial event failed: %v", err)
+	}
+	virtualPosition := mapValue(updated.State["virtualPosition"])
+	if virtualPosition == nil {
+		t.Fatal("expected virtual position to be recorded")
+	}
+	if got := stringValue(virtualPosition["id"]); got == "" || got == "virtual|live-session-main|" {
+		t.Fatalf("expected fallback virtual position id to be populated, got %q", got)
 	}
 }
 

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -1442,16 +1442,16 @@ func TestFormatBinanceDecimalUsesExchangePrecision(t *testing.T) {
 	}
 }
 
-func TestNormalizeBinanceQuantityForMinNotional(t *testing.T) {
+func TestRequiredBinanceQuantityForMinNotional(t *testing.T) {
 	rules := binanceSymbolRules{
 		StepSize:    0.001,
 		MinQty:      0.001,
 		MinNotional: 100,
 	}
-	if got := normalizeBinanceQuantityForMinNotional(0.001, 68643.6, rules); got != 0.002 {
-		t.Fatalf("expected quantity bumped to 0.002 for min notional, got %v", got)
+	if got := requiredBinanceQuantityForMinNotional(0.001, 68643.6, rules); got != 0.002 {
+		t.Fatalf("expected required quantity 0.002 for min notional, got %v", got)
 	}
-	if got := normalizeBinanceQuantityForMinNotional(0.002, 68643.6, rules); got != 0.002 {
+	if got := requiredBinanceQuantityForMinNotional(0.002, 68643.6, rules); got != 0.002 {
 		t.Fatalf("expected existing quantity to remain unchanged, got %v", got)
 	}
 }
@@ -1487,15 +1487,15 @@ func TestNormalizeRESTOrderRecordsNormalizationTelemetry(t *testing.T) {
 	normalized, _, err := adapter.normalizeRESTOrder(domain.Order{
 		Symbol:   "BTCUSDT",
 		Type:     "LIMIT",
-		Quantity: 0.0019,
+		Quantity: 0.0021,
 		Price:    68643.67,
 	}, creds)
 	if err != nil {
 		t.Fatalf("normalize REST order failed: %v", err)
 	}
 	norm := mapValue(normalized.Metadata["normalization"])
-	if got := parseFloatValue(norm["rawQuantity"]); got != 0.0019 {
-		t.Fatalf("expected raw quantity 0.0019, got %v", got)
+	if got := parseFloatValue(norm["rawQuantity"]); got != 0.0021 {
+		t.Fatalf("expected raw quantity 0.0021, got %v", got)
 	}
 	if got := parseFloatValue(norm["normalizedQuantity"]); got != 0.002 {
 		t.Fatalf("expected normalized quantity 0.002, got %v", got)
@@ -1510,14 +1510,56 @@ func TestNormalizeRESTOrderRecordsNormalizationTelemetry(t *testing.T) {
 		t.Fatalf("expected normalized order price 68643.6, got %v", got)
 	}
 	quantityAdjustmentCount := normalizationItemCount(norm["quantityAdjustments"])
-	if quantityAdjustmentCount != 2 {
-		t.Fatalf("expected 2 quantity adjustments, got %v", norm["quantityAdjustments"])
+	if quantityAdjustmentCount != 1 {
+		t.Fatalf("expected 1 quantity adjustment, got %v", norm["quantityAdjustments"])
 	}
-	if !boolValue(norm["stepSizeAdjusted"]) || !boolValue(norm["minNotionalAdjusted"]) {
-		t.Fatalf("expected step size and min notional adjustments, got %+v", norm)
+	if !boolValue(norm["stepSizeAdjusted"]) || boolValue(norm["minNotionalAdjusted"]) {
+		t.Fatalf("expected only step size adjustment, got %+v", norm)
 	}
 	if !boolValue(norm["tickSizeAdjusted"]) {
 		t.Fatalf("expected tick size adjustment, got %+v", norm)
+	}
+}
+
+func TestNormalizeRESTOrderRejectsBelowMinNotionalAfterRounding(t *testing.T) {
+	adapter := binanceFuturesLiveAdapter{}
+	creds := binanceRESTCredentials{BaseURL: "https://example.test"}
+	cacheKey := creds.BaseURL + "|BTCUSDT"
+	binanceSymbolRulesCacheMu.Lock()
+	previous, existed := binanceSymbolRulesCache[cacheKey]
+	binanceSymbolRulesCacheMu.Unlock()
+	t.Cleanup(func() {
+		binanceSymbolRulesCacheMu.Lock()
+		defer binanceSymbolRulesCacheMu.Unlock()
+		if existed {
+			binanceSymbolRulesCache[cacheKey] = previous
+		} else {
+			delete(binanceSymbolRulesCache, cacheKey)
+		}
+	})
+	binanceSymbolRulesCacheMu.Lock()
+	binanceSymbolRulesCache[cacheKey] = binanceSymbolRules{
+		Symbol:      "BTCUSDT",
+		TickSize:    0.1,
+		StepSize:    0.001,
+		MinQty:      0.001,
+		MaxQty:      1000,
+		MinNotional: 100,
+		UpdatedAt:   time.Now().UTC(),
+	}
+	binanceSymbolRulesCacheMu.Unlock()
+
+	_, _, err := adapter.normalizeRESTOrder(domain.Order{
+		Symbol:   "BTCUSDT",
+		Type:     "LIMIT",
+		Quantity: 0.0019,
+		Price:    68643.67,
+	}, creds)
+	if err == nil {
+		t.Fatal("expected normalize REST order to reject below-min-notional quantity after rounding")
+	}
+	if !strings.Contains(err.Error(), "below minNotional") {
+		t.Fatalf("expected minNotional rejection, got %v", err)
 	}
 }
 
@@ -1708,8 +1750,32 @@ func TestWithExecutionSubmissionFallbackRestoresZeroNormalizationFields(t *testi
 	if got := parseFloatValue(submission["rawQuantity"]); got != 0.0019 {
 		t.Fatalf("expected zero raw quantity to fall back, got %v", got)
 	}
-	if got := boolValue(submission["reduceOnly"]); !got {
-		t.Fatal("expected zero-value reduceOnly to fall back to original true")
+	if got := boolValue(submission["reduceOnly"]); got {
+		t.Fatal("expected explicit false reduceOnly to be preserved")
+	}
+}
+
+func TestWithExecutionSubmissionFallbackUsesFallbackForMissingExecutionControlFlags(t *testing.T) {
+	order := domain.Order{
+		Metadata: map[string]any{
+			"adapterSubmission": map[string]any{
+				"normalizedPrice": 68643.6,
+			},
+		},
+	}
+	fallback := domain.Order{
+		Metadata: map[string]any{
+			"adapterSubmission": map[string]any{
+				"postOnly":      true,
+				"reduceOnly":    true,
+				"closePosition": true,
+			},
+		},
+	}
+	merged := withExecutionSubmissionFallback(order, fallback)
+	submission := mapValue(merged.Metadata["adapterSubmission"])
+	if !boolValue(submission["postOnly"]) || !boolValue(submission["reduceOnly"]) || !boolValue(submission["closePosition"]) {
+		t.Fatalf("expected missing execution-control flags to fall back, got %+v", submission)
 	}
 }
 
@@ -1735,6 +1801,27 @@ func TestApplyLiveVirtualInitialEventUsesFallbackVirtualPositionIDWhenIntentSign
 	}
 	if got := stringValue(virtualPosition["id"]); got == "" || got == "virtual|live-session-main|" {
 		t.Fatalf("expected fallback virtual position id to be populated, got %q", got)
+	}
+}
+
+func TestBuildFallbackLiveIntentSignatureIncludesExecutionFields(t *testing.T) {
+	eventTime := time.Date(2026, 4, 10, 9, 0, 0, 0, time.UTC)
+	baseProposalMap := map[string]any{
+		"reason":            "Initial",
+		"side":              "BUY",
+		"symbol":            "BTCUSDT",
+		"type":              "LIMIT",
+		"signalBarStateKey": "bar-1",
+		"quantity":          0.001,
+		"limitPrice":        68000.0,
+		"priceHint":         68000.5,
+	}
+	baseSignature := buildFallbackLiveIntentSignature(baseProposalMap, executionProposalFromMap(baseProposalMap), eventTime)
+	variantProposalMap := cloneMetadata(baseProposalMap)
+	variantProposalMap["quantity"] = 0.002
+	variantSignature := buildFallbackLiveIntentSignature(variantProposalMap, executionProposalFromMap(variantProposalMap), eventTime)
+	if baseSignature == variantSignature {
+		t.Fatalf("expected quantity changes to alter fallback signature, got %q", baseSignature)
 	}
 }
 
@@ -2408,5 +2495,52 @@ func TestRefreshLiveSessionPositionContextRebuildsLivePositionState(t *testing.T
 	}
 	if got := stringValue(updated.State["positionRecoveryStatus"]); got != "protected-open-position" {
 		t.Fatalf("expected protected-open-position, got %s", got)
+	}
+}
+
+func TestRefreshLiveSessionPositionContextPreservesWatermarksForVirtualPosition(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	session, err := platform.CreateLiveSession("live-main", "strategy-bk-1d", map[string]any{
+		"symbol":          "BTCUSDT",
+		"signalTimeframe": "1d",
+	})
+	if err != nil {
+		t.Fatalf("create live session failed: %v", err)
+	}
+	state := cloneMetadata(session.State)
+	state["virtualPosition"] = map[string]any{
+		"id":         "virtual|session-1|signal-1",
+		"virtual":    true,
+		"symbol":     "BTCUSDT",
+		"side":       "LONG",
+		"entryPrice": 50000.0,
+		"quantity":   0.0,
+	}
+	state["watermarkPositionKey"] = "virtual|session-1|signal-1|BTCUSDT|LONG|50000.00000000"
+	state["hwm"] = 52000.0
+	state["lwm"] = 50000.0
+	session, err = platform.store.UpdateLiveSessionState(session.ID, state)
+	if err != nil {
+		t.Fatalf("update live session state failed: %v", err)
+	}
+
+	updated, err := platform.refreshLiveSessionPositionContext(session, time.Date(2026, 4, 10, 10, 0, 0, 0, time.UTC), "test-refresh")
+	if err != nil {
+		t.Fatalf("refresh live session position context failed: %v", err)
+	}
+	if got := stringValue(updated.State["watermarkPositionKey"]); got != "virtual|session-1|signal-1|BTCUSDT|LONG|50000.00000000" {
+		t.Fatalf("expected virtual watermark key to be preserved, got %s", got)
+	}
+	if got := parseFloatValue(updated.State["hwm"]); got != 52000.0 {
+		t.Fatalf("expected virtual watermark hwm to be preserved, got %v", got)
+	}
+	if got := parseFloatValue(updated.State["lwm"]); got != 50000.0 {
+		t.Fatalf("expected virtual watermark lwm to be preserved, got %v", got)
+	}
+	if !boolValue(updated.State["hasRecoveredVirtualPosition"]) {
+		t.Fatal("expected virtual recovery flag to remain set")
+	}
+	if got := stringValue(updated.State["positionRecoveryStatus"]); got != "monitoring-virtual-position" {
+		t.Fatalf("expected monitoring-virtual-position, got %s", got)
 	}
 }

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -291,6 +291,7 @@ func TestResolveLiveSessionPositionSnapshotUsesVirtualPosition(t *testing.T) {
 		AccountID: "live-main",
 		State: map[string]any{
 			"virtualPosition": map[string]any{
+				"id":         "virtual|session-1|signal-1",
 				"symbol":     "BTCUSDT",
 				"side":       "LONG",
 				"quantity":   0.0,
@@ -311,6 +312,9 @@ func TestResolveLiveSessionPositionSnapshotUsesVirtualPosition(t *testing.T) {
 	}
 	if !boolValue(position["hasVirtualPosition"]) {
 		t.Fatal("expected returned position snapshot to expose virtual position explicitly")
+	}
+	if got := stringValue(position["id"]); got != "virtual|session-1|signal-1" {
+		t.Fatalf("expected virtual position id to be preserved, got %s", got)
 	}
 }
 
@@ -685,6 +689,103 @@ func TestBookAwareExecutionStrategySetsExpiryForSLProtectionWhenConfigured(t *te
 	}
 	if !boolValue(mapValue(proposal.Metadata["executionDecisionContext"])["slProtectionBranch"]) {
 		t.Fatal("expected explicit SL protection branch marker")
+	}
+	if got := stringValue(mapValue(proposal.Metadata["executionDecisionContext"])["slProtectionDepthMode"]); got != "spread-capped-fallback" {
+		t.Fatalf("expected fallback SL depth mode without qty data, got %s", got)
+	}
+}
+
+func TestResolveAggressiveSLProtectionDecisionUsesCappedPriceWhenTopBookOutsideCap(t *testing.T) {
+	decision := resolveAggressiveSLProtectionDecision("SELL", 0.5, 68000, 68150, 1.2, 0, 68000, 20)
+	if got := decision.Price; got != 68013.85 {
+		t.Fatalf("expected capped protection price 68013.85, got %v", got)
+	}
+	if got := decision.DepthMode; got != "top-book-outside-cap" {
+		t.Fatalf("expected top-book-outside-cap mode, got %s", got)
+	}
+	if got := decision.TopDepthNotional; got != 81600 {
+		t.Fatalf("expected top depth notional 81600, got %v", got)
+	}
+	if got := decision.ExpectedCoverage; got != 1 {
+		t.Fatalf("expected full coverage, got %v", got)
+	}
+}
+
+func TestResolveAggressiveSLProtectionDecisionRecordsPartialCoverageWhenTopBookOutsideCap(t *testing.T) {
+	decision := resolveAggressiveSLProtectionDecision("SELL", 2.0, 68000, 68150, 1.0, 0, 68000, 20)
+	if got := decision.DepthMode; got != "top-book-outside-cap" {
+		t.Fatalf("expected top-book-outside-cap mode, got %s", got)
+	}
+	if got := decision.ExpectedCoverage; got != 0.5 {
+		t.Fatalf("expected 50%% coverage, got %v", got)
+	}
+	if got := decision.Price; got != 68013.85 {
+		t.Fatalf("expected capped protection price 68013.85, got %v", got)
+	}
+	if got := decision.QuoteGapBps; got <= 0 {
+		t.Fatalf("expected positive quote gap bps, got %v", got)
+	}
+}
+
+func TestResolveAggressiveSLProtectionDecisionRecordsPartialCoverageWhenTopBookOutsideCapForBuy(t *testing.T) {
+	decision := resolveAggressiveSLProtectionDecision("BUY", 2.0, 68000, 68150, 0, 1.0, 68150, 20)
+	if got := decision.DepthMode; got != "top-book-outside-cap" {
+		t.Fatalf("expected top-book-outside-cap mode, got %s", got)
+	}
+	if got := decision.ExpectedCoverage; got != 0.5 {
+		t.Fatalf("expected 50%% coverage, got %v", got)
+	}
+	if got := decision.Price; got != 68136.15 {
+		t.Fatalf("expected capped protection price 68136.15, got %v", got)
+	}
+	if got := decision.QuoteGapBps; got <= 0 {
+		t.Fatalf("expected positive quote gap bps, got %v", got)
+	}
+}
+
+func TestResolveAggressiveSLProtectionDecisionUsesTopBookWhenWithinCapForBuy(t *testing.T) {
+	decision := resolveAggressiveSLProtectionDecision("BUY", 0.5, 68000, 68010, 0, 1.2, 68010, 20)
+	if got := decision.DepthMode; got != "top-book-cover-within-cap" {
+		t.Fatalf("expected top-book-cover-within-cap mode, got %s", got)
+	}
+	if got := decision.Price; got != 68010 {
+		t.Fatalf("expected top-book ask price 68010, got %v", got)
+	}
+}
+
+func TestResolveAggressiveSLProtectionDecisionRecordsPartialCoverageWhenWithinCapForBuy(t *testing.T) {
+	decision := resolveAggressiveSLProtectionDecision("BUY", 2.0, 68000, 68010, 0, 1.0, 68010, 20)
+	if got := decision.DepthMode; got != "top-book-partial-within-cap" {
+		t.Fatalf("expected top-book-partial-within-cap mode, got %s", got)
+	}
+	if got := decision.ExpectedCoverage; got != 0.5 {
+		t.Fatalf("expected 50%% coverage, got %v", got)
+	}
+	if got := decision.Price; got != 68010 {
+		t.Fatalf("expected within-cap BUY price to remain at ask 68010, got %v", got)
+	}
+}
+
+func TestResolveAggressiveSLProtectionDecisionUsesTopBookWhenWithinCap(t *testing.T) {
+	decision := resolveAggressiveSLProtectionDecision("SELL", 0.5, 68000, 68010, 1.2, 0, 68000, 20)
+	if got := decision.DepthMode; got != "top-book-cover-within-cap" {
+		t.Fatalf("expected top-book-cover-within-cap mode, got %s", got)
+	}
+	if got := decision.Price; got != 68000 {
+		t.Fatalf("expected top-book bid price 68000, got %v", got)
+	}
+}
+
+func TestResolveAggressiveSLProtectionDecisionRecordsPartialCoverageWhenWithinCap(t *testing.T) {
+	decision := resolveAggressiveSLProtectionDecision("SELL", 2.0, 68000, 68010, 1.0, 0, 68000, 20)
+	if got := decision.DepthMode; got != "top-book-partial-within-cap" {
+		t.Fatalf("expected top-book-partial-within-cap mode, got %s", got)
+	}
+	if got := decision.Price; got != 68000 {
+		t.Fatalf("expected capped price to remain at 68000, got %v", got)
+	}
+	if got := decision.ExpectedCoverage; got != 0.5 {
+		t.Fatalf("expected 50%% coverage, got %v", got)
 	}
 }
 
@@ -1355,6 +1456,301 @@ func TestNormalizeBinanceQuantityForMinNotional(t *testing.T) {
 	}
 }
 
+func TestNormalizeRESTOrderRecordsNormalizationTelemetry(t *testing.T) {
+	adapter := binanceFuturesLiveAdapter{}
+	creds := binanceRESTCredentials{BaseURL: "https://example.test"}
+	cacheKey := creds.BaseURL + "|BTCUSDT"
+	binanceSymbolRulesCacheMu.Lock()
+	previous, existed := binanceSymbolRulesCache[cacheKey]
+	binanceSymbolRulesCacheMu.Unlock()
+	t.Cleanup(func() {
+		binanceSymbolRulesCacheMu.Lock()
+		defer binanceSymbolRulesCacheMu.Unlock()
+		if existed {
+			binanceSymbolRulesCache[cacheKey] = previous
+		} else {
+			delete(binanceSymbolRulesCache, cacheKey)
+		}
+	})
+	binanceSymbolRulesCacheMu.Lock()
+	binanceSymbolRulesCache[cacheKey] = binanceSymbolRules{
+		Symbol:      "BTCUSDT",
+		TickSize:    0.1,
+		StepSize:    0.001,
+		MinQty:      0.001,
+		MaxQty:      1000,
+		MinNotional: 100,
+		UpdatedAt:   time.Now().UTC(),
+	}
+	binanceSymbolRulesCacheMu.Unlock()
+
+	normalized, _, err := adapter.normalizeRESTOrder(domain.Order{
+		Symbol:   "BTCUSDT",
+		Type:     "LIMIT",
+		Quantity: 0.0019,
+		Price:    68643.67,
+	}, creds)
+	if err != nil {
+		t.Fatalf("normalize REST order failed: %v", err)
+	}
+	norm := mapValue(normalized.Metadata["normalization"])
+	if got := parseFloatValue(norm["rawQuantity"]); got != 0.0019 {
+		t.Fatalf("expected raw quantity 0.0019, got %v", got)
+	}
+	if got := parseFloatValue(norm["normalizedQuantity"]); got != 0.002 {
+		t.Fatalf("expected normalized quantity 0.002, got %v", got)
+	}
+	if got := parseFloatValue(norm["normalizedPrice"]); got != 68643.6 {
+		t.Fatalf("expected normalized price 68643.6, got %v", got)
+	}
+	if got := normalized.Quantity; got != 0.002 {
+		t.Fatalf("expected normalized order quantity 0.002, got %v", got)
+	}
+	if got := normalized.Price; got != 68643.6 {
+		t.Fatalf("expected normalized order price 68643.6, got %v", got)
+	}
+	quantityAdjustmentCount := normalizationItemCount(norm["quantityAdjustments"])
+	if quantityAdjustmentCount != 2 {
+		t.Fatalf("expected 2 quantity adjustments, got %v", norm["quantityAdjustments"])
+	}
+	if !boolValue(norm["stepSizeAdjusted"]) || !boolValue(norm["minNotionalAdjusted"]) {
+		t.Fatalf("expected step size and min notional adjustments, got %+v", norm)
+	}
+	if !boolValue(norm["tickSizeAdjusted"]) {
+		t.Fatalf("expected tick size adjustment, got %+v", norm)
+	}
+}
+
+func TestExecutionDispatchSummaryIncludesNormalizationTelemetry(t *testing.T) {
+	summary := executionDispatchSummary(map[string]any{
+		"type":       "LIMIT",
+		"quantity":   0.0019,
+		"limitPrice": 68643.6,
+		"priceHint":  68643.67,
+		"metadata": map[string]any{
+			"executionDecision": "direct-dispatch",
+		},
+	}, domain.Order{
+		Status:   "NEW",
+		Symbol:   "BTCUSDT",
+		Side:     "BUY",
+		Type:     "LIMIT",
+		Quantity: 0.002,
+		Price:    68643.6,
+		Metadata: map[string]any{
+			"adapterSubmission": map[string]any{
+				"rawQuantity":        0.0019,
+				"rawPriceReference":  68643.67,
+				"normalizedQuantity": 0.002,
+				"normalizedPrice":    68643.6,
+				"normalization": map[string]any{
+					"quantityAdjustments": []any{"step_size", "min_notional"},
+					"priceAdjustments":    []any{"tick_size"},
+				},
+				"symbolRules": map[string]any{
+					"stepSize":    0.001,
+					"tickSize":    0.1,
+					"minNotional": 100.0,
+				},
+			},
+		},
+	}, false)
+	if got := parseFloatValue(summary["rawQuantity"]); got != 0.0019 {
+		t.Fatalf("expected raw quantity in dispatch summary, got %v", got)
+	}
+	if got := parseFloatValue(summary["normalizedQuantity"]); got != 0.002 {
+		t.Fatalf("expected normalized quantity in dispatch summary, got %v", got)
+	}
+	if got := parseFloatValue(summary["normalizedPrice"]); got != 68643.6 {
+		t.Fatalf("expected normalized price in dispatch summary, got %v", got)
+	}
+	if got := parseFloatValue(summary["rawPriceReference"]); got != 68643.67 {
+		t.Fatalf("expected raw price reference in dispatch summary, got %v", got)
+	}
+	if normalizationItemCount(mapValue(summary["normalization"])["quantityAdjustments"]) != 2 {
+		t.Fatalf("expected quantity adjustment details in dispatch summary, got %+v", summary["normalization"])
+	}
+	if normalizationItemCount(mapValue(summary["normalization"])["priceAdjustments"]) != 1 {
+		t.Fatalf("expected price adjustment details in dispatch summary, got %+v", summary["normalization"])
+	}
+}
+
+func TestExecutionDispatchSummaryFallsBackToNestedNormalizedPrice(t *testing.T) {
+	summary := executionDispatchSummary(map[string]any{
+		"type":       "LIMIT",
+		"quantity":   0.0019,
+		"limitPrice": 68643.6,
+		"priceHint":  68643.67,
+	}, domain.Order{
+		Status:   "NEW",
+		Symbol:   "BTCUSDT",
+		Side:     "BUY",
+		Type:     "LIMIT",
+		Quantity: 0.002,
+		Price:    68643.6,
+		Metadata: map[string]any{
+			"adapterSubmission": map[string]any{
+				"normalization": map[string]any{
+					"normalizedPrice":    68643.6,
+					"normalizedQuantity": 0.002,
+					"rawPriceReference":  68643.67,
+					"rawQuantity":        0.0019,
+				},
+			},
+		},
+	}, false)
+	if got := parseFloatValue(summary["normalizedPrice"]); got != 68643.6 {
+		t.Fatalf("expected normalized price fallback from normalization payload, got %v", got)
+	}
+}
+
+func TestExecutionTimeoutTimelineMetadataUsesOriginalSubmissionNormalization(t *testing.T) {
+	order := domain.Order{
+		ID: "order-1",
+		Metadata: map[string]any{
+			"executionExpiresAt": "2026-04-10T01:00:00Z",
+			"executionProposal": map[string]any{
+				"type":       "LIMIT",
+				"quantity":   0.0019,
+				"limitPrice": 68643.6,
+				"priceHint":  68643.67,
+			},
+			"adapterSubmission": map[string]any{
+				"normalizedPrice": 68643.6,
+				"normalization": map[string]any{
+					"normalizedPrice":    68643.6,
+					"normalizedQuantity": 0.002,
+					"rawPriceReference":  68643.67,
+					"rawQuantity":        0.0019,
+				},
+			},
+		},
+	}
+	cancelledOrder := domain.Order{
+		ID:     "order-1",
+		Status: "CANCELLED",
+	}
+	metadata := executionTimeoutTimelineMetadata(order, withExecutionSubmissionFallback(cancelledOrder, order))
+	if got := parseFloatValue(metadata["normalizedPrice"]); got != 68643.6 {
+		t.Fatalf("expected timeout metadata to preserve normalized price, got %v", got)
+	}
+}
+
+func TestWithExecutionSubmissionFallbackMergesPartialSubmissionFields(t *testing.T) {
+	order := domain.Order{
+		Metadata: map[string]any{
+			"adapterSubmission": map[string]any{
+				"normalizedPrice": 68643.6,
+				"normalization": map[string]any{
+					"normalizedPrice": 68643.6,
+				},
+			},
+		},
+	}
+	fallback := domain.Order{
+		Metadata: map[string]any{
+			"adapterSubmission": map[string]any{
+				"rawQuantity":        0.0019,
+				"normalizedQuantity": 0.002,
+				"rawPriceReference":  68643.67,
+				"normalization": map[string]any{
+					"normalizedPrice":    68643.6,
+					"normalizedQuantity": 0.002,
+					"rawPriceReference":  68643.67,
+					"rawQuantity":        0.0019,
+				},
+				"symbolRules": map[string]any{
+					"stepSize": 0.001,
+				},
+			},
+		},
+	}
+	merged := withExecutionSubmissionFallback(order, fallback)
+	submission := mapValue(merged.Metadata["adapterSubmission"])
+	if got := parseFloatValue(submission["normalizedPrice"]); got != 68643.6 {
+		t.Fatalf("expected existing normalized price to survive merge, got %v", got)
+	}
+	if got := parseFloatValue(submission["normalizedQuantity"]); got != 0.002 {
+		t.Fatalf("expected normalized quantity fallback, got %v", got)
+	}
+	if got := parseFloatValue(mapValue(submission["normalization"])["rawQuantity"]); got != 0.0019 {
+		t.Fatalf("expected nested raw quantity fallback, got %v", got)
+	}
+	if got := parseFloatValue(mapValue(submission["symbolRules"])["stepSize"]); got != 0.001 {
+		t.Fatalf("expected symbol rules fallback, got %v", got)
+	}
+}
+
+func TestWithExecutionSubmissionFallbackRestoresZeroNormalizationFields(t *testing.T) {
+	order := domain.Order{
+		Metadata: map[string]any{
+			"adapterSubmission": map[string]any{
+				"normalizedPrice": 0.0,
+				"rawQuantity":     0.0,
+				"reduceOnly":      false,
+			},
+		},
+	}
+	fallback := domain.Order{
+		Metadata: map[string]any{
+			"adapterSubmission": map[string]any{
+				"normalizedPrice": 68643.6,
+				"rawQuantity":     0.0019,
+				"reduceOnly":      true,
+			},
+		},
+	}
+	merged := withExecutionSubmissionFallback(order, fallback)
+	submission := mapValue(merged.Metadata["adapterSubmission"])
+	if got := parseFloatValue(submission["normalizedPrice"]); got != 0 {
+		t.Fatalf("expected explicit zero normalized price to be preserved, got %v", got)
+	}
+	if got := parseFloatValue(submission["rawQuantity"]); got != 0.0019 {
+		t.Fatalf("expected zero raw quantity to fall back, got %v", got)
+	}
+	if got := boolValue(submission["reduceOnly"]); got {
+		t.Fatal("expected explicit false reduceOnly to be preserved")
+	}
+}
+
+func TestWithExecutionSubmissionFallbackPreservesExplicitZeroForUnknownFields(t *testing.T) {
+	order := domain.Order{
+		Metadata: map[string]any{
+			"adapterSubmission": map[string]any{
+				"queueIndex": 0.0,
+				"auditFlag":  false,
+			},
+		},
+	}
+	fallback := domain.Order{
+		Metadata: map[string]any{
+			"adapterSubmission": map[string]any{
+				"queueIndex": 7.0,
+				"auditFlag":  true,
+			},
+		},
+	}
+	merged := withExecutionSubmissionFallback(order, fallback)
+	submission := mapValue(merged.Metadata["adapterSubmission"])
+	if got := parseFloatValue(submission["queueIndex"]); got != 0 {
+		t.Fatalf("expected explicit zero queueIndex to be preserved, got %v", got)
+	}
+	if got := boolValue(submission["auditFlag"]); got {
+		t.Fatal("expected explicit false auditFlag to be preserved")
+	}
+}
+
+func normalizationItemCount(raw any) int {
+	switch value := raw.(type) {
+	case []string:
+		return len(value)
+	case []any:
+		return len(value)
+	default:
+		return 0
+	}
+}
+
 func TestShouldMarkLiveExecutionFallback(t *testing.T) {
 	order := domain.Order{
 		Status: "REJECTED",
@@ -1504,6 +1900,9 @@ func TestEvaluateLiveSessionOnSignalRecordsVirtualInitialForZeroInitialStrategy(
 	}
 	if !boolValue(mapValue(updated.State["virtualPosition"])["virtual"]) {
 		t.Fatal("expected virtualPosition to be recorded in live session state")
+	}
+	if got := stringValue(mapValue(updated.State["virtualPosition"])["id"]); got == "" {
+		t.Fatal("expected virtualPosition to carry a stable id")
 	}
 	if got := maxIntValue(updated.State["planIndex"], -1); got != 1 {
 		t.Fatalf("expected planIndex to advance after virtual initial, got %d", got)

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -1524,7 +1524,7 @@ func TestNormalizeRESTOrderRecordsNormalizationTelemetry(t *testing.T) {
 func TestExecutionDispatchSummaryIncludesNormalizationTelemetry(t *testing.T) {
 	summary := executionDispatchSummary(map[string]any{
 		"type":       "LIMIT",
-		"quantity":   0.0019,
+		"quantity":   0.0021,
 		"limitPrice": 68643.6,
 		"priceHint":  68643.67,
 		"metadata": map[string]any{
@@ -1539,12 +1539,12 @@ func TestExecutionDispatchSummaryIncludesNormalizationTelemetry(t *testing.T) {
 		Price:    68643.6,
 		Metadata: map[string]any{
 			"adapterSubmission": map[string]any{
-				"rawQuantity":        0.0019,
+				"rawQuantity":        0.0021,
 				"rawPriceReference":  68643.67,
 				"normalizedQuantity": 0.002,
 				"normalizedPrice":    68643.6,
 				"normalization": map[string]any{
-					"quantityAdjustments": []any{"step_size", "min_notional"},
+					"quantityAdjustments": []any{"step_size"},
 					"priceAdjustments":    []any{"tick_size"},
 				},
 				"symbolRules": map[string]any{
@@ -1555,7 +1555,7 @@ func TestExecutionDispatchSummaryIncludesNormalizationTelemetry(t *testing.T) {
 			},
 		},
 	}, false)
-	if got := parseFloatValue(summary["rawQuantity"]); got != 0.0019 {
+	if got := parseFloatValue(summary["rawQuantity"]); got != 0.0021 {
 		t.Fatalf("expected raw quantity in dispatch summary, got %v", got)
 	}
 	if got := parseFloatValue(summary["normalizedQuantity"]); got != 0.002 {
@@ -1567,7 +1567,7 @@ func TestExecutionDispatchSummaryIncludesNormalizationTelemetry(t *testing.T) {
 	if got := parseFloatValue(summary["rawPriceReference"]); got != 68643.67 {
 		t.Fatalf("expected raw price reference in dispatch summary, got %v", got)
 	}
-	if normalizationItemCount(mapValue(summary["normalization"])["quantityAdjustments"]) != 2 {
+	if normalizationItemCount(mapValue(summary["normalization"])["quantityAdjustments"]) != 1 {
 		t.Fatalf("expected quantity adjustment details in dispatch summary, got %+v", summary["normalization"])
 	}
 	if normalizationItemCount(mapValue(summary["normalization"])["priceAdjustments"]) != 1 {
@@ -1708,8 +1708,8 @@ func TestWithExecutionSubmissionFallbackRestoresZeroNormalizationFields(t *testi
 	if got := parseFloatValue(submission["rawQuantity"]); got != 0.0019 {
 		t.Fatalf("expected zero raw quantity to fall back, got %v", got)
 	}
-	if got := boolValue(submission["reduceOnly"]); got {
-		t.Fatal("expected explicit false reduceOnly to be preserved")
+	if got := boolValue(submission["reduceOnly"]); !got {
+		t.Fatal("expected known execution-control false to fall back to the original reduceOnly=true")
 	}
 }
 
@@ -1757,8 +1757,13 @@ func TestApplyLiveVirtualInitialEventUsesFallbackVirtualPositionIDWhenIntentSign
 	if virtualPosition == nil {
 		t.Fatal("expected virtual position to be recorded")
 	}
-	if got := stringValue(virtualPosition["id"]); got == "" || got == "virtual|live-session-main|" {
-		t.Fatalf("expected fallback virtual position id to be populated, got %q", got)
+	rawSignature := buildLiveIntentSignature(proposalMap)
+	fallbackSignature := buildFallbackLiveIntentSignature(proposalMap, executionProposalFromMap(proposalMap))
+	if got := stringValue(updated.State["lastDispatchedIntentSignature"]); got != fallbackSignature {
+		t.Fatalf("expected sparse proposal to use fallback signature %q, got %q (raw=%q)", fallbackSignature, got, rawSignature)
+	}
+	if got := stringValue(virtualPosition["id"]); got == "" || strings.HasSuffix(got, rawSignature) {
+		t.Fatalf("expected fallback virtual position id to avoid sparse raw signature, got %q", got)
 	}
 }
 
@@ -1779,6 +1784,26 @@ func TestBuildFallbackLiveIntentSignatureIncludesExecutionFields(t *testing.T) {
 	variantSignature := buildFallbackLiveIntentSignature(variantProposalMap, executionProposalFromMap(variantProposalMap))
 	if baseSignature == variantSignature {
 		t.Fatalf("expected quantity changes to alter fallback signature, got %q", baseSignature)
+	}
+}
+
+func TestBuildFallbackLiveIntentSignaturePreservesExplicitFalseBooleans(t *testing.T) {
+	proposalMap := map[string]any{
+		"reason":            "Initial",
+		"side":              "BUY",
+		"symbol":            "BTCUSDT",
+		"postOnly":          false,
+		"reduceOnly":        false,
+		"closePosition":     false,
+		"signalBarStateKey": "bar-1",
+	}
+	proposal := ExecutionProposal{
+		PostOnly:   true,
+		ReduceOnly: true,
+	}
+	signature := buildFallbackLiveIntentSignature(proposalMap, proposal)
+	if strings.Contains(signature, "|true|true|true") {
+		t.Fatalf("expected explicit false booleans to be preserved in fallback signature, got %q", signature)
 	}
 }
 
@@ -2524,5 +2549,53 @@ func TestRefreshLiveSessionPositionContextRebuildsVirtualWatermarksFromVirtualPo
 	liveState := mapValue(updated.State["livePositionState"])
 	if got := stringValue(liveState["watermarkPositionKey"]); got != expectedKey {
 		t.Fatalf("expected rebuilt livePositionState watermark key, got %s", got)
+	}
+}
+
+func TestRefreshLiveSessionPositionContextClearsStaleLivePositionStateWithoutRealOrVirtualPosition(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	session, err := platform.CreateLiveSession("live-main", "strategy-bk-1d", map[string]any{
+		"symbol":          "BTCUSDT",
+		"signalTimeframe": "1d",
+	})
+	if err != nil {
+		t.Fatalf("create live session failed: %v", err)
+	}
+	state := cloneMetadata(session.State)
+	state["livePositionState"] = map[string]any{
+		"found":                true,
+		"symbol":               "BTCUSDT",
+		"side":                 "LONG",
+		"entryPrice":           50000.0,
+		"watermarkPositionKey": encodeLivePositionWatermarkIdentityComponent("position-1") + "|BTCUSDT|LONG|50000.00000000",
+		"hwm":                  52000.0,
+		"lwm":                  50000.0,
+	}
+	state["watermarkPositionKey"] = encodeLivePositionWatermarkIdentityComponent("position-1") + "|BTCUSDT|LONG|50000.00000000"
+	state["hwm"] = 52000.0
+	state["lwm"] = 50000.0
+	session, err = platform.store.UpdateLiveSessionState(session.ID, state)
+	if err != nil {
+		t.Fatalf("update live session state failed: %v", err)
+	}
+
+	updated, err := platform.refreshLiveSessionPositionContext(session, time.Date(2026, 4, 12, 7, 0, 0, 0, time.UTC), "test-refresh")
+	if err != nil {
+		t.Fatalf("refresh live session position context failed: %v", err)
+	}
+	if got := stringValue(updated.State["positionRecoveryStatus"]); got != "flat" {
+		t.Fatalf("expected flat recovery status after stale position cleanup, got %s", got)
+	}
+	if _, ok := updated.State["watermarkPositionKey"]; ok {
+		t.Fatal("expected stale watermarkPositionKey to be cleared")
+	}
+	if _, ok := updated.State["hwm"]; ok {
+		t.Fatal("expected stale hwm to be cleared")
+	}
+	if _, ok := updated.State["lwm"]; ok {
+		t.Fatal("expected stale lwm to be cleared")
+	}
+	if liveState := mapValue(updated.State["livePositionState"]); len(liveState) != 0 {
+		t.Fatalf("expected stale livePositionState to be cleared, got %+v", liveState)
 	}
 }

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -1521,48 +1521,6 @@ func TestNormalizeRESTOrderRecordsNormalizationTelemetry(t *testing.T) {
 	}
 }
 
-func TestNormalizeRESTOrderRejectsBelowMinNotionalAfterRounding(t *testing.T) {
-	adapter := binanceFuturesLiveAdapter{}
-	creds := binanceRESTCredentials{BaseURL: "https://example.test"}
-	cacheKey := creds.BaseURL + "|BTCUSDT"
-	binanceSymbolRulesCacheMu.Lock()
-	previous, existed := binanceSymbolRulesCache[cacheKey]
-	binanceSymbolRulesCacheMu.Unlock()
-	t.Cleanup(func() {
-		binanceSymbolRulesCacheMu.Lock()
-		defer binanceSymbolRulesCacheMu.Unlock()
-		if existed {
-			binanceSymbolRulesCache[cacheKey] = previous
-		} else {
-			delete(binanceSymbolRulesCache, cacheKey)
-		}
-	})
-	binanceSymbolRulesCacheMu.Lock()
-	binanceSymbolRulesCache[cacheKey] = binanceSymbolRules{
-		Symbol:      "BTCUSDT",
-		TickSize:    0.1,
-		StepSize:    0.001,
-		MinQty:      0.001,
-		MaxQty:      1000,
-		MinNotional: 100,
-		UpdatedAt:   time.Now().UTC(),
-	}
-	binanceSymbolRulesCacheMu.Unlock()
-
-	_, _, err := adapter.normalizeRESTOrder(domain.Order{
-		Symbol:   "BTCUSDT",
-		Type:     "LIMIT",
-		Quantity: 0.0019,
-		Price:    68643.67,
-	}, creds)
-	if err == nil {
-		t.Fatal("expected normalize REST order to reject below-min-notional quantity after rounding")
-	}
-	if !strings.Contains(err.Error(), "below minNotional") {
-		t.Fatalf("expected minNotional rejection, got %v", err)
-	}
-}
-
 func TestExecutionDispatchSummaryIncludesNormalizationTelemetry(t *testing.T) {
 	summary := executionDispatchSummary(map[string]any{
 		"type":       "LIMIT",
@@ -1805,7 +1763,6 @@ func TestApplyLiveVirtualInitialEventUsesFallbackVirtualPositionIDWhenIntentSign
 }
 
 func TestBuildFallbackLiveIntentSignatureIncludesExecutionFields(t *testing.T) {
-	eventTime := time.Date(2026, 4, 10, 9, 0, 0, 0, time.UTC)
 	baseProposalMap := map[string]any{
 		"reason":            "Initial",
 		"side":              "BUY",
@@ -1816,10 +1773,10 @@ func TestBuildFallbackLiveIntentSignatureIncludesExecutionFields(t *testing.T) {
 		"limitPrice":        68000.0,
 		"priceHint":         68000.5,
 	}
-	baseSignature := buildFallbackLiveIntentSignature(baseProposalMap, executionProposalFromMap(baseProposalMap), eventTime)
+	baseSignature := buildFallbackLiveIntentSignature(baseProposalMap, executionProposalFromMap(baseProposalMap))
 	variantProposalMap := cloneMetadata(baseProposalMap)
 	variantProposalMap["quantity"] = 0.002
-	variantSignature := buildFallbackLiveIntentSignature(variantProposalMap, executionProposalFromMap(variantProposalMap), eventTime)
+	variantSignature := buildFallbackLiveIntentSignature(variantProposalMap, executionProposalFromMap(variantProposalMap))
 	if baseSignature == variantSignature {
 		t.Fatalf("expected quantity changes to alter fallback signature, got %q", baseSignature)
 	}
@@ -2498,7 +2455,7 @@ func TestRefreshLiveSessionPositionContextRebuildsLivePositionState(t *testing.T
 	}
 }
 
-func TestRefreshLiveSessionPositionContextPreservesWatermarksForVirtualPosition(t *testing.T) {
+func TestRefreshLiveSessionPositionContextRebuildsVirtualWatermarksFromVirtualPosition(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
 	session, err := platform.CreateLiveSession("live-main", "strategy-bk-1d", map[string]any{
 		"symbol":          "BTCUSDT",
@@ -2516,9 +2473,29 @@ func TestRefreshLiveSessionPositionContextPreservesWatermarksForVirtualPosition(
 		"entryPrice": 50000.0,
 		"quantity":   0.0,
 	}
-	state["watermarkPositionKey"] = "virtual|session-1|signal-1|BTCUSDT|LONG|50000.00000000"
-	state["hwm"] = 52000.0
-	state["lwm"] = 50000.0
+	state["watermarkPositionKey"] = encodeLivePositionWatermarkIdentityComponent("position-1") + "|BTCUSDT|LONG|49000.00000000"
+	state["hwm"] = 53000.0
+	state["lwm"] = 49000.0
+	state["lastStrategyEvaluationSignalBarStates"] = map[string]any{
+		signalBindingMatchKey("binance-kline", "signal", "BTCUSDT"): map[string]any{
+			"symbol":    "BTCUSDT",
+			"timeframe": "1d",
+			"atr14":     900.0,
+			"current": map[string]any{
+				"close": 51000.0,
+				"high":  51100.0,
+				"low":   50500.0,
+			},
+			"prevBar1": map[string]any{
+				"high": 50800.0,
+				"low":  49800.0,
+			},
+			"prevBar2": map[string]any{
+				"high": 50700.0,
+				"low":  49700.0,
+			},
+		},
+	}
 	session, err = platform.store.UpdateLiveSessionState(session.ID, state)
 	if err != nil {
 		t.Fatalf("update live session state failed: %v", err)
@@ -2528,19 +2505,24 @@ func TestRefreshLiveSessionPositionContextPreservesWatermarksForVirtualPosition(
 	if err != nil {
 		t.Fatalf("refresh live session position context failed: %v", err)
 	}
-	if got := stringValue(updated.State["watermarkPositionKey"]); got != "virtual|session-1|signal-1|BTCUSDT|LONG|50000.00000000" {
-		t.Fatalf("expected virtual watermark key to be preserved, got %s", got)
+	expectedKey := encodeLivePositionWatermarkIdentityComponent("virtual|session-1|signal-1") + "|BTCUSDT|LONG|50000.00000000"
+	if got := stringValue(updated.State["watermarkPositionKey"]); got != expectedKey {
+		t.Fatalf("expected virtual watermark key to be rebuilt, got %s", got)
 	}
-	if got := parseFloatValue(updated.State["hwm"]); got != 52000.0 {
-		t.Fatalf("expected virtual watermark hwm to be preserved, got %v", got)
+	if got := parseFloatValue(updated.State["hwm"]); got != 51000.0 {
+		t.Fatalf("expected virtual watermark hwm to be rebuilt from virtual position context, got %v", got)
 	}
 	if got := parseFloatValue(updated.State["lwm"]); got != 50000.0 {
-		t.Fatalf("expected virtual watermark lwm to be preserved, got %v", got)
+		t.Fatalf("expected virtual watermark lwm to be reset to entry/virtual context, got %v", got)
 	}
 	if !boolValue(updated.State["hasRecoveredVirtualPosition"]) {
 		t.Fatal("expected virtual recovery flag to remain set")
 	}
 	if got := stringValue(updated.State["positionRecoveryStatus"]); got != "monitoring-virtual-position" {
 		t.Fatalf("expected monitoring-virtual-position, got %s", got)
+	}
+	liveState := mapValue(updated.State["livePositionState"])
+	if got := stringValue(liveState["watermarkPositionKey"]); got != expectedKey {
+		t.Fatalf("expected rebuilt livePositionState watermark key, got %s", got)
 	}
 }

--- a/internal/service/strategy_optimization_test.go
+++ b/internal/service/strategy_optimization_test.go
@@ -357,6 +357,29 @@ func TestResolveLivePositionWatermarksSupportsLegacyRealPositionKey(t *testing.T
 	}
 }
 
+func TestResolveLivePositionWatermarksResetsForPositionIDOnlyLegacyKey(t *testing.T) {
+	sessionState := map[string]any{
+		"hwm":                  52000.0,
+		"lwm":                  50000.0,
+		"watermarkPositionKey": "position-1",
+	}
+	currentPosition := map[string]any{
+		"id":         "position-1",
+		"symbol":     "BTCUSDT",
+		"side":       "LONG",
+		"entryPrice": 51000.0,
+		"quantity":   1.0,
+		"found":      true,
+	}
+	watermarks := resolveLivePositionWatermarks(currentPosition, sessionState)
+	if got := watermarks.PositionKey; got != "position-1|BTCUSDT|LONG|51000.00000000" {
+		t.Fatalf("expected canonical watermark key for reused position id, got %s", got)
+	}
+	if watermarks.HWM != 51000.0 || watermarks.LWM != 51000.0 {
+		t.Fatalf("expected position-id-only legacy key to reset watermarks, got %+v", watermarks)
+	}
+}
+
 func TestEvaluateLiveSignalDecisionPreservesWatermarksWhenPositionInactive(t *testing.T) {
 	engine := bkStrategyEngine{}
 	context := StrategySignalEvaluationContext{

--- a/internal/service/strategy_optimization_test.go
+++ b/internal/service/strategy_optimization_test.go
@@ -310,15 +310,15 @@ func TestResolveLivePositionWatermarksPreservesPreviousKeyWhenIDTemporarilyMissi
 		"found":      true,
 	}
 	watermarks := resolveLivePositionWatermarks(currentPosition, sessionState)
-	if got := watermarks.PositionKey; got != "position-1|BTCUSDT|LONG|50000.00000000" {
-		t.Fatalf("expected missing id to preserve previous stable watermark key, got %s", got)
+	if got := watermarks.PositionKey; got != "BTCUSDT|LONG|50000.00000000" {
+		t.Fatalf("expected missing id to fall back to base watermark key, got %s", got)
 	}
-	if watermarks.HWM != 52000.0 || watermarks.LWM != 50000.0 {
-		t.Fatalf("expected missing id to preserve existing watermarks, got %+v", watermarks)
+	if watermarks.HWM != 50000.0 || watermarks.LWM != 50000.0 {
+		t.Fatalf("expected missing id fallback to reset watermarks, got %+v", watermarks)
 	}
 }
 
-func TestRefreshLivePositionWatermarksClearsStateWhenPositionIsInactive(t *testing.T) {
+func TestRefreshLivePositionWatermarksReturnsEmptyWhenPositionIsInactive(t *testing.T) {
 	sessionState := map[string]any{
 		"hwm":                  52000.0,
 		"lwm":                  50000.0,
@@ -331,15 +331,6 @@ func TestRefreshLivePositionWatermarksClearsStateWhenPositionIsInactive(t *testi
 	}, 0)
 	if watermarks.PositionKey != "" || watermarks.HWM != 0 || watermarks.LWM != 0 {
 		t.Fatalf("expected empty watermarks for inactive position, got %+v", watermarks)
-	}
-	if got := stringValue(sessionState["watermarkPositionKey"]); got != "position-1|BTCUSDT|LONG|50000.00000000" {
-		t.Fatalf("expected generic inactive refresh to preserve existing watermark key, got %s", got)
-	}
-	if got := parseFloatValue(sessionState["hwm"]); got != 52000.0 {
-		t.Fatalf("expected generic inactive refresh to preserve HWM, got %v", got)
-	}
-	if got := parseFloatValue(sessionState["lwm"]); got != 50000.0 {
-		t.Fatalf("expected generic inactive refresh to preserve LWM, got %v", got)
 	}
 }
 
@@ -361,8 +352,8 @@ func TestResolveLivePositionWatermarksSupportsLegacyRealPositionKey(t *testing.T
 	if got := watermarks.PositionKey; got != "position-1|BTCUSDT|LONG|50000.00000000" {
 		t.Fatalf("expected legacy real-position watermark key to migrate to canonical key, got %s", got)
 	}
-	if watermarks.HWM != 50000.0 || watermarks.LWM != 50000.0 {
-		t.Fatalf("expected legacy real-position key migration to reset watermarks, got %+v", watermarks)
+	if watermarks.HWM != 52000.0 || watermarks.LWM != 50000.0 {
+		t.Fatalf("expected legacy real-position key migration to preserve watermarks, got %+v", watermarks)
 	}
 }
 
@@ -417,6 +408,44 @@ func TestEvaluateLiveSignalDecisionClearsWatermarksWhenPositionInactive(t *testi
 	}
 	if _, ok := context.SessionState["lwm"]; ok {
 		t.Fatal("expected inactive strategy evaluation to clear lwm")
+	}
+}
+
+func TestEvaluateLivePositionStateClearsWatermarksWhenPositionInactive(t *testing.T) {
+	sessionState := map[string]any{
+		"hwm":                  52000.0,
+		"lwm":                  50000.0,
+		"watermarkPositionKey": "position-1|BTCUSDT|LONG|50000.00000000",
+	}
+	parameters := map[string]any{
+		"stop_loss_atr":              0.05,
+		"profit_protect_atr":         0.5,
+		"trailing_stop_atr":          0.3,
+		"signalDecisionMaxSpreadBps": 8.0,
+	}
+	signalBarState := map[string]any{
+		"atr14":    1000.0,
+		"current":  map[string]any{"close": 50000.0},
+		"prevBar1": map[string]any{"high": 50500.0, "low": 49500.0},
+		"prevBar2": map[string]any{"high": 50600.0, "low": 49400.0},
+	}
+	currentPosition := map[string]any{
+		"symbol":   "BTCUSDT",
+		"quantity": 0.0,
+		"found":    false,
+	}
+	state := evaluateLivePositionState(parameters, currentPosition, signalBarState, 50000.0, sessionState)
+	if len(state) != 0 {
+		t.Fatalf("expected empty live position state for inactive position, got %+v", state)
+	}
+	if _, ok := sessionState["watermarkPositionKey"]; ok {
+		t.Fatal("expected inactive position state evaluation to clear watermarkPositionKey")
+	}
+	if _, ok := sessionState["hwm"]; ok {
+		t.Fatal("expected inactive position state evaluation to clear hwm")
+	}
+	if _, ok := sessionState["lwm"]; ok {
+		t.Fatal("expected inactive position state evaluation to clear lwm")
 	}
 }
 
@@ -494,7 +523,7 @@ func TestDeriveLivePositionStateUsesProvidedWatermarksForShort(t *testing.T) {
 	}
 }
 
-func TestResolveLivePositionWatermarksIgnoresInactiveSnapshot(t *testing.T) {
+func TestResolveLivePositionWatermarksReturnsEmptyForInactiveSnapshot(t *testing.T) {
 	sessionState := map[string]any{
 		"hwm":                  52000.0,
 		"lwm":                  50000.0,
@@ -510,15 +539,6 @@ func TestResolveLivePositionWatermarksIgnoresInactiveSnapshot(t *testing.T) {
 	watermarks := resolveLivePositionWatermarks(currentPosition, sessionState)
 	if watermarks.PositionKey != "" || watermarks.HWM != 0 || watermarks.LWM != 0 {
 		t.Fatalf("expected inactive snapshot to skip watermark refresh, got %+v", watermarks)
-	}
-	if got := stringValue(sessionState["watermarkPositionKey"]); got != "position-1|BTCUSDT|LONG" {
-		t.Fatalf("expected inactive snapshot to preserve persisted watermark key, got %s", got)
-	}
-	if got := parseFloatValue(sessionState["hwm"]); got != 52000.0 {
-		t.Fatalf("expected inactive snapshot to preserve persisted HWM, got %v", got)
-	}
-	if got := parseFloatValue(sessionState["lwm"]); got != 50000.0 {
-		t.Fatalf("expected inactive snapshot to preserve persisted LWM, got %v", got)
 	}
 }
 

--- a/internal/service/strategy_optimization_test.go
+++ b/internal/service/strategy_optimization_test.go
@@ -178,7 +178,7 @@ func TestUpdateLivePositionWatermarksResetsWhenPositionChanges(t *testing.T) {
 	if lwm != 47900.0 {
 		t.Fatalf("expected lwm to update from new position context, got %v", lwm)
 	}
-	if got := stringValue(sessionState["watermarkPositionKey"]); got != "position-new|ETHUSDT|SHORT|48000.00000000" {
+	if got := stringValue(sessionState["watermarkPositionKey"]); got != encodeLivePositionWatermarkIdentityComponent("position-new")+"|ETHUSDT|SHORT|48000.00000000" {
 		t.Fatalf("expected watermark key to reset, got %s", got)
 	}
 }
@@ -187,7 +187,7 @@ func TestResolveAndApplyLivePositionWatermarksAreSeparated(t *testing.T) {
 	sessionState := map[string]any{
 		"hwm":                  52000.0,
 		"lwm":                  50000.0,
-		"watermarkPositionKey": "position-1|BTCUSDT|LONG|50000.00000000",
+		"watermarkPositionKey": encodeLivePositionWatermarkIdentityComponent("position-1") + "|BTCUSDT|LONG|50000.00000000",
 	}
 	currentPosition := map[string]any{
 		"id":         "position-1",
@@ -197,7 +197,7 @@ func TestResolveAndApplyLivePositionWatermarksAreSeparated(t *testing.T) {
 		"quantity":   1.0,
 		"found":      true,
 	}
-	expectedKey := "position-1|BTCUSDT|LONG|50000.00000000"
+	expectedKey := encodeLivePositionWatermarkIdentityComponent("position-1") + "|BTCUSDT|LONG|50000.00000000"
 	watermarks := resolveLivePositionWatermarks(currentPosition, sessionState)
 	if watermarks.HWM != 52000.0 || watermarks.LWM != 50000.0 {
 		t.Fatalf("expected resolved watermarks from session state, got %+v", watermarks)
@@ -231,7 +231,7 @@ func TestResolveLivePositionWatermarksUsesExpandedPositionContextKey(t *testing.
 	sessionState := map[string]any{
 		"hwm":                  52000.0,
 		"lwm":                  50000.0,
-		"watermarkPositionKey": "position-1|BTCUSDT|LONG|50000.00000000",
+		"watermarkPositionKey": encodeLivePositionWatermarkIdentityComponent("position-1") + "|BTCUSDT|LONG|50000.00000000",
 	}
 	currentPosition := map[string]any{
 		"id":         "position-2",
@@ -242,7 +242,7 @@ func TestResolveLivePositionWatermarksUsesExpandedPositionContextKey(t *testing.
 		"found":      true,
 	}
 	watermarks := resolveLivePositionWatermarks(currentPosition, sessionState)
-	if got := watermarks.PositionKey; got != "position-2|BTCUSDT|LONG|50000.00000000" {
+	if got := watermarks.PositionKey; got != encodeLivePositionWatermarkIdentityComponent("position-2")+"|BTCUSDT|LONG|50000.00000000" {
 		t.Fatalf("expected new position id to reset watermark key, got %s", got)
 	}
 	if watermarks.HWM != 50000.0 || watermarks.LWM != 50000.0 {
@@ -265,7 +265,7 @@ func TestResolveLivePositionWatermarksUsesVirtualPositionID(t *testing.T) {
 		"virtual":    true,
 	}
 	watermarks := resolveLivePositionWatermarks(currentPosition, sessionState)
-	if got := watermarks.PositionKey; got != "virtual|session-1|signal-2|BTCUSDT|LONG|50000.00000000" {
+	if got := watermarks.PositionKey; got != encodeLivePositionWatermarkIdentityComponent("virtual|session-1|signal-2")+"|BTCUSDT|LONG|50000.00000000" {
 		t.Fatalf("expected virtual position id to drive watermark key, got %s", got)
 	}
 	if watermarks.HWM != 50000.0 || watermarks.LWM != 50000.0 {
@@ -288,7 +288,7 @@ func TestResolveLivePositionWatermarksSupportsLegacyVirtualKey(t *testing.T) {
 		"virtual":    true,
 	}
 	watermarks := resolveLivePositionWatermarks(currentPosition, sessionState)
-	if got := watermarks.PositionKey; got != "virtual|session-1|signal-2|BTCUSDT|LONG|50000.00000000" {
+	if got := watermarks.PositionKey; got != encodeLivePositionWatermarkIdentityComponent("virtual|session-1|signal-2")+"|BTCUSDT|LONG|50000.00000000" {
 		t.Fatalf("expected legacy virtual watermark key to migrate to canonical key, got %s", got)
 	}
 	if watermarks.HWM != 52000.0 || watermarks.LWM != 50000.0 {
@@ -296,11 +296,11 @@ func TestResolveLivePositionWatermarksSupportsLegacyVirtualKey(t *testing.T) {
 	}
 }
 
-func TestResolveLivePositionWatermarksPreservesPreviousKeyWhenIDTemporarilyMissing(t *testing.T) {
+func TestResolveLivePositionWatermarksResetsWhenIDTemporarilyMissing(t *testing.T) {
 	sessionState := map[string]any{
 		"hwm":                  52000.0,
 		"lwm":                  50000.0,
-		"watermarkPositionKey": "position-1|BTCUSDT|LONG|50000.00000000",
+		"watermarkPositionKey": encodeLivePositionWatermarkIdentityComponent("position-1") + "|BTCUSDT|LONG|50000.00000000",
 	}
 	currentPosition := map[string]any{
 		"symbol":     "BTCUSDT",
@@ -310,19 +310,19 @@ func TestResolveLivePositionWatermarksPreservesPreviousKeyWhenIDTemporarilyMissi
 		"found":      true,
 	}
 	watermarks := resolveLivePositionWatermarks(currentPosition, sessionState)
-	if got := watermarks.PositionKey; got != "position-1|BTCUSDT|LONG|50000.00000000" {
-		t.Fatalf("expected missing id to preserve previous stable watermark key, got %s", got)
+	if got := watermarks.PositionKey; got != "BTCUSDT|LONG|50000.00000000" {
+		t.Fatalf("expected missing id to fall back to base watermark key, got %s", got)
 	}
-	if watermarks.HWM != 52000.0 || watermarks.LWM != 50000.0 {
-		t.Fatalf("expected missing id to preserve existing watermarks, got %+v", watermarks)
+	if watermarks.HWM != 50000.0 || watermarks.LWM != 50000.0 {
+		t.Fatalf("expected missing id to reset watermarks, got %+v", watermarks)
 	}
 }
 
-func TestRefreshLivePositionWatermarksReturnsEmptyWhenPositionIsInactive(t *testing.T) {
+func TestRefreshLivePositionWatermarksClearsSessionStateWhenPositionIsInactive(t *testing.T) {
 	sessionState := map[string]any{
 		"hwm":                  52000.0,
 		"lwm":                  50000.0,
-		"watermarkPositionKey": "position-1|BTCUSDT|LONG|50000.00000000",
+		"watermarkPositionKey": encodeLivePositionWatermarkIdentityComponent("position-1") + "|BTCUSDT|LONG|50000.00000000",
 	}
 	watermarks := refreshLivePositionWatermarks(sessionState, map[string]any{
 		"symbol":   "BTCUSDT",
@@ -332,9 +332,18 @@ func TestRefreshLivePositionWatermarksReturnsEmptyWhenPositionIsInactive(t *test
 	if watermarks.PositionKey != "" || watermarks.HWM != 0 || watermarks.LWM != 0 {
 		t.Fatalf("expected empty watermarks for inactive position, got %+v", watermarks)
 	}
+	if got := stringValue(sessionState["watermarkPositionKey"]); got != "" {
+		t.Fatalf("expected inactive position refresh to clear watermarkPositionKey, got %s", got)
+	}
+	if got := parseFloatValue(sessionState["hwm"]); got != 0 {
+		t.Fatalf("expected inactive position refresh to clear hwm, got %v", got)
+	}
+	if got := parseFloatValue(sessionState["lwm"]); got != 0 {
+		t.Fatalf("expected inactive position refresh to clear lwm, got %v", got)
+	}
 }
 
-func TestResolveLivePositionWatermarksSupportsLegacyRealPositionKey(t *testing.T) {
+func TestResolveLivePositionWatermarksResetsLegacyRealPositionKey(t *testing.T) {
 	sessionState := map[string]any{
 		"hwm":                  52000.0,
 		"lwm":                  50000.0,
@@ -349,11 +358,11 @@ func TestResolveLivePositionWatermarksSupportsLegacyRealPositionKey(t *testing.T
 		"found":      true,
 	}
 	watermarks := resolveLivePositionWatermarks(currentPosition, sessionState)
-	if got := watermarks.PositionKey; got != "position-1|BTCUSDT|LONG|50000.00000000" {
+	if got := watermarks.PositionKey; got != encodeLivePositionWatermarkIdentityComponent("position-1")+"|BTCUSDT|LONG|50000.00000000" {
 		t.Fatalf("expected legacy real-position watermark key to migrate to canonical key, got %s", got)
 	}
-	if watermarks.HWM != 52000.0 || watermarks.LWM != 50000.0 {
-		t.Fatalf("expected legacy real-position key migration to preserve watermarks, got %+v", watermarks)
+	if watermarks.HWM != 50000.0 || watermarks.LWM != 50000.0 {
+		t.Fatalf("expected legacy real-position key migration to reset watermarks, got %+v", watermarks)
 	}
 }
 
@@ -372,7 +381,7 @@ func TestResolveLivePositionWatermarksResetsForPositionIDOnlyLegacyKey(t *testin
 		"found":      true,
 	}
 	watermarks := resolveLivePositionWatermarks(currentPosition, sessionState)
-	if got := watermarks.PositionKey; got != "position-1|BTCUSDT|LONG|51000.00000000" {
+	if got := watermarks.PositionKey; got != encodeLivePositionWatermarkIdentityComponent("position-1")+"|BTCUSDT|LONG|51000.00000000" {
 		t.Fatalf("expected canonical watermark key for reused position id, got %s", got)
 	}
 	if watermarks.HWM != 51000.0 || watermarks.LWM != 51000.0 {
@@ -380,13 +389,13 @@ func TestResolveLivePositionWatermarksResetsForPositionIDOnlyLegacyKey(t *testin
 	}
 }
 
-func TestEvaluateLiveSignalDecisionPreservesWatermarksWhenPositionInactive(t *testing.T) {
+func TestEvaluateLiveSignalDecisionClearsWatermarksWhenPositionInactive(t *testing.T) {
 	engine := bkStrategyEngine{}
 	context := StrategySignalEvaluationContext{
 		SessionState: map[string]any{
 			"hwm":                  52000.0,
 			"lwm":                  50000.0,
-			"watermarkPositionKey": "position-1|BTCUSDT|LONG|50000.00000000",
+			"watermarkPositionKey": encodeLivePositionWatermarkIdentityComponent("position-1") + "|BTCUSDT|LONG|50000.00000000",
 		},
 		ExecutionContext: StrategyExecutionContext{
 			Parameters: map[string]any{
@@ -423,22 +432,22 @@ func TestEvaluateLiveSignalDecisionPreservesWatermarksWhenPositionInactive(t *te
 	if _, err := engine.EvaluateSignal(context); err != nil {
 		t.Fatalf("evaluate signal failed: %v", err)
 	}
-	if got := stringValue(context.SessionState["watermarkPositionKey"]); got != "position-1|BTCUSDT|LONG|50000.00000000" {
-		t.Fatalf("expected inactive strategy evaluation to preserve watermarkPositionKey, got %s", got)
+	if got := stringValue(context.SessionState["watermarkPositionKey"]); got != "" {
+		t.Fatalf("expected inactive strategy evaluation to clear watermarkPositionKey, got %s", got)
 	}
-	if got := parseFloatValue(context.SessionState["hwm"]); got != 52000.0 {
-		t.Fatalf("expected inactive strategy evaluation to preserve hwm, got %v", got)
+	if got := parseFloatValue(context.SessionState["hwm"]); got != 0 {
+		t.Fatalf("expected inactive strategy evaluation to clear hwm, got %v", got)
 	}
-	if got := parseFloatValue(context.SessionState["lwm"]); got != 50000.0 {
-		t.Fatalf("expected inactive strategy evaluation to preserve lwm, got %v", got)
+	if got := parseFloatValue(context.SessionState["lwm"]); got != 0 {
+		t.Fatalf("expected inactive strategy evaluation to clear lwm, got %v", got)
 	}
 }
 
-func TestEvaluateLivePositionStatePreservesWatermarksWhenPositionInactive(t *testing.T) {
+func TestEvaluateLivePositionStateClearsWatermarksWhenPositionInactive(t *testing.T) {
 	sessionState := map[string]any{
 		"hwm":                  52000.0,
 		"lwm":                  50000.0,
-		"watermarkPositionKey": "position-1|BTCUSDT|LONG|50000.00000000",
+		"watermarkPositionKey": encodeLivePositionWatermarkIdentityComponent("position-1") + "|BTCUSDT|LONG|50000.00000000",
 	}
 	parameters := map[string]any{
 		"stop_loss_atr":              0.05,
@@ -461,14 +470,14 @@ func TestEvaluateLivePositionStatePreservesWatermarksWhenPositionInactive(t *tes
 	if len(state) != 0 {
 		t.Fatalf("expected empty live position state for inactive position, got %+v", state)
 	}
-	if got := stringValue(sessionState["watermarkPositionKey"]); got != "position-1|BTCUSDT|LONG|50000.00000000" {
-		t.Fatalf("expected inactive position state evaluation to preserve watermarkPositionKey, got %s", got)
+	if got := stringValue(sessionState["watermarkPositionKey"]); got != "" {
+		t.Fatalf("expected inactive position state evaluation to clear watermarkPositionKey, got %s", got)
 	}
-	if got := parseFloatValue(sessionState["hwm"]); got != 52000.0 {
-		t.Fatalf("expected inactive position state evaluation to preserve hwm, got %v", got)
+	if got := parseFloatValue(sessionState["hwm"]); got != 0 {
+		t.Fatalf("expected inactive position state evaluation to clear hwm, got %v", got)
 	}
-	if got := parseFloatValue(sessionState["lwm"]); got != 50000.0 {
-		t.Fatalf("expected inactive position state evaluation to preserve lwm, got %v", got)
+	if got := parseFloatValue(sessionState["lwm"]); got != 0 {
+		t.Fatalf("expected inactive position state evaluation to clear lwm, got %v", got)
 	}
 }
 
@@ -569,7 +578,7 @@ func TestResolveLivePositionWatermarksIgnoresQuantityChangesWithinSamePosition(t
 	sessionState := map[string]any{
 		"hwm":                  52000.0,
 		"lwm":                  50000.0,
-		"watermarkPositionKey": "position-1|BTCUSDT|LONG|50000.00000000",
+		"watermarkPositionKey": encodeLivePositionWatermarkIdentityComponent("position-1") + "|BTCUSDT|LONG|50000.00000000",
 	}
 	currentPosition := map[string]any{
 		"id":         "position-1",
@@ -580,7 +589,7 @@ func TestResolveLivePositionWatermarksIgnoresQuantityChangesWithinSamePosition(t
 		"found":      true,
 	}
 	watermarks := resolveLivePositionWatermarks(currentPosition, sessionState)
-	if got := watermarks.PositionKey; got != "position-1|BTCUSDT|LONG|50000.00000000" {
+	if got := watermarks.PositionKey; got != encodeLivePositionWatermarkIdentityComponent("position-1")+"|BTCUSDT|LONG|50000.00000000" {
 		t.Fatalf("expected quantity changes to keep the same watermark key, got %s", got)
 	}
 	if watermarks.HWM != 52000.0 || watermarks.LWM != 50000.0 {

--- a/internal/service/strategy_optimization_test.go
+++ b/internal/service/strategy_optimization_test.go
@@ -485,6 +485,18 @@ func TestHasActiveLivePositionSnapshotUsesAbsoluteQuantity(t *testing.T) {
 	if !hasActiveLivePositionSnapshot(map[string]any{"quantity": -1.0}) {
 		t.Fatal("expected negative quantity snapshot to count as active")
 	}
+	if hasActiveLivePositionSnapshot(map[string]any{"virtual": true}) {
+		t.Fatal("expected bare virtual marker to stay inactive")
+	}
+	if !hasActiveLivePositionSnapshot(map[string]any{
+		"virtual":    true,
+		"id":         "virtual|live-session-main|signal-1",
+		"symbol":     "BTCUSDT",
+		"side":       "LONG",
+		"entryPrice": 50000.0,
+	}) {
+		t.Fatal("expected virtual snapshot with stable identity and entry context to count as active")
+	}
 }
 
 func TestDeriveLivePositionStateUsesProvidedWatermarks(t *testing.T) {

--- a/internal/service/strategy_optimization_test.go
+++ b/internal/service/strategy_optimization_test.go
@@ -162,16 +162,385 @@ func TestUpdateLivePositionWatermarksResetsWhenPositionChanges(t *testing.T) {
 	sessionState := map[string]any{
 		"hwm":                  52000.0,
 		"lwm":                  50000.0,
-		"watermarkPositionKey": "LONG|50000.00000000",
+		"watermarkPositionKey": "position-old",
 	}
-	hwm, lwm := updateLivePositionWatermarks(sessionState, "short", 48000.0, 47900.0)
+	hwm, lwm := updateLivePositionWatermarks(sessionState, map[string]any{
+		"id":         "position-new",
+		"symbol":     "ETHUSDT",
+		"side":       "short",
+		"entryPrice": 48000.0,
+		"quantity":   1.0,
+		"found":      true,
+	}, 47900.0)
 	if hwm != 48000.0 {
 		t.Fatalf("expected hwm to reset to new entry price, got %v", hwm)
 	}
 	if lwm != 47900.0 {
 		t.Fatalf("expected lwm to update from new position context, got %v", lwm)
 	}
-	if got := stringValue(sessionState["watermarkPositionKey"]); got != "SHORT|48000.00000000" {
+	if got := stringValue(sessionState["watermarkPositionKey"]); got != "position-new|ETHUSDT|SHORT|48000.00000000" {
 		t.Fatalf("expected watermark key to reset, got %s", got)
+	}
+}
+
+func TestResolveAndApplyLivePositionWatermarksAreSeparated(t *testing.T) {
+	sessionState := map[string]any{
+		"hwm":                  52000.0,
+		"lwm":                  50000.0,
+		"watermarkPositionKey": "position-1|BTCUSDT|LONG|50000.00000000",
+	}
+	currentPosition := map[string]any{
+		"id":         "position-1",
+		"symbol":     "BTCUSDT",
+		"side":       "LONG",
+		"entryPrice": 50000.0,
+		"quantity":   1.0,
+		"found":      true,
+	}
+	expectedKey := "position-1|BTCUSDT|LONG|50000.00000000"
+	watermarks := resolveLivePositionWatermarks(currentPosition, sessionState)
+	if watermarks.HWM != 52000.0 || watermarks.LWM != 50000.0 {
+		t.Fatalf("expected resolved watermarks from session state, got %+v", watermarks)
+	}
+	if got := stringValue(sessionState["watermarkPositionKey"]); got != expectedKey {
+		t.Fatalf("expected resolve to stay side-effect free, got %s", got)
+	}
+	if watermarks.PositionKey != expectedKey {
+		t.Fatalf("expected resolved position key %s, got %s", expectedKey, watermarks.PositionKey)
+	}
+	advanced := advanceLivePositionWatermarks(watermarks, 52500.0)
+	if advanced.HWM != 52500.0 {
+		t.Fatalf("expected advanced HWM 52500, got %v", advanced.HWM)
+	}
+	if parseFloatValue(sessionState["hwm"]) != 52000.0 {
+		t.Fatalf("expected advance to stay side-effect free, got %v", sessionState["hwm"])
+	}
+	applyLivePositionWatermarks(sessionState, advanced)
+	if parseFloatValue(sessionState["hwm"]) != 52500.0 {
+		t.Fatalf("expected apply to persist advanced HWM, got %v", sessionState["hwm"])
+	}
+	if parseFloatValue(sessionState["lwm"]) != 50000.0 {
+		t.Fatalf("expected apply to preserve LWM, got %v", sessionState["lwm"])
+	}
+	if got := stringValue(sessionState["watermarkPositionKey"]); got != expectedKey {
+		t.Fatalf("expected apply to persist watermark key, got %s", got)
+	}
+}
+
+func TestResolveLivePositionWatermarksUsesExpandedPositionContextKey(t *testing.T) {
+	sessionState := map[string]any{
+		"hwm":                  52000.0,
+		"lwm":                  50000.0,
+		"watermarkPositionKey": "position-1|BTCUSDT|LONG|50000.00000000",
+	}
+	currentPosition := map[string]any{
+		"id":         "position-2",
+		"symbol":     "BTCUSDT",
+		"side":       "LONG",
+		"entryPrice": 50000.0,
+		"quantity":   1.0,
+		"found":      true,
+	}
+	watermarks := resolveLivePositionWatermarks(currentPosition, sessionState)
+	if got := watermarks.PositionKey; got != "position-2|BTCUSDT|LONG|50000.00000000" {
+		t.Fatalf("expected new position id to reset watermark key, got %s", got)
+	}
+	if watermarks.HWM != 50000.0 || watermarks.LWM != 50000.0 {
+		t.Fatalf("expected watermarks to reset for new position id, got %+v", watermarks)
+	}
+}
+
+func TestResolveLivePositionWatermarksUsesVirtualPositionID(t *testing.T) {
+	sessionState := map[string]any{
+		"hwm":                  52000.0,
+		"lwm":                  50000.0,
+		"watermarkPositionKey": "virtual|session-1|signal-1",
+	}
+	currentPosition := map[string]any{
+		"id":         "virtual|session-1|signal-2",
+		"symbol":     "BTCUSDT",
+		"side":       "LONG",
+		"entryPrice": 50000.0,
+		"quantity":   1.0,
+		"virtual":    true,
+	}
+	watermarks := resolveLivePositionWatermarks(currentPosition, sessionState)
+	if got := watermarks.PositionKey; got != "virtual|session-1|signal-2|BTCUSDT|LONG|50000.00000000" {
+		t.Fatalf("expected virtual position id to drive watermark key, got %s", got)
+	}
+	if watermarks.HWM != 50000.0 || watermarks.LWM != 50000.0 {
+		t.Fatalf("expected watermarks to reset for a new virtual position identity, got %+v", watermarks)
+	}
+}
+
+func TestResolveLivePositionWatermarksSupportsLegacyVirtualKey(t *testing.T) {
+	sessionState := map[string]any{
+		"hwm":                  52000.0,
+		"lwm":                  50000.0,
+		"watermarkPositionKey": "virtual|session-1|signal-2",
+	}
+	currentPosition := map[string]any{
+		"id":         "virtual|session-1|signal-2",
+		"symbol":     "BTCUSDT",
+		"side":       "LONG",
+		"entryPrice": 50000.0,
+		"quantity":   1.0,
+		"virtual":    true,
+	}
+	watermarks := resolveLivePositionWatermarks(currentPosition, sessionState)
+	if got := watermarks.PositionKey; got != "virtual|session-1|signal-2|BTCUSDT|LONG|50000.00000000" {
+		t.Fatalf("expected legacy virtual watermark key to migrate to canonical key, got %s", got)
+	}
+	if watermarks.HWM != 52000.0 || watermarks.LWM != 50000.0 {
+		t.Fatalf("expected legacy virtual key migration to preserve watermarks, got %+v", watermarks)
+	}
+}
+
+func TestResolveLivePositionWatermarksPreservesPreviousKeyWhenIDTemporarilyMissing(t *testing.T) {
+	sessionState := map[string]any{
+		"hwm":                  52000.0,
+		"lwm":                  50000.0,
+		"watermarkPositionKey": "position-1|BTCUSDT|LONG|50000.00000000",
+	}
+	currentPosition := map[string]any{
+		"symbol":     "BTCUSDT",
+		"side":       "LONG",
+		"entryPrice": 50000.0,
+		"quantity":   1.0,
+		"found":      true,
+	}
+	watermarks := resolveLivePositionWatermarks(currentPosition, sessionState)
+	if got := watermarks.PositionKey; got != "position-1|BTCUSDT|LONG|50000.00000000" {
+		t.Fatalf("expected missing id to preserve previous stable watermark key, got %s", got)
+	}
+	if watermarks.HWM != 52000.0 || watermarks.LWM != 50000.0 {
+		t.Fatalf("expected missing id to preserve existing watermarks, got %+v", watermarks)
+	}
+}
+
+func TestRefreshLivePositionWatermarksClearsStateWhenPositionIsInactive(t *testing.T) {
+	sessionState := map[string]any{
+		"hwm":                  52000.0,
+		"lwm":                  50000.0,
+		"watermarkPositionKey": "position-1|BTCUSDT|LONG|50000.00000000",
+	}
+	watermarks := refreshLivePositionWatermarks(sessionState, map[string]any{
+		"symbol":   "BTCUSDT",
+		"quantity": 0.0,
+		"found":    false,
+	}, 0)
+	if watermarks.PositionKey != "" || watermarks.HWM != 0 || watermarks.LWM != 0 {
+		t.Fatalf("expected empty watermarks for inactive position, got %+v", watermarks)
+	}
+	if got := stringValue(sessionState["watermarkPositionKey"]); got != "position-1|BTCUSDT|LONG|50000.00000000" {
+		t.Fatalf("expected generic inactive refresh to preserve existing watermark key, got %s", got)
+	}
+	if got := parseFloatValue(sessionState["hwm"]); got != 52000.0 {
+		t.Fatalf("expected generic inactive refresh to preserve HWM, got %v", got)
+	}
+	if got := parseFloatValue(sessionState["lwm"]); got != 50000.0 {
+		t.Fatalf("expected generic inactive refresh to preserve LWM, got %v", got)
+	}
+}
+
+func TestResolveLivePositionWatermarksSupportsLegacyRealPositionKey(t *testing.T) {
+	sessionState := map[string]any{
+		"hwm":                  52000.0,
+		"lwm":                  50000.0,
+		"watermarkPositionKey": "LONG|50000.00000000",
+	}
+	currentPosition := map[string]any{
+		"id":         "position-1",
+		"symbol":     "BTCUSDT",
+		"side":       "LONG",
+		"entryPrice": 50000.0,
+		"quantity":   1.0,
+		"found":      true,
+	}
+	watermarks := resolveLivePositionWatermarks(currentPosition, sessionState)
+	if got := watermarks.PositionKey; got != "position-1|BTCUSDT|LONG|50000.00000000" {
+		t.Fatalf("expected legacy real-position watermark key to migrate to canonical key, got %s", got)
+	}
+	if watermarks.HWM != 50000.0 || watermarks.LWM != 50000.0 {
+		t.Fatalf("expected legacy real-position key migration to reset watermarks, got %+v", watermarks)
+	}
+}
+
+func TestEvaluateLiveSignalDecisionClearsWatermarksWhenPositionInactive(t *testing.T) {
+	engine := bkStrategyEngine{}
+	context := StrategySignalEvaluationContext{
+		SessionState: map[string]any{
+			"hwm":                  52000.0,
+			"lwm":                  50000.0,
+			"watermarkPositionKey": "position-1|BTCUSDT|LONG|50000.00000000",
+		},
+		ExecutionContext: StrategyExecutionContext{
+			Parameters: map[string]any{
+				"symbol":                     "BTCUSDT",
+				"signalTimeframe":            "1d",
+				"stop_loss_atr":              0.05,
+				"profit_protect_atr":         0.5,
+				"trailing_stop_atr":          0.3,
+				"signalDecisionMaxSpreadBps": 8.0,
+			},
+		},
+		NextPlannedRole: "entry",
+		NextPlannedSide: "BUY",
+	}
+	sourceStates := map[string]any{}
+	trigger := map[string]any{"price": 50000.0, "role": "trigger", "symbol": "BTCUSDT"}
+	signalBarState := map[string]any{
+		"atr14":    1000.0,
+		"current":  map[string]any{"close": 50000.0},
+		"prevBar1": map[string]any{"high": 50500.0, "low": 49500.0},
+		"prevBar2": map[string]any{"high": 50600.0, "low": 49400.0},
+	}
+	currentPosition := map[string]any{
+		"symbol":   "BTCUSDT",
+		"quantity": 0.0,
+		"found":    false,
+	}
+	context.TriggerSummary = trigger
+	context.SourceStates = sourceStates
+	context.SignalBarStates = map[string]any{
+		signalBindingMatchKey("binance-kline", "signal", "BTCUSDT"): signalBarState,
+	}
+	context.CurrentPosition = currentPosition
+	if _, err := engine.EvaluateSignal(context); err != nil {
+		t.Fatalf("evaluate signal failed: %v", err)
+	}
+	if _, ok := context.SessionState["watermarkPositionKey"]; ok {
+		t.Fatal("expected inactive strategy evaluation to clear watermarkPositionKey")
+	}
+	if _, ok := context.SessionState["hwm"]; ok {
+		t.Fatal("expected inactive strategy evaluation to clear hwm")
+	}
+	if _, ok := context.SessionState["lwm"]; ok {
+		t.Fatal("expected inactive strategy evaluation to clear lwm")
+	}
+}
+
+func TestHasActiveLivePositionSnapshotUsesAbsoluteQuantity(t *testing.T) {
+	if !hasActiveLivePositionSnapshot(map[string]any{"quantity": -1.0}) {
+		t.Fatal("expected negative quantity snapshot to count as active")
+	}
+}
+
+func TestDeriveLivePositionStateUsesProvidedWatermarks(t *testing.T) {
+	parameters := map[string]any{
+		"trailing_stop_atr":               0.3,
+		"delayed_trailing_activation_atr": 0.5,
+		"stop_loss_atr":                   0.05,
+		"stop_mode":                       "atr",
+	}
+	signalBarState := map[string]any{
+		"atr14":    1000.0,
+		"current":  map[string]any{"close": 50600.0},
+		"prevBar1": map[string]any{"high": 50500.0, "low": 49500.0},
+		"prevBar2": map[string]any{"high": 50600.0, "low": 49400.0},
+	}
+	currentPosition := map[string]any{
+		"found":      true,
+		"side":       "LONG",
+		"entryPrice": 50000.0,
+		"stopLoss":   49950.0,
+		"quantity":   1.0,
+	}
+	watermarks := livePositionWatermarks{
+		PositionKey: "position-1|BTCUSDT|LONG",
+		HWM:         50600.0,
+		LWM:         50000.0,
+	}
+	state := deriveLivePositionState(parameters, currentPosition, signalBarState, 50600.0, watermarks)
+	if got := parseFloatValue(state["stopLoss"]); got != 50300.0 {
+		t.Fatalf("expected trailing SL 50300 from provided watermarks, got %v", got)
+	}
+	if got := parseFloatValue(state["hwm"]); got != 50600.0 {
+		t.Fatalf("expected returned HWM 50600, got %v", got)
+	}
+}
+
+func TestDeriveLivePositionStateUsesProvidedWatermarksForShort(t *testing.T) {
+	parameters := map[string]any{
+		"trailing_stop_atr":               0.3,
+		"delayed_trailing_activation_atr": 0.5,
+		"stop_loss_atr":                   0.05,
+		"stop_mode":                       "atr",
+	}
+	signalBarState := map[string]any{
+		"atr14":    1000.0,
+		"current":  map[string]any{"close": 49400.0},
+		"prevBar1": map[string]any{"high": 50500.0, "low": 49500.0},
+		"prevBar2": map[string]any{"high": 50600.0, "low": 49400.0},
+	}
+	currentPosition := map[string]any{
+		"found":      true,
+		"side":       "SHORT",
+		"entryPrice": 50000.0,
+		"stopLoss":   50050.0,
+		"quantity":   1.0,
+	}
+	watermarks := livePositionWatermarks{
+		PositionKey: "position-2|BTCUSDT|SHORT",
+		HWM:         50000.0,
+		LWM:         49400.0,
+	}
+	state := deriveLivePositionState(parameters, currentPosition, signalBarState, 49400.0, watermarks)
+	if got := parseFloatValue(state["stopLoss"]); got != 49700.0 {
+		t.Fatalf("expected trailing SL 49700 from provided short watermarks, got %v", got)
+	}
+	if got := parseFloatValue(state["lwm"]); got != 49400.0 {
+		t.Fatalf("expected returned LWM 49400, got %v", got)
+	}
+}
+
+func TestResolveLivePositionWatermarksIgnoresInactiveSnapshot(t *testing.T) {
+	sessionState := map[string]any{
+		"hwm":                  52000.0,
+		"lwm":                  50000.0,
+		"watermarkPositionKey": "position-1|BTCUSDT|LONG",
+	}
+	currentPosition := map[string]any{
+		"symbol":     "BTCUSDT",
+		"side":       "LONG",
+		"entryPrice": 50000.0,
+		"quantity":   0.0,
+		"found":      false,
+	}
+	watermarks := resolveLivePositionWatermarks(currentPosition, sessionState)
+	if watermarks.PositionKey != "" || watermarks.HWM != 0 || watermarks.LWM != 0 {
+		t.Fatalf("expected inactive snapshot to skip watermark refresh, got %+v", watermarks)
+	}
+	if got := stringValue(sessionState["watermarkPositionKey"]); got != "position-1|BTCUSDT|LONG" {
+		t.Fatalf("expected inactive snapshot to preserve persisted watermark key, got %s", got)
+	}
+	if got := parseFloatValue(sessionState["hwm"]); got != 52000.0 {
+		t.Fatalf("expected inactive snapshot to preserve persisted HWM, got %v", got)
+	}
+	if got := parseFloatValue(sessionState["lwm"]); got != 50000.0 {
+		t.Fatalf("expected inactive snapshot to preserve persisted LWM, got %v", got)
+	}
+}
+
+func TestResolveLivePositionWatermarksIgnoresQuantityChangesWithinSamePosition(t *testing.T) {
+	sessionState := map[string]any{
+		"hwm":                  52000.0,
+		"lwm":                  50000.0,
+		"watermarkPositionKey": "position-1|BTCUSDT|LONG|50000.00000000",
+	}
+	currentPosition := map[string]any{
+		"id":         "position-1",
+		"symbol":     "BTCUSDT",
+		"side":       "LONG",
+		"entryPrice": 50000.0,
+		"quantity":   0.6,
+		"found":      true,
+	}
+	watermarks := resolveLivePositionWatermarks(currentPosition, sessionState)
+	if got := watermarks.PositionKey; got != "position-1|BTCUSDT|LONG|50000.00000000" {
+		t.Fatalf("expected quantity changes to keep the same watermark key, got %s", got)
+	}
+	if watermarks.HWM != 52000.0 || watermarks.LWM != 50000.0 {
+		t.Fatalf("expected quantity changes to preserve watermarks, got %+v", watermarks)
 	}
 }

--- a/internal/service/strategy_optimization_test.go
+++ b/internal/service/strategy_optimization_test.go
@@ -310,11 +310,11 @@ func TestResolveLivePositionWatermarksPreservesPreviousKeyWhenIDTemporarilyMissi
 		"found":      true,
 	}
 	watermarks := resolveLivePositionWatermarks(currentPosition, sessionState)
-	if got := watermarks.PositionKey; got != "BTCUSDT|LONG|50000.00000000" {
-		t.Fatalf("expected missing id to fall back to base watermark key, got %s", got)
+	if got := watermarks.PositionKey; got != "position-1|BTCUSDT|LONG|50000.00000000" {
+		t.Fatalf("expected missing id to preserve previous stable watermark key, got %s", got)
 	}
-	if watermarks.HWM != 50000.0 || watermarks.LWM != 50000.0 {
-		t.Fatalf("expected missing id fallback to reset watermarks, got %+v", watermarks)
+	if watermarks.HWM != 52000.0 || watermarks.LWM != 50000.0 {
+		t.Fatalf("expected missing id to preserve existing watermarks, got %+v", watermarks)
 	}
 }
 
@@ -357,7 +357,7 @@ func TestResolveLivePositionWatermarksSupportsLegacyRealPositionKey(t *testing.T
 	}
 }
 
-func TestEvaluateLiveSignalDecisionClearsWatermarksWhenPositionInactive(t *testing.T) {
+func TestEvaluateLiveSignalDecisionPreservesWatermarksWhenPositionInactive(t *testing.T) {
 	engine := bkStrategyEngine{}
 	context := StrategySignalEvaluationContext{
 		SessionState: map[string]any{
@@ -400,18 +400,18 @@ func TestEvaluateLiveSignalDecisionClearsWatermarksWhenPositionInactive(t *testi
 	if _, err := engine.EvaluateSignal(context); err != nil {
 		t.Fatalf("evaluate signal failed: %v", err)
 	}
-	if _, ok := context.SessionState["watermarkPositionKey"]; ok {
-		t.Fatal("expected inactive strategy evaluation to clear watermarkPositionKey")
+	if got := stringValue(context.SessionState["watermarkPositionKey"]); got != "position-1|BTCUSDT|LONG|50000.00000000" {
+		t.Fatalf("expected inactive strategy evaluation to preserve watermarkPositionKey, got %s", got)
 	}
-	if _, ok := context.SessionState["hwm"]; ok {
-		t.Fatal("expected inactive strategy evaluation to clear hwm")
+	if got := parseFloatValue(context.SessionState["hwm"]); got != 52000.0 {
+		t.Fatalf("expected inactive strategy evaluation to preserve hwm, got %v", got)
 	}
-	if _, ok := context.SessionState["lwm"]; ok {
-		t.Fatal("expected inactive strategy evaluation to clear lwm")
+	if got := parseFloatValue(context.SessionState["lwm"]); got != 50000.0 {
+		t.Fatalf("expected inactive strategy evaluation to preserve lwm, got %v", got)
 	}
 }
 
-func TestEvaluateLivePositionStateClearsWatermarksWhenPositionInactive(t *testing.T) {
+func TestEvaluateLivePositionStatePreservesWatermarksWhenPositionInactive(t *testing.T) {
 	sessionState := map[string]any{
 		"hwm":                  52000.0,
 		"lwm":                  50000.0,
@@ -438,14 +438,14 @@ func TestEvaluateLivePositionStateClearsWatermarksWhenPositionInactive(t *testin
 	if len(state) != 0 {
 		t.Fatalf("expected empty live position state for inactive position, got %+v", state)
 	}
-	if _, ok := sessionState["watermarkPositionKey"]; ok {
-		t.Fatal("expected inactive position state evaluation to clear watermarkPositionKey")
+	if got := stringValue(sessionState["watermarkPositionKey"]); got != "position-1|BTCUSDT|LONG|50000.00000000" {
+		t.Fatalf("expected inactive position state evaluation to preserve watermarkPositionKey, got %s", got)
 	}
-	if _, ok := sessionState["hwm"]; ok {
-		t.Fatal("expected inactive position state evaluation to clear hwm")
+	if got := parseFloatValue(sessionState["hwm"]); got != 52000.0 {
+		t.Fatalf("expected inactive position state evaluation to preserve hwm, got %v", got)
 	}
-	if _, ok := sessionState["lwm"]; ok {
-		t.Fatal("expected inactive position state evaluation to clear lwm")
+	if got := parseFloatValue(sessionState["lwm"]); got != 50000.0 {
+		t.Fatalf("expected inactive position state evaluation to preserve lwm, got %v", got)
 	}
 }
 

--- a/internal/service/strategy_registry.go
+++ b/internal/service/strategy_registry.go
@@ -806,9 +806,19 @@ func isCompatibleLivePositionWatermarkMigration(lastKey string, currentPosition 
 	baseKey := buildLivePositionWatermarkBaseKey(currentPosition)
 	legacyBaseKey := buildLegacyLivePositionWatermarkKey(currentPosition)
 	if positionID := strings.TrimSpace(stringValue(currentPosition["id"])); positionID != "" {
-		return lastKey == positionID || lastKey == baseKey || lastKey == legacyBaseKey
+		if boolValue(currentPosition["virtual"]) && lastKey == positionID {
+			return true
+		}
+		if lastKey == baseKey || lastKey == legacyBaseKey {
+			return true
+		}
+		return strings.HasPrefix(lastKey, positionID+"|") &&
+			(strings.HasSuffix(lastKey, "|"+baseKey) || strings.HasSuffix(lastKey, "|"+legacyBaseKey))
 	}
-	return lastKey == baseKey || lastKey == legacyBaseKey
+	return lastKey == baseKey ||
+		lastKey == legacyBaseKey ||
+		strings.HasSuffix(lastKey, "|"+baseKey) ||
+		strings.HasSuffix(lastKey, "|"+legacyBaseKey)
 }
 
 func clearLivePositionWatermarks(sessionState map[string]any) {

--- a/internal/service/strategy_registry.go
+++ b/internal/service/strategy_registry.go
@@ -230,8 +230,6 @@ func (e bkStrategyEngine) EvaluateSignal(context StrategySignalEvaluationContext
 		var watermarks livePositionWatermarks
 		if hasActiveLivePositionSnapshot(currentPosition) {
 			watermarks = refreshLivePositionWatermarks(context.SessionState, currentPosition, marketPrice)
-		} else {
-			clearLivePositionWatermarks(context.SessionState)
 		}
 		livePositionState = deriveLivePositionState(context.ExecutionContext.Parameters, currentPosition, signalBarState, marketPrice, watermarks)
 		if strings.EqualFold(strings.TrimSpace(context.NextPlannedRole), "exit") {
@@ -791,7 +789,7 @@ func buildLivePositionWatermarkKey(currentPosition map[string]any, sessionState 
 		return currentKey
 	}
 	if lastKey != "" {
-		if lastKey == baseKey || lastKey == legacyBaseKey {
+		if lastKey == baseKey || lastKey == legacyBaseKey || strings.HasSuffix(lastKey, "|"+baseKey) || strings.HasSuffix(lastKey, "|"+legacyBaseKey) {
 			return lastKey
 		}
 	}
@@ -906,8 +904,6 @@ func evaluateLivePositionState(parameters map[string]any, currentPosition map[st
 	var watermarks livePositionWatermarks
 	if hasActiveLivePositionSnapshot(currentPosition) {
 		watermarks = refreshLivePositionWatermarks(sessionState, currentPosition, marketPrice)
-	} else {
-		clearLivePositionWatermarks(sessionState)
 	}
 	return deriveLivePositionState(parameters, currentPosition, signalBarState, marketPrice, watermarks)
 }

--- a/internal/service/strategy_registry.go
+++ b/internal/service/strategy_registry.go
@@ -791,11 +791,26 @@ func buildLivePositionWatermarkKey(currentPosition map[string]any, sessionState 
 		return currentKey
 	}
 	if lastKey != "" {
-		if lastKey == baseKey || lastKey == legacyBaseKey || strings.HasSuffix(lastKey, "|"+baseKey) || strings.HasSuffix(lastKey, "|"+legacyBaseKey) {
+		if lastKey == baseKey || lastKey == legacyBaseKey {
 			return lastKey
 		}
 	}
 	return baseKey
+}
+
+func isCompatibleLivePositionWatermarkMigration(lastKey string, currentPosition map[string]any, positionKey string) bool {
+	if lastKey == "" || positionKey == "" {
+		return false
+	}
+	if lastKey == positionKey {
+		return true
+	}
+	baseKey := buildLivePositionWatermarkBaseKey(currentPosition)
+	legacyBaseKey := buildLegacyLivePositionWatermarkKey(currentPosition)
+	if positionID := strings.TrimSpace(stringValue(currentPosition["id"])); positionID != "" {
+		return lastKey == positionID || lastKey == baseKey || lastKey == legacyBaseKey
+	}
+	return lastKey == baseKey || lastKey == legacyBaseKey
 }
 
 func clearLivePositionWatermarks(sessionState map[string]any) {
@@ -829,7 +844,7 @@ func resolveLivePositionWatermarks(currentPosition map[string]any, sessionState 
 		lwm = entryPrice
 	}
 	if lastKey := stringValue(sessionState["watermarkPositionKey"]); lastKey != positionKey {
-		if currentID := strings.TrimSpace(stringValue(currentPosition["id"])); currentID != "" && lastKey == currentID {
+		if isCompatibleLivePositionWatermarkMigration(lastKey, currentPosition, positionKey) {
 			return livePositionWatermarks{
 				PositionKey: positionKey,
 				HWM:         hwm,

--- a/internal/service/strategy_registry.go
+++ b/internal/service/strategy_registry.go
@@ -227,9 +227,15 @@ func (e bkStrategyEngine) EvaluateSignal(context StrategySignalEvaluationContext
 	effectivePlannedPrice := context.NextPlannedPrice
 	livePositionState := map[string]any{}
 	if signalBarState != nil {
-		livePositionState = evaluateLivePositionState(context.ExecutionContext.Parameters, currentPosition, signalBarState, marketPrice, context.SessionState)
+		var watermarks livePositionWatermarks
+		if hasActiveLivePositionSnapshot(currentPosition) {
+			watermarks = refreshLivePositionWatermarks(context.SessionState, currentPosition, marketPrice)
+		} else {
+			clearLivePositionWatermarks(context.SessionState)
+		}
+		livePositionState = deriveLivePositionState(context.ExecutionContext.Parameters, currentPosition, signalBarState, marketPrice, watermarks)
 		if strings.EqualFold(strings.TrimSpace(context.NextPlannedRole), "exit") {
-			livePositionState = evaluateLiveExitState(context.ExecutionContext.Parameters, currentPosition, signalBarState, marketPrice, context.SessionState, context.NextPlannedReason)
+			livePositionState = deriveLiveExitState(context.ExecutionContext.Parameters, currentPosition, livePositionState, marketPrice, context.NextPlannedReason)
 		}
 		if len(livePositionState) > 0 {
 			mergedPosition := cloneMetadata(currentPosition)
@@ -737,10 +743,161 @@ func computePriceProximityBps(plannedPrice, marketPrice float64) float64 {
 	return math.Abs(marketPrice/plannedPrice-1) * 10000
 }
 
+type livePositionWatermarks struct {
+	PositionKey string
+	HWM         float64
+	LWM         float64
+}
+
+func hasActiveLivePositionSnapshot(currentPosition map[string]any) bool {
+	return boolValue(currentPosition["found"]) || math.Abs(parseFloatValue(currentPosition["quantity"])) > 0 || boolValue(currentPosition["virtual"])
+}
+
+func buildLivePositionWatermarkBaseKey(currentPosition map[string]any) string {
+	entryPrice := parseFloatValue(currentPosition["entryPrice"])
+	side := strings.ToUpper(strings.TrimSpace(stringValue(currentPosition["side"])))
+	if entryPrice <= 0 || side == "" {
+		return ""
+	}
+	parts := make([]string, 0, 3)
+	if symbol := NormalizeSymbol(stringValue(currentPosition["symbol"])); symbol != "" {
+		parts = append(parts, symbol)
+	}
+	parts = append(parts, side, fmt.Sprintf("%.8f", entryPrice))
+	return strings.Join(parts, "|")
+}
+
+func buildLegacyLivePositionWatermarkKey(currentPosition map[string]any) string {
+	entryPrice := parseFloatValue(currentPosition["entryPrice"])
+	side := strings.ToUpper(strings.TrimSpace(stringValue(currentPosition["side"])))
+	if entryPrice <= 0 || side == "" {
+		return ""
+	}
+	return strings.Join([]string{side, fmt.Sprintf("%.8f", entryPrice)}, "|")
+}
+
+func buildLivePositionWatermarkKey(currentPosition map[string]any, sessionState map[string]any) string {
+	baseKey := buildLivePositionWatermarkBaseKey(currentPosition)
+	if baseKey == "" {
+		return ""
+	}
+	lastKey := stringValue(sessionState["watermarkPositionKey"])
+	legacyBaseKey := buildLegacyLivePositionWatermarkKey(currentPosition)
+	if positionID := strings.TrimSpace(stringValue(currentPosition["id"])); positionID != "" {
+		currentKey := positionID + "|" + baseKey
+		if lastKey == positionID || strings.HasPrefix(lastKey, positionID+"|") {
+			return currentKey
+		}
+		return currentKey
+	}
+	if lastKey != "" {
+		if lastKey == baseKey || lastKey == legacyBaseKey || strings.HasSuffix(lastKey, "|"+baseKey) || strings.HasSuffix(lastKey, "|"+legacyBaseKey) {
+			return lastKey
+		}
+	}
+	return baseKey
+}
+
+func clearLivePositionWatermarks(sessionState map[string]any) {
+	if sessionState == nil {
+		return
+	}
+	delete(sessionState, "watermarkPositionKey")
+	delete(sessionState, "hwm")
+	delete(sessionState, "lwm")
+}
+
+func resolveLivePositionWatermarks(currentPosition map[string]any, sessionState map[string]any) livePositionWatermarks {
+	if !hasActiveLivePositionSnapshot(currentPosition) {
+		return livePositionWatermarks{}
+	}
+	entryPrice := parseFloatValue(currentPosition["entryPrice"])
+	side := strings.ToUpper(strings.TrimSpace(stringValue(currentPosition["side"])))
+	if entryPrice <= 0 || side == "" {
+		return livePositionWatermarks{}
+	}
+	positionKey := buildLivePositionWatermarkKey(currentPosition, sessionState)
+	if positionKey == "" {
+		return livePositionWatermarks{}
+	}
+	hwm := parseFloatValue(sessionState["hwm"])
+	if hwm == 0 {
+		hwm = entryPrice
+	}
+	lwm := parseFloatValue(sessionState["lwm"])
+	if lwm == 0 {
+		lwm = entryPrice
+	}
+	if lastKey := stringValue(sessionState["watermarkPositionKey"]); lastKey != positionKey {
+		if currentID := strings.TrimSpace(stringValue(currentPosition["id"])); currentID != "" && lastKey == currentID {
+			return livePositionWatermarks{
+				PositionKey: positionKey,
+				HWM:         hwm,
+				LWM:         lwm,
+			}
+		}
+		hwm = entryPrice
+		lwm = entryPrice
+	}
+	return livePositionWatermarks{
+		PositionKey: positionKey,
+		HWM:         hwm,
+		LWM:         lwm,
+	}
+}
+
+func advanceLivePositionWatermarks(watermarks livePositionWatermarks, marketPrice float64) livePositionWatermarks {
+	if marketPrice <= 0 {
+		return watermarks
+	}
+	if watermarks.HWM == 0 {
+		watermarks.HWM = marketPrice
+	}
+	if watermarks.LWM == 0 {
+		watermarks.LWM = marketPrice
+	}
+	if marketPrice > watermarks.HWM {
+		watermarks.HWM = marketPrice
+	}
+	if marketPrice < watermarks.LWM {
+		watermarks.LWM = marketPrice
+	}
+	return watermarks
+}
+
+func applyLivePositionWatermarks(sessionState map[string]any, watermarks livePositionWatermarks) {
+	if sessionState == nil || watermarks.PositionKey == "" {
+		return
+	}
+	sessionState["watermarkPositionKey"] = watermarks.PositionKey
+	sessionState["hwm"] = watermarks.HWM
+	sessionState["lwm"] = watermarks.LWM
+}
+
+func refreshLivePositionWatermarks(sessionState map[string]any, currentPosition map[string]any, marketPrice float64) livePositionWatermarks {
+	if !hasActiveLivePositionSnapshot(currentPosition) {
+		return livePositionWatermarks{}
+	}
+	watermarks := resolveLivePositionWatermarks(currentPosition, sessionState)
+	watermarks = advanceLivePositionWatermarks(watermarks, marketPrice)
+	applyLivePositionWatermarks(sessionState, watermarks)
+	return watermarks
+}
+
 // evaluateLivePositionState derives the current live position risk state.
 // When sessionState is provided, it also refreshes HWM/LWM watermarks used by
 // trailing-stop logic so callers do not need to duplicate watermark handling.
 func evaluateLivePositionState(parameters map[string]any, currentPosition map[string]any, signalBarState map[string]any, marketPrice float64, sessionState map[string]any) map[string]any {
+	var watermarks livePositionWatermarks
+	if hasActiveLivePositionSnapshot(currentPosition) {
+		watermarks = refreshLivePositionWatermarks(sessionState, currentPosition, marketPrice)
+	} else {
+		clearLivePositionWatermarks(sessionState)
+	}
+	return deriveLivePositionState(parameters, currentPosition, signalBarState, marketPrice, watermarks)
+}
+
+func deriveLivePositionState(parameters map[string]any, currentPosition map[string]any, signalBarState map[string]any, marketPrice float64, watermarks livePositionWatermarks) map[string]any {
 	if !boolValue(currentPosition["found"]) && parseFloatValue(currentPosition["quantity"]) <= 0 && !boolValue(currentPosition["virtual"]) {
 		return nil
 	}
@@ -774,8 +931,8 @@ func evaluateLivePositionState(parameters map[string]any, currentPosition map[st
 	if stopLoss <= 0 {
 		stopLoss = resolveStopPrice(side, entryPrice, sig, stopMode, stopLossATR)
 	}
-
-	hwm, lwm := updateLivePositionWatermarks(sessionState, side, entryPrice, marketPrice)
+	hwm := firstPositive(watermarks.HWM, entryPrice)
+	lwm := firstPositive(watermarks.LWM, entryPrice)
 
 	// Calculate Trailing Stop Loss
 	if trailingStopATR := parseFloatValue(parameters["trailing_stop_atr"]); trailingStopATR > 0 {
@@ -824,54 +981,35 @@ func evaluateLivePositionState(parameters map[string]any, currentPosition map[st
 		}
 	}
 	return map[string]any{
-		"found":             true,
-		"symbol":            NormalizeSymbol(stringValue(currentPosition["symbol"])),
-		"side":              strings.ToUpper(side),
-		"entryPrice":        entryPrice,
-		"stopLoss":          stopLoss,
-		"protected":         protected,
-		"protectionTrigger": protectionPrice,
-		"prevHigh1":         sig.PrevHigh1,
-		"prevLow1":          sig.PrevLow1,
-		"atr14":             sig.ATR,
-		"profitProtectATR":  profitProtectATR,
+		"found":                true,
+		"symbol":               NormalizeSymbol(stringValue(currentPosition["symbol"])),
+		"side":                 strings.ToUpper(side),
+		"entryPrice":           entryPrice,
+		"stopLoss":             stopLoss,
+		"protected":            protected,
+		"protectionTrigger":    protectionPrice,
+		"prevHigh1":            sig.PrevHigh1,
+		"prevLow1":             sig.PrevLow1,
+		"atr14":                sig.ATR,
+		"profitProtectATR":     profitProtectATR,
+		"hwm":                  hwm,
+		"lwm":                  lwm,
+		"watermarkPositionKey": watermarks.PositionKey,
 	}
 }
 
-func updateLivePositionWatermarks(sessionState map[string]any, side string, entryPrice, marketPrice float64) (float64, float64) {
-	positionKey := fmt.Sprintf("%s|%.8f", strings.ToUpper(strings.TrimSpace(side)), entryPrice)
-	if sessionState != nil {
-		if lastKey := stringValue(sessionState["watermarkPositionKey"]); lastKey != positionKey {
-			sessionState["hwm"] = entryPrice
-			sessionState["lwm"] = entryPrice
-			sessionState["watermarkPositionKey"] = positionKey
-		}
-	}
-	hwm := parseFloatValue(sessionState["hwm"])
-	if hwm == 0 {
-		hwm = entryPrice
-	}
-	lwm := parseFloatValue(sessionState["lwm"])
-	if lwm == 0 {
-		lwm = entryPrice
-	}
-	if marketPrice > 0 {
-		if marketPrice > hwm {
-			hwm = marketPrice
-		}
-		if marketPrice < lwm {
-			lwm = marketPrice
-		}
-		if sessionState != nil {
-			sessionState["hwm"] = hwm
-			sessionState["lwm"] = lwm
-		}
-	}
-	return hwm, lwm
+func updateLivePositionWatermarks(sessionState map[string]any, currentPosition map[string]any, marketPrice float64) (float64, float64) {
+	watermarks := refreshLivePositionWatermarks(sessionState, currentPosition, marketPrice)
+	return watermarks.HWM, watermarks.LWM
 }
 
 func evaluateLiveExitState(parameters map[string]any, currentPosition map[string]any, signalBarState map[string]any, marketPrice float64, sessionState map[string]any, nextReason string) map[string]any {
-	positionState := evaluateLivePositionState(parameters, currentPosition, signalBarState, marketPrice, sessionState)
+	watermarks := refreshLivePositionWatermarks(sessionState, currentPosition, marketPrice)
+	positionState := deriveLivePositionState(parameters, currentPosition, signalBarState, marketPrice, watermarks)
+	return deriveLiveExitState(parameters, currentPosition, positionState, marketPrice, nextReason)
+}
+
+func deriveLiveExitState(parameters map[string]any, currentPosition map[string]any, positionState map[string]any, marketPrice float64, nextReason string) map[string]any {
 	if len(positionState) == 0 {
 		return map[string]any{
 			"ready":      false,

--- a/internal/service/strategy_registry.go
+++ b/internal/service/strategy_registry.go
@@ -745,8 +745,29 @@ type livePositionWatermarks struct {
 	LWM         float64
 }
 
+func hasActiveVirtualPositionSnapshot(currentPosition map[string]any) bool {
+	if !boolValue(currentPosition["virtual"]) {
+		return false
+	}
+	if boolValue(currentPosition["trackingActive"]) {
+		return true
+	}
+	if strings.TrimSpace(stringValue(currentPosition["id"])) == "" {
+		return false
+	}
+	if NormalizeSymbol(stringValue(currentPosition["symbol"])) == "" {
+		return false
+	}
+	if strings.TrimSpace(stringValue(currentPosition["side"])) == "" {
+		return false
+	}
+	return parseFloatValue(currentPosition["entryPrice"]) > 0
+}
+
 func hasActiveLivePositionSnapshot(currentPosition map[string]any) bool {
-	return boolValue(currentPosition["found"]) || math.Abs(parseFloatValue(currentPosition["quantity"])) > 0 || boolValue(currentPosition["virtual"])
+	return boolValue(currentPosition["found"]) ||
+		math.Abs(parseFloatValue(currentPosition["quantity"])) > 0 ||
+		hasActiveVirtualPositionSnapshot(currentPosition)
 }
 
 func buildLivePositionWatermarkBaseKey(currentPosition map[string]any) string {

--- a/internal/service/strategy_registry.go
+++ b/internal/service/strategy_registry.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"encoding/base64"
 	"fmt"
 	"math"
 	"strings"
@@ -227,10 +228,7 @@ func (e bkStrategyEngine) EvaluateSignal(context StrategySignalEvaluationContext
 	effectivePlannedPrice := context.NextPlannedPrice
 	livePositionState := map[string]any{}
 	if signalBarState != nil {
-		var watermarks livePositionWatermarks
-		if hasActiveLivePositionSnapshot(currentPosition) {
-			watermarks = refreshLivePositionWatermarks(context.SessionState, currentPosition, marketPrice)
-		}
+		watermarks := refreshLivePositionWatermarks(context.SessionState, currentPosition, marketPrice)
 		livePositionState = deriveLivePositionState(context.ExecutionContext.Parameters, currentPosition, signalBarState, marketPrice, watermarks)
 		if strings.EqualFold(strings.TrimSpace(context.NextPlannedRole), "exit") {
 			livePositionState = deriveLiveExitState(context.ExecutionContext.Parameters, currentPosition, livePositionState, marketPrice, context.NextPlannedReason)
@@ -774,23 +772,31 @@ func buildLegacyLivePositionWatermarkKey(currentPosition map[string]any) string 
 	return strings.Join([]string{side, fmt.Sprintf("%.8f", entryPrice)}, "|")
 }
 
-func buildLivePositionWatermarkKey(currentPosition map[string]any, sessionState map[string]any) string {
+func encodeLivePositionWatermarkIdentityComponent(positionID string) string {
+	normalized := strings.TrimSpace(positionID)
+	if normalized == "" {
+		return ""
+	}
+	return "id:" + base64.RawURLEncoding.EncodeToString([]byte(normalized))
+}
+
+func buildLegacyPrefixedLivePositionWatermarkKey(currentPosition map[string]any) string {
+	positionID := strings.TrimSpace(stringValue(currentPosition["id"]))
+	baseKey := buildLivePositionWatermarkBaseKey(currentPosition)
+	if positionID == "" || baseKey == "" {
+		return ""
+	}
+	return positionID + "|" + baseKey
+}
+
+func buildLivePositionWatermarkKey(currentPosition map[string]any) string {
 	baseKey := buildLivePositionWatermarkBaseKey(currentPosition)
 	if baseKey == "" {
 		return ""
 	}
-	lastKey := stringValue(sessionState["watermarkPositionKey"])
-	legacyBaseKey := buildLegacyLivePositionWatermarkKey(currentPosition)
 	if positionID := strings.TrimSpace(stringValue(currentPosition["id"])); positionID != "" {
-		currentKey := positionID + "|" + baseKey
-		if lastKey == positionID || strings.HasPrefix(lastKey, positionID+"|") {
-			return currentKey
-		}
-		return currentKey
-	}
-	if lastKey != "" {
-		if lastKey == baseKey || lastKey == legacyBaseKey || strings.HasSuffix(lastKey, "|"+baseKey) || strings.HasSuffix(lastKey, "|"+legacyBaseKey) {
-			return lastKey
+		if identityComponent := encodeLivePositionWatermarkIdentityComponent(positionID); identityComponent != "" {
+			return identityComponent + "|" + baseKey
 		}
 	}
 	return baseKey
@@ -804,21 +810,16 @@ func isCompatibleLivePositionWatermarkMigration(lastKey string, currentPosition 
 		return true
 	}
 	baseKey := buildLivePositionWatermarkBaseKey(currentPosition)
-	legacyBaseKey := buildLegacyLivePositionWatermarkKey(currentPosition)
 	if positionID := strings.TrimSpace(stringValue(currentPosition["id"])); positionID != "" {
 		if boolValue(currentPosition["virtual"]) && lastKey == positionID {
 			return true
 		}
-		if lastKey == baseKey || lastKey == legacyBaseKey {
+		if lastKey == baseKey {
 			return true
 		}
-		return strings.HasPrefix(lastKey, positionID+"|") &&
-			(strings.HasSuffix(lastKey, "|"+baseKey) || strings.HasSuffix(lastKey, "|"+legacyBaseKey))
+		return lastKey == buildLegacyPrefixedLivePositionWatermarkKey(currentPosition)
 	}
-	return lastKey == baseKey ||
-		lastKey == legacyBaseKey ||
-		strings.HasSuffix(lastKey, "|"+baseKey) ||
-		strings.HasSuffix(lastKey, "|"+legacyBaseKey)
+	return lastKey == baseKey
 }
 
 func clearLivePositionWatermarks(sessionState map[string]any) {
@@ -839,7 +840,7 @@ func resolveLivePositionWatermarks(currentPosition map[string]any, sessionState 
 	if entryPrice <= 0 || side == "" {
 		return livePositionWatermarks{}
 	}
-	positionKey := buildLivePositionWatermarkKey(currentPosition, sessionState)
+	positionKey := buildLivePositionWatermarkKey(currentPosition)
 	if positionKey == "" {
 		return livePositionWatermarks{}
 	}
@@ -899,6 +900,7 @@ func applyLivePositionWatermarks(sessionState map[string]any, watermarks livePos
 
 func refreshLivePositionWatermarks(sessionState map[string]any, currentPosition map[string]any, marketPrice float64) livePositionWatermarks {
 	if !hasActiveLivePositionSnapshot(currentPosition) {
+		clearLivePositionWatermarks(sessionState)
 		return livePositionWatermarks{}
 	}
 	watermarks := resolveLivePositionWatermarks(currentPosition, sessionState)
@@ -911,10 +913,7 @@ func refreshLivePositionWatermarks(sessionState map[string]any, currentPosition 
 // When sessionState is provided, it also refreshes HWM/LWM watermarks used by
 // trailing-stop logic so callers do not need to duplicate watermark handling.
 func evaluateLivePositionState(parameters map[string]any, currentPosition map[string]any, signalBarState map[string]any, marketPrice float64, sessionState map[string]any) map[string]any {
-	var watermarks livePositionWatermarks
-	if hasActiveLivePositionSnapshot(currentPosition) {
-		watermarks = refreshLivePositionWatermarks(sessionState, currentPosition, marketPrice)
-	}
+	watermarks := refreshLivePositionWatermarks(sessionState, currentPosition, marketPrice)
 	return deriveLivePositionState(parameters, currentPosition, signalBarState, marketPrice, watermarks)
 }
 


### PR DESCRIPTION
## Summary
- add execution normalization telemetry so raw sizing vs normalized exchange order parameters are observable
- make SL protection pricing depth-aware with top-of-book coverage telemetry
- separate watermark refresh from live position and exit-state derivation for cleaner trailing-stop boundaries
- refresh this PR on a clean branch so AI review sees the final diff without the old commit history

## Testing
- go test ./internal/service/...
- go test ./...