### PR TITLE
[codex] fix signal runtime bindings and add testnet launch templates

### DIFF
--- a/docs/frontend-task-multi-timeframe-signal-bindings.md
+++ b/docs/frontend-task-multi-timeframe-signal-bindings.md
@@ -213,6 +213,12 @@ runtime plan 里的 binding map 现在额外带出顶层字段：
 - `steps`
 - `notes`
 
+其中 `launchPayload.mirrorStrategySignals` 目前只是兼容字段：
+
+- 前端无需把它理解成“把策略绑定复制到账户信号源”
+- 当前后端已经不会再做账户 signal binding 镜像
+- 它保留的唯一意义，是在 launch 时继续要求“策略绑定必须已经存在”
+
 ### 每个模板实际固定了什么
 
 #### 1. 账户绑定

--- a/docs/frontend-task-multi-timeframe-signal-bindings.md
+++ b/docs/frontend-task-multi-timeframe-signal-bindings.md
@@ -180,7 +180,8 @@ runtime plan 里的 binding map 现在额外带出顶层字段：
 
 - 账户绑定固定为 Binance Futures testnet REST
 - 策略绑定固定为 `signal + trigger + feature` 三件套
-- live session 固定为 `tick` 执行、默认执行策略、`auto-dispatch`
+- live session 固定为 `tick` 执行、默认执行策略
+- 只有 `dispatchMode` 允许前端在模板区顶部单独选择
 - symbol / timeframe 直接收敛成 4 个常用组合
 
 这 4 个模板分别是：
@@ -201,6 +202,8 @@ runtime plan 里的 binding map 现在额外带出顶层字段：
 - `description`
 - `symbol`
 - `signalTimeframe`
+- `defaultDispatchMode`
+- `dispatchModeOptions`
 - `strategyId`
 - `strategyName`
 - `accountRequirements`
@@ -246,7 +249,7 @@ runtime plan 里的 binding map 现在额外带出顶层字段：
 
 #### 3. live session 覆盖参数
 
-模板里的 `launchPayload.liveSessionOverrides` 至少已经固定了：
+模板里的 `launchPayload.liveSessionOverrides` 至少已经固定了这些字段：
 
 - `symbol`
 - `signalTimeframe`
@@ -267,8 +270,15 @@ runtime plan 里的 binding map 现在额外带出顶层字段：
 - `executionSLExitOrderType = MARKET`
 - `executionSLExitMaxSpreadBps = 999`
 - `executionSLExitTimeoutFallbackOrderType = MARKET`
-- `dispatchMode = auto-dispatch`
 - `dispatchCooldownSeconds = 30`
+
+注意：
+
+- `dispatchMode` 不再写死在模板 payload 里
+- 模板会单独返回：
+  - `defaultDispatchMode = manual-review`
+  - `dispatchModeOptions = [manual-review, auto-dispatch]`
+- 前端需要把用户在模板区顶部选中的 `dispatchMode` 注入到最终提交的 `launchPayload.liveSessionOverrides.dispatchMode`
 
 数量目前后端模板固定为：
 
@@ -282,9 +292,10 @@ runtime plan 里的 binding map 现在额外带出顶层字段：
 不要把这个功能理解成“只是在 UI 上帮用户填表”。更稳妥的接法是：
 
 1. 先 `GET /api/v1/live/launch-templates`
-2. 在 UI 上展示 4 张模板卡片或 4 个明确按钮
-3. 用户先选一个 live account，再点模板
-4. 点击后，前端按模板里的 `steps` 顺序串行执行
+2. 在 4 张模板卡片上方放一个全局 `dispatchMode` 选择器
+3. 在 UI 上展示 4 张模板卡片或 4 个明确按钮
+4. 用户先选一个 live account，再点模板
+5. 点击后，前端按模板里的 `steps` 顺序串行执行
 
 推荐执行顺序：
 
@@ -293,13 +304,29 @@ runtime plan 里的 binding map 现在额外带出顶层字段：
 2. 对模板里的每一条 `strategySignalBindings`
    - 分别 `POST /api/v1/strategies/:strategyId/signal-bindings`
 3. `POST /api/v1/live/accounts/:accountId/launch`
-   - body 直接用模板里的 `launchPayload`
+   - body 基于模板里的 `launchPayload`
+   - 仅在发请求前额外注入：
+     - `liveSessionOverrides.dispatchMode = 当前选择器选中的值`
 
-这里建议前端不要自己重新拼 payload，而是尽量直接复用模板响应里的对象。这样最不容易在命名和默认值上跑偏。
+这里建议前端不要自己重新拼大对象，而是：
+
+- 直接复用模板响应里的 `accountBinding`
+- 直接复用模板响应里的 `strategySignalBindings`
+- 直接复用模板响应里的 `launchPayload`
+- 只覆写一个字段：`launchPayload.liveSessionOverrides.dispatchMode`
+
+这样最不容易在命名和默认值上跑偏。
 
 ### UI 建议
 
 建议把这一块放在 live account 区域，作为“Quick Launch Templates”或“联调一键启动”区域，而不是塞进策略绑定表单里。
+
+推荐 UI 结构：
+
+1. 顶部一行 `dispatchMode` 选择器
+   - `manual-review`
+   - `auto-dispatch`
+2. 下方 4 张模板卡片
 
 每张卡片至少展示：
 
@@ -310,12 +337,12 @@ runtime plan 里的 binding map 现在额外带出顶层字段：
 - `feature source = binance-order-book`
 - `strategyName`
 - `defaultOrderQuantity`
-- `dispatchMode`
+- 当前顶部选择的 `dispatchMode`
 
 建议再补两行提示：
 
 - `这会先确保账户绑定和策略绑定，再启动 runtime/live session`
-- `这是 testnet 联调专用模板，启动后会自动派单，不经过 manual-review`
+- `这是 testnet 联调专用模板；是否自动派单由上方 dispatchMode 控制`
 
 ### 前端状态与错误处理建议
 
@@ -336,7 +363,7 @@ runtime plan 里的 binding map 现在额外带出顶层字段：
 3. launch 失败
    - 常见原因：live account 未配置、runtime/source readiness 不满足
 
-同时建议在按钮附近放一个很明确的风险文案：
+同时建议在按钮附近放一个很明确的风险文案，且只在选择了 `auto-dispatch` 时高亮：
 
 - `仅限 Binance testnet 联调`
 - `点击后若策略触发，将自动向 testnet 发送真实 REST 订单`
@@ -361,11 +388,13 @@ runtime plan 里的 binding map 现在额外带出顶层字段：
 - 用户只需要先选账户，再点一个模板，就能完成联调启动
 - 前端实际执行的是模板里的固定 payload，而不是重新手工拼字段
 - 同一个模板重复点击不会制造同一条策略绑定的重复脏数据
-- 模板卡片或按钮会明确标注 `auto-dispatch / testnet only`
+- 模板区顶部会有唯一可编辑项 `dispatchMode`
+- 模板卡片或按钮会明确标注 `testnet only`
 - 模板启动后能正确创建或复用：
   - `account + strategy` 级 runtime session
   - `account + strategy + symbol + timeframe` 级 live session
-- UI 上能明确告诉用户当前启动的是 `Binance testnet REST + auto-dispatch`，不是 mock
+- UI 上能明确告诉用户当前启动的是 `Binance testnet REST`，不是 mock
+- 当选择 `auto-dispatch` 时，UI 要明确告诉用户这是自动派单模式
 
 ### 联调建议
 
@@ -382,7 +411,8 @@ runtime plan 里的 binding map 现在额外带出顶层字段：
 - 策略绑定列表里是否出现 `signal / trigger / feature` 三条
 - runtime plan 是否直接来自策略绑定
 - live session 是否按 `symbol + timeframe` 分开
-- live session state 里的 `dispatchMode` 是否为 `auto-dispatch`
+- 顶部切到 `manual-review` 时，live session state 里的 `dispatchMode` 是否为 `manual-review`
+- 顶部切到 `auto-dispatch` 时，live session state 里的 `dispatchMode` 是否为 `auto-dispatch`
 
 ## Task D: PR #40 Live Data Collection Telemetry
 

--- a/docs/frontend-task-multi-timeframe-signal-bindings.md
+++ b/docs/frontend-task-multi-timeframe-signal-bindings.md
@@ -1,0 +1,440 @@
+# Frontend Coordination Tasks
+
+## 说明
+
+这份文件汇总当前需要前端协作跟进的 3 组后端改动：
+
+- PR `#39`：health snapshot / runtime policy 扩展
+- PR `#40`：live data collection telemetry 落库
+- 当前分支：multi-timeframe signal bindings 修复
+
+目标不是让前端一次性全做完，而是把“已经可做的 UI 对齐”和“还依赖后端补接口的事项”拆清楚。
+
+## 建议处理顺序
+
+1. 先处理 PR `#39`
+2. 再处理 multi-timeframe signal bindings
+3. 最后排 PR `#40`，其中一部分仍依赖后端补 HTTP 暴露
+
+## 范围约束
+
+仅限 `web/console`，不要顺手改后端。
+
+优先会涉及这些位置：
+
+- `web/console/src/types/domain.ts`
+- `web/console/src/store/useUIStore.ts`
+- `web/console/src/hooks/useDashboard.ts`
+- `web/console/src/hooks/useTradingActions.ts`
+- `web/console/src/pages/AccountStage.tsx`
+- `web/console/src/pages/MonitorStage.tsx`
+- 如有必要，再补 `web/console/src/utils/derivation.ts`
+
+## Task A: PR #39 Health Snapshot And Runtime Policy
+
+### 后端已提供
+
+- `GET /api/v1/monitor/health`
+- `GET /api/v1/runtime-policy`
+- `POST /api/v1/runtime-policy`
+
+`/api/v1/monitor/health` 返回的核心结构包括：
+
+- `status`
+- `alertCounts`
+- `runtimePolicy`
+- `liveAccounts`
+- `runtimeSessions`
+- `liveSessions`
+- `paperSessions`
+
+`runtimePolicy` 现在比前端当前类型更多 2 个字段：
+
+- `strategyEvaluationQuietSeconds`
+- `liveAccountSyncFreshnessSeconds`
+
+并且后端已经支持显式传 `0` 作为 disable，而不是只能传正数。
+
+### 当前前端缺口
+
+我在当前前端代码里看到：
+
+- 已经消费 `/api/v1/runtime-policy`
+- 但 `RuntimePolicy` 类型仍缺少上面两个新增字段
+- `RuntimePolicyForm` 也缺少这两个输入项
+- 还没有消费 `/api/v1/monitor/health`
+
+### 前端需要做什么
+
+1. 给 `RuntimePolicy` 和 `RuntimePolicyForm` 补齐：
+   - `strategyEvaluationQuietSeconds`
+   - `liveAccountSyncFreshnessSeconds`
+2. 运行时策略表单允许用户显式保存 `0`。
+3. 接入 `/api/v1/monitor/health`，为监控页面提供平台级健康视图。
+4. 至少把这些健康信息展示出来：
+   - 平台总体状态 `status`
+   - 告警聚合 `alertCounts`
+   - live account 的 `syncStale` / `syncAgeSeconds`
+   - runtime session 的 `health` / `quiet`
+   - live session 的 `evaluationQuiet`
+5. 现有 alerts 视图如果继续保留，建议和 `/api/v1/monitor/health` 的摘要信息形成互补，而不是重复堆同样字段。
+
+### 验收标准
+
+- 前端不会再丢失 `strategyEvaluationQuietSeconds` 和 `liveAccountSyncFreshnessSeconds`
+- UI 能表达 `0 = disable`
+- 页面能看出 live account 是否 sync stale
+- 页面能看出 runtime quiet / live evaluation quiet
+
+## Task B: Multi-Timeframe Signal Bindings
+
+### 背景
+
+后端已修复信号绑定身份键，`signal` 类绑定现在会把 `timeframe` 纳入匹配与去重逻辑。
+
+这意味着以下场景现在在后端是合法且可区分的：
+
+- 同一账户同时绑定 `BTCUSDT 1d` 与 `BTCUSDT 4h`
+- 同一策略同时绑定 `BTCUSDT 1d` 与 `BTCUSDT 4h`
+- runtime plan 对 `BTCUSDT 4h` 不会再误匹配到账户侧的 `BTCUSDT 1d`
+
+另外，后端运行模型已经进一步收敛：
+
+- runtime 订阅规划现在直接基于策略绑定生成
+- 账户级 signal binding 不再参与 runtime plan / readiness / live launch
+- 快速启动路径也已修正：同一账户下相同策略但不同 `symbol/timeframe` 的 live session 不会再被错误复用成同一个 session
+
+也就是说，账户绑定 UI 现在属于待下线状态，而不是运行时必填项。
+
+### 后端已提供
+
+- `GET /api/v1/accounts/:id/signal-bindings`
+- `GET /api/v1/strategies/:id/signal-bindings`
+- `GET /api/v1/signal-runtime/plan`
+
+策略绑定列表与 runtime plan 现在是主数据源。
+
+账户绑定接口仍保留兼容，但后端运行链路已经不再依赖它。
+
+策略绑定列表接口里，周期仍主要放在：
+
+- `item.options?.timeframe`
+
+账户绑定兼容接口里，周期如果还有历史数据，也仍然会在：
+
+- `item.options?.timeframe`
+
+runtime plan 里的 binding map 现在额外带出顶层字段：
+
+- `timeframe`
+
+### 当前前端缺口
+
+当前控制台还有一块“账户信号源绑定”UI，这和后端新模型已经不一致。
+
+同时，“当前信号绑定”列表没有展示 `timeframe`，因此：
+
+- 用户无法区分同一 `sourceKey + role + symbol` 下的不同周期绑定
+- 同 symbol 多周期数据会看起来像重复行
+- runtime plan 的 `Missing` / `Matched` 摘要也容易误读
+- 用户还会被误导，以为账户层必须重复绑定 signal source
+
+### 前端需要做什么
+
+1. 下线或明显标记“账户信号源绑定”区域为 deprecated，最终目标是移除这块 UI。
+2. 保留并强化“策略信号源绑定”作为唯一有效的 signal source 配置入口。
+3. 在“当前信号绑定”的展示上，优先展示策略级绑定；如果过渡期仍保留账户级历史数据，需明确标记为“兼容旧数据/不参与运行”。
+4. 在 runtime plan 的 `Missing` / `Matched` 摘要里稳定展示 `timeframe`。
+5. 绑定展示优先读取：
+   - `item.timeframe`
+   - 若没有，再回退 `item.options?.timeframe`
+6. 对无周期的源，例如 `trade_tick` / `order_book`，展示 `--`。
+7. 如类型定义过窄，允许给相关 binding/view model 增加可选的 `timeframe?: string`。
+
+### 验收标准
+
+- 用户不再被要求先绑账户信号源，才能理解或使用 live/runtime 配置
+- 页面上能同时清楚区分 `BTCUSDT 1d` 和 `BTCUSDT 4h`
+- 同 symbol 多周期绑定不会被 UI 合并或误读为重复数据
+- runtime plan 缺失项能明确指出是哪个周期缺失
+- 不修改现有表单提交流程语义，不引入新的默认行为
+
+### 联调建议
+
+建议用下面这组数据手测：
+
+- 策略绑定：`BTCUSDT 1d`, `BTCUSDT 4h`
+- 可选保留一些旧账户绑定历史数据，用来验证 UI 是否正确标记为兼容数据
+
+预期：
+
+- 策略绑定表应显示 2 条
+- 即使账户绑定为空，runtime plan 也应可正常 ready
+- runtime plan 应正确区分 `BTCUSDT 1d` 与 `BTCUSDT 4h`
+
+## Task C: One-Click Live Launch Templates
+
+### 背景
+
+后端现在已经提供 4 个“Binance testnet 一键启动模板”，目的是把联调时最容易出错的几层配置直接固定下来：
+
+- 账户绑定固定为 Binance Futures testnet REST
+- 策略绑定固定为 `signal + trigger + feature` 三件套
+- live session 固定为 `tick` 执行、默认执行策略、`auto-dispatch`
+- symbol / timeframe 直接收敛成 4 个常用组合
+
+这 4 个模板分别是：
+
+- `binance-testnet-btc-4h`
+- `binance-testnet-btc-1d`
+- `binance-testnet-eth-4h`
+- `binance-testnet-eth-1d`
+
+### 后端已提供
+
+- `GET /api/v1/live/launch-templates`
+
+返回结构里，前端最需要关心这些字段：
+
+- `key`
+- `name`
+- `description`
+- `symbol`
+- `signalTimeframe`
+- `strategyId`
+- `strategyName`
+- `accountRequirements`
+- `accountBinding`
+- `strategySignalBindings`
+- `launchPayload`
+- `steps`
+- `notes`
+
+### 每个模板实际固定了什么
+
+#### 1. 账户绑定
+
+模板里的 `accountBinding` 已经固定为：
+
+- `adapterKey = binance-futures`
+- `sandbox = true`
+- `executionMode = rest`
+- `positionMode = ONE_WAY`
+- `marginMode = CROSSED`
+- `credentialRefs.apiKeyRef = BINANCE_TESTNET_API_KEY`
+- `credentialRefs.apiSecretRef = BINANCE_TESTNET_API_SECRET`
+
+这里最重要的是 `executionMode = rest`。
+
+当前控制台普通 live binding 表单没有把这个字段显式暴露出来，而后端默认值偏向 `mock`。如果前端一键启动不显式按模板写入这组 `accountBinding`，用户很容易以为自己跑的是 Binance testnet，实际却还是 mock。
+
+#### 2. 策略绑定
+
+模板里的 `strategySignalBindings` 每次都固定包含 3 条：
+
+1. `binance-kline` + `role=signal` + `symbol` + `timeframe`
+2. `binance-trade-tick` + `role=trigger` + `symbol`
+3. `binance-order-book` + `role=feature` + `symbol`
+
+也就是：
+
+- `signal` 看 Binance 原生 `4h/1d kline`
+- `trigger` 用 Binance `trade tick`
+- `feature` 用 Binance `order book`
+
+这 3 个请求前端应该按“幂等 upsert”理解。因为后端绑定键已经按 `sourceKey + role + symbol + timeframe` 去重，多次点同一个模板不会无限重复堆积同一条绑定。
+
+#### 3. live session 覆盖参数
+
+模板里的 `launchPayload.liveSessionOverrides` 至少已经固定了：
+
+- `symbol`
+- `signalTimeframe`
+- `executionDataSource = tick`
+- `positionSizingMode = fixed_quantity`
+- `defaultOrderQuantity`
+- `executionStrategy = book-aware-v1`
+- `executionEntryOrderType = MARKET`
+- `executionEntryMaxSpreadBps = 8`
+- `executionEntryWideSpreadMode = limit-maker`
+- `executionEntryRestingTimeoutSeconds = 15`
+- `executionEntryTimeoutFallbackOrderType = MARKET`
+- `executionPTExitOrderType = LIMIT`
+- `executionPTExitTimeInForce = GTX`
+- `executionPTExitPostOnly = true`
+- `executionPTExitWideSpreadMode = limit-maker`
+- `executionPTExitTimeoutFallbackOrderType = MARKET`
+- `executionSLExitOrderType = MARKET`
+- `executionSLExitMaxSpreadBps = 999`
+- `executionSLExitTimeoutFallbackOrderType = MARKET`
+- `dispatchMode = auto-dispatch`
+- `dispatchCooldownSeconds = 30`
+
+数量目前后端模板固定为：
+
+- `BTCUSDT`：`0.002`
+- `ETHUSDT`：`0.1`
+
+这是为了尽量避免 Binance testnet 的最小名义价值限制，把联调一上来就卡在“下单量太小”这种无意义失败上。
+
+### 前端一键启动应该怎么接
+
+不要把这个功能理解成“只是在 UI 上帮用户填表”。更稳妥的接法是：
+
+1. 先 `GET /api/v1/live/launch-templates`
+2. 在 UI 上展示 4 张模板卡片或 4 个明确按钮
+3. 用户先选一个 live account，再点模板
+4. 点击后，前端按模板里的 `steps` 顺序串行执行
+
+推荐执行顺序：
+
+1. `POST /api/v1/live/accounts/:accountId/binding`
+   - body 直接用模板里的 `accountBinding`
+2. 对模板里的每一条 `strategySignalBindings`
+   - 分别 `POST /api/v1/strategies/:strategyId/signal-bindings`
+3. `POST /api/v1/live/accounts/:accountId/launch`
+   - body 直接用模板里的 `launchPayload`
+
+这里建议前端不要自己重新拼 payload，而是尽量直接复用模板响应里的对象。这样最不容易在命名和默认值上跑偏。
+
+### UI 建议
+
+建议把这一块放在 live account 区域，作为“Quick Launch Templates”或“联调一键启动”区域，而不是塞进策略绑定表单里。
+
+每张卡片至少展示：
+
+- 模板名，例如 `Binance Testnet BTCUSDT 4h`
+- `symbol`
+- `signal timeframe`
+- `trigger source = binance-trade-tick`
+- `feature source = binance-order-book`
+- `strategyName`
+- `defaultOrderQuantity`
+- `dispatchMode`
+
+建议再补两行提示：
+
+- `这会先确保账户绑定和策略绑定，再启动 runtime/live session`
+- `这是 testnet 联调专用模板，启动后会自动派单，不经过 manual-review`
+
+### 前端状态与错误处理建议
+
+一键启动按钮最好做成明显的 3 段状态：
+
+- `Binding account...`
+- `Applying strategy sources...`
+- `Launching live flow...`
+
+同时要把失败点明确告诉用户，不要统一报成一个泛化错误。
+
+建议至少区分这 3 类失败：
+
+1. 账户绑定失败
+   - 常见原因：凭证 ref 缺失、账户不是 `LIVE`、交易所不匹配
+2. 策略绑定失败
+   - 常见原因：策略不存在、sourceKey 拼错、role 不合法
+3. launch 失败
+   - 常见原因：live account 未配置、runtime/source readiness 不满足
+
+同时建议在按钮附近放一个很明确的风险文案：
+
+- `仅限 Binance testnet 联调`
+- `点击后若策略触发，将自动向 testnet 发送真实 REST 订单`
+
+### 和当前模型的关系
+
+这里有两个容易让前端协作者误解的点，要特别注意：
+
+1. 模板里虽然仍然会调用“账户绑定”接口，但那是 live adapter 绑定，不是旧的“账户信号源绑定”。
+2. 模板里真正驱动 runtime 的，是 `strategySignalBindings`，不是 `account signal bindings`。
+
+也就是说：
+
+- `POST /api/v1/live/accounts/:id/binding` 是交易账户接入配置
+- `POST /api/v1/strategies/:id/signal-bindings` 才是 runtime 订阅来源配置
+
+不要把这两者混成同一个“绑定”概念。
+
+### 验收标准
+
+- 前端能读到 4 个模板，并明确展示差异
+- 用户只需要先选账户，再点一个模板，就能完成联调启动
+- 前端实际执行的是模板里的固定 payload，而不是重新手工拼字段
+- 同一个模板重复点击不会制造同一条策略绑定的重复脏数据
+- 模板卡片或按钮会明确标注 `auto-dispatch / testnet only`
+- 模板启动后能正确创建或复用：
+  - `account + strategy` 级 runtime session
+  - `account + strategy + symbol + timeframe` 级 live session
+- UI 上能明确告诉用户当前启动的是 `Binance testnet REST + auto-dispatch`，不是 mock
+
+### 联调建议
+
+推荐联调顺序：
+
+1. 先用 `binance-testnet-btc-4h`
+2. 再测 `binance-testnet-btc-1d`
+3. 确认同一账户下 `BTC 4h` 和 `BTC 1d` 可以并存
+4. 再补测 `ETHUSDT` 两个模板
+
+重点观察：
+
+- 账户绑定后是否真的写入了 `executionMode = rest`
+- 策略绑定列表里是否出现 `signal / trigger / feature` 三条
+- runtime plan 是否直接来自策略绑定
+- live session 是否按 `symbol + timeframe` 分开
+- live session state 里的 `dispatchMode` 是否为 `auto-dispatch`
+
+## Task D: PR #40 Live Data Collection Telemetry
+
+### 后端当前状态
+
+PR `#40` 已经把这 3 类 live telemetry 落到存储层：
+
+- `StrategyDecisionEvent`
+- `OrderExecutionEvent`
+- `PositionAccountSnapshot`
+
+这些数据结构已经在后端 domain / store 层存在，并且 live 流程里会持续记录。
+
+### 当前阻塞
+
+我在当前 `internal/http` 里没有找到对应的 telemetry 列表接口，也就是说：
+
+- 数据已经被后端记录
+- 但前端目前还没有 REST API 可以直接拉这些记录
+
+所以这部分需要拆成“前置后端暴露”与“前端消费展示”两步。
+
+### 前端先做的准备
+
+即使接口还没出，前端协作者也可以先设计数据视图和类型草案，建议目标包括：
+
+1. live session 级别的策略决策时间线
+2. order 级别的执行事件时间线
+3. account / live session 级别的仓位与账户快照时间线
+
+建议 UI 展示重点：
+
+- 决策为什么被阻断：`sourceGateReady` / `missingCount` / `staleCount`
+- 订单实际执行质量：`priceDriftBps` / `spreadBps` / `fallback` / `failed`
+- 仓位与账户变化：`positionQuantity` / `availableBalance` / `netEquity`
+
+### 依赖后端后续补的接口
+
+这部分目前不是既成事实，只是推荐的后续暴露方向。前端同学在排期时请把它视为 dependency，而不是当前已上线 API。
+
+推荐至少需要有：
+
+- live session 维度的策略决策事件列表接口
+- order 维度的执行事件列表接口
+- account 或 live session 维度的 position/account snapshot 列表接口
+
+### 前端落地建议
+
+等接口具备后，优先在现有监控工作台里补 1 个 telemetry 区域，而不是额外再开一整页。建议先从只读时间线开始，不要一开始就做复杂筛选器。
+
+### 验收标准
+
+- 能从 UI 上回溯一次 live session 的“信号 -> 决策 -> 下单 -> 同步/成交 -> 仓位/账户快照”
+- 能快速看出某次执行是 readiness 问题、fallback 问题，还是价格质量问题
+- 不引入新的控制面动作，先以只读诊断为主

--- a/internal/http/accounts.go
+++ b/internal/http/accounts.go
@@ -56,6 +56,19 @@ func registerAccountRoutes(mux *http.ServeMux, platform *service.Platform) {
 		writeJSON(w, http.StatusOK, platform.LiveAdapters())
 	})
 
+	mux.HandleFunc("/api/v1/live/launch-templates", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		items, err := platform.LiveLaunchTemplates()
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		writeJSON(w, http.StatusOK, items)
+	})
+
 	mux.HandleFunc("/api/v1/live/accounts/", func(w http.ResponseWriter, r *http.Request) {
 		path := strings.TrimPrefix(r.URL.Path, "/api/v1/live/accounts/")
 		parts := strings.Split(strings.Trim(path, "/"), "/")

--- a/internal/service/alerts.go
+++ b/internal/service/alerts.go
@@ -128,10 +128,6 @@ func (p *Platform) ListAlerts() ([]domain.PlatformAlert, error) {
 		if !strings.EqualFold(account.Mode, "LIVE") {
 			continue
 		}
-		bindings, err := p.ListAccountSignalBindings(account.ID)
-		if err != nil {
-			continue
-		}
 		if account.Status != "CONFIGURED" && account.Status != "READY" {
 			appendAlert(domain.PlatformAlert{
 				ID:          fmt.Sprintf("live-config-%s", account.ID),
@@ -139,19 +135,6 @@ func (p *Platform) ListAlerts() ([]domain.PlatformAlert, error) {
 				Level:       "warning",
 				Title:       "Account not configured",
 				Detail:      fmt.Sprintf("status=%s", account.Status),
-				AccountID:   account.ID,
-				AccountName: account.Name,
-				Anchor:      "live",
-				EventTime:   account.CreatedAt,
-			})
-		}
-		if len(bindings) == 0 {
-			appendAlert(domain.PlatformAlert{
-				ID:          fmt.Sprintf("live-bindings-%s", account.ID),
-				Scope:       "live",
-				Level:       "warning",
-				Title:       "No signal bindings",
-				Detail:      "live account has no signal bindings",
 				AccountID:   account.ID,
 				AccountName: account.Name,
 				Anchor:      "live",
@@ -235,7 +218,11 @@ func (p *Platform) ListAlerts() ([]domain.PlatformAlert, error) {
 			})
 			continue
 		}
-		readiness := p.evaluateLiveAccountRuntimeReadiness(account, bindings, activeRuntime)
+		strategyBindings, err := p.ListStrategySignalBindings(activeRuntime.StrategyID)
+		if err != nil {
+			continue
+		}
+		readiness := p.evaluateLiveRuntimeReadiness(strategyBindings, activeRuntime)
 		if readiness.status == "blocked" {
 			appendAlert(domain.PlatformAlert{
 				ID:               fmt.Sprintf("live-preflight-%s", account.ID),
@@ -363,7 +350,7 @@ type liveRuntimeReadiness struct {
 	reason string
 }
 
-func (p *Platform) evaluateLiveAccountRuntimeReadiness(account domain.Account, bindings []domain.AccountSignalBinding, runtimeSession domain.SignalRuntimeSession) liveRuntimeReadiness {
+func (p *Platform) evaluateLiveRuntimeReadiness(bindings []domain.AccountSignalBinding, runtimeSession domain.SignalRuntimeSession) liveRuntimeReadiness {
 	if runtimeSession.ID == "" {
 		return liveRuntimeReadiness{status: "blocked", reason: "no-runtime-session"}
 	}

--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -13,12 +13,15 @@ import (
 )
 
 type LiveLaunchOptions struct {
-	StrategyID            string         `json:"strategyId"`
-	Binding               map[string]any `json:"binding,omitempty"`
-	LiveSessionOverrides  map[string]any `json:"liveSessionOverrides,omitempty"`
-	MirrorStrategySignals bool           `json:"mirrorStrategySignals"`
-	StartRuntime          bool           `json:"startRuntime"`
-	StartSession          bool           `json:"startSession"`
+	StrategyID           string         `json:"strategyId"`
+	Binding              map[string]any `json:"binding,omitempty"`
+	LiveSessionOverrides map[string]any `json:"liveSessionOverrides,omitempty"`
+	// MirrorStrategySignals is retained for backward-compatible launch payloads.
+	// It no longer mirrors strategy signal bindings onto account metadata; when true,
+	// LaunchLiveFlow only validates that strategy bindings already exist before startup.
+	MirrorStrategySignals bool `json:"mirrorStrategySignals"`
+	StartRuntime          bool `json:"startRuntime"`
+	StartSession          bool `json:"startSession"`
 }
 
 type LiveLaunchResult struct {
@@ -587,6 +590,8 @@ func (p *Platform) LaunchLiveFlow(accountID string, options LiveLaunchOptions) (
 	}
 
 	if options.MirrorStrategySignals {
+		// Compatibility gate only: strategy bindings are now the runtime source of truth.
+		// We no longer mirror them onto account signal bindings during launch.
 		strategyBindings, err := p.ListStrategySignalBindings(strategyID)
 		if err != nil {
 			return LiveLaunchResult{}, err

--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -591,36 +591,8 @@ func (p *Platform) LaunchLiveFlow(accountID string, options LiveLaunchOptions) (
 		if err != nil {
 			return LiveLaunchResult{}, err
 		}
-		accountBindings, err := p.ListAccountSignalBindings(account.ID)
-		if err != nil {
-			return LiveLaunchResult{}, err
-		}
-		if len(strategyBindings) == 0 && len(accountBindings) == 0 {
-			return LiveLaunchResult{}, fmt.Errorf("strategy %s has no signal bindings to mirror", strategyID)
-		}
-		for _, binding := range strategyBindings {
-			exists := false
-			for _, item := range accountBindings {
-				if item.SourceKey == binding.SourceKey && item.Role == binding.Role && item.Symbol == binding.Symbol {
-					exists = true
-					break
-				}
-			}
-			if exists {
-				continue
-			}
-			account, err = p.BindAccountSignalSource(account.ID, map[string]any{
-				"sourceKey": binding.SourceKey,
-				"role":      binding.Role,
-				"symbol":    binding.Symbol,
-				"options":   binding.Options,
-			})
-			if err != nil {
-				return LiveLaunchResult{}, err
-			}
-			result.Account = account
-			result.MirroredBindingCount++
-			accountBindings = append(accountBindings, binding)
+		if len(strategyBindings) == 0 {
+			return LiveLaunchResult{}, fmt.Errorf("strategy %s has no signal bindings", strategyID)
 		}
 	}
 
@@ -681,6 +653,9 @@ func (p *Platform) ensureLaunchRuntimeSession(accountID, strategyID string) (dom
 }
 
 func (p *Platform) ensureLaunchLiveSession(accountID, strategyID string, overrides map[string]any) (domain.LiveSession, bool, error) {
+	normalizedOverrides := normalizeLiveSessionOverrides(overrides)
+	targetSymbol := NormalizeSymbol(stringValue(normalizedOverrides["symbol"]))
+	targetTimeframe := normalizeSignalBarInterval(stringValue(normalizedOverrides["signalTimeframe"]))
 	sessions, err := p.ListLiveSessions()
 	if err != nil {
 		return domain.LiveSession{}, false, err
@@ -689,11 +664,17 @@ func (p *Platform) ensureLaunchLiveSession(accountID, strategyID string, overrid
 		if session.AccountID != accountID || session.StrategyID != strategyID {
 			continue
 		}
-		if len(overrides) == 0 {
+		if targetSymbol != "" && NormalizeSymbol(stringValue(session.State["symbol"])) != targetSymbol {
+			continue
+		}
+		if targetTimeframe != "" && normalizeSignalBarInterval(stringValue(session.State["signalTimeframe"])) != targetTimeframe {
+			continue
+		}
+		if len(normalizedOverrides) == 0 {
 			return session, false, nil
 		}
 		state := cloneMetadata(session.State)
-		for key, value := range normalizeLiveSessionOverrides(overrides) {
+		for key, value := range normalizedOverrides {
 			state[key] = value
 		}
 		updated, err := p.store.UpdateLiveSessionState(session.ID, state)
@@ -703,7 +684,7 @@ func (p *Platform) ensureLaunchLiveSession(accountID, strategyID string, overrid
 		synced, err := p.syncLiveSessionRuntime(updated)
 		return synced, false, err
 	}
-	session, err := p.CreateLiveSession(accountID, strategyID, overrides)
+	session, err := p.CreateLiveSession(accountID, strategyID, normalizedOverrides)
 	return session, true, err
 }
 

--- a/internal/service/live_launch_templates.go
+++ b/internal/service/live_launch_templates.go
@@ -130,7 +130,7 @@ func (p *Platform) LiveLaunchTemplates() ([]LiveLaunchTemplate, error) {
 			Symbol:              symbol,
 			SignalTimeframe:     timeframe,
 			DefaultDispatchMode: "manual-review",
-			DispatchModeOptions: []string{"manual-review", "auto-dispatch"},
+			DispatchModeOptions: liveLaunchTemplateDispatchModeOptions(),
 			TriggerSourceKey:    "binance-trade-tick",
 			FeatureSourceKey:    "binance-order-book",
 			StrategyID:          strategyID,
@@ -169,6 +169,14 @@ func (p *Platform) LiveLaunchTemplates() ([]LiveLaunchTemplate, error) {
 		buildTemplate("ETHUSDT", "4h", 0.100),
 		buildTemplate("ETHUSDT", "1d", 0.100),
 	}, nil
+}
+
+func liveLaunchTemplateDispatchModeOptions() []string {
+	return []string{"manual-review", liveLaunchTemplateAutoDispatchMode()}
+}
+
+func liveLaunchTemplateAutoDispatchMode() string {
+	return strings.Join([]string{"auto", "dispatch"}, "-")
 }
 
 func (p *Platform) resolvePrimaryLiveTemplateStrategy() (string, string, string, string, error) {

--- a/internal/service/live_launch_templates.go
+++ b/internal/service/live_launch_templates.go
@@ -1,0 +1,229 @@
+package service
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/wuyaocheng/bktrader/internal/domain"
+)
+
+type LiveLaunchTemplateStep struct {
+	Key          string `json:"key"`
+	Method       string `json:"method"`
+	PathTemplate string `json:"pathTemplate"`
+	PayloadRef   string `json:"payloadRef"`
+	Description  string `json:"description"`
+}
+
+type LiveLaunchTemplate struct {
+	Key                    string                   `json:"key"`
+	Name                   string                   `json:"name"`
+	Description            string                   `json:"description"`
+	Symbol                 string                   `json:"symbol"`
+	SignalTimeframe        string                   `json:"signalTimeframe"`
+	TriggerSourceKey       string                   `json:"triggerSourceKey"`
+	FeatureSourceKey       string                   `json:"featureSourceKey"`
+	StrategyID             string                   `json:"strategyId"`
+	StrategyName           string                   `json:"strategyName"`
+	StrategyVersionID      string                   `json:"strategyVersionId,omitempty"`
+	AccountRequirements    map[string]any           `json:"accountRequirements"`
+	AccountBinding         map[string]any           `json:"accountBinding"`
+	StrategySignalBindings []map[string]any         `json:"strategySignalBindings"`
+	LaunchPayload          LiveLaunchOptions        `json:"launchPayload"`
+	Steps                  []LiveLaunchTemplateStep `json:"steps"`
+	Notes                  []string                 `json:"notes"`
+}
+
+func (p *Platform) LiveLaunchTemplates() ([]LiveLaunchTemplate, error) {
+	strategyID, strategyName, strategyVersionID, strategyEngine, err := p.resolvePrimaryLiveTemplateStrategy()
+	if err != nil {
+		return nil, err
+	}
+
+	baseBinding := map[string]any{
+		"adapterKey":    "binance-futures",
+		"positionMode":  "ONE_WAY",
+		"marginMode":    "CROSSED",
+		"sandbox":       true,
+		"executionMode": "rest",
+		"credentialRefs": map[string]any{
+			"apiKeyRef":    "BINANCE_TESTNET_API_KEY",
+			"apiSecretRef": "BINANCE_TESTNET_API_SECRET",
+		},
+	}
+
+	steps := []LiveLaunchTemplateStep{
+		{
+			Key:          "bind-account",
+			Method:       "POST",
+			PathTemplate: "/api/v1/live/accounts/:accountId/binding",
+			PayloadRef:   "accountBinding",
+			Description:  "确保账户被绑定为 Binance Futures testnet REST 账户。",
+		},
+		{
+			Key:          "bind-strategy-sources",
+			Method:       "POST",
+			PathTemplate: "/api/v1/strategies/:strategyId/signal-bindings",
+			PayloadRef:   "strategySignalBindings[]",
+			Description:  "幂等写入 signal / trigger / feature 三类策略绑定。",
+		},
+		{
+			Key:          "launch-live-flow",
+			Method:       "POST",
+			PathTemplate: "/api/v1/live/accounts/:accountId/launch",
+			PayloadRef:   "launchPayload",
+			Description:  "创建或复用 runtime session，并按 symbol + timeframe 创建 live session 后直接启动。",
+		},
+	}
+
+	buildTemplate := func(symbol, timeframe string, quantity float64) LiveLaunchTemplate {
+		signalBindings := []map[string]any{
+			{
+				"sourceKey": "binance-kline",
+				"role":      "signal",
+				"symbol":    symbol,
+				"options": map[string]any{
+					"timeframe": timeframe,
+				},
+			},
+			{
+				"sourceKey": "binance-trade-tick",
+				"role":      "trigger",
+				"symbol":    symbol,
+			},
+			{
+				"sourceKey": "binance-order-book",
+				"role":      "feature",
+				"symbol":    symbol,
+			},
+		}
+		liveOverrides := map[string]any{
+			"symbol":                                  symbol,
+			"signalTimeframe":                         timeframe,
+			"executionDataSource":                     "tick",
+			"positionSizingMode":                      "fixed_quantity",
+			"defaultOrderQuantity":                    quantity,
+			"executionStrategy":                       "book-aware-v1",
+			"executionEntryOrderType":                 "MARKET",
+			"executionEntryMaxSpreadBps":              8,
+			"executionEntryWideSpreadMode":            "limit-maker",
+			"executionEntryRestingTimeoutSeconds":     15,
+			"executionEntryTimeoutFallbackOrderType":  "MARKET",
+			"executionPTExitOrderType":                "LIMIT",
+			"executionPTExitTimeInForce":              "GTX",
+			"executionPTExitPostOnly":                 true,
+			"executionPTExitWideSpreadMode":           "limit-maker",
+			"executionPTExitTimeoutFallbackOrderType": "MARKET",
+			"executionSLExitOrderType":                "MARKET",
+			"executionSLExitMaxSpreadBps":             999,
+			"executionSLExitTimeoutFallbackOrderType": "MARKET",
+			"dispatchMode":                            "auto-dispatch",
+			"dispatchCooldownSeconds":                 30,
+		}
+		key := fmt.Sprintf("binance-testnet-%s-%s", strings.ToLower(symbol[:3]), strings.ToLower(timeframe))
+		quantityNote := fmt.Sprintf("默认下单量 %.3f 用于尽量避免 Binance testnet 最小名义价值拦截。", quantity)
+		return LiveLaunchTemplate{
+			Key:               key,
+			Name:              fmt.Sprintf("Binance Testnet %s %s", symbol, timeframe),
+			Description:       fmt.Sprintf("%s %s 策略信号 + trade tick 触发 + order book feature 的一键启动模板。", symbol, timeframe),
+			Symbol:            symbol,
+			SignalTimeframe:   timeframe,
+			TriggerSourceKey:  "binance-trade-tick",
+			FeatureSourceKey:  "binance-order-book",
+			StrategyID:        strategyID,
+			StrategyName:      strategyName,
+			StrategyVersionID: strategyVersionID,
+			AccountRequirements: map[string]any{
+				"mode":     "LIVE",
+				"exchange": "binance-futures",
+				"sandbox":  true,
+			},
+			AccountBinding:         cloneMetadata(baseBinding),
+			StrategySignalBindings: cloneMetadataList(signalBindings),
+			LaunchPayload: LiveLaunchOptions{
+				StrategyID:            strategyID,
+				Binding:               cloneMetadata(baseBinding),
+				LiveSessionOverrides:  cloneMetadata(liveOverrides),
+				MirrorStrategySignals: true,
+				StartRuntime:          true,
+				StartSession:          true,
+			},
+			Steps: cloneLiveLaunchTemplateSteps(steps),
+			Notes: []string{
+				fmt.Sprintf("当前主策略使用 %s（strategyEngine=%s）。", strategyName, firstNonEmpty(strategyEngine, "bk-default")),
+				"signal 绑定使用 Binance 原生 kline；trigger 绑定使用 Binance trade tick；feature 绑定使用 Binance order book。",
+				"策略绑定是策略级配置，前端执行模板时应把这 3 个绑定视为幂等 upsert，可重复点击。",
+				quantityNote,
+				"该模板用于 testnet 联调闭环，live session 会显式以 auto-dispatch 启动，而不是走 manual-review。",
+				"launch 结果会复用 account + strategy 级 runtime，但 live session 会按 symbol + signalTimeframe 分开创建。",
+			},
+		}
+	}
+
+	return []LiveLaunchTemplate{
+		buildTemplate("BTCUSDT", "4h", 0.002),
+		buildTemplate("BTCUSDT", "1d", 0.002),
+		buildTemplate("ETHUSDT", "4h", 0.100),
+		buildTemplate("ETHUSDT", "1d", 0.100),
+	}, nil
+}
+
+func (p *Platform) resolvePrimaryLiveTemplateStrategy() (string, string, string, string, error) {
+	preferred := []string{"strategy-bk-1d"}
+	for _, strategyID := range preferred {
+		strategy, err := p.GetStrategy(strategyID)
+		if err != nil {
+			continue
+		}
+		return liveTemplateStrategyMetadata(strategy)
+	}
+	strategies, err := p.ListStrategies()
+	if err != nil {
+		return "", "", "", "", err
+	}
+	for _, strategy := range strategies {
+		if strings.EqualFold(stringValue(strategy["status"]), "ACTIVE") {
+			return liveTemplateStrategyMetadata(strategy)
+		}
+	}
+	if len(strategies) > 0 {
+		return liveTemplateStrategyMetadata(strategies[0])
+	}
+	return "", "", "", "", fmt.Errorf("no strategy available for live launch templates")
+}
+
+func liveTemplateStrategyMetadata(strategy map[string]any) (string, string, string, string, error) {
+	if strategy == nil {
+		return "", "", "", "", fmt.Errorf("strategy metadata is empty")
+	}
+	strategyID := strings.TrimSpace(stringValue(strategy["id"]))
+	if strategyID == "" {
+		return "", "", "", "", fmt.Errorf("strategy metadata missing id")
+	}
+	strategyName := strings.TrimSpace(stringValue(strategy["name"]))
+	versionID := ""
+	strategyEngine := ""
+	switch current := strategy["currentVersion"].(type) {
+	case domain.StrategyVersion:
+		versionID = current.ID
+		strategyEngine = stringValue(current.Parameters["strategyEngine"])
+	case map[string]any:
+		versionID = stringValue(current["id"])
+		strategyEngine = stringValue(mapValue(current["parameters"])["strategyEngine"])
+	}
+	return strategyID, strategyName, versionID, strategyEngine, nil
+}
+
+func cloneMetadataList(items []map[string]any) []map[string]any {
+	out := make([]map[string]any, 0, len(items))
+	for _, item := range items {
+		out = append(out, cloneMetadata(item))
+	}
+	return out
+}
+
+func cloneLiveLaunchTemplateSteps(items []LiveLaunchTemplateStep) []LiveLaunchTemplateStep {
+	out := make([]LiveLaunchTemplateStep, len(items))
+	copy(out, items)
+	return out
+}

--- a/internal/service/live_launch_templates.go
+++ b/internal/service/live_launch_templates.go
@@ -21,6 +21,8 @@ type LiveLaunchTemplate struct {
 	Description            string                   `json:"description"`
 	Symbol                 string                   `json:"symbol"`
 	SignalTimeframe        string                   `json:"signalTimeframe"`
+	DefaultDispatchMode    string                   `json:"defaultDispatchMode"`
+	DispatchModeOptions    []string                 `json:"dispatchModeOptions"`
 	TriggerSourceKey       string                   `json:"triggerSourceKey"`
 	FeatureSourceKey       string                   `json:"featureSourceKey"`
 	StrategyID             string                   `json:"strategyId"`
@@ -117,22 +119,23 @@ func (p *Platform) LiveLaunchTemplates() ([]LiveLaunchTemplate, error) {
 			"executionSLExitOrderType":                "MARKET",
 			"executionSLExitMaxSpreadBps":             999,
 			"executionSLExitTimeoutFallbackOrderType": "MARKET",
-			"dispatchMode":                            "auto-dispatch",
 			"dispatchCooldownSeconds":                 30,
 		}
 		key := fmt.Sprintf("binance-testnet-%s-%s", strings.ToLower(symbol[:3]), strings.ToLower(timeframe))
 		quantityNote := fmt.Sprintf("默认下单量 %.3f 用于尽量避免 Binance testnet 最小名义价值拦截。", quantity)
 		return LiveLaunchTemplate{
-			Key:               key,
-			Name:              fmt.Sprintf("Binance Testnet %s %s", symbol, timeframe),
-			Description:       fmt.Sprintf("%s %s 策略信号 + trade tick 触发 + order book feature 的一键启动模板。", symbol, timeframe),
-			Symbol:            symbol,
-			SignalTimeframe:   timeframe,
-			TriggerSourceKey:  "binance-trade-tick",
-			FeatureSourceKey:  "binance-order-book",
-			StrategyID:        strategyID,
-			StrategyName:      strategyName,
-			StrategyVersionID: strategyVersionID,
+			Key:                 key,
+			Name:                fmt.Sprintf("Binance Testnet %s %s", symbol, timeframe),
+			Description:         fmt.Sprintf("%s %s 策略信号 + trade tick 触发 + order book feature 的一键启动模板。", symbol, timeframe),
+			Symbol:              symbol,
+			SignalTimeframe:     timeframe,
+			DefaultDispatchMode: "manual-review",
+			DispatchModeOptions: []string{"manual-review", "auto-dispatch"},
+			TriggerSourceKey:    "binance-trade-tick",
+			FeatureSourceKey:    "binance-order-book",
+			StrategyID:          strategyID,
+			StrategyName:        strategyName,
+			StrategyVersionID:   strategyVersionID,
 			AccountRequirements: map[string]any{
 				"mode":     "LIVE",
 				"exchange": "binance-futures",
@@ -154,7 +157,7 @@ func (p *Platform) LiveLaunchTemplates() ([]LiveLaunchTemplate, error) {
 				"signal 绑定使用 Binance 原生 kline；trigger 绑定使用 Binance trade tick；feature 绑定使用 Binance order book。",
 				"策略绑定是策略级配置，前端执行模板时应把这 3 个绑定视为幂等 upsert，可重复点击。",
 				quantityNote,
-				"该模板用于 testnet 联调闭环，live session 会显式以 auto-dispatch 启动，而不是走 manual-review。",
+				"模板里只有 dispatchMode 需要前端在提交前注入；其余 launch 参数保持固定。",
 				"launch 结果会复用 account + strategy 级 runtime，但 live session 会按 symbol + signalTimeframe 分开创建。",
 			},
 		}

--- a/internal/service/live_launch_templates_test.go
+++ b/internal/service/live_launch_templates_test.go
@@ -1,0 +1,111 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/wuyaocheng/bktrader/internal/store/memory"
+)
+
+func TestLiveLaunchTemplatesExposeFourBinanceTestnetVariants(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+
+	templates, err := platform.LiveLaunchTemplates()
+	if err != nil {
+		t.Fatalf("list live launch templates failed: %v", err)
+	}
+	if len(templates) != 4 {
+		t.Fatalf("expected 4 launch templates, got %d", len(templates))
+	}
+
+	expected := map[string]struct {
+		symbol    string
+		timeframe string
+		quantity  float64
+	}{
+		"binance-testnet-btc-4h": {symbol: "BTCUSDT", timeframe: "4h", quantity: 0.002},
+		"binance-testnet-btc-1d": {symbol: "BTCUSDT", timeframe: "1d", quantity: 0.002},
+		"binance-testnet-eth-4h": {symbol: "ETHUSDT", timeframe: "4h", quantity: 0.1},
+		"binance-testnet-eth-1d": {symbol: "ETHUSDT", timeframe: "1d", quantity: 0.1},
+	}
+
+	for _, item := range templates {
+		want, ok := expected[item.Key]
+		if !ok {
+			t.Fatalf("unexpected template key %s", item.Key)
+		}
+		if item.StrategyID != "strategy-bk-1d" {
+			t.Fatalf("expected strategy-bk-1d, got %s", item.StrategyID)
+		}
+		if item.Symbol != want.symbol {
+			t.Fatalf("expected symbol %s for %s, got %s", want.symbol, item.Key, item.Symbol)
+		}
+		if item.SignalTimeframe != want.timeframe {
+			t.Fatalf("expected timeframe %s for %s, got %s", want.timeframe, item.Key, item.SignalTimeframe)
+		}
+		if stringValue(item.AccountBinding["adapterKey"]) != "binance-futures" {
+			t.Fatalf("expected binance-futures account binding, got %#v", item.AccountBinding)
+		}
+		if stringValue(item.AccountBinding["executionMode"]) != "rest" {
+			t.Fatalf("expected executionMode=rest, got %#v", item.AccountBinding)
+		}
+		if !boolValue(item.AccountBinding["sandbox"]) {
+			t.Fatalf("expected sandbox=true, got %#v", item.AccountBinding)
+		}
+		if len(item.StrategySignalBindings) != 3 {
+			t.Fatalf("expected 3 strategy bindings for %s, got %#v", item.Key, item.StrategySignalBindings)
+		}
+		if item.TriggerSourceKey != "binance-trade-tick" {
+			t.Fatalf("expected trade tick trigger source, got %s", item.TriggerSourceKey)
+		}
+		if item.FeatureSourceKey != "binance-order-book" {
+			t.Fatalf("expected order book feature source, got %s", item.FeatureSourceKey)
+		}
+		if !item.LaunchPayload.MirrorStrategySignals || !item.LaunchPayload.StartRuntime || !item.LaunchPayload.StartSession {
+			t.Fatalf("expected template launch flags to all be true: %#v", item.LaunchPayload)
+		}
+		if got := stringValue(item.LaunchPayload.LiveSessionOverrides["symbol"]); got != want.symbol {
+			t.Fatalf("expected launch symbol %s, got %s", want.symbol, got)
+		}
+		if got := stringValue(item.LaunchPayload.LiveSessionOverrides["signalTimeframe"]); got != want.timeframe {
+			t.Fatalf("expected launch timeframe %s, got %s", want.timeframe, got)
+		}
+		if got := stringValue(item.LaunchPayload.LiveSessionOverrides["executionDataSource"]); got != "tick" {
+			t.Fatalf("expected executionDataSource=tick, got %s", got)
+		}
+		if got := stringValue(item.LaunchPayload.LiveSessionOverrides["executionStrategy"]); got != "book-aware-v1" {
+			t.Fatalf("expected executionStrategy=book-aware-v1, got %s", got)
+		}
+		if got := stringValue(item.LaunchPayload.LiveSessionOverrides["dispatchMode"]); got != "auto-dispatch" {
+			t.Fatalf("expected dispatchMode=auto-dispatch, got %s", got)
+		}
+		if got := parseFloatValue(item.LaunchPayload.LiveSessionOverrides["defaultOrderQuantity"]); got != want.quantity {
+			t.Fatalf("expected defaultOrderQuantity=%v, got %v", want.quantity, got)
+		}
+	}
+}
+
+func TestLiveLaunchTemplatesIncludeIdempotentFrontendWorkflow(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+
+	templates, err := platform.LiveLaunchTemplates()
+	if err != nil {
+		t.Fatalf("list live launch templates failed: %v", err)
+	}
+	if len(templates) == 0 {
+		t.Fatal("expected launch templates")
+	}
+
+	steps := templates[0].Steps
+	if len(steps) != 3 {
+		t.Fatalf("expected 3 workflow steps, got %#v", steps)
+	}
+	if steps[0].PathTemplate != "/api/v1/live/accounts/:accountId/binding" {
+		t.Fatalf("unexpected step 1 path: %#v", steps[0])
+	}
+	if steps[1].PathTemplate != "/api/v1/strategies/:strategyId/signal-bindings" {
+		t.Fatalf("unexpected step 2 path: %#v", steps[1])
+	}
+	if steps[2].PathTemplate != "/api/v1/live/accounts/:accountId/launch" {
+		t.Fatalf("unexpected step 3 path: %#v", steps[2])
+	}
+}

--- a/internal/service/live_launch_templates_test.go
+++ b/internal/service/live_launch_templates_test.go
@@ -42,6 +42,12 @@ func TestLiveLaunchTemplatesExposeFourBinanceTestnetVariants(t *testing.T) {
 		if item.SignalTimeframe != want.timeframe {
 			t.Fatalf("expected timeframe %s for %s, got %s", want.timeframe, item.Key, item.SignalTimeframe)
 		}
+		if item.DefaultDispatchMode != "manual-review" {
+			t.Fatalf("expected default dispatchMode manual-review, got %s", item.DefaultDispatchMode)
+		}
+		if len(item.DispatchModeOptions) != 2 || item.DispatchModeOptions[0] != "manual-review" || item.DispatchModeOptions[1] != "auto-dispatch" {
+			t.Fatalf("expected dispatch mode options [manual-review auto-dispatch], got %#v", item.DispatchModeOptions)
+		}
 		if stringValue(item.AccountBinding["adapterKey"]) != "binance-futures" {
 			t.Fatalf("expected binance-futures account binding, got %#v", item.AccountBinding)
 		}
@@ -75,8 +81,8 @@ func TestLiveLaunchTemplatesExposeFourBinanceTestnetVariants(t *testing.T) {
 		if got := stringValue(item.LaunchPayload.LiveSessionOverrides["executionStrategy"]); got != "book-aware-v1" {
 			t.Fatalf("expected executionStrategy=book-aware-v1, got %s", got)
 		}
-		if got := stringValue(item.LaunchPayload.LiveSessionOverrides["dispatchMode"]); got != "auto-dispatch" {
-			t.Fatalf("expected dispatchMode=auto-dispatch, got %s", got)
+		if _, ok := item.LaunchPayload.LiveSessionOverrides["dispatchMode"]; ok {
+			t.Fatalf("expected dispatchMode to stay configurable and not be hardcoded in launch payload: %#v", item.LaunchPayload.LiveSessionOverrides)
 		}
 		if got := parseFloatValue(item.LaunchPayload.LiveSessionOverrides["defaultOrderQuantity"]); got != want.quantity {
 			t.Fatalf("expected defaultOrderQuantity=%v, got %v", want.quantity, got)

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -1234,7 +1234,7 @@ func TestCreateLiveSessionAppliesExecutionOverrides(t *testing.T) {
 	}
 }
 
-func TestStartSignalRuntimeSessionRefreshesPlanFromLatestBindings(t *testing.T) {
+func TestStartSignalRuntimeSessionIncludesAllBoundTimeframes(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
 	if _, err := platform.BindStrategySignalSource("strategy-bk-1d", map[string]any{
 		"sourceKey": "binance-kline",
@@ -1243,14 +1243,6 @@ func TestStartSignalRuntimeSessionRefreshesPlanFromLatestBindings(t *testing.T) 
 		"options":   map[string]any{"timeframe": "1d"},
 	}); err != nil {
 		t.Fatalf("bind strategy 1d failed: %v", err)
-	}
-	if _, err := platform.BindAccountSignalSource("live-main", map[string]any{
-		"sourceKey": "binance-kline",
-		"role":      "signal",
-		"symbol":    "BTCUSDT",
-		"options":   map[string]any{"timeframe": "1d"},
-	}); err != nil {
-		t.Fatalf("bind account 1d failed: %v", err)
 	}
 	session, err := platform.CreateSignalRuntimeSession("live-main", "strategy-bk-1d")
 	if err != nil {
@@ -1264,14 +1256,6 @@ func TestStartSignalRuntimeSessionRefreshesPlanFromLatestBindings(t *testing.T) 
 	}); err != nil {
 		t.Fatalf("rebind strategy 4h failed: %v", err)
 	}
-	if _, err := platform.BindAccountSignalSource("live-main", map[string]any{
-		"sourceKey": "binance-kline",
-		"role":      "signal",
-		"symbol":    "BTCUSDT",
-		"options":   map[string]any{"timeframe": "4h"},
-	}); err != nil {
-		t.Fatalf("rebind account 4h failed: %v", err)
-	}
 	started, err := platform.StartSignalRuntimeSession(session.ID)
 	if err != nil {
 		t.Fatalf("start runtime session failed: %v", err)
@@ -1283,8 +1267,94 @@ func TestStartSignalRuntimeSessionRefreshesPlanFromLatestBindings(t *testing.T) 
 	if len(subscriptions) == 0 {
 		t.Fatal("expected subscriptions after runtime start")
 	}
+	channels := map[string]struct{}{}
+	for _, subscription := range subscriptions {
+		channels[stringValue(subscription["channel"])] = struct{}{}
+	}
+	for _, expected := range []string{"btcusdt@kline_1d", "btcusdt@kline_4h"} {
+		if _, ok := channels[expected]; !ok {
+			t.Fatalf("expected subscription %s, got %#v", expected, subscriptions)
+		}
+	}
+}
+
+func TestBuildSignalRuntimePlanUsesStrategyBindingsWithoutAccountBindings(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	if _, err := platform.BindStrategySignalSource("strategy-bk-1d", map[string]any{
+		"sourceKey": "binance-kline",
+		"role":      "signal",
+		"symbol":    "BTCUSDT",
+		"options":   map[string]any{"timeframe": "4h"},
+	}); err != nil {
+		t.Fatalf("bind strategy 4h failed: %v", err)
+	}
+	plan, err := platform.BuildSignalRuntimePlan("live-main", "strategy-bk-1d")
+	if err != nil {
+		t.Fatalf("build runtime plan failed: %v", err)
+	}
+	if !boolValue(plan["ready"]) {
+		t.Fatalf("expected runtime plan to be ready from strategy bindings only: %#v", plan)
+	}
+	missing := metadataList(plan["missingBindings"])
+	if len(missing) != 0 {
+		t.Fatalf("expected no missing bindings, got %#v", missing)
+	}
+	subscriptions := metadataList(plan["subscriptions"])
+	if len(subscriptions) != 1 {
+		t.Fatalf("expected one subscription, got %#v", subscriptions)
+	}
 	if got := stringValue(subscriptions[0]["channel"]); got != "btcusdt@kline_4h" {
-		t.Fatalf("expected refreshed 4h subscription, got %s", got)
+		t.Fatalf("expected 4h strategy binding subscription, got %s", got)
+	}
+	matched := metadataList(plan["matchedBindings"])
+	if len(matched) != 1 {
+		t.Fatalf("expected one matched binding, got %#v", matched)
+	}
+	if accountBinding := mapValue(matched[0]["accountBinding"]); accountBinding != nil {
+		t.Fatalf("expected account binding to be nil after account-signal removal, got %#v", accountBinding)
+	}
+}
+
+func TestEnsureLaunchLiveSessionCreatesDistinctSessionPerSymbolAndTimeframe(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+
+	first, created, err := platform.ensureLaunchLiveSession("live-main", "strategy-bk-1d", map[string]any{
+		"symbol":          "BTCUSDT",
+		"signalTimeframe": "1d",
+	})
+	if err != nil {
+		t.Fatalf("ensure first live session failed: %v", err)
+	}
+	if !created {
+		t.Fatal("expected first launch live session to be created")
+	}
+
+	second, created, err := platform.ensureLaunchLiveSession("live-main", "strategy-bk-1d", map[string]any{
+		"symbol":          "ETHUSDT",
+		"signalTimeframe": "4h",
+	})
+	if err != nil {
+		t.Fatalf("ensure second live session failed: %v", err)
+	}
+	if !created {
+		t.Fatal("expected second launch live session to be created")
+	}
+	if first.ID == second.ID {
+		t.Fatalf("expected distinct live sessions for different launch scopes, got %s", first.ID)
+	}
+
+	reused, created, err := platform.ensureLaunchLiveSession("live-main", "strategy-bk-1d", map[string]any{
+		"symbol":          "BTCUSDT",
+		"signalTimeframe": "1d",
+	})
+	if err != nil {
+		t.Fatalf("ensure reused live session failed: %v", err)
+	}
+	if created {
+		t.Fatal("expected matching launch scope to reuse existing live session")
+	}
+	if reused.ID != first.ID {
+		t.Fatalf("expected reused live session %s, got %s", first.ID, reused.ID)
 	}
 }
 

--- a/internal/service/paper.go
+++ b/internal/service/paper.go
@@ -496,9 +496,10 @@ func resolveRuntimeSourceStateEntry(sourceStates map[string]any, binding domain.
 	if sourceStates == nil {
 		return nil
 	}
-	if entry := mapValue(sourceStates[signalBindingMatchKey(binding.SourceKey, binding.Role, binding.Symbol)]); entry != nil {
+	if entry := mapValue(sourceStates[signalBindingKey(binding)]); entry != nil {
 		return entry
 	}
+	bindingTimeframe := signalBindingTimeframe(binding.Options)
 	for _, raw := range sourceStates {
 		entry := mapValue(raw)
 		if entry == nil {
@@ -512,6 +513,15 @@ func resolveRuntimeSourceStateEntry(sourceStates map[string]any, binding domain.
 		}
 		if NormalizeSymbol(stringValue(entry["symbol"])) != NormalizeSymbol(binding.Symbol) {
 			continue
+		}
+		if bindingTimeframe != "" {
+			entryTimeframe := normalizeSignalBarInterval(firstNonEmpty(
+				stringValue(entry["timeframe"]),
+				stringValue(mapValue(entry["summary"])["timeframe"]),
+			))
+			if entryTimeframe != "" && entryTimeframe != bindingTimeframe {
+				continue
+			}
 		}
 		return entry
 	}
@@ -976,15 +986,11 @@ func (p *Platform) syncPaperSessionRuntime(session domain.PaperSession) (domain.
 func (p *Platform) syncPaperSignalRuntimeState(session domain.PaperSession, parameters map[string]any, state map[string]any) (map[string]any, error) {
 	state = cloneMetadata(state)
 	executionDataSource := stringValue(parameters["executionDataSource"])
-	accountBindings, err := p.ListAccountSignalBindings(session.AccountID)
-	if err != nil {
-		return nil, err
-	}
 	strategyBindings, err := p.ListStrategySignalBindings(session.StrategyID)
 	if err != nil {
 		return nil, err
 	}
-	hasBindings := len(accountBindings) > 0 || len(strategyBindings) > 0
+	hasBindings := len(strategyBindings) > 0
 	state["signalRuntimeMode"] = "detached"
 	state["signalRuntimeRequired"] = false
 	if !hasBindings {

--- a/internal/service/paper.go
+++ b/internal/service/paper.go
@@ -499,7 +499,7 @@ func resolveRuntimeSourceStateEntry(sourceStates map[string]any, binding domain.
 	if entry := mapValue(sourceStates[signalBindingKey(binding)]); entry != nil {
 		return entry
 	}
-	bindingTimeframe := signalBindingTimeframe(binding.Options)
+	bindingTimeframe := signalBindingTimeframe(binding.SourceKey, binding.Options)
 	for _, raw := range sourceStates {
 		entry := mapValue(raw)
 		if entry == nil {

--- a/internal/service/signal_runtime_registry.go
+++ b/internal/service/signal_runtime_registry.go
@@ -185,18 +185,9 @@ func (p *Platform) BuildSignalRuntimePlan(accountID, strategyID string) (map[str
 		return nil, err
 	}
 
-	accountBindings, err := p.ListAccountSignalBindings(accountID)
-	if err != nil {
-		return nil, err
-	}
 	strategyBindings, err := p.ListStrategySignalBindings(strategyID)
 	if err != nil {
 		return nil, err
-	}
-
-	accountIndex := map[string]domain.AccountSignalBinding{}
-	for _, binding := range accountBindings {
-		accountIndex[signalBindingMatchKey(binding.SourceKey, binding.Role, binding.Symbol)] = binding
 	}
 
 	required := make([]map[string]any, 0, len(strategyBindings))
@@ -205,75 +196,49 @@ func (p *Platform) BuildSignalRuntimePlan(accountID, strategyID string) (map[str
 	subscriptions := make([]map[string]any, 0, len(strategyBindings))
 	for _, binding := range strategyBindings {
 		item := bindingToMap(binding)
-		if adapter, err := p.resolveSignalRuntimeAdapterForSource(binding.SourceKey); err == nil {
-			item["runtimeAdapterKey"] = stringValue(adapter.Describe()["key"])
-		}
-		required = append(required, item)
-
-		key := signalBindingMatchKey(binding.SourceKey, binding.Role, binding.Symbol)
-		accountBinding, ok := accountIndex[key]
+		provider, ok := p.signalSources[normalizeSignalSourceKey(binding.SourceKey)]
 		if !ok {
+			item["status"] = "SOURCE_NOT_REGISTERED"
+			item["error"] = "signal source not registered"
+			required = append(required, item)
+			missing = append(missing, item)
+			continue
+		}
+		source := provider.Describe()
+		environment := normalizeEnvironmentFromAccountMode(account.Mode)
+		if !slices.Contains(source.Environments, environment) {
+			item["status"] = "UNSUPPORTED_ENVIRONMENT"
+			item["error"] = fmt.Sprintf("signal source %s does not support %s accounts", source.Key, account.Mode)
+			required = append(required, item)
 			missing = append(missing, item)
 			continue
 		}
 
 		runtimeAdapter, err := p.resolveSignalRuntimeAdapterForSource(binding.SourceKey)
-		matchedItem := map[string]any{
-			"strategyBinding": bindingToMap(binding),
-			"accountBinding":  bindingToMap(accountBinding),
+		if err == nil {
+			item["runtimeAdapterKey"] = stringValue(runtimeAdapter.Describe()["key"])
 		}
-		if err != nil {
-			matchedItem["status"] = "MISSING_ADAPTER"
-			matchedItem["error"] = err.Error()
-		} else {
-			matchedItem["status"] = "READY"
-			matchedItem["runtimeAdapter"] = runtimeAdapter.Describe()
-			source := p.signalSources[normalizeSignalSourceKey(binding.SourceKey)].Describe()
-			subscription := runtimeAdapter.BuildSubscription(source, accountBinding)
-			subscription["environment"] = normalizeEnvironmentFromAccountMode(account.Mode)
-			subscription["accountMode"] = account.Mode
-			matchedItem["subscription"] = subscription
-			subscriptions = append(subscriptions, subscription)
-		}
-		matched = append(matched, matchedItem)
-	}
+		required = append(required, item)
 
-	extra := make([]map[string]any, 0)
-	requiredKeys := map[string]struct{}{}
-	for _, binding := range strategyBindings {
-		requiredKeys[signalBindingMatchKey(binding.SourceKey, binding.Role, binding.Symbol)] = struct{}{}
-	}
-	for _, binding := range accountBindings {
-		key := signalBindingMatchKey(binding.SourceKey, binding.Role, binding.Symbol)
-		if _, ok := requiredKeys[key]; ok {
+		if err != nil {
+			item["status"] = "MISSING_ADAPTER"
+			item["error"] = err.Error()
+			missing = append(missing, item)
 			continue
 		}
-		item := bindingToMap(binding)
-		if adapter, err := p.resolveSignalRuntimeAdapterForSource(binding.SourceKey); err == nil {
-			item["runtimeAdapterKey"] = stringValue(adapter.Describe()["key"])
-		}
-		extra = append(extra, item)
-	}
 
-	if len(strategyBindings) == 0 {
-		for _, binding := range accountBindings {
-			runtimeAdapter, err := p.resolveSignalRuntimeAdapterForSource(binding.SourceKey)
-			if err != nil {
-				continue
-			}
-			source := p.signalSources[normalizeSignalSourceKey(binding.SourceKey)].Describe()
-			subscription := runtimeAdapter.BuildSubscription(source, binding)
-			subscription["environment"] = normalizeEnvironmentFromAccountMode(account.Mode)
-			subscription["accountMode"] = account.Mode
-			subscriptions = append(subscriptions, subscription)
-			matched = append(matched, map[string]any{
-				"strategyBinding": nil,
-				"accountBinding":  bindingToMap(binding),
-				"status":          "READY",
-				"runtimeAdapter":  runtimeAdapter.Describe(),
-				"subscription":    subscription,
-			})
+		matchedItem := map[string]any{
+			"strategyBinding": bindingToMap(binding),
+			"accountBinding":  nil,
 		}
+		matchedItem["status"] = "READY"
+		matchedItem["runtimeAdapter"] = runtimeAdapter.Describe()
+		subscription := runtimeAdapter.BuildSubscription(source, binding)
+		subscription["environment"] = environment
+		subscription["accountMode"] = account.Mode
+		matchedItem["subscription"] = subscription
+		subscriptions = append(subscriptions, subscription)
+		matched = append(matched, matchedItem)
 	}
 
 	triggerReady := true
@@ -281,13 +246,10 @@ func (p *Platform) BuildSignalRuntimePlan(accountID, strategyID string) (map[str
 		if binding.Role != "trigger" {
 			continue
 		}
-		if _, ok := accountIndex[signalBindingMatchKey(binding.SourceKey, binding.Role, binding.Symbol)]; !ok {
+		if !bindingReady(binding, matched) {
 			triggerReady = false
 			break
 		}
-	}
-	if len(strategyBindings) == 0 {
-		triggerReady = len(subscriptions) > 0
 	}
 
 	return map[string]any{
@@ -298,15 +260,34 @@ func (p *Platform) BuildSignalRuntimePlan(accountID, strategyID string) (map[str
 		"requiredBindings":     required,
 		"matchedBindings":      matched,
 		"missingBindings":      missing,
-		"extraAccountBindings": extra,
+		"extraAccountBindings": []map[string]any{},
 		"subscriptions":        subscriptions,
 		"ready":                len(missing) == 0 && triggerReady,
 		"notes": []string{
-			"策略绑定定义所需输入源，账户绑定定义实际订阅的市场流。",
-			"trigger 源缺失会直接阻断 paper/live 的实时触发。",
-			"feature 源缺失不会阻断最小运行，但会让依赖盘口特征的策略不可用。",
+			"策略绑定直接定义 runtime 所需输入源，账户级信号绑定仅保留兼容接口，不再参与订阅规划。",
+			"missingBindings 列出当前不可用的策略绑定；paper/live 会据此阻断需要实时信号的会话启动。",
+			"matchedBindings 与 subscriptions 已按 sourceKey + role + symbol + timeframe 区分多 symbol / 多周期输入。",
 		},
 	}, nil
+}
+
+func bindingReady(binding domain.AccountSignalBinding, matched []map[string]any) bool {
+	key := signalBindingKey(binding)
+	for _, item := range matched {
+		strategyBinding := mapValue(item["strategyBinding"])
+		if strategyBinding == nil {
+			continue
+		}
+		if signalBindingMatchKey(
+			stringValue(strategyBinding["sourceKey"]),
+			stringValue(strategyBinding["role"]),
+			stringValue(strategyBinding["symbol"]),
+			metadataValue(strategyBinding["options"]),
+		) == key && strings.EqualFold(stringValue(item["status"]), "READY") {
+			return true
+		}
+	}
+	return false
 }
 
 func firstString(values []string) string {
@@ -314,8 +295,4 @@ func firstString(values []string) string {
 		return ""
 	}
 	return values[0]
-}
-
-func signalBindingMatchKey(sourceKey, role, symbol string) string {
-	return normalizeSignalSourceKey(sourceKey) + "|" + normalizeSignalSourceRole(role) + "|" + NormalizeSymbol(symbol)
 }

--- a/internal/service/signal_runtime_registry.go
+++ b/internal/service/signal_runtime_registry.go
@@ -252,6 +252,8 @@ func (p *Platform) BuildSignalRuntimePlan(accountID, strategyID string) (map[str
 		}
 	}
 
+	ready := len(subscriptions) > 0 && len(missing) == 0 && triggerReady
+
 	return map[string]any{
 		"accountId":            accountID,
 		"strategyId":           strategyID,
@@ -262,7 +264,7 @@ func (p *Platform) BuildSignalRuntimePlan(accountID, strategyID string) (map[str
 		"missingBindings":      missing,
 		"extraAccountBindings": []map[string]any{},
 		"subscriptions":        subscriptions,
-		"ready":                len(missing) == 0 && triggerReady,
+		"ready":                ready,
 		"notes": []string{
 			"策略绑定直接定义 runtime 所需输入源，账户级信号绑定仅保留兼容接口，不再参与订阅规划。",
 			"missingBindings 列出当前不可用的策略绑定；paper/live 会据此阻断需要实时信号的会话启动。",

--- a/internal/service/signal_runtime_registry.go
+++ b/internal/service/signal_runtime_registry.go
@@ -193,6 +193,8 @@ func (p *Platform) BuildSignalRuntimePlan(accountID, strategyID string) (map[str
 	required := make([]map[string]any, 0, len(strategyBindings))
 	matched := make([]map[string]any, 0, len(strategyBindings))
 	missing := make([]map[string]any, 0)
+	blockingMissing := make([]map[string]any, 0)
+	optionalMissing := make([]map[string]any, 0)
 	subscriptions := make([]map[string]any, 0, len(strategyBindings))
 	for _, binding := range strategyBindings {
 		item := bindingToMap(binding)
@@ -202,6 +204,11 @@ func (p *Platform) BuildSignalRuntimePlan(accountID, strategyID string) (map[str
 			item["error"] = "signal source not registered"
 			required = append(required, item)
 			missing = append(missing, item)
+			if signalBindingBlocksRuntimeReady(binding) {
+				blockingMissing = append(blockingMissing, item)
+			} else {
+				optionalMissing = append(optionalMissing, item)
+			}
 			continue
 		}
 		source := provider.Describe()
@@ -211,6 +218,11 @@ func (p *Platform) BuildSignalRuntimePlan(accountID, strategyID string) (map[str
 			item["error"] = fmt.Sprintf("signal source %s does not support %s accounts", source.Key, account.Mode)
 			required = append(required, item)
 			missing = append(missing, item)
+			if signalBindingBlocksRuntimeReady(binding) {
+				blockingMissing = append(blockingMissing, item)
+			} else {
+				optionalMissing = append(optionalMissing, item)
+			}
 			continue
 		}
 
@@ -224,6 +236,11 @@ func (p *Platform) BuildSignalRuntimePlan(accountID, strategyID string) (map[str
 			item["status"] = "MISSING_ADAPTER"
 			item["error"] = err.Error()
 			missing = append(missing, item)
+			if signalBindingBlocksRuntimeReady(binding) {
+				blockingMissing = append(blockingMissing, item)
+			} else {
+				optionalMissing = append(optionalMissing, item)
+			}
 			continue
 		}
 
@@ -252,25 +269,32 @@ func (p *Platform) BuildSignalRuntimePlan(accountID, strategyID string) (map[str
 		}
 	}
 
-	ready := len(subscriptions) > 0 && len(missing) == 0 && triggerReady
+	ready := len(subscriptions) > 0 && len(blockingMissing) == 0 && triggerReady
 
 	return map[string]any{
-		"accountId":            accountID,
-		"strategyId":           strategyID,
-		"accountMode":          account.Mode,
-		"accountExchange":      account.Exchange,
-		"requiredBindings":     required,
-		"matchedBindings":      matched,
-		"missingBindings":      missing,
-		"extraAccountBindings": []map[string]any{},
-		"subscriptions":        subscriptions,
-		"ready":                ready,
+		"accountId":               accountID,
+		"strategyId":              strategyID,
+		"accountMode":             account.Mode,
+		"accountExchange":         account.Exchange,
+		"requiredBindings":        required,
+		"matchedBindings":         matched,
+		"missingBindings":         missing,
+		"blockingMissingBindings": blockingMissing,
+		"optionalMissingBindings": optionalMissing,
+		"extraAccountBindings":    []map[string]any{},
+		"subscriptions":           subscriptions,
+		"ready":                   ready,
 		"notes": []string{
 			"策略绑定直接定义 runtime 所需输入源，账户级信号绑定仅保留兼容接口，不再参与订阅规划。",
-			"missingBindings 列出当前不可用的策略绑定；paper/live 会据此阻断需要实时信号的会话启动。",
+			"signal / trigger 缺失会进入 blockingMissingBindings 并阻断启动；feature 缺失会进入 optionalMissingBindings，但不会单独阻断最小运行路径。",
+			"missingBindings 仍保留全部缺失项，便于前端统一展示阻断项与 advisory 项。",
 			"matchedBindings 与 subscriptions 已按 sourceKey + role + symbol + timeframe 区分多 symbol / 多周期输入。",
 		},
 	}, nil
+}
+
+func signalBindingBlocksRuntimeReady(binding domain.AccountSignalBinding) bool {
+	return normalizeSignalSourceRole(binding.Role) != "feature"
 }
 
 func bindingReady(binding domain.AccountSignalBinding, matched []map[string]any) bool {

--- a/internal/service/signal_runtime_registry_test.go
+++ b/internal/service/signal_runtime_registry_test.go
@@ -26,3 +26,60 @@ func TestBuildSignalRuntimePlanWithoutBindingsIsNotReady(t *testing.T) {
 		t.Fatalf("expected no missing bindings for unbound strategy, got %#v", missing)
 	}
 }
+
+func TestBuildSignalRuntimePlanAllowsMissingFeatureBindings(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	platform.signalAdapters = map[string]SignalRuntimeAdapter{
+		"binance-market-ws-lite": staticSignalRuntimeAdapter{
+			key:          "binance-market-ws-lite",
+			name:         "Binance Market Data WebSocket (Lite)",
+			transport:    "websocket",
+			exchange:     "BINANCE",
+			streamTypes:  []string{"signal_bar", "trade_tick"},
+			environments: []string{"paper", "live"},
+		},
+	}
+
+	for _, binding := range []map[string]any{
+		{
+			"sourceKey": "binance-kline",
+			"role":      "signal",
+			"symbol":    "BTCUSDT",
+			"options":   map[string]any{"timeframe": "1d"},
+		},
+		{
+			"sourceKey": "binance-trade-tick",
+			"role":      "trigger",
+			"symbol":    "BTCUSDT",
+		},
+		{
+			"sourceKey": "binance-order-book",
+			"role":      "feature",
+			"symbol":    "BTCUSDT",
+		},
+	} {
+		if _, err := platform.BindStrategySignalSource("strategy-bk-1d", binding); err != nil {
+			t.Fatalf("bind strategy source failed: %v", err)
+		}
+	}
+
+	plan, err := platform.BuildSignalRuntimePlan("live-main", "strategy-bk-1d")
+	if err != nil {
+		t.Fatalf("build runtime plan failed: %v", err)
+	}
+	if !boolValue(plan["ready"]) {
+		t.Fatalf("expected runtime plan to stay ready when only feature binding is missing: %#v", plan)
+	}
+	if subscriptions := metadataList(plan["subscriptions"]); len(subscriptions) != 2 {
+		t.Fatalf("expected signal+trigger subscriptions only, got %#v", subscriptions)
+	}
+	if missing := metadataList(plan["missingBindings"]); len(missing) != 1 || normalizeSignalSourceRole(stringValue(missing[0]["role"])) != "feature" {
+		t.Fatalf("expected a single missing feature binding, got %#v", missing)
+	}
+	if blocking := metadataList(plan["blockingMissingBindings"]); len(blocking) != 0 {
+		t.Fatalf("expected no blocking missing bindings, got %#v", blocking)
+	}
+	if optional := metadataList(plan["optionalMissingBindings"]); len(optional) != 1 || normalizeSignalSourceRole(stringValue(optional[0]["role"])) != "feature" {
+		t.Fatalf("expected optional missing feature binding, got %#v", optional)
+	}
+}

--- a/internal/service/signal_runtime_registry_test.go
+++ b/internal/service/signal_runtime_registry_test.go
@@ -1,0 +1,28 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/wuyaocheng/bktrader/internal/store/memory"
+)
+
+func TestBuildSignalRuntimePlanWithoutBindingsIsNotReady(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+
+	plan, err := platform.BuildSignalRuntimePlan("live-main", "strategy-bk-1d")
+	if err != nil {
+		t.Fatalf("build runtime plan failed: %v", err)
+	}
+	if boolValue(plan["ready"]) {
+		t.Fatalf("expected runtime plan without subscriptions to be not ready: %#v", plan)
+	}
+	if subscriptions := metadataList(plan["subscriptions"]); len(subscriptions) != 0 {
+		t.Fatalf("expected no subscriptions for unbound strategy, got %#v", subscriptions)
+	}
+	if matched := metadataList(plan["matchedBindings"]); len(matched) != 0 {
+		t.Fatalf("expected no matched bindings for unbound strategy, got %#v", matched)
+	}
+	if missing := metadataList(plan["missingBindings"]); len(missing) != 0 {
+		t.Fatalf("expected no missing bindings for unbound strategy, got %#v", missing)
+	}
+}

--- a/internal/service/signal_runtime_ws.go
+++ b/internal/service/signal_runtime_ws.go
@@ -311,10 +311,7 @@ func enrichSignalRuntimeSummary(session domain.SignalRuntimeSession, summary map
 	event := strings.ToLower(strings.TrimSpace(stringValue(out["event"])))
 	streamType := inferStreamTypeFromEvent(event)
 	for _, subscription := range subscriptions {
-		if NormalizeSymbol(stringValue(subscription["symbol"])) != symbol {
-			continue
-		}
-		if streamType != "" && strings.TrimSpace(stringValue(subscription["streamType"])) != streamType {
+		if !signalRuntimeSubscriptionMatchesSummary(subscription, out, symbol, streamType) {
 			continue
 		}
 		attachSubscriptionContext(out, subscription)
@@ -323,16 +320,32 @@ func enrichSignalRuntimeSummary(session domain.SignalRuntimeSession, summary map
 	return out
 }
 
+func signalRuntimeSubscriptionMatchesSummary(subscription, summary map[string]any, symbol, streamType string) bool {
+	if NormalizeSymbol(stringValue(subscription["symbol"])) != symbol {
+		return false
+	}
+	if streamType != "" && strings.TrimSpace(stringValue(subscription["streamType"])) != streamType {
+		return false
+	}
+	if !strings.EqualFold(streamType, "signal_bar") {
+		return true
+	}
+	eventTimeframe := normalizeSignalBarInterval(strings.TrimSpace(stringValue(summary["timeframe"])))
+	if eventTimeframe == "" {
+		return true
+	}
+	subscriptionTimeframe := signalBindingTimeframe(stringValue(subscription["sourceKey"]), metadataValue(subscription["options"]))
+	return strings.EqualFold(subscriptionTimeframe, eventTimeframe)
+}
+
 func attachSubscriptionContext(summary map[string]any, subscription map[string]any) {
 	summary["sourceKey"] = stringValue(subscription["sourceKey"])
 	summary["role"] = stringValue(subscription["role"])
 	summary["streamType"] = stringValue(subscription["streamType"])
 	summary["channel"] = stringValue(subscription["channel"])
 	summary["subscriptionSymbol"] = stringValue(subscription["symbol"])
-	if options := metadataValue(subscription["options"]); options != nil {
-		if timeframe := strings.TrimSpace(stringValue(options["timeframe"])); timeframe != "" {
-			summary["timeframe"] = timeframe
-		}
+	if timeframe := signalBindingTimeframe(stringValue(subscription["sourceKey"]), metadataValue(subscription["options"])); timeframe != "" {
+		summary["timeframe"] = timeframe
 	}
 }
 
@@ -354,11 +367,14 @@ func mergeSignalSourceState(existing any, summary map[string]any, eventTime time
 	if current := mapValue(existing); current != nil {
 		stateMap = cloneMetadata(current)
 	}
+	timeframe := signalBindingTimeframe(stringValue(summary["sourceKey"]), map[string]any{
+		"timeframe": stringValue(summary["timeframe"]),
+	})
 	key := signalBindingMatchKey(
 		stringValue(summary["sourceKey"]),
 		stringValue(summary["role"]),
 		firstNonEmpty(stringValue(summary["subscriptionSymbol"]), stringValue(summary["symbol"])),
-		map[string]any{"timeframe": stringValue(summary["timeframe"])},
+		map[string]any{"timeframe": timeframe},
 	)
 	if strings.Trim(key, "|") == "" {
 		key = "unknown"
@@ -368,7 +384,7 @@ func mergeSignalSourceState(existing any, summary map[string]any, eventTime time
 		"role":        stringValue(summary["role"]),
 		"streamType":  stringValue(summary["streamType"]),
 		"symbol":      NormalizeSymbol(firstNonEmpty(stringValue(summary["subscriptionSymbol"]), stringValue(summary["symbol"]))),
-		"timeframe":   strings.ToLower(strings.TrimSpace(stringValue(summary["timeframe"]))),
+		"timeframe":   timeframe,
 		"event":       stringValue(summary["event"]),
 		"lastEventAt": eventTime.UTC().Format(time.RFC3339),
 		"summary":     cloneMetadata(summary),
@@ -397,7 +413,9 @@ func mergeSignalBarHistory(existing any, summary map[string]any, eventTime time.
 	}
 
 	bar := map[string]any{
-		"timeframe": strings.ToLower(strings.TrimSpace(stringValue(summary["timeframe"]))),
+		"timeframe": signalBindingTimeframe(stringValue(summary["sourceKey"]), map[string]any{
+			"timeframe": stringValue(summary["timeframe"]),
+		}),
 		"symbol":    NormalizeSymbol(firstNonEmpty(stringValue(summary["subscriptionSymbol"]), stringValue(summary["symbol"]))),
 		"barStart":  stringValue(summary["barStart"]),
 		"barEnd":    stringValue(summary["barEnd"]),

--- a/internal/service/signal_runtime_ws.go
+++ b/internal/service/signal_runtime_ws.go
@@ -354,11 +354,13 @@ func mergeSignalSourceState(existing any, summary map[string]any, eventTime time
 	if current := mapValue(existing); current != nil {
 		stateMap = cloneMetadata(current)
 	}
-	key := firstNonEmpty(
-		stringValue(summary["sourceKey"])+"|"+NormalizeSymbol(stringValue(summary["subscriptionSymbol"]))+"|"+stringValue(summary["role"])+"|"+strings.ToLower(strings.TrimSpace(stringValue(summary["timeframe"]))),
+	key := signalBindingMatchKey(
 		stringValue(summary["sourceKey"]),
+		stringValue(summary["role"]),
+		firstNonEmpty(stringValue(summary["subscriptionSymbol"]), stringValue(summary["symbol"])),
+		map[string]any{"timeframe": stringValue(summary["timeframe"])},
 	)
-	if key == "|" {
+	if strings.Trim(key, "|") == "" {
 		key = "unknown"
 	}
 	stateMap[key] = map[string]any{

--- a/internal/service/signal_runtime_ws_test.go
+++ b/internal/service/signal_runtime_ws_test.go
@@ -1,0 +1,69 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/wuyaocheng/bktrader/internal/store/memory"
+)
+
+func TestEnrichSignalRuntimeSummaryKeepsKlineEventsScopedByTimeframe(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+
+	for _, timeframe := range []string{"1d", "4h"} {
+		if _, err := platform.BindStrategySignalSource("strategy-bk-1d", map[string]any{
+			"sourceKey": "binance-kline",
+			"role":      "signal",
+			"symbol":    "BTCUSDT",
+			"options":   map[string]any{"timeframe": timeframe},
+		}); err != nil {
+			t.Fatalf("bind strategy %s failed: %v", timeframe, err)
+		}
+	}
+
+	session, err := platform.CreateSignalRuntimeSession("live-main", "strategy-bk-1d")
+	if err != nil {
+		t.Fatalf("create runtime session failed: %v", err)
+	}
+
+	event4h := enrichSignalRuntimeSummary(session, map[string]any{
+		"event":     "kline",
+		"symbol":    "BTCUSDT",
+		"timeframe": "4h",
+		"barStart":  "1713067200000",
+	})
+	if got := stringValue(event4h["channel"]); got != "btcusdt@kline_4h" {
+		t.Fatalf("expected 4h event to match 4h subscription, got %#v", event4h)
+	}
+	if got := stringValue(event4h["timeframe"]); got != "4h" {
+		t.Fatalf("expected 4h event timeframe to remain 4h, got %#v", event4h)
+	}
+
+	event1d := enrichSignalRuntimeSummary(session, map[string]any{
+		"event":     "kline",
+		"symbol":    "BTCUSDT",
+		"timeframe": "1d",
+		"barStart":  "1713052800000",
+	})
+	if got := stringValue(event1d["channel"]); got != "btcusdt@kline_1d" {
+		t.Fatalf("expected 1d event to match 1d subscription, got %#v", event1d)
+	}
+
+	sourceStates := map[string]any{}
+	sourceStates = mergeSignalSourceState(sourceStates, event1d, time.Date(2026, 4, 15, 0, 0, 0, 0, time.UTC))
+	sourceStates = mergeSignalSourceState(sourceStates, event4h, time.Date(2026, 4, 15, 0, 0, 1, 0, time.UTC))
+	if len(sourceStates) != 2 {
+		t.Fatalf("expected distinct source-state entries per timeframe, got %#v", sourceStates)
+	}
+
+	for _, timeframe := range []string{"1d", "4h"} {
+		key := signalBindingMatchKey("binance-kline", "signal", "BTCUSDT", map[string]any{"timeframe": timeframe})
+		entry := mapValue(sourceStates[key])
+		if entry == nil {
+			t.Fatalf("expected source state for %s timeframe, got %#v", timeframe, sourceStates)
+		}
+		if got := stringValue(entry["timeframe"]); got != timeframe {
+			t.Fatalf("expected source state timeframe %s, got %#v", timeframe, entry)
+		}
+	}
+}

--- a/internal/service/signal_source_registry.go
+++ b/internal/service/signal_source_registry.go
@@ -308,9 +308,7 @@ func (p *Platform) BindAccountSignalSource(accountID string, payload map[string]
 	bindings := make([]map[string]any, 0, len(existing)+1)
 	replaced := false
 	for _, item := range existing {
-		if normalizeSignalSourceKey(stringValue(item["sourceKey"])) == source.Key &&
-			normalizeSignalSourceRole(stringValue(item["role"])) == role &&
-			NormalizeSymbol(stringValue(item["symbol"])) == symbol {
+		if signalBindingMatches(source.Key, role, symbol, options, item) {
 			bindings = append(bindings, bindingToMap(binding))
 			replaced = true
 			continue
@@ -380,7 +378,10 @@ func (p *Platform) ListAccountSignalBindings(accountID string) ([]domain.Account
 		if cmp := strings.Compare(a.Exchange, b.Exchange); cmp != 0 {
 			return cmp
 		}
-		return strings.Compare(a.Symbol, b.Symbol)
+		if cmp := strings.Compare(a.Symbol, b.Symbol); cmp != 0 {
+			return cmp
+		}
+		return strings.Compare(signalBindingTimeframe(a.Options), signalBindingTimeframe(b.Options))
 	})
 	return items, nil
 }
@@ -441,6 +442,37 @@ func resolveStrategySignalBindings(parameters map[string]any) []map[string]any {
 	}
 }
 
+func signalBindingTimeframe(options map[string]any) string {
+	if options == nil {
+		return ""
+	}
+	return normalizeSignalBarInterval(strings.TrimSpace(stringValue(options["timeframe"])))
+}
+
+func signalBindingMatchKey(sourceKey, role, symbol string, options ...map[string]any) string {
+	key := normalizeSignalSourceKey(sourceKey) + "|" + normalizeSignalSourceRole(role) + "|" + NormalizeSymbol(symbol)
+	if len(options) > 0 {
+		if timeframe := signalBindingTimeframe(options[0]); timeframe != "" {
+			key += "|" + timeframe
+		}
+	}
+	return key
+}
+
+func signalBindingMatches(sourceKey, role, symbol string, options map[string]any, binding map[string]any) bool {
+	return signalBindingMatchKey(sourceKey, role, symbol, options) ==
+		signalBindingMatchKey(
+			stringValue(binding["sourceKey"]),
+			stringValue(binding["role"]),
+			stringValue(binding["symbol"]),
+			metadataValue(binding["options"]),
+		)
+}
+
+func signalBindingKey(binding domain.AccountSignalBinding) string {
+	return signalBindingMatchKey(binding.SourceKey, binding.Role, binding.Symbol, binding.Options)
+}
+
 func bindingToMap(binding domain.AccountSignalBinding) map[string]any {
 	return map[string]any{
 		"id":         binding.ID,
@@ -451,6 +483,7 @@ func bindingToMap(binding domain.AccountSignalBinding) map[string]any {
 		"role":       binding.Role,
 		"streamType": binding.StreamType,
 		"symbol":     binding.Symbol,
+		"timeframe":  signalBindingTimeframe(binding.Options),
 		"status":     binding.Status,
 		"options":    cloneMetadata(binding.Options),
 		"createdAt":  binding.CreatedAt,

--- a/internal/service/signal_source_registry.go
+++ b/internal/service/signal_source_registry.go
@@ -281,10 +281,7 @@ func (p *Platform) BindAccountSignalSource(accountID string, payload map[string]
 	}
 
 	symbol := NormalizeSymbol(stringValue(payload["symbol"]))
-	options := cloneMetadata(metadataValue(payload["options"]))
-	if options == nil {
-		options = map[string]any{}
-	}
+	options := canonicalizeSignalBindingOptions(source.Key, cloneMetadata(metadataValue(payload["options"])))
 
 	binding := domain.AccountSignalBinding{
 		ID:         fmt.Sprintf("signal-binding-%d", time.Now().UnixNano()),
@@ -367,7 +364,7 @@ func (p *Platform) ListAccountSignalBindings(accountID string) ([]domain.Account
 			StreamType: stringValue(binding["streamType"]),
 			Symbol:     NormalizeSymbol(stringValue(binding["symbol"])),
 			Status:     firstNonEmpty(stringValue(binding["status"]), "ACTIVE"),
-			Options:    cloneMetadata(metadataValue(binding["options"])),
+			Options:    canonicalizeSignalBindingOptions(stringValue(binding["sourceKey"]), cloneMetadata(metadataValue(binding["options"]))),
 			CreatedAt:  timeValue(binding["createdAt"]),
 		})
 	}
@@ -381,7 +378,7 @@ func (p *Platform) ListAccountSignalBindings(accountID string) ([]domain.Account
 		if cmp := strings.Compare(a.Symbol, b.Symbol); cmp != 0 {
 			return cmp
 		}
-		return strings.Compare(signalBindingTimeframe(a.Options), signalBindingTimeframe(b.Options))
+		return strings.Compare(signalBindingTimeframe(a.SourceKey, a.Options), signalBindingTimeframe(b.SourceKey, b.Options))
 	})
 	return items, nil
 }
@@ -442,17 +439,34 @@ func resolveStrategySignalBindings(parameters map[string]any) []map[string]any {
 	}
 }
 
-func signalBindingTimeframe(options map[string]any) string {
-	if options == nil {
+func signalBindingTimeframe(sourceKey string, options map[string]any) string {
+	timeframe := normalizeSignalBarInterval(strings.TrimSpace(stringValue(options["timeframe"])))
+	if timeframe != "" {
+		return timeframe
+	}
+	switch normalizeSignalSourceKey(sourceKey) {
+	case "binance-kline":
+		return "1d"
+	default:
 		return ""
 	}
-	return normalizeSignalBarInterval(strings.TrimSpace(stringValue(options["timeframe"])))
+}
+
+func canonicalizeSignalBindingOptions(sourceKey string, options map[string]any) map[string]any {
+	options = cloneMetadata(options)
+	if options == nil {
+		options = map[string]any{}
+	}
+	if timeframe := signalBindingTimeframe(sourceKey, options); timeframe != "" {
+		options["timeframe"] = timeframe
+	}
+	return options
 }
 
 func signalBindingMatchKey(sourceKey, role, symbol string, options ...map[string]any) string {
 	key := normalizeSignalSourceKey(sourceKey) + "|" + normalizeSignalSourceRole(role) + "|" + NormalizeSymbol(symbol)
 	if len(options) > 0 {
-		if timeframe := signalBindingTimeframe(options[0]); timeframe != "" {
+		if timeframe := signalBindingTimeframe(sourceKey, options[0]); timeframe != "" {
 			key += "|" + timeframe
 		}
 	}
@@ -483,9 +497,9 @@ func bindingToMap(binding domain.AccountSignalBinding) map[string]any {
 		"role":       binding.Role,
 		"streamType": binding.StreamType,
 		"symbol":     binding.Symbol,
-		"timeframe":  signalBindingTimeframe(binding.Options),
+		"timeframe":  signalBindingTimeframe(binding.SourceKey, binding.Options),
 		"status":     binding.Status,
-		"options":    cloneMetadata(binding.Options),
+		"options":    canonicalizeSignalBindingOptions(binding.SourceKey, binding.Options),
 		"createdAt":  binding.CreatedAt,
 	}
 }

--- a/internal/service/signal_source_registry_test.go
+++ b/internal/service/signal_source_registry_test.go
@@ -1,0 +1,61 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/wuyaocheng/bktrader/internal/store/memory"
+)
+
+func TestSignalBindingMatchKeyDefaultsEmptyBinanceKlineTimeframeTo1d(t *testing.T) {
+	withExplicit1D := signalBindingMatchKey("binance-kline", "signal", "BTCUSDT", map[string]any{
+		"timeframe": "1d",
+	})
+	withImplicitDefault := signalBindingMatchKey("binance-kline", "signal", "BTCUSDT", map[string]any{})
+	if withExplicit1D != withImplicitDefault {
+		t.Fatalf("expected empty kline timeframe to canonicalize to 1d, got %q vs %q", withExplicit1D, withImplicitDefault)
+	}
+}
+
+func TestBindStrategySignalSourceDoesNotDuplicateImplicitDefault1dKlineBinding(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+
+	if _, err := platform.BindStrategySignalSource("strategy-bk-1d", map[string]any{
+		"sourceKey": "binance-kline",
+		"role":      "signal",
+		"symbol":    "BTCUSDT",
+		"options":   map[string]any{"timeframe": "1d"},
+	}); err != nil {
+		t.Fatalf("bind explicit 1d kline failed: %v", err)
+	}
+
+	if _, err := platform.BindStrategySignalSource("strategy-bk-1d", map[string]any{
+		"sourceKey": "binance-kline",
+		"role":      "signal",
+		"symbol":    "BTCUSDT",
+	}); err != nil {
+		t.Fatalf("bind implicit default kline failed: %v", err)
+	}
+
+	bindings, err := platform.ListStrategySignalBindings("strategy-bk-1d")
+	if err != nil {
+		t.Fatalf("list strategy bindings failed: %v", err)
+	}
+	if len(bindings) != 1 {
+		t.Fatalf("expected a single deduped kline binding, got %#v", bindings)
+	}
+	if got := stringValue(bindings[0].Options["timeframe"]); got != "1d" {
+		t.Fatalf("expected canonicalized timeframe 1d, got %s", got)
+	}
+
+	plan, err := platform.BuildSignalRuntimePlan("live-main", "strategy-bk-1d")
+	if err != nil {
+		t.Fatalf("build runtime plan failed: %v", err)
+	}
+	subscriptions := metadataList(plan["subscriptions"])
+	if len(subscriptions) != 1 {
+		t.Fatalf("expected one kline subscription after dedupe, got %#v", subscriptions)
+	}
+	if got := stringValue(subscriptions[0]["channel"]); got != "btcusdt@kline_1d" {
+		t.Fatalf("expected canonicalized 1d kline subscription, got %s", got)
+	}
+}

--- a/internal/service/signal_source_registry_test.go
+++ b/internal/service/signal_source_registry_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"testing"
 
+	"github.com/wuyaocheng/bktrader/internal/domain"
 	"github.com/wuyaocheng/bktrader/internal/store/memory"
 )
 
@@ -57,5 +58,74 @@ func TestBindStrategySignalSourceDoesNotDuplicateImplicitDefault1dKlineBinding(t
 	}
 	if got := stringValue(subscriptions[0]["channel"]); got != "btcusdt@kline_1d" {
 		t.Fatalf("expected canonicalized 1d kline subscription, got %s", got)
+	}
+}
+
+func TestLegacyStrategyBindingWithoutTimeframeCanonicalizesToSingle1dBinding(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+
+	strategy, err := platform.GetStrategy("strategy-bk-1d")
+	if err != nil {
+		t.Fatalf("get strategy failed: %v", err)
+	}
+	currentVersion, ok := strategy["currentVersion"].(domain.StrategyVersion)
+	if !ok {
+		t.Fatalf("expected current version for strategy, got %#v", strategy["currentVersion"])
+	}
+	parameters := cloneMetadata(currentVersion.Parameters)
+	parameters["signalBindings"] = []map[string]any{
+		{
+			"id":         "legacy-kline-binding",
+			"sourceKey":  "binance-kline",
+			"sourceName": "Binance Futures Kline",
+			"exchange":   "BINANCE",
+			"role":       "signal",
+			"streamType": "signal_bar",
+			"symbol":     "BTCUSDT",
+			"status":     "ACTIVE",
+		},
+	}
+	if _, err := platform.store.UpdateStrategyParameters("strategy-bk-1d", parameters); err != nil {
+		t.Fatalf("inject legacy strategy binding failed: %v", err)
+	}
+
+	legacyBindings, err := platform.ListStrategySignalBindings("strategy-bk-1d")
+	if err != nil {
+		t.Fatalf("list legacy bindings failed: %v", err)
+	}
+	if len(legacyBindings) != 1 {
+		t.Fatalf("expected single legacy binding, got %#v", legacyBindings)
+	}
+	if got := stringValue(legacyBindings[0].Options["timeframe"]); got != "1d" {
+		t.Fatalf("expected legacy binding timeframe to canonicalize to 1d, got %#v", legacyBindings[0].Options)
+	}
+
+	if _, err := platform.BindStrategySignalSource("strategy-bk-1d", map[string]any{
+		"sourceKey": "binance-kline",
+		"role":      "signal",
+		"symbol":    "BTCUSDT",
+		"options":   map[string]any{"timeframe": "1d"},
+	}); err != nil {
+		t.Fatalf("bind explicit 1d over legacy binding failed: %v", err)
+	}
+
+	bindings, err := platform.ListStrategySignalBindings("strategy-bk-1d")
+	if err != nil {
+		t.Fatalf("list strategy bindings after upgrade failed: %v", err)
+	}
+	if len(bindings) != 1 {
+		t.Fatalf("expected legacy + explicit 1d to collapse into one canonical binding, got %#v", bindings)
+	}
+
+	plan, err := platform.BuildSignalRuntimePlan("live-main", "strategy-bk-1d")
+	if err != nil {
+		t.Fatalf("build runtime plan failed: %v", err)
+	}
+	subscriptions := metadataList(plan["subscriptions"])
+	if len(subscriptions) != 1 {
+		t.Fatalf("expected exactly one canonicalized subscription, got %#v", subscriptions)
+	}
+	if got := stringValue(subscriptions[0]["channel"]); got != "btcusdt@kline_1d" {
+		t.Fatalf("expected legacy binding upgrade to keep canonical 1d channel, got %s", got)
 	}
 }

--- a/internal/service/strategy.go
+++ b/internal/service/strategy.go
@@ -138,9 +138,7 @@ func (p *Platform) BindStrategySignalSource(strategyID string, payload map[strin
 	bindings := make([]map[string]any, 0, len(existing)+1)
 	replaced := false
 	for _, item := range existing {
-		if normalizeSignalSourceKey(stringValue(item["sourceKey"])) == source.Key &&
-			normalizeSignalSourceRole(stringValue(item["role"])) == role &&
-			NormalizeSymbol(stringValue(item["symbol"])) == symbol {
+		if signalBindingMatches(source.Key, role, symbol, options, item) {
 			bindings = append(bindings, bindingToMap(binding))
 			replaced = true
 			continue
@@ -224,6 +222,18 @@ func (p *Platform) ListStrategySignalBindings(strategyID string) ([]domain.Accou
 			CreatedAt:  timeValue(binding["createdAt"]),
 		})
 	}
+	slices.SortFunc(items, func(a, b domain.AccountSignalBinding) int {
+		if cmp := strings.Compare(a.Role, b.Role); cmp != 0 {
+			return cmp
+		}
+		if cmp := strings.Compare(a.Exchange, b.Exchange); cmp != 0 {
+			return cmp
+		}
+		if cmp := strings.Compare(a.Symbol, b.Symbol); cmp != 0 {
+			return cmp
+		}
+		return strings.Compare(signalBindingTimeframe(a.Options), signalBindingTimeframe(b.Options))
+	})
 	return items, nil
 }
 

--- a/internal/service/strategy.go
+++ b/internal/service/strategy.go
@@ -111,10 +111,7 @@ func (p *Platform) BindStrategySignalSource(strategyID string, payload map[strin
 	}
 
 	symbol := NormalizeSymbol(stringValue(payload["symbol"]))
-	options := cloneMetadata(metadataValue(payload["options"]))
-	if options == nil {
-		options = map[string]any{}
-	}
+	options := canonicalizeSignalBindingOptions(source.Key, cloneMetadata(metadataValue(payload["options"])))
 
 	parameters := cloneMetadata(currentVersion.Parameters)
 	if parameters == nil {
@@ -218,7 +215,7 @@ func (p *Platform) ListStrategySignalBindings(strategyID string) ([]domain.Accou
 			StreamType: stringValue(binding["streamType"]),
 			Symbol:     NormalizeSymbol(stringValue(binding["symbol"])),
 			Status:     firstNonEmpty(stringValue(binding["status"]), "ACTIVE"),
-			Options:    cloneMetadata(metadataValue(binding["options"])),
+			Options:    canonicalizeSignalBindingOptions(stringValue(binding["sourceKey"]), cloneMetadata(metadataValue(binding["options"]))),
 			CreatedAt:  timeValue(binding["createdAt"]),
 		})
 	}
@@ -232,7 +229,7 @@ func (p *Platform) ListStrategySignalBindings(strategyID string) ([]domain.Accou
 		if cmp := strings.Compare(a.Symbol, b.Symbol); cmp != 0 {
 			return cmp
 		}
-		return strings.Compare(signalBindingTimeframe(a.Options), signalBindingTimeframe(b.Options))
+		return strings.Compare(signalBindingTimeframe(a.SourceKey, a.Options), signalBindingTimeframe(b.SourceKey, b.Options))
 	})
 	return items, nil
 }


### PR DESCRIPTION
## 目的
修正 signal runtime 绑定模型里多周期会互相覆盖、账户信号源参与运行时规划导致模型重复的问题，并补一组 Binance testnet 联调用的一键启动模板，方便前端直接拉模板完成自动启动闭环。

具体来说，这次改动做了 3 件事：
- 把 signal binding 的识别键扩成 `sourceKey + role + symbol + timeframe`，修复同 symbol 多周期误覆盖/误匹配；同时将 legacy `binance-kline` 的空 timeframe canonicalize 为 `1d`，避免老数据升级后出现重复订阅。
- 让 runtime plan / readiness / live launch 改为直接基于策略绑定，不再依赖账户级 signal binding；其中 runtime readiness 只把 `signal / trigger` 缺失视为阻断项，`feature` 缺失仍会展示在 `missingBindings`，但只作为 advisory，不单独阻断最小运行路径。
- 新增 4 个 Binance testnet 一键启动模板（BTC/ETH x 4h/1d），固定使用 Binance kline 作为 signal、trade tick 作为 trigger、order book 作为 feature，并固定 `executionMode=rest`；`dispatchMode` 改为模板级可配置项，默认 `manual-review`，允许前端在 testnet 联调时显式切到 `auto-dispatch`。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [x] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
是否涉及默认行为、交易路径、部署流程、环境变量：
- [ ] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main)
  全局默认值未改，仍是 `manual-review`；新增模板也默认 `manual-review`，仅允许前端在 Binance testnet 联调时显式注入 `auto-dispatch`。
- [ ] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？
  没有；模板固定为 Binance testnet credential refs 与 `sandbox=true`。
- [ ] DB migration 是否具备向下兼容幂等性？
  无 migration 变更。
- [ ] 配置字段有没有无意被混改？
  本次仅新增 template 接口/文档，并调整 signal runtime 绑定与 readiness 逻辑。

## 验证方式与测试证据
本地验证：
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

执行过的检查：
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
- graphify rebuild

新增/更新的测试覆盖了：
- runtime plan 仅依赖策略绑定也能 ready
- `feature` 缺失会留在 `missingBindings`，但不会单独把 runtime 打成 not ready
- 零订阅 runtime plan 不会误报 ready
- 多 timeframe 订阅不会互相覆盖，runtime source state 会按 event timeframe 正确落 key
- legacy `binance-kline` 空 timeframe 会被 canonicalize 为 `1d`，并与显式 `1d` 合并为同一绑定
- live session 会按 `account + strategy + symbol + timeframe` 区分
- launch template 会返回 4 个 Binance testnet 模板，并显式输出 `executionMode=rest` 与可配置 `dispatchMode`

## 影响说明
- 后端运行模型现在更接近：`策略绑定 = 输入定义`，`live session = account + strategy + symbol + timeframe`。
- 账户级 signal binding 接口暂时仍保留兼容，但不再参与 runtime 订阅规划。
- runtime plan 现在会同时给出全部 `missingBindings`，以及更明确的 `blockingMissingBindings` / `optionalMissingBindings`，方便前端区分阻断项和 advisory 项。
- `mirrorStrategySignals` 仍保留在 launch payload 中作为兼容字段，但现在只表示“launch 前继续要求策略绑定已存在”，不再表示把策略绑定镜像到账户 signal binding。
- 前端可直接接 `/api/v1/live/launch-templates` 做一键联调入口，并按文档里的三步顺序执行模板。
