### PR TITLE
Add ETH tick replay research and data pipeline fixes

### DIFF
--- a/docs/20260413-eth-tick-replay-research.md
+++ b/docs/20260413-eth-tick-replay-research.md
@@ -1,0 +1,217 @@
+# ETH Tick Replay Research
+
+## Scope
+
+This branch focuses on two closely related research tasks:
+
+1. Make `research/backTest.py` support a safer monthly tick replay path that stays aligned with the current enhanced 1-minute backtest logic.
+2. Download ETHUSDT 2023 monthly tick archives and compare `tick replay` vs `1min OHLC replay` under the same strategy configuration.
+
+The intent is to answer a practical question:
+
+- Does the edge still exist once we replay a more realistic intraminute path?
+
+## What Changed
+
+### 1. Tick replay logic in `research/backTest.py`
+
+`run_tick_full_scan_dual(...)` no longer relies on the older raw per-tick scan assumptions.
+
+The updated flow is:
+
+1. Load raw monthly tick CSV in chunks.
+2. Aggregate ticks into minute summaries:
+   - `open`
+   - `high`
+   - `low`
+   - `close`
+   - `first_ts`
+   - `last_ts`
+   - `high_ts`
+   - `low_ts`
+3. Reconstruct a minute-level event stream that preserves intraminute ordering:
+   - `open`
+   - then `high/low` in actual observed order
+   - then `close`
+4. Reuse the current enhanced strategy state machine on top of that event stream.
+
+This makes tick replay:
+
+- much closer to the current `1min` backtest semantics
+- more realistic than plain `1min OHLC`
+- still fast enough to run month-by-month on full 2023 data
+
+The parser now supports both archive formats we observed:
+
+- BTC monthly files without a header
+- ETH monthly files with header:
+  - `id,price,qty,quote_qty,time,is_buyer_maker`
+
+### 2. ETH data scripts
+
+The ETH research helpers were cleaned up so the dataset pipeline can run reliably:
+
+- `research/ethusdt_1min.py`
+- `research/parquet_to_csv_ETHUSDT.py`
+
+Notable fixes:
+
+- funding schema compatibility
+- open-interest API defensive handling
+- parquet fallback via `pyarrow` when pandas parquet support is missing
+
+## Test Data
+
+### ETH 1-minute clean data
+
+- Source file:
+  - `ETH_1min_Clean.csv`
+
+### ETH 2023 monthly tick archives
+
+Downloaded under:
+
+- `dataset/archive/ETHUSDT-trades-2023-01/...`
+- ...
+- `dataset/archive/ETHUSDT-trades-2023-12/...`
+
+Total downloaded size is about `46.3 GB`.
+
+## Strategy Configuration Used
+
+All `ETH 2023 tick vs 1min` comparisons in this branch used the same canonical enhanced configuration:
+
+- `dir2_zero_initial=True`
+- `fixed_slippage=0.0005`
+- `stop_loss_atr=0.05`
+- `stop_mode='atr'`
+- `max_trades_per_bar=4`
+- `reentry_size_schedule=[0.10, 0.05, 0.025]`
+- `trailing_stop_atr=0.3`
+- `delayed_trailing_activation=0.5`
+- `long_reentry_atr=0.1`
+- `short_reentry_atr=0.0`
+
+## Backtests Run
+
+### A. BTC 2023 full-year control run
+
+Purpose:
+
+- validate that the new tick replay path stays close to the current enhanced `1min` engine
+
+Result:
+
+- `enhanced_1m`: `+69.41%`
+- `tick_replay`: `+67.77%`
+
+Interpretation:
+
+- the updated tick replay is aligned with the current strategy logic
+- `1min OHLC` is still mildly optimistic, but not catastrophically divergent
+
+### B. ETH 2023 full-year tick vs 1min comparison
+
+Output files:
+
+- `tmp_eth_2023_full_tick_vs_1m_overall.csv`
+- `tmp_eth_2023_full_tick_vs_1m_monthly.csv`
+- `tmp_eth_2023_full_1m_ledger.csv`
+- `tmp_eth_2023_full_tick_ledger.csv`
+
+Overall result:
+
+- `enhanced_1m`
+  - return: `+79.54%`
+  - trades: `273`
+  - maxDD: `-0.0888%`
+  - final balance: `179,540.45`
+
+- `tick_replay`
+  - return: `+65.97%`
+  - trades: `245`
+  - maxDD: `-0.0830%`
+  - final balance: `165,965.89`
+
+Monthly tick replay result:
+
+- `2023-01`: `+5.30%`
+- `2023-02`: `+9.44%`
+- `2023-03`: `+5.38%`
+- `2023-04`: `+4.41%`
+- `2023-05`: `+5.85%`
+- `2023-06`: `+3.90%`
+- `2023-07`: `+1.49%`
+- `2023-08`: `+3.78%`
+- `2023-09`: `+1.48%`
+- `2023-10`: `+4.31%`
+- `2023-11`: `+6.29%`
+- `2023-12`: `+0.43%`
+
+## Main Findings
+
+### 1. The edge still exists under tick replay
+
+ETH 2023 remains clearly profitable after moving from `1min OHLC` replay to the more realistic tick-derived replay.
+
+That is the most important result from this branch.
+
+### 2. `1min OHLC` is still optimistic
+
+The same strategy on the same year drops from:
+
+- `+79.54%` in enhanced `1min`
+- to `+65.97%` in tick replay
+
+So the minute-bar version overstates annual performance by roughly `13.58` percentage points in this configuration.
+
+### 3. The difference mainly comes from intraminute path realism
+
+The new tick replay preserves whether price reached:
+
+- `high` before `low`
+- or `low` before `high`
+
+inside a minute.
+
+That matters for:
+
+- breakout entry timing
+- same-minute whipsaw exits
+- quick `SL -> reentry` chains
+- trailing/protection updates
+
+### 4. ETH still looks stronger than BTC, but less extreme after tick replay
+
+The older `1min-only` ETH studies looked extremely strong.
+
+This branch suggests:
+
+- ETH still has edge
+- but part of the apparent strength was amplified by `1min OHLC` assumptions
+
+That makes the tick-based number more credible for further parameter research.
+
+## Practical Conclusion
+
+For research quality, ETH should no longer be judged only by `1min OHLC` replay.
+
+The safer default interpretation is:
+
+- use `1min` replay for fast iteration
+- use tick replay to validate whether a promising edge survives intraminute ordering
+
+## Validation Performed
+
+- `python3 -m py_compile research/backTest.py`
+- `python3 -m py_compile research/ethusdt_1min.py research/parquet_to_csv_ETHUSDT.py`
+- ETH monthly tick replay smoke on `2023-01`
+- ETH full-year `2023 tick vs 1min` run
+- BTC 2023 full-year control comparison
+
+## Notes
+
+- Attempted graph refresh per repo instructions:
+  - `python3 -c "from graphify.watch import _rebuild_code; from pathlib import Path; _rebuild_code(Path('.'))"`
+- Current local environment does not have the `graphify` Python module installed, so refresh failed with:
+  - `ModuleNotFoundError: No module named 'graphify'`

--- a/research/backTest.py
+++ b/research/backTest.py
@@ -6,6 +6,23 @@ from tqdm import tqdm
 import matplotlib.pyplot as plt
 
 
+def _normalize_utc_index(df):
+    normalized = df.copy(deep=False)
+    normalized.index = pd.to_datetime(normalized.index, utc=True)
+    return normalized
+
+
+def _empty_tick_event_stream():
+    return pd.DataFrame(
+        {
+            'price': pd.Series(dtype='float64'),
+            'event': pd.Series(dtype='object'),
+            'minute_ms': pd.Series(dtype='int64'),
+        },
+        index=pd.DatetimeIndex([], tz='UTC', name='timestamp'),
+    )
+
+
 def _summarize_complete_tick_chunk(df_ticks):
     if df_ticks.empty:
         return pd.DataFrame(columns=[
@@ -100,7 +117,7 @@ def _build_tick_event_stream(tick_file, start_ts=None, end_ts=None, chunksize=2_
         summaries.append(_summarize_complete_tick_chunk(pending))
 
     if not summaries:
-        return pd.DataFrame(columns=['price', 'event', 'minute_ms'])
+        return _empty_tick_event_stream()
 
     minute_df = pd.concat(summaries, ignore_index=True)
     events = []
@@ -154,8 +171,8 @@ def run_tick_full_scan_dual(df_4h, tick_file, current_bal,
                             max_drawdown_pct=None,
                             cooldown_bars=6,
                             reentry_mode='default'):
-    df_4h = df_4h.copy()
-    df_4h.index = pd.to_datetime(df_4h.index, utc=True)
+    # Keep both signal windows and tick windows on the same UTC-aware contract.
+    df_4h = _normalize_utc_index(df_4h)
 
     replay_start = df_4h.index[0]
     replay_end = df_4h.index[-1]
@@ -165,6 +182,7 @@ def run_tick_full_scan_dual(df_4h, tick_file, current_bal,
         start_ts=replay_start,
         end_ts=replay_end,
     )
+    df_tick = _normalize_utc_index(df_tick)
 
     balance = current_bal
     peak_balance = current_bal
@@ -756,6 +774,9 @@ def run_backtest_1min_granularity(df_1min, df_4h, initial_balance=100000.0,
     df_1min: 包含 open, high, low, close 的标准化 1min 数据
     df_4h: 包含策略锚点(ma20, atr, prev_high_2 等)的 4H 数据
     """
+    df_1min = _normalize_utc_index(df_1min)
+    df_4h = _normalize_utc_index(df_4h)
+
     balance = initial_balance
     position = None # {'side', 'entry_p', 'sl', 'protected', 'notional'}
     trade_logs = []
@@ -1282,6 +1303,9 @@ def run_backtest_enhanced(df_1min, df_4h, initial_balance=100000.0,
     - cooldown_bars: int, 熔断冷却期（信号 bar 数量）。
     - reentry_mode: str, 'default'=原始递增, 'fixed'=固定大小, 'decreasing'=递减。
     """
+    df_1min = _normalize_utc_index(df_1min)
+    df_4h = _normalize_utc_index(df_4h)
+
     balance = initial_balance
     peak_balance = initial_balance
     position = None

--- a/research/backTest.py
+++ b/research/backTest.py
@@ -6,40 +6,219 @@ from tqdm import tqdm
 import matplotlib.pyplot as plt
 
 
-def run_tick_full_scan_dual(df_4h, tick_file,current_bal):
-    # ... (加载数据部分保持不变) ...
-    print(f"正在加载原始 Tick 数据: {tick_file} ...")
-    df_tick = pd.read_csv(
-        tick_file, engine='python', header=None, 
-        usecols=[1, 4], names=['price', 'timestamp'],
-        on_bad_lines='skip', dtype={'price': 'float32', 'timestamp': 'int64'}
+def _summarize_complete_tick_chunk(df_ticks):
+    if df_ticks.empty:
+        return pd.DataFrame(columns=[
+            'minute_ms', 'open', 'high', 'low', 'close',
+            'first_ts', 'last_ts', 'high_ts', 'low_ts'
+        ])
+
+    grouped = df_ticks.groupby('minute_ms', sort=False)
+    summary = grouped.agg(
+        open=('price', 'first'),
+        high=('price', 'max'),
+        low=('price', 'min'),
+        close=('price', 'last'),
+        first_ts=('timestamp', 'first'),
+        last_ts=('timestamp', 'last'),
     )
-    df_tick['timestamp'] = pd.to_datetime(df_tick['timestamp'], unit='ms')
-    df_tick.set_index('timestamp', inplace=True)
-    
-    # 策略常量
-    COMMISSION = 0.0010
-    STOP_LOSS_ATR_LONG = 0.1    # 多头止损
-    STOP_LOSS_ATR_SHORT = 0.1  # 空头止损：较宽，防止在空头趋势中被反抽洗掉
-    REENTRY_ATR = 0.1
-    MAX_TRADES_PER_BAR = 2
-    CASH_USAGE_RATE=0.2
-    SLIPPAGE = 0.0005 
+
+    high_idx = grouped['price'].idxmax()
+    low_idx = grouped['price'].idxmin()
+
+    high_ts = df_ticks.loc[high_idx, ['minute_ms', 'timestamp']].set_index('minute_ms')['timestamp']
+    low_ts = df_ticks.loc[low_idx, ['minute_ms', 'timestamp']].set_index('minute_ms')['timestamp']
+
+    summary['high_ts'] = high_ts
+    summary['low_ts'] = low_ts
+    summary = summary.reset_index()
+    return summary
+
+
+def _build_tick_event_stream(tick_file, start_ts=None, end_ts=None, chunksize=2_000_000):
+    start_ms = int(pd.Timestamp(start_ts).timestamp() * 1000) if start_ts is not None else None
+    end_ms = int(pd.Timestamp(end_ts).timestamp() * 1000) if end_ts is not None else None
+
+    summaries = []
+    pending = None
+    with open(tick_file, 'r', encoding='utf-8') as fh:
+        first_line = fh.readline().strip().lower()
+
+    if first_line.startswith('id,price,qty,quote_qty,time'):
+        reader = pd.read_csv(
+            tick_file,
+            header=0,
+            usecols=['price', 'time'],
+            dtype={'price': 'float32', 'time': 'int64'},
+            chunksize=chunksize,
+        )
+    else:
+        reader = pd.read_csv(
+            tick_file,
+            header=None,
+            usecols=[1, 4],
+            names=['price', 'timestamp'],
+            dtype={'price': 'float32', 'timestamp': 'int64'},
+            chunksize=chunksize,
+        )
+
+    for chunk in reader:
+        if 'time' in chunk.columns:
+            chunk = chunk.rename(columns={'time': 'timestamp'})
+        if end_ms is not None and not chunk.empty and chunk['timestamp'].iloc[0] > end_ms:
+            break
+        if start_ms is not None and not chunk.empty and chunk['timestamp'].iloc[-1] < start_ms:
+            continue
+
+        reached_end = False
+        if end_ms is not None and not chunk.empty and chunk['timestamp'].iloc[-1] > end_ms:
+            chunk = chunk[chunk['timestamp'] <= end_ms]
+            reached_end = True
+        if start_ms is not None:
+            chunk = chunk[chunk['timestamp'] >= start_ms]
+        if chunk.empty:
+            if reached_end:
+                break
+            continue
+
+        if pending is not None and not pending.empty:
+            chunk = pd.concat([pending, chunk], ignore_index=True)
+            pending = None
+
+        chunk['minute_ms'] = (chunk['timestamp'] // 60000) * 60000
+        last_minute = chunk['minute_ms'].iloc[-1]
+        pending = chunk[chunk['minute_ms'] == last_minute].copy()
+        complete = chunk[chunk['minute_ms'] != last_minute]
+
+        if not complete.empty:
+            summaries.append(_summarize_complete_tick_chunk(complete))
+
+        if reached_end:
+            break
+
+    if pending is not None and not pending.empty:
+        summaries.append(_summarize_complete_tick_chunk(pending))
+
+    if not summaries:
+        return pd.DataFrame(columns=['price', 'event', 'minute_ms'])
+
+    minute_df = pd.concat(summaries, ignore_index=True)
+    events = []
+    for row in minute_df.itertuples(index=False):
+        if row.high_ts <= row.low_ts:
+            ordered = [
+                ('open', row.first_ts, float(row.open)),
+                ('high', row.high_ts, float(row.high)),
+                ('low', row.low_ts, float(row.low)),
+                ('close', row.last_ts, float(row.close)),
+            ]
+        else:
+            ordered = [
+                ('open', row.first_ts, float(row.open)),
+                ('low', row.low_ts, float(row.low)),
+                ('high', row.high_ts, float(row.high)),
+                ('close', row.last_ts, float(row.close)),
+            ]
+
+        deduped = []
+        for label, ts_ms, price in ordered:
+            if deduped and deduped[-1][0] == ts_ms and deduped[-1][1] == price:
+                continue
+            deduped.append((ts_ms, price, label))
+
+        for seq, (ts_ms, price, label) in enumerate(deduped):
+            events.append((ts_ms, seq, price, label, row.minute_ms))
+
+    event_df = pd.DataFrame(events, columns=['timestamp_ms', 'seq', 'price', 'event', 'minute_ms'])
+    event_df.sort_values(['timestamp_ms', 'seq'], inplace=True)
+    event_df['timestamp'] = pd.to_datetime(event_df['timestamp_ms'], unit='ms', utc=True)
+    event_df.set_index('timestamp', inplace=True)
+    return event_df[['price', 'event', 'minute_ms']]
+
+
+def run_tick_full_scan_dual(df_4h, tick_file, current_bal,
+                            dir1_reentry_confirm=False,
+                            dir2_zero_initial=False,
+                            dir3_structural_sl=False,
+                            fixed_slippage=None,
+                            stop_loss_atr=0.05,
+                            max_trades_per_bar=4,
+                            reentry_size_schedule=None,
+                            long_reentry_atr=0.1,
+                            short_reentry_atr=0.0,
+                            stop_mode=None,
+                            profit_protect_atr=1.0,
+                            trailing_stop_atr=0.3,
+                            delayed_trailing_activation=0.5,
+                            tiered_protection=False,
+                            max_drawdown_pct=None,
+                            cooldown_bars=6,
+                            reentry_mode='default'):
+    replay_start = df_4h.index[0]
+    replay_end = df_4h.index[-1]
+    print(f"正在构建 Tick 事件流: {tick_file} ({replay_start} ~ {replay_end}) ...")
+    df_tick = _build_tick_event_stream(
+        tick_file,
+        start_ts=replay_start,
+        end_ts=replay_end,
+    )
 
     balance = current_bal
-    position = None 
+    peak_balance = current_bal
+    position = None
     trade_logs = []
-    last_exit_reason, last_exit_side = None, None
+
+    COMMISSION = 0.0010
+    MAX_TRADES_PER_BAR = max_trades_per_bar
+    SLIPPAGE = np.random.uniform(0.0005, 0.002) if fixed_slippage is None else fixed_slippage
+    CASH_USAGE_INITIAL = 0.0 if dir2_zero_initial else 0.10
+    REENTRY_SIZE_SCHEDULE = _normalize_reentry_sizes(reentry_size_schedule)
+    PROFIT_PROTECT = profit_protect_atr
+    stop_mode = 'structural' if dir3_structural_sl and stop_mode is None else (stop_mode or 'atr')
+
+    if reentry_mode == 'fixed':
+        base = REENTRY_SIZE_SCHEDULE[0] if REENTRY_SIZE_SCHEDULE else 0.10
+        REENTRY_SIZE_SCHEDULE = [base] * max(len(REENTRY_SIZE_SCHEDULE), 3)
+    elif reentry_mode == 'decreasing':
+        base = REENTRY_SIZE_SCHEDULE[0] if REENTRY_SIZE_SCHEDULE else 0.10
+        REENTRY_SIZE_SCHEDULE = [base * (0.5 ** i) for i in range(max(len(REENTRY_SIZE_SCHEDULE), 3))]
+
     last_exit_bar_index = -999
     REENTRY_TIMEOUT = 1
+    last_exit_reason = None
+    last_exit_side = None
+    circuit_breaker_until = -999
 
-    # 4H 信号迭代
-    for i in range(len(df_4h)-1):
-        start_t, end_t = df_4h.index[i], df_4h.index[i+1]
+    label_parts = []
+    if trailing_stop_atr:
+        label_parts.append(f"Trail:{trailing_stop_atr}")
+    if tiered_protection:
+        label_parts.append("TieredPT")
+    if max_drawdown_pct:
+        label_parts.append(f"CB:{max_drawdown_pct:.0%}")
+    if reentry_mode != 'default':
+        label_parts.append(f"Re:{reentry_mode}")
+    label_parts.append(f"ReATR:{long_reentry_atr}/{short_reentry_atr}")
+    label = " | ".join(label_parts) if label_parts else "TickEnhanced"
+
+    print(
+        f"🎯 Tick回放 [{label}] | Stop:{stop_mode} ATR:{stop_loss_atr} | "
+        f"Slippage:{SLIPPAGE}"
+    )
+
+    for i in range(len(df_4h) - 1):
+        start_t, end_t = df_4h.index[i], df_4h.index[i + 1]
         window_ticks = df_tick.loc[start_t:end_t]
-        if window_ticks.empty: continue
-        
+        if window_ticks.empty:
+            continue
+
         sig = df_4h.iloc[i]
+        if pd.isna(sig['atr']):
+            continue
+        long_regime_ready, short_regime_ready = _resolve_regime_ready(
+            sig, '1d' if 'ma5' in df_4h.columns else '4h'
+        )
+
         trades_in_bar = 0
         idx = 0
         total_ticks = len(window_ticks)
@@ -47,112 +226,314 @@ def run_tick_full_scan_dual(df_4h, tick_file,current_bal):
         if i - last_exit_bar_index > REENTRY_TIMEOUT:
             last_exit_side = None
 
-        
-        
         while idx < total_ticks:
-            # 1. 获取当前 Tick 价格和时间
             current_tick = window_ticks.iloc[idx]
-            current_p = current_tick['price']
+            current_p = float(current_tick['price'])
             current_time = window_ticks.index[idx]
-            
+            prev_p = float(window_ticks.iloc[idx - 1]['price']) if idx > 0 else np.nan
+
             if not position:
-                # --- [A. 寻找进场/重入] ---
+                if max_drawdown_pct is not None and i < circuit_breaker_until:
+                    idx += 1
+                    continue
+
                 executed = False
-                
-                # 多头逻辑
-                if sig['close'] > sig['ma20']:
-                    re_p = sig['prev_low_1'] + (REENTRY_ATR * sig['atr'])
-                    # 初始进场
+
+                if long_regime_ready:
+                    re_p = sig['prev_low_1'] + (long_reentry_atr * sig['atr'])
                     if trades_in_bar == 0 and sig['prev_high_2'] > sig['prev_high_1']:
                         if current_p >= sig['prev_high_2']:
-                            entry_p = max(current_p, sig['prev_high_2'])
-                            entry_p *= (1 + SLIPPAGE)
-                            notional_value = balance * CASH_USAGE_RATE
-                            position = {'side': 'long', 'entry_p': entry_p, 'sl': entry_p - (STOP_LOSS_ATR_LONG * sig['atr']), 'protected': False,'notional': notional_value}
+                            entry_raw = max(current_p, sig['prev_high_2'])
+                            entry_p = entry_raw * (1 + SLIPPAGE)
+                            notional_value = balance * CASH_USAGE_INITIAL
+                            initial_sl = _resolve_stop_price('long', entry_p, sig, stop_mode, stop_loss_atr)
+                            position = {
+                                'side': 'long',
+                                'entry_p': entry_p,
+                                'sl': initial_sl,
+                                'protected': False,
+                                'notional': notional_value,
+                                'hwm': entry_p,
+                            }
                             balance -= notional_value * COMMISSION
-                            trade_logs.append({'time': current_time, 'type': 'BUY', 'price': entry_p, 'reason': 'Initial', 'notional': notional_value,'bal': balance})
-                            trades_in_bar += 1; executed = True
-                    
-                    # 重入逻辑 (增加状态清除)
-                    elif last_exit_side == 'long':
-                        if current_p >= re_p and (i - last_exit_bar_index <= REENTRY_TIMEOUT):
+                            trade_logs.append({
+                                'time': current_time,
+                                'type': 'BUY',
+                                'price': entry_p,
+                                'reason': 'Initial',
+                                'notional': notional_value,
+                                'bal': balance,
+                            })
+                            trades_in_bar += 1
+                            executed = True
+                    elif last_exit_side == 'long' and (i - last_exit_bar_index <= REENTRY_TIMEOUT):
+                        is_triggered = False
+                        entry_p_raw = re_p
+                        if dir1_reentry_confirm:
+                            if not pd.isna(prev_p) and current_p > re_p and prev_p > re_p:
+                                is_triggered = True
+                                entry_p_raw = current_p
+                        else:
+                            if current_p >= re_p:
+                                is_triggered = True
+                        if is_triggered:
                             reason = 'SL-Reentry' if last_exit_reason == 'SL' else 'PT-Reentry'
-                            if (reason == 'SL-Reentry' and trades_in_bar < MAX_TRADES_PER_BAR) or reason == 'PT-Reentry':
-                                notional_value = balance * CASH_USAGE_RATE
-                                entry_price = re_p * (1 + SLIPPAGE)
-                                position = {'side': 'long', 'entry_p': entry_price, 'sl': sig['prev_low_1'], 'protected': reason.startswith('PT'),'notional': notional_value}
+                            if trades_in_bar < MAX_TRADES_PER_BAR:
+                                current_reentry_size = _get_reentry_size(trades_in_bar, REENTRY_SIZE_SCHEDULE)
+                                notional_value = balance * current_reentry_size
+                                entry_price = entry_p_raw * (1 + SLIPPAGE)
+                                reentry_sl = _resolve_stop_price('long', entry_price, sig, stop_mode, stop_loss_atr)
+                                position = {
+                                    'side': 'long',
+                                    'entry_p': entry_price,
+                                    'sl': reentry_sl,
+                                    'protected': (reason == 'PT-Reentry'),
+                                    'notional': notional_value,
+                                    'hwm': entry_price,
+                                }
                                 balance -= notional_value * COMMISSION
-                                trade_logs.append({'time': current_time, 'type': 'BUY', 'price': entry_price, 'reason': reason, 'bal': balance,'notional': notional_value})
-                                if reason == 'SL-Reentry': trades_in_bar += 1
-                                executed = True
-                            # 无论是否重入成功，只要触碰了触发线或逻辑已过期，就清除状态，防止在同一位置反复刷单
-                            last_exit_side = None 
-
-                # 空头逻辑 (同样增加状态清除)
-                elif sig['close'] < sig['ma20']:
-                    re_p = sig['prev_high_1']
-                    if trades_in_bar == 0 and sig['prev_low_2'] < sig['prev_low_1']:
-                        if current_p <= sig['prev_low_2']:
-                            entry_p = min(current_p, sig['prev_low_2'])
-                            entry_p *= (1 - SLIPPAGE)
-                            notional_value = balance * CASH_USAGE_RATE
-                            position = {'side': 'short', 'entry_p': entry_p, 'sl': entry_p + (STOP_LOSS_ATR_SHORT * sig['atr']), 'protected': False,'notional': notional_value}
-                            balance -= notional_value * COMMISSION
-                            trade_logs.append({'time': current_time, 'type': 'SHORT', 'price': entry_p, 'reason': 'Initial','notional': notional_value, 'bal': balance})
-                            trades_in_bar += 1; executed = True
-                    elif last_exit_side == 'short':
-                        if current_p <= re_p and (i - last_exit_bar_index <= REENTRY_TIMEOUT):
-                            reason = 'SL-Reentry' if last_exit_reason == 'SL' else 'PT-Reentry'
-                            if (reason == 'SL-Reentry' and trades_in_bar < MAX_TRADES_PER_BAR) or reason == 'PT-Reentry':
-                                notional_value = balance * CASH_USAGE_RATE
-                                entry_price=re_p*(1 - SLIPPAGE)
-                                position = {'side': 'short', 'entry_p': entry_price, 'sl': sig['prev_high_1'], 'protected': reason.startswith('PT'),'notional': notional_value}
-                                balance -= notional_value * COMMISSION
-                                trade_logs.append({'time': current_time, 'type': 'SHORT', 'price': entry_price, 'reason': reason,'notional': notional_value, 'bal': balance})
-                                if reason == 'SL-Reentry': trades_in_bar += 1
+                                trade_logs.append({
+                                    'time': current_time,
+                                    'type': 'BUY',
+                                    'price': entry_price,
+                                    'reason': reason,
+                                    'notional': notional_value,
+                                    'bal': balance,
+                                })
+                                trades_in_bar += 1
                                 executed = True
                             last_exit_side = None
 
-                # 步进逻辑：如果成交了，跳过当前秒的所有 Tick；没成交则看下一个 Tick
+                elif short_regime_ready:
+                    re_p = sig['prev_high_1'] - (short_reentry_atr * sig['atr'])
+                    if trades_in_bar == 0 and sig['prev_low_2'] < sig['prev_low_1']:
+                        if current_p <= sig['prev_low_2']:
+                            entry_raw = min(current_p, sig['prev_low_2'])
+                            entry_p = entry_raw * (1 - SLIPPAGE)
+                            notional_value = balance * CASH_USAGE_INITIAL
+                            initial_sl = _resolve_stop_price('short', entry_p, sig, stop_mode, stop_loss_atr)
+                            position = {
+                                'side': 'short',
+                                'entry_p': entry_p,
+                                'sl': initial_sl,
+                                'protected': False,
+                                'notional': notional_value,
+                                'lwm': entry_p,
+                            }
+                            balance -= notional_value * COMMISSION
+                            trade_logs.append({
+                                'time': current_time,
+                                'type': 'SHORT',
+                                'price': entry_p,
+                                'reason': 'Initial',
+                                'notional': notional_value,
+                                'bal': balance,
+                            })
+                            trades_in_bar += 1
+                            executed = True
+                    elif last_exit_side == 'short' and (i - last_exit_bar_index <= REENTRY_TIMEOUT):
+                        is_triggered = False
+                        entry_p_raw = re_p
+                        if dir1_reentry_confirm:
+                            if not pd.isna(prev_p) and current_p < re_p and prev_p < re_p:
+                                is_triggered = True
+                                entry_p_raw = current_p
+                        else:
+                            if current_p <= re_p:
+                                is_triggered = True
+                        if is_triggered:
+                            reason = 'SL-Reentry' if last_exit_reason == 'SL' else 'PT-Reentry'
+                            if trades_in_bar < MAX_TRADES_PER_BAR:
+                                current_reentry_size = _get_reentry_size(trades_in_bar, REENTRY_SIZE_SCHEDULE)
+                                notional_value = balance * current_reentry_size
+                                entry_price = entry_p_raw * (1 - SLIPPAGE)
+                                reentry_sl = _resolve_stop_price('short', entry_price, sig, stop_mode, stop_loss_atr)
+                                position = {
+                                    'side': 'short',
+                                    'entry_p': entry_price,
+                                    'sl': reentry_sl,
+                                    'protected': (reason == 'PT-Reentry'),
+                                    'notional': notional_value,
+                                    'lwm': entry_price,
+                                }
+                                balance -= notional_value * COMMISSION
+                                trade_logs.append({
+                                    'time': current_time,
+                                    'type': 'SHORT',
+                                    'price': entry_price,
+                                    'reason': reason,
+                                    'notional': notional_value,
+                                    'bal': balance,
+                                })
+                                trades_in_bar += 1
+                                executed = True
+                            last_exit_side = None
+
                 if executed:
                     idx = window_ticks.index.searchsorted(current_time, side='right')
                 else:
                     idx += 1
-
             else:
-                # --- [B. 监控持仓退出] ---
                 exit_triggered = False
+                exit_p = 0.0
+                reason = ''
+
                 if position['side'] == 'long':
-                    # 激活保护
-                    if not position['protected'] and current_p >= position['entry_p'] + sig['atr']:
-                        position['protected'] = True
-                    
-                    # 检查止损或止盈
+                    prev_hwm = position.get('hwm', position['entry_p'])
+                    protected_before_tick = position.get('protected', False)
+
+                    if trailing_stop_atr is not None:
+                        is_active = True
+                        if delayed_trailing_activation is not None:
+                            profit_atr = (prev_hwm - position['entry_p']) / sig['atr'] if sig['atr'] > 0 else 0
+                            if profit_atr < delayed_trailing_activation:
+                                is_active = False
+                        if is_active:
+                            trailing_sl = prev_hwm - trailing_stop_atr * sig['atr']
+                            position['sl'] = max(position['sl'], trailing_sl)
+
                     if current_p <= position['sl']:
                         exit_p, reason, exit_triggered = position['sl'], 'SL', True
-                    elif position['protected'] and current_p <= sig['prev_low_1']:
-                        exit_p, reason, exit_triggered = sig['prev_low_1'], 'PT', True
-                
-                else: # 空头持仓
-                    if not position['protected'] and current_p <= position['entry_p'] - sig['atr']:
-                        position['protected'] = True
+                    elif tiered_protection:
+                        profit_atr = (prev_hwm - position['entry_p']) / sig['atr'] if sig['atr'] > 0 else 0
+                        if protected_before_tick and profit_atr >= 3.0:
+                            tiered_exit = max(sig['prev_low_1'], prev_hwm - 1.5 * sig['atr'])
+                            if current_p <= tiered_exit:
+                                exit_p, reason, exit_triggered = tiered_exit, 'PT-T3', True
+                        elif protected_before_tick and profit_atr >= 2.0:
+                            tiered_exit = max(sig['prev_low_1'], position['entry_p'] + 0.5 * sig['atr'])
+                            if current_p <= tiered_exit:
+                                exit_p, reason, exit_triggered = tiered_exit, 'PT-T2', True
+                        elif protected_before_tick and current_p <= sig['prev_low_1']:
+                            exit_p, reason, exit_triggered = sig['prev_low_1'], 'PT', True
+                    else:
+                        if protected_before_tick and current_p <= sig['prev_low_1']:
+                            exit_p, reason, exit_triggered = sig['prev_low_1'], 'PT', True
+
+                    if not exit_triggered:
+                        position['hwm'] = max(prev_hwm, current_p)
+                        if tiered_protection:
+                            profit_atr = (position['hwm'] - position['entry_p']) / sig['atr'] if sig['atr'] > 0 else 0
+                            if profit_atr >= PROFIT_PROTECT and not position['protected']:
+                                position['protected'] = True
+                        else:
+                            if not position['protected'] and current_p >= position['entry_p'] + PROFIT_PROTECT * sig['atr']:
+                                position['protected'] = True
+                        if trailing_stop_atr is not None:
+                            is_active = True
+                            if delayed_trailing_activation is not None:
+                                profit_atr = (position['hwm'] - position['entry_p']) / sig['atr'] if sig['atr'] > 0 else 0
+                                if profit_atr < delayed_trailing_activation:
+                                    is_active = False
+                            if is_active:
+                                trailing_sl = position['hwm'] - trailing_stop_atr * sig['atr']
+                                position['sl'] = max(position['sl'], trailing_sl)
+
+                else:
+                    prev_lwm = position.get('lwm', position['entry_p'])
+                    protected_before_tick = position.get('protected', False)
+
+                    if trailing_stop_atr is not None:
+                        is_active = True
+                        if delayed_trailing_activation is not None:
+                            profit_atr = (position['entry_p'] - prev_lwm) / sig['atr'] if sig['atr'] > 0 else 0
+                            if profit_atr < delayed_trailing_activation:
+                                is_active = False
+                        if is_active:
+                            trailing_sl = prev_lwm + trailing_stop_atr * sig['atr']
+                            position['sl'] = min(position['sl'], trailing_sl)
+
                     if current_p >= position['sl']:
                         exit_p, reason, exit_triggered = position['sl'], 'SL', True
-                    elif position['protected'] and current_p >= sig['prev_high_1']:
-                        exit_p, reason, exit_triggered = sig['prev_high_1'], 'PT', True
+                    elif tiered_protection:
+                        profit_atr = (position['entry_p'] - prev_lwm) / sig['atr'] if sig['atr'] > 0 else 0
+                        if protected_before_tick and profit_atr >= 3.0:
+                            tiered_exit = min(sig['prev_high_1'], prev_lwm + 1.5 * sig['atr'])
+                            if current_p >= tiered_exit:
+                                exit_p, reason, exit_triggered = tiered_exit, 'PT-T3', True
+                        elif protected_before_tick and profit_atr >= 2.0:
+                            tiered_exit = min(sig['prev_high_1'], position['entry_p'] - 0.5 * sig['atr'])
+                            if current_p >= tiered_exit:
+                                exit_p, reason, exit_triggered = tiered_exit, 'PT-T2', True
+                        elif protected_before_tick and current_p >= sig['prev_high_1']:
+                            exit_p, reason, exit_triggered = sig['prev_high_1'], 'PT', True
+                    else:
+                        if protected_before_tick and current_p >= sig['prev_high_1']:
+                            exit_p, reason, exit_triggered = sig['prev_high_1'], 'PT', True
+
+                    if not exit_triggered:
+                        position['lwm'] = min(prev_lwm, current_p)
+                        if tiered_protection:
+                            profit_atr = (position['entry_p'] - position['lwm']) / sig['atr'] if sig['atr'] > 0 else 0
+                            if profit_atr >= PROFIT_PROTECT and not position['protected']:
+                                position['protected'] = True
+                        else:
+                            if not position['protected'] and current_p <= position['entry_p'] - PROFIT_PROTECT * sig['atr']:
+                                position['protected'] = True
+                        if trailing_stop_atr is not None:
+                            is_active = True
+                            if delayed_trailing_activation is not None:
+                                profit_atr = (position['entry_p'] - position['lwm']) / sig['atr'] if sig['atr'] > 0 else 0
+                                if profit_atr < delayed_trailing_activation:
+                                    is_active = False
+                            if is_active:
+                                trailing_sl = position['lwm'] + trailing_stop_atr * sig['atr']
+                                position['sl'] = min(position['sl'], trailing_sl)
 
                 if exit_triggered:
                     side_mult = 1 if position['side'] == 'long' else -1
-                    exit_p= exit_p * (1 - SLIPPAGE) if position['side'] == 'long' else exit_p* (1 + SLIPPAGE)
-                    pnl = side_mult * (exit_p - position['entry_p']) / position['entry_p'] * position['notional']
-                    balance += pnl - (position['notional'] * COMMISSION)
-                    trade_logs.append({'time': current_time, 'type': 'EXIT', 'price': exit_p, 'reason': reason,'notional': position['notional'], 'bal': balance})
-                    last_exit_reason, last_exit_side, position = reason, position['side'], None
-                    idx = window_ticks.index.searchsorted(current_time, side='right')
+                    exit_p = exit_p * (1 - SLIPPAGE) if position['side'] == 'long' else exit_p * (1 + SLIPPAGE)
+                    if position['notional'] > 0:
+                        pnl = side_mult * (exit_p - position['entry_p']) / position['entry_p'] * position['notional']
+                        balance += pnl - (position['notional'] * COMMISSION)
+                    trade_logs.append({
+                        'time': current_time,
+                        'type': 'EXIT',
+                        'price': exit_p,
+                        'reason': reason,
+                        'notional': position['notional'],
+                        'bal': balance,
+                    })
+                    last_exit_reason = reason
+                    last_exit_side = position['side']
                     last_exit_bar_index = i
+                    position = None
 
+                    if balance > peak_balance:
+                        peak_balance = balance
+                    if max_drawdown_pct is not None and peak_balance > 0:
+                        current_dd = (peak_balance - balance) / peak_balance
+                        if current_dd > max_drawdown_pct:
+                            circuit_breaker_until = i + cooldown_bars
+                            trade_logs.append({
+                                'time': current_time,
+                                'type': 'CIRCUIT_BREAKER',
+                                'price': 0,
+                                'reason': f'DD:{current_dd:.2%}',
+                                'notional': 0,
+                                'bal': balance,
+                            })
+                    idx = window_ticks.index.searchsorted(current_time, side='right')
                 else:
                     idx += 1
+
+    if position is not None and not df_tick.empty:
+        last_tick_time = df_tick.index[-1]
+        last_price = float(df_tick.iloc[-1]['price'])
+        side_mult = 1 if position['side'] == 'long' else -1
+        final_exit_p = last_price * (1 - SLIPPAGE) if position['side'] == 'long' else last_price * (1 + SLIPPAGE)
+        if position['notional'] > 0:
+            pnl = side_mult * (final_exit_p - position['entry_p']) / position['entry_p'] * position['notional']
+            balance += pnl - (position['notional'] * COMMISSION)
+        trade_logs.append({
+            'time': last_tick_time,
+            'type': 'EXIT',
+            'price': final_exit_p,
+            'reason': 'FinalMarkToMarket',
+            'notional': position['notional'],
+            'bal': balance,
+        })
+
     return pd.DataFrame(trade_logs), balance
 
 def analyze_long_short_performance(trade_df):
@@ -363,6 +744,8 @@ def run_backtest_1min_granularity(df_1min, df_4h, initial_balance=100000.0,
                                   stop_loss_atr=0.2,
                                   max_trades_per_bar=3,
                                   reentry_size_schedule=None,
+                                  long_reentry_atr=0.1,
+                                  short_reentry_atr=0.0,
                                   stop_mode=None,
                                   profit_protect_atr=1.0):
     """
@@ -374,7 +757,6 @@ def run_backtest_1min_granularity(df_1min, df_4h, initial_balance=100000.0,
     position = None # {'side', 'entry_p', 'sl', 'protected', 'notional'}
     trade_logs = []
     # 策略参数
-    REENTRY_ATR = 0.1
     COMMISSION = 0.0010 # 千分之一手续费
     MAX_TRADES_PER_BAR = max_trades_per_bar
     
@@ -397,6 +779,7 @@ def run_backtest_1min_granularity(df_1min, df_4h, initial_balance=100000.0,
         f"🚀 1min回测 | InitialSize:{CASH_USAGE_INITIAL:.0%} | "
         f"Stop:{stop_mode} | Reentry:{'Confirm' if dir1_reentry_confirm else 'Touch'} | "
         f"MaxTrades:{MAX_TRADES_PER_BAR} | ReentrySizes:{REENTRY_SIZE_SCHEDULE} | "
+        f"ReentryATR(L/S):{long_reentry_atr}/{short_reentry_atr} | "
         f"Slippage:{SLIPPAGE}"
     )
 
@@ -432,7 +815,7 @@ def run_backtest_1min_granularity(df_1min, df_4h, initial_balance=100000.0,
                 
                 # 1. 多头逻辑 (MA20 之上)
                 if long_regime_ready:
-                    re_p = sig['prev_low_1'] + (REENTRY_ATR * sig['atr'])
+                    re_p = sig['prev_low_1'] + (long_reentry_atr * sig['atr'])
                     # 初始进场
                     if trades_in_bar == 0 and sig['prev_high_2'] > sig['prev_high_1']:
                         if bar['high'] >= sig['prev_high_2']:
@@ -485,7 +868,7 @@ def run_backtest_1min_granularity(df_1min, df_4h, initial_balance=100000.0,
 
                 # 2. 空头逻辑 (MA20 之下)
                 elif short_regime_ready:
-                    re_p = sig['prev_high_1']
+                    re_p = sig['prev_high_1'] - (short_reentry_atr * sig['atr'])
                     # 初始进场
                     if trades_in_bar == 0 and sig['prev_low_2'] < sig['prev_low_1']:
                         if bar['low'] <= sig['prev_low_2']:
@@ -873,6 +1256,8 @@ def run_backtest_enhanced(df_1min, df_4h, initial_balance=100000.0,
                           stop_loss_atr=0.2,
                           max_trades_per_bar=3,
                           reentry_size_schedule=None,
+                          long_reentry_atr=0.1,
+                          short_reentry_atr=0.0,
                           stop_mode=None,
                           profit_protect_atr=1.0,
                           # ===== 新增优化参数 =====
@@ -899,7 +1284,6 @@ def run_backtest_enhanced(df_1min, df_4h, initial_balance=100000.0,
     position = None
     trade_logs = []
 
-    REENTRY_ATR = 0.1
     COMMISSION = 0.0010
     MAX_TRADES_PER_BAR = max_trades_per_bar
     SLIPPAGE = np.random.uniform(0.0005, 0.002) if fixed_slippage is None else fixed_slippage
@@ -929,6 +1313,7 @@ def run_backtest_enhanced(df_1min, df_4h, initial_balance=100000.0,
     if tiered_protection: label_parts.append("TieredPT")
     if max_drawdown_pct: label_parts.append(f"CB:{max_drawdown_pct:.0%}")
     if reentry_mode != 'default': label_parts.append(f"Re:{reentry_mode}")
+    label_parts.append(f"ReATR:{long_reentry_atr}/{short_reentry_atr}")
     label = " | ".join(label_parts) if label_parts else "Enhanced"
 
     print(
@@ -971,7 +1356,7 @@ def run_backtest_enhanced(df_1min, df_4h, initial_balance=100000.0,
 
                 # 多头逻辑
                 if long_regime_ready:
-                    re_p = sig['prev_low_1'] + (REENTRY_ATR * sig['atr'])
+                    re_p = sig['prev_low_1'] + (long_reentry_atr * sig['atr'])
                     if trades_in_bar == 0 and sig['prev_high_2'] > sig['prev_high_1']:
                         if bar['high'] >= sig['prev_high_2']:
                             entry_p = max(bar['open'], sig['prev_high_2']) * (1 + SLIPPAGE)
@@ -1021,7 +1406,7 @@ def run_backtest_enhanced(df_1min, df_4h, initial_balance=100000.0,
                             last_exit_side = None
 
                 elif short_regime_ready:
-                    re_p = sig['prev_high_1']
+                    re_p = sig['prev_high_1'] - (short_reentry_atr * sig['atr'])
                     if trades_in_bar == 0 and sig['prev_low_2'] < sig['prev_low_1']:
                         if bar['low'] <= sig['prev_low_2']:
                             entry_p = min(bar['open'], sig['prev_low_2']) * (1 - SLIPPAGE)

--- a/research/backTest.py
+++ b/research/backTest.py
@@ -154,6 +154,9 @@ def run_tick_full_scan_dual(df_4h, tick_file, current_bal,
                             max_drawdown_pct=None,
                             cooldown_bars=6,
                             reentry_mode='default'):
+    df_4h = df_4h.copy()
+    df_4h.index = pd.to_datetime(df_4h.index, utc=True)
+
     replay_start = df_4h.index[0]
     replay_end = df_4h.index[-1]
     print(f"正在构建 Tick 事件流: {tick_file} ({replay_start} ~ {replay_end}) ...")

--- a/research/ethusdt_1min.py
+++ b/research/ethusdt_1min.py
@@ -190,7 +190,7 @@ if index is not None:
 else:
     print("⚠️  No index price data available")
 
-# Step 4: Funding Rates
+# Step 4: Funding Rates (fixed schema handling)
 print("\n")
 print("STEP 4: Fetching Funding Rate Data")
 
@@ -215,7 +215,7 @@ with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
                 for inner in z.namelist():
                     with z.open(inner) as f:
                         fd = pd.read_csv(f)
-                        fd["fundingTime"] = pd.to_datetime(fd["fundingTime"], unit="ms", utc=True)
+                        fd["calc_time"] = pd.to_datetime(fd["calc_time"], unit="ms", utc=True)
                         fund_dfs.append(fd)
             except Exception as e:
                 print(f"Error processing {url}: {e}")
@@ -223,9 +223,13 @@ with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
 funding = pd.concat(fund_dfs, ignore_index=True) if fund_dfs else None
 
 if funding is not None:
-    funding = funding[["fundingTime","fundingRate"]].rename(columns={"fundingTime":"timestamp_utc"})
+    funding = funding[["calc_time", "last_funding_rate"]].rename(
+        columns={"calc_time": "timestamp_utc", "last_funding_rate": "fundingRate"}
+    )
     funding["fundingRate"] = funding["fundingRate"].astype(float)
     print(f"  ✅ Funding rates: {len(funding)} rows")
+else:
+    print("⚠️  No funding rate data available")
 
 # Step 5: Recent Open Interest
 print("\n")
@@ -242,6 +246,9 @@ with tqdm(desc="Open Interest") as pbar:
             data = r.json()
             if not data:
                 break
+            if isinstance(data, dict) and 'code' in data:
+                print(f"API Error: {data}")
+                break
             oi_data.extend(data)
             pbar.update(len(data))
             
@@ -255,10 +262,15 @@ with tqdm(desc="Open Interest") as pbar:
 df_oi = None
 if oi_data:
     df_oi = pd.DataFrame(oi_data)
-    df_oi["timestamp_utc"] = pd.to_datetime(df_oi["timestamp"], unit="ms", utc=True)
-    df_oi["open_interest"] = df_oi["sumOpenInterest"].astype(float)
-    df_oi = df_oi[["timestamp_utc", "open_interest"]]
-    print(f"  ✅ Open Interest: {len(df_oi)} rows")
+    if "timestamp" in df_oi.columns:
+        df_oi["timestamp_utc"] = pd.to_datetime(df_oi["timestamp"], unit="ms", utc=True)
+        df_oi["open_interest"] = df_oi["sumOpenInterest"].astype(float)
+        df_oi = df_oi[["timestamp_utc", "open_interest"]]
+        print(f"  ✅ Open Interest: {len(df_oi)} rows")
+    else:
+        print(f"  ⚠️  OI data missing 'timestamp' column. Available columns: {list(df_oi.columns)}")
+else:
+    print("  ⚠️  No Open Interest data fetched")
 
 # Step 6: Merge All Data
 print("\n")
@@ -306,7 +318,15 @@ if invalid_ohlc.any():
     print(f"  ⚠️  {invalid_ohlc.sum()} rows with invalid OHLC relationships")
 
 # Save
-full.to_parquet(OUTPUT_FILE, index=False, compression='snappy')
+try:
+    full.to_parquet(OUTPUT_FILE, index=False, compression='snappy')
+except Exception as e:
+    print(f"  ⚠️  pandas.to_parquet unavailable ({e}), falling back to pyarrow")
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+
+    table = pa.Table.from_pandas(full, preserve_index=False)
+    pq.write_table(table, OUTPUT_FILE, compression="snappy")
 
 # Final report
 print(f"\n")

--- a/research/parquet_to_csv_ETHUSDT.py
+++ b/research/parquet_to_csv_ETHUSDT.py
@@ -3,7 +3,14 @@ import os
 
 # Load the parquet file
 print("Loading parquet file...")
-df = pd.read_parquet("eth_perp_1m_dataset/ETHUSDT_perp_1m_master.parquet")
+parquet_file = "eth_perp_1m_dataset/ETHUSDT_perp_1m_master.parquet"
+try:
+    df = pd.read_parquet(parquet_file)
+except Exception as e:
+    print(f"pandas.read_parquet unavailable ({e}), falling back to pyarrow")
+    import pyarrow.parquet as pq
+
+    df = pq.read_table(parquet_file).to_pandas()
 
 print(f"Loaded {len(df):,} rows")
 


### PR DESCRIPTION
## Summary

This PR wraps up the ETH research branch and focuses on two things:

1. make `research/backTest.py` support a safer monthly tick replay path that stays aligned with the current enhanced 1-minute backtest logic
2. add the ETH-specific dataset pipeline fixes needed to build and study ETHUSDT data reliably

It also adds a research note documenting the exact test setup, replay logic, and conclusions.

## What changed

- updated `research/backTest.py`
  - replaced the older raw tick scan assumptions with a chunked tick-to-minute event stream replay
  - preserves intraminute `high/low` ordering when replaying monthly tick archives
  - supports both archive formats we encountered:
    - BTC monthly tick files without headers
    - ETH monthly tick files with `id,price,qty,quote_qty,time,...` headers
  - parameterized long/short reentry ATR offsets in the replay paths
- updated `research/ethusdt_1min.py`
  - funding schema compatibility
  - defensive open-interest handling
  - parquet fallback via `pyarrow`
- updated `research/parquet_to_csv_ETHUSDT.py`
  - parquet fallback via `pyarrow`
- added research write-up:
  - `docs/20260413-eth-tick-replay-research.md`

## Test coverage / experiments run

### BTC 2023 control run
Used the new tick replay path as a control to confirm it stays close to the current enhanced 1-minute engine.

Result:
- enhanced_1m: `+69.41%`
- tick_replay: `+67.77%`

Interpretation:
- the new tick replay path is aligned with the current strategy logic
- 1-minute OHLC remains mildly optimistic, but not catastrophically different

### ETH 2023 full-year tick vs 1m comparison
Used the same enhanced configuration for both replay modes:
- `dir2_zero_initial=True`
- `fixed_slippage=0.0005`
- `stop_loss_atr=0.05`
- `stop_mode='atr'`
- `max_trades_per_bar=4`
- `reentry_size_schedule=[0.10, 0.05, 0.025]`
- `trailing_stop_atr=0.3`
- `delayed_trailing_activation=0.5`
- `long_reentry_atr=0.1`
- `short_reentry_atr=0.0`

Result:
- enhanced_1m: `+79.54%`, `273` trades, maxDD `-0.0888%`
- tick_replay: `+65.97%`, `245` trades, maxDD `-0.0830%`

Interpretation:
- the ETH edge still exists under more realistic tick replay
- 1-minute OHLC is still optimistic and overstates annual performance by about `13.58` percentage points in this configuration
- the difference mainly comes from more realistic intraminute path ordering for breakout, whipsaw, and reentry behavior

### Validation performed
- `python3 -m py_compile research/backTest.py research/ethusdt_1min.py research/parquet_to_csv_ETHUSDT.py`
- ETH monthly tick replay smoke on `2023-01`
- ETH full-year `2023 tick vs 1min` run
- BTC 2023 full-year control comparison

## Notes

- The research outputs referenced in the doc are local result artifacts and are not committed in this PR.
- Per repo instructions I also attempted the graph refresh command, but the local environment is currently missing the `graphify` Python module (`ModuleNotFoundError`).