### PR TITLE
chore: disable automatic AI review

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -2,9 +2,9 @@ name: AI PR Review
 
 on:
   workflow_dispatch:
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
-    branches: [main]
+#   pull_request:
+#     types: [opened, synchronize, reopened, ready_for_review]
+#     branches: [main]
 
 permissions:
   contents: read


### PR DESCRIPTION
This PR comments out the pull_request trigger in the AI review workflow to disable automatic reviews on PRs.