### PR TITLE
[codex] add live data collection telemetry

### DIFF
--- a/db/migrations/013_live_data_collection_phase1.sql
+++ b/db/migrations/013_live_data_collection_phase1.sql
@@ -1,0 +1,121 @@
+create table if not exists strategy_decision_events (
+    id text primary key,
+    live_session_id text not null references live_sessions(id) on delete cascade,
+    runtime_session_id text,
+    account_id text not null references accounts(id),
+    strategy_id text not null references strategies(id),
+    strategy_version_id text references strategy_versions(id),
+    symbol text not null,
+    trigger_type text,
+    action text not null,
+    reason text not null,
+    signal_kind text,
+    decision_state text,
+    intent_signature text,
+    source_gate_ready boolean not null default false,
+    missing_count integer not null default 0,
+    stale_count integer not null default 0,
+    event_time timestamptz not null,
+    recorded_at timestamptz not null default now(),
+    trigger_summary jsonb not null default '{}'::jsonb,
+    source_gate jsonb not null default '{}'::jsonb,
+    source_states jsonb not null default '{}'::jsonb,
+    signal_bar_states jsonb not null default '{}'::jsonb,
+    position_snapshot jsonb not null default '{}'::jsonb,
+    decision_metadata jsonb not null default '{}'::jsonb,
+    signal_intent jsonb not null default '{}'::jsonb,
+    execution_proposal jsonb not null default '{}'::jsonb,
+    evaluation_context jsonb not null default '{}'::jsonb
+);
+
+create index if not exists idx_strategy_decision_events_live_session_event_time
+    on strategy_decision_events (live_session_id, event_time desc);
+create index if not exists idx_strategy_decision_events_account_event_time
+    on strategy_decision_events (account_id, event_time desc);
+
+create table if not exists order_execution_events (
+    id text primary key,
+    order_id text not null references orders(id) on delete cascade,
+    exchange_order_id text,
+    live_session_id text references live_sessions(id) on delete set null,
+    decision_event_id text references strategy_decision_events(id) on delete set null,
+    runtime_session_id text,
+    account_id text not null references accounts(id),
+    strategy_version_id text references strategy_versions(id),
+    symbol text not null,
+    side text not null,
+    order_type text not null,
+    event_type text not null,
+    status text not null,
+    execution_strategy text,
+    execution_decision text,
+    execution_mode text,
+    quantity numeric(24, 8) not null default 0,
+    price numeric(24, 8) not null default 0,
+    expected_price numeric(24, 8) not null default 0,
+    price_drift_bps numeric(18, 8) not null default 0,
+    raw_quantity numeric(24, 8) not null default 0,
+    normalized_quantity numeric(24, 8) not null default 0,
+    raw_price_reference numeric(24, 8) not null default 0,
+    normalized_price numeric(24, 8) not null default 0,
+    spread_bps numeric(18, 8) not null default 0,
+    book_imbalance numeric(18, 8) not null default 0,
+    submit_latency_ms integer not null default 0,
+    sync_latency_ms integer not null default 0,
+    fill_latency_ms integer not null default 0,
+    event_time timestamptz not null,
+    recorded_at timestamptz not null default now(),
+    fallback boolean not null default false,
+    post_only boolean not null default false,
+    reduce_only boolean not null default false,
+    failed boolean not null default false,
+    error text,
+    runtime_preflight jsonb not null default '{}'::jsonb,
+    dispatch_summary jsonb not null default '{}'::jsonb,
+    adapter_submission jsonb not null default '{}'::jsonb,
+    adapter_sync jsonb not null default '{}'::jsonb,
+    normalization jsonb not null default '{}'::jsonb,
+    symbol_rules jsonb not null default '{}'::jsonb,
+    metadata jsonb not null default '{}'::jsonb
+);
+
+create index if not exists idx_order_execution_events_order_event_time
+    on order_execution_events (order_id, event_time desc);
+create index if not exists idx_order_execution_events_live_session_event_time
+    on order_execution_events (live_session_id, event_time desc);
+
+create table if not exists position_account_snapshots (
+    id text primary key,
+    live_session_id text not null references live_sessions(id) on delete cascade,
+    decision_event_id text references strategy_decision_events(id) on delete set null,
+    order_id text references orders(id) on delete set null,
+    account_id text not null references accounts(id),
+    strategy_id text not null references strategies(id),
+    symbol text not null,
+    trigger text not null,
+    intent_signature text,
+    position_found boolean not null default false,
+    position_side text,
+    position_quantity numeric(24, 8) not null default 0,
+    entry_price numeric(24, 8) not null default 0,
+    mark_price numeric(24, 8) not null default 0,
+    net_equity numeric(24, 8) not null default 0,
+    available_balance numeric(24, 8) not null default 0,
+    margin_balance numeric(24, 8) not null default 0,
+    wallet_balance numeric(24, 8) not null default 0,
+    exposure_notional numeric(24, 8) not null default 0,
+    open_position_count integer not null default 0,
+    sync_status text,
+    event_time timestamptz not null,
+    recorded_at timestamptz not null default now(),
+    position_snapshot jsonb not null default '{}'::jsonb,
+    live_position_state jsonb not null default '{}'::jsonb,
+    account_snapshot jsonb not null default '{}'::jsonb,
+    account_summary jsonb not null default '{}'::jsonb,
+    metadata jsonb not null default '{}'::jsonb
+);
+
+create index if not exists idx_position_account_snapshots_live_session_event_time
+    on position_account_snapshots (live_session_id, event_time desc);
+create index if not exists idx_position_account_snapshots_account_event_time
+    on position_account_snapshots (account_id, event_time desc);

--- a/internal/domain/models.go
+++ b/internal/domain/models.go
@@ -248,6 +248,116 @@ type RuntimePolicy struct {
 	UpdatedAt                      time.Time `json:"updatedAt"`
 }
 
+// StrategyDecisionEvent 记录 live 运行时的策略评估输入、决策和执行意图。
+type StrategyDecisionEvent struct {
+	ID                string         `json:"id"`
+	LiveSessionID     string         `json:"liveSessionId"`
+	RuntimeSessionID  string         `json:"runtimeSessionId,omitempty"`
+	AccountID         string         `json:"accountId"`
+	StrategyID        string         `json:"strategyId"`
+	StrategyVersionID string         `json:"strategyVersionId,omitempty"`
+	Symbol            string         `json:"symbol"`
+	TriggerType       string         `json:"triggerType,omitempty"`
+	Action            string         `json:"action"`
+	Reason            string         `json:"reason"`
+	SignalKind        string         `json:"signalKind,omitempty"`
+	DecisionState     string         `json:"decisionState,omitempty"`
+	IntentSignature   string         `json:"intentSignature,omitempty"`
+	SourceGateReady   bool           `json:"sourceGateReady"`
+	MissingCount      int            `json:"missingCount"`
+	StaleCount        int            `json:"staleCount"`
+	EventTime         time.Time      `json:"eventTime"`
+	RecordedAt        time.Time      `json:"recordedAt"`
+	TriggerSummary    map[string]any `json:"triggerSummary,omitempty"`
+	SourceGate        map[string]any `json:"sourceGate,omitempty"`
+	SourceStates      map[string]any `json:"sourceStates,omitempty"`
+	SignalBarStates   map[string]any `json:"signalBarStates,omitempty"`
+	PositionSnapshot  map[string]any `json:"positionSnapshot,omitempty"`
+	DecisionMetadata  map[string]any `json:"decisionMetadata,omitempty"`
+	SignalIntent      map[string]any `json:"signalIntent,omitempty"`
+	ExecutionProposal map[string]any `json:"executionProposal,omitempty"`
+	EvaluationContext map[string]any `json:"evaluationContext,omitempty"`
+}
+
+// OrderExecutionEvent 记录 live 订单在提交、同步、成交等生命周期中的结构化执行数据。
+type OrderExecutionEvent struct {
+	ID                string         `json:"id"`
+	OrderID           string         `json:"orderId"`
+	ExchangeOrderID   string         `json:"exchangeOrderId,omitempty"`
+	LiveSessionID     string         `json:"liveSessionId,omitempty"`
+	DecisionEventID   string         `json:"decisionEventId,omitempty"`
+	RuntimeSessionID  string         `json:"runtimeSessionId,omitempty"`
+	AccountID         string         `json:"accountId"`
+	StrategyVersionID string         `json:"strategyVersionId,omitempty"`
+	Symbol            string         `json:"symbol"`
+	Side              string         `json:"side"`
+	OrderType         string         `json:"orderType"`
+	EventType         string         `json:"eventType"`
+	Status            string         `json:"status"`
+	ExecutionStrategy string         `json:"executionStrategy,omitempty"`
+	ExecutionDecision string         `json:"executionDecision,omitempty"`
+	ExecutionMode     string         `json:"executionMode,omitempty"`
+	Quantity          float64        `json:"quantity"`
+	Price             float64        `json:"price"`
+	ExpectedPrice     float64        `json:"expectedPrice"`
+	PriceDriftBps     float64        `json:"priceDriftBps"`
+	RawQuantity       float64        `json:"rawQuantity"`
+	NormalizedQty     float64        `json:"normalizedQuantity"`
+	RawPriceReference float64        `json:"rawPriceReference"`
+	NormalizedPrice   float64        `json:"normalizedPrice"`
+	SpreadBps         float64        `json:"spreadBps"`
+	BookImbalance     float64        `json:"bookImbalance"`
+	SubmitLatencyMs   int            `json:"submitLatencyMs"`
+	SyncLatencyMs     int            `json:"syncLatencyMs"`
+	FillLatencyMs     int            `json:"fillLatencyMs"`
+	EventTime         time.Time      `json:"eventTime"`
+	RecordedAt        time.Time      `json:"recordedAt"`
+	Fallback          bool           `json:"fallback"`
+	PostOnly          bool           `json:"postOnly"`
+	ReduceOnly        bool           `json:"reduceOnly"`
+	Failed            bool           `json:"failed"`
+	Error             string         `json:"error,omitempty"`
+	RuntimePreflight  map[string]any `json:"runtimePreflight,omitempty"`
+	DispatchSummary   map[string]any `json:"dispatchSummary,omitempty"`
+	AdapterSubmission map[string]any `json:"adapterSubmission,omitempty"`
+	AdapterSync       map[string]any `json:"adapterSync,omitempty"`
+	Normalization     map[string]any `json:"normalization,omitempty"`
+	SymbolRules       map[string]any `json:"symbolRules,omitempty"`
+	Metadata          map[string]any `json:"metadata,omitempty"`
+}
+
+// PositionAccountSnapshot 记录 live session 在关键事件后的仓位和账户状态快照。
+type PositionAccountSnapshot struct {
+	ID                string         `json:"id"`
+	LiveSessionID     string         `json:"liveSessionId"`
+	DecisionEventID   string         `json:"decisionEventId,omitempty"`
+	OrderID           string         `json:"orderId,omitempty"`
+	AccountID         string         `json:"accountId"`
+	StrategyID        string         `json:"strategyId"`
+	Symbol            string         `json:"symbol"`
+	Trigger           string         `json:"trigger"`
+	IntentSignature   string         `json:"intentSignature,omitempty"`
+	PositionFound     bool           `json:"positionFound"`
+	PositionSide      string         `json:"positionSide,omitempty"`
+	PositionQuantity  float64        `json:"positionQuantity"`
+	EntryPrice        float64        `json:"entryPrice"`
+	MarkPrice         float64        `json:"markPrice"`
+	NetEquity         float64        `json:"netEquity"`
+	AvailableBalance  float64        `json:"availableBalance"`
+	MarginBalance     float64        `json:"marginBalance"`
+	WalletBalance     float64        `json:"walletBalance"`
+	ExposureNotional  float64        `json:"exposureNotional"`
+	OpenPositionCount int            `json:"openPositionCount"`
+	SyncStatus        string         `json:"syncStatus,omitempty"`
+	EventTime         time.Time      `json:"eventTime"`
+	RecordedAt        time.Time      `json:"recordedAt"`
+	PositionSnapshot  map[string]any `json:"positionSnapshot,omitempty"`
+	LivePositionState map[string]any `json:"livePositionState,omitempty"`
+	AccountSnapshot   map[string]any `json:"accountSnapshot,omitempty"`
+	AccountSummary    map[string]any `json:"accountSummary,omitempty"`
+	Metadata          map[string]any `json:"metadata,omitempty"`
+}
+
 // PlatformAlert 是统一告警中心消费的聚合告警记录。
 type PlatformAlert struct {
 	ID               string         `json:"id"`

--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -1148,6 +1148,34 @@ func (p *Platform) evaluateLiveSessionOnSignal(session domain.LiveSession, runti
 		delete(state, "lastStrategyIntent")
 		delete(state, "lastStrategyIntentSignature")
 	}
+	decisionEvent, decisionEventErr := p.recordStrategyDecisionEvent(
+		session,
+		firstNonEmpty(runtimeSessionID, stringValue(state["signalRuntimeSessionId"])),
+		eventTime,
+		summary,
+		sourceStates,
+		signalBarStates,
+		sourceGate,
+		executionContext,
+		decision,
+		cloneMetadata(mapValue(state["lastSignalIntent"])),
+		executionProposal,
+	)
+	if decisionEventErr != nil {
+		state["lastStrategyDecisionEventError"] = decisionEventErr.Error()
+	} else {
+		delete(state, "lastStrategyDecisionEventError")
+		state["lastStrategyDecisionEventId"] = decisionEvent.ID
+		if len(executionProposal) > 0 {
+			executionProposal["decisionEventId"] = decisionEvent.ID
+			proposalMetadata := cloneMetadata(mapValue(executionProposal["metadata"]))
+			proposalMetadata["decisionEventId"] = decisionEvent.ID
+			executionProposal["metadata"] = proposalMetadata
+			intent = executionProposal
+			state["lastExecutionProposal"] = executionProposal
+			state["lastStrategyIntent"] = executionProposal
+		}
+	}
 	appendTimelineEvent(state, "strategy", eventTime, "decision", map[string]any{
 		"action":            decision.Action,
 		"reason":            decision.Reason,

--- a/internal/service/live_execution.go
+++ b/internal/service/live_execution.go
@@ -344,6 +344,7 @@ func buildLiveOrderFromExecutionProposal(session domain.LiveSession, strategyVer
 			"timeInForce":        proposal.TimeInForce,
 			"postOnly":           proposal.PostOnly,
 			"reduceOnly":         proposal.ReduceOnly,
+			"decisionEventId":    stringValue(proposalMap["decisionEventId"]),
 			"executionStrategy":  proposal.ExecutionStrategy,
 			"executionExpiresAt": stringValue(proposal.Metadata["executionExpiresAt"]),
 			"executionProposal":  cloneMetadata(proposalMap),

--- a/internal/service/live_recovery.go
+++ b/internal/service/live_recovery.go
@@ -76,6 +76,15 @@ func (p *Platform) refreshLiveSessionProtectionState(session domain.LiveSession)
 }
 
 func (p *Platform) refreshLiveSessionPositionContext(session domain.LiveSession, eventTime time.Time, source string) (domain.LiveSession, error) {
+	persistSnapshot := func(updated domain.LiveSession) (domain.LiveSession, error) {
+		if updated.ID == "" {
+			return updated, nil
+		}
+		if err := p.recordLivePositionAccountSnapshot(updated, eventTime, source, ""); err != nil {
+			p.logger("service.live_recovery", "session_id", updated.ID).Warn("record live position/account snapshot failed", "error", err)
+		}
+		return updated, nil
+	}
 	refreshed, err := p.refreshLiveSessionProtectionState(session)
 	if err != nil {
 		return domain.LiveSession{}, err
@@ -103,7 +112,11 @@ func (p *Platform) refreshLiveSessionPositionContext(session domain.LiveSession,
 		delete(state, "livePositionState")
 		state["lastLivePositionState"] = map[string]any{}
 		state["positionRecoveryStatus"] = "flat"
-		return p.store.UpdateLiveSessionState(refreshed.ID, state)
+		updated, updateErr := p.store.UpdateLiveSessionState(refreshed.ID, state)
+		if updateErr != nil {
+			return domain.LiveSession{}, updateErr
+		}
+		return persistSnapshot(updated)
 	}
 	if hasVirtualPosition {
 		state["positionRecoveryStatus"] = "monitoring-virtual-position"
@@ -137,12 +150,20 @@ func (p *Platform) refreshLiveSessionPositionContext(session domain.LiveSession,
 				applyLivePositionWatermarks(state, watermarks)
 			}
 		}
-		return p.store.UpdateLiveSessionState(refreshed.ID, state)
+		updated, updateErr := p.store.UpdateLiveSessionState(refreshed.ID, state)
+		if updateErr != nil {
+			return domain.LiveSession{}, updateErr
+		}
+		return persistSnapshot(updated)
 	}
 	marketPrice := firstPositive(parseFloatValue(positionSnapshot["markPrice"]), parseFloatValue(mapValue(signalBarState["current"])["close"]))
 	livePositionState := evaluateLivePositionState(parameters, positionSnapshot, signalBarState, marketPrice, state)
 	if len(livePositionState) == 0 {
-		return p.store.UpdateLiveSessionState(refreshed.ID, state)
+		updated, updateErr := p.store.UpdateLiveSessionState(refreshed.ID, state)
+		if updateErr != nil {
+			return domain.LiveSession{}, updateErr
+		}
+		return persistSnapshot(updated)
 	}
 	state["livePositionState"] = livePositionState
 	state["lastLivePositionState"] = livePositionState
@@ -151,7 +172,11 @@ func (p *Platform) refreshLiveSessionPositionContext(session domain.LiveSession,
 	if boolValue(livePositionState["protected"]) && len(metadataList(state["recoveredProtectionOrders"])) > 0 {
 		state["positionRecoveryStatus"] = "protected-open-position"
 	}
-	return p.store.UpdateLiveSessionState(refreshed.ID, state)
+	updated, updateErr := p.store.UpdateLiveSessionState(refreshed.ID, state)
+	if updateErr != nil {
+		return domain.LiveSession{}, updateErr
+	}
+	return persistSnapshot(updated)
 }
 
 func isProtectionOrder(order map[string]any) bool {

--- a/internal/service/order.go
+++ b/internal/service/order.go
@@ -182,6 +182,9 @@ func (p *Platform) applyLiveSubmissionResult(
 		if updateErr != nil {
 			return domain.Order{}, updateErr
 		}
+		if telemetryErr := p.recordLiveOrderExecutionEvent(updatedOrder, "submitted", time.Now().UTC(), true, submitErr); telemetryErr != nil {
+			logger.Warn("record live order submission event failed", "error", telemetryErr)
+		}
 		logger.Warn("live order submission failed", "error", submitErr)
 		return updatedOrder, submitErr
 	}
@@ -200,7 +203,14 @@ func (p *Platform) applyLiveSubmissionResult(
 		"status", order.Status,
 		"exchange_order_id", submission.ExchangeOrderID,
 	)
-	return p.store.UpdateOrder(order)
+	updatedOrder, err := p.store.UpdateOrder(order)
+	if err != nil {
+		return domain.Order{}, err
+	}
+	if telemetryErr := p.recordLiveOrderExecutionEvent(updatedOrder, "submitted", time.Now().UTC(), false, nil); telemetryErr != nil {
+		logger.Warn("record live order submission event failed", "error", telemetryErr)
+	}
+	return updatedOrder, nil
 }
 
 func (p *Platform) ensureLiveRuntimeReady(account domain.Account, order domain.Order) (domain.SignalRuntimeSession, map[string]any, error) {
@@ -400,10 +410,20 @@ func (p *Platform) applyLiveSyncResult(account domain.Account, order domain.Orde
 			"last_price", lastPrice,
 			"funding_pnl", lastFundingPnL,
 		)
+		if telemetryErr := p.recordLiveOrderExecutionEvent(order, "synced", parseOptionalRFC3339(firstNonEmpty(syncResult.SyncedAt, stringValue(order.Metadata["lastSyncAt"]))), false, nil); telemetryErr != nil {
+			logger.Warn("record live order sync event failed", "error", telemetryErr)
+		}
 		return p.finalizeExecutedOrder(account, order, fills)
 	}
 	logger.Debug("live order sync applied", "status", order.Status)
-	return p.store.UpdateOrder(order)
+	updatedOrder, err := p.store.UpdateOrder(order)
+	if err != nil {
+		return domain.Order{}, err
+	}
+	if telemetryErr := p.recordLiveOrderExecutionEvent(updatedOrder, "synced", parseOptionalRFC3339(firstNonEmpty(syncResult.SyncedAt, stringValue(updatedOrder.Metadata["lastSyncAt"]))), false, nil); telemetryErr != nil {
+		logger.Warn("record live order sync event failed", "error", telemetryErr)
+	}
+	return updatedOrder, nil
 }
 
 func buildLiveSyncSettlement(order domain.Order, syncResult LiveOrderSync) ([]domain.Fill, float64, float64) {
@@ -458,6 +478,11 @@ func (p *Platform) finalizeExecutedOrder(account domain.Account, order domain.Or
 	updatedOrder, err := p.store.UpdateOrder(order)
 	if err != nil {
 		return domain.Order{}, err
+	}
+	if strings.EqualFold(account.Mode, "LIVE") {
+		if telemetryErr := p.recordLiveOrderExecutionEvent(updatedOrder, "filled", parseOptionalRFC3339(stringValue(updatedOrder.Metadata["lastFilledAt"])), false, nil); telemetryErr != nil {
+			p.logger("service.order", "order_id", updatedOrder.ID).Warn("record live order fill event failed", "error", telemetryErr)
+		}
 	}
 	if err := p.captureAccountSnapshot(account.ID); err != nil {
 		return domain.Order{}, err

--- a/internal/service/telemetry.go
+++ b/internal/service/telemetry.go
@@ -1,0 +1,253 @@
+package service
+
+import (
+	"strings"
+	"time"
+
+	"github.com/wuyaocheng/bktrader/internal/domain"
+)
+
+func (p *Platform) recordStrategyDecisionEvent(
+	session domain.LiveSession,
+	runtimeSessionID string,
+	eventTime time.Time,
+	triggerSummary map[string]any,
+	sourceStates map[string]any,
+	signalBarStates map[string]any,
+	sourceGate map[string]any,
+	executionContext StrategyExecutionContext,
+	decision StrategySignalDecision,
+	signalIntent map[string]any,
+	executionProposal map[string]any,
+) (domain.StrategyDecisionEvent, error) {
+	intentSignature := ""
+	if len(executionProposal) > 0 {
+		intentSignature = buildLiveIntentSignature(executionProposal)
+	}
+	if intentSignature == "" && len(signalIntent) > 0 {
+		intentSignature = buildLiveIntentSignature(signalIntent)
+	}
+
+	event := domain.StrategyDecisionEvent{
+		LiveSessionID:     session.ID,
+		RuntimeSessionID:  runtimeSessionID,
+		AccountID:         session.AccountID,
+		StrategyID:        session.StrategyID,
+		StrategyVersionID: executionContext.StrategyVersionID,
+		Symbol: firstNonEmpty(
+			NormalizeSymbol(executionContext.Symbol),
+			NormalizeSymbol(stringValue(executionProposal["symbol"])),
+			NormalizeSymbol(stringValue(signalIntent["symbol"])),
+			NormalizeSymbol(stringValue(session.State["symbol"])),
+		),
+		TriggerType:       firstNonEmpty(stringValue(triggerSummary["event"]), stringValue(triggerSummary["type"])),
+		Action:            firstNonEmpty(decision.Action, "wait"),
+		Reason:            firstNonEmpty(decision.Reason, "unspecified"),
+		SignalKind:        firstNonEmpty(stringValue(decision.Metadata["signalKind"]), stringValue(executionProposal["signalKind"])),
+		DecisionState:     firstNonEmpty(stringValue(decision.Metadata["decisionState"]), stringValue(executionProposal["decisionState"])),
+		IntentSignature:   intentSignature,
+		SourceGateReady:   boolValue(sourceGate["ready"]),
+		MissingCount:      len(metadataList(sourceGate["missing"])),
+		StaleCount:        len(metadataList(sourceGate["stale"])),
+		EventTime:         eventTime.UTC(),
+		TriggerSummary:    cloneMetadata(triggerSummary),
+		SourceGate:        cloneMetadata(sourceGate),
+		SourceStates:      cloneMetadata(sourceStates),
+		SignalBarStates:   cloneMetadata(signalBarStates),
+		PositionSnapshot:  cloneMetadata(mapValue(session.State["recoveredPosition"])),
+		DecisionMetadata:  cloneMetadata(decision.Metadata),
+		SignalIntent:      cloneMetadata(signalIntent),
+		ExecutionProposal: cloneMetadata(executionProposal),
+		EvaluationContext: map[string]any{
+			"strategyEngineKey":    executionContext.StrategyEngineKey,
+			"strategyVersionId":    executionContext.StrategyVersionID,
+			"signalTimeframe":      executionContext.SignalTimeframe,
+			"executionDataSource":  executionContext.ExecutionDataSource,
+			"symbol":               executionContext.Symbol,
+			"executionMode":        string(executionContext.Semantics.Mode),
+			"slippageMode":         string(executionContext.Semantics.SlippageMode),
+			"tradingFeeBps":        executionContext.Semantics.TradingFeeBps,
+			"fundingRateBps":       executionContext.Semantics.FundingRateBps,
+			"fundingIntervalHours": executionContext.Semantics.FundingIntervalHours,
+		},
+	}
+	return p.store.CreateStrategyDecisionEvent(event)
+}
+
+func (p *Platform) recordLiveOrderExecutionEvent(order domain.Order, eventType string, eventTime time.Time, failed bool, eventErr error) error {
+	if !stringsEqualFoldSafe(stringValue(order.Metadata["executionMode"]), "live") && !stringsEqualFoldSafe(stringValue(order.Metadata["source"]), "live-session-intent") {
+		return nil
+	}
+
+	proposalMap := cloneMetadata(mapValue(order.Metadata["executionProposal"]))
+	dispatchSummary := executionDispatchSummary(proposalMap, order, failed)
+	if eventTime.IsZero() {
+		eventTime = firstNonZeroTime(
+			parseOptionalRFC3339(stringValue(order.Metadata["lastFilledAt"])),
+			parseOptionalRFC3339(stringValue(order.Metadata["lastSyncAt"])),
+			parseOptionalRFC3339(stringValue(order.Metadata["acceptedAt"])),
+			order.CreatedAt,
+			time.Now().UTC(),
+		)
+	}
+
+	event := domain.OrderExecutionEvent{
+		OrderID:           order.ID,
+		ExchangeOrderID:   firstNonEmpty(stringValue(order.Metadata["exchangeOrderId"]), stringValue(dispatchSummary["exchangeOrderId"])),
+		LiveSessionID:     stringValue(order.Metadata["liveSessionId"]),
+		DecisionEventID:   firstNonEmpty(stringValue(order.Metadata["decisionEventId"]), stringValue(proposalMap["decisionEventId"])),
+		RuntimeSessionID:  stringValue(order.Metadata["runtimeSessionId"]),
+		AccountID:         order.AccountID,
+		StrategyVersionID: order.StrategyVersionID,
+		Symbol:            firstNonEmpty(order.Symbol, stringValue(dispatchSummary["symbol"])),
+		Side:              firstNonEmpty(order.Side, stringValue(dispatchSummary["side"])),
+		OrderType:         firstNonEmpty(order.Type, stringValue(dispatchSummary["orderType"])),
+		EventType:         eventType,
+		Status:            firstNonEmpty(order.Status, stringValue(dispatchSummary["status"])),
+		ExecutionStrategy: stringValue(dispatchSummary["executionStrategy"]),
+		ExecutionDecision: stringValue(dispatchSummary["executionDecision"]),
+		ExecutionMode:     firstNonEmpty(stringValue(dispatchSummary["executionMode"]), stringValue(order.Metadata["executionMode"])),
+		Quantity:          firstPositive(order.Quantity, parseFloatValue(dispatchSummary["quantity"])),
+		Price:             firstPositive(order.Price, parseFloatValue(dispatchSummary["price"])),
+		ExpectedPrice:     parseFloatValue(dispatchSummary["expectedPrice"]),
+		PriceDriftBps:     parseFloatValue(dispatchSummary["priceDriftBps"]),
+		RawQuantity:       parseFloatValue(dispatchSummary["rawQuantity"]),
+		NormalizedQty:     parseFloatValue(dispatchSummary["normalizedQuantity"]),
+		RawPriceReference: parseFloatValue(dispatchSummary["rawPriceReference"]),
+		NormalizedPrice:   parseFloatValue(dispatchSummary["normalizedPrice"]),
+		SpreadBps:         parseFloatValue(dispatchSummary["spreadBps"]),
+		BookImbalance:     parseFloatValue(dispatchSummary["bookImbalance"]),
+		SubmitLatencyMs:   latencyMillis(order.CreatedAt, parseOptionalRFC3339(stringValue(order.Metadata["acceptedAt"]))),
+		SyncLatencyMs:     latencyMillis(order.CreatedAt, parseOptionalRFC3339(stringValue(order.Metadata["lastSyncAt"]))),
+		FillLatencyMs:     latencyMillis(order.CreatedAt, parseOptionalRFC3339(stringValue(order.Metadata["lastFilledAt"]))),
+		EventTime:         eventTime.UTC(),
+		Fallback:          boolValue(dispatchSummary["fallback"]),
+		PostOnly:          boolValue(dispatchSummary["postOnly"]),
+		ReduceOnly:        boolValue(dispatchSummary["reduceOnly"]),
+		Failed:            failed,
+		Error:             errorString(eventErr),
+		RuntimePreflight:  cloneMetadata(mapValue(order.Metadata["runtimePreflight"])),
+		DispatchSummary:   dispatchSummary,
+		AdapterSubmission: cloneMetadata(mapValue(order.Metadata["adapterSubmission"])),
+		AdapterSync:       cloneMetadata(mapValue(order.Metadata["adapterSync"])),
+		Normalization:     cloneMetadata(mapValue(dispatchSummary["normalization"])),
+		SymbolRules:       cloneMetadata(mapValue(dispatchSummary["symbolRules"])),
+		Metadata:          cloneMetadata(order.Metadata),
+	}
+	_, err := p.store.CreateOrderExecutionEvent(event)
+	return err
+}
+
+func (p *Platform) recordLivePositionAccountSnapshot(session domain.LiveSession, eventTime time.Time, trigger string, orderID string) error {
+	account, err := p.store.GetAccount(session.AccountID)
+	if err != nil {
+		return err
+	}
+	summary, _ := p.accountSummaryByID(session.AccountID)
+	state := cloneMetadata(session.State)
+	positionSnapshot := cloneMetadata(mapValue(state["recoveredPosition"]))
+	livePositionState := cloneMetadata(mapValue(state["livePositionState"]))
+	accountSnapshot := cloneMetadata(mapValue(account.Metadata["liveSyncSnapshot"]))
+	symbol := NormalizeSymbol(firstNonEmpty(
+		stringValue(positionSnapshot["symbol"]),
+		stringValue(livePositionState["symbol"]),
+		stringValue(state["symbol"]),
+		stringValue(state["lastSymbol"]),
+	))
+	if symbol == "" {
+		return nil
+	}
+	if eventTime.IsZero() {
+		eventTime = time.Now().UTC()
+	}
+	if orderID == "" {
+		orderID = stringValue(state["lastDispatchedOrderId"])
+	}
+
+	snapshot := domain.PositionAccountSnapshot{
+		LiveSessionID:     session.ID,
+		DecisionEventID:   stringValue(state["lastStrategyDecisionEventId"]),
+		OrderID:           orderID,
+		AccountID:         session.AccountID,
+		StrategyID:        session.StrategyID,
+		Symbol:            symbol,
+		Trigger:           firstNonEmpty(trigger, "live-position-refresh"),
+		IntentSignature:   firstNonEmpty(stringValue(state["lastDispatchedIntentSignature"]), stringValue(state["lastStrategyIntentSignature"])),
+		PositionFound:     boolValue(state["hasRecoveredPosition"]),
+		PositionSide:      firstNonEmpty(stringValue(positionSnapshot["side"]), stringValue(livePositionState["side"])),
+		PositionQuantity:  firstPositive(parseFloatValue(positionSnapshot["quantity"]), parseFloatValue(livePositionState["quantity"])),
+		EntryPrice:        firstPositive(parseFloatValue(positionSnapshot["entryPrice"]), parseFloatValue(livePositionState["entryPrice"])),
+		MarkPrice:         firstPositive(parseFloatValue(positionSnapshot["markPrice"]), parseFloatValue(livePositionState["markPrice"])),
+		NetEquity:         summary.NetEquity,
+		AvailableBalance:  summary.AvailableBalance,
+		MarginBalance:     summary.MarginBalance,
+		WalletBalance:     summary.WalletBalance,
+		ExposureNotional:  summary.ExposureNotional,
+		OpenPositionCount: summary.OpenPositionCount,
+		SyncStatus:        stringValue(accountSnapshot["syncStatus"]),
+		EventTime:         eventTime.UTC(),
+		PositionSnapshot:  positionSnapshot,
+		LivePositionState: livePositionState,
+		AccountSnapshot:   accountSnapshot,
+		AccountSummary: map[string]any{
+			"netEquity":         summary.NetEquity,
+			"availableBalance":  summary.AvailableBalance,
+			"walletBalance":     summary.WalletBalance,
+			"marginBalance":     summary.MarginBalance,
+			"exposureNotional":  summary.ExposureNotional,
+			"openPositionCount": summary.OpenPositionCount,
+			"updatedAt":         summary.UpdatedAt.Format(time.RFC3339),
+		},
+		Metadata: map[string]any{
+			"positionRecoveryStatus":      stringValue(state["positionRecoveryStatus"]),
+			"lastPositionContextSource":   stringValue(state["lastPositionContextSource"]),
+			"lastPositionContextAt":       stringValue(state["lastPositionContextRefreshAt"]),
+			"hasRecoveredRealPosition":    boolValue(state["hasRecoveredRealPosition"]),
+			"hasRecoveredVirtualPosition": boolValue(state["hasRecoveredVirtualPosition"]),
+			"protectionRecoveryStatus":    stringValue(state["protectionRecoveryStatus"]),
+			"recoveredProtectionCount":    maxIntValue(state["recoveredProtectionCount"], 0),
+		},
+	}
+	_, err = p.store.CreatePositionAccountSnapshot(snapshot)
+	return err
+}
+
+func (p *Platform) accountSummaryByID(accountID string) (domain.AccountSummary, bool) {
+	summaries, err := p.ListAccountSummaries()
+	if err != nil {
+		return domain.AccountSummary{}, false
+	}
+	for _, item := range summaries {
+		if item.AccountID == accountID {
+			return item, true
+		}
+	}
+	return domain.AccountSummary{}, false
+}
+
+func latencyMillis(start, end time.Time) int {
+	if start.IsZero() || end.IsZero() || end.Before(start) {
+		return 0
+	}
+	return int(end.Sub(start) / time.Millisecond)
+}
+
+func firstNonZeroTime(values ...time.Time) time.Time {
+	for _, value := range values {
+		if !value.IsZero() {
+			return value
+		}
+	}
+	return time.Time{}
+}
+
+func errorString(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}
+
+func stringsEqualFoldSafe(left, right string) bool {
+	return left != "" && right != "" && strings.EqualFold(left, right)
+}

--- a/internal/service/telemetry_test.go
+++ b/internal/service/telemetry_test.go
@@ -1,0 +1,343 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/wuyaocheng/bktrader/internal/domain"
+	"github.com/wuyaocheng/bktrader/internal/store/memory"
+)
+
+func TestEvaluateLiveSessionOnSignalPersistsStrategyDecisionEvent(t *testing.T) {
+	platform, session, runtimeSessionID, summary, eventTime := prepareLiveDecisionTelemetryFixture(t)
+
+	if err := platform.evaluateLiveSessionOnSignal(session, runtimeSessionID, summary, eventTime); err != nil {
+		t.Fatalf("evaluate live session failed: %v", err)
+	}
+
+	updated, err := platform.store.GetLiveSession(session.ID)
+	if err != nil {
+		t.Fatalf("get updated live session failed: %v", err)
+	}
+	events, err := platform.store.ListStrategyDecisionEvents(session.ID)
+	if err != nil {
+		t.Fatalf("list strategy decision events failed: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("expected 1 strategy decision event, got %d", len(events))
+	}
+	if got := stringValue(updated.State["lastStrategyDecisionEventId"]); got != events[0].ID {
+		t.Fatalf("expected session to record latest decision event id %s, got %s", events[0].ID, got)
+	}
+	if events[0].RuntimeSessionID != runtimeSessionID {
+		t.Fatalf("expected runtime session id %s, got %s", runtimeSessionID, events[0].RuntimeSessionID)
+	}
+	if events[0].Action == "" || events[0].Reason == "" {
+		t.Fatalf("expected non-empty action/reason, got %+v", events[0])
+	}
+	dispatchedIntent := mapValue(updated.State["lastDispatchedIntent"])
+	if got := stringValue(dispatchedIntent["decisionEventId"]); got != events[0].ID {
+		t.Fatalf("expected dispatched intent to carry decision event id %s, got %s", events[0].ID, got)
+	}
+}
+
+func TestApplyLiveSubmissionResultPersistsOrderExecutionEvent(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	order, err := platform.store.CreateOrder(domain.Order{
+		AccountID:         "live-main",
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "BUY",
+		Type:              "LIMIT",
+		Quantity:          0.002,
+		Price:             68999.0,
+		Metadata: map[string]any{
+			"source":          "live-session-intent",
+			"liveSessionId":   "live-session-main",
+			"decisionEventId": "decision-1",
+			"executionProposal": map[string]any{
+				"symbol":            "BTCUSDT",
+				"side":              "BUY",
+				"type":              "LIMIT",
+				"quantity":          0.002,
+				"priceHint":         68999.0,
+				"executionStrategy": "book-aware-v1",
+				"metadata": map[string]any{
+					"executionDecision": "maker-resting",
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("create order failed: %v", err)
+	}
+
+	acceptedAt := order.CreatedAt.Add(2 * time.Second)
+	updated, err := platform.applyLiveSubmissionResult(
+		order,
+		map[string]any{"adapterKey": "binance-futures"},
+		domain.SignalRuntimeSession{ID: "runtime-1"},
+		map[string]any{"ready": true},
+		LiveOrderSubmission{
+			Status:          "ACCEPTED",
+			ExchangeOrderID: "exchange-order-1",
+			AcceptedAt:      acceptedAt.Format(time.RFC3339),
+			Metadata: map[string]any{
+				"rawQuantity":        0.0021,
+				"normalizedQuantity": 0.002,
+				"rawPriceReference":  68999.3,
+				"normalizedPrice":    68999.0,
+			},
+		},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("apply live submission result failed: %v", err)
+	}
+
+	events, err := platform.store.ListOrderExecutionEvents(updated.ID)
+	if err != nil {
+		t.Fatalf("list order execution events failed: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("expected 1 order execution event, got %d", len(events))
+	}
+	if events[0].EventType != "submitted" {
+		t.Fatalf("expected submitted event type, got %s", events[0].EventType)
+	}
+	if events[0].DecisionEventID != "decision-1" {
+		t.Fatalf("expected decision event id decision-1, got %s", events[0].DecisionEventID)
+	}
+	if events[0].RuntimeSessionID != "runtime-1" {
+		t.Fatalf("expected runtime session id runtime-1, got %s", events[0].RuntimeSessionID)
+	}
+	if events[0].Status != "ACCEPTED" {
+		t.Fatalf("expected status ACCEPTED, got %s", events[0].Status)
+	}
+	if events[0].SubmitLatencyMs <= 0 {
+		t.Fatalf("expected positive submit latency, got %d", events[0].SubmitLatencyMs)
+	}
+}
+
+func TestRefreshLiveSessionPositionContextPersistsPositionAccountSnapshot(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	account, err := platform.store.GetAccount("live-main")
+	if err != nil {
+		t.Fatalf("get account failed: %v", err)
+	}
+	account.Status = "READY"
+	account.Metadata = cloneMetadata(account.Metadata)
+	account.Metadata["liveSyncSnapshot"] = map[string]any{
+		"syncStatus":         "SYNCED",
+		"availableBalance":   9200.0,
+		"totalWalletBalance": 9500.0,
+		"totalMarginBalance": 9400.0,
+		"positionCount":      1,
+		"openOrders":         []map[string]any{},
+	}
+	if _, err := platform.store.UpdateAccount(account); err != nil {
+		t.Fatalf("update account failed: %v", err)
+	}
+
+	session, err := platform.store.GetLiveSession("live-session-main")
+	if err != nil {
+		t.Fatalf("get live session failed: %v", err)
+	}
+	state := cloneMetadata(session.State)
+	state["symbol"] = "BTCUSDT"
+	state["signalTimeframe"] = "1d"
+	state["lastStrategyDecisionEventId"] = "decision-ctx-1"
+	state["lastDispatchedIntentSignature"] = "intent|btc"
+	state["lastStrategyEvaluationSignalBarStates"] = map[string]any{
+		signalBindingMatchKey("binance-kline", "signal", "BTCUSDT"): map[string]any{
+			"symbol":    "BTCUSDT",
+			"timeframe": "1d",
+			"atr14":     900.0,
+			"ma20":      68000.0,
+			"current": map[string]any{
+				"close": 70100.0,
+				"high":  70250.0,
+				"low":   69500.0,
+			},
+			"prevBar1": map[string]any{
+				"high": 69900.0,
+				"low":  68800.0,
+			},
+			"prevBar2": map[string]any{
+				"high": 69750.0,
+				"low":  68750.0,
+			},
+		},
+	}
+	session, err = platform.store.UpdateLiveSessionState(session.ID, state)
+	if err != nil {
+		t.Fatalf("update live session state failed: %v", err)
+	}
+
+	if _, err := platform.store.SavePosition(domain.Position{
+		AccountID:         session.AccountID,
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "LONG",
+		Quantity:          0.003,
+		EntryPrice:        69000.0,
+		MarkPrice:         70100.0,
+	}); err != nil {
+		t.Fatalf("save position failed: %v", err)
+	}
+
+	eventTime := time.Date(2026, 4, 14, 3, 0, 0, 0, time.UTC)
+	if _, err := platform.refreshLiveSessionPositionContext(session, eventTime, "telemetry-test"); err != nil {
+		t.Fatalf("refresh live session position context failed: %v", err)
+	}
+
+	snapshots, err := platform.store.ListPositionAccountSnapshots(session.AccountID)
+	if err != nil {
+		t.Fatalf("list position/account snapshots failed: %v", err)
+	}
+	if len(snapshots) == 0 {
+		t.Fatal("expected at least one position/account snapshot")
+	}
+	got := snapshots[len(snapshots)-1]
+	if got.LiveSessionID != session.ID {
+		t.Fatalf("expected snapshot live session id %s, got %s", session.ID, got.LiveSessionID)
+	}
+	if got.Trigger != "telemetry-test" {
+		t.Fatalf("expected trigger telemetry-test, got %s", got.Trigger)
+	}
+	if got.PositionQuantity <= 0 {
+		t.Fatalf("expected positive position quantity, got %v", got.PositionQuantity)
+	}
+	if got.AvailableBalance != 9200.0 {
+		t.Fatalf("expected available balance 9200, got %v", got.AvailableBalance)
+	}
+	if got.DecisionEventID != "decision-ctx-1" {
+		t.Fatalf("expected decision event id decision-ctx-1, got %s", got.DecisionEventID)
+	}
+}
+
+func prepareLiveDecisionTelemetryFixture(t *testing.T) (*Platform, domain.LiveSession, string, map[string]any, time.Time) {
+	t.Helper()
+
+	platform := NewPlatform(memory.NewStore())
+	if _, err := platform.BindStrategySignalSource("strategy-bk-1d", map[string]any{
+		"sourceKey": "binance-kline",
+		"role":      "signal",
+		"symbol":    "BTCUSDT",
+		"options":   map[string]any{"timeframe": "1d"},
+	}); err != nil {
+		t.Fatalf("bind strategy signal failed: %v", err)
+	}
+	if _, err := platform.BindStrategySignalSource("strategy-bk-1d", map[string]any{
+		"sourceKey": "binance-trade-tick",
+		"role":      "trigger",
+		"symbol":    "BTCUSDT",
+	}); err != nil {
+		t.Fatalf("bind strategy trigger failed: %v", err)
+	}
+	if _, err := platform.BindAccountSignalSource("live-main", map[string]any{
+		"sourceKey": "binance-kline",
+		"role":      "signal",
+		"symbol":    "BTCUSDT",
+		"options":   map[string]any{"timeframe": "1d"},
+	}); err != nil {
+		t.Fatalf("bind account signal failed: %v", err)
+	}
+	if _, err := platform.BindAccountSignalSource("live-main", map[string]any{
+		"sourceKey": "binance-trade-tick",
+		"role":      "trigger",
+		"symbol":    "BTCUSDT",
+	}); err != nil {
+		t.Fatalf("bind account trigger failed: %v", err)
+	}
+
+	session, err := platform.CreateLiveSession("live-main", "strategy-bk-1d", map[string]any{
+		"symbol":              "BTCUSDT",
+		"signalTimeframe":     "1d",
+		"executionDataSource": "tick",
+		"dispatchMode":        "manual-review",
+	})
+	if err != nil {
+		t.Fatalf("create live session failed: %v", err)
+	}
+	runtimeSessionID := stringValue(session.State["signalRuntimeSessionId"])
+	if runtimeSessionID == "" {
+		t.Fatal("expected linked runtime session id")
+	}
+
+	eventTime := time.Date(2026, 4, 7, 9, 0, 0, 0, time.UTC)
+	platform.mu.Lock()
+	platform.livePlans[session.ID] = []paperPlannedOrder{{
+		EventTime: eventTime,
+		Price:     69000.0,
+		Side:      "BUY",
+		Role:      "entry",
+		Reason:    "Initial",
+	}}
+	platform.mu.Unlock()
+
+	signalKey := signalBindingMatchKey("binance-kline", "signal", "BTCUSDT")
+	triggerKey := signalBindingMatchKey("binance-trade-tick", "trigger", "BTCUSDT")
+	summary := map[string]any{
+		"role":               "trigger",
+		"symbol":             "BTCUSDT",
+		"subscriptionSymbol": "BTCUSDT",
+		"price":              69010.0,
+		"event":              "trade_tick",
+	}
+	err = platform.updateSignalRuntimeSessionState(runtimeSessionID, func(runtimeSession *domain.SignalRuntimeSession) {
+		runtimeSession.Status = "RUNNING"
+		state := cloneMetadata(runtimeSession.State)
+		state["health"] = "healthy"
+		state["lastEventAt"] = eventTime.UTC().Format(time.RFC3339)
+		state["lastHeartbeatAt"] = eventTime.UTC().Format(time.RFC3339)
+		state["lastEventSummary"] = cloneMetadata(summary)
+		state["sourceStates"] = map[string]any{
+			triggerKey: map[string]any{
+				"sourceKey":   "binance-trade-tick",
+				"role":        "trigger",
+				"symbol":      "BTCUSDT",
+				"streamType":  "trade_tick",
+				"lastEventAt": eventTime.UTC().Format(time.RFC3339),
+				"summary": map[string]any{
+					"price": 69010.0,
+				},
+			},
+			signalKey: map[string]any{
+				"sourceKey":   "binance-kline",
+				"role":        "signal",
+				"symbol":      "BTCUSDT",
+				"streamType":  "signal_bar",
+				"lastEventAt": eventTime.UTC().Format(time.RFC3339),
+			},
+		}
+		state["signalBarStates"] = map[string]any{
+			signalKey: map[string]any{
+				"symbol":    "BTCUSDT",
+				"timeframe": "1d",
+				"ma20":      68000.0,
+				"atr14":     900.0,
+				"current": map[string]any{
+					"close": 68100.0,
+					"high":  69010.0,
+					"low":   67800.0,
+				},
+				"prevBar1": map[string]any{
+					"high": 68850.0,
+					"low":  67750.0,
+				},
+				"prevBar2": map[string]any{
+					"high": 69000.0,
+					"low":  67600.0,
+				},
+			},
+		}
+		runtimeSession.State = state
+		runtimeSession.UpdatedAt = eventTime
+	})
+	if err != nil {
+		t.Fatalf("update runtime state failed: %v", err)
+	}
+
+	return platform, session, runtimeSessionID, summary, eventTime
+}

--- a/internal/store/memory/store.go
+++ b/internal/store/memory/store.go
@@ -1,6 +1,7 @@
 package memory
 
 import (
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
@@ -23,6 +24,9 @@ type Store struct {
 	paperSessions    map[string]domain.PaperSession
 	liveSessions     map[string]domain.LiveSession
 	equitySnapshots  map[string][]domain.AccountEquitySnapshot
+	decisionEvents   []domain.StrategyDecisionEvent
+	executionEvents  []domain.OrderExecutionEvent
+	liveSnapshots    []domain.PositionAccountSnapshot
 	marketBars       map[string]domain.MarketBar
 	signalSources    []map[string]any
 	annotations      []domain.ChartAnnotation
@@ -729,6 +733,114 @@ func (s *Store) CreateAccountEquitySnapshot(snapshot domain.AccountEquitySnapsho
 	return snapshot, nil
 }
 
+func (s *Store) ListStrategyDecisionEvents(liveSessionID string) ([]domain.StrategyDecisionEvent, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	items := make([]domain.StrategyDecisionEvent, 0, len(s.decisionEvents))
+	for _, item := range s.decisionEvents {
+		if liveSessionID != "" && item.LiveSessionID != liveSessionID {
+			continue
+		}
+		items = append(items, cloneJSONValue(item))
+	}
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].EventTime.Equal(items[j].EventTime) {
+			return items[i].RecordedAt.Before(items[j].RecordedAt)
+		}
+		return items[i].EventTime.Before(items[j].EventTime)
+	})
+	return items, nil
+}
+
+func (s *Store) CreateStrategyDecisionEvent(event domain.StrategyDecisionEvent) (domain.StrategyDecisionEvent, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if event.ID == "" {
+		event.ID = s.nextID("strategy-decision-event")
+	}
+	if event.EventTime.IsZero() {
+		event.EventTime = time.Now().UTC()
+	}
+	if event.RecordedAt.IsZero() {
+		event.RecordedAt = time.Now().UTC()
+	}
+	event = cloneJSONValue(event)
+	s.decisionEvents = append(s.decisionEvents, event)
+	return cloneJSONValue(event), nil
+}
+
+func (s *Store) ListOrderExecutionEvents(orderID string) ([]domain.OrderExecutionEvent, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	items := make([]domain.OrderExecutionEvent, 0, len(s.executionEvents))
+	for _, item := range s.executionEvents {
+		if orderID != "" && item.OrderID != orderID {
+			continue
+		}
+		items = append(items, cloneJSONValue(item))
+	}
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].EventTime.Equal(items[j].EventTime) {
+			return items[i].RecordedAt.Before(items[j].RecordedAt)
+		}
+		return items[i].EventTime.Before(items[j].EventTime)
+	})
+	return items, nil
+}
+
+func (s *Store) CreateOrderExecutionEvent(event domain.OrderExecutionEvent) (domain.OrderExecutionEvent, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if event.ID == "" {
+		event.ID = s.nextID("order-execution-event")
+	}
+	if event.EventTime.IsZero() {
+		event.EventTime = time.Now().UTC()
+	}
+	if event.RecordedAt.IsZero() {
+		event.RecordedAt = time.Now().UTC()
+	}
+	event = cloneJSONValue(event)
+	s.executionEvents = append(s.executionEvents, event)
+	return cloneJSONValue(event), nil
+}
+
+func (s *Store) ListPositionAccountSnapshots(accountID string) ([]domain.PositionAccountSnapshot, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	items := make([]domain.PositionAccountSnapshot, 0, len(s.liveSnapshots))
+	for _, item := range s.liveSnapshots {
+		if accountID != "" && item.AccountID != accountID {
+			continue
+		}
+		items = append(items, cloneJSONValue(item))
+	}
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].EventTime.Equal(items[j].EventTime) {
+			return items[i].RecordedAt.Before(items[j].RecordedAt)
+		}
+		return items[i].EventTime.Before(items[j].EventTime)
+	})
+	return items, nil
+}
+
+func (s *Store) CreatePositionAccountSnapshot(snapshot domain.PositionAccountSnapshot) (domain.PositionAccountSnapshot, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if snapshot.ID == "" {
+		snapshot.ID = s.nextID("position-account-snapshot")
+	}
+	if snapshot.EventTime.IsZero() {
+		snapshot.EventTime = time.Now().UTC()
+	}
+	if snapshot.RecordedAt.IsZero() {
+		snapshot.RecordedAt = time.Now().UTC()
+	}
+	snapshot = cloneJSONValue(snapshot)
+	s.liveSnapshots = append(s.liveSnapshots, snapshot)
+	return cloneJSONValue(snapshot), nil
+}
+
 func (s *Store) ListMarketBars(exchange, symbol, timeframe string, from, to int64, limit int) ([]domain.MarketBar, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -793,6 +905,18 @@ func marketBarMemoryKey(exchange, symbol, timeframe string, openTime time.Time) 
 		strings.ToUpper(strings.TrimSpace(symbol)) + "|" +
 		strings.ToLower(strings.TrimSpace(timeframe)) + "|" +
 		openTime.UTC().Format(time.RFC3339)
+}
+
+func cloneJSONValue[T any](value T) T {
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return value
+	}
+	var cloned T
+	if err := json.Unmarshal(raw, &cloned); err != nil {
+		return value
+	}
+	return cloned
 }
 
 func accountStatusForMode(mode string) string {

--- a/internal/store/postgres/store.go
+++ b/internal/store/postgres/store.go
@@ -977,6 +977,279 @@ func (s *Store) CreateAccountEquitySnapshot(snapshot domain.AccountEquitySnapsho
 	return snapshot, err
 }
 
+func (s *Store) ListStrategyDecisionEvents(liveSessionID string) ([]domain.StrategyDecisionEvent, error) {
+	rows, err := s.db.Query(`
+		select
+			id, live_session_id, runtime_session_id, account_id, strategy_id, strategy_version_id, symbol,
+			trigger_type, action, reason, signal_kind, decision_state, intent_signature,
+			source_gate_ready, missing_count, stale_count, event_time, recorded_at,
+			trigger_summary, source_gate, source_states, signal_bar_states, position_snapshot,
+			decision_metadata, signal_intent, execution_proposal, evaluation_context
+		from strategy_decision_events
+		where ($1 = '' or live_session_id = $1)
+		order by event_time asc, recorded_at asc
+	`, liveSessionID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	items := make([]domain.StrategyDecisionEvent, 0)
+	for rows.Next() {
+		var item domain.StrategyDecisionEvent
+		var runtimeSessionID sql.NullString
+		var strategyVersionID sql.NullString
+		var triggerType sql.NullString
+		var signalKind sql.NullString
+		var decisionState sql.NullString
+		var intentSignature sql.NullString
+		var triggerSummaryRaw, sourceGateRaw, sourceStatesRaw, signalBarStatesRaw []byte
+		var positionSnapshotRaw, decisionMetadataRaw, signalIntentRaw, executionProposalRaw, evaluationContextRaw []byte
+		if err := rows.Scan(
+			&item.ID, &item.LiveSessionID, &runtimeSessionID, &item.AccountID, &item.StrategyID, &strategyVersionID, &item.Symbol,
+			&triggerType, &item.Action, &item.Reason, &signalKind, &decisionState, &intentSignature,
+			&item.SourceGateReady, &item.MissingCount, &item.StaleCount, &item.EventTime, &item.RecordedAt,
+			&triggerSummaryRaw, &sourceGateRaw, &sourceStatesRaw, &signalBarStatesRaw, &positionSnapshotRaw,
+			&decisionMetadataRaw, &signalIntentRaw, &executionProposalRaw, &evaluationContextRaw,
+		); err != nil {
+			return nil, err
+		}
+		item.RuntimeSessionID = runtimeSessionID.String
+		item.StrategyVersionID = strategyVersionID.String
+		item.TriggerType = triggerType.String
+		item.SignalKind = signalKind.String
+		item.DecisionState = decisionState.String
+		item.IntentSignature = intentSignature.String
+		item.TriggerSummary = unmarshalJSONMap(triggerSummaryRaw)
+		item.SourceGate = unmarshalJSONMap(sourceGateRaw)
+		item.SourceStates = unmarshalJSONMap(sourceStatesRaw)
+		item.SignalBarStates = unmarshalJSONMap(signalBarStatesRaw)
+		item.PositionSnapshot = unmarshalJSONMap(positionSnapshotRaw)
+		item.DecisionMetadata = unmarshalJSONMap(decisionMetadataRaw)
+		item.SignalIntent = unmarshalJSONMap(signalIntentRaw)
+		item.ExecutionProposal = unmarshalJSONMap(executionProposalRaw)
+		item.EvaluationContext = unmarshalJSONMap(evaluationContextRaw)
+		items = append(items, item)
+	}
+	return items, rows.Err()
+}
+
+func (s *Store) CreateStrategyDecisionEvent(event domain.StrategyDecisionEvent) (domain.StrategyDecisionEvent, error) {
+	if event.ID == "" {
+		event.ID = fmt.Sprintf("strategy-decision-event-%d", time.Now().UTC().UnixNano())
+	}
+	if event.EventTime.IsZero() {
+		event.EventTime = time.Now().UTC()
+	}
+	if event.RecordedAt.IsZero() {
+		event.RecordedAt = time.Now().UTC()
+	}
+	_, err := s.db.Exec(`
+		insert into strategy_decision_events (
+			id, live_session_id, runtime_session_id, account_id, strategy_id, strategy_version_id, symbol,
+			trigger_type, action, reason, signal_kind, decision_state, intent_signature,
+			source_gate_ready, missing_count, stale_count, event_time, recorded_at,
+			trigger_summary, source_gate, source_states, signal_bar_states, position_snapshot,
+			decision_metadata, signal_intent, execution_proposal, evaluation_context
+		) values (
+			$1, $2, $3, $4, $5, $6, $7,
+			$8, $9, $10, $11, $12, $13,
+			$14, $15, $16, $17, $18,
+			$19, $20, $21, $22, $23,
+			$24, $25, $26, $27
+		)
+	`,
+		event.ID, event.LiveSessionID, nullIfEmpty(event.RuntimeSessionID), event.AccountID, event.StrategyID, nullIfEmpty(event.StrategyVersionID), event.Symbol,
+		nullIfEmpty(event.TriggerType), event.Action, event.Reason, nullIfEmpty(event.SignalKind), nullIfEmpty(event.DecisionState), nullIfEmpty(event.IntentSignature),
+		event.SourceGateReady, event.MissingCount, event.StaleCount, event.EventTime, event.RecordedAt,
+		marshalJSONValue(event.TriggerSummary), marshalJSONValue(event.SourceGate), marshalJSONValue(event.SourceStates), marshalJSONValue(event.SignalBarStates), marshalJSONValue(event.PositionSnapshot),
+		marshalJSONValue(event.DecisionMetadata), marshalJSONValue(event.SignalIntent), marshalJSONValue(event.ExecutionProposal), marshalJSONValue(event.EvaluationContext),
+	)
+	return event, err
+}
+
+func (s *Store) ListOrderExecutionEvents(orderID string) ([]domain.OrderExecutionEvent, error) {
+	rows, err := s.db.Query(`
+		select
+			id, order_id, exchange_order_id, live_session_id, decision_event_id, runtime_session_id, account_id,
+			strategy_version_id, symbol, side, order_type, event_type, status,
+			execution_strategy, execution_decision, execution_mode,
+			quantity, price, expected_price, price_drift_bps, raw_quantity, normalized_quantity,
+			raw_price_reference, normalized_price, spread_bps, book_imbalance,
+			submit_latency_ms, sync_latency_ms, fill_latency_ms, event_time, recorded_at,
+			fallback, post_only, reduce_only, failed, error,
+			runtime_preflight, dispatch_summary, adapter_submission, adapter_sync, normalization, symbol_rules, metadata
+		from order_execution_events
+		where ($1 = '' or order_id = $1)
+		order by event_time asc, recorded_at asc
+	`, orderID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	items := make([]domain.OrderExecutionEvent, 0)
+	for rows.Next() {
+		var item domain.OrderExecutionEvent
+		var exchangeOrderID, liveSessionID, decisionEventID, runtimeSessionID, strategyVersionID sql.NullString
+		var executionStrategy, executionDecision, executionMode, errText sql.NullString
+		var runtimePreflightRaw, dispatchSummaryRaw, adapterSubmissionRaw, adapterSyncRaw, normalizationRaw, symbolRulesRaw, metadataRaw []byte
+		if err := rows.Scan(
+			&item.ID, &item.OrderID, &exchangeOrderID, &liveSessionID, &decisionEventID, &runtimeSessionID, &item.AccountID,
+			&strategyVersionID, &item.Symbol, &item.Side, &item.OrderType, &item.EventType, &item.Status,
+			&executionStrategy, &executionDecision, &executionMode,
+			&item.Quantity, &item.Price, &item.ExpectedPrice, &item.PriceDriftBps, &item.RawQuantity, &item.NormalizedQty,
+			&item.RawPriceReference, &item.NormalizedPrice, &item.SpreadBps, &item.BookImbalance,
+			&item.SubmitLatencyMs, &item.SyncLatencyMs, &item.FillLatencyMs, &item.EventTime, &item.RecordedAt,
+			&item.Fallback, &item.PostOnly, &item.ReduceOnly, &item.Failed, &errText,
+			&runtimePreflightRaw, &dispatchSummaryRaw, &adapterSubmissionRaw, &adapterSyncRaw, &normalizationRaw, &symbolRulesRaw, &metadataRaw,
+		); err != nil {
+			return nil, err
+		}
+		item.ExchangeOrderID = exchangeOrderID.String
+		item.LiveSessionID = liveSessionID.String
+		item.DecisionEventID = decisionEventID.String
+		item.RuntimeSessionID = runtimeSessionID.String
+		item.StrategyVersionID = strategyVersionID.String
+		item.ExecutionStrategy = executionStrategy.String
+		item.ExecutionDecision = executionDecision.String
+		item.ExecutionMode = executionMode.String
+		item.Error = errText.String
+		item.RuntimePreflight = unmarshalJSONMap(runtimePreflightRaw)
+		item.DispatchSummary = unmarshalJSONMap(dispatchSummaryRaw)
+		item.AdapterSubmission = unmarshalJSONMap(adapterSubmissionRaw)
+		item.AdapterSync = unmarshalJSONMap(adapterSyncRaw)
+		item.Normalization = unmarshalJSONMap(normalizationRaw)
+		item.SymbolRules = unmarshalJSONMap(symbolRulesRaw)
+		item.Metadata = unmarshalJSONMap(metadataRaw)
+		items = append(items, item)
+	}
+	return items, rows.Err()
+}
+
+func (s *Store) CreateOrderExecutionEvent(event domain.OrderExecutionEvent) (domain.OrderExecutionEvent, error) {
+	if event.ID == "" {
+		event.ID = fmt.Sprintf("order-execution-event-%d", time.Now().UTC().UnixNano())
+	}
+	if event.EventTime.IsZero() {
+		event.EventTime = time.Now().UTC()
+	}
+	if event.RecordedAt.IsZero() {
+		event.RecordedAt = time.Now().UTC()
+	}
+	_, err := s.db.Exec(`
+		insert into order_execution_events (
+			id, order_id, exchange_order_id, live_session_id, decision_event_id, runtime_session_id, account_id,
+			strategy_version_id, symbol, side, order_type, event_type, status,
+			execution_strategy, execution_decision, execution_mode,
+			quantity, price, expected_price, price_drift_bps, raw_quantity, normalized_quantity,
+			raw_price_reference, normalized_price, spread_bps, book_imbalance,
+			submit_latency_ms, sync_latency_ms, fill_latency_ms, event_time, recorded_at,
+			fallback, post_only, reduce_only, failed, error,
+			runtime_preflight, dispatch_summary, adapter_submission, adapter_sync, normalization, symbol_rules, metadata
+		) values (
+			$1, $2, $3, $4, $5, $6, $7,
+			$8, $9, $10, $11, $12, $13,
+			$14, $15, $16,
+			$17, $18, $19, $20, $21, $22,
+			$23, $24, $25, $26,
+			$27, $28, $29, $30, $31,
+			$32, $33, $34, $35, $36,
+			$37, $38, $39, $40, $41, $42, $43
+		)
+	`,
+		event.ID, event.OrderID, nullIfEmpty(event.ExchangeOrderID), nullIfEmpty(event.LiveSessionID), nullIfEmpty(event.DecisionEventID), nullIfEmpty(event.RuntimeSessionID), event.AccountID,
+		nullIfEmpty(event.StrategyVersionID), event.Symbol, event.Side, event.OrderType, event.EventType, event.Status,
+		nullIfEmpty(event.ExecutionStrategy), nullIfEmpty(event.ExecutionDecision), nullIfEmpty(event.ExecutionMode),
+		event.Quantity, event.Price, event.ExpectedPrice, event.PriceDriftBps, event.RawQuantity, event.NormalizedQty,
+		event.RawPriceReference, event.NormalizedPrice, event.SpreadBps, event.BookImbalance,
+		event.SubmitLatencyMs, event.SyncLatencyMs, event.FillLatencyMs, event.EventTime, event.RecordedAt,
+		event.Fallback, event.PostOnly, event.ReduceOnly, event.Failed, nullIfEmpty(event.Error),
+		marshalJSONValue(event.RuntimePreflight), marshalJSONValue(event.DispatchSummary), marshalJSONValue(event.AdapterSubmission), marshalJSONValue(event.AdapterSync), marshalJSONValue(event.Normalization), marshalJSONValue(event.SymbolRules), marshalJSONValue(event.Metadata),
+	)
+	return event, err
+}
+
+func (s *Store) ListPositionAccountSnapshots(accountID string) ([]domain.PositionAccountSnapshot, error) {
+	rows, err := s.db.Query(`
+		select
+			id, live_session_id, decision_event_id, order_id, account_id, strategy_id, symbol, trigger, intent_signature,
+			position_found, position_side, position_quantity, entry_price, mark_price,
+			net_equity, available_balance, margin_balance, wallet_balance, exposure_notional, open_position_count,
+			sync_status, event_time, recorded_at,
+			position_snapshot, live_position_state, account_snapshot, account_summary, metadata
+		from position_account_snapshots
+		where ($1 = '' or account_id = $1)
+		order by event_time asc, recorded_at asc
+	`, accountID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	items := make([]domain.PositionAccountSnapshot, 0)
+	for rows.Next() {
+		var item domain.PositionAccountSnapshot
+		var decisionEventID, orderID, intentSignature, positionSide, syncStatus sql.NullString
+		var positionSnapshotRaw, livePositionStateRaw, accountSnapshotRaw, accountSummaryRaw, metadataRaw []byte
+		if err := rows.Scan(
+			&item.ID, &item.LiveSessionID, &decisionEventID, &orderID, &item.AccountID, &item.StrategyID, &item.Symbol, &item.Trigger, &intentSignature,
+			&item.PositionFound, &positionSide, &item.PositionQuantity, &item.EntryPrice, &item.MarkPrice,
+			&item.NetEquity, &item.AvailableBalance, &item.MarginBalance, &item.WalletBalance, &item.ExposureNotional, &item.OpenPositionCount,
+			&syncStatus, &item.EventTime, &item.RecordedAt,
+			&positionSnapshotRaw, &livePositionStateRaw, &accountSnapshotRaw, &accountSummaryRaw, &metadataRaw,
+		); err != nil {
+			return nil, err
+		}
+		item.DecisionEventID = decisionEventID.String
+		item.OrderID = orderID.String
+		item.IntentSignature = intentSignature.String
+		item.PositionSide = positionSide.String
+		item.SyncStatus = syncStatus.String
+		item.PositionSnapshot = unmarshalJSONMap(positionSnapshotRaw)
+		item.LivePositionState = unmarshalJSONMap(livePositionStateRaw)
+		item.AccountSnapshot = unmarshalJSONMap(accountSnapshotRaw)
+		item.AccountSummary = unmarshalJSONMap(accountSummaryRaw)
+		item.Metadata = unmarshalJSONMap(metadataRaw)
+		items = append(items, item)
+	}
+	return items, rows.Err()
+}
+
+func (s *Store) CreatePositionAccountSnapshot(snapshot domain.PositionAccountSnapshot) (domain.PositionAccountSnapshot, error) {
+	if snapshot.ID == "" {
+		snapshot.ID = fmt.Sprintf("position-account-snapshot-%d", time.Now().UTC().UnixNano())
+	}
+	if snapshot.EventTime.IsZero() {
+		snapshot.EventTime = time.Now().UTC()
+	}
+	if snapshot.RecordedAt.IsZero() {
+		snapshot.RecordedAt = time.Now().UTC()
+	}
+	_, err := s.db.Exec(`
+		insert into position_account_snapshots (
+			id, live_session_id, decision_event_id, order_id, account_id, strategy_id, symbol, trigger, intent_signature,
+			position_found, position_side, position_quantity, entry_price, mark_price,
+			net_equity, available_balance, margin_balance, wallet_balance, exposure_notional, open_position_count,
+			sync_status, event_time, recorded_at,
+			position_snapshot, live_position_state, account_snapshot, account_summary, metadata
+		) values (
+			$1, $2, $3, $4, $5, $6, $7, $8, $9,
+			$10, $11, $12, $13, $14,
+			$15, $16, $17, $18, $19, $20,
+			$21, $22, $23,
+			$24, $25, $26, $27, $28
+		)
+	`,
+		snapshot.ID, snapshot.LiveSessionID, nullIfEmpty(snapshot.DecisionEventID), nullIfEmpty(snapshot.OrderID), snapshot.AccountID, snapshot.StrategyID, snapshot.Symbol, snapshot.Trigger, nullIfEmpty(snapshot.IntentSignature),
+		snapshot.PositionFound, nullIfEmpty(snapshot.PositionSide), snapshot.PositionQuantity, snapshot.EntryPrice, snapshot.MarkPrice,
+		snapshot.NetEquity, snapshot.AvailableBalance, snapshot.MarginBalance, snapshot.WalletBalance, snapshot.ExposureNotional, snapshot.OpenPositionCount,
+		nullIfEmpty(snapshot.SyncStatus), snapshot.EventTime, snapshot.RecordedAt,
+		marshalJSONValue(snapshot.PositionSnapshot), marshalJSONValue(snapshot.LivePositionState), marshalJSONValue(snapshot.AccountSnapshot), marshalJSONValue(snapshot.AccountSummary), marshalJSONValue(snapshot.Metadata),
+	)
+	return snapshot, err
+}
+
 func (s *Store) ListMarketBars(exchange, symbol, timeframe string, from, to int64, limit int) ([]domain.MarketBar, error) {
 	query := `
 		select id, exchange, symbol, timeframe, open_time, close_time, open, high, low, close, volume, is_closed, source, updated_at
@@ -1085,6 +1358,28 @@ func nullIfEmpty(v string) any {
 		return nil
 	}
 	return v
+}
+
+func marshalJSONValue(value any) []byte {
+	if value == nil {
+		return []byte(`{}`)
+	}
+	raw, _ := json.Marshal(value)
+	if len(raw) == 0 || string(raw) == "null" {
+		return []byte(`{}`)
+	}
+	return raw
+}
+
+func unmarshalJSONMap(raw []byte) map[string]any {
+	if len(raw) == 0 {
+		return map[string]any{}
+	}
+	out := map[string]any{}
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return map[string]any{}
+	}
+	return out
 }
 
 func accountStatusForMode(mode string) string {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -100,6 +100,21 @@ type Repository interface {
 	// CreateAccountEquitySnapshot 创建新的净值快照。
 	CreateAccountEquitySnapshot(snapshot domain.AccountEquitySnapshot) (domain.AccountEquitySnapshot, error)
 
+	// --- Live 决策 / 执行 / 快照采集 ---
+
+	// ListStrategyDecisionEvents 获取指定 live session 的策略决策事件；sessionID 为空时返回全部。
+	ListStrategyDecisionEvents(liveSessionID string) ([]domain.StrategyDecisionEvent, error)
+	// CreateStrategyDecisionEvent 创建新的策略决策事件。
+	CreateStrategyDecisionEvent(event domain.StrategyDecisionEvent) (domain.StrategyDecisionEvent, error)
+	// ListOrderExecutionEvents 获取指定订单的执行事件；orderID 为空时返回全部。
+	ListOrderExecutionEvents(orderID string) ([]domain.OrderExecutionEvent, error)
+	// CreateOrderExecutionEvent 创建新的订单执行事件。
+	CreateOrderExecutionEvent(event domain.OrderExecutionEvent) (domain.OrderExecutionEvent, error)
+	// ListPositionAccountSnapshots 获取指定账户的仓位/账户快照；accountID 为空时返回全部。
+	ListPositionAccountSnapshots(accountID string) ([]domain.PositionAccountSnapshot, error)
+	// CreatePositionAccountSnapshot 创建新的仓位/账户快照。
+	CreatePositionAccountSnapshot(snapshot domain.PositionAccountSnapshot) (domain.PositionAccountSnapshot, error)
+
 	// --- 市场 Bar 缓存 ---
 
 	// ListMarketBars 获取指定交易所/交易对/周期的缓存 K 线。


### PR DESCRIPTION
## What changed

This PR adds phase-1 persistent live telemetry for production analysis and strategy optimization.

- add three new persistence models and tables for `strategy_decision_events`, `order_execution_events`, and `position_account_snapshots`
- extend the repository plus postgres/memory stores to write and list those records
- record strategy decision events from the live signal evaluation flow
- record order execution events at live submit, sync, and fill lifecycle points
- record live position/account snapshots after position context refresh
- add focused tests covering all three telemetry paths

## Why it changed

The live system already had useful execution and decision context in session state and order metadata, but it was not stored in a durable, queryable form. That made real-money post-trade analysis, strategy attribution, and execution-quality debugging much harder than it needed to be.

This change keeps the existing runtime behavior, but turns the most important live decision and execution data into structured records that can be analyzed after the fact.

## User and developer impact

- operators can now analyze why a live decision was made, what execution proposal was generated, and what actually happened at the order layer
- strategy iteration gets a durable bridge between runtime decisions, exchange execution, and position/account state
- the added store interfaces keep the new telemetry available in both memory tests and postgres-backed environments

## Root cause

The root issue was not missing logs, but missing durable telemetry boundaries between:

- strategy evaluation
- execution submission/sync/fill
- position/account state after those events

Without those boundaries, later analysis depended on transient session state or log scraping.

## Validation

- `go test ./internal/service ./internal/store/...`
- `go test ./...`
- graphify rebuild via repo watcher during push
