### PR TITLE
Add backend health snapshots and sync monitoring

### DIFF
--- a/db/migrations/012_runtime_policy_health_thresholds.sql
+++ b/db/migrations/012_runtime_policy_health_thresholds.sql
@@ -1,0 +1,3 @@
+alter table runtime_policies
+    add column if not exists strategy_evaluation_quiet_seconds integer not null default 15,
+    add column if not exists live_account_sync_freshness_seconds integer not null default 60;

--- a/internal/app/server.go
+++ b/internal/app/server.go
@@ -40,6 +40,8 @@ func NewServer(cfg config.Config) (*http.Server, error) {
 		OrderBookFreshnessSeconds:      cfg.OrderBookFreshnessSeconds,
 		SignalBarFreshnessSeconds:      cfg.SignalBarFreshnessSeconds,
 		RuntimeQuietSeconds:            cfg.RuntimeQuietSeconds,
+		StrategyEvaluationQuietSeconds: cfg.StrategyEvaluationQuietSeconds,
+		LiveAccountSyncFreshnessSecs:   cfg.LiveAccountSyncFreshnessSecs,
 		PaperStartReadinessTimeoutSecs: cfg.PaperStartReadinessTimeoutSecs,
 	})
 	platform.SetTelegramConfig(domain.TelegramConfig{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,6 +32,8 @@ type Config struct {
 	OrderBookFreshnessSeconds      int    // order book 新鲜度阈值
 	SignalBarFreshnessSeconds      int    // signal bar 新鲜度阈值
 	RuntimeQuietSeconds            int    // runtime quiet 告警阈值
+	StrategyEvaluationQuietSeconds int    // 策略触发进入评估的静默阈值
+	LiveAccountSyncFreshnessSecs   int    // live account 同步陈旧阈值
 	PaperStartReadinessTimeoutSecs int    // paper 启动前 runtime readiness 等待阈值
 	TelegramEnabled                bool   // Telegram 通知是否启用
 	TelegramBotToken               string // Telegram Bot Token
@@ -51,6 +53,8 @@ func Load() Config {
 	orderBookFreshness := intFromEnv("ORDER_BOOK_FRESHNESS_SECONDS", 10)
 	signalBarFreshness := intFromEnv("SIGNAL_BAR_FRESHNESS_SECONDS", 30)
 	runtimeQuiet := intFromEnv("RUNTIME_QUIET_SECONDS", 30)
+	strategyEvaluationQuiet := intFromEnv("STRATEGY_EVALUATION_QUIET_SECONDS", 15)
+	liveAccountSyncFreshness := intFromEnv("LIVE_ACCOUNT_SYNC_FRESHNESS_SECONDS", 60)
 	paperReadinessTimeout := intFromEnv("PAPER_START_READINESS_TIMEOUT_SECONDS", 5)
 
 	authTokenTTL := 720
@@ -84,6 +88,8 @@ func Load() Config {
 		OrderBookFreshnessSeconds:      orderBookFreshness,
 		SignalBarFreshnessSeconds:      signalBarFreshness,
 		RuntimeQuietSeconds:            runtimeQuiet,
+		StrategyEvaluationQuietSeconds: strategyEvaluationQuiet,
+		LiveAccountSyncFreshnessSecs:   liveAccountSyncFreshness,
 		PaperStartReadinessTimeoutSecs: paperReadinessTimeout,
 		TelegramEnabled:                boolFromEnv("TELEGRAM_ENABLED", false),
 		TelegramBotToken:               getenv("TELEGRAM_BOT_TOKEN", ""),

--- a/internal/domain/models.go
+++ b/internal/domain/models.go
@@ -242,6 +242,8 @@ type RuntimePolicy struct {
 	OrderBookFreshnessSeconds      int       `json:"orderBookFreshnessSeconds"`
 	SignalBarFreshnessSeconds      int       `json:"signalBarFreshnessSeconds"`
 	RuntimeQuietSeconds            int       `json:"runtimeQuietSeconds"`
+	StrategyEvaluationQuietSeconds int       `json:"strategyEvaluationQuietSeconds"`
+	LiveAccountSyncFreshnessSecs   int       `json:"liveAccountSyncFreshnessSeconds"`
 	PaperStartReadinessTimeoutSecs int       `json:"paperStartReadinessTimeoutSeconds"`
 	UpdatedAt                      time.Time `json:"updatedAt"`
 }
@@ -262,6 +264,70 @@ type PlatformAlert struct {
 	Anchor           string         `json:"anchor,omitempty"`
 	EventTime        time.Time      `json:"eventTime"`
 	Metadata         map[string]any `json:"metadata,omitempty"`
+}
+
+type PlatformHealthAlertCounts struct {
+	Total    int `json:"total"`
+	Critical int `json:"critical"`
+	Warning  int `json:"warning"`
+	Info     int `json:"info"`
+}
+
+type PlatformHealthAccountSnapshot struct {
+	ID                      string         `json:"id"`
+	Name                    string         `json:"name"`
+	Exchange                string         `json:"exchange"`
+	Status                  string         `json:"status"`
+	LastLiveSyncAt          string         `json:"lastLiveSyncAt"`
+	SyncAgeSeconds          int            `json:"syncAgeSeconds"`
+	SyncStale               bool           `json:"syncStale"`
+	RuntimeSessionCount     int            `json:"runtimeSessionCount"`
+	RunningLiveSessionCount int            `json:"runningLiveSessionCount"`
+	AccountSync             map[string]any `json:"accountSync,omitempty"`
+}
+
+type PlatformHealthRuntimeSessionSnapshot struct {
+	ID              string         `json:"id"`
+	AccountID       string         `json:"accountId"`
+	StrategyID      string         `json:"strategyId"`
+	StrategyName    string         `json:"strategyName,omitempty"`
+	Status          string         `json:"status"`
+	Transport       string         `json:"transport"`
+	Health          string         `json:"health"`
+	LastEventAt     string         `json:"lastEventAt,omitempty"`
+	LastHeartbeatAt string         `json:"lastHeartbeatAt,omitempty"`
+	Quiet           bool           `json:"quiet"`
+	TradeTick       map[string]any `json:"tradeTick,omitempty"`
+	OrderBook       map[string]any `json:"orderBook,omitempty"`
+}
+
+type PlatformHealthStrategySessionSnapshot struct {
+	ID                           string         `json:"id"`
+	Mode                         string         `json:"mode"`
+	AccountID                    string         `json:"accountId"`
+	StrategyID                   string         `json:"strategyId"`
+	StrategyName                 string         `json:"strategyName,omitempty"`
+	Status                       string         `json:"status"`
+	RuntimeSessionID             string         `json:"runtimeSessionId,omitempty"`
+	LastSignalRuntimeEventAt     string         `json:"lastSignalRuntimeEventAt,omitempty"`
+	LastStrategyEvaluationAt     string         `json:"lastStrategyEvaluationAt,omitempty"`
+	LastStrategyEvaluationStatus string         `json:"lastStrategyEvaluationStatus,omitempty"`
+	LastSyncedOrderStatus        string         `json:"lastSyncedOrderStatus,omitempty"`
+	EvaluationQuiet              bool           `json:"evaluationQuiet"`
+	StrategyIngress              map[string]any `json:"strategyIngress,omitempty"`
+	Execution                    map[string]any `json:"execution,omitempty"`
+	SourceGate                   map[string]any `json:"sourceGate,omitempty"`
+}
+
+type PlatformHealthSnapshot struct {
+	GeneratedAt     time.Time                               `json:"generatedAt"`
+	Status          string                                  `json:"status"`
+	AlertCounts     PlatformHealthAlertCounts               `json:"alertCounts"`
+	RuntimePolicy   RuntimePolicy                           `json:"runtimePolicy"`
+	LiveAccounts    []PlatformHealthAccountSnapshot         `json:"liveAccounts"`
+	RuntimeSessions []PlatformHealthRuntimeSessionSnapshot  `json:"runtimeSessions"`
+	LiveSessions    []PlatformHealthStrategySessionSnapshot `json:"liveSessions"`
+	PaperSessions   []PlatformHealthStrategySessionSnapshot `json:"paperSessions"`
 }
 
 // NotificationAck 保存用户已确认的通知键。

--- a/internal/http/signals.go
+++ b/internal/http/signals.go
@@ -43,6 +43,19 @@ func registerSignalRoutes(mux *http.ServeMux, platform *service.Platform) {
 		writeJSON(w, http.StatusOK, items)
 	})
 
+	mux.HandleFunc("/api/v1/monitor/health", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		snapshot, err := platform.HealthSnapshot()
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		writeJSON(w, http.StatusOK, snapshot)
+	})
+
 	mux.HandleFunc("/api/v1/notifications", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			w.WriteHeader(http.StatusMethodNotAllowed)

--- a/internal/http/signals.go
+++ b/internal/http/signals.go
@@ -7,6 +7,16 @@ import (
 	"github.com/wuyaocheng/bktrader/internal/service"
 )
 
+type runtimePolicyPatch struct {
+	TradeTickFreshnessSeconds      *int `json:"tradeTickFreshnessSeconds"`
+	OrderBookFreshnessSeconds      *int `json:"orderBookFreshnessSeconds"`
+	SignalBarFreshnessSeconds      *int `json:"signalBarFreshnessSeconds"`
+	RuntimeQuietSeconds            *int `json:"runtimeQuietSeconds"`
+	StrategyEvaluationQuietSeconds *int `json:"strategyEvaluationQuietSeconds"`
+	LiveAccountSyncFreshnessSecs   *int `json:"liveAccountSyncFreshnessSeconds"`
+	PaperStartReadinessTimeoutSecs *int `json:"paperStartReadinessTimeoutSeconds"`
+}
+
 // registerSignalRoutes 注册信号源相关路由。
 func registerSignalRoutes(mux *http.ServeMux, platform *service.Platform) {
 	// GET /api/v1/signal-sources — 获取信号源列表
@@ -156,12 +166,34 @@ func registerSignalRoutes(mux *http.ServeMux, platform *service.Platform) {
 		case http.MethodGet:
 			writeJSON(w, http.StatusOK, platform.RuntimePolicy())
 		case http.MethodPost:
-			var payload service.RuntimePolicy
+			var payload runtimePolicyPatch
 			if err := decodeJSON(r, &payload); err != nil {
 				writeError(w, http.StatusBadRequest, err.Error())
 				return
 			}
-			policy, err := platform.UpdateRuntimePolicy(payload)
+			current := platform.RuntimePolicy()
+			if payload.TradeTickFreshnessSeconds != nil {
+				current.TradeTickFreshnessSeconds = *payload.TradeTickFreshnessSeconds
+			}
+			if payload.OrderBookFreshnessSeconds != nil {
+				current.OrderBookFreshnessSeconds = *payload.OrderBookFreshnessSeconds
+			}
+			if payload.SignalBarFreshnessSeconds != nil {
+				current.SignalBarFreshnessSeconds = *payload.SignalBarFreshnessSeconds
+			}
+			if payload.RuntimeQuietSeconds != nil {
+				current.RuntimeQuietSeconds = *payload.RuntimeQuietSeconds
+			}
+			if payload.StrategyEvaluationQuietSeconds != nil {
+				current.StrategyEvaluationQuietSeconds = *payload.StrategyEvaluationQuietSeconds
+			}
+			if payload.LiveAccountSyncFreshnessSecs != nil {
+				current.LiveAccountSyncFreshnessSecs = *payload.LiveAccountSyncFreshnessSecs
+			}
+			if payload.PaperStartReadinessTimeoutSecs != nil {
+				current.PaperStartReadinessTimeoutSecs = *payload.PaperStartReadinessTimeoutSecs
+			}
+			policy, err := platform.UpdateRuntimePolicy(current)
 			if err != nil {
 				writeError(w, http.StatusBadRequest, "invalid runtime policy payload")
 				return

--- a/internal/http/signals_test.go
+++ b/internal/http/signals_test.go
@@ -1,0 +1,52 @@
+package http
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/wuyaocheng/bktrader/internal/service"
+	"github.com/wuyaocheng/bktrader/internal/store/memory"
+)
+
+func TestRuntimePolicyPatchPreservesOmittedFieldsAndAllowsZeroHealthThresholds(t *testing.T) {
+	platform := service.NewPlatform(memory.NewStore())
+	mux := http.NewServeMux()
+	registerSignalRoutes(mux, platform)
+
+	updateRequest := func(body string) {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/runtime-policy", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected runtime policy update to succeed, got %d body=%s", rec.Code, rec.Body.String())
+		}
+	}
+
+	updateRequest(`{"runtimeQuietSeconds":45}`)
+	current := platform.RuntimePolicy()
+	if current.RuntimeQuietSeconds != 45 {
+		t.Fatalf("expected runtime quiet threshold to update to 45, got %d", current.RuntimeQuietSeconds)
+	}
+	if current.StrategyEvaluationQuietSeconds != 15 {
+		t.Fatalf("expected omitted strategy evaluation quiet threshold to remain 15, got %d", current.StrategyEvaluationQuietSeconds)
+	}
+	if current.LiveAccountSyncFreshnessSecs != 60 {
+		t.Fatalf("expected omitted live account sync freshness threshold to remain 60, got %d", current.LiveAccountSyncFreshnessSecs)
+	}
+
+	updateRequest(`{"strategyEvaluationQuietSeconds":0,"liveAccountSyncFreshnessSeconds":0}`)
+	current = platform.RuntimePolicy()
+	if current.RuntimeQuietSeconds != 45 {
+		t.Fatalf("expected unrelated runtime quiet threshold to be preserved at 45, got %d", current.RuntimeQuietSeconds)
+	}
+	if current.StrategyEvaluationQuietSeconds != 0 {
+		t.Fatalf("expected strategy evaluation quiet threshold to allow explicit zero, got %d", current.StrategyEvaluationQuietSeconds)
+	}
+	if current.LiveAccountSyncFreshnessSecs != 0 {
+		t.Fatalf("expected live account sync freshness threshold to allow explicit zero, got %d", current.LiveAccountSyncFreshnessSecs)
+	}
+}

--- a/internal/service/alerts.go
+++ b/internal/service/alerts.go
@@ -271,7 +271,7 @@ func (p *Platform) ListAlerts() ([]domain.PlatformAlert, error) {
 
 	for _, session := range liveSessions {
 		state := cloneMetadata(session.State)
-		if strings.EqualFold(session.Status, "RUNNING") && p.strategyEvaluationQuiet(state) {
+		if p.liveSessionEvaluationQuiet("LIVE", session.Status, state) {
 			appendAlert(domain.PlatformAlert{
 				ID:           fmt.Sprintf("live-strategy-eval-quiet-%s", session.ID),
 				Scope:        "live",
@@ -481,6 +481,12 @@ func (p *Platform) strategyEvaluationQuiet(sessionState map[string]any) bool {
 		return false
 	}
 	return time.Since(lastTriggeredAt) > threshold
+}
+
+func (p *Platform) liveSessionEvaluationQuiet(mode, status string, sessionState map[string]any) bool {
+	return strings.EqualFold(mode, "LIVE") &&
+		strings.EqualFold(status, "RUNNING") &&
+		p.strategyEvaluationQuiet(sessionState)
 }
 
 func (p *Platform) liveAccountSyncStale(account domain.Account, referenceTime time.Time) (bool, int) {

--- a/internal/service/alerts.go
+++ b/internal/service/alerts.go
@@ -171,6 +171,7 @@ func (p *Platform) ListAlerts() ([]domain.PlatformAlert, error) {
 			}
 		}
 		snapshot := cloneMetadata(mapValue(account.Metadata["liveSyncSnapshot"]))
+		accountSyncSummary := cloneMetadata(mapValue(mapValue(account.Metadata["healthSummary"])["accountSync"]))
 		openPositionCount := maxIntValue(snapshot["positionCount"], 0)
 		if openPositionCount > 0 && len(runningLiveSessionsForAccount) == 0 {
 			appendAlert(domain.PlatformAlert{
@@ -183,6 +184,40 @@ func (p *Platform) ListAlerts() ([]domain.PlatformAlert, error) {
 				AccountName: account.Name,
 				Anchor:      "live",
 				EventTime:   parseOptionalRFC3339(stringValue(account.Metadata["lastLiveSyncAt"])),
+			})
+		}
+		if stale, ageSeconds := p.liveAccountSyncStale(account, time.Now().UTC()); stale {
+			level := "warning"
+			if openPositionCount > 0 || len(runningLiveSessionsForAccount) > 0 {
+				level = "critical"
+			}
+			appendAlert(domain.PlatformAlert{
+				ID:          fmt.Sprintf("live-account-sync-stale-%s", account.ID),
+				Scope:       "live",
+				Level:       level,
+				Title:       "Live account sync stale",
+				Detail:      fmt.Sprintf("last successful account sync was %ds ago", ageSeconds),
+				AccountID:   account.ID,
+				AccountName: account.Name,
+				Anchor:      "live",
+				EventTime:   parseOptionalRFC3339(stringValue(account.Metadata["lastLiveSyncAt"])),
+			})
+		}
+		if consecutiveErrors := maxIntValue(accountSyncSummary["consecutiveErrorCount"], 0); consecutiveErrors > 0 {
+			level := "warning"
+			if consecutiveErrors >= 3 {
+				level = "critical"
+			}
+			appendAlert(domain.PlatformAlert{
+				ID:          fmt.Sprintf("live-account-sync-error-%s", account.ID),
+				Scope:       "live",
+				Level:       level,
+				Title:       "Live account sync errors",
+				Detail:      fmt.Sprintf("consecutive_errors=%d last_error=%s", consecutiveErrors, firstNonEmpty(stringValue(accountSyncSummary["lastError"]), "unknown")),
+				AccountID:   account.ID,
+				AccountName: account.Name,
+				Anchor:      "live",
+				EventTime:   parseOptionalRFC3339(stringValue(accountSyncSummary["lastErrorAt"])),
 			})
 		}
 		activeRuntime, hasRuntime := pickActiveRuntime(runtimeSessionsForAccount)
@@ -236,6 +271,20 @@ func (p *Platform) ListAlerts() ([]domain.PlatformAlert, error) {
 
 	for _, session := range liveSessions {
 		state := cloneMetadata(session.State)
+		if strings.EqualFold(session.Status, "RUNNING") && p.strategyEvaluationQuiet(state) {
+			appendAlert(domain.PlatformAlert{
+				ID:           fmt.Sprintf("live-strategy-eval-quiet-%s", session.ID),
+				Scope:        "live",
+				Level:        "warning",
+				Title:        "Strategy evaluation quiet",
+				Detail:       fmt.Sprintf("runtime triggers observed but no strategy evaluation recorded in the last %ds", p.runtimePolicy.StrategyEvaluationQuietSeconds),
+				AccountID:    session.AccountID,
+				StrategyID:   session.StrategyID,
+				StrategyName: strategyNameByID[session.StrategyID],
+				Anchor:       "live",
+				EventTime:    parseOptionalRFC3339(firstNonEmpty(stringValue(mapValue(mapValue(state["healthSummary"])["strategyIngress"])["lastTriggeredAt"]), stringValue(state["lastSignalRuntimeEventAt"]))),
+			})
+		}
 		recoveryStatus := strings.TrimSpace(stringValue(state["protectionRecoveryStatus"]))
 		recoveryError := strings.TrimSpace(stringValue(state["lastRecoveryError"]))
 		eventTime := parseOptionalRFC3339(firstNonEmpty(stringValue(state["lastProtectionRecoveryAt"]), stringValue(state["lastRecoveryAttemptAt"])))
@@ -410,6 +459,48 @@ func (p *Platform) runtimeSessionQuiet(runtimeState map[string]any) bool {
 		return false
 	}
 	return time.Since(lastEventAt) > time.Duration(p.runtimePolicy.RuntimeQuietSeconds)*time.Second
+}
+
+func (p *Platform) strategyEvaluationQuiet(sessionState map[string]any) bool {
+	lastTriggeredAt := parseOptionalRFC3339(firstNonEmpty(
+		stringValue(mapValue(mapValue(sessionState["healthSummary"])["strategyIngress"])["lastTriggeredAt"]),
+		stringValue(sessionState["lastSignalRuntimeEventAt"]),
+	))
+	if lastTriggeredAt.IsZero() {
+		return false
+	}
+	lastEvaluationAt := parseOptionalRFC3339(firstNonEmpty(
+		stringValue(mapValue(mapValue(sessionState["healthSummary"])["strategyIngress"])["lastEvaluationAt"]),
+		stringValue(sessionState["lastStrategyEvaluationAt"]),
+	))
+	if !lastEvaluationAt.IsZero() && !lastTriggeredAt.After(lastEvaluationAt) {
+		return false
+	}
+	threshold := time.Duration(p.runtimePolicy.StrategyEvaluationQuietSeconds) * time.Second
+	if threshold <= 0 {
+		return false
+	}
+	return time.Since(lastTriggeredAt) > threshold
+}
+
+func (p *Platform) liveAccountSyncStale(account domain.Account, referenceTime time.Time) (bool, int) {
+	threshold := time.Duration(p.runtimePolicy.LiveAccountSyncFreshnessSecs) * time.Second
+	if threshold <= 0 {
+		return false, 0
+	}
+	lastSuccessAt := parseOptionalRFC3339(firstNonEmpty(
+		stringValue(mapValue(mapValue(account.Metadata["healthSummary"])["accountSync"])["lastSuccessAt"]),
+		stringValue(account.Metadata["lastLiveSyncAt"]),
+	))
+	if lastSuccessAt.IsZero() {
+		age := 0
+		if !account.CreatedAt.IsZero() {
+			age = int(referenceTime.Sub(account.CreatedAt).Seconds())
+		}
+		return true, age
+	}
+	age := int(referenceTime.Sub(lastSuccessAt).Seconds())
+	return referenceTime.Sub(lastSuccessAt) > threshold, age
 }
 
 func summarizeSourceGate(sourceGate map[string]any) string {

--- a/internal/service/alerts.go
+++ b/internal/service/alerts.go
@@ -469,10 +469,10 @@ func (p *Platform) strategyEvaluationQuiet(sessionState map[string]any) bool {
 	if lastTriggeredAt.IsZero() {
 		return false
 	}
-	lastEvaluationAt := parseOptionalRFC3339(firstNonEmpty(
-		stringValue(mapValue(mapValue(sessionState["healthSummary"])["strategyIngress"])["lastEvaluationAt"]),
-		stringValue(sessionState["lastStrategyEvaluationAt"]),
-	))
+	lastEvaluationAt := parseOptionalRFC3339(stringValue(mapValue(mapValue(sessionState["healthSummary"])["strategyIngress"])["lastEvaluationAt"]))
+	if stateEvaluationAt := parseOptionalRFC3339(stringValue(sessionState["lastStrategyEvaluationAt"])); stateEvaluationAt.After(lastEvaluationAt) {
+		lastEvaluationAt = stateEvaluationAt
+	}
 	if !lastEvaluationAt.IsZero() && !lastTriggeredAt.After(lastEvaluationAt) {
 		return false
 	}

--- a/internal/service/health_snapshot.go
+++ b/internal/service/health_snapshot.go
@@ -1,0 +1,212 @@
+package service
+
+import (
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/wuyaocheng/bktrader/internal/domain"
+)
+
+func (p *Platform) HealthSnapshot() (domain.PlatformHealthSnapshot, error) {
+	generatedAt := time.Now().UTC()
+
+	accounts, err := p.ListAccounts()
+	if err != nil {
+		return domain.PlatformHealthSnapshot{}, err
+	}
+	liveSessions, err := p.ListLiveSessions()
+	if err != nil {
+		return domain.PlatformHealthSnapshot{}, err
+	}
+	paperSessions, err := p.ListPaperSessions()
+	if err != nil {
+		return domain.PlatformHealthSnapshot{}, err
+	}
+	strategies, err := p.ListStrategies()
+	if err != nil {
+		return domain.PlatformHealthSnapshot{}, err
+	}
+	alerts, err := p.ListAlerts()
+	if err != nil {
+		return domain.PlatformHealthSnapshot{}, err
+	}
+	runtimeSessions := p.ListSignalRuntimeSessions()
+
+	strategyNameByID := make(map[string]string, len(strategies))
+	for _, strategy := range strategies {
+		strategyNameByID[stringValue(strategy["id"])] = stringValue(strategy["name"])
+	}
+
+	snapshot := domain.PlatformHealthSnapshot{
+		GeneratedAt:     generatedAt,
+		AlertCounts:     summarizePlatformHealthAlertCounts(alerts),
+		RuntimePolicy:   currentRuntimePolicyDomain(p.runtimePolicy),
+		LiveAccounts:    make([]domain.PlatformHealthAccountSnapshot, 0),
+		RuntimeSessions: make([]domain.PlatformHealthRuntimeSessionSnapshot, 0, len(runtimeSessions)),
+		LiveSessions:    make([]domain.PlatformHealthStrategySessionSnapshot, 0, len(liveSessions)),
+		PaperSessions:   make([]domain.PlatformHealthStrategySessionSnapshot, 0, len(paperSessions)),
+	}
+	snapshot.Status = platformHealthStatus(snapshot.AlertCounts)
+
+	runtimeCountByAccount := make(map[string]int)
+	runningLiveCountByAccount := make(map[string]int)
+	for _, session := range runtimeSessions {
+		runtimeCountByAccount[session.AccountID]++
+	}
+	for _, session := range liveSessions {
+		if strings.EqualFold(session.Status, "RUNNING") {
+			runningLiveCountByAccount[session.AccountID]++
+		}
+	}
+
+	for _, account := range accounts {
+		if !strings.EqualFold(account.Mode, "LIVE") {
+			continue
+		}
+		stale, ageSeconds := p.liveAccountSyncStale(account, generatedAt)
+		accountSync := cloneMetadata(mapValue(mapValue(account.Metadata["healthSummary"])["accountSync"]))
+		snapshot.LiveAccounts = append(snapshot.LiveAccounts, domain.PlatformHealthAccountSnapshot{
+			ID:                      account.ID,
+			Name:                    account.Name,
+			Exchange:                account.Exchange,
+			Status:                  account.Status,
+			LastLiveSyncAt:          stringValue(account.Metadata["lastLiveSyncAt"]),
+			SyncAgeSeconds:          ageSeconds,
+			SyncStale:               stale,
+			RuntimeSessionCount:     runtimeCountByAccount[account.ID],
+			RunningLiveSessionCount: runningLiveCountByAccount[account.ID],
+			AccountSync:             accountSync,
+		})
+	}
+
+	for _, runtime := range runtimeSessions {
+		state := cloneMetadata(runtime.State)
+		healthSummary := cloneMetadata(mapValue(state["healthSummary"]))
+		snapshot.RuntimeSessions = append(snapshot.RuntimeSessions, domain.PlatformHealthRuntimeSessionSnapshot{
+			ID:              runtime.ID,
+			AccountID:       runtime.AccountID,
+			StrategyID:      runtime.StrategyID,
+			StrategyName:    strategyNameByID[runtime.StrategyID],
+			Status:          runtime.Status,
+			Transport:       runtime.Transport,
+			Health:          firstNonEmpty(stringValue(state["health"]), "unknown"),
+			LastEventAt:     stringValue(state["lastEventAt"]),
+			LastHeartbeatAt: stringValue(state["lastHeartbeatAt"]),
+			Quiet:           p.runtimeSessionQuiet(state),
+			TradeTick:       cloneMetadata(mapValue(healthSummary["tradeTick"])),
+			OrderBook:       cloneMetadata(mapValue(healthSummary["orderBook"])),
+		})
+	}
+
+	for _, session := range liveSessions {
+		snapshot.LiveSessions = append(snapshot.LiveSessions, p.platformHealthStrategySessionSnapshot("LIVE", session.ID, session.AccountID, session.StrategyID, session.Status, session.State, strategyNameByID[session.StrategyID]))
+	}
+	for _, session := range paperSessions {
+		snapshot.PaperSessions = append(snapshot.PaperSessions, p.platformHealthStrategySessionSnapshot("PAPER", session.ID, session.AccountID, session.StrategyID, session.Status, session.State, strategyNameByID[session.StrategyID]))
+	}
+
+	slices.SortFunc(snapshot.LiveAccounts, func(a, b domain.PlatformHealthAccountSnapshot) int {
+		switch {
+		case a.Name < b.Name:
+			return -1
+		case a.Name > b.Name:
+			return 1
+		default:
+			return 0
+		}
+	})
+	slices.SortFunc(snapshot.RuntimeSessions, func(a, b domain.PlatformHealthRuntimeSessionSnapshot) int {
+		switch {
+		case a.ID < b.ID:
+			return -1
+		case a.ID > b.ID:
+			return 1
+		default:
+			return 0
+		}
+	})
+	slices.SortFunc(snapshot.LiveSessions, func(a, b domain.PlatformHealthStrategySessionSnapshot) int {
+		switch {
+		case a.ID < b.ID:
+			return -1
+		case a.ID > b.ID:
+			return 1
+		default:
+			return 0
+		}
+	})
+	slices.SortFunc(snapshot.PaperSessions, func(a, b domain.PlatformHealthStrategySessionSnapshot) int {
+		switch {
+		case a.ID < b.ID:
+			return -1
+		case a.ID > b.ID:
+			return 1
+		default:
+			return 0
+		}
+	})
+
+	return snapshot, nil
+}
+
+func currentRuntimePolicyDomain(policy RuntimePolicy) domain.RuntimePolicy {
+	return domain.RuntimePolicy{
+		TradeTickFreshnessSeconds:      policy.TradeTickFreshnessSeconds,
+		OrderBookFreshnessSeconds:      policy.OrderBookFreshnessSeconds,
+		SignalBarFreshnessSeconds:      policy.SignalBarFreshnessSeconds,
+		RuntimeQuietSeconds:            policy.RuntimeQuietSeconds,
+		StrategyEvaluationQuietSeconds: policy.StrategyEvaluationQuietSeconds,
+		LiveAccountSyncFreshnessSecs:   policy.LiveAccountSyncFreshnessSecs,
+		PaperStartReadinessTimeoutSecs: policy.PaperStartReadinessTimeoutSecs,
+	}
+}
+
+func summarizePlatformHealthAlertCounts(alerts []domain.PlatformAlert) domain.PlatformHealthAlertCounts {
+	counts := domain.PlatformHealthAlertCounts{
+		Total: len(alerts),
+	}
+	for _, alert := range alerts {
+		switch strings.ToLower(strings.TrimSpace(alert.Level)) {
+		case "critical":
+			counts.Critical++
+		case "warning":
+			counts.Warning++
+		case "info":
+			counts.Info++
+		}
+	}
+	return counts
+}
+
+func platformHealthStatus(counts domain.PlatformHealthAlertCounts) string {
+	switch {
+	case counts.Critical > 0:
+		return "critical"
+	case counts.Warning > 0:
+		return "warning"
+	default:
+		return "healthy"
+	}
+}
+
+func (p *Platform) platformHealthStrategySessionSnapshot(mode, sessionID, accountID, strategyID, status string, state map[string]any, strategyName string) domain.PlatformHealthStrategySessionSnapshot {
+	sectionRoot := cloneMetadata(mapValue(state["healthSummary"]))
+	return domain.PlatformHealthStrategySessionSnapshot{
+		ID:                           sessionID,
+		Mode:                         mode,
+		AccountID:                    accountID,
+		StrategyID:                   strategyID,
+		StrategyName:                 strategyName,
+		Status:                       status,
+		RuntimeSessionID:             firstNonEmpty(stringValue(state["signalRuntimeSessionId"]), stringValue(state["lastSignalRuntimeSessionId"])),
+		LastSignalRuntimeEventAt:     stringValue(state["lastSignalRuntimeEventAt"]),
+		LastStrategyEvaluationAt:     stringValue(state["lastStrategyEvaluationAt"]),
+		LastStrategyEvaluationStatus: stringValue(state["lastStrategyEvaluationStatus"]),
+		LastSyncedOrderStatus:        firstNonEmpty(stringValue(state["lastSyncedOrderStatus"]), stringValue(state["lastDispatchedOrderStatus"])),
+		EvaluationQuiet:              strings.EqualFold(mode, "LIVE") && p.strategyEvaluationQuiet(state),
+		StrategyIngress:              cloneMetadata(mapValue(sectionRoot["strategyIngress"])),
+		Execution:                    cloneMetadata(mapValue(sectionRoot["execution"])),
+		SourceGate:                   cloneMetadata(mapValue(state["lastStrategyEvaluationSourceGate"])),
+	}
+}

--- a/internal/service/health_snapshot.go
+++ b/internal/service/health_snapshot.go
@@ -159,6 +159,7 @@ func currentRuntimePolicyDomain(policy RuntimePolicy) domain.RuntimePolicy {
 		StrategyEvaluationQuietSeconds: policy.StrategyEvaluationQuietSeconds,
 		LiveAccountSyncFreshnessSecs:   policy.LiveAccountSyncFreshnessSecs,
 		PaperStartReadinessTimeoutSecs: policy.PaperStartReadinessTimeoutSecs,
+		UpdatedAt:                      policy.UpdatedAt,
 	}
 }
 
@@ -204,7 +205,7 @@ func (p *Platform) platformHealthStrategySessionSnapshot(mode, sessionID, accoun
 		LastStrategyEvaluationAt:     stringValue(state["lastStrategyEvaluationAt"]),
 		LastStrategyEvaluationStatus: stringValue(state["lastStrategyEvaluationStatus"]),
 		LastSyncedOrderStatus:        firstNonEmpty(stringValue(state["lastSyncedOrderStatus"]), stringValue(state["lastDispatchedOrderStatus"])),
-		EvaluationQuiet:              strings.EqualFold(mode, "LIVE") && p.strategyEvaluationQuiet(state),
+		EvaluationQuiet:              strings.EqualFold(mode, "LIVE") && strings.EqualFold(status, "RUNNING") && p.strategyEvaluationQuiet(state),
 		StrategyIngress:              cloneMetadata(mapValue(sectionRoot["strategyIngress"])),
 		Execution:                    cloneMetadata(mapValue(sectionRoot["execution"])),
 		SourceGate:                   cloneMetadata(mapValue(state["lastStrategyEvaluationSourceGate"])),

--- a/internal/service/health_snapshot.go
+++ b/internal/service/health_snapshot.go
@@ -205,7 +205,7 @@ func (p *Platform) platformHealthStrategySessionSnapshot(mode, sessionID, accoun
 		LastStrategyEvaluationAt:     stringValue(state["lastStrategyEvaluationAt"]),
 		LastStrategyEvaluationStatus: stringValue(state["lastStrategyEvaluationStatus"]),
 		LastSyncedOrderStatus:        firstNonEmpty(stringValue(state["lastSyncedOrderStatus"]), stringValue(state["lastDispatchedOrderStatus"])),
-		EvaluationQuiet:              strings.EqualFold(mode, "LIVE") && strings.EqualFold(status, "RUNNING") && p.strategyEvaluationQuiet(state),
+		EvaluationQuiet:              p.liveSessionEvaluationQuiet(mode, status, state),
 		StrategyIngress:              cloneMetadata(mapValue(sectionRoot["strategyIngress"])),
 		Execution:                    cloneMetadata(mapValue(sectionRoot["execution"])),
 		SourceGate:                   cloneMetadata(mapValue(state["lastStrategyEvaluationSourceGate"])),

--- a/internal/service/health_state.go
+++ b/internal/service/health_state.go
@@ -1,0 +1,343 @@
+package service
+
+import (
+	"strings"
+	"time"
+
+	"github.com/wuyaocheng/bktrader/internal/domain"
+)
+
+func healthDayKey(ts time.Time) string {
+	if ts.IsZero() {
+		ts = time.Now()
+	}
+	return ts.In(time.Local).Format("2006-01-02")
+}
+
+func ensureHealthSection(container map[string]any, sectionKey string) map[string]any {
+	root := cloneMetadata(mapValue(container["healthSummary"]))
+	section := cloneMetadata(mapValue(root[sectionKey]))
+	root[sectionKey] = section
+	container["healthSummary"] = root
+	return section
+}
+
+func ensureHealthToday(section map[string]any, eventTime time.Time) map[string]any {
+	day := healthDayKey(eventTime)
+	today := cloneMetadata(mapValue(section["today"]))
+	if strings.TrimSpace(stringValue(today["day"])) != day {
+		today = map[string]any{"day": day}
+	}
+	section["today"] = today
+	return today
+}
+
+func incrementHealthToday(section map[string]any, eventTime time.Time, key string, delta int) {
+	if section == nil || delta == 0 {
+		return
+	}
+	today := ensureHealthToday(section, eventTime)
+	today[key] = maxIntValue(today[key], 0) + delta
+}
+
+func accumulateHealthTodayAverage(section map[string]any, eventTime time.Time, sumKey, countKey, avgKey string, value float64) {
+	if section == nil || value == 0 {
+		return
+	}
+	today := ensureHealthToday(section, eventTime)
+	today[sumKey] = parseFloatValue(today[sumKey]) + value
+	today[countKey] = maxIntValue(today[countKey], 0) + 1
+	count := maxIntValue(today[countKey], 0)
+	if count > 0 {
+		today[avgKey] = parseFloatValue(today[sumKey]) / float64(count)
+	}
+}
+
+func updateRuntimeHealthSummary(state map[string]any, summary map[string]any, eventTime time.Time) {
+	if state == nil {
+		return
+	}
+	streamType := strings.ToLower(strings.TrimSpace(firstNonEmpty(
+		stringValue(summary["streamType"]),
+		inferStreamTypeFromEvent(strings.ToLower(strings.TrimSpace(stringValue(summary["event"])))),
+	)))
+	if streamType == "" {
+		return
+	}
+
+	sectionKey := ""
+	switch streamType {
+	case "trade_tick":
+		sectionKey = "tradeTick"
+	case "order_book":
+		sectionKey = "orderBook"
+	default:
+		return
+	}
+
+	section := ensureHealthSection(state, sectionKey)
+	incrementHealthToday(section, eventTime, "eventCount", 1)
+	section["streamType"] = streamType
+	section["lastEventAt"] = eventTime.UTC().Format(time.RFC3339)
+	section["lastSourceKey"] = stringValue(summary["sourceKey"])
+	section["lastEvent"] = firstNonEmpty(stringValue(summary["event"]), stringValue(summary["type"]))
+
+	symbol := NormalizeSymbol(firstNonEmpty(stringValue(summary["subscriptionSymbol"]), stringValue(summary["symbol"])))
+	if symbol != "" {
+		section["lastSymbol"] = symbol
+	}
+
+	switch streamType {
+	case "trade_tick":
+		if price := parseFloatValue(summary["price"]); price > 0 {
+			section["lastPrice"] = price
+		}
+	case "order_book":
+		bestBid := parseFloatValue(summary["bestBid"])
+		bestAsk := parseFloatValue(summary["bestAsk"])
+		bestBidQty := parseFloatValue(summary["bestBidQty"])
+		bestAskQty := parseFloatValue(summary["bestAskQty"])
+		if bestBid > 0 {
+			section["lastBestBid"] = bestBid
+		}
+		if bestAsk > 0 {
+			section["lastBestAsk"] = bestAsk
+		}
+		if bestBidQty > 0 {
+			section["lastBestBidQty"] = bestBidQty
+		}
+		if bestAskQty > 0 {
+			section["lastBestAskQty"] = bestAskQty
+		}
+		if spreadBps := parseFloatValue(summary["spreadBps"]); spreadBps > 0 {
+			section["lastSpreadBps"] = spreadBps
+		}
+		if imbalance := parseFloatValue(summary["imbalance"]); imbalance != 0 {
+			section["lastBookImbalance"] = imbalance
+		}
+	}
+}
+
+func recordStrategyTriggerHealth(state map[string]any, summary map[string]any, eventTime time.Time) {
+	if state == nil {
+		return
+	}
+	section := ensureHealthSection(state, "strategyIngress")
+	incrementHealthToday(section, eventTime, "triggeredCount", 1)
+
+	streamType := strings.ToLower(strings.TrimSpace(firstNonEmpty(
+		stringValue(summary["streamType"]),
+		inferStreamTypeFromEvent(strings.ToLower(strings.TrimSpace(stringValue(summary["event"])))),
+	)))
+	switch streamType {
+	case "trade_tick":
+		incrementHealthToday(section, eventTime, "tradeTickTriggeredCount", 1)
+	case "order_book":
+		incrementHealthToday(section, eventTime, "orderBookTriggeredCount", 1)
+	}
+
+	section["lastTriggeredAt"] = eventTime.UTC().Format(time.RFC3339)
+	section["lastTriggerStreamType"] = streamType
+	section["lastTriggerSymbol"] = NormalizeSymbol(firstNonEmpty(stringValue(summary["subscriptionSymbol"]), stringValue(summary["symbol"])))
+	section["lastRuntimeEvent"] = firstNonEmpty(stringValue(summary["event"]), stringValue(summary["type"]))
+}
+
+func recordStrategySourceGateHealth(state map[string]any, sourceGate map[string]any, eventTime time.Time) {
+	if state == nil {
+		return
+	}
+	section := ensureHealthSection(state, "strategyIngress")
+	missingCount := len(metadataList(sourceGate["missing"]))
+	staleCount := len(metadataList(sourceGate["stale"]))
+	section["lastSourceGateAt"] = eventTime.UTC().Format(time.RFC3339)
+	section["lastSourceGateReady"] = boolValue(sourceGate["ready"])
+	section["lastSourceGateMissingCount"] = missingCount
+	section["lastSourceGateStaleCount"] = staleCount
+	if !boolValue(sourceGate["ready"]) {
+		incrementHealthToday(section, eventTime, "sourceGateBlockedCount", 1)
+		incrementHealthToday(section, eventTime, "sourceGateMissingCount", missingCount)
+		incrementHealthToday(section, eventTime, "sourceGateStaleCount", staleCount)
+	}
+}
+
+func recordStrategyDecisionHealth(state map[string]any, decision StrategySignalDecision, eventTime time.Time) {
+	if state == nil {
+		return
+	}
+	section := ensureHealthSection(state, "strategyIngress")
+	incrementHealthToday(section, eventTime, "evaluatedCount", 1)
+
+	action := strings.ToLower(strings.TrimSpace(decision.Action))
+	reason := strings.ToLower(strings.TrimSpace(decision.Reason))
+	switch action {
+	case "wait":
+		incrementHealthToday(section, eventTime, "waitCount", 1)
+	case "advance-plan":
+		incrementHealthToday(section, eventTime, "advancePlanCount", 1)
+	}
+
+	section["lastEvaluationAt"] = eventTime.UTC().Format(time.RFC3339)
+	section["lastDecisionAction"] = decision.Action
+	section["lastDecisionReason"] = decision.Reason
+	section["lastDecisionState"] = stringValue(decision.Metadata["decisionState"])
+	section["lastSignalKind"] = stringValue(decision.Metadata["signalKind"])
+	if marketPrice := parseFloatValue(decision.Metadata["marketPrice"]); marketPrice > 0 {
+		section["lastMarketPrice"] = marketPrice
+	}
+
+	bestBid := parseFloatValue(decision.Metadata["bestBid"])
+	bestAsk := parseFloatValue(decision.Metadata["bestAsk"])
+	spreadBps := parseFloatValue(decision.Metadata["spreadBps"])
+	imbalance := parseFloatValue(decision.Metadata["bookImbalance"])
+	hasOrderBookContext := bestBid > 0 || bestAsk > 0 || spreadBps > 0 || strings.TrimSpace(stringValue(decision.Metadata["liquidityBias"])) != ""
+	if !hasOrderBookContext {
+		return
+	}
+
+	incrementHealthToday(section, eventTime, "orderBookEvaluatedCount", 1)
+	section["lastOrderBookUsedAt"] = eventTime.UTC().Format(time.RFC3339)
+	section["lastLiquidityBias"] = stringValue(decision.Metadata["liquidityBias"])
+	if bestBid > 0 {
+		section["lastBestBid"] = bestBid
+	}
+	if bestAsk > 0 {
+		section["lastBestAsk"] = bestAsk
+	}
+	if spreadBps > 0 {
+		section["lastSpreadBps"] = spreadBps
+		accumulateHealthTodayAverage(section, eventTime, "spreadBpsSum", "spreadBpsSampleCount", "avgSpreadBps", spreadBps)
+	}
+	if imbalance != 0 {
+		section["lastBookImbalance"] = imbalance
+		accumulateHealthTodayAverage(section, eventTime, "bookImbalanceSum", "bookImbalanceSampleCount", "avgBookImbalance", imbalance)
+	}
+	if reason == "spread-too-wide" || reason == "bias-unfavorable" {
+		incrementHealthToday(section, eventTime, "orderBookBlockedCount", 1)
+	}
+}
+
+func recordStrategyDecisionErrorHealth(state map[string]any, eventTime time.Time, err error) {
+	if state == nil || err == nil {
+		return
+	}
+	section := ensureHealthSection(state, "strategyIngress")
+	incrementHealthToday(section, eventTime, "decisionErrorCount", 1)
+	section["lastDecisionErrorAt"] = eventTime.UTC().Format(time.RFC3339)
+	section["lastDecisionError"] = err.Error()
+}
+
+func recordExecutionPlanningHealth(state map[string]any, executionProposal map[string]any, eventTime time.Time) {
+	if state == nil || len(executionProposal) == 0 {
+		return
+	}
+	section := ensureHealthSection(state, "execution")
+	incrementHealthToday(section, eventTime, "intentReadyCount", 1)
+
+	status := strings.ToLower(strings.TrimSpace(stringValue(executionProposal["status"])))
+	if status == "dispatchable" {
+		incrementHealthToday(section, eventTime, "dispatchableIntentCount", 1)
+	}
+
+	section["lastIntentAt"] = eventTime.UTC().Format(time.RFC3339)
+	section["lastProposalStatus"] = status
+	section["lastExecutionStrategy"] = stringValue(executionProposal["executionStrategy"])
+	section["lastExecutionDecision"] = stringValue(mapValue(executionProposal["metadata"])["executionDecision"])
+}
+
+func recordExecutionPlanningErrorHealth(state map[string]any, eventTime time.Time, err error) {
+	if state == nil || err == nil {
+		return
+	}
+	section := ensureHealthSection(state, "execution")
+	incrementHealthToday(section, eventTime, "planningErrorCount", 1)
+	section["lastPlanningErrorAt"] = eventTime.UTC().Format(time.RFC3339)
+	section["lastPlanningError"] = err.Error()
+}
+
+func recordExecutionDispatchHealth(state map[string]any, order domain.Order, eventTime time.Time, dispatchErr error) {
+	if state == nil {
+		return
+	}
+	section := ensureHealthSection(state, "execution")
+	section["lastDispatchAt"] = eventTime.UTC().Format(time.RFC3339)
+	if order.ID != "" || strings.TrimSpace(order.Status) != "" {
+		incrementHealthToday(section, eventTime, "dispatchCount", 1)
+		if order.ID != "" {
+			section["lastOrderId"] = order.ID
+		}
+		section["lastOrderStatus"] = order.Status
+		section["lastOrderType"] = order.Type
+		section["lastOrderSymbol"] = NormalizeSymbol(order.Symbol)
+	}
+	if dispatchErr != nil {
+		incrementHealthToday(section, eventTime, "dispatchErrorCount", 1)
+		section["lastDispatchErrorAt"] = eventTime.UTC().Format(time.RFC3339)
+		section["lastDispatchError"] = dispatchErr.Error()
+		return
+	}
+	delete(section, "lastDispatchErrorAt")
+	delete(section, "lastDispatchError")
+}
+
+func recordExecutionSyncAttemptHealth(state map[string]any, eventTime time.Time) {
+	if state == nil {
+		return
+	}
+	section := ensureHealthSection(state, "execution")
+	incrementHealthToday(section, eventTime, "syncAttemptCount", 1)
+	section["lastSyncAttemptAt"] = eventTime.UTC().Format(time.RFC3339)
+}
+
+func recordExecutionSyncResultHealth(state map[string]any, eventTime time.Time, status string, syncErr error) {
+	if state == nil {
+		return
+	}
+	section := ensureHealthSection(state, "execution")
+	if syncErr != nil {
+		incrementHealthToday(section, eventTime, "syncErrorCount", 1)
+		section["lastSyncErrorAt"] = eventTime.UTC().Format(time.RFC3339)
+		section["lastSyncError"] = syncErr.Error()
+		return
+	}
+	incrementHealthToday(section, eventTime, "syncSuccessCount", 1)
+	section["lastSyncSuccessAt"] = eventTime.UTC().Format(time.RFC3339)
+	section["lastSyncedOrderStatus"] = status
+	delete(section, "lastSyncErrorAt")
+	delete(section, "lastSyncError")
+}
+
+func updateAccountSyncSuccessHealth(account *domain.Account, syncedAt time.Time, previousSuccessAt time.Time) {
+	if account == nil {
+		return
+	}
+	account.Metadata = cloneMetadata(account.Metadata)
+	section := ensureHealthSection(account.Metadata, "accountSync")
+	incrementHealthToday(section, syncedAt, "syncCount", 1)
+
+	snapshot := cloneMetadata(mapValue(account.Metadata["liveSyncSnapshot"]))
+	section["lastAttemptAt"] = syncedAt.UTC().Format(time.RFC3339)
+	section["lastSuccessAt"] = syncedAt.UTC().Format(time.RFC3339)
+	section["lastStatus"] = firstNonEmpty(stringValue(snapshot["syncStatus"]), "SYNCED")
+	section["lastSource"] = firstNonEmpty(stringValue(snapshot["source"]), stringValue(snapshot["adapterKey"]))
+	section["positionCount"] = maxIntValue(snapshot["positionCount"], 0)
+	section["openOrderCount"] = maxIntValue(snapshot["openOrderCount"], 0)
+	section["consecutiveErrorCount"] = 0
+	if !previousSuccessAt.IsZero() && syncedAt.After(previousSuccessAt) {
+		section["lastSyncGapSeconds"] = int(syncedAt.Sub(previousSuccessAt).Seconds())
+	}
+	delete(section, "lastError")
+	delete(section, "lastErrorAt")
+}
+
+func updateAccountSyncFailureHealth(account *domain.Account, attemptedAt time.Time, err error) {
+	if account == nil || err == nil {
+		return
+	}
+	account.Metadata = cloneMetadata(account.Metadata)
+	section := ensureHealthSection(account.Metadata, "accountSync")
+	incrementHealthToday(section, attemptedAt, "errorCount", 1)
+	section["lastAttemptAt"] = attemptedAt.UTC().Format(time.RFC3339)
+	section["lastErrorAt"] = attemptedAt.UTC().Format(time.RFC3339)
+	section["lastError"] = err.Error()
+	section["consecutiveErrorCount"] = maxIntValue(section["consecutiveErrorCount"], 0) + 1
+}

--- a/internal/service/health_state_test.go
+++ b/internal/service/health_state_test.go
@@ -192,6 +192,9 @@ func TestLiveAccountSyncStaleAndRefreshThreshold(t *testing.T) {
 func TestHealthSnapshotAggregatesBackendHealthState(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
 	now := time.Now().UTC()
+	policy := platform.RuntimePolicy()
+	policy.UpdatedAt = now
+	platform.SetRuntimePolicy(policy)
 
 	account, err := platform.store.GetAccount("live-main")
 	if err != nil {
@@ -234,6 +237,26 @@ func TestHealthSnapshotAggregatesBackendHealthState(t *testing.T) {
 	}
 	if _, err := platform.store.UpdateLiveSessionState("live-session-main", liveState); err != nil {
 		t.Fatalf("update live session state failed: %v", err)
+	}
+	stoppedSession, err := platform.CreateLiveSession("live-main", "strategy-bk-1d", map[string]any{
+		"symbol":          "BTCUSDT",
+		"signalTimeframe": "1d",
+	})
+	if err != nil {
+		t.Fatalf("create stopped live session failed: %v", err)
+	}
+	if _, err := platform.store.UpdateLiveSessionStatus(stoppedSession.ID, "STOPPED"); err != nil {
+		t.Fatalf("update stopped live session status failed: %v", err)
+	}
+	if _, err := platform.store.UpdateLiveSessionState(stoppedSession.ID, map[string]any{
+		"lastSignalRuntimeEventAt": now.Add(-1 * time.Minute).Format(time.RFC3339),
+		"healthSummary": map[string]any{
+			"strategyIngress": map[string]any{
+				"lastTriggeredAt": now.Add(-1 * time.Minute).Format(time.RFC3339),
+			},
+		},
+	}); err != nil {
+		t.Fatalf("update stopped live session state failed: %v", err)
 	}
 
 	paperAccount, err := platform.CreateAccount("Paper", "PAPER", "binance-futures")
@@ -291,11 +314,14 @@ func TestHealthSnapshotAggregatesBackendHealthState(t *testing.T) {
 	if len(snapshot.RuntimeSessions) != 1 {
 		t.Fatalf("expected 1 runtime snapshot, got %d", len(snapshot.RuntimeSessions))
 	}
-	if len(snapshot.LiveSessions) != 1 {
-		t.Fatalf("expected 1 live session snapshot, got %d", len(snapshot.LiveSessions))
+	if len(snapshot.LiveSessions) != 2 {
+		t.Fatalf("expected 2 live session snapshots, got %d", len(snapshot.LiveSessions))
 	}
 	if len(snapshot.PaperSessions) != 1 {
 		t.Fatalf("expected 1 paper session snapshot, got %d", len(snapshot.PaperSessions))
+	}
+	if snapshot.RuntimePolicy.UpdatedAt.IsZero() {
+		t.Fatal("expected runtime policy updatedAt to be populated")
 	}
 	if got := snapshot.LiveAccounts[0].RuntimeSessionCount; got != 1 {
 		t.Fatalf("expected runtime session count 1, got %d", got)
@@ -306,8 +332,15 @@ func TestHealthSnapshotAggregatesBackendHealthState(t *testing.T) {
 	if got := parseFloatValue(snapshot.RuntimeSessions[0].TradeTick["lastPrice"]); got != 68000.0 {
 		t.Fatalf("expected trade tick last price 68000, got %v", got)
 	}
-	if got := snapshot.LiveSessions[0].RuntimeSessionID; got != "runtime-1" {
+	liveSnapshotsByID := make(map[string]domain.PlatformHealthStrategySessionSnapshot, len(snapshot.LiveSessions))
+	for _, item := range snapshot.LiveSessions {
+		liveSnapshotsByID[item.ID] = item
+	}
+	if got := liveSnapshotsByID["live-session-main"].RuntimeSessionID; got != "runtime-1" {
 		t.Fatalf("expected live session runtime id runtime-1, got %s", got)
+	}
+	if liveSnapshotsByID[stoppedSession.ID].EvaluationQuiet {
+		t.Fatal("expected stopped live session to suppress evaluationQuiet")
 	}
 	if got := snapshot.PaperSessions[0].Mode; got != "PAPER" {
 		t.Fatalf("expected paper session mode PAPER, got %s", got)

--- a/internal/service/health_state_test.go
+++ b/internal/service/health_state_test.go
@@ -144,6 +144,16 @@ func TestStrategyEvaluationQuietUsesLatestTrigger(t *testing.T) {
 	if platform.strategyEvaluationQuiet(state) {
 		t.Fatal("expected strategy evaluation quiet to clear once evaluation catches up")
 	}
+	state["healthSummary"] = map[string]any{
+		"strategyIngress": map[string]any{
+			"lastTriggeredAt":  now.Add(-20 * time.Second).Format(time.RFC3339),
+			"lastEvaluationAt": now.Add(-40 * time.Second).Format(time.RFC3339),
+		},
+	}
+	state["lastStrategyEvaluationAt"] = now.Add(-5 * time.Second).Format(time.RFC3339)
+	if platform.strategyEvaluationQuiet(state) {
+		t.Fatal("expected newer lastStrategyEvaluationAt to suppress quiet alert even when healthSummary lags")
+	}
 }
 
 func TestLiveAccountSyncStaleAndRefreshThreshold(t *testing.T) {

--- a/internal/service/health_state_test.go
+++ b/internal/service/health_state_test.go
@@ -1,0 +1,315 @@
+package service
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/wuyaocheng/bktrader/internal/domain"
+	"github.com/wuyaocheng/bktrader/internal/store/memory"
+)
+
+func TestUpdateRuntimeHealthSummaryResetsDailyBucket(t *testing.T) {
+	originalLocal := time.Local
+	loc := time.FixedZone("UTC+8", 8*60*60)
+	time.Local = loc
+	defer func() {
+		time.Local = originalLocal
+	}()
+
+	state := map[string]any{}
+	updateRuntimeHealthSummary(state, map[string]any{
+		"streamType": "trade_tick",
+		"symbol":     "BTCUSDT",
+		"price":      64000.5,
+	}, time.Date(2026, 4, 14, 9, 0, 0, 0, loc))
+	updateRuntimeHealthSummary(state, map[string]any{
+		"streamType": "trade_tick",
+		"symbol":     "BTCUSDT",
+		"price":      64010.5,
+	}, time.Date(2026, 4, 15, 9, 0, 0, 0, loc))
+
+	health := mapValue(state["healthSummary"])
+	tradeTick := mapValue(health["tradeTick"])
+	today := mapValue(tradeTick["today"])
+	if got := stringValue(today["day"]); got != "2026-04-15" {
+		t.Fatalf("expected latest local day 2026-04-15, got %s", got)
+	}
+	if got := maxIntValue(today["eventCount"], 0); got != 1 {
+		t.Fatalf("expected daily event count reset to 1, got %d", got)
+	}
+	if got := NormalizeSymbol(stringValue(tradeTick["lastSymbol"])); got != "BTCUSDT" {
+		t.Fatalf("expected last symbol BTCUSDT, got %s", got)
+	}
+	if got := parseFloatValue(tradeTick["lastPrice"]); got != 64010.5 {
+		t.Fatalf("expected last price 64010.5, got %v", got)
+	}
+}
+
+func TestRecordStrategyDecisionHealthTracksOrderBookUsage(t *testing.T) {
+	state := map[string]any{}
+	eventTime := time.Date(2026, 4, 14, 10, 30, 0, 0, time.UTC)
+	recordStrategyDecisionHealth(state, StrategySignalDecision{
+		Action: "wait",
+		Reason: "spread-too-wide",
+		Metadata: map[string]any{
+			"decisionState": "waiting-price",
+			"signalKind":    "initial-entry-watch",
+			"bestBid":       100.0,
+			"bestAsk":       100.1,
+			"spreadBps":     10.0,
+			"bookImbalance": 0.25,
+			"liquidityBias": "ask-heavy",
+			"marketPrice":   100.05,
+		},
+	}, eventTime)
+
+	health := mapValue(state["healthSummary"])
+	ingress := mapValue(health["strategyIngress"])
+	today := mapValue(ingress["today"])
+	if got := maxIntValue(today["evaluatedCount"], 0); got != 1 {
+		t.Fatalf("expected evaluatedCount 1, got %d", got)
+	}
+	if got := maxIntValue(today["waitCount"], 0); got != 1 {
+		t.Fatalf("expected waitCount 1, got %d", got)
+	}
+	if got := maxIntValue(today["orderBookEvaluatedCount"], 0); got != 1 {
+		t.Fatalf("expected orderBookEvaluatedCount 1, got %d", got)
+	}
+	if got := maxIntValue(today["orderBookBlockedCount"], 0); got != 1 {
+		t.Fatalf("expected orderBookBlockedCount 1, got %d", got)
+	}
+	if got := parseFloatValue(today["avgSpreadBps"]); got != 10.0 {
+		t.Fatalf("expected avgSpreadBps 10.0, got %v", got)
+	}
+	if got := stringValue(ingress["lastLiquidityBias"]); got != "ask-heavy" {
+		t.Fatalf("expected liquidity bias ask-heavy, got %s", got)
+	}
+}
+
+func TestAccountSyncHealthTracksGapAndFailures(t *testing.T) {
+	account := domain.Account{
+		Metadata: map[string]any{
+			"liveSyncSnapshot": map[string]any{
+				"syncStatus":     "SYNCED",
+				"source":         "binance-rest-account-v3",
+				"positionCount":  2,
+				"openOrderCount": 1,
+			},
+		},
+	}
+	prevSuccessAt := time.Date(2026, 4, 14, 9, 0, 0, 0, time.UTC)
+	syncedAt := prevSuccessAt.Add(45 * time.Second)
+	updateAccountSyncSuccessHealth(&account, syncedAt, prevSuccessAt)
+	updateAccountSyncFailureHealth(&account, syncedAt.Add(30*time.Second), errors.New("sync failed"))
+
+	health := mapValue(account.Metadata["healthSummary"])
+	accountSync := mapValue(health["accountSync"])
+	today := mapValue(accountSync["today"])
+	if got := maxIntValue(today["syncCount"], 0); got != 1 {
+		t.Fatalf("expected syncCount 1, got %d", got)
+	}
+	if got := maxIntValue(today["errorCount"], 0); got != 1 {
+		t.Fatalf("expected errorCount 1, got %d", got)
+	}
+	if got := maxIntValue(accountSync["lastSyncGapSeconds"], 0); got != 45 {
+		t.Fatalf("expected lastSyncGapSeconds 45, got %d", got)
+	}
+	if got := maxIntValue(accountSync["consecutiveErrorCount"], 0); got != 1 {
+		t.Fatalf("expected consecutiveErrorCount 1, got %d", got)
+	}
+	if got := stringValue(accountSync["lastError"]); got != "sync failed" {
+		t.Fatalf("expected lastError sync failed, got %s", got)
+	}
+}
+
+func TestStrategyEvaluationQuietUsesLatestTrigger(t *testing.T) {
+	platform := &Platform{
+		runtimePolicy: RuntimePolicy{
+			StrategyEvaluationQuietSeconds: 15,
+		},
+	}
+	now := time.Now().UTC()
+	state := map[string]any{
+		"healthSummary": map[string]any{
+			"strategyIngress": map[string]any{
+				"lastTriggeredAt": now.Add(-20 * time.Second).Format(time.RFC3339),
+			},
+		},
+	}
+	if !platform.strategyEvaluationQuiet(state) {
+		t.Fatal("expected strategy evaluation to be quiet when trigger is stale and no evaluation exists")
+	}
+	state["lastStrategyEvaluationAt"] = now.Add(-5 * time.Second).Format(time.RFC3339)
+	if platform.strategyEvaluationQuiet(state) {
+		t.Fatal("expected strategy evaluation quiet to clear once evaluation catches up")
+	}
+}
+
+func TestLiveAccountSyncStaleAndRefreshThreshold(t *testing.T) {
+	platform := &Platform{
+		runtimePolicy: RuntimePolicy{
+			LiveAccountSyncFreshnessSecs: 60,
+		},
+	}
+	now := time.Now().UTC()
+	account := domain.Account{
+		ID: "live-1",
+		Metadata: map[string]any{
+			"healthSummary": map[string]any{
+				"accountSync": map[string]any{
+					"lastSuccessAt": now.Add(-61 * time.Second).Format(time.RFC3339),
+				},
+			},
+			"lastLiveSyncAt": now.Add(-61 * time.Second).Format(time.RFC3339),
+		},
+	}
+	stale, ageSeconds := platform.liveAccountSyncStale(account, now)
+	if !stale {
+		t.Fatal("expected live account sync to be stale")
+	}
+	if ageSeconds < 61 {
+		t.Fatalf("expected stale age at least 61 seconds, got %d", ageSeconds)
+	}
+	if !platform.shouldRefreshLiveAccountSync(account, now) {
+		t.Fatal("expected live account refresh to be requested once threshold is exceeded")
+	}
+	account.Metadata["lastLiveSyncAt"] = now.Add(-30 * time.Second).Format(time.RFC3339)
+	account.Metadata["healthSummary"] = map[string]any{
+		"accountSync": map[string]any{
+			"lastSuccessAt": now.Add(-30 * time.Second).Format(time.RFC3339),
+		},
+	}
+	stale, _ = platform.liveAccountSyncStale(account, now)
+	if stale {
+		t.Fatal("expected live account sync to be fresh under threshold")
+	}
+	if platform.shouldRefreshLiveAccountSync(account, now) {
+		t.Fatal("did not expect live account refresh under threshold")
+	}
+}
+
+func TestHealthSnapshotAggregatesBackendHealthState(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	now := time.Now().UTC()
+
+	account, err := platform.store.GetAccount("live-main")
+	if err != nil {
+		t.Fatalf("get live account failed: %v", err)
+	}
+	account.Status = "CONFIGURED"
+	account.Metadata = cloneMetadata(account.Metadata)
+	account.Metadata["lastLiveSyncAt"] = now.Add(-20 * time.Second).Format(time.RFC3339)
+	account.Metadata["healthSummary"] = map[string]any{
+		"accountSync": map[string]any{
+			"lastSuccessAt":         now.Add(-20 * time.Second).Format(time.RFC3339),
+			"lastStatus":            "SYNCED",
+			"consecutiveErrorCount": 0,
+		},
+	}
+	if _, err := platform.store.UpdateAccount(account); err != nil {
+		t.Fatalf("update live account failed: %v", err)
+	}
+
+	if _, err := platform.store.UpdateLiveSessionStatus("live-session-main", "RUNNING"); err != nil {
+		t.Fatalf("update live session status failed: %v", err)
+	}
+	liveState := map[string]any{
+		"signalRuntimeSessionId":           "runtime-1",
+		"lastSignalRuntimeEventAt":         now.Add(-5 * time.Second).Format(time.RFC3339),
+		"lastStrategyEvaluationAt":         now.Add(-3 * time.Second).Format(time.RFC3339),
+		"lastStrategyEvaluationStatus":     "evaluated",
+		"lastSyncedOrderStatus":            "FILLED",
+		"lastStrategyEvaluationSourceGate": map[string]any{"ready": true},
+		"healthSummary": map[string]any{
+			"strategyIngress": map[string]any{
+				"lastTriggeredAt":  now.Add(-5 * time.Second).Format(time.RFC3339),
+				"lastEvaluationAt": now.Add(-3 * time.Second).Format(time.RFC3339),
+			},
+			"execution": map[string]any{
+				"lastDispatchAt":     now.Add(-2 * time.Second).Format(time.RFC3339),
+				"lastProposalStatus": "dispatchable",
+			},
+		},
+	}
+	if _, err := platform.store.UpdateLiveSessionState("live-session-main", liveState); err != nil {
+		t.Fatalf("update live session state failed: %v", err)
+	}
+
+	paperAccount, err := platform.CreateAccount("Paper", "PAPER", "binance-futures")
+	if err != nil {
+		t.Fatalf("create paper account failed: %v", err)
+	}
+	paperSession, err := platform.store.CreatePaperSession(paperAccount.ID, "strategy-bk-1d", 1000)
+	if err != nil {
+		t.Fatalf("create paper session failed: %v", err)
+	}
+	paperState := map[string]any{
+		"lastStrategyEvaluationAt":     now.Add(-4 * time.Second).Format(time.RFC3339),
+		"lastStrategyEvaluationStatus": "waiting-decision",
+		"healthSummary": map[string]any{
+			"strategyIngress": map[string]any{
+				"lastTriggeredAt": now.Add(-6 * time.Second).Format(time.RFC3339),
+			},
+		},
+	}
+	if _, err := platform.store.UpdatePaperSessionState(paperSession.ID, paperState); err != nil {
+		t.Fatalf("update paper session state failed: %v", err)
+	}
+
+	platform.signalSessions["runtime-1"] = domain.SignalRuntimeSession{
+		ID:         "runtime-1",
+		AccountID:  "live-main",
+		StrategyID: "strategy-bk-1d",
+		Status:     "RUNNING",
+		Transport:  "websocket",
+		State: map[string]any{
+			"health":          "healthy",
+			"lastEventAt":     now.Add(-1 * time.Second).Format(time.RFC3339),
+			"lastHeartbeatAt": now.Add(-1 * time.Second).Format(time.RFC3339),
+			"healthSummary": map[string]any{
+				"tradeTick": map[string]any{
+					"lastPrice": 68000.0,
+				},
+				"orderBook": map[string]any{
+					"lastBestBid": 67999.0,
+					"lastBestAsk": 68001.0,
+				},
+			},
+		},
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+
+	snapshot, err := platform.HealthSnapshot()
+	if err != nil {
+		t.Fatalf("build health snapshot failed: %v", err)
+	}
+	if len(snapshot.LiveAccounts) != 1 {
+		t.Fatalf("expected 1 live account snapshot, got %d", len(snapshot.LiveAccounts))
+	}
+	if len(snapshot.RuntimeSessions) != 1 {
+		t.Fatalf("expected 1 runtime snapshot, got %d", len(snapshot.RuntimeSessions))
+	}
+	if len(snapshot.LiveSessions) != 1 {
+		t.Fatalf("expected 1 live session snapshot, got %d", len(snapshot.LiveSessions))
+	}
+	if len(snapshot.PaperSessions) != 1 {
+		t.Fatalf("expected 1 paper session snapshot, got %d", len(snapshot.PaperSessions))
+	}
+	if got := snapshot.LiveAccounts[0].RuntimeSessionCount; got != 1 {
+		t.Fatalf("expected runtime session count 1, got %d", got)
+	}
+	if got := snapshot.RuntimeSessions[0].Health; got != "healthy" {
+		t.Fatalf("expected runtime health healthy, got %s", got)
+	}
+	if got := parseFloatValue(snapshot.RuntimeSessions[0].TradeTick["lastPrice"]); got != 68000.0 {
+		t.Fatalf("expected trade tick last price 68000, got %v", got)
+	}
+	if got := snapshot.LiveSessions[0].RuntimeSessionID; got != "runtime-1" {
+		t.Fatalf("expected live session runtime id runtime-1, got %s", got)
+	}
+	if got := snapshot.PaperSessions[0].Mode; got != "PAPER" {
+		t.Fatalf("expected paper session mode PAPER, got %s", got)
+	}
+}

--- a/internal/service/health_state_test.go
+++ b/internal/service/health_state_test.go
@@ -222,6 +222,81 @@ func TestUpdateRuntimePolicyAllowsDisablingHealthThresholds(t *testing.T) {
 	}
 }
 
+func TestLoadPersistedRuntimePolicyKeepsDisabledHealthThresholds(t *testing.T) {
+	store := memory.NewStore()
+	platform := NewPlatform(store)
+	updated, err := platform.UpdateRuntimePolicy(RuntimePolicy{
+		TradeTickFreshnessSeconds:      15,
+		OrderBookFreshnessSeconds:      10,
+		SignalBarFreshnessSeconds:      30,
+		RuntimeQuietSeconds:            30,
+		StrategyEvaluationQuietSeconds: 0,
+		LiveAccountSyncFreshnessSecs:   0,
+		PaperStartReadinessTimeoutSecs: 5,
+	})
+	if err != nil {
+		t.Fatalf("update runtime policy failed: %v", err)
+	}
+
+	reloaded := NewPlatform(store)
+	if err := reloaded.LoadPersistedRuntimePolicy(); err != nil {
+		t.Fatalf("load persisted runtime policy failed: %v", err)
+	}
+	current := reloaded.RuntimePolicy()
+	if current.StrategyEvaluationQuietSeconds != 0 {
+		t.Fatalf("expected persisted strategy evaluation quiet threshold 0, got %d", current.StrategyEvaluationQuietSeconds)
+	}
+	if current.LiveAccountSyncFreshnessSecs != 0 {
+		t.Fatalf("expected persisted live account sync freshness threshold 0, got %d", current.LiveAccountSyncFreshnessSecs)
+	}
+	if current.UpdatedAt.IsZero() {
+		t.Fatal("expected persisted runtime policy updatedAt to be populated")
+	}
+
+	snapshot, err := reloaded.HealthSnapshot()
+	if err != nil {
+		t.Fatalf("build health snapshot failed: %v", err)
+	}
+	if snapshot.RuntimePolicy.StrategyEvaluationQuietSeconds != 0 {
+		t.Fatalf("expected health snapshot strategy evaluation quiet threshold 0, got %d", snapshot.RuntimePolicy.StrategyEvaluationQuietSeconds)
+	}
+	if snapshot.RuntimePolicy.LiveAccountSyncFreshnessSecs != 0 {
+		t.Fatalf("expected health snapshot live account sync freshness threshold 0, got %d", snapshot.RuntimePolicy.LiveAccountSyncFreshnessSecs)
+	}
+	if snapshot.RuntimePolicy.UpdatedAt != updated.UpdatedAt {
+		t.Fatalf("expected health snapshot updatedAt %s, got %s", updated.UpdatedAt.Format(time.RFC3339), snapshot.RuntimePolicy.UpdatedAt.Format(time.RFC3339))
+	}
+
+	staleState := map[string]any{
+		"healthSummary": map[string]any{
+			"strategyIngress": map[string]any{
+				"lastTriggeredAt": time.Now().UTC().Add(-5 * time.Minute).Format(time.RFC3339),
+			},
+		},
+	}
+	if reloaded.strategyEvaluationQuiet(staleState) {
+		t.Fatal("expected strategy evaluation quiet to stay disabled when threshold is 0")
+	}
+
+	account := domain.Account{
+		CreatedAt: time.Now().UTC().Add(-10 * time.Minute),
+		Metadata: map[string]any{
+			"lastLiveSyncAt": time.Now().UTC().Add(-10 * time.Minute).Format(time.RFC3339),
+			"healthSummary": map[string]any{
+				"accountSync": map[string]any{
+					"lastSuccessAt": time.Now().UTC().Add(-10 * time.Minute).Format(time.RFC3339),
+				},
+			},
+		},
+	}
+	if stale, _ := reloaded.liveAccountSyncStale(account, time.Now().UTC()); stale {
+		t.Fatal("expected live account sync stale to stay disabled when threshold is 0")
+	}
+	if reloaded.shouldRefreshLiveAccountSync(account, time.Now().UTC()) {
+		t.Fatal("expected live account refresh to stay disabled when threshold is 0")
+	}
+}
+
 func TestHealthSnapshotAggregatesBackendHealthState(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
 	now := time.Now().UTC()
@@ -377,5 +452,81 @@ func TestHealthSnapshotAggregatesBackendHealthState(t *testing.T) {
 	}
 	if got := snapshot.PaperSessions[0].Mode; got != "PAPER" {
 		t.Fatalf("expected paper session mode PAPER, got %s", got)
+	}
+}
+
+func TestLiveSessionEvaluationQuietMatchesAlertsAndSnapshot(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	now := time.Now().UTC()
+
+	session, err := platform.store.GetLiveSession("live-session-main")
+	if err != nil {
+		t.Fatalf("get live session failed: %v", err)
+	}
+	state := cloneMetadata(session.State)
+	state["healthSummary"] = map[string]any{
+		"strategyIngress": map[string]any{
+			"lastTriggeredAt": now.Add(-30 * time.Second).Format(time.RFC3339),
+		},
+	}
+	state["lastSignalRuntimeEventAt"] = now.Add(-30 * time.Second).Format(time.RFC3339)
+	session.State = state
+	session.Status = "RUNNING"
+	if _, err := platform.store.UpdateLiveSession(session); err != nil {
+		t.Fatalf("update live session failed: %v", err)
+	}
+
+	alerts, err := platform.ListAlerts()
+	if err != nil {
+		t.Fatalf("list alerts failed: %v", err)
+	}
+	foundQuietAlert := false
+	for _, alert := range alerts {
+		if alert.ID == "live-strategy-eval-quiet-"+session.ID {
+			foundQuietAlert = true
+			break
+		}
+	}
+	if !foundQuietAlert {
+		t.Fatal("expected running live session quiet alert to be present")
+	}
+
+	snapshot, err := platform.HealthSnapshot()
+	if err != nil {
+		t.Fatalf("build health snapshot failed: %v", err)
+	}
+	liveSnapshotsByID := make(map[string]domain.PlatformHealthStrategySessionSnapshot, len(snapshot.LiveSessions))
+	for _, item := range snapshot.LiveSessions {
+		liveSnapshotsByID[item.ID] = item
+	}
+	if !liveSnapshotsByID[session.ID].EvaluationQuiet {
+		t.Fatal("expected running live session snapshot to report evaluationQuiet")
+	}
+
+	session.Status = "STOPPED"
+	if _, err := platform.store.UpdateLiveSession(session); err != nil {
+		t.Fatalf("stop live session failed: %v", err)
+	}
+
+	alerts, err = platform.ListAlerts()
+	if err != nil {
+		t.Fatalf("list alerts after stop failed: %v", err)
+	}
+	for _, alert := range alerts {
+		if alert.ID == "live-strategy-eval-quiet-"+session.ID {
+			t.Fatal("expected stopped live session quiet alert to be suppressed")
+		}
+	}
+
+	snapshot, err = platform.HealthSnapshot()
+	if err != nil {
+		t.Fatalf("build health snapshot after stop failed: %v", err)
+	}
+	liveSnapshotsByID = make(map[string]domain.PlatformHealthStrategySessionSnapshot, len(snapshot.LiveSessions))
+	for _, item := range snapshot.LiveSessions {
+		liveSnapshotsByID[item.ID] = item
+	}
+	if liveSnapshotsByID[session.ID].EvaluationQuiet {
+		t.Fatal("expected stopped live session snapshot to suppress evaluationQuiet")
 	}
 }

--- a/internal/service/health_state_test.go
+++ b/internal/service/health_state_test.go
@@ -189,6 +189,29 @@ func TestLiveAccountSyncStaleAndRefreshThreshold(t *testing.T) {
 	}
 }
 
+func TestUpdateRuntimePolicyAllowsDisablingHealthThresholds(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+
+	updated, err := platform.UpdateRuntimePolicy(RuntimePolicy{
+		TradeTickFreshnessSeconds:      15,
+		OrderBookFreshnessSeconds:      10,
+		SignalBarFreshnessSeconds:      30,
+		RuntimeQuietSeconds:            30,
+		StrategyEvaluationQuietSeconds: 0,
+		LiveAccountSyncFreshnessSecs:   0,
+		PaperStartReadinessTimeoutSecs: 5,
+	})
+	if err != nil {
+		t.Fatalf("update runtime policy failed: %v", err)
+	}
+	if updated.StrategyEvaluationQuietSeconds != 0 {
+		t.Fatalf("expected strategy evaluation quiet threshold to allow zero, got %d", updated.StrategyEvaluationQuietSeconds)
+	}
+	if updated.LiveAccountSyncFreshnessSecs != 0 {
+		t.Fatalf("expected live account sync freshness threshold to allow zero, got %d", updated.LiveAccountSyncFreshnessSecs)
+	}
+}
+
 func TestHealthSnapshotAggregatesBackendHealthState(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
 	now := time.Now().UTC()

--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -33,6 +33,10 @@ type LiveLaunchResult struct {
 	LiveSessionStarted    bool                        `json:"liveSessionStarted"`
 }
 
+type liveAccountSyncSuccessOwner interface {
+	PersistsLiveAccountSyncSuccess() bool
+}
+
 const (
 	liveOrderStatusVirtualInitial = "VIRTUAL_INITIAL"
 	liveOrderStatusVirtualExit    = "VIRTUAL_EXIT"
@@ -112,10 +116,12 @@ func (p *Platform) SyncLiveAccount(accountID string) (domain.Account, error) {
 	var adapterSyncErr error
 	if syncCapable, ok := adapter.(LiveAccountSyncAdapter); ok {
 		if synced, syncErr := syncCapable.SyncAccountSnapshot(p, account, binding); syncErr == nil {
-			synced, syncErr = p.persistLiveAccountSyncSuccess(synced, binding, previousSuccessAt)
-			if syncErr != nil {
-				logger.Warn("persist adapter live account sync success failed", "error", syncErr)
-				return synced, syncErr
+			if healthOwner, ok := adapter.(liveAccountSyncSuccessOwner); !ok || !healthOwner.PersistsLiveAccountSyncSuccess() {
+				synced, syncErr = p.persistLiveAccountSyncSuccess(synced, binding, previousSuccessAt)
+				if syncErr != nil {
+					logger.Warn("persist adapter live account sync success failed", "error", syncErr)
+					return synced, syncErr
+				}
 			}
 			p.syncLiveSessionsForAccountSnapshot(synced)
 			logger.Info("live account synced via adapter", "exchange", synced.Exchange, "status", synced.Status)

--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -92,6 +92,7 @@ func (p *Platform) UpdateLiveSession(sessionID, accountID, strategyID string, ov
 func (p *Platform) SyncLiveAccount(accountID string) (domain.Account, error) {
 	logger := p.logger("service.live", "account_id", accountID)
 	logger.Debug("syncing live account")
+	attemptedAt := time.Now().UTC()
 	account, err := p.store.GetAccount(accountID)
 	if err != nil {
 		logger.Warn("load live account failed", "error", err)
@@ -104,6 +105,7 @@ func (p *Platform) SyncLiveAccount(accountID string) (domain.Account, error) {
 	if err != nil {
 		return domain.Account{}, err
 	}
+	var adapterSyncErr error
 	if syncCapable, ok := adapter.(LiveAccountSyncAdapter); ok {
 		if synced, syncErr := syncCapable.SyncAccountSnapshot(p, account, binding); syncErr == nil {
 			p.syncLiveSessionsForAccountSnapshot(synced)
@@ -111,6 +113,7 @@ func (p *Platform) SyncLiveAccount(accountID string) (domain.Account, error) {
 			return synced, nil
 		} else {
 			logger.Warn("adapter live account sync failed, falling back to local state", "error", syncErr)
+			adapterSyncErr = syncErr
 		}
 	}
 	synced, err := p.syncLiveAccountFromLocalState(account, binding)
@@ -119,6 +122,14 @@ func (p *Platform) SyncLiveAccount(accountID string) (domain.Account, error) {
 		logger.Debug("live account synced from local state", "status", synced.Status)
 	} else {
 		logger.Warn("local-state live account sync failed", "error", err)
+		return synced, nil
+	}
+	if adapterSyncErr != nil {
+		err = fmt.Errorf("adapter sync failed: %v; local fallback failed: %w", adapterSyncErr, err)
+	}
+	updateAccountSyncFailureHealth(&account, attemptedAt, err)
+	if updated, updateErr := p.store.UpdateAccount(account); updateErr == nil {
+		account = updated
 	}
 	return synced, err
 }
@@ -210,6 +221,7 @@ func (p *Platform) RecoverLiveTradingOnStartup(ctx context.Context) {
 }
 
 func (p *Platform) syncLiveAccountFromLocalState(account domain.Account, binding map[string]any) (domain.Account, error) {
+	previousSuccessAt := parseOptionalRFC3339(stringValue(account.Metadata["lastLiveSyncAt"]))
 	orders, err := p.store.ListOrders()
 	if err != nil {
 		return domain.Account{}, err
@@ -274,10 +286,12 @@ func (p *Platform) syncLiveAccountFromLocalState(account domain.Account, binding
 		"accountExchange": account.Exchange,
 	}
 	account.Metadata["lastLiveSyncAt"] = syncedAt.Format(time.RFC3339)
+	updateAccountSyncSuccessHealth(&account, syncedAt, previousSuccessAt)
 	return p.store.UpdateAccount(account)
 }
 
 func (p *Platform) syncLiveAccountFromBinance(account domain.Account, binding map[string]any) (domain.Account, error) {
+	previousSuccessAt := parseOptionalRFC3339(stringValue(account.Metadata["lastLiveSyncAt"]))
 	resolved, err := resolveBinanceRESTCredentials(binding)
 	if err != nil {
 		return domain.Account{}, err
@@ -386,11 +400,12 @@ func (p *Platform) syncLiveAccountFromBinance(account domain.Account, binding ma
 			"updateTime":    parseBinanceMillisToRFC3339(item["updateTime"]),
 		})
 	}
+	syncedAt := time.Now().UTC()
 	account.Metadata = cloneMetadata(account.Metadata)
 	account.Metadata["liveSyncSnapshot"] = map[string]any{
 		"source":                "binance-rest-account-v3",
 		"adapterKey":            normalizeLiveAdapterKey(stringValue(binding["adapterKey"])),
-		"syncedAt":              time.Now().UTC().Format(time.RFC3339),
+		"syncedAt":              syncedAt.Format(time.RFC3339),
 		"bindingMode":           stringValue(binding["connectionMode"]),
 		"executionMode":         "rest",
 		"accountExchange":       account.Exchange,
@@ -414,7 +429,8 @@ func (p *Platform) syncLiveAccountFromBinance(account domain.Account, binding ma
 		"apiKeyRef":             resolved.APIKeyRef,
 		"restBaseUrl":           resolved.BaseURL,
 	}
-	account.Metadata["lastLiveSyncAt"] = time.Now().UTC().Format(time.RFC3339)
+	account.Metadata["lastLiveSyncAt"] = syncedAt.Format(time.RFC3339)
+	updateAccountSyncSuccessHealth(&account, syncedAt, previousSuccessAt)
 	account, err = p.store.UpdateAccount(account)
 	if err != nil {
 		return domain.Account{}, err
@@ -698,11 +714,53 @@ func (p *Platform) StartLiveSyncDispatcher(ctx context.Context) {
 			logger.Info("live sync dispatcher stopped")
 			return
 		case <-ticker.C:
-			if err := p.syncActiveLiveSessions(time.Now().UTC()); err != nil {
+			now := time.Now().UTC()
+			if err := p.syncActiveLiveSessions(now); err != nil {
 				logger.Warn("sync active live sessions failed", "error", err)
+			}
+			if err := p.syncActiveLiveAccounts(now); err != nil {
+				logger.Warn("sync active live accounts failed", "error", err)
 			}
 		}
 	}
+}
+
+func (p *Platform) syncActiveLiveAccounts(eventTime time.Time) error {
+	sessions, err := p.ListLiveSessions()
+	if err != nil {
+		return err
+	}
+	seen := make(map[string]struct{})
+	for _, session := range sessions {
+		if !strings.EqualFold(session.Status, "RUNNING") {
+			continue
+		}
+		if _, ok := seen[session.AccountID]; ok {
+			continue
+		}
+		seen[session.AccountID] = struct{}{}
+		account, accountErr := p.store.GetAccount(session.AccountID)
+		if accountErr != nil {
+			continue
+		}
+		if !p.shouldRefreshLiveAccountSync(account, eventTime) {
+			continue
+		}
+		_, _ = p.SyncLiveAccount(account.ID)
+	}
+	return nil
+}
+
+func (p *Platform) shouldRefreshLiveAccountSync(account domain.Account, eventTime time.Time) bool {
+	threshold := time.Duration(p.runtimePolicy.LiveAccountSyncFreshnessSecs) * time.Second
+	if threshold <= 0 {
+		return false
+	}
+	lastSuccessAt := parseOptionalRFC3339(stringValue(account.Metadata["lastLiveSyncAt"]))
+	if lastSuccessAt.IsZero() {
+		return true
+	}
+	return eventTime.Sub(lastSuccessAt) >= threshold
 }
 
 func (p *Platform) recoverRunningLiveSession(session domain.LiveSession) (domain.LiveSession, error) {
@@ -833,6 +891,7 @@ func (p *Platform) triggerLiveSessionFromSignal(sessionID, runtimeSessionID stri
 	state["lastSignalRuntimeEventAt"] = eventTime.UTC().Format(time.RFC3339)
 	state["lastSignalRuntimeEvent"] = cloneMetadata(summary)
 	state["lastSignalRuntimeSessionId"] = runtimeSessionID
+	recordStrategyTriggerHealth(state, summary, eventTime)
 	updatedSession, err := p.store.UpdateLiveSessionState(session.ID, state)
 	if err != nil {
 		return err
@@ -919,6 +978,7 @@ func (p *Platform) evaluateLiveSessionOnSignal(session domain.LiveSession, runti
 		state["lastStrategyEvaluationRuntimeSummary"] = cloneMetadata(mapValue(runtimeSession.State["lastEventSummary"]))
 		sourceGate = p.evaluateRuntimeSignalSourceReadiness(session.StrategyID, runtimeSession, eventTime)
 		state["lastStrategyEvaluationSourceGate"] = sourceGate
+		recordStrategySourceGateHealth(state, sourceGate, eventTime)
 	}
 	if len(signalBarStates) == 0 {
 		bootstrapStates, bootstrapErr := p.liveSignalBarStates(stringValue(state["symbol"]), stringValue(state["signalTimeframe"]))
@@ -947,6 +1007,7 @@ func (p *Platform) evaluateLiveSessionOnSignal(session domain.LiveSession, runti
 			"reason": err.Error(),
 		}
 		appendTimelineEvent(state, "strategy", eventTime, "decision-error", map[string]any{"error": err.Error()})
+		recordStrategyDecisionErrorHealth(state, eventTime, err)
 		_, updateErr := p.store.UpdateLiveSessionState(session.ID, state)
 		if updateErr != nil {
 			return updateErr
@@ -962,6 +1023,7 @@ func (p *Platform) evaluateLiveSessionOnSignal(session domain.LiveSession, runti
 		"reason":   decision.Reason,
 		"metadata": cloneMetadata(decision.Metadata),
 	}
+	recordStrategyDecisionHealth(state, decision, eventTime)
 	if livePositionState := cloneMetadata(mapValue(decision.Metadata["livePositionState"])); len(livePositionState) > 0 {
 		state["lastLivePositionState"] = livePositionState
 		symbol := NormalizeSymbol(firstNonEmpty(stringValue(livePositionState["symbol"]), stringValue(state["symbol"])))
@@ -995,6 +1057,7 @@ func (p *Platform) evaluateLiveSessionOnSignal(session domain.LiveSession, runti
 		if proposalErr != nil {
 			state["lastStrategyEvaluationStatus"] = "execution-planning-error"
 			state["lastExecutionProposalError"] = proposalErr.Error()
+			recordExecutionPlanningErrorHealth(state, eventTime, proposalErr)
 			appendTimelineEvent(state, "strategy", eventTime, "execution-planning-error", map[string]any{"error": proposalErr.Error()})
 			_, updateErr := p.store.UpdateLiveSessionState(session.ID, state)
 			if updateErr != nil {
@@ -1006,6 +1069,7 @@ func (p *Platform) evaluateLiveSessionOnSignal(session domain.LiveSession, runti
 		executionProposal = executionProposalToMap(proposal)
 		state["lastExecutionProposal"] = executionProposal
 		state["lastExecutionProfile"] = executionProposalSummary(executionProposal)
+		recordExecutionPlanningHealth(state, executionProposal, eventTime)
 		state["lastExecutionTelemetry"] = map[string]any{
 			"evaluatedAt":     stringValue(mapValue(executionProposal["metadata"])["executionEvaluatedAt"]),
 			"decision":        stringValue(mapValue(executionProposal["metadata"])["executionDecision"]),

--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -342,9 +342,7 @@ func (p *Platform) syncLiveAccountFromLocalState(account domain.Account, binding
 		"syncStatus":      "SYNCED",
 		"accountExchange": account.Exchange,
 	}
-	account.Metadata["lastLiveSyncAt"] = syncedAt.Format(time.RFC3339)
-	updateAccountSyncSuccessHealth(&account, syncedAt, previousSuccessAt)
-	return p.store.UpdateAccount(account)
+	return p.persistLiveAccountSyncSuccess(account, binding, previousSuccessAt)
 }
 
 func (p *Platform) syncLiveAccountFromBinance(account domain.Account, binding map[string]any) (domain.Account, error) {
@@ -486,9 +484,7 @@ func (p *Platform) syncLiveAccountFromBinance(account domain.Account, binding ma
 		"apiKeyRef":             resolved.APIKeyRef,
 		"restBaseUrl":           resolved.BaseURL,
 	}
-	account.Metadata["lastLiveSyncAt"] = syncedAt.Format(time.RFC3339)
-	updateAccountSyncSuccessHealth(&account, syncedAt, previousSuccessAt)
-	account, err = p.store.UpdateAccount(account)
+	account, err = p.persistLiveAccountSyncSuccess(account, binding, previousSuccessAt)
 	if err != nil {
 		return domain.Account{}, err
 	}

--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -116,22 +116,21 @@ func (p *Platform) SyncLiveAccount(accountID string) (domain.Account, error) {
 			adapterSyncErr = syncErr
 		}
 	}
-	synced, err := p.syncLiveAccountFromLocalState(account, binding)
-	if err == nil {
+	synced, fallbackErr := p.syncLiveAccountFromLocalState(account, binding)
+	if fallbackErr == nil {
 		p.syncLiveSessionsForAccountSnapshot(synced)
 		logger.Debug("live account synced from local state", "status", synced.Status)
-	} else {
-		logger.Warn("local-state live account sync failed", "error", err)
 		return synced, nil
 	}
+	logger.Warn("local-state live account sync failed", "error", fallbackErr)
 	if adapterSyncErr != nil {
-		err = fmt.Errorf("adapter sync failed: %v; local fallback failed: %w", adapterSyncErr, err)
+		fallbackErr = fmt.Errorf("adapter sync failed: %v; local fallback failed: %w", adapterSyncErr, fallbackErr)
 	}
-	updateAccountSyncFailureHealth(&account, attemptedAt, err)
+	updateAccountSyncFailureHealth(&account, attemptedAt, fallbackErr)
 	if updated, updateErr := p.store.UpdateAccount(account); updateErr == nil {
 		account = updated
 	}
-	return synced, err
+	return account, fallbackErr
 }
 
 func (p *Platform) syncLiveSessionsForAccountSnapshot(account domain.Account) {

--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"strings"
@@ -103,7 +104,9 @@ func (p *Platform) SyncLiveAccount(accountID string) (domain.Account, error) {
 	}
 	adapter, binding, err := p.resolveLiveAdapterForAccount(account)
 	if err != nil {
-		return domain.Account{}, err
+		logger.Warn("resolve live adapter for account sync failed", "error", err)
+		account = p.persistLiveAccountSyncFailure(account, attemptedAt, err)
+		return account, err
 	}
 	var adapterSyncErr error
 	if syncCapable, ok := adapter.(LiveAccountSyncAdapter); ok {
@@ -126,11 +129,21 @@ func (p *Platform) SyncLiveAccount(accountID string) (domain.Account, error) {
 	if adapterSyncErr != nil {
 		fallbackErr = fmt.Errorf("adapter sync failed: %v; local fallback failed: %w", adapterSyncErr, fallbackErr)
 	}
-	updateAccountSyncFailureHealth(&account, attemptedAt, fallbackErr)
-	if updated, updateErr := p.store.UpdateAccount(account); updateErr == nil {
-		account = updated
-	}
+	account = p.persistLiveAccountSyncFailure(account, attemptedAt, fallbackErr)
 	return account, fallbackErr
+}
+
+func (p *Platform) persistLiveAccountSyncFailure(account domain.Account, attemptedAt time.Time, err error) domain.Account {
+	if err == nil {
+		return account
+	}
+	updateAccountSyncFailureHealth(&account, attemptedAt, err)
+	updated, updateErr := p.store.UpdateAccount(account)
+	if updateErr != nil {
+		p.logger("service.live", "account_id", account.ID).Warn("persist live account sync failure health failed", "error", updateErr)
+		return account
+	}
+	return updated
 }
 
 func (p *Platform) syncLiveSessionsForAccountSnapshot(account domain.Account) {
@@ -730,6 +743,7 @@ func (p *Platform) syncActiveLiveAccounts(eventTime time.Time) error {
 		return err
 	}
 	seen := make(map[string]struct{})
+	var syncErrs []error
 	for _, session := range sessions {
 		if !strings.EqualFold(session.Status, "RUNNING") {
 			continue
@@ -745,9 +759,11 @@ func (p *Platform) syncActiveLiveAccounts(eventTime time.Time) error {
 		if !p.shouldRefreshLiveAccountSync(account, eventTime) {
 			continue
 		}
-		_, _ = p.SyncLiveAccount(account.ID)
+		if _, syncErr := p.SyncLiveAccount(account.ID); syncErr != nil {
+			syncErrs = append(syncErrs, fmt.Errorf("live account %s sync failed: %w", account.ID, syncErr))
+		}
 	}
-	return nil
+	return errors.Join(syncErrs...)
 }
 
 func (p *Platform) shouldRefreshLiveAccountSync(account domain.Account, eventTime time.Time) bool {

--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -102,6 +102,7 @@ func (p *Platform) SyncLiveAccount(accountID string) (domain.Account, error) {
 	if !strings.EqualFold(account.Mode, "LIVE") {
 		return domain.Account{}, fmt.Errorf("account %s is not a LIVE account", accountID)
 	}
+	previousSuccessAt := parseOptionalRFC3339(stringValue(account.Metadata["lastLiveSyncAt"]))
 	adapter, binding, err := p.resolveLiveAdapterForAccount(account)
 	if err != nil {
 		logger.Warn("resolve live adapter for account sync failed", "error", err)
@@ -111,6 +112,11 @@ func (p *Platform) SyncLiveAccount(accountID string) (domain.Account, error) {
 	var adapterSyncErr error
 	if syncCapable, ok := adapter.(LiveAccountSyncAdapter); ok {
 		if synced, syncErr := syncCapable.SyncAccountSnapshot(p, account, binding); syncErr == nil {
+			synced, syncErr = p.persistLiveAccountSyncSuccess(synced, binding, previousSuccessAt)
+			if syncErr != nil {
+				logger.Warn("persist adapter live account sync success failed", "error", syncErr)
+				return synced, syncErr
+			}
 			p.syncLiveSessionsForAccountSnapshot(synced)
 			logger.Info("live account synced via adapter", "exchange", synced.Exchange, "status", synced.Status)
 			return synced, nil
@@ -144,6 +150,39 @@ func (p *Platform) persistLiveAccountSyncFailure(account domain.Account, attempt
 		return account
 	}
 	return updated
+}
+
+func (p *Platform) persistLiveAccountSyncSuccess(account domain.Account, binding map[string]any, previousSuccessAt time.Time) (domain.Account, error) {
+	account.Metadata = cloneMetadata(account.Metadata)
+	snapshot := cloneMetadata(mapValue(account.Metadata["liveSyncSnapshot"]))
+	syncedAt := parseOptionalRFC3339(stringValue(account.Metadata["lastLiveSyncAt"]))
+	if syncedAt.IsZero() {
+		syncedAt = parseOptionalRFC3339(stringValue(snapshot["syncedAt"]))
+	}
+	if syncedAt.IsZero() {
+		syncedAt = time.Now().UTC()
+	}
+
+	snapshot["source"] = firstNonEmpty(stringValue(snapshot["source"]), "live-account-adapter")
+	snapshot["adapterKey"] = firstNonEmpty(
+		normalizeLiveAdapterKey(stringValue(snapshot["adapterKey"])),
+		normalizeLiveAdapterKey(stringValue(binding["adapterKey"])),
+	)
+	snapshot["syncedAt"] = syncedAt.Format(time.RFC3339)
+	snapshot["syncStatus"] = firstNonEmpty(stringValue(snapshot["syncStatus"]), "SYNCED")
+	snapshot["accountExchange"] = firstNonEmpty(stringValue(snapshot["accountExchange"]), account.Exchange)
+	snapshot["bindingMode"] = firstNonEmpty(stringValue(snapshot["bindingMode"]), stringValue(binding["connectionMode"]))
+	snapshot["executionMode"] = firstNonEmpty(
+		stringValue(snapshot["executionMode"]),
+		normalizeLiveExecutionMode(binding["executionMode"], boolValue(binding["sandbox"])),
+	)
+	snapshot["feeSource"] = firstNonEmpty(stringValue(snapshot["feeSource"]), "exchange")
+	snapshot["fundingSource"] = firstNonEmpty(stringValue(snapshot["fundingSource"]), "exchange")
+
+	account.Metadata["liveSyncSnapshot"] = snapshot
+	account.Metadata["lastLiveSyncAt"] = syncedAt.Format(time.RFC3339)
+	updateAccountSyncSuccessHealth(&account, syncedAt, previousSuccessAt)
+	return p.store.UpdateAccount(account)
 }
 
 func (p *Platform) syncLiveSessionsForAccountSnapshot(account domain.Account) {

--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -771,11 +771,15 @@ func (p *Platform) shouldRefreshLiveAccountSync(account domain.Account, eventTim
 	if threshold <= 0 {
 		return false
 	}
-	lastSuccessAt := parseOptionalRFC3339(stringValue(account.Metadata["lastLiveSyncAt"]))
-	if lastSuccessAt.IsZero() {
+	lastSyncActivityAt := parseOptionalRFC3339(stringValue(account.Metadata["lastLiveSyncAt"]))
+	accountSync := mapValue(mapValue(account.Metadata["healthSummary"])["accountSync"])
+	if attemptedAt := parseOptionalRFC3339(stringValue(accountSync["lastAttemptAt"])); attemptedAt.After(lastSyncActivityAt) {
+		lastSyncActivityAt = attemptedAt
+	}
+	if lastSyncActivityAt.IsZero() {
 		return true
 	}
-	return eventTime.Sub(lastSuccessAt) >= threshold
+	return eventTime.Sub(lastSyncActivityAt) >= threshold
 }
 
 func (p *Platform) recoverRunningLiveSession(session domain.LiveSession) (domain.LiveSession, error) {

--- a/internal/service/live_execution.go
+++ b/internal/service/live_execution.go
@@ -256,6 +256,7 @@ func (p *Platform) dispatchLiveSessionIntent(session domain.LiveSession) (domain
 	state["lastDispatchedAt"] = dispatchedAt.Format(time.RFC3339)
 	state["lastDispatchedIntent"] = proposalMap
 	state["lastDispatchedIntentSignature"] = intentSignature
+	recordExecutionDispatchHealth(state, created, dispatchedAt, createErr)
 	delete(state, "lastExecutionTimeoutAt")
 	delete(state, "lastExecutionTimeoutReason")
 	delete(state, "lastExecutionTimeoutIntentSignature")
@@ -378,6 +379,12 @@ func (p *Platform) applyLiveVirtualInitialEvent(session domain.LiveSession, prop
 	state["lastDispatchedIntentSignature"] = intentSignature
 	state["lastDispatchedOrderStatus"] = liveOrderStatusVirtualInitial
 	state["lastSyncedOrderStatus"] = liveOrderStatusVirtualInitial
+	recordExecutionDispatchHealth(state, domain.Order{
+		Side:   proposal.Side,
+		Symbol: proposal.Symbol,
+		Type:   proposal.Type,
+		Status: liveOrderStatusVirtualInitial,
+	}, eventTime, nil)
 	state["lastExecutionDispatch"] = executionDispatchSummary(proposalMap, domain.Order{
 		Side:     proposal.Side,
 		Symbol:   proposal.Symbol,
@@ -478,6 +485,12 @@ func (p *Platform) applyLiveVirtualExitEvent(session domain.LiveSession, proposa
 	state["lastDispatchedIntentSignature"] = intentSignature
 	state["lastDispatchedOrderStatus"] = liveOrderStatusVirtualExit
 	state["lastSyncedOrderStatus"] = liveOrderStatusVirtualExit
+	recordExecutionDispatchHealth(state, domain.Order{
+		Side:   proposal.Side,
+		Symbol: proposal.Symbol,
+		Type:   proposal.Type,
+		Status: liveOrderStatusVirtualExit,
+	}, eventTime, nil)
 	state["lastExecutionDispatch"] = executionDispatchSummary(proposalMap, domain.Order{
 		Side:     proposal.Side,
 		Symbol:   proposal.Symbol,
@@ -543,8 +556,10 @@ func (p *Platform) syncLatestLiveSessionOrder(session domain.LiveSession, eventT
 	if shouldCancelLiveOrderForExecutionTimeout(order, eventTime) {
 		cancelledOrder, cancelErr := p.CancelLiveOrder(order.ID)
 		state["lastSyncAttemptAt"] = eventTime.UTC().Format(time.RFC3339)
+		recordExecutionSyncAttemptHealth(state, eventTime)
 		if cancelErr != nil {
 			state["lastSyncError"] = cancelErr.Error()
+			recordExecutionSyncResultHealth(state, eventTime, order.Status, cancelErr)
 			appendTimelineEvent(state, "order", eventTime, "live-order-cancel-error", map[string]any{
 				"orderId": order.ID,
 				"error":   cancelErr.Error(),
@@ -560,6 +575,7 @@ func (p *Platform) syncLatestLiveSessionOrder(session domain.LiveSession, eventT
 		state["lastSyncedOrderStatus"] = cancelledOrder.Status
 		state["lastDispatchedOrderStatus"] = cancelledOrder.Status
 		state["lastSyncedAt"] = eventTime.UTC().Format(time.RFC3339)
+		recordExecutionSyncResultHealth(state, eventTime, cancelledOrder.Status, nil)
 		state["lastExecutionTimeoutAt"] = eventTime.UTC().Format(time.RFC3339)
 		state["lastExecutionTimeoutReason"] = "resting-order-expired"
 		timeoutOrder := withExecutionSubmissionFallback(cancelledOrder, order)
@@ -577,8 +593,10 @@ func (p *Platform) syncLatestLiveSessionOrder(session domain.LiveSession, eventT
 	}
 	syncedOrder, err := p.SyncLiveOrder(order.ID)
 	state["lastSyncAttemptAt"] = eventTime.UTC().Format(time.RFC3339)
+	recordExecutionSyncAttemptHealth(state, eventTime)
 	if err != nil {
 		state["lastSyncError"] = err.Error()
+		recordExecutionSyncResultHealth(state, eventTime, order.Status, err)
 		appendTimelineEvent(state, "order", eventTime, "live-order-sync-error", map[string]any{
 			"orderId": order.ID,
 			"error":   err.Error(),
@@ -595,6 +613,7 @@ func (p *Platform) syncLatestLiveSessionOrder(session domain.LiveSession, eventT
 	state["lastSyncedOrderStatus"] = syncedOrder.Status
 	state["lastDispatchedOrderStatus"] = syncedOrder.Status
 	state["lastSyncedAt"] = time.Now().UTC().Format(time.RFC3339)
+	recordExecutionSyncResultHealth(state, eventTime, syncedOrder.Status, nil)
 	state["lastExecutionDispatch"] = executionDispatchSummary(mapValue(order.Metadata["executionProposal"]), syncedOrder, false)
 	updateExecutionEventStats(state, mapValue(order.Metadata["executionProposal"]), mapValue(state["lastExecutionDispatch"]))
 	if strings.EqualFold(syncedOrder.Status, "FILLED") {

--- a/internal/service/live_registry.go
+++ b/internal/service/live_registry.go
@@ -249,6 +249,10 @@ func (a binanceFuturesLiveAdapter) SyncAccountSnapshot(platform *Platform, accou
 	return platform.syncLiveAccountFromBinance(account, binding)
 }
 
+func (a binanceFuturesLiveAdapter) PersistsLiveAccountSyncSuccess() bool {
+	return true
+}
+
 func (a binanceFuturesLiveAdapter) CancelOrder(account domain.Account, order domain.Order, binding map[string]any) (LiveOrderSync, error) {
 	switch normalizeLiveExecutionMode(binding["executionMode"], boolValue(binding["sandbox"])) {
 	case "rest":

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -2859,6 +2859,56 @@ func TestSyncActiveLiveAccountsReturnsPerAccountSyncErrors(t *testing.T) {
 	}
 }
 
+func TestSyncActiveLiveAccountsThrottlesFailedRetriesUntilFreshnessWindow(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	platform.runtimePolicy.LiveAccountSyncFreshnessSecs = 60
+
+	account, err := platform.store.GetAccount("live-main")
+	if err != nil {
+		t.Fatalf("get account failed: %v", err)
+	}
+	account.Metadata = cloneMetadata(account.Metadata)
+	account.Metadata["liveBinding"] = map[string]any{
+		"adapterKey": "missing-adapter",
+	}
+	if _, err := platform.store.UpdateAccount(account); err != nil {
+		t.Fatalf("update account failed: %v", err)
+	}
+
+	session, err := platform.CreateLiveSession("live-main", "strategy-bk-1d", map[string]any{
+		"symbol":          "BTCUSDT",
+		"signalTimeframe": "1d",
+	})
+	if err != nil {
+		t.Fatalf("create live session failed: %v", err)
+	}
+	if _, err := platform.store.UpdateLiveSessionStatus(session.ID, "RUNNING"); err != nil {
+		t.Fatalf("mark live session running failed: %v", err)
+	}
+
+	firstTick := time.Now().UTC()
+	if err := platform.syncActiveLiveAccounts(firstTick); err == nil {
+		t.Fatal("expected first active live account sync attempt to fail")
+	}
+
+	updated, err := platform.store.GetAccount("live-main")
+	if err != nil {
+		t.Fatalf("reload account failed: %v", err)
+	}
+	accountSync := mapValue(mapValue(updated.Metadata["healthSummary"])["accountSync"])
+	lastAttemptAt := parseOptionalRFC3339(stringValue(accountSync["lastAttemptAt"]))
+	if lastAttemptAt.IsZero() {
+		t.Fatal("expected failed sync attempt to record lastAttemptAt")
+	}
+
+	if err := platform.syncActiveLiveAccounts(lastAttemptAt.Add(10 * time.Second)); err != nil {
+		t.Fatalf("expected retry within freshness window to be throttled, got %v", err)
+	}
+	if err := platform.syncActiveLiveAccounts(lastAttemptAt.Add(61 * time.Second)); err == nil {
+		t.Fatal("expected retry after freshness window to attempt sync again")
+	}
+}
+
 type testLiveAccountSyncAdapter struct {
 	key     string
 	syncErr error

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -2909,6 +2909,59 @@ func TestSyncActiveLiveAccountsThrottlesFailedRetriesUntilFreshnessWindow(t *tes
 	}
 }
 
+func TestSyncLiveAccountNormalizesAdapterSuccessHealthState(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	platform.runtimePolicy.LiveAccountSyncFreshnessSecs = 60
+	platform.registerLiveAdapter(testLiveAccountSyncAdapter{
+		key: "test-sync-success",
+	})
+
+	account, err := platform.store.GetAccount("live-main")
+	if err != nil {
+		t.Fatalf("get account failed: %v", err)
+	}
+	account.Metadata = cloneMetadata(account.Metadata)
+	account.Metadata["liveBinding"] = map[string]any{
+		"adapterKey":     "test-sync-success",
+		"connectionMode": "mock",
+		"executionMode":  "mock",
+	}
+	account.Metadata["healthSummary"] = map[string]any{
+		"accountSync": map[string]any{
+			"consecutiveErrorCount": 2,
+			"lastError":             "stale failure",
+			"lastErrorAt":           time.Date(2026, 4, 14, 23, 0, 0, 0, time.UTC).Format(time.RFC3339),
+		},
+	}
+	if _, err := platform.store.UpdateAccount(account); err != nil {
+		t.Fatalf("update account failed: %v", err)
+	}
+
+	synced, err := platform.SyncLiveAccount("live-main")
+	if err != nil {
+		t.Fatalf("expected adapter sync success, got %v", err)
+	}
+	if stringValue(synced.Metadata["lastLiveSyncAt"]) == "" {
+		t.Fatal("expected adapter sync success to persist lastLiveSyncAt")
+	}
+	accountSync := mapValue(mapValue(synced.Metadata["healthSummary"])["accountSync"])
+	if got := parseFloatValue(accountSync["consecutiveErrorCount"]); got != 0 {
+		t.Fatalf("expected adapter sync success to clear consecutiveErrorCount, got %v", got)
+	}
+	if got := stringValue(accountSync["lastError"]); got != "" {
+		t.Fatalf("expected adapter sync success to clear lastError, got %s", got)
+	}
+	if stringValue(accountSync["lastSuccessAt"]) == "" {
+		t.Fatal("expected adapter sync success to record lastSuccessAt")
+	}
+	if got := stringValue(accountSync["lastSource"]); got != "live-account-adapter" && got != "test-sync-success" {
+		t.Fatalf("expected adapter sync success to set a normalized lastSource, got %s", got)
+	}
+	if platform.shouldRefreshLiveAccountSync(synced, time.Now().UTC().Add(10*time.Second)) {
+		t.Fatal("expected freshly normalized adapter sync to stay within freshness window")
+	}
+}
+
 type testLiveAccountSyncAdapter struct {
 	key     string
 	syncErr error
@@ -2938,8 +2991,11 @@ func (a testLiveAccountSyncAdapter) CancelOrder(domain.Account, domain.Order, ma
 	return LiveOrderSync{}, nil
 }
 
-func (a testLiveAccountSyncAdapter) SyncAccountSnapshot(*Platform, domain.Account, map[string]any) (domain.Account, error) {
-	return domain.Account{}, a.syncErr
+func (a testLiveAccountSyncAdapter) SyncAccountSnapshot(_ *Platform, account domain.Account, _ map[string]any) (domain.Account, error) {
+	if a.syncErr != nil {
+		return domain.Account{}, a.syncErr
+	}
+	return account, nil
 }
 
 type testFailingListOrdersStore struct {

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -2954,6 +2954,9 @@ func TestSyncLiveAccountNormalizesAdapterSuccessHealthState(t *testing.T) {
 	if stringValue(accountSync["lastSuccessAt"]) == "" {
 		t.Fatal("expected adapter sync success to record lastSuccessAt")
 	}
+	if got := parseFloatValue(mapValue(accountSync["today"])["syncCount"]); got != 1 {
+		t.Fatalf("expected adapter sync success to record one syncCount, got %v", got)
+	}
 	if got := stringValue(accountSync["lastSource"]); got != "live-account-adapter" && got != "test-sync-success" {
 		t.Fatalf("expected adapter sync success to set a normalized lastSource, got %s", got)
 	}
@@ -2962,9 +2965,65 @@ func TestSyncLiveAccountNormalizesAdapterSuccessHealthState(t *testing.T) {
 	}
 }
 
+func TestSyncLiveAccountDoesNotDoubleCountPersistedAdapterSuccessHealth(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	platform.runtimePolicy.LiveAccountSyncFreshnessSecs = 60
+	syncedAt := time.Date(2026, 4, 15, 2, 20, 0, 0, time.UTC)
+	platform.registerLiveAdapter(testLiveAccountSyncAdapter{
+		key:                 "test-sync-persisted-success",
+		persistsSyncSuccess: true,
+		syncSnapshotFunc: func(p *Platform, account domain.Account, binding map[string]any) (domain.Account, error) {
+			account.Metadata = cloneMetadata(account.Metadata)
+			account.Metadata["liveSyncSnapshot"] = map[string]any{
+				"source":          "persisted-adapter",
+				"adapterKey":      normalizeLiveAdapterKey(stringValue(binding["adapterKey"])),
+				"syncedAt":        syncedAt.Format(time.RFC3339),
+				"bindingMode":     stringValue(binding["connectionMode"]),
+				"executionMode":   stringValue(binding["executionMode"]),
+				"syncStatus":      "SYNCED",
+				"accountExchange": account.Exchange,
+			}
+			account.Metadata["lastLiveSyncAt"] = syncedAt.Format(time.RFC3339)
+			updateAccountSyncSuccessHealth(&account, syncedAt, time.Time{})
+			return p.store.UpdateAccount(account)
+		},
+	})
+
+	account, err := platform.store.GetAccount("live-main")
+	if err != nil {
+		t.Fatalf("get account failed: %v", err)
+	}
+	account.Metadata = cloneMetadata(account.Metadata)
+	account.Metadata["liveBinding"] = map[string]any{
+		"adapterKey":     "test-sync-persisted-success",
+		"connectionMode": "mock",
+		"executionMode":  "mock",
+	}
+	if _, err := platform.store.UpdateAccount(account); err != nil {
+		t.Fatalf("update account failed: %v", err)
+	}
+
+	synced, err := platform.SyncLiveAccount("live-main")
+	if err != nil {
+		t.Fatalf("expected persisted adapter sync success, got %v", err)
+	}
+	accountSync := mapValue(mapValue(synced.Metadata["healthSummary"])["accountSync"])
+	if got := parseFloatValue(mapValue(accountSync["today"])["syncCount"]); got != 1 {
+		t.Fatalf("expected persisted adapter sync success to keep syncCount at one, got %v", got)
+	}
+	if got := stringValue(accountSync["lastSuccessAt"]); got != syncedAt.Format(time.RFC3339) {
+		t.Fatalf("expected persisted adapter sync success to keep lastSuccessAt, got %s", got)
+	}
+	if platform.shouldRefreshLiveAccountSync(synced, syncedAt.Add(10*time.Second)) {
+		t.Fatal("expected persisted adapter sync success to stay within freshness window")
+	}
+}
+
 type testLiveAccountSyncAdapter struct {
-	key     string
-	syncErr error
+	key                 string
+	syncErr             error
+	persistsSyncSuccess bool
+	syncSnapshotFunc    func(*Platform, domain.Account, map[string]any) (domain.Account, error)
 }
 
 func (a testLiveAccountSyncAdapter) Key() string {
@@ -2973,6 +3032,10 @@ func (a testLiveAccountSyncAdapter) Key() string {
 
 func (a testLiveAccountSyncAdapter) Describe() map[string]any {
 	return map[string]any{"key": a.key}
+}
+
+func (a testLiveAccountSyncAdapter) PersistsLiveAccountSyncSuccess() bool {
+	return a.persistsSyncSuccess
 }
 
 func (a testLiveAccountSyncAdapter) ValidateAccountConfig(map[string]any) error {
@@ -2991,9 +3054,12 @@ func (a testLiveAccountSyncAdapter) CancelOrder(domain.Account, domain.Order, ma
 	return LiveOrderSync{}, nil
 }
 
-func (a testLiveAccountSyncAdapter) SyncAccountSnapshot(_ *Platform, account domain.Account, _ map[string]any) (domain.Account, error) {
+func (a testLiveAccountSyncAdapter) SyncAccountSnapshot(platform *Platform, account domain.Account, binding map[string]any) (domain.Account, error) {
 	if a.syncErr != nil {
 		return domain.Account{}, a.syncErr
+	}
+	if a.syncSnapshotFunc != nil {
+		return a.syncSnapshotFunc(platform, account, binding)
 	}
 	return account, nil
 }

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -2736,6 +2736,9 @@ func TestSyncLiveAccountReturnsFallbackSnapshotWithoutReportingAdapterFailure(t 
 	if stringValue(accountSync["lastSuccessAt"]) == "" {
 		t.Fatal("expected accountSync health to retain successful fallback state")
 	}
+	if got := parseFloatValue(mapValue(accountSync["today"])["syncCount"]); got != 1 {
+		t.Fatalf("expected fallback sync to record one syncCount, got %v", got)
+	}
 	if got := stringValue(accountSync["lastError"]); got != "" {
 		t.Fatalf("expected no accountSync error after successful fallback, got %s", got)
 	}

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -2699,4 +2700,128 @@ func TestRefreshLiveSessionPositionContextClearsStaleLivePositionStateWithoutRea
 	if liveState := mapValue(updated.State["livePositionState"]); len(liveState) != 0 {
 		t.Fatalf("expected stale livePositionState to be cleared, got %+v", liveState)
 	}
+}
+
+func TestSyncLiveAccountReturnsFallbackSnapshotWithoutReportingAdapterFailure(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	platform.registerLiveAdapter(testLiveAccountSyncAdapter{
+		key:     "test-sync-fallback",
+		syncErr: errors.New("adapter sync failed"),
+	})
+
+	account, err := platform.store.GetAccount("live-main")
+	if err != nil {
+		t.Fatalf("get account failed: %v", err)
+	}
+	account.Metadata = cloneMetadata(account.Metadata)
+	account.Metadata["liveBinding"] = map[string]any{
+		"adapterKey":     "test-sync-fallback",
+		"connectionMode": "disabled",
+	}
+	if _, err := platform.store.UpdateAccount(account); err != nil {
+		t.Fatalf("update account failed: %v", err)
+	}
+
+	synced, err := platform.SyncLiveAccount("live-main")
+	if err != nil {
+		t.Fatalf("expected fallback sync to succeed, got %v", err)
+	}
+	if stringValue(synced.Metadata["lastLiveSyncAt"]) == "" {
+		t.Fatal("expected fallback sync to persist lastLiveSyncAt")
+	}
+	if mapValue(synced.Metadata["liveSyncSnapshot"]) == nil {
+		t.Fatal("expected fallback sync snapshot to be persisted")
+	}
+	accountSync := mapValue(mapValue(synced.Metadata["healthSummary"])["accountSync"])
+	if stringValue(accountSync["lastSuccessAt"]) == "" {
+		t.Fatal("expected accountSync health to retain successful fallback state")
+	}
+	if got := stringValue(accountSync["lastError"]); got != "" {
+		t.Fatalf("expected no accountSync error after successful fallback, got %s", got)
+	}
+}
+
+func TestSyncLiveAccountReturnsFailureWhenLocalFallbackFails(t *testing.T) {
+	baseStore := memory.NewStore()
+	platform := NewPlatform(&testFailingListOrdersStore{
+		Store:     baseStore,
+		listError: errors.New("orders unavailable"),
+	})
+	platform.registerLiveAdapter(testLiveAccountSyncAdapter{
+		key:     "test-sync-failing",
+		syncErr: errors.New("adapter sync failed"),
+	})
+
+	account, err := platform.store.GetAccount("live-main")
+	if err != nil {
+		t.Fatalf("get account failed: %v", err)
+	}
+	account.Metadata = cloneMetadata(account.Metadata)
+	account.Metadata["liveBinding"] = map[string]any{
+		"adapterKey":     "test-sync-failing",
+		"connectionMode": "disabled",
+	}
+	if _, err := platform.store.UpdateAccount(account); err != nil {
+		t.Fatalf("update account failed: %v", err)
+	}
+
+	if _, err := platform.SyncLiveAccount("live-main"); err == nil {
+		t.Fatal("expected local fallback failure to be returned")
+	} else if !strings.Contains(err.Error(), "orders unavailable") {
+		t.Fatalf("expected local fallback error in returned message, got %v", err)
+	}
+
+	updated, err := platform.store.GetAccount("live-main")
+	if err != nil {
+		t.Fatalf("reload account failed: %v", err)
+	}
+	accountSync := mapValue(mapValue(updated.Metadata["healthSummary"])["accountSync"])
+	if got := maxIntValue(accountSync["consecutiveErrorCount"], 0); got != 1 {
+		t.Fatalf("expected one recorded sync failure, got %d", got)
+	}
+	if !strings.Contains(stringValue(accountSync["lastError"]), "orders unavailable") {
+		t.Fatalf("expected recorded sync failure to mention local fallback error, got %s", stringValue(accountSync["lastError"]))
+	}
+}
+
+type testLiveAccountSyncAdapter struct {
+	key     string
+	syncErr error
+}
+
+func (a testLiveAccountSyncAdapter) Key() string {
+	return a.key
+}
+
+func (a testLiveAccountSyncAdapter) Describe() map[string]any {
+	return map[string]any{"key": a.key}
+}
+
+func (a testLiveAccountSyncAdapter) ValidateAccountConfig(map[string]any) error {
+	return nil
+}
+
+func (a testLiveAccountSyncAdapter) SubmitOrder(domain.Account, domain.Order, map[string]any) (LiveOrderSubmission, error) {
+	return LiveOrderSubmission{}, nil
+}
+
+func (a testLiveAccountSyncAdapter) SyncOrder(domain.Account, domain.Order, map[string]any) (LiveOrderSync, error) {
+	return LiveOrderSync{}, nil
+}
+
+func (a testLiveAccountSyncAdapter) CancelOrder(domain.Account, domain.Order, map[string]any) (LiveOrderSync, error) {
+	return LiveOrderSync{}, nil
+}
+
+func (a testLiveAccountSyncAdapter) SyncAccountSnapshot(*Platform, domain.Account, map[string]any) (domain.Account, error) {
+	return domain.Account{}, a.syncErr
+}
+
+type testFailingListOrdersStore struct {
+	*memory.Store
+	listError error
+}
+
+func (s *testFailingListOrdersStore) ListOrders() ([]domain.Order, error) {
+	return nil, s.listError
 }

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -2784,6 +2784,81 @@ func TestSyncLiveAccountReturnsFailureWhenLocalFallbackFails(t *testing.T) {
 	}
 }
 
+func TestSyncLiveAccountRecordsAdapterResolutionFailuresInHealthSummary(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+
+	account, err := platform.store.GetAccount("live-main")
+	if err != nil {
+		t.Fatalf("get account failed: %v", err)
+	}
+	account.Metadata = cloneMetadata(account.Metadata)
+	account.Metadata["liveBinding"] = map[string]any{
+		"adapterKey": "missing-adapter",
+	}
+	if _, err := platform.store.UpdateAccount(account); err != nil {
+		t.Fatalf("update account failed: %v", err)
+	}
+
+	if _, err := platform.SyncLiveAccount("live-main"); err == nil {
+		t.Fatal("expected adapter resolution failure to be returned")
+	} else if !strings.Contains(err.Error(), "live adapter not registered") {
+		t.Fatalf("expected adapter resolution failure in returned error, got %v", err)
+	}
+
+	updated, err := platform.store.GetAccount("live-main")
+	if err != nil {
+		t.Fatalf("reload account failed: %v", err)
+	}
+	accountSync := mapValue(mapValue(updated.Metadata["healthSummary"])["accountSync"])
+	if got := maxIntValue(accountSync["consecutiveErrorCount"], 0); got != 1 {
+		t.Fatalf("expected one recorded adapter resolution failure, got %d", got)
+	}
+	if stringValue(accountSync["lastAttemptAt"]) == "" {
+		t.Fatal("expected adapter resolution failure to record lastAttemptAt")
+	}
+	if !strings.Contains(stringValue(accountSync["lastError"]), "live adapter not registered") {
+		t.Fatalf("expected recorded adapter resolution failure, got %s", stringValue(accountSync["lastError"]))
+	}
+}
+
+func TestSyncActiveLiveAccountsReturnsPerAccountSyncErrors(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+
+	account, err := platform.store.GetAccount("live-main")
+	if err != nil {
+		t.Fatalf("get account failed: %v", err)
+	}
+	account.Metadata = cloneMetadata(account.Metadata)
+	account.Metadata["liveBinding"] = map[string]any{
+		"adapterKey": "missing-adapter",
+	}
+	if _, err := platform.store.UpdateAccount(account); err != nil {
+		t.Fatalf("update account failed: %v", err)
+	}
+
+	session, err := platform.CreateLiveSession("live-main", "strategy-bk-1d", map[string]any{
+		"symbol":          "BTCUSDT",
+		"signalTimeframe": "1d",
+	})
+	if err != nil {
+		t.Fatalf("create live session failed: %v", err)
+	}
+	if _, err := platform.store.UpdateLiveSessionStatus(session.ID, "RUNNING"); err != nil {
+		t.Fatalf("mark live session running failed: %v", err)
+	}
+
+	err = platform.syncActiveLiveAccounts(time.Now().UTC())
+	if err == nil {
+		t.Fatal("expected active live account sync failure to be surfaced")
+	}
+	if !strings.Contains(err.Error(), "live-main") {
+		t.Fatalf("expected returned error to include account id, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "live adapter not registered") {
+		t.Fatalf("expected returned error to include sync failure reason, got %v", err)
+	}
+}
+
 type testLiveAccountSyncAdapter struct {
 	key     string
 	syncErr error

--- a/internal/service/paper.go
+++ b/internal/service/paper.go
@@ -191,6 +191,7 @@ func (p *Platform) triggerPaperSessionFromSignal(sessionID, runtimeSessionID str
 	state["lastSignalRuntimeEventAt"] = eventTime.UTC().Format(time.RFC3339)
 	state["lastSignalRuntimeEvent"] = cloneMetadata(summary)
 	state["lastSignalRuntimeSessionId"] = runtimeSessionID
+	recordStrategyTriggerHealth(state, summary, eventTime)
 
 	throttleSeconds := maxIntValue(state["signalTriggerThrottleSeconds"], 5)
 	lastTriggeredAt := parseOptionalRFC3339(stringValue(state["lastSignalDrivenTickAt"]))
@@ -288,6 +289,7 @@ func (p *Platform) evaluatePaperSessionOnSignal(session domain.PaperSession, run
 		state["lastStrategyEvaluationRuntimeSummary"] = cloneMetadata(mapValue(runtimeSession.State["lastEventSummary"]))
 		sourceGate = p.evaluateSignalSourceReadiness(session, runtimeSession, eventTime)
 		state["lastStrategyEvaluationSourceGate"] = sourceGate
+		recordStrategySourceGateHealth(state, sourceGate, eventTime)
 	}
 	if !boolValue(sourceGate["ready"]) {
 		state["lastStrategyEvaluationStatus"] = "waiting-source-states"
@@ -311,6 +313,7 @@ func (p *Platform) evaluatePaperSessionOnSignal(session domain.PaperSession, run
 		appendTimelineEvent(state, "strategy", eventTime, "decision-error", map[string]any{
 			"error": err.Error(),
 		})
+		recordStrategyDecisionErrorHealth(state, eventTime, err)
 		updatedSession, updateErr := p.store.UpdatePaperSessionState(session.ID, state)
 		if updateErr != nil {
 			return domain.Order{}, updateErr
@@ -322,6 +325,7 @@ func (p *Platform) evaluatePaperSessionOnSignal(session domain.PaperSession, run
 		"reason":   signalDecision.Reason,
 		"metadata": cloneMetadata(signalDecision.Metadata),
 	}
+	recordStrategyDecisionHealth(state, signalDecision, eventTime)
 	appendTimelineEvent(state, "strategy", eventTime, "decision", map[string]any{
 		"action":        signalDecision.Action,
 		"reason":        signalDecision.Reason,
@@ -371,6 +375,7 @@ func (p *Platform) evaluatePaperSessionOnSignal(session domain.PaperSession, run
 	}
 	state["lastStrategyEvaluationStatus"] = "order-dispatched"
 	state["lastStrategyEvaluationOrderId"] = order.ID
+	recordExecutionDispatchHealth(state, order, eventTime, nil)
 	appendTimelineEvent(state, "order", eventTime, "order-dispatched", map[string]any{
 		"orderId": order.ID,
 		"symbol":  order.Symbol,

--- a/internal/service/platform.go
+++ b/internal/service/platform.go
@@ -129,10 +129,10 @@ func (p *Platform) SetRuntimePolicy(policy RuntimePolicy) {
 	if policy.RuntimeQuietSeconds > 0 {
 		p.runtimePolicy.RuntimeQuietSeconds = policy.RuntimeQuietSeconds
 	}
-	if policy.StrategyEvaluationQuietSeconds > 0 {
+	if policy.StrategyEvaluationQuietSeconds >= 0 {
 		p.runtimePolicy.StrategyEvaluationQuietSeconds = policy.StrategyEvaluationQuietSeconds
 	}
-	if policy.LiveAccountSyncFreshnessSecs > 0 {
+	if policy.LiveAccountSyncFreshnessSecs >= 0 {
 		p.runtimePolicy.LiveAccountSyncFreshnessSecs = policy.LiveAccountSyncFreshnessSecs
 	}
 	if policy.PaperStartReadinessTimeoutSecs > 0 {

--- a/internal/service/platform.go
+++ b/internal/service/platform.go
@@ -14,6 +14,7 @@ import (
 	"log/slog"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/wuyaocheng/bktrader/internal/domain"
 	"github.com/wuyaocheng/bktrader/internal/store"
@@ -52,13 +53,14 @@ type Platform struct {
 }
 
 type RuntimePolicy struct {
-	TradeTickFreshnessSeconds      int `json:"tradeTickFreshnessSeconds"`
-	OrderBookFreshnessSeconds      int `json:"orderBookFreshnessSeconds"`
-	SignalBarFreshnessSeconds      int `json:"signalBarFreshnessSeconds"`
-	RuntimeQuietSeconds            int `json:"runtimeQuietSeconds"`
-	StrategyEvaluationQuietSeconds int `json:"strategyEvaluationQuietSeconds"`
-	LiveAccountSyncFreshnessSecs   int `json:"liveAccountSyncFreshnessSeconds"`
-	PaperStartReadinessTimeoutSecs int `json:"paperStartReadinessTimeoutSeconds"`
+	TradeTickFreshnessSeconds      int       `json:"tradeTickFreshnessSeconds"`
+	OrderBookFreshnessSeconds      int       `json:"orderBookFreshnessSeconds"`
+	SignalBarFreshnessSeconds      int       `json:"signalBarFreshnessSeconds"`
+	RuntimeQuietSeconds            int       `json:"runtimeQuietSeconds"`
+	StrategyEvaluationQuietSeconds int       `json:"strategyEvaluationQuietSeconds"`
+	LiveAccountSyncFreshnessSecs   int       `json:"liveAccountSyncFreshnessSeconds"`
+	PaperStartReadinessTimeoutSecs int       `json:"paperStartReadinessTimeoutSeconds"`
+	UpdatedAt                      time.Time `json:"updatedAt"`
 }
 
 // NewPlatform 创建并初始化平台服务实例。
@@ -84,6 +86,7 @@ func NewPlatform(store store.Repository) *Platform {
 			StrategyEvaluationQuietSeconds: 15,
 			LiveAccountSyncFreshnessSecs:   60,
 			PaperStartReadinessTimeoutSecs: 5,
+			UpdatedAt:                      time.Now().UTC(),
 		},
 	}
 	platform.registerBuiltInStrategyEngines()
@@ -135,12 +138,16 @@ func (p *Platform) SetRuntimePolicy(policy RuntimePolicy) {
 	if policy.PaperStartReadinessTimeoutSecs > 0 {
 		p.runtimePolicy.PaperStartReadinessTimeoutSecs = policy.PaperStartReadinessTimeoutSecs
 	}
+	if !policy.UpdatedAt.IsZero() {
+		p.runtimePolicy.UpdatedAt = policy.UpdatedAt
+	}
 	p.logger("service.platform").Info("runtime policy applied",
 		"trade_tick_freshness_seconds", p.runtimePolicy.TradeTickFreshnessSeconds,
 		"order_book_freshness_seconds", p.runtimePolicy.OrderBookFreshnessSeconds,
 		"signal_bar_freshness_seconds", p.runtimePolicy.SignalBarFreshnessSeconds,
 		"runtime_quiet_seconds", p.runtimePolicy.RuntimeQuietSeconds,
 		"paper_start_readiness_timeout_seconds", p.runtimePolicy.PaperStartReadinessTimeoutSecs,
+		"updated_at", p.runtimePolicy.UpdatedAt,
 	)
 }
 
@@ -187,6 +194,7 @@ func (p *Platform) UpdateRuntimePolicy(policy RuntimePolicy) (RuntimePolicy, err
 		StrategyEvaluationQuietSeconds: saved.StrategyEvaluationQuietSeconds,
 		LiveAccountSyncFreshnessSecs:   saved.LiveAccountSyncFreshnessSecs,
 		PaperStartReadinessTimeoutSecs: saved.PaperStartReadinessTimeoutSecs,
+		UpdatedAt:                      saved.UpdatedAt,
 	})
 	p.logger("service.platform").Info("runtime policy updated")
 	return p.runtimePolicy, nil
@@ -210,6 +218,7 @@ func (p *Platform) LoadPersistedRuntimePolicy() error {
 		StrategyEvaluationQuietSeconds: policy.StrategyEvaluationQuietSeconds,
 		LiveAccountSyncFreshnessSecs:   policy.LiveAccountSyncFreshnessSecs,
 		PaperStartReadinessTimeoutSecs: policy.PaperStartReadinessTimeoutSecs,
+		UpdatedAt:                      policy.UpdatedAt,
 	})
 	p.logger("service.platform").Info("persisted runtime policy loaded")
 	return nil

--- a/internal/service/platform.go
+++ b/internal/service/platform.go
@@ -56,6 +56,8 @@ type RuntimePolicy struct {
 	OrderBookFreshnessSeconds      int `json:"orderBookFreshnessSeconds"`
 	SignalBarFreshnessSeconds      int `json:"signalBarFreshnessSeconds"`
 	RuntimeQuietSeconds            int `json:"runtimeQuietSeconds"`
+	StrategyEvaluationQuietSeconds int `json:"strategyEvaluationQuietSeconds"`
+	LiveAccountSyncFreshnessSecs   int `json:"liveAccountSyncFreshnessSeconds"`
 	PaperStartReadinessTimeoutSecs int `json:"paperStartReadinessTimeoutSeconds"`
 }
 
@@ -79,6 +81,8 @@ func NewPlatform(store store.Repository) *Platform {
 			OrderBookFreshnessSeconds:      10,
 			SignalBarFreshnessSeconds:      30,
 			RuntimeQuietSeconds:            30,
+			StrategyEvaluationQuietSeconds: 15,
+			LiveAccountSyncFreshnessSecs:   60,
 			PaperStartReadinessTimeoutSecs: 5,
 		},
 	}
@@ -122,6 +126,12 @@ func (p *Platform) SetRuntimePolicy(policy RuntimePolicy) {
 	if policy.RuntimeQuietSeconds > 0 {
 		p.runtimePolicy.RuntimeQuietSeconds = policy.RuntimeQuietSeconds
 	}
+	if policy.StrategyEvaluationQuietSeconds > 0 {
+		p.runtimePolicy.StrategyEvaluationQuietSeconds = policy.StrategyEvaluationQuietSeconds
+	}
+	if policy.LiveAccountSyncFreshnessSecs > 0 {
+		p.runtimePolicy.LiveAccountSyncFreshnessSecs = policy.LiveAccountSyncFreshnessSecs
+	}
 	if policy.PaperStartReadinessTimeoutSecs > 0 {
 		p.runtimePolicy.PaperStartReadinessTimeoutSecs = policy.PaperStartReadinessTimeoutSecs
 	}
@@ -143,6 +153,8 @@ func (p *Platform) UpdateRuntimePolicy(policy RuntimePolicy) (RuntimePolicy, err
 		policy.OrderBookFreshnessSeconds < 0 ||
 		policy.SignalBarFreshnessSeconds < 0 ||
 		policy.RuntimeQuietSeconds < 0 ||
+		policy.StrategyEvaluationQuietSeconds < 0 ||
+		policy.LiveAccountSyncFreshnessSecs < 0 ||
 		policy.PaperStartReadinessTimeoutSecs < 0 {
 		p.logger("service.platform").Warn("reject invalid runtime policy",
 			"trade_tick_freshness_seconds", policy.TradeTickFreshnessSeconds,
@@ -159,6 +171,8 @@ func (p *Platform) UpdateRuntimePolicy(policy RuntimePolicy) (RuntimePolicy, err
 		OrderBookFreshnessSeconds:      p.runtimePolicy.OrderBookFreshnessSeconds,
 		SignalBarFreshnessSeconds:      p.runtimePolicy.SignalBarFreshnessSeconds,
 		RuntimeQuietSeconds:            p.runtimePolicy.RuntimeQuietSeconds,
+		StrategyEvaluationQuietSeconds: p.runtimePolicy.StrategyEvaluationQuietSeconds,
+		LiveAccountSyncFreshnessSecs:   p.runtimePolicy.LiveAccountSyncFreshnessSecs,
 		PaperStartReadinessTimeoutSecs: p.runtimePolicy.PaperStartReadinessTimeoutSecs,
 	})
 	if err != nil {
@@ -170,6 +184,8 @@ func (p *Platform) UpdateRuntimePolicy(policy RuntimePolicy) (RuntimePolicy, err
 		OrderBookFreshnessSeconds:      saved.OrderBookFreshnessSeconds,
 		SignalBarFreshnessSeconds:      saved.SignalBarFreshnessSeconds,
 		RuntimeQuietSeconds:            saved.RuntimeQuietSeconds,
+		StrategyEvaluationQuietSeconds: saved.StrategyEvaluationQuietSeconds,
+		LiveAccountSyncFreshnessSecs:   saved.LiveAccountSyncFreshnessSecs,
 		PaperStartReadinessTimeoutSecs: saved.PaperStartReadinessTimeoutSecs,
 	})
 	p.logger("service.platform").Info("runtime policy updated")
@@ -191,6 +207,8 @@ func (p *Platform) LoadPersistedRuntimePolicy() error {
 		OrderBookFreshnessSeconds:      policy.OrderBookFreshnessSeconds,
 		SignalBarFreshnessSeconds:      policy.SignalBarFreshnessSeconds,
 		RuntimeQuietSeconds:            policy.RuntimeQuietSeconds,
+		StrategyEvaluationQuietSeconds: policy.StrategyEvaluationQuietSeconds,
+		LiveAccountSyncFreshnessSecs:   policy.LiveAccountSyncFreshnessSecs,
 		PaperStartReadinessTimeoutSecs: policy.PaperStartReadinessTimeoutSecs,
 	})
 	p.logger("service.platform").Info("persisted runtime policy loaded")

--- a/internal/service/signal_runtime_ws.go
+++ b/internal/service/signal_runtime_ws.go
@@ -211,6 +211,7 @@ func (p *Platform) runExchangeWebsocketLoop(
 				state["signalEventCount"] = maxIntValue(state["signalEventCount"], 0) + 1
 				state["sourceStates"] = mergeSignalSourceState(state["sourceStates"], summary, now)
 				state["signalBarStates"] = deriveSignalBarStates(mapValue(state["sourceStates"]))
+				updateRuntimeHealthSummary(state, summary, now)
 				appendSignalRuntimeTimeline(state, now, "market", firstNonEmpty(stringValue(summary["event"]), "message"), map[string]any{
 					"symbol":    stringValue(summary["symbol"]),
 					"timeframe": stringValue(summary["timeframe"]),

--- a/internal/store/postgres/store.go
+++ b/internal/store/postgres/store.go
@@ -40,7 +40,7 @@ func (s *Store) Close() error {
 func (s *Store) GetRuntimePolicy() (domain.RuntimePolicy, bool, error) {
 	var item domain.RuntimePolicy
 	err := s.db.QueryRow(`
-		select trade_tick_freshness_seconds, order_book_freshness_seconds, signal_bar_freshness_seconds, runtime_quiet_seconds, paper_start_readiness_timeout_seconds, updated_at
+		select trade_tick_freshness_seconds, order_book_freshness_seconds, signal_bar_freshness_seconds, runtime_quiet_seconds, strategy_evaluation_quiet_seconds, live_account_sync_freshness_seconds, paper_start_readiness_timeout_seconds, updated_at
 		from runtime_policies
 		where id = 1
 	`).Scan(
@@ -48,6 +48,8 @@ func (s *Store) GetRuntimePolicy() (domain.RuntimePolicy, bool, error) {
 		&item.OrderBookFreshnessSeconds,
 		&item.SignalBarFreshnessSeconds,
 		&item.RuntimeQuietSeconds,
+		&item.StrategyEvaluationQuietSeconds,
+		&item.LiveAccountSyncFreshnessSecs,
 		&item.PaperStartReadinessTimeoutSecs,
 		&item.UpdatedAt,
 	)
@@ -63,28 +65,34 @@ func (s *Store) GetRuntimePolicy() (domain.RuntimePolicy, bool, error) {
 func (s *Store) UpsertRuntimePolicy(policy domain.RuntimePolicy) (domain.RuntimePolicy, error) {
 	policy.UpdatedAt = time.Now().UTC()
 	_, err := s.db.Exec(`
-		insert into runtime_policies (
-			id,
-			trade_tick_freshness_seconds,
-			order_book_freshness_seconds,
-			signal_bar_freshness_seconds,
-			runtime_quiet_seconds,
-			paper_start_readiness_timeout_seconds,
-			updated_at
-		)
-		values (1, $1, $2, $3, $4, $5, $6)
-		on conflict (id) do update set
-			trade_tick_freshness_seconds = excluded.trade_tick_freshness_seconds,
-			order_book_freshness_seconds = excluded.order_book_freshness_seconds,
-			signal_bar_freshness_seconds = excluded.signal_bar_freshness_seconds,
-			runtime_quiet_seconds = excluded.runtime_quiet_seconds,
-			paper_start_readiness_timeout_seconds = excluded.paper_start_readiness_timeout_seconds,
-			updated_at = excluded.updated_at
-	`,
+			insert into runtime_policies (
+				id,
+				trade_tick_freshness_seconds,
+				order_book_freshness_seconds,
+				signal_bar_freshness_seconds,
+				runtime_quiet_seconds,
+				strategy_evaluation_quiet_seconds,
+				live_account_sync_freshness_seconds,
+				paper_start_readiness_timeout_seconds,
+				updated_at
+			)
+			values (1, $1, $2, $3, $4, $5, $6, $7, $8)
+			on conflict (id) do update set
+				trade_tick_freshness_seconds = excluded.trade_tick_freshness_seconds,
+				order_book_freshness_seconds = excluded.order_book_freshness_seconds,
+				signal_bar_freshness_seconds = excluded.signal_bar_freshness_seconds,
+				runtime_quiet_seconds = excluded.runtime_quiet_seconds,
+				strategy_evaluation_quiet_seconds = excluded.strategy_evaluation_quiet_seconds,
+				live_account_sync_freshness_seconds = excluded.live_account_sync_freshness_seconds,
+				paper_start_readiness_timeout_seconds = excluded.paper_start_readiness_timeout_seconds,
+				updated_at = excluded.updated_at
+		`,
 		policy.TradeTickFreshnessSeconds,
 		policy.OrderBookFreshnessSeconds,
 		policy.SignalBarFreshnessSeconds,
 		policy.RuntimeQuietSeconds,
+		policy.StrategyEvaluationQuietSeconds,
+		policy.LiveAccountSyncFreshnessSecs,
 		policy.PaperStartReadinessTimeoutSecs,
 		policy.UpdatedAt,
 	)


### PR DESCRIPTION
## 目的
为后端补齐统一的健康状态与心跳可观测性，不改前端展示逻辑。

本次改动包括：
- 为 runtime / live session / account metadata 补充 `healthSummary` 摘要，覆盖 `tradeTick`、`orderBook`、`strategyIngress`、`execution`、`accountSync`
- 新增 `GET /api/v1/monitor/health`，聚合 live account、runtime session、live session、paper session 的健康快照
- 新增 `strategyEvaluationQuietSeconds`、`liveAccountSyncFreshnessSeconds` 两个 runtime policy 阈值及对应 migration
- 在后端告警中补充策略评估静默、账户同步过期、连续同步失败等场景
- 保持 `dispatchMode` 与前端职责不变

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [x] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main)
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？
- [x] DB migration 是否具备向下兼容幂等性？
- [x] 配置字段有没有无意被混改？

已确认：
- `dispatchMode` 默认值未变化
- 未引入 `mainnet` 凭证或路由硬编码
- migration 使用 `add column if not exists`，具备幂等性
- 配置字段仅新增健康监控阈值

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

已执行：
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
- `git push` 触发 pre-push harness，已完成 graphify 重建与 scope check
