### PR TITLE
[codex] rework console account workflow layout

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -67,6 +67,7 @@ jobs:
         with:
           name: ai-review
           path: pr/.ai-review/
+          retention-days: 1
 
       - name: Publish inline comments
         if: github.event_name == 'pull_request'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,8 +18,9 @@ This project has a graphify knowledge graph at `graphify-out/`.
 
 - Before answering architecture or codebase questions, read `graphify-out/GRAPH_REPORT.md` for god nodes and community structure.
 - If `graphify-out/wiki/index.md` exists, navigate it instead of reading raw files.
-- After modifying code files in this session, run `/usr/local/opt/python@3.12/bin/python3.12 -c "from graphify.watch import _rebuild_code; from pathlib import Path; _rebuild_code(Path('.'))"` to keep the graph current.
-- **Automated Workflow**: A `pre-push` git hook has been installed to automatically rebuild the graph before every `git push`.
+- Do not rebuild graphify after every code change in a session.
+- Rebuild graphify immediately before `git push` by running `/usr/local/opt/python@3.12/bin/python3.12 -c "from graphify.watch import _rebuild_code; from pathlib import Path; _rebuild_code(Path('.'))"` if needed.
+- **Automated Workflow**: A `pre-push` git hook is installed and should be the default path for rebuilding the graph before every `git push`.
 
 ### 面向 Gemini 的技能组 (Skills)
 

--- a/web/console/src/pages/AccountStage.tsx
+++ b/web/console/src/pages/AccountStage.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useUIStore } from '../store/useUIStore';
 import { useTradingStore } from '../store/useTradingStore';
 import { ActionButton } from '../components/ui/ActionButton';
@@ -219,6 +219,98 @@ export function AccountStage({
   const selectedSignalRuntimeSubscriptions = Array.isArray(selectedSignalRuntimeState.subscriptions)
     ? (selectedSignalRuntimeState.subscriptions as Array<Record<string, unknown>>)
     : [];
+  const [expandedLiveSection, setExpandedLiveSection] = useState<string>("执行与分发");
+  const [expandedAccountId, setExpandedAccountId] = useState<string | null>(null);
+
+  const primaryLiveSummaryItems = primaryLiveSession ? [
+    { label: "运行环境", value: `${String(primaryLiveSession.state?.signalRuntimeStatus ?? "--")} · ${formatTime(String(primaryLiveSession.state?.lastSignalRuntimeEventAt ?? ""))}` },
+    { label: "就绪预检", value: `${primaryLiveSessionRuntimeReadiness.status} · ${primaryLiveSessionRuntimeReadiness.reason}` },
+    { label: "信号意图", value: `${String(primaryLiveSessionIntent.action ?? "无")} · ${String(primaryLiveSessionIntent.side ?? "--")} · ${formatMaybeNumber(primaryLiveSessionIntent.priceHint)}` },
+    { label: "指令分发", value: `${String(primaryLiveSession?.state?.dispatchMode ?? "--")} · 冷却 ${String(primaryLiveSession?.state?.dispatchCooldownSeconds ?? "--")}s` },
+    { label: "恢复状态", value: `${String(primaryLiveSession?.state?.positionRecoveryStatus ?? "--")} / ${String(primaryLiveSession?.state?.protectionRecoveryStatus ?? "--")}` },
+    { label: "执行汇总", value: `订单 ${primaryLiveExecutionSummary.orderCount} · 成交 ${primaryLiveExecutionSummary.fillCount} · ${String(primaryLiveExecutionSummary.latestOrder?.status ?? "--")}` },
+  ] : [];
+
+  const primaryLiveSections = primaryLiveSession ? [
+    {
+      title: "运行与行情",
+      items: [
+        { label: "行情数据", value: `${formatMaybeNumber(primaryLiveSessionMarket.tradePrice)} · ${formatMaybeNumber(primaryLiveSessionMarket.bestBid)} / ${formatMaybeNumber(primaryLiveSessionMarket.bestAsk)}` },
+        { label: "数据同步", value: `${String(primaryLiveSession?.state?.lastSyncedOrderStatus ?? "--")} · ${formatTime(String(primaryLiveSession?.state?.lastSyncedAt ?? ""))} · 错误 ${String(primaryLiveSession?.state?.lastSyncError ?? "--")}` },
+        { label: "自动分发", value: `最后触发 ${formatTime(String(primaryLiveSession?.state?.lastDispatchedAt ?? ""))} · 最后错误 ${String(primaryLiveSession?.state?.lastAutoDispatchError ?? "--")}` },
+        { label: "时间线", value: buildTimelineNotes(primaryLiveSessionTimeline).slice(0, 2).join(" · ") || "--" },
+      ],
+    },
+    {
+      title: "信号与意图",
+      items: [
+        { label: "意图预览", value: `数量 ${formatMaybeNumber(primaryLiveSessionIntent.quantity)} · 报价源 ${String(primaryLiveSessionIntent.priceSource ?? "--")} · 信号种类 ${String(primaryLiveSessionIntent.signalKind ?? "--")}` },
+        { label: "意图上下文", value: `价差 ${formatMaybeNumber(primaryLiveSessionIntent.spreadBps)} bps · 偏置 ${String(primaryLiveSessionIntent.liquidityBias ?? "--")} · ma20 ${formatMaybeNumber(primaryLiveSessionIntent.ma20)} · atr14 ${formatMaybeNumber(primaryLiveSessionIntent.atr14)}` },
+        { label: "信号过滤", value: `周期 ${String(primaryLiveSessionSignalBarDecision.timeframe ?? "--")} · sma5 ${formatMaybeNumber(primaryLiveSessionSignalBarDecision.sma5)} · 多头 ${boolLabel(primaryLiveSessionSignalBarDecision.longEarlyReversalReady)} · 空头 ${boolLabel(primaryLiveSessionSignalBarDecision.shortEarlyReversalReady)}` },
+        { label: "信号备注", value: String(primaryLiveSessionSignalBarDecision.reason ?? "--") },
+      ],
+    },
+    {
+      title: "执行与分发",
+      items: [
+        { label: "执行配置", value: `${String(getRecord(primaryLiveSession?.state?.lastExecutionProfile).executionProfile ?? "--")} · ${String(getRecord(primaryLiveSession?.state?.lastExecutionProfile).orderType ?? "--")} · TIF ${String(getRecord(primaryLiveSession?.state?.lastExecutionProfile).timeInForce ?? "--")} · 只减仓 ${boolLabel(getRecord(primaryLiveSession?.state?.lastExecutionProfile).reduceOnly)}` },
+        { label: "执行遥测", value: `${String(getRecord(primaryLiveSession?.state?.lastExecutionTelemetry).decision ?? "--")} · 价差 ${formatMaybeNumber(getRecord(getRecord(primaryLiveSession?.state?.lastExecutionTelemetry).book).spreadBps)} bps · 盘口不平衡 ${formatMaybeNumber(getRecord(getRecord(primaryLiveSession?.state?.lastExecutionTelemetry).book).bookImbalance)}` },
+        { label: "分发状态", value: `${String(getRecord(primaryLiveSession?.state?.lastExecutionDispatch).status ?? "--")} · ${String(getRecord(primaryLiveSession?.state?.lastExecutionDispatch).executionMode ?? "--")} · 备选方案 ${boolLabel(getRecord(primaryLiveSession?.state?.lastExecutionDispatch).fallback)}` },
+        { label: "成交分析", value: `预期价格 ${formatMaybeNumber(getRecord(primaryLiveSession?.state?.lastExecutionDispatch).expectedPrice)} · 滑点偏移 ${formatMaybeNumber(getRecord(primaryLiveSession?.state?.lastExecutionDispatch).priceDriftBps)} bps` },
+        { label: "执行统计", value: `方案数 ${String(getRecord(primaryLiveSession?.state?.executionEventStats).proposalCount ?? "--")} · Maker ${String(getRecord(primaryLiveSession?.state?.executionEventStats).makerRestingDecisionCount ?? "--")} · 备选 ${String(getRecord(primaryLiveSession?.state?.executionEventStats).fallbackDispatchCount ?? "--")} · 平均偏移 ${formatMaybeNumber(getRecord(primaryLiveSession?.state?.executionEventStats).avgPriceDriftBps)} bps` },
+        { label: "分发预览", value: `${primaryLiveDispatchPreview.reason} · ${primaryLiveDispatchPreview.detail}` },
+        { label: "最终指令", value: `${String(primaryLiveDispatchPreview.payload.side ?? "--")} ${formatMaybeNumber(primaryLiveDispatchPreview.payload.quantity)} ${String(primaryLiveDispatchPreview.payload.symbol ?? "--")} · ${String(primaryLiveDispatchPreview.payload.type ?? "--")} @ ${formatMaybeNumber(primaryLiveDispatchPreview.payload.price)}` },
+      ],
+    },
+    {
+      title: "恢复与仓位",
+      items: [
+        { label: "恢复详情", value: `${String(primaryLiveSession?.state?.lastRecoveryStatus ?? "--")} · 仓位恢复 ${String(primaryLiveSession?.state?.positionRecoveryStatus ?? "--")} · 保护恢复 ${String(primaryLiveSession?.state?.protectionRecoveryStatus ?? "--")}` },
+        { label: "恢复统计", value: `最后尝试 ${formatTime(String(primaryLiveSession?.state?.lastRecoveryAttemptAt ?? primaryLiveSession?.state?.lastProtectionRecoveryAt ?? ""))} · 保护订单 ${String(primaryLiveSession?.state?.recoveredProtectionCount ?? "--")} · 止损 ${String(primaryLiveSession?.state?.recoveredStopOrderCount ?? "--")} · 止盈 ${String(primaryLiveSession?.state?.recoveredTakeProfitOrderCount ?? "--")}` },
+        { label: "策略持仓", value: `${String(primaryLiveExecutionSummary.position?.side ?? "平仓")} · ${formatMaybeNumber(primaryLiveExecutionSummary.position?.quantity)} @ ${formatMaybeNumber(primaryLiveExecutionSummary.position?.entryPrice)} · 标记价 ${formatMaybeNumber(primaryLiveExecutionSummary.position?.markPrice)}` },
+        { label: "已恢复持仓", value: `${String(getRecord(primaryLiveSession?.state?.recoveredPosition).side ?? "平仓")} · ${formatMaybeNumber(getRecord(primaryLiveSession?.state?.recoveredPosition).quantity)} @ ${formatMaybeNumber(getRecord(primaryLiveSession?.state?.recoveredPosition).entryPrice)}` },
+      ],
+    },
+  ] : [];
+
+  const hasConfiguredAccount = liveAccounts.some((account) => account.status === "CONFIGURED" || account.status === "READY");
+  const hasSignalBinding = liveAccounts.some((account) => (accountSignalBindingMap[account.id] ?? []).length > 0);
+  const hasRunningRuntime = signalRuntimeSessions.some((session) => session.status === "RUNNING");
+  const hasLiveSession = validLiveSessions.length > 0;
+  const hasRunningLiveSession = validLiveSessions.some((session) => session.status === "RUNNING");
+
+  const onboardingSteps = [
+    {
+      key: "account",
+      title: "准备账户",
+      detail: hasConfiguredAccount ? "已具备可用实盘账户" : "先新建账户并绑定交易所适配器",
+      status: hasConfiguredAccount ? "done" : "current",
+    },
+    {
+      key: "signal",
+      title: "接通信号",
+      detail: hasSignalBinding ? "已绑定信号源" : "为账户或策略绑定 signal source",
+      status: !hasConfiguredAccount ? "pending" : hasSignalBinding ? "done" : "current",
+    },
+    {
+      key: "runtime",
+      title: "启动运行时",
+      detail: hasRunningRuntime ? "signal runtime 正在运行" : "创建并启动 signal runtime session",
+      status: !hasSignalBinding ? "pending" : hasRunningRuntime ? "done" : "current",
+    },
+    {
+      key: "session",
+      title: "创建会话",
+      detail: hasLiveSession ? "已有实盘策略会话" : "选择账户 + 策略 + 交易对创建会话",
+      status: !hasRunningRuntime ? "pending" : hasLiveSession ? "done" : "current",
+    },
+    {
+      key: "monitor",
+      title: "启动监控",
+      detail: hasRunningLiveSession ? "已有运行中的会话" : "启动会话并开始监控 / 干预",
+      status: !hasLiveSession ? "pending" : hasRunningLiveSession ? "done" : "current",
+    },
+  ];
 
   const syncableLiveOrders = orders.filter((item) => item.metadata?.executionMode === "live" && item.status === "ACCEPTED");
 
@@ -231,299 +323,78 @@ export function AccountStage({
       <section id="overview" className="hero">
         <div>
           <p className="eyebrow">交易主控</p>
-          <h2>实盘 / 模拟统一监控与执行运行台</h2>
+          <h2>先准备账户，再接通信号，然后创建并启动实盘会话</h2>
           <p className="hero-copy">
-            当前页面直接消费平台 API，主监控优先展示正在运行的实盘会话；如果当前没有实盘会话，则回退展示模拟盘。大周期 K 线直接来自交易所信号源，执行侧信息则展示实时 tick、盘口、持仓、订单和盈亏。
+            这页不是给你同时看所有对象的。按顺序完成账户、信号源、运行时、实盘会话四步后，再进入监控和人工干预。
           </p>
         </div>
-
+        <div className="hero-side hero-account-toolbar">
+          <div className="hero-user-card hero-account-card">
+            <div>
+              <strong>当前选中账户</strong>
+              <p>{quickLiveAccount?.name ?? "--"} · {quickLiveAccount?.status ?? "--"} · {quickLiveAccount?.exchange ?? "--"}</p>
+            </div>
+          </div>
+          <div className="session-actions hero-actions">
+            <ActionButton label="新建账户" variant="ghost" onClick={openLiveAccountModal} />
+            <ActionButton
+              label="绑定适配器"
+              variant="ghost"
+              disabled={!quickLiveAccountId}
+              onClick={() => {
+                if (quickLiveAccountId) {
+                  selectQuickLiveAccount(quickLiveAccountId);
+                }
+                openLiveBindingModal();
+              }}
+            />
+            <ActionButton
+              label="创建会话"
+              variant="ghost"
+              disabled={!quickLiveAccountId}
+              onClick={() => {
+                if (quickLiveAccountId) {
+                  selectQuickLiveAccount(quickLiveAccountId);
+                }
+                openLiveSessionModal();
+              }}
+            />
+          </div>
+        </div>
       </section>
 
-      <section id="live" className="panel panel-session">
+      <section className="panel panel-session">
         <div className="panel-header">
           <div>
-            <p className="panel-kicker">Live Trading</p>
-            <h3>实盘账户与订单同步</h3>
+            <p className="panel-kicker">Workflow</p>
+            <h3>创建一条可运行的实盘链路</h3>
           </div>
         </div>
-        {highlightedLiveSession ? (
-          <div className="live-grid">
-            <div className="session-card session-card-primary">
-              <div className="session-card-header">
-                <div>
-                  <p className="panel-kicker">Live Overview</p>
-                  <h4>当前优先处理会话</h4>
-                </div>
-                <StatusPill tone={liveSessionHealthTone(highlightedLiveSession.health.status)}>
-                  {highlightedLiveSession.health.status}
+        <div className="workflow-grid">
+          {onboardingSteps.map((step, index) => (
+            <div key={step.key} className={`workflow-card workflow-card-${step.status}`}>
+              <div className="workflow-card-head">
+                <span className="workflow-step-index">{index + 1}</span>
+                <StatusPill tone={step.status === "done" ? "ready" : step.status === "current" ? "watch" : "neutral"}>
+                  {step.status === "done" ? "已就绪" : step.status === "current" ? "当前步骤" : "待完成"}
                 </StatusPill>
               </div>
-              <div className="live-account-meta">
-                <span title="会话 ID">{shrink(highlightedLiveSession.session.id)}</span>
-                <span title="账户 ID">{highlightedLiveSession.session.accountId}</span>
-                <span title="策略 ID">{highlightedLiveSession.session.strategyId}</span>
-                <span title="信号周期">{String(highlightedLiveSession.session.state?.signalTimeframe ?? "--")}</span>
-              </div>
-              <div className="backtest-notes">
-                <div className="note-item">健康状态: {highlightedLiveSession.health.detail}</div>
-                <div className="backtest-grid-notes">
-                   <div className="note-item">恢复状态: {String(highlightedLiveSession.session.state?.positionRecoveryStatus ?? "--")}</div>
-                   <div className="note-item">保护恢复: {String(highlightedLiveSession.session.state?.protectionRecoveryStatus ?? "--")} ({String(highlightedLiveSession.session.state?.recoveredProtectionCount ?? "--")})</div>
-                   <div className="note-item">执行统计: 订单 {highlightedLiveSession.execution.orderCount} · 成交 {highlightedLiveSession.execution.fillCount}</div>
-                   <div className="note-item">最后订单: {String(highlightedLiveSession.execution.latestOrder?.status ?? "--")} · {String(highlightedLiveSession.execution.latestOrder?.side ?? "--")} @ {formatMaybeNumber(highlightedLiveSession.execution.latestOrder?.price)}</div>
-                   <div className="note-item">当前持仓: {String(highlightedLiveSession.execution.position?.side ?? "平仓")} · {formatMaybeNumber(highlightedLiveSession.execution.position?.quantity)} @ {formatMaybeNumber(highlightedLiveSession.execution.position?.entryPrice)}</div>
-                </div>
-              </div>
-              <div className="flow-row">
-                {highlightedLiveSessionFlow.map((step) => (
-                  <div key={step.key} className="flow-step">
-                    <StatusPill tone={step.status}>{step.label}</StatusPill>
-                    <span>{step.detail}</span>
-                  </div>
-                ))}
-              </div>
+              <h4>{step.title}</h4>
+              <p>{step.detail}</p>
             </div>
-          </div>
-        ) : null}
-        <div className="live-grid">
-          <div className="backtest-form session-form panel-compact">
-            <h4>配置入口已收进弹窗</h4>
-            <div className="backtest-notes notes-compact">
-              <div className="note-item">首屏顶部提供账户下拉、创建账户、绑定适配器、创建会话和一键拉起。</div>
-              <div className="note-item">当前选中账户：{quickLiveAccount?.name ?? "--"} · {quickLiveAccount?.status ?? "--"} · {quickLiveAccount?.exchange ?? "--"}</div>
-              <div className="note-item">sandbox=true 时默认从 `.env` 读取 `BINANCE_TESTNET_API_KEY` / `BINANCE_TESTNET_API_SECRET`。</div>
-            </div>
-            <div className="backtest-actions inline-actions">
-              <ActionButton label="新建账户" variant="ghost" onClick={openLiveAccountModal} />
-              <ActionButton
-                label="绑定适配器"
-                variant="ghost"
-                disabled={!quickLiveAccountId}
-                onClick={() => {
-                  if (quickLiveAccountId) {
-                    selectQuickLiveAccount(quickLiveAccountId);
-                  }
-                  openLiveBindingModal();
-                }}
-              />
-              <ActionButton
-                label="创建会话"
-                variant="ghost"
-                disabled={!quickLiveAccountId}
-                onClick={() => {
-                  if (quickLiveAccountId) {
-                    selectQuickLiveAccount(quickLiveAccountId);
-                  }
-                  openLiveSessionModal();
-                }}
-              />
-            </div>
-          </div>
+          ))}
+        </div>
+      </section>
 
-          <div className="backtest-list">
-            <h4>实盘策略会话</h4>
-            <div className="backtest-notes notes-compact">
-              <div className="note-item">有效会话：{validLiveSessions.length}</div>
-            </div>
-            {validLiveSessions.length > 0 ? (
-              <div className="live-card-list">
-                {validLiveSessions.map((session) => {
-                  const intent = getRecord(session.state?.lastStrategyIntent);
-                  const executionSummary = deriveLiveSessionExecutionSummary(session, orders, fills, positions);
-                  const sessionHealth = deriveLiveSessionHealth(session, executionSummary);
-                  const sessionAccount = liveAccounts.find((account) => account.id === session.accountId) ?? null;
-                  const sessionBinding = getRecord(sessionAccount?.metadata?.liveBinding);
-                  const sessionAccountReady =
-                    sessionAccount?.status === "CONFIGURED" ||
-                    sessionAccount?.status === "READY" ||
-                    (String(sessionBinding.connectionMode ?? "") !== "" && String(sessionBinding.connectionMode ?? "") !== "disabled");
-                  return (
-                    <div key={session.id} className="session-row">
-                      <div className="session-row-main">
-                        <div className="session-row-title">
-                          <strong>{shrink(session.id)}</strong>
-                          <StatusPill tone={liveSessionHealthTone(sessionHealth.status)}>{sessionHealth.status}</StatusPill>
-                          <StatusPill tone={session.status === "RUNNING" ? "ready" : session.status === "STOPPED" ? "watch" : "neutral"}>
-                            {session.status}
-                          </StatusPill>
-                        </div>
-                        <div className="live-account-meta session-row-meta">
-                          <span>{session.accountId}</span>
-                          <span>{strategyLabel(strategies.find((strategy) => strategy.id === session.strategyId))}</span>
-                          <span>{String(session.state?.signalTimeframe ?? "--")}</span>
-                          <span>{sessionAccount?.status ?? "--"}</span>
-                          <span>{String(intent.action ?? "no-intent")}</span>
-                          <span>{String(executionSummary.position?.side ?? "FLAT")}</span>
-                          <span>{formatMaybeNumber(executionSummary.position?.quantity)}</span>
-                          <span>{executionSummary.orderCount}/{executionSummary.fillCount}</span>
-                          {!sessionAccountReady ? <span>先绑定适配器</span> : null}
-                        </div>
-                      </div>
-                      <div className="session-row-actions inline-actions">
-                        <ActionButton
-                          label="编辑"
-                          variant="ghost"
-                          disabled={liveSessionAction !== null || liveSessionDeleteAction !== null}
-                          onClick={() => openLiveSessionModal(session)}
-                        />
-                        {String(session.state?.signalRuntimeSessionId ?? "") ? (
-                          <ActionButton
-                            label="打开运行时"
-                            variant="ghost"
-                            onClick={() => jumpToSignalRuntimeSession(String(session.state?.signalRuntimeSessionId ?? ""))}
-                          />
-                        ) : null}
-                        <ActionButton
-                          label={liveSessionAction === `${session.id}:start` ? "启动中..." : "启动"}
-                          disabled={liveSessionAction !== null || session.status === "RUNNING" || !sessionAccountReady}
-                          onClick={() => runLiveSessionAction(session.id, "start")}
-                        />
-                        {!sessionAccountReady ? (
-                          <ActionButton
-                            label="绑定适配器"
-                            variant="ghost"
-                            disabled={liveSessionAction !== null || liveSessionDeleteAction !== null}
-                            onClick={() => {
-                              selectQuickLiveAccount(session.accountId);
-                              openLiveBindingModal();
-                            }}
-                          />
-                        ) : null}
-                        <ActionButton
-                          label={liveSessionAction === `${session.id}:dispatch` ? "分发中..." : "分发意图"}
-                          disabled={
-                            liveSessionAction !== null ||
-                            !getRecord(session.state?.lastStrategyIntent).action ||
-                            String(session.state?.dispatchMode ?? "") !== "manual-review" ||
-                            (primaryLiveSession?.id === session.id && primaryLiveDispatchPreview.status === "blocked")
-                          }
-                          onClick={() => dispatchLiveSessionIntent(session.id)}
-                        />
-                        <ActionButton
-                          label={liveSessionAction === `${session.id}:sync` ? "同步中..." : "同步最新订单"}
-                          variant="ghost"
-                          disabled={liveSessionAction !== null || !String(session.state?.lastDispatchedOrderId ?? "")}
-                          onClick={() => syncLiveSession(session.id)}
-                        />
-                        <ActionButton
-                          label={liveSessionAction === `${session.id}:stop` ? "停止中..." : "停止"}
-                          variant="ghost"
-                          disabled={liveSessionAction !== null || session.status === "STOPPED"}
-                          onClick={() => runLiveSessionAction(session.id, "stop")}
-                        />
-                        <ActionButton
-                          label={liveSessionDeleteAction === session.id ? "删除中..." : "删除"}
-                          variant="ghost"
-                          disabled={liveSessionAction !== null || liveSessionDeleteAction !== null}
-                          onClick={() => void deleteLiveSession(session.id)}
-                        />
-                      </div>
-                    </div>
-                  );
-                })}
-              </div>
-            ) : (
-              <div className="empty-state empty-state-compact">暂无有效实盘会话</div>
-            )}
-            {primaryLiveSession ? (
-              <div className="backtest-notes">
-                <div className="note-item">
-                  运行环境: {String(primaryLiveSession.state?.signalRuntimeStatus ?? "--")} · {formatTime(String(primaryLiveSession.state?.lastSignalRuntimeEventAt ?? ""))}
-                </div>
-                <div className="note-item">
-                  行情数据: {formatMaybeNumber(primaryLiveSessionMarket.tradePrice)} · {formatMaybeNumber(primaryLiveSessionMarket.bestBid)} / {formatMaybeNumber(primaryLiveSessionMarket.bestAsk)}
-                </div>
-                <div className="note-item">
-                  就续预检: {primaryLiveSessionRuntimeReadiness.status} · {primaryLiveSessionRuntimeReadiness.reason}
-                </div>
-                <div className="note-item">
-                  信号意图: {String(primaryLiveSessionIntent.action ?? "无")} · {String(primaryLiveSessionIntent.side ?? "--")} · {formatMaybeNumber(primaryLiveSessionIntent.priceHint)}
-                </div>
-                <div className="note-item">
-                  意图预览: 数量 {formatMaybeNumber(primaryLiveSessionIntent.quantity)} · 报价源 {String(primaryLiveSessionIntent.priceSource ?? "--")} · 信号种类 {String(primaryLiveSessionIntent.signalKind ?? "--")}
-                </div>
-                <div className="note-item">
-                  意图上下文: 价差 {formatMaybeNumber(primaryLiveSessionIntent.spreadBps)} bps · 偏置 {String(primaryLiveSessionIntent.liquidityBias ?? "--")} · ma20 {formatMaybeNumber(primaryLiveSessionIntent.ma20)} · atr14 {formatMaybeNumber(primaryLiveSessionIntent.atr14)}
-                </div>
-                <div className="note-item">
-                  信号过滤: 周期 {String(primaryLiveSessionSignalBarDecision.timeframe ?? "--")} · sma5 {formatMaybeNumber(primaryLiveSessionSignalBarDecision.sma5)} · 做多反转触发{" "}
-                  {boolLabel(primaryLiveSessionSignalBarDecision.longEarlyReversalReady)} · 做空反转触发 {boolLabel(primaryLiveSessionSignalBarDecision.shortEarlyReversalReady)} ·{" "}
-                  {String(primaryLiveSessionSignalBarDecision.reason ?? "--")}
-                </div>
-                <div className="note-item">
-                  指令分发: {String(primaryLiveSession?.state?.dispatchMode ?? "--")} · 冷却 {String(primaryLiveSession?.state?.dispatchCooldownSeconds ?? "--")}s · 最后订单 {String(primaryLiveSession?.state?.lastDispatchedOrderId ?? "--")}
-                </div>
-                <div className="note-item">
-                  执行配置: {String(getRecord(primaryLiveSession?.state?.lastExecutionProfile).executionProfile ?? "--")} ·{" "}
-                  {String(getRecord(primaryLiveSession?.state?.lastExecutionProfile).orderType ?? "--")} · TIF {" "}
-                  {String(getRecord(primaryLiveSession?.state?.lastExecutionProfile).timeInForce ?? "--")} · 只减仓{" "}
-                  {boolLabel(getRecord(primaryLiveSession?.state?.lastExecutionProfile).reduceOnly)}
-                </div>
-                <div className="note-item">
-                  执行遥测: {String(getRecord(primaryLiveSession?.state?.lastExecutionTelemetry).decision ?? "--")} · 价差{" "}
-                  {formatMaybeNumber(getRecord(getRecord(primaryLiveSession?.state?.lastExecutionTelemetry).book).spreadBps)} bps · 盘口不平衡{" "}
-                  {formatMaybeNumber(getRecord(getRecord(primaryLiveSession?.state?.lastExecutionTelemetry).book).bookImbalance)}
-                </div>
-                <div className="note-item">
-                  分发状态: {String(getRecord(primaryLiveSession?.state?.lastExecutionDispatch).status ?? "--")} ·{" "}
-                  {String(getRecord(primaryLiveSession?.state?.lastExecutionDispatch).executionMode ?? "--")} · 备选方案{" "}
-                  {boolLabel(getRecord(primaryLiveSession?.state?.lastExecutionDispatch).fallback)}
-                </div>
-                <div className="note-item">
-                  成交分析: 预期价格 {formatMaybeNumber(getRecord(primaryLiveSession?.state?.lastExecutionDispatch).expectedPrice)} · 滑点偏移{" "}
-                  {formatMaybeNumber(getRecord(primaryLiveSession?.state?.lastExecutionDispatch).priceDriftBps)} bps
-                </div>
-                <div className="note-item">
-                  执行统计: 方案数 {String(getRecord(primaryLiveSession?.state?.executionEventStats).proposalCount ?? "--")} · Maker 决策{" "}
-                  {String(getRecord(primaryLiveSession?.state?.executionEventStats).makerRestingDecisionCount ?? "--")} · 备选分发{" "}
-                  {String(getRecord(primaryLiveSession?.state?.executionEventStats).fallbackDispatchCount ?? "--")} · 平均偏移{" "}
-                  {formatMaybeNumber(getRecord(primaryLiveSession?.state?.executionEventStats).avgPriceDriftBps)} bps
-                </div>
-                <div className="note-item">
-                  自动分发: 最后触发 {formatTime(String(primaryLiveSession?.state?.lastDispatchedAt ?? ""))} · 最后错误 {String(primaryLiveSession?.state?.lastAutoDispatchError ?? "--")}
-                </div>
-                <div className="note-item">
-                  数据同步: {String(primaryLiveSession?.state?.lastSyncedOrderStatus ?? "--")} · {formatTime(String(primaryLiveSession?.state?.lastSyncedAt ?? ""))} · 错误 {String(primaryLiveSession?.state?.lastSyncError ?? "--")}
-                </div>
-                <div className="note-item">
-                  恢复详情: {String(primaryLiveSession?.state?.lastRecoveryStatus ?? "--")} · 仓位恢复 {String(primaryLiveSession?.state?.positionRecoveryStatus ?? "--")} · 保护恢复{" "}
-                  {String(primaryLiveSession?.state?.protectionRecoveryStatus ?? "--")}
-                </div>
-                <div className="note-item">
-                  恢复统计: 最后尝试 {formatTime(String(primaryLiveSession?.state?.lastRecoveryAttemptAt ?? primaryLiveSession?.state?.lastProtectionRecoveryAt ?? ""))} · 保护订单数{" "}
-                  {String(primaryLiveSession?.state?.recoveredProtectionCount ?? "--")} · 止损 {String(primaryLiveSession?.state?.recoveredStopOrderCount ?? "--")} · 止盈{" "}
-                  {String(primaryLiveSession?.state?.recoveredTakeProfitOrderCount ?? "--")}
-                </div>
-                <div className="note-item">
-                  执行汇总: 订单 {primaryLiveExecutionSummary.orderCount} · 成交 {primaryLiveExecutionSummary.fillCount} · 最新订单状态 {String(primaryLiveExecutionSummary.latestOrder?.status ?? "--")}
-                </div>
-                <div className="note-item">
-                  策略持仓: {String(primaryLiveExecutionSummary.position?.side ?? "平仓")} · {formatMaybeNumber(primaryLiveExecutionSummary.position?.quantity)} @ {formatMaybeNumber(primaryLiveExecutionSummary.position?.entryPrice)} · 标记价 {formatMaybeNumber(primaryLiveExecutionSummary.position?.markPrice)}
-                </div>
-                <div className="note-item">
-                  已恢复持仓: {String(getRecord(primaryLiveSession?.state?.recoveredPosition).side ?? "平仓")} ·{" "}
-                  {formatMaybeNumber(getRecord(primaryLiveSession?.state?.recoveredPosition).quantity)} @{" "}
-                  {formatMaybeNumber(getRecord(primaryLiveSession?.state?.recoveredPosition).entryPrice)}
-                </div>
-                <div className="note-item">
-                  分发预览: {primaryLiveDispatchPreview.reason} · {primaryLiveDispatchPreview.detail}
-                </div>
-                <div className="note-item">
-                  最终指令: {String(primaryLiveDispatchPreview.payload.side ?? "--")} {formatMaybeNumber(primaryLiveDispatchPreview.payload.quantity)} {String(primaryLiveDispatchPreview.payload.symbol ?? "--")} · {String(primaryLiveDispatchPreview.payload.type ?? "--")} @ {formatMaybeNumber(primaryLiveDispatchPreview.payload.price)}
-                </div>
-                {buildTimelineNotes(primaryLiveSessionTimeline).slice(0, 4).map((line) => (
-                  <div key={line} className="note-item">
-                    {line}
-                  </div>
-                ))}
-              </div>
-            ) : null}
+      <section id="accounts" className="panel panel-session">
+        <div className="panel-header">
+          <div>
+            <p className="panel-kicker">Accounts</p>
+            <h3>第一步：准备账户</h3>
           </div>
         </div>
-
         <div className="live-grid">
-          <div className="backtest-list">
-            <h4>实盘账户</h4>
+          <div className="backtest-list live-grid-span-2">
             {liveAccounts.length > 0 ? (
               <div className="live-card-list">
                 {liveAccounts.map((account) => {
@@ -562,90 +433,45 @@ export function AccountStage({
                     activeSignalAction,
                     runtimePolicy
                   );
+                  const accountDetailOpen = expandedAccountId === account.id;
                   return (
-                    <div key={account.id} className="session-stat">
-                      <span>{account.name}</span>
-                      <strong>{account.status}</strong>
-                      <div className="live-account-meta">
-                        <span>交易所: {account.exchange}</span>
-                        <span>适配器: {String(binding.adapterKey ?? "--")}</span>
-                        <span>持仓模式: {String(binding.positionMode ?? "--")} / {String(binding.marginMode ?? "--")}</span>
-                      </div>
-                      <div className="live-account-meta">
-                        <span>同步状态: {String(syncSnapshot.syncStatus ?? "未同步")}</span>
-                        <span>最后同步: {formatTime(String(getRecord(account.metadata).lastLiveSyncAt ?? ""))}</span>
-                        <span>来源: {String(syncSnapshot.source ?? "--")}</span>
-                      </div>
-                      <div className="live-account-meta">
-                        <span>{bindings.length} 个信号绑定</span>
-                        <span>{runtimeSessionsForAccount.length} 个运行实例</span>
-                        <span>{activeRuntime ? `${activeRuntime.status} · ${String(activeRuntimeState.health ?? "--")}` : "无运行实例"}</span>
-                      </div>
-                      <div className="live-account-meta">
-                        <span>最后事件: {String(activeRuntimeSummary.event ?? "--")}</span>
-                        <span>最后心跳: {formatTime(String(activeRuntimeState.lastHeartbeatAt ?? ""))}</span>
-                        <span>更新时间: {formatTime(String(activeRuntimeState.lastEventAt ?? ""))}</span>
-                      </div>
-                      <div className="live-account-meta">
-                        <span>成交价: {formatMaybeNumber(activeRuntimeMarket.tradePrice)}</span>
-                        <span>买/卖: {formatMaybeNumber(activeRuntimeMarket.bestBid)} / {formatMaybeNumber(activeRuntimeMarket.bestAsk)}</span>
-                        <span>价差: {formatMaybeNumber(activeRuntimeMarket.spreadBps)} bps</span>
-                      </div>
-                      <div className="live-account-meta">
-                        <span>成交笔数: {activeRuntimeSourceSummary.tradeTickCount}</span>
-                        <span>盘口笔数: {activeRuntimeSourceSummary.orderBookCount}</span>
-                        <span>陈旧数: {activeRuntimeSourceSummary.staleCount}</span>
-                        <span>最后采集: {formatTime(String(activeRuntimeSourceSummary.latestEventAt ?? ""))}</span>
-                      </div>
-                      <div className="live-account-meta">
-                        <span>
+                    <div key={account.id} className="live-account-card">
+                      <div className="live-account-card-header">
+                        <div className="session-stat">
+                          <span>{account.name}</span>
+                          <strong>{account.status}</strong>
+                        </div>
+                        <div className="live-account-status">
                           <StatusPill tone={runtimeReadinessTone(activeRuntimeReadiness.status)}>
                             {activeRuntimeReadiness.status}
                           </StatusPill>
-                        </span>
-                        <span>{activeRuntimeReadiness.reason}</span>
-                      </div>
-                      <div className="live-account-meta">
-                        <span>
                           <StatusPill tone={runtimeReadinessTone(livePreflight.status)}>
                             {livePreflight.status}
                           </StatusPill>
-                        </span>
-                        <span>{livePreflight.reason}</span>
-                        <span>{livePreflight.detail}</span>
+                        </div>
                       </div>
                       <div className="live-account-meta">
-                        <span>下一步操作</span>
-                        <span>{liveNextAction.label}</span>
-                        <span>{liveNextAction.detail}</span>
-                        <button
-                          type="button"
-                          className="filter-chip"
-                          disabled={
-                            liveFlowAction !== null ||
-                            liveBindAction ||
-                            signalBindingAction !== null ||
-                            signalRuntimeAction !== null ||
-                            liveSessionAction !== null ||
-                            liveSessionCreateAction ||
-                            liveSessionLaunchAction
-                          }
-                          onClick={() => launchLiveFlow(account)}
-                        >
-                          {liveFlowAction === account.id ? "启动中..." : "启动实盘流程"}
-                        </button>
-                        <button
-                          type="button"
-                          className="filter-chip"
-                          onClick={() => runLiveNextAction(account, liveNextAction, activeRuntime)}
-                        >
-                          详情/查看
-                        </button>
+                        <span>交易所: {account.exchange}</span>
+                        <span>适配器: {String(binding.adapterKey ?? "--")}</span>
+                        <span>{activeRuntime ? `${activeRuntime.status} · ${String(activeRuntimeState.health ?? "--")}` : "无运行实例"}</span>
                       </div>
-                      <div className="live-account-meta">
-                        <span>周期: {String(activeSignalBarState.timeframe ?? "--")}</span>
-                        <span>ma20: {formatMaybeNumber(activeSignalBarState.ma20)}</span>
-                        <span>atr14: {formatMaybeNumber(activeSignalBarState.atr14)}</span>
+                      <div className="live-account-metrics">
+                        <div className="detail-item detail-item-compact">
+                          <span>最新价</span>
+                          <strong>{formatMaybeNumber(activeRuntimeMarket.tradePrice)}</strong>
+                        </div>
+                        <div className="detail-item detail-item-compact">
+                          <span>买/卖</span>
+                          <strong>{formatMaybeNumber(activeRuntimeMarket.bestBid)} / {formatMaybeNumber(activeRuntimeMarket.bestAsk)}</strong>
+                        </div>
+                        <div className="detail-item detail-item-compact">
+                          <span>价差</span>
+                          <strong>{formatMaybeNumber(activeRuntimeMarket.spreadBps)} bps</strong>
+                        </div>
+                        <div className="detail-item detail-item-compact">
+                          <span>最后心跳</span>
+                          <strong>{formatTime(String(activeRuntimeState.lastHeartbeatAt ?? ""))}</strong>
+                        </div>
                       </div>
                       <div className="live-account-meta">
                         <span>
@@ -660,48 +486,29 @@ export function AccountStage({
                         </span>
                         <span>{activeSignalAction.reason}</span>
                       </div>
-                      <div className="backtest-notes">
-                        {buildAlertNotes(liveAlerts).map((item) => (
-                          <div key={`${account.id}-${item.title}-${item.detail}`} className={`note-item note-item-alert note-item-alert-${item.level}`}>
-                            <strong>{item.title}</strong> {item.detail}
-                          </div>
-                        ))}
-                        {buildSignalActionNotes(activeSignalAction).map((line) => (
-                          <div key={line} className="note-item">
-                            {line}
-                          </div>
-                        ))}
-                        <div className="note-item">
-                          实盘预检: {livePreflight.reason} · {livePreflight.detail}
-                        </div>
-                        <div className="note-item">
-                          下一步操作: {liveNextAction.label} · {liveNextAction.detail}
-                        </div>
-                        <div className="note-item">
-                          账户同步: 订单 {String(syncSnapshot.orderCount ?? "--")} · 成交 {String(syncSnapshot.fillCount ?? "--")} · 持仓 {String(syncSnapshot.positionCount ?? "--")}
-                        </div>
-                        {buildSignalBarStateNotes(activeSignalBarState).map((line) => (
-                          <div key={line} className="note-item">
-                            {line}
-                          </div>
-                        ))}
-                        {buildRuntimeEventNotes(activeRuntimeSummary).map((line) => (
-                          <div key={line} className="note-item">
-                            {line}
-                          </div>
-                        ))}
-                        {buildSourceStateNotes(getRecord(activeRuntimeState.sourceStates)).map((line) => (
-                          <div key={line} className="note-item">
-                            {line}
-                          </div>
-                        ))}
-                        {buildTimelineNotes(activeRuntimeTimeline).slice(0, 3).map((line) => (
-                          <div key={line} className="note-item">
-                            {line}
-                          </div>
-                        ))}
+                      <div className="live-account-summary">
+                        <div className="note-item">实盘预检: {livePreflight.reason} · {livePreflight.detail}</div>
+                        <div className="note-item">下一步操作: {liveNextAction.label} · {liveNextAction.detail}</div>
                       </div>
-                      <div className="inline-actions">
+                      <div className="inline-actions live-account-actions">
+                        <ActionButton
+                          label={liveFlowAction === account.id ? "启动中..." : "启动实盘流程"}
+                          disabled={
+                            liveFlowAction !== null ||
+                            liveBindAction ||
+                            signalBindingAction !== null ||
+                            signalRuntimeAction !== null ||
+                            liveSessionAction !== null ||
+                            liveSessionCreateAction ||
+                            liveSessionLaunchAction
+                          }
+                          onClick={() => launchLiveFlow(account)}
+                        />
+                        <ActionButton
+                          label={accountDetailOpen ? "收起详情" : "查看详情"}
+                          variant="ghost"
+                          onClick={() => setExpandedAccountId((current) => current === account.id ? null : account.id)}
+                        />
                         <ActionButton
                           label={liveAccountSyncAction === account.id ? "同步中..." : "同步账户"}
                           variant="ghost"
@@ -716,6 +523,60 @@ export function AccountStage({
                           />
                         ) : null}
                       </div>
+                      {accountDetailOpen ? (
+                        <div className="live-account-detail">
+                          <div className="live-account-detail-grid">
+                            <div className="detail-item detail-item-compact">
+                              <span>同步状态</span>
+                              <strong>{String(syncSnapshot.syncStatus ?? "未同步")} · {formatTime(String(getRecord(account.metadata).lastLiveSyncAt ?? ""))}</strong>
+                            </div>
+                            <div className="detail-item detail-item-compact">
+                              <span>来源与实例</span>
+                              <strong>{String(syncSnapshot.source ?? "--")} · {bindings.length} 绑定 · {runtimeSessionsForAccount.length} 实例</strong>
+                            </div>
+                            <div className="detail-item detail-item-compact">
+                              <span>指标</span>
+                              <strong>周期 {String(activeSignalBarState.timeframe ?? "--")} · ma20 {formatMaybeNumber(activeSignalBarState.ma20)} · atr14 {formatMaybeNumber(activeSignalBarState.atr14)}</strong>
+                            </div>
+                            <div className="detail-item detail-item-compact">
+                              <span>账户同步</span>
+                              <strong>订单 {String(syncSnapshot.orderCount ?? "--")} · 成交 {String(syncSnapshot.fillCount ?? "--")} · 持仓 {String(syncSnapshot.positionCount ?? "--")}</strong>
+                            </div>
+                          </div>
+                          <div className="backtest-notes">
+                            {buildAlertNotes(liveAlerts).map((item) => (
+                              <div key={`${account.id}-${item.title}-${item.detail}`} className={`note-item note-item-alert note-item-alert-${item.level}`}>
+                                <strong>{item.title}</strong> {item.detail}
+                              </div>
+                            ))}
+                            {buildSignalActionNotes(activeSignalAction).map((line) => (
+                              <div key={line} className="note-item">
+                                {line}
+                              </div>
+                            ))}
+                            {buildSignalBarStateNotes(activeSignalBarState).map((line) => (
+                              <div key={line} className="note-item">
+                                {line}
+                              </div>
+                            ))}
+                            {buildRuntimeEventNotes(activeRuntimeSummary).map((line) => (
+                              <div key={line} className="note-item">
+                                {line}
+                              </div>
+                            ))}
+                            {buildSourceStateNotes(getRecord(activeRuntimeState.sourceStates)).map((line) => (
+                              <div key={line} className="note-item">
+                                {line}
+                              </div>
+                            ))}
+                            {buildTimelineNotes(activeRuntimeTimeline).slice(0, 3).map((line) => (
+                              <div key={line} className="note-item">
+                                {line}
+                              </div>
+                            ))}
+                          </div>
+                        </div>
+                      ) : null}
                     </div>
                   );
                 })}
@@ -724,40 +585,14 @@ export function AccountStage({
               <div className="empty-state empty-state-compact">暂无实盘账户</div>
             )}
           </div>
-
-          <div className="backtest-list">
-            <h4>已接受的实盘订单</h4>
-            {syncableLiveOrders.length > 0 ? (
-              <SimpleTable
-                columns={["订单", "账户", "代码", "方向", "数量", "状态", "操作"]}
-                rows={syncableLiveOrders.map((order) => [
-                  shrink(order.id),
-                  order.accountId,
-                  order.symbol,
-                  order.side,
-                  formatMaybeNumber(order.quantity),
-                  order.status,
-                  <ActionButton
-                    key={order.id}
-                    label={liveSyncAction === order.id ? "Syncing..." : "Sync"}
-                    disabled={liveSyncAction !== null}
-                    onClick={() => syncLiveOrder(order.id)}
-                  />,
-                ])}
-                emptyMessage="暂无已接受的实盘订单"
-              />
-            ) : (
-              <div className="empty-state empty-state-compact">暂无已接受的实盘订单</div>
-            )}
-          </div>
         </div>
       </section>
 
       <section id="signals" className="panel panel-session">
         <div className="panel-header">
           <div>
-            <p className="panel-kicker">Signal Runtime</p>
-            <h3>信号源绑定与市场数据运行时</h3>
+            <p className="panel-kicker">Signal Pipeline</p>
+            <h3>第二步：接通信号源并启动运行时</h3>
           </div>
           <div className="range-box">
             <span>{signalCatalog?.sources?.length ?? 0} 个源</span>
@@ -767,7 +602,7 @@ export function AccountStage({
 
         <div className="live-grid">
           <div className="backtest-form session-form">
-            <h4>绑定账户信号源</h4>
+            <h4>2.1 绑定账户信号源</h4>
             <div className="form-grid">
               <label className="form-field">
                 <span>账户</span>
@@ -815,7 +650,7 @@ export function AccountStage({
           </div>
 
           <div className="backtest-form session-form">
-            <h4>绑定策略信号源</h4>
+            <h4>2.2 绑定策略信号源</h4>
             <div className="form-grid">
               <label className="form-field">
                 <span>绑定策略</span>
@@ -865,7 +700,7 @@ export function AccountStage({
 
         <div className="live-grid">
           <div className="backtest-list">
-            <h4>信号源目录</h4>
+            <h4>信号源目录与说明</h4>
             {signalCatalog?.sources?.length ? (
               <SimpleTable
                 columns={["名称", "交易所", "流类型", "角色", "环境", "传输方式"]}
@@ -897,7 +732,7 @@ export function AccountStage({
           </div>
 
           <div className="backtest-list">
-            <h4>当前信号绑定</h4>
+            <h4>当前信号绑定结果</h4>
             <div className="backtest-breakdown">
               <h5>账户级别</h5>
               <SimpleTable
@@ -943,7 +778,7 @@ export function AccountStage({
 
         <div className="live-grid">
           <div className="backtest-form session-form">
-            <h4>运行时策略</h4>
+            <h4>2.3 运行时策略</h4>
             <div className="form-grid">
               <label className="form-field">
                 <span>成交价格新鲜度 (秒)</span>
@@ -1013,7 +848,7 @@ export function AccountStage({
           </div>
 
           <div className="backtest-form session-form">
-            <h4>创建信号运行时</h4>
+            <h4>2.4 创建信号运行时</h4>
             <div className="form-grid">
               <label className="form-field">
                 <span>账户</span>
@@ -1078,7 +913,7 @@ export function AccountStage({
         </div>
 
         <div className="backtest-list mt-8 pt-8 border-t border-white/5">
-          <h4 className="text-sm font-medium text-emerald-400 mb-4">运行时会话</h4>
+          <h4 className="text-sm font-medium text-emerald-400 mb-4">2.5 运行时会话与结果</h4>
             {signalRuntimeSessions.length > 0 ? (
               <>
                 <div className="table-wrap">
@@ -1134,7 +969,7 @@ export function AccountStage({
 
                 <div className="backtest-detail-card">
                   <div className="flex items-center justify-between mb-4 mt-8 pt-8 border-t border-white/5">
-                    <h5 className="text-sm font-medium text-emerald-400">选中运行时细节</h5>
+                    <h5 className="text-sm font-medium text-emerald-400">运行时详情</h5>
                     <div className="flex items-center space-x-3 text-[10px] text-zinc-500 bg-white/5 px-2 py-1 rounded-md">
                       <span>状态: {selectedSignalRuntime?.status ?? "未选择"}</span>
                       <span className="opacity-30">|</span>
@@ -1286,6 +1121,245 @@ export function AccountStage({
             )}
           </div>
         </section>
+
+      <section id="sessions" className="panel panel-session">
+        <div className="panel-header">
+          <div>
+            <p className="panel-kicker">Sessions</p>
+            <h3>第三步：创建实盘策略会话</h3>
+          </div>
+        </div>
+        <div className="live-grid">
+          <div className="backtest-list live-grid-span-2">
+            <div className="backtest-notes notes-compact">
+              <div className="note-item">有效会话：{validLiveSessions.length}</div>
+            </div>
+            {validLiveSessions.length > 0 ? (
+              <div className="live-card-list">
+                {validLiveSessions.map((session) => {
+                  const intent = getRecord(session.state?.lastStrategyIntent);
+                  const executionSummary = deriveLiveSessionExecutionSummary(session, orders, fills, positions);
+                  const sessionHealth = deriveLiveSessionHealth(session, executionSummary);
+                  const sessionAccount = liveAccounts.find((account) => account.id === session.accountId) ?? null;
+                  const sessionBinding = getRecord(sessionAccount?.metadata?.liveBinding);
+                  const sessionAccountReady =
+                    sessionAccount?.status === "CONFIGURED" ||
+                    sessionAccount?.status === "READY" ||
+                    (String(sessionBinding.connectionMode ?? "") !== "" && String(sessionBinding.connectionMode ?? "") !== "disabled");
+                  return (
+                    <div key={session.id} className="session-row">
+                      <div className="session-row-main">
+                        <div className="session-row-title">
+                          <strong>{shrink(session.id)}</strong>
+                          <StatusPill tone={liveSessionHealthTone(sessionHealth.status)}>{sessionHealth.status}</StatusPill>
+                          <StatusPill tone={session.status === "RUNNING" ? "ready" : session.status === "STOPPED" ? "watch" : "neutral"}>
+                            {session.status}
+                          </StatusPill>
+                        </div>
+                        <div className="live-account-meta session-row-meta">
+                          <span>{session.accountId}</span>
+                          <span>{strategyLabel(strategies.find((strategy) => strategy.id === session.strategyId))}</span>
+                          <span>{String(session.state?.signalTimeframe ?? "--")}</span>
+                          <span>{sessionAccount?.status ?? "--"}</span>
+                          <span>{String(intent.action ?? "no-intent")}</span>
+                          <span>{String(executionSummary.position?.side ?? "FLAT")}</span>
+                          <span>{formatMaybeNumber(executionSummary.position?.quantity)}</span>
+                          <span>{executionSummary.orderCount}/{executionSummary.fillCount}</span>
+                          {!sessionAccountReady ? <span>先绑定适配器</span> : null}
+                        </div>
+                      </div>
+                      <div className="session-row-actions inline-actions">
+                        <ActionButton
+                          label="编辑"
+                          variant="ghost"
+                          disabled={liveSessionAction !== null || liveSessionDeleteAction !== null}
+                          onClick={() => openLiveSessionModal(session)}
+                        />
+                        {String(session.state?.signalRuntimeSessionId ?? "") ? (
+                          <ActionButton
+                            label="打开运行时"
+                            variant="ghost"
+                            onClick={() => jumpToSignalRuntimeSession(String(session.state?.signalRuntimeSessionId ?? ""))}
+                          />
+                        ) : null}
+                        <ActionButton
+                          label={liveSessionAction === `${session.id}:start` ? "启动中..." : "启动"}
+                          disabled={liveSessionAction !== null || session.status === "RUNNING" || !sessionAccountReady}
+                          onClick={() => runLiveSessionAction(session.id, "start")}
+                        />
+                        {!sessionAccountReady ? (
+                          <ActionButton
+                            label="绑定适配器"
+                            variant="ghost"
+                            disabled={liveSessionAction !== null || liveSessionDeleteAction !== null}
+                            onClick={() => {
+                              selectQuickLiveAccount(session.accountId);
+                              openLiveBindingModal();
+                            }}
+                          />
+                        ) : null}
+                        <ActionButton
+                          label={liveSessionAction === `${session.id}:dispatch` ? "分发中..." : "分发意图"}
+                          disabled={
+                            liveSessionAction !== null ||
+                            !getRecord(session.state?.lastStrategyIntent).action ||
+                            String(session.state?.dispatchMode ?? "") !== "manual-review" ||
+                            (primaryLiveSession?.id === session.id && primaryLiveDispatchPreview.status === "blocked")
+                          }
+                          onClick={() => dispatchLiveSessionIntent(session.id)}
+                        />
+                        <ActionButton
+                          label={liveSessionAction === `${session.id}:sync` ? "同步中..." : "同步最新订单"}
+                          variant="ghost"
+                          disabled={liveSessionAction !== null || !String(session.state?.lastDispatchedOrderId ?? "")}
+                          onClick={() => syncLiveSession(session.id)}
+                        />
+                        <ActionButton
+                          label={liveSessionAction === `${session.id}:stop` ? "停止中..." : "停止"}
+                          variant="ghost"
+                          disabled={liveSessionAction !== null || session.status === "STOPPED"}
+                          onClick={() => runLiveSessionAction(session.id, "stop")}
+                        />
+                        <ActionButton
+                          label={liveSessionDeleteAction === session.id ? "删除中..." : "删除"}
+                          variant="ghost"
+                          disabled={liveSessionAction !== null || liveSessionDeleteAction !== null}
+                          onClick={() => void deleteLiveSession(session.id)}
+                        />
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            ) : (
+              <div className="empty-state empty-state-compact">暂无有效实盘会话</div>
+            )}
+          </div>
+        </div>
+      </section>
+
+      <section id="monitoring" className="panel panel-session">
+        <div className="panel-header">
+          <div>
+            <p className="panel-kicker">Monitoring</p>
+            <h3>第四步：监控与人工干预</h3>
+          </div>
+        </div>
+        <div className="live-grid">
+          {highlightedLiveSession ? (
+            <div className="session-card session-card-primary">
+              <div className="session-card-header">
+                <div>
+                  <p className="panel-kicker">Primary Session</p>
+                  <h4>当前优先处理会话</h4>
+                </div>
+                <StatusPill tone={liveSessionHealthTone(highlightedLiveSession.health.status)}>
+                  {highlightedLiveSession.health.status}
+                </StatusPill>
+              </div>
+              <div className="live-account-meta">
+                <span title="会话 ID">{shrink(highlightedLiveSession.session.id)}</span>
+                <span title="账户 ID">{highlightedLiveSession.session.accountId}</span>
+                <span title="策略 ID">{highlightedLiveSession.session.strategyId}</span>
+                <span title="信号周期">{String(highlightedLiveSession.session.state?.signalTimeframe ?? "--")}</span>
+              </div>
+              <div className="backtest-notes">
+                <div className="note-item">健康状态: {highlightedLiveSession.health.detail}</div>
+                <div className="backtest-grid-notes">
+                   <div className="note-item">恢复状态: {String(highlightedLiveSession.session.state?.positionRecoveryStatus ?? "--")}</div>
+                   <div className="note-item">保护恢复: {String(highlightedLiveSession.session.state?.protectionRecoveryStatus ?? "--")} ({String(highlightedLiveSession.session.state?.recoveredProtectionCount ?? "--")})</div>
+                   <div className="note-item">执行统计: 订单 {highlightedLiveSession.execution.orderCount} · 成交 {highlightedLiveSession.execution.fillCount}</div>
+                   <div className="note-item">最后订单: {String(highlightedLiveSession.execution.latestOrder?.status ?? "--")} · {String(highlightedLiveSession.execution.latestOrder?.side ?? "--")} @ {formatMaybeNumber(highlightedLiveSession.execution.latestOrder?.price)}</div>
+                   <div className="note-item">当前持仓: {String(highlightedLiveSession.execution.position?.side ?? "平仓")} · {formatMaybeNumber(highlightedLiveSession.execution.position?.quantity)} @ {formatMaybeNumber(highlightedLiveSession.execution.position?.entryPrice)}</div>
+                </div>
+              </div>
+              <div className="flow-row">
+                {highlightedLiveSessionFlow.map((step) => (
+                  <div key={step.key} className="flow-step">
+                    <StatusPill tone={step.status}>{step.label}</StatusPill>
+                    <span>{step.detail}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ) : (
+            <div className="backtest-list">
+              <div className="empty-state empty-state-compact">当前没有可优先处理的运行中实盘会话</div>
+            </div>
+          )}
+          <div className="backtest-list">
+            <h4>当前会话监控细节</h4>
+            {primaryLiveSession ? (
+              <div className="live-detail-layout">
+                <div className="live-summary-grid">
+                  {primaryLiveSummaryItems.map((item) => (
+                    <div key={item.label} className="detail-item">
+                      <span>{item.label}</span>
+                      <strong>{item.value}</strong>
+                    </div>
+                  ))}
+                </div>
+                <div className="live-section-grid">
+                  {primaryLiveSections.map((section) => (
+                    <section key={section.title} className="live-section-card">
+                      <button
+                        type="button"
+                        className="live-section-toggle"
+                        onClick={() => setExpandedLiveSection((current) => current === section.title ? "" : section.title)}
+                      >
+                        <div>
+                          <h5>{section.title}</h5>
+                          <span>{expandedLiveSection === section.title ? "收起详情" : "点击查看详情"}</span>
+                        </div>
+                        <strong>{expandedLiveSection === section.title ? "−" : "+"}</strong>
+                      </button>
+                      {expandedLiveSection === section.title ? (
+                        <div className="live-section-items">
+                          {section.items.map((item) => (
+                            <div key={`${section.title}-${item.label}`} className="detail-item detail-item-compact">
+                              <span>{item.label}</span>
+                              <strong>{item.value}</strong>
+                            </div>
+                          ))}
+                        </div>
+                      ) : null}
+                    </section>
+                  ))}
+                </div>
+              </div>
+            ) : (
+              <div className="empty-state empty-state-compact">启动并选中一个实盘会话后，这里会显示监控细节</div>
+            )}
+          </div>
+        </div>
+        <div className="live-grid">
+          <div className="backtest-list live-grid-span-2">
+            <h4>待同步的实盘订单</h4>
+            {syncableLiveOrders.length > 0 ? (
+              <SimpleTable
+                columns={["订单", "账户", "代码", "方向", "数量", "状态", "操作"]}
+                rows={syncableLiveOrders.map((order) => [
+                  shrink(order.id),
+                  order.accountId,
+                  order.symbol,
+                  order.side,
+                  formatMaybeNumber(order.quantity),
+                  order.status,
+                  <ActionButton
+                    key={order.id}
+                    label={liveSyncAction === order.id ? "Syncing..." : "Sync"}
+                    disabled={liveSyncAction !== null}
+                    onClick={() => syncLiveOrder(order.id)}
+                  />,
+                ])}
+                emptyMessage="暂无已接受的实盘订单"
+              />
+            ) : (
+              <div className="empty-state empty-state-compact">暂无已接受的实盘订单</div>
+            )}
+          </div>
+        </div>
+      </section>
       </div>
     );
 }

--- a/web/console/src/store/useUIStore.ts
+++ b/web/console/src/store/useUIStore.ts
@@ -6,12 +6,57 @@ import {
 import { readStoredAuthSession } from '../utils/auth';
 import { resolveUpdater } from './helpers';
 
+type SidebarTab = "monitor" | "strategy" | "account";
+type DockTab = "orders" | "positions" | "fills" | "alerts";
+
+const CONSOLE_NAV_STORAGE_KEY = "bktrader-console-nav";
+const DEFAULT_SIDEBAR_TAB: SidebarTab = "monitor";
+const DEFAULT_DOCK_TAB: DockTab = "orders";
+
+function readStoredConsoleNav(): { sidebarTab: SidebarTab; dockTab: DockTab } {
+  if (typeof window === "undefined") {
+    return { sidebarTab: DEFAULT_SIDEBAR_TAB, dockTab: DEFAULT_DOCK_TAB };
+  }
+
+  try {
+    const raw = window.localStorage.getItem(CONSOLE_NAV_STORAGE_KEY);
+    if (!raw) {
+      return { sidebarTab: DEFAULT_SIDEBAR_TAB, dockTab: DEFAULT_DOCK_TAB };
+    }
+
+    const parsed = JSON.parse(raw) as Partial<{ sidebarTab: SidebarTab; dockTab: DockTab }>;
+    const sidebarTab = parsed.sidebarTab === "strategy" || parsed.sidebarTab === "account" || parsed.sidebarTab === "monitor"
+      ? parsed.sidebarTab
+      : DEFAULT_SIDEBAR_TAB;
+    const dockTab = parsed.dockTab === "positions" || parsed.dockTab === "fills" || parsed.dockTab === "alerts" || parsed.dockTab === "orders"
+      ? parsed.dockTab
+      : DEFAULT_DOCK_TAB;
+
+    return { sidebarTab, dockTab };
+  } catch {
+    return { sidebarTab: DEFAULT_SIDEBAR_TAB, dockTab: DEFAULT_DOCK_TAB };
+  }
+}
+
+function writeStoredConsoleNav(partial: Partial<{ sidebarTab: SidebarTab; dockTab: DockTab }>) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  const current = readStoredConsoleNav();
+  window.localStorage.setItem(CONSOLE_NAV_STORAGE_KEY, JSON.stringify({
+    ...current,
+    ...partial,
+  }));
+}
+
+const initialConsoleNav = readStoredConsoleNav();
 
 export interface useUIStoreState {
-  sidebarTab: "monitor" | "strategy" | "account";
-  setSidebarTab: (val: "monitor" | "strategy" | "account") => void;
-  dockTab: "orders" | "positions" | "fills" | "alerts";
-  setDockTab: (val: "orders" | "positions" | "fills" | "alerts") => void;
+  sidebarTab: SidebarTab;
+  setSidebarTab: (val: SidebarTab) => void;
+  dockTab: DockTab;
+  setDockTab: (val: DockTab) => void;
   loading: boolean;
   setLoading: (valOrUpdater: boolean | ((prev: boolean) => boolean)) => void;
   error: string | null;
@@ -125,10 +170,16 @@ export interface useUIStoreState {
 }
 
 export const useUIStore = create<useUIStoreState>((set) => ({
-  sidebarTab: "monitor",
-  setSidebarTab: (val) => set({ sidebarTab: val }),
-  dockTab: "orders",
-  setDockTab: (val) => set({ dockTab: val }),
+  sidebarTab: initialConsoleNav.sidebarTab,
+  setSidebarTab: (val) => {
+    writeStoredConsoleNav({ sidebarTab: val });
+    set({ sidebarTab: val });
+  },
+  dockTab: initialConsoleNav.dockTab,
+  setDockTab: (val) => {
+    writeStoredConsoleNav({ dockTab: val });
+    set({ dockTab: val });
+  },
   loading: true,
   setLoading: (valOrUpdater) => set((state) => ({ loading: resolveUpdater(valOrUpdater, state.loading) })),
   error: null,

--- a/web/console/src/styles.css
+++ b/web/console/src/styles.css
@@ -236,24 +236,27 @@ a {
 .eyebrow,
 .panel-kicker {
   margin: 0;
-  font-size: 0.82rem;
+  font-size: 0.72rem;
+  font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.08em;
   color: var(--accent);
 }
 
 .hero h2 {
-  margin: 4px 0 6px;
-  font-size: clamp(1.2rem, 2vw, 1.8rem);
-  line-height: 1.1;
+  margin: 6px 0 8px;
+  font-size: clamp(0.98rem, 1.4vw, 1.16rem);
+  line-height: 1.3;
+  font-weight: 700;
+  color: var(--ink);
 }
 
 .hero-copy {
   margin: 0;
   max-width: 720px;
-  color: var(--muted);
-  font-size: 0.92rem;
-  line-height: 1.4;
+  color: color-mix(in srgb, var(--ink) 72%, var(--muted) 28%);
+  font-size: 0.82rem;
+  line-height: 1.55;
 }
 
 .hero-side {
@@ -262,6 +265,37 @@ a {
   gap: 10px;
   justify-content: flex-end;
   align-items: flex-start;
+}
+
+.hero-account-toolbar {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 12px;
+  min-width: min(100%, 520px);
+}
+
+.hero-account-card {
+  width: 100%;
+  min-width: 0;
+}
+
+.hero-actions {
+  width: 100%;
+}
+
+.hero-actions .action-button {
+  min-width: 0;
+  padding: 8px 12px;
+  border-radius: 12px;
+  font-size: 0.74rem;
+  font-weight: 600;
+  line-height: 1.2;
+}
+
+.hero-actions .action-button-ghost {
+  background: rgba(255, 255, 255, 0.82);
+  color: color-mix(in srgb, var(--ink) 92%, var(--muted) 8%);
 }
 
 .hero-menu {
@@ -314,10 +348,10 @@ a {
 
 .hero-user-card {
   min-width: 220px;
-  padding: 12px 14px;
-  border-radius: 18px;
+  padding: 9px 12px;
+  border-radius: 14px;
   border: 1px solid var(--line);
-  background: rgba(255, 255, 255, 0.74);
+  background: rgba(255, 255, 255, 0.78);
   display: flex;
   gap: 12px;
   align-items: center;
@@ -326,12 +360,17 @@ a {
 
 .hero-user-card strong {
   display: block;
+  color: color-mix(in srgb, var(--ink) 64%, white 36%);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
 }
 
 .hero-user-card p {
-  margin: 4px 0 0;
-  color: var(--muted);
-  font-size: 0.84rem;
+  margin: 3px 0 0;
+  color: var(--ink);
+  font-size: 0.72rem;
+  line-height: 1.35;
 }
 
 .hero-logout {
@@ -439,6 +478,10 @@ a {
   margin-bottom: 12px;
 }
 
+.live-grid-span-2 {
+  grid-column: 1 / -1;
+}
+
 .monitor-top-grid {
   display: grid;
   grid-template-columns: minmax(0, 1.6fr) minmax(320px, 0.8fr);
@@ -469,6 +512,65 @@ a {
 .panel-header h3 {
   margin: 4px 0 0;
   font-size: 1.08rem;
+}
+
+.workflow-grid {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.workflow-card {
+  display: grid;
+  gap: 10px;
+  padding: 12px;
+  border-radius: 16px;
+  border: 1px solid var(--line);
+  background: rgba(255, 255, 255, 0.46);
+}
+
+.workflow-card-current {
+  background: rgba(255, 251, 242, 0.9);
+  border-color: rgba(240, 180, 41, 0.32);
+}
+
+.workflow-card-done {
+  background: rgba(217, 238, 232, 0.62);
+  border-color: rgba(14, 109, 96, 0.22);
+}
+
+.workflow-card-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.workflow-step-index {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid var(--line);
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: var(--ink);
+}
+
+.workflow-card h4 {
+  margin: 0;
+  font-size: 0.92rem;
+  color: var(--ink);
+}
+
+.workflow-card p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.8rem;
+  line-height: 1.45;
 }
 
 .panel-header-tight {
@@ -783,6 +885,58 @@ a {
   font-size: 0.82rem;
 }
 
+.live-account-card {
+  display: grid;
+  gap: 10px;
+  padding: 14px;
+  border-radius: 16px;
+  border: 1px solid var(--line);
+  background: rgba(255, 255, 255, 0.56);
+}
+
+.live-account-card-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.live-account-status {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.live-account-metrics {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.live-account-summary {
+  display: grid;
+  gap: 8px;
+}
+
+.live-account-actions {
+  flex-wrap: wrap;
+}
+
+.live-account-detail {
+  display: grid;
+  gap: 10px;
+  padding-top: 10px;
+  border-top: 1px solid rgba(216, 207, 186, 0.8);
+}
+
+.live-account-detail-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
 .inline-actions {
   display: flex;
   align-items: center;
@@ -803,6 +957,79 @@ a {
   margin-top: 16px;
   display: grid;
   gap: 14px;
+}
+
+.live-detail-layout {
+  margin-top: 14px;
+  display: grid;
+  gap: 14px;
+}
+
+.live-summary-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.live-section-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.live-section-card {
+  display: grid;
+  gap: 10px;
+  padding: 12px;
+  border-radius: 16px;
+  border: 1px solid var(--line);
+  background: rgba(255, 255, 255, 0.48);
+}
+
+.live-section-card h5 {
+  margin: 0;
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+
+.live-section-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  width: 100%;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.live-section-toggle span {
+  display: block;
+  margin-top: 4px;
+  font-size: 0.72rem;
+  color: var(--muted);
+}
+
+.live-section-toggle strong {
+  color: var(--accent);
+  font-size: 1rem;
+  line-height: 1;
+}
+
+.live-section-items {
+  display: grid;
+  gap: 8px;
+}
+
+.detail-item-compact strong {
+  font-size: 0.82rem;
+  line-height: 1.45;
 }
 
 .backtest-breakdown h4,
@@ -862,16 +1089,25 @@ a {
   border-color: rgba(90, 104, 114, 0.14);
 }
 
-.status-pill {
+.status-pill,
+.action-button {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+  height: 20.48px;
   border-radius: 999px;
   padding: 3px 10px;
   font-size: 0.78rem;
   font-weight: 700;
   letter-spacing: 0.01em;
+  line-height: 1;
   border: 1px solid transparent;
   vertical-align: middle;
+  white-space: nowrap;
+}
+
+.status-pill {
   margin-right: 6px;
 }
 
@@ -900,16 +1136,15 @@ a {
 }
 
 .action-button {
-  border: none;
-  border-radius: 14px;
-  padding: 12px 16px;
+  appearance: none;
+  -webkit-appearance: none;
   background: linear-gradient(135deg, rgba(14, 109, 96, 0.95), rgba(7, 87, 74, 1));
   color: white;
-  font: inherit;
+  font-family: inherit;
   cursor: pointer;
-  min-width: 88px;
+  min-width: 0;
   transition: 140ms ease;
-  box-shadow: 0 10px 24px rgba(14, 109, 96, 0.18);
+  box-shadow: 0 6px 16px rgba(14, 109, 96, 0.14);
 }
 
 .action-button:hover:not(:disabled) {
@@ -1384,6 +1619,15 @@ tbody tr:last-child td {
     grid-template-columns: 1fr;
   }
 
+  .hero-account-toolbar {
+    min-width: 0;
+    align-items: flex-start;
+  }
+
+  .hero-actions {
+    justify-content: flex-start;
+  }
+
   .session-layout {
     grid-template-columns: 1fr;
   }
@@ -1397,8 +1641,16 @@ tbody tr:last-child td {
   }
 
   .detail-grid-compact,
-  .notes-compact {
+  .notes-compact,
+  .live-summary-grid,
+  .live-section-grid,
+  .live-account-detail-grid,
+  .workflow-grid {
     grid-template-columns: 1fr;
+  }
+
+  .live-account-metrics {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
   .form-grid {
@@ -1418,6 +1670,6 @@ tbody tr:last-child td {
   }
 
   .hero h2 {
-    font-size: 1.45rem;
+    font-size: 1rem;
   }
 }


### PR DESCRIPTION
## 目的
重排控制台账户页的信息架构和交互层级，让用户按“准备账户 -> 接通信号与运行时 -> 创建实盘会话 -> 监控与干预”的顺序完成操作，并补上导航状态刷新恢复与 graphify 文档规则调整。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [x] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main)
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？
- [x] DB migration 是否具备向下兼容幂等性？
- [x] 配置字段有没有无意被混改？

说明：本次未修改 dispatchMode 默认值、交易所路由、DB migration 或配置字段语义；改动集中在前端控制台信息架构、导航持久化和 AGENTS 文档规则。

## 本次改动
- 重构 `AccountStage`，按用户流程拆成准备账户、接通信号源并启动运行时、创建实盘策略会话、监控与人工干预四段。
- 收敛实盘账户卡和会话监控细节，减少信息墙，增加分组详情展开。
- 持久化控制台 `sidebarTab` / `dockTab`，刷新后恢复当前页签。
- 调整全局控制台按钮与状态胶囊尺寸，统一交互基线。
- 更新 `AGENTS.md`，改为在 `git push` 前重建 graphify，并依赖 `pre-push` hook 作为默认路径。

## 验证方式与测试证据
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

已执行：
- `cd web/console && npm run build`
- `git push` 过程中由 `pre-push` hook 自动执行 graphify rebuild
