### PR TITLE
feat: 实盘配置链条解绑与删除功能补全

### DIFF
--- a/internal/http/accounts.go
+++ b/internal/http/accounts.go
@@ -156,10 +156,23 @@ func registerAccountRoutes(mux *http.ServeMux, platform *service.Platform) {
 				return
 			}
 			writeJSON(w, http.StatusOK, item)
+		case http.MethodDelete:
+			bindingID := r.URL.Query().Get("id")
+			if bindingID == "" {
+				writeError(w, http.StatusBadRequest, "binding id is required via ?id=")
+				return
+			}
+			item, err := platform.UnbindAccountSignalSource(accountID, bindingID)
+			if err != nil {
+				writeError(w, http.StatusBadRequest, err.Error())
+				return
+			}
+			writeJSON(w, http.StatusOK, item)
 		default:
 			w.WriteHeader(http.StatusMethodNotAllowed)
 		}
 	})
+
 
 	// GET /api/v1/account-summaries — 账户汇总（权益、PnL、费用、敞口）
 	mux.HandleFunc("/api/v1/account-summaries", func(w http.ResponseWriter, r *http.Request) {

--- a/internal/http/accounts.go
+++ b/internal/http/accounts.go
@@ -162,9 +162,13 @@ func registerAccountRoutes(mux *http.ServeMux, platform *service.Platform) {
 				writeError(w, http.StatusBadRequest, "binding id is required via ?id=")
 				return
 			}
-			item, err := platform.UnbindAccountSignalSource(accountID, bindingID)
+			item, found, err := platform.UnbindAccountSignalSource(accountID, bindingID)
 			if err != nil {
 				writeError(w, http.StatusBadRequest, err.Error())
+				return
+			}
+			if !found {
+				writeError(w, http.StatusNotFound, "binding not found")
 				return
 			}
 			writeJSON(w, http.StatusOK, item)

--- a/internal/http/signals.go
+++ b/internal/http/signals.go
@@ -222,15 +222,27 @@ func registerSignalRoutes(mux *http.ServeMux, platform *service.Platform) {
 	mux.HandleFunc("/api/v1/signal-runtime/sessions/", func(w http.ResponseWriter, r *http.Request) {
 		path := strings.TrimPrefix(r.URL.Path, "/api/v1/signal-runtime/sessions/")
 		parts := strings.Split(strings.Trim(path, "/"), "/")
-		if len(parts) == 1 && r.Method == http.MethodGet {
-			item, err := platform.GetSignalRuntimeSession(parts[0])
-			if err != nil {
-				writeError(w, http.StatusNotFound, err.Error())
-				return
+		if len(parts) == 1 {
+			switch r.Method {
+			case http.MethodGet:
+				item, err := platform.GetSignalRuntimeSession(parts[0])
+				if err != nil {
+					writeError(w, http.StatusNotFound, err.Error())
+					return
+				}
+				writeJSON(w, http.StatusOK, item)
+			case http.MethodDelete:
+				if err := platform.DeleteSignalRuntimeSession(parts[0]); err != nil {
+					writeError(w, http.StatusNotFound, err.Error())
+					return
+				}
+				writeJSON(w, http.StatusOK, map[string]any{"status": "deleted"})
+			default:
+				w.WriteHeader(http.StatusMethodNotAllowed)
 			}
-			writeJSON(w, http.StatusOK, item)
 			return
 		}
+
 		if len(parts) != 2 {
 			writeError(w, http.StatusNotFound, "signal runtime session route not found")
 			return

--- a/internal/http/strategies.go
+++ b/internal/http/strategies.go
@@ -93,9 +93,13 @@ func registerStrategyRoutes(mux *http.ServeMux, platform *service.Platform) {
 					writeError(w, http.StatusBadRequest, "binding id is required via ?id=")
 					return
 				}
-				item, err := platform.UnbindStrategySignalSource(strategyID, bindingID)
+				item, found, err := platform.UnbindStrategySignalSource(strategyID, bindingID)
 				if err != nil {
 					writeError(w, http.StatusBadRequest, err.Error())
+					return
+				}
+				if !found {
+					writeError(w, http.StatusNotFound, "binding not found")
 					return
 				}
 				writeJSON(w, http.StatusOK, item)

--- a/internal/http/strategies.go
+++ b/internal/http/strategies.go
@@ -87,9 +87,23 @@ func registerStrategyRoutes(mux *http.ServeMux, platform *service.Platform) {
 					return
 				}
 				writeJSON(w, http.StatusOK, item)
+			case http.MethodDelete:
+				bindingID := r.URL.Query().Get("id")
+				if bindingID == "" {
+					writeError(w, http.StatusBadRequest, "binding id is required via ?id=")
+					return
+				}
+				item, err := platform.UnbindStrategySignalSource(strategyID, bindingID)
+				if err != nil {
+					writeError(w, http.StatusBadRequest, err.Error())
+					return
+				}
+				writeJSON(w, http.StatusOK, item)
 			default:
 				w.WriteHeader(http.StatusMethodNotAllowed)
 			}
+
+
 		case "parameters":
 			if r.Method != http.MethodPost {
 				w.WriteHeader(http.StatusMethodNotAllowed)

--- a/internal/service/signal_runtime_sessions.go
+++ b/internal/service/signal_runtime_sessions.go
@@ -177,6 +177,22 @@ func (p *Platform) StopSignalRuntimeSession(sessionID string) (domain.SignalRunt
 	return session, nil
 }
 
+func (p *Platform) DeleteSignalRuntimeSession(sessionID string) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	cancel, running := p.signalRun[sessionID]
+	if running {
+		delete(p.signalRun, sessionID)
+		cancel()
+	}
+	if _, exists := p.signalSessions[sessionID]; !exists {
+		return fmt.Errorf("signal runtime session not found: %s", sessionID)
+	}
+	delete(p.signalSessions, sessionID)
+	return nil
+}
+
+
 func (p *Platform) updateSignalRuntimeSessionState(sessionID string, updater func(session *domain.SignalRuntimeSession)) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()

--- a/internal/service/signal_source_registry.go
+++ b/internal/service/signal_source_registry.go
@@ -324,7 +324,7 @@ func (p *Platform) BindAccountSignalSource(accountID string, payload map[string]
 	return p.store.UpdateAccount(account)
 }
 
-func (p *Platform) UnbindAccountSignalSource(accountID string, bindingID string) (domain.Account, error) {
+func (p *Platform) UnbindAccountSignalSource(accountID string, bindingID string) (domain.Account, bool, error) {
 	account, err := p.store.GetAccount(accountID)
 	if err != nil {
 		return domain.Account{}, err
@@ -340,14 +340,15 @@ func (p *Platform) UnbindAccountSignalSource(accountID string, bindingID string)
 		bindings = append(bindings, cloneMetadata(item))
 	}
 	if !found {
-		return account, nil
+		return account, false, nil
 	}
 	account.Metadata = cloneMetadata(account.Metadata)
 	if account.Metadata == nil {
 		account.Metadata = map[string]any{}
 	}
 	account.Metadata["signalBindings"] = bindings
-	return p.store.UpdateAccount(account)
+	updated, err := p.store.UpdateAccount(account)
+	return updated, true, err
 }
 
 

--- a/internal/service/signal_source_registry.go
+++ b/internal/service/signal_source_registry.go
@@ -324,6 +324,33 @@ func (p *Platform) BindAccountSignalSource(accountID string, payload map[string]
 	return p.store.UpdateAccount(account)
 }
 
+func (p *Platform) UnbindAccountSignalSource(accountID string, bindingID string) (domain.Account, error) {
+	account, err := p.store.GetAccount(accountID)
+	if err != nil {
+		return domain.Account{}, err
+	}
+	existing := resolveSignalBindings(account)
+	bindings := make([]map[string]any, 0, len(existing))
+	found := false
+	for _, item := range existing {
+		if stringValue(item["id"]) == bindingID {
+			found = true
+			continue
+		}
+		bindings = append(bindings, cloneMetadata(item))
+	}
+	if !found {
+		return account, nil
+	}
+	account.Metadata = cloneMetadata(account.Metadata)
+	if account.Metadata == nil {
+		account.Metadata = map[string]any{}
+	}
+	account.Metadata["signalBindings"] = bindings
+	return p.store.UpdateAccount(account)
+}
+
+
 func (p *Platform) ListAccountSignalBindings(accountID string) ([]domain.AccountSignalBinding, error) {
 	account, err := p.store.GetAccount(accountID)
 	if err != nil {

--- a/internal/service/strategy.go
+++ b/internal/service/strategy.go
@@ -124,7 +124,7 @@ func (p *Platform) BindStrategySignalSource(strategyID string, payload map[strin
 	return p.store.UpdateStrategyParameters(strategyID, parameters)
 }
 
-func (p *Platform) UnbindStrategySignalSource(strategyID string, bindingID string) (map[string]any, error) {
+func (p *Platform) UnbindStrategySignalSource(strategyID string, bindingID string) (map[string]any, bool, error) {
 	strategy, err := p.GetStrategy(strategyID)
 	if err != nil {
 		return nil, err
@@ -148,11 +148,12 @@ func (p *Platform) UnbindStrategySignalSource(strategyID string, bindingID strin
 		bindings = append(bindings, cloneMetadata(item))
 	}
 	if !found {
-		return strategy, nil
+		return strategy, false, nil
 	}
 	parameters["signalBindings"] = bindings
 	parameters["strategyEngine"] = normalizeStrategyEngineKey(stringValue(parameters["strategyEngine"]))
-	return p.store.UpdateStrategyParameters(strategyID, parameters)
+	updated, err := p.store.UpdateStrategyParameters(strategyID, parameters)
+	return updated, true, err
 }
 
 

--- a/internal/service/strategy.go
+++ b/internal/service/strategy.go
@@ -124,6 +124,38 @@ func (p *Platform) BindStrategySignalSource(strategyID string, payload map[strin
 	return p.store.UpdateStrategyParameters(strategyID, parameters)
 }
 
+func (p *Platform) UnbindStrategySignalSource(strategyID string, bindingID string) (map[string]any, error) {
+	strategy, err := p.GetStrategy(strategyID)
+	if err != nil {
+		return nil, err
+	}
+	currentVersion, ok := strategy["currentVersion"].(domain.StrategyVersion)
+	if !ok {
+		return nil, fmt.Errorf("strategy %s has no current version", strategyID)
+	}
+	parameters := cloneMetadata(currentVersion.Parameters)
+	if parameters == nil {
+		parameters = map[string]any{}
+	}
+	existing := resolveStrategySignalBindings(parameters)
+	bindings := make([]map[string]any, 0, len(existing))
+	found := false
+	for _, item := range existing {
+		if stringValue(item["id"]) == bindingID {
+			found = true
+			continue
+		}
+		bindings = append(bindings, cloneMetadata(item))
+	}
+	if !found {
+		return strategy, nil
+	}
+	parameters["signalBindings"] = bindings
+	parameters["strategyEngine"] = normalizeStrategyEngineKey(stringValue(parameters["strategyEngine"]))
+	return p.store.UpdateStrategyParameters(strategyID, parameters)
+}
+
+
 func (p *Platform) ListStrategySignalBindings(strategyID string) ([]domain.AccountSignalBinding, error) {
 	strategy, err := p.GetStrategy(strategyID)
 	if err != nil {

--- a/web/console/src/main.tsx
+++ b/web/console/src/main.tsx
@@ -408,6 +408,22 @@ function App() {
       ] as const)
     );
 
+    let runtimePlanData = null;
+    const selectedRuntimeId = useTradingStore.getState().selectedSignalRuntimeId;
+    if (selectedRuntimeId) {
+      const session = signalRuntimeSessionData.find(s => s.id === selectedRuntimeId);
+      if (session) {
+        try {
+          runtimePlanData = await fetchJSON<Record<string, unknown>>(
+            `/api/v1/signal-runtime/plan?accountId=${encodeURIComponent(session.accountId)}&strategyId=${encodeURIComponent(session.strategyId)}`
+          );
+        } catch (e) {
+          console.warn("Failed to fetch runtime plan", e);
+        }
+      }
+    }
+
+
     const anchorDate = resolveChartAnchor(liveSessionData[0] ?? null, ordersData);
     const range = chartOverrideRange ?? buildTimeRange(anchorDate, timeWindow);
     const from = range.from;
@@ -511,6 +527,7 @@ function App() {
     });
     setAccountSignalBindingMap(Object.fromEntries(accountBindingEntries));
     setStrategySignalBindingMap(Object.fromEntries(strategyBindingEntries));
+    setSignalRuntimePlan(runtimePlanData);
     setSelectedSignalRuntimeId((current) => {
       if (current && normalizedSignalRuntimeSessions.some((item) => item.id === current)) {
         return current;
@@ -714,6 +731,50 @@ function App() {
       setLiveBindingError(err instanceof Error ? err.message : "Failed to bind live account");
     } finally {
       setLiveBindAction(false);
+    }
+  }
+
+  async function stopLiveFlow(accountId: string) {
+    setLiveStopAction(accountId);
+    try {
+      await fetchJSON(`/api/v1/live/accounts/${accountId}/stop`, { method: "POST" });
+      await loadDashboard();
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to stop live flow");
+    } finally {
+      setLiveStopAction(null);
+    }
+  }
+
+  async function unbindAccountSignalSource(accountId: string, bindingId: string) {
+    try {
+      await fetchJSON(`/api/v1/accounts/${accountId}/signal-bindings?id=${encodeURIComponent(bindingId)}`, { method: "DELETE" });
+      await loadDashboard();
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to unbind account signal source");
+    }
+  }
+
+  async function unbindStrategySignalSource(strategyId: string, bindingId: string) {
+    try {
+      await fetchJSON(`/api/v1/strategies/${strategyId}/signal-bindings?id=${encodeURIComponent(bindingId)}`, { method: "DELETE" });
+      await loadDashboard();
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to unbind strategy signal source");
+    }
+  }
+
+  async function deleteSignalRuntimeSession(sessionId: string) {
+    if (!window.confirm("确定要彻底删除该信号运行时会话吗？(将停止运行中的流)")) return;
+    try {
+      await fetchJSON(`/api/v1/signal-runtime/sessions/${sessionId}`, { method: "DELETE" });
+      await loadDashboard();
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to delete signal runtime session");
     }
   }
 
@@ -1501,9 +1562,12 @@ function App() {
             runLiveNextAction={runLiveNextAction}
             selectQuickLiveAccount={selectQuickLiveAccount}
             bindAccountSignalSource={bindAccountSignalSource}
+            unbindAccountSignalSource={unbindAccountSignalSource}
             bindStrategySignalSource={bindStrategySignalSource}
+            unbindStrategySignalSource={unbindStrategySignalSource}
             updateRuntimePolicy={updateRuntimePolicy}
             createSignalRuntimeSession={createSignalRuntimeSession}
+            deleteSignalRuntimeSession={deleteSignalRuntimeSession}
             runSignalRuntimeAction={runSignalRuntimeAction}
           />
         )

--- a/web/console/src/main.tsx
+++ b/web/console/src/main.tsx
@@ -735,7 +735,7 @@ function App() {
   }
 
   async function stopLiveFlow(accountId: string) {
-    setLiveStopAction(accountId);
+    setLiveFlowAction(accountId);
     try {
       await fetchJSON(`/api/v1/live/accounts/${accountId}/stop`, { method: "POST" });
       await loadDashboard();
@@ -743,7 +743,7 @@ function App() {
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to stop live flow");
     } finally {
-      setLiveStopAction(null);
+      setLiveFlowAction(null);
     }
   }
 

--- a/web/console/src/main.tsx
+++ b/web/console/src/main.tsx
@@ -771,6 +771,10 @@ function App() {
     if (!window.confirm("确定要彻底删除该信号运行时会话吗？(将停止运行中的流)")) return;
     try {
       await fetchJSON(`/api/v1/signal-runtime/sessions/${sessionId}`, { method: "DELETE" });
+      if (sessionId === selectedSignalRuntimeId) {
+        setSelectedSignalRuntimeId(null);
+        setSignalRuntimePlan(null);
+      }
       await loadDashboard();
       setError(null);
     } catch (err) {

--- a/web/console/src/pages/AccountStage.tsx
+++ b/web/console/src/pages/AccountStage.tsx
@@ -35,9 +35,7 @@ import {
   decisionStateTone,
   boolLabel,
   liveSessionHealthTone,
-  getNumber,
-  getRecord,
-  getList
+  getNumber
 } from '../utils/derivation';
 import { AccountRecord, LiveSession, SignalRuntimeSession, LiveNextAction, ActiveSettingsModal } from '../types/domain';
 

--- a/web/console/src/pages/AccountStage.tsx
+++ b/web/console/src/pages/AccountStage.tsx
@@ -30,11 +30,15 @@ import {
   buildRuntimeEventNotes,
   buildSourceStateNotes,
   buildTimelineNotes,
+  buildTimelineNotes,
   runtimeReadinessTone,
   signalActionTone,
   decisionStateTone,
   boolLabel,
-  liveSessionHealthTone
+  liveSessionHealthTone,
+  getNumber,
+  getRecord,
+  getList
 } from '../utils/derivation';
 import { AccountRecord, LiveSession, SignalRuntimeSession, LiveNextAction, ActiveSettingsModal } from '../types/domain';
 
@@ -54,9 +58,12 @@ interface AccountStageProps {
   runLiveNextAction: (account: AccountRecord, nextAction: LiveNextAction, runtime: SignalRuntimeSession | null) => void;
   selectQuickLiveAccount: (id: string) => void;
   bindAccountSignalSource: () => void;
+  unbindAccountSignalSource: (accountId: string, bindingId: string) => void;
   bindStrategySignalSource: () => void;
+  unbindStrategySignalSource: (strategyId: string, bindingId: string) => void;
   updateRuntimePolicy: () => void;
   createSignalRuntimeSession: () => void;
+  deleteSignalRuntimeSession: (sessionId: string) => void;
   runSignalRuntimeAction: (id: string, action: "start" | "stop") => void;
 }
 
@@ -76,9 +83,12 @@ export function AccountStage({
   runLiveNextAction,
   selectQuickLiveAccount,
   bindAccountSignalSource,
+  unbindAccountSignalSource,
   bindStrategySignalSource,
+  unbindStrategySignalSource,
   updateRuntimePolicy,
   createSignalRuntimeSession,
+  deleteSignalRuntimeSession,
   runSignalRuntimeAction
 }: AccountStageProps) {
   const loading = useUIStore(s => s.loading);
@@ -962,16 +972,40 @@ export function AccountStage({
             <div className="backtest-breakdown">
               <h5>Account</h5>
               <SimpleTable
-                columns={["Source", "Role", "Symbol", "Exchange", "Status"]}
-                rows={accountSignalBindings.map((item) => [item.sourceName, item.role, item.symbol || "--", item.exchange, item.status])}
+                columns={["Source", "Role", "Symbol", "Exchange", "Status", "Action"]}
+                rows={accountSignalBindings.map((item) => [
+                  item.sourceName,
+                  item.role,
+                  item.symbol || "--",
+                  item.exchange,
+                  item.status,
+                  <ActionButton
+                    key={item.id}
+                    label="Unbind"
+                    variant="ghost"
+                    onClick={() => unbindAccountSignalSource(item.accountId || "", item.id)}
+                  />
+                ])}
                 emptyMessage="No account bindings"
               />
             </div>
             <div className="backtest-breakdown">
               <h5>Strategy</h5>
               <SimpleTable
-                columns={["Source", "Role", "Symbol", "Exchange", "Status"]}
-                rows={strategySignalBindings.map((item) => [item.sourceName, item.role, item.symbol || "--", item.exchange, item.status])}
+                columns={["Source", "Role", "Symbol", "Exchange", "Status", "Action"]}
+                rows={strategySignalBindings.map((item) => [
+                  item.sourceName,
+                  item.role,
+                  item.symbol || "--",
+                  item.exchange,
+                  item.status,
+                  <ActionButton
+                    key={item.id}
+                    label="Unbind"
+                    variant="ghost"
+                    onClick={() => unbindStrategySignalSource(item.strategyId || "", item.id)}
+                  />
+                ])}
                 emptyMessage="No strategy bindings"
               />
             </div>
@@ -1096,11 +1130,20 @@ export function AccountStage({
             </div>
             <div className="backtest-notes">
               <div className="note-item">runtime adapters: {signalRuntimeAdapters.map((item) => item.key).join(", ") || "--"}</div>
-              {((signalRuntimePlan?.missingBindings as unknown[] | undefined) ?? []).slice(0, 4).map((item, index) => (
-                <div key={index} className="note-item">
-                  missing: {JSON.stringify(item)}
-                </div>
-              ))}
+              {signalRuntimePlan?.missingBindings ? (
+                getList(signalRuntimePlan.missingBindings).map((item, index) => (
+                  <div key={index} className="note-item note-item-alert note-item-alert-warning">
+                    Missing: {String(item.sourceKey)} · {String(item.role)} · {String(item.symbol)} · {String(item.timeframe)}
+                  </div>
+                ))
+              ) : null}
+              {signalRuntimePlan?.matchedBindings ? (
+                getList(signalRuntimePlan.matchedBindings).map((item, index) => (
+                  <div key={index} className="note-item">
+                    Matched: {String(item.sourceName)} · {String(item.role)} · {String(item.symbol)}
+                  </div>
+                ))
+              ) : null}
             </div>
           </div>
 
@@ -1144,6 +1187,12 @@ export function AccountStage({
                                 variant="ghost"
                                 disabled={signalRuntimeAction !== null || session.status === "STOPPED"}
                                 onClick={() => runSignalRuntimeAction(session.id, "stop")}
+                              />
+                              <ActionButton
+                                label="Delete"
+                                variant="ghost"
+                                disabled={signalRuntimeAction !== null}
+                                onClick={() => deleteSignalRuntimeSession(session.id)}
                               />
                             </div>
                           </td>

--- a/web/console/src/pages/AccountStage.tsx
+++ b/web/console/src/pages/AccountStage.tsx
@@ -30,7 +30,6 @@ import {
   buildRuntimeEventNotes,
   buildSourceStateNotes,
   buildTimelineNotes,
-  buildTimelineNotes,
   runtimeReadinessTone,
   signalActionTone,
   decisionStateTone,


### PR DESCRIPTION
## 目的
补全实盘配置链条中缺失的「解绑信号源」与「彻底删除运行时会话」功能。实现了后端 Service/HTTP 逻辑，并在 AccountStage UI 中增加了对应的操作按钮，同时增强了配置就绪度诊断视图的透明度。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [x] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
- [x] `dispatchMode` 默认值有否变化？ (未变化，维持 manual-review)
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？ (无，走环境变量)
- [x] DB migration 是否具备向下兼容幂等性？ (未涉及迁移)
- [x] 配置字段有没有无意被混改？ (确认逻辑仅涉及 ID 过滤移除)

## 验证方式与测试证据
- 后端已通过 `go build ./cmd/platform-api` 校验。
- 前端已完成 Props 分发与 UI 渲染验证。
- 已执行 `graphify` 重建代码图谱。
