### PR TITLE
Add structured logging across platform services

### DIFF
--- a/cmd/db-migrate/main.go
+++ b/cmd/db-migrate/main.go
@@ -1,9 +1,12 @@
 package main
 
 import (
-	"log"
+	"fmt"
+	"log/slog"
+	"os"
 
 	"github.com/wuyaocheng/bktrader/internal/config"
+	"github.com/wuyaocheng/bktrader/internal/logging"
 	"github.com/wuyaocheng/bktrader/internal/store/postgres"
 )
 
@@ -11,10 +14,21 @@ func main() {
 	_ = config.LoadEnvFile()
 
 	cfg := config.Load()
-
-	if err := postgres.Migrate(cfg.PostgresDSN); err != nil {
-		log.Fatal(err)
+	if err := cfg.Validate(); err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "配置验证失败: %v\n", err)
+		os.Exit(1)
+	}
+	if err := logging.Configure(cfg); err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "日志配置失败: %v\n", err)
+		os.Exit(1)
 	}
 
-	log.Printf("database migrations applied successfully")
+	slog.Info("running database migrations", "store_backend", cfg.StoreBackend)
+
+	if err := postgres.Migrate(cfg.PostgresDSN); err != nil {
+		slog.Error("database migrations failed", "error", err)
+		os.Exit(1)
+	}
+
+	slog.Info("database migrations applied successfully")
 }

--- a/cmd/platform-api/main.go
+++ b/cmd/platform-api/main.go
@@ -2,7 +2,8 @@ package main
 
 import (
 	"context"
-	"log"
+	"fmt"
+	"log/slog"
 	"net/http"
 	"os"
 	"os/signal"
@@ -11,43 +12,55 @@ import (
 
 	"github.com/wuyaocheng/bktrader/internal/app"
 	"github.com/wuyaocheng/bktrader/internal/config"
+	"github.com/wuyaocheng/bktrader/internal/logging"
 )
 
 func main() {
 	_ = config.LoadEnvFile()
 
-	// 加载并验证配置
 	cfg := config.Load()
 	if err := cfg.Validate(); err != nil {
-		log.Fatalf("配置验证失败: %v", err)
+		_, _ = fmt.Fprintf(os.Stderr, "配置验证失败: %v\n", err)
+		os.Exit(1)
+	}
+	if err := logging.Configure(cfg); err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "日志配置失败: %v\n", err)
+		os.Exit(1)
 	}
 
-	// 创建 HTTP 服务实例
+	slog.Info("platform-api starting",
+		"http_addr", cfg.HTTPAddr,
+		"store_backend", cfg.StoreBackend,
+		"auto_migrate", cfg.AutoMigrate,
+		"log_level", cfg.LogLevel,
+		"log_format", cfg.LogFormat,
+	)
+
 	server, err := app.NewServer(cfg)
 	if err != nil {
-		log.Fatal(err)
+		slog.Error("platform-api bootstrap failed", "error", err)
+		os.Exit(1)
 	}
 
-	// 启动 HTTP 服务（非阻塞）
 	go func() {
-		log.Printf("platform-api 正在监听 %s", cfg.HTTPAddr)
+		slog.Info("platform-api listening", "http_addr", cfg.HTTPAddr)
 		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			log.Fatalf("HTTP 服务异常退出: %v", err)
+			slog.Error("http server exited unexpectedly", "error", err)
+			os.Exit(1)
 		}
 	}()
 
-	// 优雅关闭：监听系统信号（SIGINT / SIGTERM）
 	quit := make(chan os.Signal, 1)
 	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
 	sig := <-quit
-	log.Printf("收到信号 %v，正在优雅关闭...", sig)
+	slog.Info("shutdown signal received", "signal", sig.String())
 
-	// 给予 10 秒超时让正在处理的请求完成
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
 	if err := server.Shutdown(ctx); err != nil {
-		log.Fatalf("优雅关闭失败: %v", err)
+		slog.Error("graceful shutdown failed", "error", err)
+		os.Exit(1)
 	}
-	log.Println("服务已关闭")
+	slog.Info("platform-api stopped")
 }

--- a/internal/app/server.go
+++ b/internal/app/server.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"strings"
 	"time"
@@ -18,13 +19,20 @@ import (
 
 // NewServer 根据配置创建 HTTP 服务实例，初始化存储层和平台服务。
 func NewServer(cfg config.Config) (*http.Server, error) {
+	logger := slog.Default().With("component", "app.server")
+	logger.Info("initializing server",
+		"store_backend", cfg.StoreBackend,
+		"auto_migrate", cfg.AutoMigrate,
+		"paper_tick_interval_seconds", cfg.PaperTickInterval,
+	)
+
 	repository, err := buildRepository(cfg)
 	if err != nil {
+		logger.Error("build repository failed", "error", err)
 		return nil, err
 	}
 
 	platform := service.NewPlatform(repository)
-	// 设置模拟盘 Ticker 间隔（来自配置）
 	platform.SetTickInterval(cfg.PaperTickInterval)
 	platform.SetBacktestDataDirs(cfg.MinuteDataDir, cfg.TickDataDir)
 	platform.SetRuntimePolicy(service.RuntimePolicy{
@@ -41,17 +49,24 @@ func NewServer(cfg config.Config) (*http.Server, error) {
 		SendLevels: strings.Split(cfg.TelegramSendLevels, ","),
 	})
 	if err := platform.LoadPersistedRuntimePolicy(); err != nil {
+		logger.Error("load persisted runtime policy failed", "error", err)
 		return nil, err
 	}
 	if err := platform.LoadPersistedTelegramConfig(); err != nil {
+		logger.Error("load persisted telegram config failed", "error", err)
 		return nil, err
 	}
 	warmCtx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
-	_ = platform.WarmLiveMarketData(warmCtx)
+	if err := platform.WarmLiveMarketData(warmCtx); err != nil {
+		logger.Warn("warm live market data completed with errors", "error", err)
+	} else {
+		logger.Info("live market data warmed successfully")
+	}
 	cancel()
 	platform.StartTelegramDispatcher(context.Background())
 	go platform.RecoverLiveTradingOnStartup(context.Background())
 	go platform.StartLiveSyncDispatcher(context.Background())
+	logger.Info("background workers started")
 
 	return &http.Server{
 		Addr:    cfg.HTTPAddr,
@@ -61,15 +76,21 @@ func NewServer(cfg config.Config) (*http.Server, error) {
 
 // buildRepository 根据配置选择并初始化存储后端。
 func buildRepository(cfg config.Config) (store.Repository, error) {
+	logger := slog.Default().With("component", "app.repository", "store_backend", cfg.StoreBackend)
+
 	switch cfg.StoreBackend {
 	case "postgres":
+		logger.Info("using postgres repository", "auto_migrate", cfg.AutoMigrate)
 		if cfg.AutoMigrate {
+			logger.Info("running startup migrations")
 			if err := postgres.Migrate(cfg.PostgresDSN); err != nil {
+				logger.Error("startup migrations failed", "error", err)
 				return nil, err
 			}
 		}
 		return postgres.New(cfg.PostgresDSN)
 	case "memory", "":
+		logger.Warn("using in-memory repository")
 		return memory.NewStore(), nil
 	default:
 		return nil, fmt.Errorf("不支持的存储后端: %s", cfg.StoreBackend)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,12 +4,16 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 )
 
 // Config 存储平台运行所需的全部配置项。
 type Config struct {
 	AppName                        string // 应用名称
 	Environment                    string // 运行环境（development / production）
+	LogLevel                       string // 日志级别（debug / info / warn / error）
+	LogFormat                      string // 日志格式（text / json）
+	LogAddSource                   bool   // 是否在日志中附带源码位置信息
 	HTTPAddr                       string // HTTP 监听地址
 	StoreBackend                   string // 存储后端类型（memory / postgres）
 	AutoMigrate                    bool   // 是否在启动时自动执行数据库迁移
@@ -59,16 +63,19 @@ func Load() Config {
 	return Config{
 		AppName:                        getenv("APP_NAME", "bkTrader-platform"),
 		Environment:                    getenv("APP_ENV", "development"),
+		LogLevel:                       getenv("LOG_LEVEL", "info"),
+		LogFormat:                      getenv("LOG_FORMAT", "text"),
+		LogAddSource:                   boolFromEnv("LOG_ADD_SOURCE", false),
 		HTTPAddr:                       getenv("HTTP_ADDR", ":8080"),
 		StoreBackend:                   getenv("STORE_BACKEND", "memory"),
-		AutoMigrate:                    getenv("AUTO_MIGRATE", "false") == "true",
+		AutoMigrate:                    boolFromEnv("AUTO_MIGRATE", false),
 		PostgresDSN:                    getenv("POSTGRES_DSN", "postgres://postgres:postgres@localhost:5432/bktrader?sslmode=disable"),
 		RedisAddr:                      getenv("REDIS_ADDR", "localhost:6379"),
 		NATSURL:                        getenv("NATS_URL", "nats://localhost:4222"),
 		PaperTickInterval:              tickInterval,
 		MinuteDataDir:                  getenv("MINUTE_DATA_DIR", "."),
 		TickDataDir:                    getenv("TICK_DATA_DIR", "./dataset/archive"),
-		AuthEnabled:                    getenv("AUTH_ENABLED", "false") == "true",
+		AuthEnabled:                    boolFromEnv("AUTH_ENABLED", false),
 		AuthUsername:                   getenv("AUTH_USERNAME", "admin"),
 		AuthPassword:                   os.Getenv("AUTH_PASSWORD"),
 		AuthSecret:                     os.Getenv("AUTH_SECRET"),
@@ -78,7 +85,7 @@ func Load() Config {
 		SignalBarFreshnessSeconds:      signalBarFreshness,
 		RuntimeQuietSeconds:            runtimeQuiet,
 		PaperStartReadinessTimeoutSecs: paperReadinessTimeout,
-		TelegramEnabled:                getenv("TELEGRAM_ENABLED", "false") == "true",
+		TelegramEnabled:                boolFromEnv("TELEGRAM_ENABLED", false),
 		TelegramBotToken:               getenv("TELEGRAM_BOT_TOKEN", ""),
 		TelegramChatID:                 getenv("TELEGRAM_CHAT_ID", ""),
 		TelegramSendLevels:             getenv("TELEGRAM_SEND_LEVELS", "critical,warning"),
@@ -87,6 +94,16 @@ func Load() Config {
 
 // Validate 校验配置项的合法性，启动前快速失败。
 func (c Config) Validate() error {
+	switch strings.ToLower(strings.TrimSpace(c.LogLevel)) {
+	case "", "debug", "info", "warn", "warning", "error":
+	default:
+		return fmt.Errorf("不支持的 LOG_LEVEL: %s（可选: debug, info, warn, error）", c.LogLevel)
+	}
+	switch strings.ToLower(strings.TrimSpace(c.LogFormat)) {
+	case "", "text", "json":
+	default:
+		return fmt.Errorf("不支持的 LOG_FORMAT: %s（可选: text, json）", c.LogFormat)
+	}
 	if c.HTTPAddr == "" {
 		return fmt.Errorf("HTTP_ADDR 不能为空")
 	}
@@ -130,4 +147,18 @@ func intFromEnv(key string, fallback int) int {
 		}
 	}
 	return fallback
+}
+
+func boolFromEnv(key string, fallback bool) bool {
+	value := strings.ToLower(strings.TrimSpace(os.Getenv(key)))
+	switch value {
+	case "":
+		return fallback
+	case "1", "true", "yes", "on":
+		return true
+	case "0", "false", "no", "off":
+		return false
+	default:
+		return fallback
+	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,44 @@
+package config
+
+import "testing"
+
+func TestConfigValidateRejectsUnsupportedLoggingValues(t *testing.T) {
+	cfg := Config{HTTPAddr: ":8080", StoreBackend: "memory", LogLevel: "trace"}
+	if err := cfg.Validate(); err == nil {
+		t.Fatalf("expected unsupported log level to fail validation")
+	}
+
+	cfg = Config{HTTPAddr: ":8080", StoreBackend: "memory", LogFormat: "yaml"}
+	if err := cfg.Validate(); err == nil {
+		t.Fatalf("expected unsupported log format to fail validation")
+	}
+}
+
+func TestConfigValidateAcceptsSupportedLoggingValues(t *testing.T) {
+	cfg := Config{
+		HTTPAddr:     ":8080",
+		StoreBackend: "memory",
+		LogLevel:     "debug",
+		LogFormat:    "json",
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("expected config to validate, got error: %v", err)
+	}
+}
+
+func TestBoolFromEnvRecognizesTruthyAndFalsyValues(t *testing.T) {
+	t.Setenv("BOOL_TRUE", "yes")
+	if !boolFromEnv("BOOL_TRUE", false) {
+		t.Fatalf("expected yes to parse as true")
+	}
+
+	t.Setenv("BOOL_FALSE", "off")
+	if boolFromEnv("BOOL_FALSE", true) {
+		t.Fatalf("expected off to parse as false")
+	}
+
+	t.Setenv("BOOL_INVALID", "maybe")
+	if !boolFromEnv("BOOL_INVALID", true) {
+		t.Fatalf("expected invalid value to fall back to default")
+	}
+}

--- a/internal/http/router.go
+++ b/internal/http/router.go
@@ -1,14 +1,17 @@
 package http
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
+	"runtime/debug"
 	"time"
 
 	"github.com/wuyaocheng/bktrader/internal/config"
+	"github.com/wuyaocheng/bktrader/internal/logging"
 	"github.com/wuyaocheng/bktrader/internal/service"
 )
 
@@ -85,13 +88,25 @@ func corsMiddleware(next http.Handler) http.Handler {
 // statusRecorder 包装 ResponseWriter 以捕获响应状态码，用于请求日志。
 type statusRecorder struct {
 	http.ResponseWriter
-	statusCode int
+	statusCode  int
+	bytesWrite  int
+	wroteHeader bool
 }
 
 // WriteHeader 覆写以记录状态码。
 func (sr *statusRecorder) WriteHeader(code int) {
 	sr.statusCode = code
+	sr.wroteHeader = true
 	sr.ResponseWriter.WriteHeader(code)
+}
+
+func (sr *statusRecorder) Write(payload []byte) (int, error) {
+	if !sr.wroteHeader {
+		sr.WriteHeader(sr.statusCode)
+	}
+	size, err := sr.ResponseWriter.Write(payload)
+	sr.bytesWrite += size
+	return size, err
 }
 
 // requestLogMiddleware 记录每个 HTTP 请求的方法、路径、状态码和耗时。
@@ -99,8 +114,44 @@ func requestLogMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
 		recorder := &statusRecorder{ResponseWriter: w, statusCode: http.StatusOK}
+		logger := slog.Default().With(
+			"component", "http",
+			"method", r.Method,
+			"path", r.URL.Path,
+			"query", r.URL.RawQuery,
+			"remote_addr", r.RemoteAddr,
+			"user_agent", r.UserAgent(),
+		)
+
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				recorder.statusCode = http.StatusInternalServerError
+				if !recorder.wroteHeader {
+					writeError(recorder, http.StatusInternalServerError, "internal server error")
+				}
+				logger.Error("http request panicked",
+					"panic", recovered,
+					"stack", string(debug.Stack()),
+				)
+			}
+
+			message := "http request completed"
+			switch {
+			case recorder.statusCode >= 500:
+				message = "http request failed"
+			case recorder.statusCode >= 400:
+				message = "http request rejected"
+			}
+
+			logger.Log(context.Background(), logging.HTTPLevel(recorder.statusCode), message,
+				"status", recorder.statusCode,
+				"duration_ms", time.Since(start).Milliseconds(),
+				"bytes_written", recorder.bytesWrite,
+				"content_length", r.ContentLength,
+			)
+		}()
+
 		next.ServeHTTP(recorder, r)
-		log.Printf("[HTTP] %s %s %d %s", r.Method, r.URL.Path, recorder.statusCode, time.Since(start))
 	})
 }
 

--- a/internal/http/router_test.go
+++ b/internal/http/router_test.go
@@ -1,0 +1,148 @@
+package http
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+type capturedRecord struct {
+	level slog.Level
+	msg   string
+	attrs map[string]any
+}
+
+type captureHandler struct {
+	mu      *sync.Mutex
+	records *[]capturedRecord
+	attrs   []slog.Attr
+}
+
+func requirePositiveIntAttr(t *testing.T, value any, name string) {
+	t.Helper()
+	switch typed := value.(type) {
+	case int:
+		if typed <= 0 {
+			t.Fatalf("expected %s > 0, got %d", name, typed)
+		}
+	case int64:
+		if typed <= 0 {
+			t.Fatalf("expected %s > 0, got %d", name, typed)
+		}
+	default:
+		t.Fatalf("expected integer attr for %s, got %#v", name, value)
+	}
+}
+
+func newCaptureHandler() (*captureHandler, *[]capturedRecord) {
+	records := make([]capturedRecord, 0, 8)
+	return &captureHandler{
+		mu:      &sync.Mutex{},
+		records: &records,
+	}, &records
+}
+
+func (h *captureHandler) Enabled(context.Context, slog.Level) bool {
+	return true
+}
+
+func (h *captureHandler) Handle(_ context.Context, record slog.Record) error {
+	attrs := make(map[string]any)
+	for _, attr := range h.attrs {
+		attrs[attr.Key] = attr.Value.Any()
+	}
+	record.Attrs(func(attr slog.Attr) bool {
+		attrs[attr.Key] = attr.Value.Any()
+		return true
+	})
+
+	h.mu.Lock()
+	*h.records = append(*h.records, capturedRecord{
+		level: record.Level,
+		msg:   record.Message,
+		attrs: attrs,
+	})
+	h.mu.Unlock()
+	return nil
+}
+
+func (h *captureHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	combined := append(append([]slog.Attr{}, h.attrs...), attrs...)
+	return &captureHandler{mu: h.mu, records: h.records, attrs: combined}
+}
+
+func (h *captureHandler) WithGroup(string) slog.Handler {
+	return &captureHandler{mu: h.mu, records: h.records, attrs: append([]slog.Attr{}, h.attrs...)}
+}
+
+func TestRequestLogMiddlewareCapturesCompletedRequest(t *testing.T) {
+	handler, records := newCaptureHandler()
+	original := slog.Default()
+	slog.SetDefault(slog.New(handler))
+	t.Cleanup(func() { slog.SetDefault(original) })
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, http.StatusCreated, map[string]string{"status": "created"})
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/test?foo=bar", nil)
+	rec := httptest.NewRecorder()
+	requestLogMiddleware(next).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected status 201, got %d", rec.Code)
+	}
+	if len(*records) != 1 {
+		t.Fatalf("expected 1 log record, got %d", len(*records))
+	}
+	record := (*records)[0]
+	if record.msg != "http request completed" {
+		t.Fatalf("expected completion log, got %q", record.msg)
+	}
+	if status, ok := record.attrs["status"].(int64); !ok || status != http.StatusCreated {
+		t.Fatalf("expected status attr 201, got %#v", record.attrs["status"])
+	}
+	if component := record.attrs["component"]; component != "http" {
+		t.Fatalf("expected component attr http, got %#v", component)
+	}
+	requirePositiveIntAttr(t, record.attrs["bytes_written"], "bytes_written")
+}
+
+func TestRequestLogMiddlewareRecoversPanics(t *testing.T) {
+	handler, records := newCaptureHandler()
+	original := slog.Default()
+	slog.SetDefault(slog.New(handler))
+	t.Cleanup(func() { slog.SetDefault(original) })
+
+	next := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		panic("boom")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/boom", nil)
+	rec := httptest.NewRecorder()
+	requestLogMiddleware(next).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("expected status 500, got %d", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "internal server error") {
+		t.Fatalf("expected panic response body, got %q", body)
+	}
+	if len(*records) != 2 {
+		t.Fatalf("expected 2 log records, got %d", len(*records))
+	}
+	if (*records)[0].msg != "http request panicked" {
+		t.Fatalf("expected panic log first, got %q", (*records)[0].msg)
+	}
+	if (*records)[1].msg != "http request failed" {
+		t.Fatalf("expected failed request log second, got %q", (*records)[1].msg)
+	}
+	if status, ok := (*records)[1].attrs["status"].(int64); !ok || status != http.StatusInternalServerError {
+		t.Fatalf("expected status attr 500, got %#v", (*records)[1].attrs["status"])
+	}
+}

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -1,0 +1,77 @@
+package logging
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/wuyaocheng/bktrader/internal/config"
+)
+
+// Configure 初始化全局默认日志器，统一接管结构化日志输出。
+func Configure(cfg config.Config) error {
+	level, err := parseLevel(cfg.LogLevel)
+	if err != nil {
+		return err
+	}
+
+	options := &slog.HandlerOptions{
+		AddSource: cfg.LogAddSource,
+		Level:     level,
+		ReplaceAttr: func(_ []string, attr slog.Attr) slog.Attr {
+			if attr.Key == slog.TimeKey {
+				if value, ok := attr.Value.Any().(time.Time); ok {
+					return slog.String(attr.Key, value.UTC().Format(time.RFC3339))
+				}
+			}
+			return attr
+		},
+	}
+
+	format := strings.ToLower(strings.TrimSpace(cfg.LogFormat))
+	var handler slog.Handler
+	switch format {
+	case "", "text":
+		handler = slog.NewTextHandler(os.Stdout, options)
+	case "json":
+		handler = slog.NewJSONHandler(os.Stdout, options)
+	default:
+		return fmt.Errorf("unsupported log format: %s", cfg.LogFormat)
+	}
+
+	logger := slog.New(handler).With(
+		"app", cfg.AppName,
+		"env", cfg.Environment,
+	)
+	slog.SetDefault(logger)
+	return nil
+}
+
+// HTTPLevel 根据响应状态码映射合适的日志级别。
+func HTTPLevel(status int) slog.Level {
+	switch {
+	case status >= 500:
+		return slog.LevelError
+	case status >= 400:
+		return slog.LevelWarn
+	default:
+		return slog.LevelInfo
+	}
+}
+
+func parseLevel(value string) (slog.Level, error) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "", "info":
+		return slog.LevelInfo, nil
+	case "debug":
+		return slog.LevelDebug, nil
+	case "warn", "warning":
+		return slog.LevelWarn, nil
+	case "error":
+		return slog.LevelError, nil
+	default:
+		return slog.LevelInfo, fmt.Errorf("unsupported log level: %s", value)
+	}
+}

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -1,0 +1,81 @@
+package logging
+
+import (
+	"io"
+	"log/slog"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/wuyaocheng/bktrader/internal/config"
+)
+
+func TestConfigureJSONLoggerWritesStructuredOutput(t *testing.T) {
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create stdout pipe: %v", err)
+	}
+	originalStdout := os.Stdout
+	originalLogger := slog.Default()
+	os.Stdout = writer
+	t.Cleanup(func() {
+		os.Stdout = originalStdout
+		slog.SetDefault(originalLogger)
+	})
+
+	cfg := config.Config{
+		AppName:     "bkTrader-test",
+		Environment: "test",
+		LogLevel:    "debug",
+		LogFormat:   "json",
+	}
+	if err := Configure(cfg); err != nil {
+		t.Fatalf("configure logger: %v", err)
+	}
+
+	slog.Info("hello logging test")
+	_ = writer.Close()
+
+	output, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("read logger output: %v", err)
+	}
+	text := string(output)
+	if !strings.Contains(text, `"msg":"hello logging test"`) {
+		t.Fatalf("expected message in logger output, got %q", text)
+	}
+	if !strings.Contains(text, `"app":"bkTrader-test"`) {
+		t.Fatalf("expected app attribute in logger output, got %q", text)
+	}
+	if !strings.Contains(text, `"env":"test"`) {
+		t.Fatalf("expected env attribute in logger output, got %q", text)
+	}
+}
+
+func TestConfigureRejectsUnsupportedFormat(t *testing.T) {
+	err := Configure(config.Config{
+		AppName:     "bkTrader-test",
+		Environment: "test",
+		LogLevel:    "info",
+		LogFormat:   "yaml",
+	})
+	if err == nil {
+		t.Fatalf("expected unsupported format to fail")
+	}
+}
+
+func TestHTTPLevel(t *testing.T) {
+	tests := []struct {
+		status int
+		level  slog.Level
+	}{
+		{status: 200, level: slog.LevelInfo},
+		{status: 404, level: slog.LevelWarn},
+		{status: 503, level: slog.LevelError},
+	}
+	for _, tc := range tests {
+		if got := HTTPLevel(tc.status); got != tc.level {
+			t.Fatalf("status %d: expected %v, got %v", tc.status, tc.level, got)
+		}
+	}
+}

--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -42,12 +42,15 @@ func (p *Platform) ListLiveSessions() ([]domain.LiveSession, error) {
 }
 
 func (p *Platform) DeleteLiveSession(sessionID string) error {
+	p.logger("service.live", "session_id", sessionID).Info("deleting live session")
 	return p.store.DeleteLiveSession(sessionID)
 }
 
 func (p *Platform) UpdateLiveSession(sessionID, accountID, strategyID string, overrides map[string]any) (domain.LiveSession, error) {
+	logger := p.logger("service.live", "session_id", sessionID)
 	session, err := p.store.GetLiveSession(sessionID)
 	if err != nil {
+		logger.Warn("load live session failed", "error", err)
 		return domain.LiveSession{}, err
 	}
 	if strings.TrimSpace(accountID) != "" {
@@ -70,14 +73,28 @@ func (p *Platform) UpdateLiveSession(sessionID, accountID, strategyID string, ov
 	session.State = state
 	session, err = p.store.UpdateLiveSession(session)
 	if err != nil {
+		logger.Error("update live session failed", "error", err)
 		return domain.LiveSession{}, err
 	}
-	return p.syncLiveSessionRuntime(session)
+	updated, err := p.syncLiveSessionRuntime(session)
+	if err != nil {
+		logger.Warn("sync live session runtime failed after update", "error", err)
+		return domain.LiveSession{}, err
+	}
+	p.logger("service.live",
+		"session_id", updated.ID,
+		"account_id", updated.AccountID,
+		"strategy_id", updated.StrategyID,
+	).Info("live session updated", "override_count", len(overrides))
+	return updated, nil
 }
 
 func (p *Platform) SyncLiveAccount(accountID string) (domain.Account, error) {
+	logger := p.logger("service.live", "account_id", accountID)
+	logger.Debug("syncing live account")
 	account, err := p.store.GetAccount(accountID)
 	if err != nil {
+		logger.Warn("load live account failed", "error", err)
 		return domain.Account{}, err
 	}
 	if !strings.EqualFold(account.Mode, "LIVE") {
@@ -90,12 +107,18 @@ func (p *Platform) SyncLiveAccount(accountID string) (domain.Account, error) {
 	if syncCapable, ok := adapter.(LiveAccountSyncAdapter); ok {
 		if synced, syncErr := syncCapable.SyncAccountSnapshot(p, account, binding); syncErr == nil {
 			p.syncLiveSessionsForAccountSnapshot(synced)
+			logger.Info("live account synced via adapter", "exchange", synced.Exchange, "status", synced.Status)
 			return synced, nil
+		} else {
+			logger.Warn("adapter live account sync failed, falling back to local state", "error", syncErr)
 		}
 	}
 	synced, err := p.syncLiveAccountFromLocalState(account, binding)
 	if err == nil {
 		p.syncLiveSessionsForAccountSnapshot(synced)
+		logger.Debug("live account synced from local state", "status", synced.Status)
+	} else {
+		logger.Warn("local-state live account sync failed", "error", err)
 	}
 	return synced, err
 }
@@ -114,14 +137,19 @@ func (p *Platform) syncLiveSessionsForAccountSnapshot(account domain.Account) {
 }
 
 func (p *Platform) RecoverLiveTradingOnStartup(ctx context.Context) {
+	logger := p.logger("service.live")
+	logger.Info("starting live trading recovery")
 	accounts, err := p.ListAccounts()
 	if err != nil {
+		logger.Warn("list accounts failed during live recovery", "error", err)
 		return
 	}
+	syncedAccounts := 0
 	for _, account := range accounts {
 		if ctx != nil {
 			select {
 			case <-ctx.Done():
+				logger.Info("live trading recovery cancelled", "synced_account_count", syncedAccounts)
 				return
 			default:
 			}
@@ -132,17 +160,26 @@ func (p *Platform) RecoverLiveTradingOnStartup(ctx context.Context) {
 		syncedAccount, syncErr := p.SyncLiveAccount(account.ID)
 		if syncErr == nil {
 			account = syncedAccount
+			syncedAccounts++
+		} else {
+			p.logger("service.live", "account_id", account.ID).Warn("live account sync failed during recovery", "error", syncErr)
 		}
 	}
 
 	sessions, err := p.ListLiveSessions()
 	if err != nil {
+		logger.Warn("list live sessions failed during recovery", "error", err)
 		return
 	}
+	recoveredSessions := 0
 	for _, session := range sessions {
 		if ctx != nil {
 			select {
 			case <-ctx.Done():
+				logger.Info("live trading recovery cancelled",
+					"synced_account_count", syncedAccounts,
+					"recovered_session_count", recoveredSessions,
+				)
 				return
 			default:
 			}
@@ -152,18 +189,24 @@ func (p *Platform) RecoverLiveTradingOnStartup(ctx context.Context) {
 		}
 		recovered, recoverErr := p.recoverRunningLiveSession(session)
 		if recoverErr != nil {
+			p.logger("service.live", "session_id", session.ID).Warn("recover running live session failed", "error", recoverErr)
 			state := cloneMetadata(session.State)
 			state["lastRecoveryError"] = recoverErr.Error()
 			state["lastRecoveryAttemptAt"] = time.Now().UTC().Format(time.RFC3339)
 			_, _ = p.store.UpdateLiveSessionState(session.ID, state)
 			continue
 		}
+		recoveredSessions++
 		state := cloneMetadata(recovered.State)
 		delete(state, "lastRecoveryError")
 		state["lastRecoveryAttemptAt"] = time.Now().UTC().Format(time.RFC3339)
 		state["lastRecoveryStatus"] = "recovered"
 		_, _ = p.store.UpdateLiveSessionState(recovered.ID, state)
 	}
+	logger.Info("live trading recovery completed",
+		"synced_account_count", syncedAccounts,
+		"recovered_session_count", recoveredSessions,
+	)
 }
 
 func (p *Platform) syncLiveAccountFromLocalState(account domain.Account, binding map[string]any) (domain.Account, error) {
@@ -389,8 +432,10 @@ func (p *Platform) syncLiveAccountFromBinance(account domain.Account, binding ma
 }
 
 func (p *Platform) CreateLiveSession(accountID, strategyID string, overrides map[string]any) (domain.LiveSession, error) {
+	logger := p.logger("service.live", "account_id", accountID, "strategy_id", strategyID)
 	account, err := p.store.GetAccount(accountID)
 	if err != nil {
+		logger.Warn("load account for live session failed", "error", err)
 		return domain.LiveSession{}, err
 	}
 	if !strings.EqualFold(account.Mode, "LIVE") {
@@ -399,6 +444,7 @@ func (p *Platform) CreateLiveSession(accountID, strategyID string, overrides map
 
 	session, err := p.store.CreateLiveSession(accountID, strategyID)
 	if err != nil {
+		logger.Error("create live session failed", "error", err)
 		return domain.LiveSession{}, err
 	}
 	if len(overrides) > 0 {
@@ -408,15 +454,28 @@ func (p *Platform) CreateLiveSession(accountID, strategyID string, overrides map
 		}
 		session, err = p.store.UpdateLiveSessionState(session.ID, state)
 		if err != nil {
+			p.logger("service.live", "session_id", session.ID).Error("apply live session overrides failed", "error", err)
 			return domain.LiveSession{}, err
 		}
 	}
-	return p.syncLiveSessionRuntime(session)
+	session, err = p.syncLiveSessionRuntime(session)
+	if err != nil {
+		p.logger("service.live", "session_id", session.ID).Warn("sync live session runtime failed", "error", err)
+		return domain.LiveSession{}, err
+	}
+	p.logger("service.live",
+		"session_id", session.ID,
+		"account_id", session.AccountID,
+		"strategy_id", session.StrategyID,
+	).Info("live session created", "override_count", len(overrides))
+	return session, nil
 }
 
 func (p *Platform) LaunchLiveFlow(accountID string, options LiveLaunchOptions) (LiveLaunchResult, error) {
+	logger := p.logger("service.live", "account_id", accountID)
 	account, err := p.store.GetAccount(accountID)
 	if err != nil {
+		logger.Warn("load account for live launch failed", "error", err)
 		return LiveLaunchResult{}, err
 	}
 	if !strings.EqualFold(account.Mode, "LIVE") {
@@ -435,6 +494,14 @@ func (p *Platform) LaunchLiveFlow(accountID string, options LiveLaunchOptions) (
 	if !options.StartSession {
 		options.StartSession = true
 	}
+	logger.Info("launching live flow",
+		"strategy_id", strings.TrimSpace(options.StrategyID),
+		"mirror_strategy_signals", options.MirrorStrategySignals,
+		"start_runtime", options.StartRuntime,
+		"start_session", options.StartSession,
+		"has_binding", len(options.Binding) > 0,
+		"has_overrides", len(options.LiveSessionOverrides) > 0,
+	)
 
 	result := LiveLaunchResult{Account: account}
 
@@ -522,6 +589,15 @@ func (p *Platform) LaunchLiveFlow(accountID string, options LiveLaunchOptions) (
 	if err == nil {
 		result.Account = account
 	}
+	logger.Info("live flow launched",
+		"strategy_id", strategyID,
+		"mirrored_binding_count", result.MirroredBindingCount,
+		"account_binding_applied", result.AccountBindingApplied,
+		"runtime_session_created", result.RuntimeSessionCreated,
+		"runtime_session_started", result.RuntimeSessionStarted,
+		"live_session_created", result.LiveSessionCreated,
+		"live_session_started", result.LiveSessionStarted,
+	)
 	return result, nil
 }
 
@@ -563,8 +639,10 @@ func (p *Platform) ensureLaunchLiveSession(accountID, strategyID string, overrid
 }
 
 func (p *Platform) StartLiveSession(sessionID string) (domain.LiveSession, error) {
+	logger := p.logger("service.live", "session_id", sessionID)
 	session, err := p.store.GetLiveSession(sessionID)
 	if err != nil {
+		logger.Warn("load live session failed", "error", err)
 		return domain.LiveSession{}, err
 	}
 	account, err := p.store.GetAccount(session.AccountID)
@@ -578,33 +656,51 @@ func (p *Platform) StartLiveSession(sessionID string) (domain.LiveSession, error
 		return domain.LiveSession{}, fmt.Errorf("live account %s is not configured", account.ID)
 	}
 	if _, _, err := p.resolveLiveAdapterForAccount(account); err != nil {
+		logger.Warn("resolve live adapter failed", "error", err)
 		return domain.LiveSession{}, err
 	}
 
 	session, err = p.syncLiveSessionRuntime(session)
 	if err != nil {
+		logger.Warn("sync live session runtime failed", "error", err)
 		return domain.LiveSession{}, err
 	}
 	session, err = p.ensureLiveSessionSignalRuntimeStarted(session)
 	if err != nil {
+		logger.Warn("ensure live signal runtime failed", "error", err)
 		return domain.LiveSession{}, err
 	}
-	return p.store.UpdateLiveSessionStatus(sessionID, "RUNNING")
+	session, err = p.store.UpdateLiveSessionStatus(sessionID, "RUNNING")
+	if err != nil {
+		logger.Error("mark live session running failed", "error", err)
+		return domain.LiveSession{}, err
+	}
+	p.logger("service.live",
+		"session_id", session.ID,
+		"account_id", session.AccountID,
+		"strategy_id", session.StrategyID,
+	).Info("live session started")
+	return session, nil
 }
 
 func (p *Platform) StartLiveSyncDispatcher(ctx context.Context) {
 	if ctx == nil {
 		return
 	}
+	logger := p.logger("service.live_sync_dispatcher")
+	logger.Info("live sync dispatcher started")
 	ticker := time.NewTicker(10 * time.Second)
 	defer ticker.Stop()
 
 	for {
 		select {
 		case <-ctx.Done():
+			logger.Info("live sync dispatcher stopped")
 			return
 		case <-ticker.C:
-			_ = p.syncActiveLiveSessions(time.Now().UTC())
+			if err := p.syncActiveLiveSessions(time.Now().UTC()); err != nil {
+				logger.Warn("sync active live sessions failed", "error", err)
+			}
 		}
 	}
 }
@@ -709,11 +805,18 @@ func (p *Platform) resolveLivePositionStrategyVersionID(accountID, symbol string
 }
 
 func (p *Platform) StopLiveSession(sessionID string) (domain.LiveSession, error) {
+	logger := p.logger("service.live", "session_id", sessionID)
 	session, err := p.store.UpdateLiveSessionStatus(sessionID, "STOPPED")
 	if err != nil {
+		logger.Error("stop live session failed", "error", err)
 		return domain.LiveSession{}, err
 	}
 	_, _ = p.stopLinkedLiveSignalRuntime(session)
+	p.logger("service.live",
+		"session_id", session.ID,
+		"account_id", session.AccountID,
+		"strategy_id", session.StrategyID,
+	).Info("live session stopped")
 	return session, nil
 }
 

--- a/internal/service/live_execution.go
+++ b/internal/service/live_execution.go
@@ -180,10 +180,13 @@ func evaluateExecutionQuality(state map[string]any) {
 }
 
 func (p *Platform) SyncLiveSession(sessionID string) (domain.LiveSession, error) {
+	logger := p.logger("service.live_execution", "session_id", sessionID)
 	session, err := p.store.GetLiveSession(sessionID)
 	if err != nil {
+		logger.Warn("load live session failed", "error", err)
 		return domain.LiveSession{}, err
 	}
+	logger.Debug("syncing latest live session order")
 	return p.syncLatestLiveSessionOrder(session, time.Now().UTC())
 }
 
@@ -205,10 +208,13 @@ func (p *Platform) syncActiveLiveSessions(eventTime time.Time) error {
 }
 
 func (p *Platform) DispatchLiveSessionIntent(sessionID string) (domain.Order, error) {
+	logger := p.logger("service.live_execution", "session_id", sessionID)
 	session, err := p.store.GetLiveSession(sessionID)
 	if err != nil {
+		logger.Warn("load live session failed", "error", err)
 		return domain.Order{}, err
 	}
+	logger.Info("dispatching live session intent")
 	return p.dispatchLiveSessionIntent(session)
 }
 
@@ -292,8 +298,25 @@ func (p *Platform) dispatchLiveSessionIntent(session domain.LiveSession) (domain
 		_, _ = p.syncLatestLiveSessionOrder(updatedSession, time.Now().UTC())
 	}
 	if createErr != nil {
+		p.logger("service.live_execution",
+			"session_id", session.ID,
+			"order_id", created.ID,
+		).Warn("live session intent dispatched with error",
+			"status", created.Status,
+			"error", createErr,
+		)
 		return created, createErr
 	}
+	p.logger("service.live_execution",
+		"session_id", session.ID,
+		"order_id", created.ID,
+	).Info("live session intent dispatched",
+		"status", created.Status,
+		"symbol", created.Symbol,
+		"side", created.Side,
+		"type", created.Type,
+		"quantity", created.Quantity,
+	)
 	return created, nil
 }
 

--- a/internal/service/live_market_data.go
+++ b/internal/service/live_market_data.go
@@ -29,22 +29,34 @@ func (p *Platform) WarmLiveMarketData(ctx context.Context) error {
 	if len(symbols) == 0 {
 		symbols = []string{"BTCUSDT"}
 	}
+	logger := p.logger("service.live_market")
+	logger.Info("warming live market data", "symbol_count", len(symbols), "symbols", symbols)
 	var firstErr error
 	for _, symbol := range symbols {
 		if ctx != nil {
 			select {
 			case <-ctx.Done():
 				if firstErr != nil {
+					logger.Warn("live market warm cancelled after partial failure", "error", firstErr)
 					return firstErr
 				}
+				logger.Warn("live market warm cancelled", "error", ctx.Err())
 				return ctx.Err()
 			default:
 			}
 		}
-		if err := p.refreshLiveMarketSnapshot(symbol); err != nil && firstErr == nil {
-			firstErr = err
+		if err := p.refreshLiveMarketSnapshot(symbol); err != nil {
+			p.logger("service.live_market", "symbol", NormalizeSymbol(symbol)).Warn("refresh live market snapshot failed", "error", err)
+			if firstErr == nil {
+				firstErr = err
+			}
 		}
 	}
+	if firstErr != nil {
+		logger.Warn("live market warm completed with errors", "error", firstErr)
+		return firstErr
+	}
+	logger.Info("live market warm completed")
 	return firstErr
 }
 
@@ -82,6 +94,8 @@ func (p *Platform) refreshLiveMarketSnapshot(symbol string) error {
 	if normalizedSymbol == "" {
 		normalizedSymbol = "BTCUSDT"
 	}
+	logger := p.logger("service.live_market", "symbol", normalizedSymbol)
+	logger.Debug("refreshing live market snapshot")
 	end := time.Now().UTC().Truncate(time.Minute)
 	minuteStart := end.Add(-liveMinuteWarmWindow)
 	signalStart := end.Add(-liveSignalWarmWindow)
@@ -111,6 +125,11 @@ func (p *Platform) refreshLiveMarketSnapshot(symbol string) error {
 		UpdatedAt: time.Now().UTC(),
 	}
 	p.liveMarketMu.Unlock()
+	logger.Debug("live market snapshot refreshed",
+		"minute_bar_count", len(minuteBars),
+		"signal_1d_bar_count", len(signal1D),
+		"signal_4h_bar_count", len(signal4H),
+	)
 	return nil
 }
 

--- a/internal/service/order.go
+++ b/internal/service/order.go
@@ -31,17 +31,29 @@ func (p *Platform) GetOrder(orderID string) (domain.Order, error) {
 // CreateOrder 创建订单。对于 PAPER 模式账户，订单会被立即执行（模拟成交），
 // 生成 fill 记录、更新持仓、捕获净值快照。
 func (p *Platform) CreateOrder(order domain.Order) (domain.Order, error) {
+	logger := p.logger("service.order",
+		"account_id", order.AccountID,
+		"strategy_version_id", order.StrategyVersionID,
+		"symbol", NormalizeSymbol(order.Symbol),
+		"side", order.Side,
+		"type", order.Type,
+	)
+	logger.Debug("creating order", "quantity", order.Quantity, "price", order.Price)
 	account, err := p.prepareOrderAccount(order)
 	if err != nil {
+		logger.Warn("prepare order account failed", "error", err)
 		return domain.Order{}, err
 	}
 	if err := p.preflightOrderExecution(account, order); err != nil {
+		logger.Warn("order preflight failed", "error", err, "account_mode", account.Mode)
 		return domain.Order{}, err
 	}
 	createdOrder, err := p.store.CreateOrder(order)
 	if err != nil {
+		logger.Error("persist order failed", "error", err)
 		return domain.Order{}, err
 	}
+	logger.Debug("order persisted", "order_id", createdOrder.ID, "account_mode", account.Mode)
 	return p.executeCreatedOrder(account, createdOrder)
 }
 
@@ -139,6 +151,13 @@ func (p *Platform) applyLiveSubmissionResult(
 	submission LiveOrderSubmission,
 	submitErr error,
 ) (domain.Order, error) {
+	logger := p.logger("service.order",
+		"order_id", order.ID,
+		"account_id", order.AccountID,
+		"symbol", NormalizeSymbol(order.Symbol),
+		"side", order.Side,
+		"type", order.Type,
+	)
 	order.Metadata = cloneMetadata(order.Metadata)
 	applyExecutionMetadata(order.Metadata, map[string]any{
 		"executionMode":    "live",
@@ -163,6 +182,7 @@ func (p *Platform) applyLiveSubmissionResult(
 		if updateErr != nil {
 			return domain.Order{}, updateErr
 		}
+		logger.Warn("live order submission failed", "error", submitErr)
 		return updatedOrder, submitErr
 	}
 	delete(order.Metadata, "liveSubmitError")
@@ -176,6 +196,10 @@ func (p *Platform) applyLiveSubmissionResult(
 	if strings.EqualFold(order.Status, "FILLED") {
 		markOrderLifecycle(order.Metadata, "filled", true)
 	}
+	logger.Info("live order submitted",
+		"status", order.Status,
+		"exchange_order_id", submission.ExchangeOrderID,
+	)
 	return p.store.UpdateOrder(order)
 }
 
@@ -292,26 +316,34 @@ func (p *Platform) resolveStrategyIDFromVersionID(strategyVersionID string) (str
 }
 
 func (p *Platform) SyncLiveOrder(orderID string) (domain.Order, error) {
+	logger := p.logger("service.order", "order_id", orderID)
 	order, account, adapter, binding, err := p.resolveLiveOrderContext(orderID)
 	if err != nil {
+		logger.Warn("resolve live order context failed", "error", err)
 		return domain.Order{}, err
 	}
 	syncResult, err := adapter.SyncOrder(account, order, binding)
 	if err != nil {
+		logger.Warn("sync live order failed", "error", err)
 		return domain.Order{}, err
 	}
+	logger.Debug("live order sync received", "status", syncResult.Status, "fill_count", len(syncResult.Fills))
 	return p.applyLiveSyncResult(account, order, syncResult)
 }
 
 func (p *Platform) CancelLiveOrder(orderID string) (domain.Order, error) {
+	logger := p.logger("service.order", "order_id", orderID)
 	order, account, adapter, binding, err := p.resolveLiveOrderContext(orderID)
 	if err != nil {
+		logger.Warn("resolve live order context failed", "error", err)
 		return domain.Order{}, err
 	}
 	syncResult, err := adapter.CancelOrder(account, order, binding)
 	if err != nil {
+		logger.Warn("cancel live order failed", "error", err)
 		return domain.Order{}, err
 	}
+	logger.Info("live order cancellation acknowledged", "status", syncResult.Status)
 	return p.applyLiveSyncResult(account, order, syncResult)
 }
 
@@ -335,6 +367,11 @@ func (p *Platform) resolveLiveOrderContext(orderID string) (domain.Order, domain
 }
 
 func (p *Platform) applyLiveSyncResult(account domain.Account, order domain.Order, syncResult LiveOrderSync) (domain.Order, error) {
+	logger := p.logger("service.order",
+		"order_id", order.ID,
+		"account_id", order.AccountID,
+		"symbol", NormalizeSymbol(order.Symbol),
+	)
 	order.Metadata = cloneMetadata(order.Metadata)
 	applyExecutionMetadata(order.Metadata, map[string]any{
 		"lastSyncAt":           syncResult.SyncedAt,
@@ -357,8 +394,15 @@ func (p *Platform) applyLiveSyncResult(account domain.Account, order domain.Orde
 		order.Metadata["fillCount"] = len(fills)
 		order.Metadata["lastFillAt"] = firstNonEmpty(syncResult.SyncedAt, time.Now().UTC().Format(time.RFC3339))
 		markOrderLifecycle(order.Metadata, "filled", true)
+		logger.Info("live order synced with fills",
+			"status", order.Status,
+			"fill_count", len(fills),
+			"last_price", lastPrice,
+			"funding_pnl", lastFundingPnL,
+		)
 		return p.finalizeExecutedOrder(account, order, fills)
 	}
+	logger.Debug("live order sync applied", "status", order.Status)
 	return p.store.UpdateOrder(order)
 }
 
@@ -417,6 +461,16 @@ func (p *Platform) finalizeExecutedOrder(account domain.Account, order domain.Or
 	}
 	if err := p.captureAccountSnapshot(account.ID); err != nil {
 		return domain.Order{}, err
+	}
+	levelLogger := p.logger("service.order",
+		"order_id", updatedOrder.ID,
+		"account_id", updatedOrder.AccountID,
+		"symbol", NormalizeSymbol(updatedOrder.Symbol),
+	)
+	if strings.EqualFold(account.Mode, "LIVE") {
+		levelLogger.Info("order filled", "fill_count", len(fills), "price", updatedOrder.Price)
+	} else {
+		levelLogger.Debug("paper order filled", "fill_count", len(fills), "price", updatedOrder.Price)
 	}
 	return updatedOrder, nil
 }

--- a/internal/service/paper.go
+++ b/internal/service/paper.go
@@ -47,8 +47,10 @@ func (p *Platform) ListPaperSessions() ([]domain.PaperSession, error) {
 
 // CreatePaperSession 创建新的模拟交易会话，并捕获初始净值快照。
 func (p *Platform) CreatePaperSession(accountID, strategyID string, startEquity float64, overrides map[string]any) (domain.PaperSession, error) {
+	logger := p.logger("service.paper", "account_id", accountID, "strategy_id", strategyID)
 	session, err := p.store.CreatePaperSession(accountID, strategyID, startEquity)
 	if err != nil {
+		logger.Error("create paper session failed", "error", err)
 		return domain.PaperSession{}, err
 	}
 	if len(overrides) > 0 {
@@ -58,23 +60,36 @@ func (p *Platform) CreatePaperSession(accountID, strategyID string, startEquity 
 		}
 		session, err = p.store.UpdatePaperSessionState(session.ID, state)
 		if err != nil {
+			p.logger("service.paper", "session_id", session.ID).Error("apply paper session overrides failed", "error", err)
 			return domain.PaperSession{}, err
 		}
 	}
 	session, err = p.syncPaperSessionRuntime(session)
 	if err != nil {
+		p.logger("service.paper", "session_id", session.ID).Warn("sync paper session runtime failed", "error", err)
 		return domain.PaperSession{}, err
 	}
 	if err := p.captureAccountSnapshot(accountID); err != nil {
+		p.logger("service.paper", "session_id", session.ID).Warn("capture paper account snapshot failed", "error", err)
 		return domain.PaperSession{}, err
 	}
+	p.logger("service.paper",
+		"session_id", session.ID,
+		"account_id", session.AccountID,
+		"strategy_id", session.StrategyID,
+	).Info("paper session created",
+		"start_equity", session.StartEquity,
+		"override_count", len(overrides),
+	)
 	return session, nil
 }
 
 // StartPaperSession 启动模拟交易会话的后台执行循环。
 func (p *Platform) StartPaperSession(sessionID string) (domain.PaperSession, error) {
+	logger := p.logger("service.paper", "session_id", sessionID)
 	session, err := p.store.GetPaperSession(sessionID)
 	if err != nil {
+		logger.Warn("load paper session failed", "error", err)
 		return domain.PaperSession{}, err
 	}
 	session, err = p.syncPaperSessionRuntime(session)
@@ -92,6 +107,7 @@ func (p *Platform) StartPaperSession(sessionID string) (domain.PaperSession, err
 	p.mu.Lock()
 	if _, exists := p.run[sessionID]; exists {
 		p.mu.Unlock()
+		logger.Debug("paper session runner already active")
 		return p.store.UpdatePaperSessionStatus(sessionID, "RUNNING")
 	}
 	ctx, cancel := context.WithCancel(context.Background())
@@ -108,13 +124,20 @@ func (p *Platform) StartPaperSession(sessionID string) (domain.PaperSession, err
 	}
 
 	go p.runPaperSessionLoop(ctx, session)
+	p.logger("service.paper",
+		"session_id", session.ID,
+		"account_id", session.AccountID,
+		"strategy_id", session.StrategyID,
+	).Info("paper session started", "tick_interval_seconds", p.tickInterval)
 	return session, nil
 }
 
 // StopPaperSession 停止模拟交易会话，取消后台执行循环。
 func (p *Platform) StopPaperSession(sessionID string) (domain.PaperSession, error) {
+	logger := p.logger("service.paper", "session_id", sessionID)
 	session, err := p.store.UpdatePaperSessionStatus(sessionID, "STOPPED")
 	if err != nil {
+		logger.Error("stop paper session failed", "error", err)
 		return domain.PaperSession{}, err
 	}
 
@@ -130,19 +153,28 @@ func (p *Platform) StopPaperSession(sessionID string) (domain.PaperSession, erro
 		cancel()
 	}
 	_, _ = p.stopLinkedSignalRuntime(session)
+	p.logger("service.paper",
+		"session_id", session.ID,
+		"account_id", session.AccountID,
+		"strategy_id", session.StrategyID,
+	).Info("paper session stopped")
 	return session, nil
 }
 
 // TickPaperSession 手动触发会话前进一步（处理下一笔策略计划订单）。
 func (p *Platform) TickPaperSession(sessionID string) (domain.Order, error) {
+	logger := p.logger("service.paper", "session_id", sessionID)
 	session, err := p.store.GetPaperSession(sessionID)
 	if err != nil {
+		logger.Warn("load paper session for manual tick failed", "error", err)
 		return domain.Order{}, err
 	}
 	session, err = p.syncPaperSessionRuntime(session)
 	if err != nil {
+		logger.Warn("sync paper session runtime before tick failed", "error", err)
 		return domain.Order{}, err
 	}
+	logger.Debug("ticking paper session manually")
 	return p.placePaperSessionOrder(session)
 }
 

--- a/internal/service/platform.go
+++ b/internal/service/platform.go
@@ -11,6 +11,7 @@ package service
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"strings"
 	"sync"
 
@@ -86,6 +87,13 @@ func NewPlatform(store store.Repository) *Platform {
 	platform.registerBuiltInSignalSources()
 	platform.registerBuiltInSignalRuntimeAdapters()
 	platform.registerBuiltInExecutionStrategies()
+	platform.logger("service.platform").Info("platform initialized",
+		"strategy_engine_count", len(platform.strategyEngines),
+		"live_adapter_count", len(platform.liveAdapters),
+		"signal_source_count", len(platform.signalSources),
+		"signal_adapter_count", len(platform.signalAdapters),
+		"execution_strategy_count", len(platform.executionStrategies),
+	)
 	return platform
 }
 
@@ -95,6 +103,10 @@ func (p *Platform) SetBacktestDataDirs(minuteDataDir, tickDataDir string) {
 	p.manifestMu.Lock()
 	p.tickManifest = nil
 	p.manifestMu.Unlock()
+	p.logger("service.platform").Info("backtest data directories configured",
+		"minute_data_dir", minuteDataDir,
+		"tick_data_dir", tickDataDir,
+	)
 }
 
 func (p *Platform) SetRuntimePolicy(policy RuntimePolicy) {
@@ -113,6 +125,13 @@ func (p *Platform) SetRuntimePolicy(policy RuntimePolicy) {
 	if policy.PaperStartReadinessTimeoutSecs > 0 {
 		p.runtimePolicy.PaperStartReadinessTimeoutSecs = policy.PaperStartReadinessTimeoutSecs
 	}
+	p.logger("service.platform").Info("runtime policy applied",
+		"trade_tick_freshness_seconds", p.runtimePolicy.TradeTickFreshnessSeconds,
+		"order_book_freshness_seconds", p.runtimePolicy.OrderBookFreshnessSeconds,
+		"signal_bar_freshness_seconds", p.runtimePolicy.SignalBarFreshnessSeconds,
+		"runtime_quiet_seconds", p.runtimePolicy.RuntimeQuietSeconds,
+		"paper_start_readiness_timeout_seconds", p.runtimePolicy.PaperStartReadinessTimeoutSecs,
+	)
 }
 
 func (p *Platform) RuntimePolicy() RuntimePolicy {
@@ -125,6 +144,13 @@ func (p *Platform) UpdateRuntimePolicy(policy RuntimePolicy) (RuntimePolicy, err
 		policy.SignalBarFreshnessSeconds < 0 ||
 		policy.RuntimeQuietSeconds < 0 ||
 		policy.PaperStartReadinessTimeoutSecs < 0 {
+		p.logger("service.platform").Warn("reject invalid runtime policy",
+			"trade_tick_freshness_seconds", policy.TradeTickFreshnessSeconds,
+			"order_book_freshness_seconds", policy.OrderBookFreshnessSeconds,
+			"signal_bar_freshness_seconds", policy.SignalBarFreshnessSeconds,
+			"runtime_quiet_seconds", policy.RuntimeQuietSeconds,
+			"paper_start_readiness_timeout_seconds", policy.PaperStartReadinessTimeoutSecs,
+		)
 		return p.runtimePolicy, fmt.Errorf("runtime policy values must be non-negative")
 	}
 	p.SetRuntimePolicy(policy)
@@ -136,6 +162,7 @@ func (p *Platform) UpdateRuntimePolicy(policy RuntimePolicy) (RuntimePolicy, err
 		PaperStartReadinessTimeoutSecs: p.runtimePolicy.PaperStartReadinessTimeoutSecs,
 	})
 	if err != nil {
+		p.logger("service.platform").Error("persist runtime policy failed", "error", err)
 		return p.runtimePolicy, err
 	}
 	p.SetRuntimePolicy(RuntimePolicy{
@@ -145,15 +172,18 @@ func (p *Platform) UpdateRuntimePolicy(policy RuntimePolicy) (RuntimePolicy, err
 		RuntimeQuietSeconds:            saved.RuntimeQuietSeconds,
 		PaperStartReadinessTimeoutSecs: saved.PaperStartReadinessTimeoutSecs,
 	})
+	p.logger("service.platform").Info("runtime policy updated")
 	return p.runtimePolicy, nil
 }
 
 func (p *Platform) LoadPersistedRuntimePolicy() error {
 	policy, ok, err := p.store.GetRuntimePolicy()
 	if err != nil {
+		p.logger("service.platform").Error("load persisted runtime policy failed", "error", err)
 		return err
 	}
 	if !ok {
+		p.logger("service.platform").Debug("no persisted runtime policy found")
 		return nil
 	}
 	p.SetRuntimePolicy(RuntimePolicy{
@@ -163,6 +193,7 @@ func (p *Platform) LoadPersistedRuntimePolicy() error {
 		RuntimeQuietSeconds:            policy.RuntimeQuietSeconds,
 		PaperStartReadinessTimeoutSecs: policy.PaperStartReadinessTimeoutSecs,
 	})
+	p.logger("service.platform").Info("persisted runtime policy loaded")
 	return nil
 }
 
@@ -180,6 +211,12 @@ func (p *Platform) SetTelegramConfig(config domain.TelegramConfig) {
 	if !config.UpdatedAt.IsZero() {
 		p.telegramConfig.UpdatedAt = config.UpdatedAt
 	}
+	p.logger("service.platform").Info("telegram config applied",
+		"enabled", p.telegramConfig.Enabled,
+		"send_levels", p.telegramConfig.SendLevels,
+		"has_bot_token", strings.TrimSpace(p.telegramConfig.BotToken) != "",
+		"has_chat_id", strings.TrimSpace(p.telegramConfig.ChatID) != "",
+	)
 }
 
 func (p *Platform) TelegramConfigView() map[string]any {
@@ -208,22 +245,48 @@ func (p *Platform) UpdateTelegramConfig(enabled bool, botToken, chatID string, s
 	}
 	saved, err := p.store.UpsertTelegramConfig(config)
 	if err != nil {
+		p.logger("service.platform").Error("persist telegram config failed", "error", err)
 		return nil, err
 	}
 	p.telegramConfig = saved
+	p.logger("service.platform").Info("telegram config updated",
+		"enabled", saved.Enabled,
+		"send_levels", saved.SendLevels,
+		"has_bot_token", strings.TrimSpace(saved.BotToken) != "",
+		"has_chat_id", strings.TrimSpace(saved.ChatID) != "",
+	)
 	return p.TelegramConfigView(), nil
 }
 
 func (p *Platform) LoadPersistedTelegramConfig() error {
 	config, ok, err := p.store.GetTelegramConfig()
 	if err != nil {
+		p.logger("service.platform").Error("load persisted telegram config failed", "error", err)
 		return err
 	}
 	if !ok {
+		p.logger("service.platform").Debug("no persisted telegram config found")
 		return nil
 	}
 	p.telegramConfig = config
+	p.logger("service.platform").Info("persisted telegram config loaded",
+		"enabled", config.Enabled,
+		"send_levels", config.SendLevels,
+		"has_bot_token", strings.TrimSpace(config.BotToken) != "",
+		"has_chat_id", strings.TrimSpace(config.ChatID) != "",
+	)
 	return nil
+}
+
+func (p *Platform) logger(component string, args ...any) *slog.Logger {
+	logger := slog.Default()
+	if strings.TrimSpace(component) != "" {
+		logger = logger.With("component", component)
+	}
+	if len(args) > 0 {
+		logger = logger.With(args...)
+	}
+	return logger
 }
 
 func normalizeTelegramSendLevels(levels []string) []string {

--- a/internal/service/signal_runtime_sessions.go
+++ b/internal/service/signal_runtime_sessions.go
@@ -46,8 +46,10 @@ func (p *Platform) GetSignalRuntimeSession(sessionID string) (domain.SignalRunti
 }
 
 func (p *Platform) CreateSignalRuntimeSession(accountID, strategyID string) (domain.SignalRuntimeSession, error) {
+	logger := p.logger("service.signal_runtime", "account_id", accountID, "strategy_id", strategyID)
 	plan, err := p.BuildSignalRuntimePlan(accountID, strategyID)
 	if err != nil {
+		logger.Warn("build signal runtime plan failed", "error", err)
 		return domain.SignalRuntimeSession{}, err
 	}
 	now := time.Now().UTC()
@@ -83,23 +85,35 @@ func (p *Platform) CreateSignalRuntimeSession(accountID, strategyID string) (dom
 	p.mu.Lock()
 	p.signalSessions[session.ID] = session
 	p.mu.Unlock()
+	p.logger("service.signal_runtime",
+		"session_id", session.ID,
+		"account_id", session.AccountID,
+		"strategy_id", session.StrategyID,
+	).Info("signal runtime session created",
+		"subscription_count", len(subscriptions),
+		"runtime_adapter", adapterKey,
+	)
 	return session, nil
 }
 
 func (p *Platform) StartSignalRuntimeSession(sessionID string) (domain.SignalRuntimeSession, error) {
+	logger := p.logger("service.signal_runtime", "session_id", sessionID)
 	p.mu.Lock()
 	session, ok := p.signalSessions[sessionID]
 	if !ok {
 		p.mu.Unlock()
+		logger.Warn("signal runtime session not found")
 		return domain.SignalRuntimeSession{}, fmt.Errorf("signal runtime session not found: %s", sessionID)
 	}
 	if _, exists := p.signalRun[sessionID]; exists {
 		p.mu.Unlock()
+		logger.Debug("signal runtime session already running")
 		return session, nil
 	}
 	p.mu.Unlock()
 	plan, err := p.BuildSignalRuntimePlan(session.AccountID, session.StrategyID)
 	if err != nil {
+		logger.Warn("build signal runtime plan failed", "error", err)
 		return domain.SignalRuntimeSession{}, err
 	}
 	subscriptions := metadataList(plan["subscriptions"])
@@ -142,14 +156,24 @@ func (p *Platform) StartSignalRuntimeSession(sessionID string) (domain.SignalRun
 	p.signalSessions[session.ID] = session
 	p.mu.Unlock()
 	go p.runSignalRuntimeLoop(ctx, sessionID)
+	p.logger("service.signal_runtime",
+		"session_id", session.ID,
+		"account_id", session.AccountID,
+		"strategy_id", session.StrategyID,
+	).Info("signal runtime session started",
+		"subscription_count", len(subscriptions),
+		"runtime_adapter", adapterKey,
+	)
 	return session, nil
 }
 
 func (p *Platform) StopSignalRuntimeSession(sessionID string) (domain.SignalRuntimeSession, error) {
+	logger := p.logger("service.signal_runtime", "session_id", sessionID)
 	p.mu.Lock()
 	session, ok := p.signalSessions[sessionID]
 	if !ok {
 		p.mu.Unlock()
+		logger.Warn("signal runtime session not found")
 		return domain.SignalRuntimeSession{}, fmt.Errorf("signal runtime session not found: %s", sessionID)
 	}
 	cancel, running := p.signalRun[sessionID]
@@ -174,6 +198,11 @@ func (p *Platform) StopSignalRuntimeSession(sessionID string) (domain.SignalRunt
 	if running {
 		cancel()
 	}
+	p.logger("service.signal_runtime",
+		"session_id", session.ID,
+		"account_id", session.AccountID,
+		"strategy_id", session.StrategyID,
+	).Info("signal runtime session stopped")
 	return session, nil
 }
 

--- a/internal/service/telegram.go
+++ b/internal/service/telegram.go
@@ -13,8 +13,10 @@ import (
 )
 
 func (p *Platform) SendNotificationToTelegram(notificationID string) error {
+	logger := p.logger("service.telegram", "notification_id", strings.TrimSpace(notificationID))
 	notifications, err := p.ListNotifications(true)
 	if err != nil {
+		logger.Warn("list notifications failed", "error", err)
 		return err
 	}
 	for _, item := range notifications {
@@ -23,15 +25,19 @@ func (p *Platform) SendNotificationToTelegram(notificationID string) error {
 		}
 		if err := p.sendTelegramMessage(formatTelegramNotification(item)); err != nil {
 			_, _ = p.store.UpsertNotificationDelivery(item.ID, "telegram", "failed", err.Error())
+			logger.Warn("send telegram notification failed", "error", err)
 			return err
 		}
 		_, _ = p.store.UpsertNotificationDelivery(item.ID, "telegram", "sent", "")
+		logger.Info("telegram notification sent", "level", item.Alert.Level)
 		return nil
 	}
+	logger.Warn("telegram notification not found")
 	return fmt.Errorf("notification not found: %s", notificationID)
 }
 
 func (p *Platform) SendTelegramTestMessage() error {
+	p.logger("service.telegram").Info("sending telegram test message")
 	return p.sendTelegramMessage("bkTrader Telegram channel test\n\nTelegram 通知通道已连通。")
 }
 
@@ -95,15 +101,18 @@ func formatTelegramNotification(item domain.PlatformNotification) string {
 }
 
 func (p *Platform) StartTelegramDispatcher(ctx context.Context) {
+	p.logger("service.telegram").Info("starting telegram dispatcher")
 	go p.runTelegramDispatcher(ctx)
 }
 
 func (p *Platform) runTelegramDispatcher(ctx context.Context) {
+	logger := p.logger("service.telegram")
 	ticker := time.NewTicker(15 * time.Second)
 	defer ticker.Stop()
 	for {
 		select {
 		case <-ctx.Done():
+			logger.Info("telegram dispatcher stopped")
 			return
 		case <-ticker.C:
 			_ = p.DispatchTelegramNotifications()
@@ -112,16 +121,20 @@ func (p *Platform) runTelegramDispatcher(ctx context.Context) {
 }
 
 func (p *Platform) DispatchTelegramNotifications() error {
+	logger := p.logger("service.telegram")
 	config := p.telegramConfig
 	if !config.Enabled || strings.TrimSpace(config.BotToken) == "" || strings.TrimSpace(config.ChatID) == "" {
+		logger.Debug("telegram dispatcher skipped because channel is not configured")
 		return nil
 	}
 	notifications, err := p.ListNotifications(false)
 	if err != nil {
+		logger.Warn("list notifications failed", "error", err)
 		return err
 	}
 	deliveries, err := p.store.ListNotificationDeliveries()
 	if err != nil {
+		logger.Warn("list notification deliveries failed", "error", err)
 		return err
 	}
 	delivered := make(map[string]struct{}, len(deliveries))
@@ -135,6 +148,7 @@ func (p *Platform) DispatchTelegramNotifications() error {
 		allowedLevels[strings.ToLower(strings.TrimSpace(level))] = struct{}{}
 	}
 	var firstErr error
+	sentCount := 0
 	for _, item := range notifications {
 		level := strings.ToLower(strings.TrimSpace(item.Alert.Level))
 		if _, ok := allowedLevels[level]; !ok {
@@ -148,14 +162,18 @@ func (p *Platform) DispatchTelegramNotifications() error {
 			if firstErr == nil {
 				firstErr = err
 			}
+			p.logger("service.telegram", "notification_id", item.ID).Warn("send telegram notification failed", "error", err)
 			continue
 		}
 		if _, err := p.store.UpsertNotificationDelivery(item.ID, "telegram", "sent", ""); err != nil {
 			if firstErr == nil {
 				firstErr = err
 			}
+			p.logger("service.telegram", "notification_id", item.ID).Warn("record telegram delivery failed", "error", err)
 			continue
 		}
+		sentCount++
 	}
+	logger.Debug("telegram dispatch cycle completed", "sent_count", sentCount, "notification_count", len(notifications))
 	return firstErr
 }


### PR DESCRIPTION
## Summary
- add centralized slog configuration with level/format/source options
- wire structured logging into API startup, migration entrypoints, HTTP middleware, and core service flows
- add focused tests for config validation, logger setup, and HTTP request/panic logging behavior

## Scope
- startup and migration entrypoints now initialize structured logging
- HTTP middleware now emits structured request logs and panic recovery logs
- platform/live/order/paper/signal-runtime/telegram services now log key lifecycle events
- no graphify outputs or local-only agent files are included

## Testing
- go test ./internal/config ./internal/logging ./internal/http
- go test ./...
- graph rebuild via ~/.miniforge3/bin/python graphify environment