### PR TITLE
Console: reorganize monitor flow and add log console plan

### DIFF
--- a/docs/20260415-日志查看台建设计划.md
+++ b/docs/20260415-日志查看台建设计划.md
@@ -1,0 +1,506 @@
+# 日志查看台建设计划
+
+## 1. 背景与目标
+
+当前前端控制台存在两个明显问题：
+
+1. 顶部“运行正常 / 连接异常”只能反映瞬时状态，异常可能一闪而过，用户无法回看。
+2. 后端已经存在多类“日志 / 事件 / 告警 / 时间线”数据，但在前端并没有统一的日志查看入口，排障成本高。
+
+本计划目标是建设一个标准化的“日志查看台”，逐步实现以下能力：
+
+- 回看最近异常与恢复记录
+- 查看平台告警、通知、运行时时间线
+- 支持滚动、分页、筛选、时间范围查询
+- 支持实时跟踪
+- 逐步引入结构化业务事件日志
+- 为后续实盘故障排查与审计提供统一入口
+
+## 2. 当前后端可用日志类型盘点
+
+基于当前代码，后端现有“日志型数据”可分为 8 类：
+
+### 2.1 系统日志 `slog`
+
+来源：
+
+- `cmd/platform-api/main.go`
+- `internal/app/server.go`
+- `internal/service/**`
+- `internal/logging/logging.go`
+
+特点：
+
+- 记录服务启动、关闭、worker、runtime、telegram、live market 等系统级日志
+- 当前主要输出到 stdout
+- 当前前端不可直接消费
+
+### 2.2 HTTP 请求日志
+
+来源：
+
+- `internal/http/router.go` 中的 `requestLogMiddleware`
+
+特点：
+
+- 记录 method、path、query、status、duration_ms、bytes_written、panic stack
+- 当前同样走 `slog`
+- 当前前端不可直接消费
+
+### 2.3 平台告警 `PlatformAlert`
+
+定义：
+
+- `internal/domain/models.go`
+
+已有接口：
+
+- `GET /api/v1/alerts`
+
+特点：
+
+- 已经适合前端消费
+- 支持 `scope / level / title / detail / eventTime`
+- 是日志台第一期最容易落地的数据源
+
+### 2.4 平台通知 `PlatformNotification`
+
+来源：
+
+- `internal/service/notifications.go`
+
+已有接口：
+
+- `GET /api/v1/notifications?includeAcked=true`
+
+特点：
+
+- 属于告警的投递 / 确认 / telegram 发送态
+- 适合日志台中的“通知与处置”视图
+
+### 2.5 Runtime / Session 时间线 `timeline`
+
+来源：
+
+- `internal/service/signal_runtime_ws.go`
+- `internal/service/paper.go`
+- live session state 中也存在 timeline 数据
+
+特点：
+
+- 属于结构化时间线，不是纯文本日志
+- 一般包含 `time / category / title / metadata`
+- 非常适合前端做“实时跟踪”
+
+### 2.6 策略决策事件 `StrategyDecisionEvent`
+
+定义：
+
+- `internal/domain/models.go`
+
+落库：
+
+- `internal/service/telemetry.go`
+- `internal/store/postgres/store.go`
+- `internal/store/memory/store.go`
+
+特点：
+
+- 记录策略触发、决策、source gate、signal intent、execution proposal 等完整上下文
+- 业务价值极高
+- 当前后端已持久化，但前端暂无对应接口
+
+### 2.7 订单执行事件 `OrderExecutionEvent`
+
+定义：
+
+- `internal/domain/models.go`
+
+落库：
+
+- `internal/service/telemetry.go`
+- `internal/store/postgres/store.go`
+- `internal/store/memory/store.go`
+
+特点：
+
+- 记录 live 订单提交、同步、成交等生命周期事件
+- 包含延迟、价差、fallback、error、adapter sync 等关键信息
+- 当前后端已持久化，但前端暂无对应接口
+
+### 2.8 仓位账户快照 `PositionAccountSnapshot`
+
+定义：
+
+- `internal/domain/models.go`
+
+落库：
+
+- `internal/service/telemetry.go`
+
+特点：
+
+- 记录 live session 在关键时刻的仓位与账户状态快照
+- 非常适合做“执行后审计 / 事故复盘”
+- 当前后端已持久化，但前端暂无对应接口
+
+## 3. 建设原则
+
+### 3.1 分两期建设
+
+避免一口气做成大而全的系统，先把用户最痛的“看不见刚才发生了什么”解决，再补后端统一日志能力。
+
+### 3.2 优先结构化事件
+
+对于交易系统，结构化事件比单纯 stdout 文本日志更有排障价值。日志台最终应以业务事件链为核心，而不是只做一个文本 tail 面板。
+
+### 3.3 不修改高风险实盘默认行为
+
+日志台建设只做观测与排障能力，不改变 live dispatch / execution strategy / manual-review 等高风险默认行为。
+
+## 4. 建设路线
+
+## Phase 1：前端可见性补齐
+
+目标：
+
+- 用户能看到最近错误、恢复记录、告警、通知、runtime timeline
+- 顶部状态可点击打开最近日志
+- 提供一个独立“日志查看台”页面雏形
+
+### Phase 1.1 顶部状态日志入口
+
+状态：
+
+- 已完成基础版
+
+已做内容：
+
+- 顶部“运行正常 / 连接异常”可点击
+- 可查看最近状态记录与最近告警
+- 错误恢复时自动记录“连接已恢复正常”
+
+后续补强：
+
+- 记录持久化到 `localStorage`
+- 支持保留更长历史
+- 支持跳转到告警 / 监控对象
+
+### Phase 1.2 新建“日志查看台”页面
+
+目标：
+
+- 左侧菜单新增“日志查看台”
+- 页面为单独舞台，不与监控台混用
+
+页面结构建议：
+
+1. 顶部工具栏
+2. 日志类型切换
+3. 筛选区
+4. 日志列表区
+5. 详情侧栏或抽屉
+
+第一期日志类型：
+
+- 最近状态
+- 平台告警
+- 平台通知
+- Runtime 时间线
+- Session 时间线
+
+### Phase 1.3 前端交互能力
+
+第一期需要支持：
+
+- 滚动加载
+- 前端分页或分段渲染
+- 时间范围切换：
+  - 最近 5 分钟
+  - 最近 1 小时
+  - 最近 12 小时
+  - 最近 24 小时
+- 按级别筛选：
+  - 全部
+  - 严重
+  - 警告
+  - 信息
+- 按对象筛选：
+  - accountId
+  - strategyId
+  - runtimeSessionId
+  - liveSessionId
+- 自动刷新
+- 手动暂停刷新
+
+### Phase 1.4 第一阶段数据来源
+
+直接复用现有接口 / 状态：
+
+- `/api/v1/alerts`
+- `/api/v1/notifications`
+- `signal runtime session.state.timeline`
+- `live session.state.timeline`
+- UI store 中的最近状态记录
+
+### Phase 1 验收标准
+
+- 顶部状态区点击后可查看最近异常与恢复记录
+- 新页面可查看最近告警与通知
+- 可按时间和级别筛选
+- 可滚动浏览较长列表
+- 用户不再依赖“瞬时状态闪过”来判断系统是否出错
+
+## Phase 2：后端统一日志接口
+
+目标：
+
+- 暴露真正可分页、可筛选、可实时追踪的日志 API
+- 将结构化业务事件纳入日志台
+
+### Phase 2.1 新增统一日志 API
+
+建议新增以下接口：
+
+#### 1. 结构化事件日志
+
+`GET /api/v1/logs/events`
+
+聚合：
+
+- `StrategyDecisionEvent`
+- `OrderExecutionEvent`
+- `PositionAccountSnapshot`
+
+建议查询参数：
+
+- `type`
+- `accountId`
+- `strategyId`
+- `runtimeSessionId`
+- `liveSessionId`
+- `orderId`
+- `decisionEventId`
+- `level`
+- `from`
+- `to`
+- `cursor`
+- `limit`
+
+#### 2. 系统日志
+
+`GET /api/v1/logs/system`
+
+目标：
+
+- 暴露 `slog` 系统日志
+- 支持分页 / 时间范围 / 级别过滤
+
+候选实现：
+
+- 服务内 ring buffer
+- 读取滚动文件
+- 容器环境日志桥接
+
+#### 3. HTTP 请求日志
+
+`GET /api/v1/logs/http`
+
+目标：
+
+- 查询 requestLogMiddleware 产生的请求日志
+- 支持 status / path / duration_ms 等过滤
+
+### Phase 2.2 实时跟踪接口
+
+建议新增：
+
+- `GET /api/v1/logs/stream`
+
+候选协议：
+
+- SSE 优先
+- WebSocket 作为增强方案
+
+用途：
+
+- 实时跟踪 live / runtime / alerts / execution events
+- 支持前端“实时跟踪”开关
+
+### Phase 2.3 日志事件统一模型
+
+前端聚合层建议统一成：
+
+```ts
+type ConsoleLogEvent = {
+  id: string;
+  source: "system" | "http" | "alert" | "notification" | "runtime" | "session" | "decision" | "execution" | "snapshot";
+  level: "critical" | "warning" | "info" | "debug";
+  title: string;
+  message: string;
+  eventTime: string;
+  accountId?: string;
+  strategyId?: string;
+  runtimeSessionId?: string;
+  liveSessionId?: string;
+  orderId?: string;
+  decisionEventId?: string;
+  metadata?: Record<string, unknown>;
+};
+```
+
+### Phase 2 验收标准
+
+- 前端可查询结构化业务事件
+- 支持 cursor / limit 分页
+- 支持实时流式跟踪
+- 支持按 live session / runtime / order / strategy 追踪事件链
+
+## 5. 前端日志台页面设计建议
+
+## 5.1 菜单归属
+
+建议新增左侧菜单一级入口：
+
+- `日志查看台`
+
+不要继续塞在：
+
+- 账户配置页
+- 监控台页
+
+原因：
+
+- 监控台强调运行中状态与人工干预
+- 日志查看台强调排障、检索、回看、审计
+- 两者心智不同
+
+## 5.2 页面信息架构
+
+### 顶部工具栏
+
+- 关键词搜索
+- 时间范围
+- 自动刷新开关
+- 实时跟踪开关
+- 清除筛选
+
+### 左侧过滤器
+
+- 日志类型
+- 级别
+- account
+- strategy
+- runtime session
+- live session
+
+### 中间日志列表
+
+- 支持虚拟滚动
+- 支持加载更多
+- 每条日志展示摘要、级别、时间、关联对象
+
+### 右侧详情面板
+
+- 展示 metadata
+- 展示上下文链接：
+  - 跳转到账户
+  - 跳转到监控台
+  - 跳转到相关 session
+
+## 6. 技术任务拆解
+
+## Task Group A：前端第一期
+
+- [ ] 顶部状态日志持久化到 `localStorage`
+- [ ] 新建 `LogStage`
+- [ ] 菜单增加“日志查看台”
+- [ ] 接入 alerts / notifications / timeline
+- [ ] 实现滚动加载与筛选
+- [ ] 支持自动刷新和暂停
+
+## Task Group B：后端事件接口
+
+- [ ] 梳理 store 中已有 decision / execution / snapshot 查询能力
+- [ ] 新增 `/api/v1/logs/events`
+- [ ] 增加过滤、分页、cursor 能力
+- [ ] 对接前端日志台
+
+## Task Group C：系统日志与请求日志
+
+- [ ] 明确 `slog` 采集方案
+- [ ] 增加系统日志读取接口
+- [ ] 增加 HTTP 请求日志读取接口
+- [ ] 增加实时跟踪接口
+
+## 7. 风险与注意事项
+
+### 7.1 不碰高风险执行逻辑
+
+本计划不涉及：
+
+- `internal/service/live*.go` 执行策略默认行为修改
+- `dispatchMode` 默认值调整
+- 实盘自动分发默认开启
+
+### 7.2 日志接口需要控制体量
+
+必须避免：
+
+- 一次性返回全量日志
+- 前端直接拉整个事件表
+
+必须支持：
+
+- limit
+- cursor
+- 时间范围
+- 筛选条件
+
+### 7.3 实时流必须可关闭
+
+日志实时跟踪必须允许用户关闭，避免：
+
+- 高频刷新影响控制台性能
+- 造成主监控渲染抖动
+
+## 8. 建议执行顺序
+
+建议按以下顺序推进：
+
+1. 完成顶部状态日志持久化
+2. 新建前端 `日志查看台` 页面
+3. 接入现有 `alerts / notifications / timeline`
+4. 确认筛选与滚动交互
+5. 新增后端结构化事件接口
+6. 接入决策事件 / 执行事件 / 快照事件
+7. 最后再引入系统日志 / HTTP 请求日志 / 实时流
+
+## 9. 下一步
+
+下一步建议直接开始：
+
+### Step 1
+
+实现前端 `日志查看台` 页面骨架：
+
+- 新增左侧菜单入口
+- 新建 `LogStage`
+- 先接入：
+  - 顶部状态日志
+  - alerts
+  - notifications
+
+### Step 2
+
+完成第一期筛选和滚动体验：
+
+- 时间范围
+- 级别
+- 类型
+- 自动刷新
+
+### Step 3
+
+再回头补后端统一事件接口。
+

--- a/web/console/src/App.tsx
+++ b/web/console/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef } from 'react';
+import React, { useMemo, useRef, useState } from 'react';
 import { LogOut, ChevronDown } from 'lucide-react';
 import { WorkbenchLayout } from './layouts/WorkbenchLayout';
 import { useUIStore } from './store/useUIStore';
@@ -6,6 +6,7 @@ import { useTradingStore } from './store/useTradingStore';
 import { useDashboard } from './hooks/useDashboard';
 import { useTradingActions } from './hooks/useTradingActions';
 import { fetchJSON } from './utils/api';
+import { useClickOutside } from './hooks/useClickOutside';
 
 import { MetricCard } from './components/ui/MetricCard';
 import { ActionButton } from './components/ui/ActionButton';
@@ -35,6 +36,8 @@ export default function App() {
   const dockTab = useUIStore(s => s.dockTab);
   const setDockTab = useUIStore(s => s.setDockTab);
   const error = useUIStore(s => s.error);
+  const systemLogs = useUIStore(s => s.systemLogs);
+  const clearSystemLogs = useUIStore(s => s.clearSystemLogs);
   const authSession = useUIStore(s => s.authSession);
   const settingsMenuOpen = useUIStore(s => s.settingsMenuOpen);
   const setSettingsMenuOpen = useUIStore(s => s.setSettingsMenuOpen);
@@ -61,6 +64,7 @@ export default function App() {
   const liveSessionLaunchAction = useUIStore(s => s.liveSessionLaunchAction);
   const liveSessionAction = useUIStore(s => s.liveSessionAction);
   const telegramAction = useUIStore(s => s.telegramAction);
+  const [systemLogOpen, setSystemLogOpen] = useState(false);
 
   // Trading State
   const accounts = useTradingStore(s => s.accounts);
@@ -77,6 +81,16 @@ export default function App() {
   const editingLiveSessionId = useTradingStore(s => s.editingLiveSessionId);
 
   const userMenuRef = useRef<HTMLDivElement>(null);
+  const systemLogRef = useRef<HTMLDivElement>(null);
+
+  // Close menus when clicking outside
+  useClickOutside(systemLogRef, () => {
+    if (systemLogOpen) setSystemLogOpen(false);
+  });
+  
+  useClickOutside(userMenuRef, () => {
+    if (settingsMenuOpen) setSettingsMenuOpen(false);
+  });
 
   // Derived State
   const highlightedLiveSession = useMemo(
@@ -96,38 +110,9 @@ export default function App() {
   );
 
   const strategyOptions = useMemo(() => strategies.map(s => ({ value: s.id, label: s.name })), [strategies]);
-
-  const mainStageContent = (
-    <div className="h-full relative overflow-hidden">
-      {sidebarTab === 'monitor' && <MonitorStage />}
-      {sidebarTab === 'strategy' && <StrategyStage createStrategy={actions.createStrategy} saveStrategyParameters={actions.saveStrategyParameters} />}
-      {sidebarTab === 'account' && (
-        <AccountStage 
-          logout={actions.logout}
-          openLiveAccountModal={actions.openLiveAccountModal}
-          openLiveBindingModal={() => actions.openLiveBindingModal(quickLiveAccountId)}
-          openLiveSessionModal={(s) => actions.openLiveSessionModal(s ?? null, quickLiveAccountId, strategies)}
-          launchLiveFlow={actions.launchLiveFlow}
-          runLiveSessionAction={actions.runLiveSessionAction}
-          dispatchLiveSessionIntent={actions.dispatchLiveSessionIntent}
-          syncLiveSession={actions.syncLiveSession}
-          deleteLiveSession={actions.deleteLiveSession}
-          syncLiveAccount={actions.syncLiveAccount}
-          syncLiveOrder={actions.syncLiveOrder}
-          jumpToSignalRuntimeSession={actions.jumpToSignalRuntimeSession}
-          runLiveNextAction={actions.runLiveNextAction}
-          selectQuickLiveAccount={actions.selectQuickLiveAccount}
-          bindAccountSignalSource={actions.bindAccountSignalSource}
-          unbindAccountSignalSource={actions.unbindAccountSignalSource}
-          bindStrategySignalSource={actions.bindStrategySignalSource}
-          unbindStrategySignalSource={actions.unbindStrategySignalSource}
-          updateRuntimePolicy={actions.updateRuntimePolicy}
-          createSignalRuntimeSession={actions.createSignalRuntimeSession}
-          deleteSignalRuntimeSession={(id) => actions.deleteSignalRuntimeSession(id, null)}
-          runSignalRuntimeAction={actions.runSignalRuntimeAction}
-        />
-      )}
-    </div>
+  const recentAlerts = useMemo(
+    () => [...alerts].sort((left, right) => Date.parse(right.eventTime ?? "") - Date.parse(left.eventTime ?? "")).slice(0, 6),
+    [alerts]
   );
 
   const dockContent = (
@@ -199,6 +184,47 @@ export default function App() {
     </div>
   );
 
+  const mainStageContent = (
+    <div className="h-full relative overflow-hidden">
+      {sidebarTab === 'monitor' && (
+        <MonitorStage
+          syncLiveOrder={actions.syncLiveOrder}
+          dockTab={dockTab}
+          onDockTabChange={setDockTab}
+          dockContent={dockContent}
+        />
+      )}
+      {sidebarTab === 'strategy' && <StrategyStage createStrategy={actions.createStrategy} saveStrategyParameters={actions.saveStrategyParameters} />}
+      {sidebarTab === 'account' && (
+        <AccountStage 
+          logout={actions.logout}
+          openLiveAccountModal={actions.openLiveAccountModal}
+          openLiveBindingModal={() => actions.openLiveBindingModal(quickLiveAccountId)}
+          openLiveSessionModal={(s) => actions.openLiveSessionModal(s ?? null, quickLiveAccountId, strategies)}
+          openMonitorStage={() => setSidebarTab('monitor')}
+          launchLiveFlow={actions.launchLiveFlow}
+          stopLiveFlow={actions.stopLiveFlow}
+          runLiveSessionAction={actions.runLiveSessionAction}
+          dispatchLiveSessionIntent={actions.dispatchLiveSessionIntent}
+          syncLiveSession={actions.syncLiveSession}
+          deleteLiveSession={actions.deleteLiveSession}
+          syncLiveAccount={actions.syncLiveAccount}
+          jumpToSignalRuntimeSession={actions.jumpToSignalRuntimeSession}
+          runLiveNextAction={actions.runLiveNextAction}
+          selectQuickLiveAccount={actions.selectQuickLiveAccount}
+          bindAccountSignalSource={actions.bindAccountSignalSource}
+          unbindAccountSignalSource={actions.unbindAccountSignalSource}
+          bindStrategySignalSource={actions.bindStrategySignalSource}
+          unbindStrategySignalSource={actions.unbindStrategySignalSource}
+          updateRuntimePolicy={actions.updateRuntimePolicy}
+          createSignalRuntimeSession={actions.createSignalRuntimeSession}
+          deleteSignalRuntimeSession={(id) => actions.deleteSignalRuntimeSession(id, null)}
+          runSignalRuntimeAction={actions.runSignalRuntimeAction}
+        />
+      )}
+    </div>
+  );
+
   return (
     <>
       <WorkbenchLayout
@@ -217,15 +243,102 @@ export default function App() {
           </div>
         }
         headerConnection={
-          <div 
-            className={`flex items-center space-x-2 ${error ? 'cursor-pointer hover:bg-white/5 px-2 py-1 rounded transition-colors' : ''}`}
-            onClick={() => { if (error) actions.setError(null); }}
-            title={error || undefined}
-          >
-            <span className={!authSession?.token || error ? "w-2 h-2 rounded-full bg-rose-500" : "w-2 h-2 rounded-full bg-emerald-500"} />
-            <span className="text-zinc-400 text-xs truncate max-w-[200px]">
-              {!authSession?.token ? "需要登录" : error ? `连接异常: ${error}` : "运行正常"}
-            </span>
+          <div className="relative" ref={systemLogRef}>
+            <button
+              type="button"
+              className="flex items-center space-x-2 px-2 py-1 rounded transition-colors hover:bg-white/5"
+              onClick={() => setSystemLogOpen((current) => !current)}
+              title={error || "打开最近日志"}
+            >
+              <span className={!authSession?.token || error ? "w-2 h-2 rounded-full bg-rose-500" : "w-2 h-2 rounded-full bg-emerald-500"} />
+              <span className="text-zinc-400 text-xs truncate max-w-[220px]">
+                {!authSession?.token ? "需要登录" : error ? `连接异常` : "运行正常"}
+              </span>
+            </button>
+
+            {systemLogOpen && (
+              <div className="absolute right-0 top-full mt-2 w-[420px] max-w-[80vw] p-3 rounded-2xl border border-white/10 bg-zinc-950/90 backdrop-blur-2xl shadow-2xl z-50">
+                <div className="flex items-start justify-between gap-3 mb-3">
+                  <div>
+                    <p className="text-[10px] text-zinc-500 uppercase tracking-wider mb-1">System Logs</p>
+                    <p className="text-sm text-zinc-100 font-medium">最近状态与告警</p>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    {error ? (
+                      <button
+                        type="button"
+                        className="px-2 py-1 text-[11px] rounded-lg text-rose-300 hover:bg-rose-500/10 transition-colors"
+                        onClick={() => actions.setError(null)}
+                      >
+                        清除当前错误
+                      </button>
+                    ) : null}
+                    <button
+                      type="button"
+                      className="px-2 py-1 text-[11px] rounded-lg text-zinc-400 hover:bg-white/5 transition-colors"
+                      onClick={clearSystemLogs}
+                    >
+                      清空记录
+                    </button>
+                  </div>
+                </div>
+
+                <div className="space-y-2 max-h-[360px] overflow-y-auto pr-1">
+                  {error ? (
+                    <div className="rounded-xl border border-rose-500/20 bg-rose-500/10 px-3 py-2">
+                      <div className="text-[11px] text-rose-300 font-semibold">当前错误</div>
+                      <div className="text-xs text-zinc-200 mt-1">{error}</div>
+                    </div>
+                  ) : (
+                    <div className="rounded-xl border border-emerald-500/20 bg-emerald-500/10 px-3 py-2">
+                      <div className="text-[11px] text-emerald-300 font-semibold">当前状态</div>
+                      <div className="text-xs text-zinc-200 mt-1">运行正常</div>
+                    </div>
+                  )}
+
+                  {systemLogs.length > 0 ? (
+                    <div className="rounded-xl border border-white/5 bg-white/5 p-2">
+                      <div className="text-[11px] text-zinc-400 font-semibold px-1 pb-2">最近状态记录</div>
+                      <div className="space-y-2">
+                        {systemLogs.map((item) => (
+                          <div key={item.id} className="px-2 py-2 rounded-lg bg-black/10 border border-white/5">
+                            <div className="flex items-center justify-between gap-3">
+                              <span className={`text-[11px] font-semibold ${item.level === 'error' ? 'text-rose-300' : 'text-emerald-300'}`}>
+                                {item.level === 'error' ? '异常' : '恢复'}
+                              </span>
+                              <span className="text-[11px] text-zinc-500">{formatTime(item.createdAt)}</span>
+                            </div>
+                            <div className="text-xs text-zinc-200 mt-1">{item.message}</div>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  ) : null}
+
+                  <div className="rounded-xl border border-white/5 bg-white/5 p-2">
+                    <div className="text-[11px] text-zinc-400 font-semibold px-1 pb-2">最近告警</div>
+                    {recentAlerts.length > 0 ? (
+                      <div className="space-y-2">
+                        {recentAlerts.map((alert) => (
+                          <div key={alert.id} className="px-2 py-2 rounded-lg bg-black/10 border border-white/5">
+                            <div className="flex items-center justify-between gap-3">
+                              <span className={`text-[11px] font-semibold ${alert.level === 'critical' ? 'text-rose-300' : alert.level === 'warning' ? 'text-amber-300' : 'text-zinc-300'}`}>
+                                {alert.level === 'critical' ? '严重' : alert.level === 'warning' ? '警告' : '信息'}
+                              </span>
+                              <span className="text-[11px] text-zinc-500">{formatTime(alert.eventTime ?? "")}</span>
+                            </div>
+                            <div className="text-xs text-zinc-100 mt-1">{alert.title}</div>
+                            <div className="text-xs text-zinc-400 mt-1">{alert.detail}</div>
+                          </div>
+                        ))}
+                      </div>
+                    ) : (
+                      <div className="px-2 py-3 text-xs text-zinc-500">最近没有告警</div>
+                    )}
+                  </div>
+                </div>
+              </div>
+            )}
           </div>
         }
         headerActions={
@@ -254,6 +367,12 @@ export default function App() {
                     </div>
                   
                   <div className="space-y-1">
+                    <button
+                      className="w-full text-left px-3 py-2 text-xs text-emerald-300 hover:bg-emerald-500/10 rounded-lg transition-colors"
+                      onClick={() => { setSidebarTab('monitor'); setSettingsMenuOpen(false); }}
+                    >
+                      打开监控台
+                    </button>
                     <button
                       className="w-full text-left px-3 py-2 text-xs text-zinc-300 hover:bg-white/5 rounded-lg transition-colors"
                       onClick={() => { actions.openLiveAccountModal(); setSettingsMenuOpen(false); }}

--- a/web/console/src/App.tsx
+++ b/web/console/src/App.tsx
@@ -1,49 +1,49 @@
-import React, { useMemo, useRef, useState } from 'react';
-import { LogOut, ChevronDown } from 'lucide-react';
+/**
+ * 注意：这里是全局路由与容器编排层 (Root Orchestrator)。
+ * 请勿在此实现具体的 UI 片段或复杂的业务功能逻辑。
+ * 具体的 UI 功能应拆分到 src/components/layout/ 或 src/pages/ 中实现。
+ **/
+
+import React, { useMemo } from 'react';
 import { WorkbenchLayout } from './layouts/WorkbenchLayout';
 import { useUIStore } from './store/useUIStore';
 import { useTradingStore } from './store/useTradingStore';
 import { useDashboard } from './hooks/useDashboard';
 import { useTradingActions } from './hooks/useTradingActions';
 import { fetchJSON } from './utils/api';
-import { useClickOutside } from './hooks/useClickOutside';
 
-import { MetricCard } from './components/ui/MetricCard';
-import { ActionButton } from './components/ui/ActionButton';
-import { SimpleTable } from './components/ui/SimpleTable';
-import { StatusPill } from './components/ui/StatusPill';
+// Layout Components
+import { HeaderMetrics } from './components/layout/HeaderMetrics';
+import { SystemStatusMenu } from './components/layout/SystemStatusMenu';
+import { UserMenu } from './components/layout/UserMenu';
+import { DockContent } from './components/layout/DockContent';
+import { MainContent } from './components/layout/MainContent';
+
+// Modals
 import { LoginModal } from './modals/LoginModal';
 import { LiveAccountModal } from './modals/LiveAccountModal';
 import { LiveBindingModal } from './modals/LiveBindingModal';
 import { LiveSessionModal } from './modals/LiveSessionModal';
 import { TelegramModal } from './modals/TelegramModal';
+
+// Pages
 import { StrategySidePanel } from './pages/StrategySidePanel';
-import { MonitorStage } from './pages/MonitorStage';
-import { StrategyStage } from './pages/StrategyStage';
-import { AccountStage } from './pages/AccountStage';
-import { formatTime, formatMaybeNumber, shrink } from './utils/format';
-import { 
-  deriveHighlightedLiveSession, technicalStatusLabel 
-} from './utils/derivation';
 
 export default function App() {
   const { loadDashboard } = useDashboard();
   const actions = useTradingActions(loadDashboard);
 
-  // UI State
+  // UI State from Store
   const sidebarTab = useUIStore(s => s.sidebarTab);
   const setSidebarTab = useUIStore(s => s.setSidebarTab);
   const dockTab = useUIStore(s => s.dockTab);
   const setDockTab = useUIStore(s => s.setDockTab);
   const error = useUIStore(s => s.error);
-  const systemLogs = useUIStore(s => s.systemLogs);
-  const clearSystemLogs = useUIStore(s => s.clearSystemLogs);
   const authSession = useUIStore(s => s.authSession);
-  const settingsMenuOpen = useUIStore(s => s.settingsMenuOpen);
-  const setSettingsMenuOpen = useUIStore(s => s.setSettingsMenuOpen);
   const activeSettingsModal = useUIStore(s => s.activeSettingsModal);
   const setActiveSettingsModal = useUIStore(s => s.setActiveSettingsModal);
   
+  // Form States & Actions from Store
   const loginForm = useUIStore(s => s.loginForm);
   const loginAction = useUIStore(s => s.loginAction);
   const liveAccountForm = useUIStore(s => s.liveAccountForm);
@@ -64,166 +64,29 @@ export default function App() {
   const liveSessionLaunchAction = useUIStore(s => s.liveSessionLaunchAction);
   const liveSessionAction = useUIStore(s => s.liveSessionAction);
   const telegramAction = useUIStore(s => s.telegramAction);
-  const [systemLogOpen, setSystemLogOpen] = useState(false);
 
-  // Trading State
+  // Trading State from Store
   const accounts = useTradingStore(s => s.accounts);
   const liveSessions = useTradingStore(s => s.liveSessions);
-  const orders = useTradingStore(s => s.orders);
-  const fills = useTradingStore(s => s.fills);
-  const positions = useTradingStore(s => s.positions);
   const strategies = useTradingStore(s => s.strategies);
-  const signalRuntimeSessions = useTradingStore(s => s.signalRuntimeSessions);
-  const signalCatalog = useTradingStore(s => s.signalCatalog);
   const liveAdapters = useTradingStore(s => s.liveAdapters);
   const telegramConfig = useTradingStore(s => s.telegramConfig);
-  const alerts = useTradingStore(s => s.alerts);
   const editingLiveSessionId = useTradingStore(s => s.editingLiveSessionId);
 
-  const userMenuRef = useRef<HTMLDivElement>(null);
-  const systemLogRef = useRef<HTMLDivElement>(null);
-
-  // Close menus when clicking outside
-  useClickOutside(systemLogRef, () => {
-    if (systemLogOpen) setSystemLogOpen(false);
-  });
-  
-  useClickOutside(userMenuRef, () => {
-    if (settingsMenuOpen) setSettingsMenuOpen(false);
-  });
-
-  // Derived State
-  const highlightedLiveSession = useMemo(
-    () => deriveHighlightedLiveSession(liveSessions, orders, fills, positions),
-    [liveSessions, orders, fills, positions]
-  );
-  
-  const monitorMode = highlightedLiveSession?.session ? "LIVE" : "--";
+  // Quick Account Resolution
   const liveAccounts = accounts;
   const quickLiveAccountId = liveSessionForm.accountId || liveBindingForm.accountId || liveAccounts[0]?.id || "";
   const quickLiveAccount = useMemo(() => liveAccounts.find(a => a.id === quickLiveAccountId) || null, [liveAccounts, quickLiveAccountId]);
-
-  const strategyIds = useMemo(() => new Set(strategies.map((item) => item.id)), [strategies]);
+  const strategyIds = useMemo(() => new Set(strategies.map(s => s.id)), [strategies]);
   const validLiveSessions = useMemo(
-    () => liveSessions.filter((item) => strategyIds.has(item.strategyId)),
+    () => liveSessions.filter(s => strategyIds.has(s.strategyId)),
     [liveSessions, strategyIds]
   );
-
   const strategyOptions = useMemo(() => strategies.map(s => ({ value: s.id, label: s.name })), [strategies]);
-  const recentAlerts = useMemo(
-    () => [...alerts].sort((left, right) => Date.parse(right.eventTime ?? "") - Date.parse(left.eventTime ?? "")).slice(0, 6),
-    [alerts]
-  );
 
-  const dockContent = (
-    <div className="h-full relative overflow-hidden">
-      {dockTab === 'orders' && (
-        <SimpleTable
-          columns={["ID", "策略版本", "Symbol", "Side", "Type", "数量", "价格", "状态", "创建时间", "操作"]}
-          rows={orders.map((order) => [
-            shrink(order.id),
-            shrink(String(order.metadata?.strategyVersionId ?? order.metadata?.source ?? "--")),
-            order.symbol,
-            <StatusPill key={`${order.id}-side`} tone={order.side === "buy" ? "ready" : "neutral"}>{order.side}</StatusPill>,
-            order.type,
-            formatMaybeNumber(order.quantity),
-            formatMaybeNumber(order.price),
-            technicalStatusLabel(order.status),
-            formatTime(order.createdAt),
-            <div key={`${order.id}-actions`} className="inline-actions">
-              <ActionButton label="Sync" variant="ghost" onClick={() => actions.syncLiveOrder(order.id)} />
-            </div>,
-          ])}
-          emptyMessage="暂无订单"
-        />
-      )}
-      {dockTab === 'positions' && (
-        <SimpleTable
-          columns={["ID", "账户", "Symbol", "Side", "仓位大小", "开仓价", "标记价", "更新时间"]}
-          rows={positions.map((pos) => [
-            shrink(pos.id),
-            shrink(pos.accountId),
-            pos.symbol,
-            <StatusPill key={`${pos.id}-side`} tone={pos.side === "long" ? "ready" : "neutral"}>{pos.side}</StatusPill>,
-            formatMaybeNumber(pos.quantity),
-            formatMaybeNumber(pos.entryPrice),
-            formatMaybeNumber(pos.markPrice),
-            formatTime(pos.updatedAt),
-          ])}
-          emptyMessage="暂无持仓"
-        />
-      )}
-      {dockTab === 'fills' && (
-        <SimpleTable
-          columns={["ID", "订单ID", "成交量", "成交价", "费用", "时间"]}
-          rows={fills.map((fill) => [
-            shrink(fill.id),
-            shrink(fill.orderId),
-            formatMaybeNumber(fill.quantity),
-            formatMaybeNumber(fill.price),
-            formatMaybeNumber(fill.fee),
-            formatTime(fill.createdAt),
-          ])}
-          emptyMessage="暂无成交记录"
-        />
-      )}
-      {dockTab === 'alerts' && (
-        <SimpleTable
-          columns={["时间", "级别", "模块", "消息"]}
-          rows={alerts.map((alert) => [
-            formatTime(alert.eventTime ?? ""),
-            <StatusPill key={`${alert.id}-level`} tone={alert.level === "critical" ? "blocked" : alert.level === "warning" ? "watch" : "neutral"}>
-              {alert.level}
-            </StatusPill>,
-            alert.title,
-            alert.detail,
-          ])}
-          emptyMessage="暂无告警信息"
-        />
-      )}
-    </div>
-  );
-
-  const mainStageContent = (
-    <div className="h-full relative overflow-hidden">
-      {sidebarTab === 'monitor' && (
-        <MonitorStage
-          syncLiveOrder={actions.syncLiveOrder}
-          dockTab={dockTab}
-          onDockTabChange={setDockTab}
-          dockContent={dockContent}
-        />
-      )}
-      {sidebarTab === 'strategy' && <StrategyStage createStrategy={actions.createStrategy} saveStrategyParameters={actions.saveStrategyParameters} />}
-      {sidebarTab === 'account' && (
-        <AccountStage 
-          logout={actions.logout}
-          openLiveAccountModal={actions.openLiveAccountModal}
-          openLiveBindingModal={() => actions.openLiveBindingModal(quickLiveAccountId)}
-          openLiveSessionModal={(s) => actions.openLiveSessionModal(s ?? null, quickLiveAccountId, strategies)}
-          openMonitorStage={() => setSidebarTab('monitor')}
-          launchLiveFlow={actions.launchLiveFlow}
-          stopLiveFlow={actions.stopLiveFlow}
-          runLiveSessionAction={actions.runLiveSessionAction}
-          dispatchLiveSessionIntent={actions.dispatchLiveSessionIntent}
-          syncLiveSession={actions.syncLiveSession}
-          deleteLiveSession={actions.deleteLiveSession}
-          syncLiveAccount={actions.syncLiveAccount}
-          jumpToSignalRuntimeSession={actions.jumpToSignalRuntimeSession}
-          runLiveNextAction={actions.runLiveNextAction}
-          selectQuickLiveAccount={actions.selectQuickLiveAccount}
-          bindAccountSignalSource={actions.bindAccountSignalSource}
-          unbindAccountSignalSource={actions.unbindAccountSignalSource}
-          bindStrategySignalSource={actions.bindStrategySignalSource}
-          unbindStrategySignalSource={actions.unbindStrategySignalSource}
-          updateRuntimePolicy={actions.updateRuntimePolicy}
-          createSignalRuntimeSession={actions.createSignalRuntimeSession}
-          deleteSignalRuntimeSession={(id) => actions.deleteSignalRuntimeSession(id, null)}
-          runSignalRuntimeAction={actions.runSignalRuntimeAction}
-        />
-      )}
-    </div>
-  );
+  // Compose dynamic content
+  const dockContent = <DockContent dockTab={dockTab} actions={actions} />;
+  const mainStageContent = <MainContent actions={actions} dockContent={dockContent} strategies={strategies} quickLiveAccountId={quickLiveAccountId} />;
 
   return (
     <>
@@ -232,185 +95,15 @@ export default function App() {
         onSidebarTabChange={setSidebarTab}
         dockTab={dockTab}
         onDockTabChange={setDockTab}
-        headerMetrics={
-          <div className="flex space-x-2">
-            <MetricCard label="账户" value={monitorMode} />
-            <MetricCard label="策略" value={String(highlightedLiveSession?.session?.strategyId ?? "--")} />
-            <MetricCard label="实盘会话" value={String(validLiveSessions.length)} />
-            <MetricCard label="运行时会话" value={String(signalRuntimeSessions.length)} />
-            <MetricCard label="可用信号源" value={String(signalCatalog?.sources?.length ?? 0)} />
-            <MetricCard label="实盘状态" value={highlightedLiveSession?.health.status ?? "--"} tone={highlightedLiveSession?.health.status === "ready" ? "accent" : undefined} />
-          </div>
-        }
-        headerConnection={
-          <div className="relative" ref={systemLogRef}>
-            <button
-              type="button"
-              className="flex items-center space-x-2 px-2 py-1 rounded transition-colors hover:bg-white/5"
-              onClick={() => setSystemLogOpen((current) => !current)}
-              title={error || "打开最近日志"}
-            >
-              <span className={!authSession?.token || error ? "w-2 h-2 rounded-full bg-rose-500" : "w-2 h-2 rounded-full bg-emerald-500"} />
-              <span className="text-zinc-400 text-xs truncate max-w-[220px]">
-                {!authSession?.token ? "需要登录" : error ? `连接异常` : "运行正常"}
-              </span>
-            </button>
-
-            {systemLogOpen && (
-              <div className="absolute right-0 top-full mt-2 w-[420px] max-w-[80vw] p-3 rounded-2xl border border-white/10 bg-zinc-950/90 backdrop-blur-2xl shadow-2xl z-50">
-                <div className="flex items-start justify-between gap-3 mb-3">
-                  <div>
-                    <p className="text-[10px] text-zinc-500 uppercase tracking-wider mb-1">System Logs</p>
-                    <p className="text-sm text-zinc-100 font-medium">最近状态与告警</p>
-                  </div>
-                  <div className="flex items-center gap-2">
-                    {error ? (
-                      <button
-                        type="button"
-                        className="px-2 py-1 text-[11px] rounded-lg text-rose-300 hover:bg-rose-500/10 transition-colors"
-                        onClick={() => actions.setError(null)}
-                      >
-                        清除当前错误
-                      </button>
-                    ) : null}
-                    <button
-                      type="button"
-                      className="px-2 py-1 text-[11px] rounded-lg text-zinc-400 hover:bg-white/5 transition-colors"
-                      onClick={clearSystemLogs}
-                    >
-                      清空记录
-                    </button>
-                  </div>
-                </div>
-
-                <div className="space-y-2 max-h-[360px] overflow-y-auto pr-1">
-                  {error ? (
-                    <div className="rounded-xl border border-rose-500/20 bg-rose-500/10 px-3 py-2">
-                      <div className="text-[11px] text-rose-300 font-semibold">当前错误</div>
-                      <div className="text-xs text-zinc-200 mt-1">{error}</div>
-                    </div>
-                  ) : (
-                    <div className="rounded-xl border border-emerald-500/20 bg-emerald-500/10 px-3 py-2">
-                      <div className="text-[11px] text-emerald-300 font-semibold">当前状态</div>
-                      <div className="text-xs text-zinc-200 mt-1">运行正常</div>
-                    </div>
-                  )}
-
-                  {systemLogs.length > 0 ? (
-                    <div className="rounded-xl border border-white/5 bg-white/5 p-2">
-                      <div className="text-[11px] text-zinc-400 font-semibold px-1 pb-2">最近状态记录</div>
-                      <div className="space-y-2">
-                        {systemLogs.map((item) => (
-                          <div key={item.id} className="px-2 py-2 rounded-lg bg-black/10 border border-white/5">
-                            <div className="flex items-center justify-between gap-3">
-                              <span className={`text-[11px] font-semibold ${item.level === 'error' ? 'text-rose-300' : 'text-emerald-300'}`}>
-                                {item.level === 'error' ? '异常' : '恢复'}
-                              </span>
-                              <span className="text-[11px] text-zinc-500">{formatTime(item.createdAt)}</span>
-                            </div>
-                            <div className="text-xs text-zinc-200 mt-1">{item.message}</div>
-                          </div>
-                        ))}
-                      </div>
-                    </div>
-                  ) : null}
-
-                  <div className="rounded-xl border border-white/5 bg-white/5 p-2">
-                    <div className="text-[11px] text-zinc-400 font-semibold px-1 pb-2">最近告警</div>
-                    {recentAlerts.length > 0 ? (
-                      <div className="space-y-2">
-                        {recentAlerts.map((alert) => (
-                          <div key={alert.id} className="px-2 py-2 rounded-lg bg-black/10 border border-white/5">
-                            <div className="flex items-center justify-between gap-3">
-                              <span className={`text-[11px] font-semibold ${alert.level === 'critical' ? 'text-rose-300' : alert.level === 'warning' ? 'text-amber-300' : 'text-zinc-300'}`}>
-                                {alert.level === 'critical' ? '严重' : alert.level === 'warning' ? '警告' : '信息'}
-                              </span>
-                              <span className="text-[11px] text-zinc-500">{formatTime(alert.eventTime ?? "")}</span>
-                            </div>
-                            <div className="text-xs text-zinc-100 mt-1">{alert.title}</div>
-                            <div className="text-xs text-zinc-400 mt-1">{alert.detail}</div>
-                          </div>
-                        ))}
-                      </div>
-                    ) : (
-                      <div className="px-2 py-3 text-xs text-zinc-500">最近没有告警</div>
-                    )}
-                  </div>
-                </div>
-              </div>
-            )}
-          </div>
-        }
+        headerMetrics={<HeaderMetrics />}
+        headerConnection={<SystemStatusMenu setError={actions.setError} />}
         headerActions={
-          authSession ? (
-            <div className="relative" ref={userMenuRef}>
-              <button
-                type="button"
-                className="flex items-center space-x-2 px-3 py-1.5 rounded-xl hover:bg-white/10 transition-colors text-zinc-200"
-                onClick={() => setSettingsMenuOpen((current) => !current)}
-              >
-                <div className="w-6 h-6 rounded-lg bg-emerald-500/20 flex items-center justify-center text-emerald-400 font-bold uppercase text-[10px]">
-                  {authSession.username.slice(0, 2)}
-                </div>
-                <span className="text-sm font-medium">{authSession.username}</span>
-                <ChevronDown size={14} className={`text-zinc-500 transition-transform ${settingsMenuOpen ? 'rotate-180' : ''}`} />
-              </button>
-
-              {settingsMenuOpen && (
-                <div className="absolute right-0 top-full mt-2 w-56 p-2 rounded-2xl border border-white/10 bg-zinc-950/80 backdrop-blur-2xl shadow-2xl z-50">
-                    <div className="px-3 py-2 border-b border-white/5 mb-2">
-                      <p className="text-[10px] text-zinc-500 uppercase tracking-wider mb-1">身份与会话</p>
-                      <p className="text-xs text-zinc-200 font-medium truncate">{authSession.username}</p>
-                      <p className="text-[10px] text-zinc-500 mt-1 italic">
-                        {authSession.expiresAt ? `有效期至 ${formatTime(authSession.expiresAt)}` : "已登录"}
-                      </p>
-                    </div>
-                  
-                  <div className="space-y-1">
-                    <button
-                      className="w-full text-left px-3 py-2 text-xs text-emerald-300 hover:bg-emerald-500/10 rounded-lg transition-colors"
-                      onClick={() => { setSidebarTab('monitor'); setSettingsMenuOpen(false); }}
-                    >
-                      打开监控台
-                    </button>
-                    <button
-                      className="w-full text-left px-3 py-2 text-xs text-zinc-300 hover:bg-white/5 rounded-lg transition-colors"
-                      onClick={() => { actions.openLiveAccountModal(); setSettingsMenuOpen(false); }}
-                    >
-                      新建账户
-                    </button>
-                    <button
-                      className="w-full text-left px-3 py-2 text-xs text-zinc-300 hover:bg-white/5 rounded-lg transition-colors"
-                      onClick={() => { 
-                        actions.openLiveBindingModal(quickLiveAccountId); 
-                        setSettingsMenuOpen(false); 
-                      }}
-                    >
-                      绑定账户
-                    </button>
-                    <button
-                      className="w-full text-left px-3 py-2 text-xs text-zinc-300 hover:bg-white/5 rounded-lg transition-colors"
-                      onClick={() => { setActiveSettingsModal("telegram"); setSettingsMenuOpen(false); }}
-                    >
-                      Telegram 通知
-                    </button>
-                  </div>
-
-                  <div className="mt-2 pt-2 border-t border-white/5">
-                    <button
-                      className="w-full flex items-center px-3 py-2 text-xs text-rose-400 hover:bg-rose-500/10 rounded-lg transition-colors"
-                      onClick={() => { actions.logout(); setSettingsMenuOpen(false); }}
-                    >
-                      <LogOut size={14} className="mr-2" />
-                      退出登录
-                    </button>
-                  </div>
-                  </div>
-              )}
-            </div>
-          ) : (
-            <div className="text-zinc-500 text-xs">需要登录</div>
-          )
+          <UserMenu 
+            actions={actions} 
+            setSidebarTab={setSidebarTab} 
+            setActiveSettingsModal={setActiveSettingsModal} 
+            quickLiveAccountId={quickLiveAccountId} 
+          />
         }
         sidePanelContent={
           sidebarTab === 'strategy' ? (

--- a/web/console/src/components/layout/DockContent.tsx
+++ b/web/console/src/components/layout/DockContent.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { SimpleTable } from '../ui/SimpleTable';
+import { StatusPill } from '../ui/StatusPill';
+import { ActionButton } from '../ui/ActionButton';
+import { formatTime, formatMaybeNumber, shrink } from '../../utils/format';
+import { technicalStatusLabel } from '../../utils/derivation';
+import { useTradingStore } from '../../store/useTradingStore';
+
+interface DockContentProps {
+  dockTab: 'orders' | 'positions' | 'fills' | 'alerts';
+  actions: any;
+}
+
+export function DockContent({ dockTab, actions }: DockContentProps) {
+  const orders = useTradingStore(s => s.orders);
+  const fills = useTradingStore(s => s.fills);
+  const positions = useTradingStore(s => s.positions);
+  const alerts = useTradingStore(s => s.alerts);
+
+  return (
+    <div className="h-full relative overflow-hidden">
+      {dockTab === 'orders' && (
+        <SimpleTable
+          columns={["ID", "策略版本", "Symbol", "Side", "Type", "数量", "价格", "状态", "创建时间", "操作"]}
+          rows={orders.map((order) => [
+            shrink(order.id),
+            shrink(String(order.metadata?.strategyVersionId ?? order.metadata?.source ?? "--")),
+            order.symbol,
+            <StatusPill key={`${order.id}-side`} tone={order.side === "buy" ? "ready" : "neutral"}>{order.side}</StatusPill>,
+            order.type,
+            formatMaybeNumber(order.quantity),
+            formatMaybeNumber(order.price),
+            technicalStatusLabel(order.status),
+            formatTime(order.createdAt),
+            <div key={`${order.id}-actions`} className="inline-actions">
+              <ActionButton label="Sync" variant="ghost" onClick={() => actions.syncLiveOrder(order.id)} />
+            </div>,
+          ])}
+          emptyMessage="暂无订单"
+        />
+      )}
+      {dockTab === 'positions' && (
+        <SimpleTable
+          columns={["ID", "账户", "Symbol", "Side", "仓位大小", "开仓价", "标记价", "更新时间"]}
+          rows={positions.map((pos) => [
+            shrink(pos.id),
+            shrink(pos.accountId),
+            pos.symbol,
+            <StatusPill key={`${pos.id}-side`} tone={pos.side === "long" ? "ready" : "neutral"}>{pos.side}</StatusPill>,
+            formatMaybeNumber(pos.quantity),
+            formatMaybeNumber(pos.entryPrice),
+            formatMaybeNumber(pos.markPrice),
+            formatTime(pos.updatedAt),
+          ])}
+          emptyMessage="暂无持仓"
+        />
+      )}
+      {dockTab === 'fills' && (
+        <SimpleTable
+          columns={["ID", "订单ID", "成交量", "成交价", "费用", "时间"]}
+          rows={fills.map((fill) => [
+            shrink(fill.id),
+            shrink(fill.orderId),
+            formatMaybeNumber(fill.quantity),
+            formatMaybeNumber(fill.price),
+            formatMaybeNumber(fill.fee),
+            formatTime(fill.createdAt),
+          ])}
+          emptyMessage="暂无成交记录"
+        />
+      )}
+      {dockTab === 'alerts' && (
+        <SimpleTable
+          columns={["时间", "级别", "模块", "消息"]}
+          rows={alerts.map((alert) => [
+            formatTime(alert.eventTime ?? ""),
+            <StatusPill key={`${alert.id}-level`} tone={alert.level === "critical" ? "blocked" : alert.level === "warning" ? "watch" : "neutral"}>
+              {alert.level}
+            </StatusPill>,
+            alert.title,
+            alert.detail,
+          ])}
+          emptyMessage="暂无告警信息"
+        />
+      )}
+    </div>
+  );
+}

--- a/web/console/src/components/layout/HeaderMetrics.tsx
+++ b/web/console/src/components/layout/HeaderMetrics.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { MetricCard } from '../ui/MetricCard';
+import { useTradingStore } from '../../store/useTradingStore';
+import { useMemo } from 'react';
+import { deriveHighlightedLiveSession } from '../../utils/derivation';
+
+export function HeaderMetrics() {
+  const accounts = useTradingStore(s => s.accounts);
+  const liveSessions = useTradingStore(s => s.liveSessions);
+  const orders = useTradingStore(s => s.orders);
+  const fills = useTradingStore(s => s.fills);
+  const positions = useTradingStore(s => s.positions);
+  const strategies = useTradingStore(s => s.strategies);
+  const signalRuntimeSessions = useTradingStore(s => s.signalRuntimeSessions);
+  const signalCatalog = useTradingStore(s => s.signalCatalog);
+
+  const highlightedLiveSession = useMemo(
+    () => deriveHighlightedLiveSession(liveSessions, orders, fills, positions),
+    [liveSessions, orders, fills, positions]
+  );
+  
+  const strategyIds = useMemo(() => new Set(strategies.map((item) => item.id)), [strategies]);
+  const validLiveSessions = useMemo(
+    () => liveSessions.filter((item) => strategyIds.has(item.strategyId)),
+    [liveSessions, strategyIds]
+  );
+
+  const monitorMode = highlightedLiveSession?.session ? "LIVE" : "--";
+
+  return (
+    <div className="flex space-x-2">
+      <MetricCard label="账户" value={monitorMode} />
+      <MetricCard label="策略" value={String(highlightedLiveSession?.session?.strategyId ?? "--")} />
+      <MetricCard label="实盘会话" value={String(validLiveSessions.length)} />
+      <MetricCard label="运行时会话" value={String(signalRuntimeSessions.length)} />
+      <MetricCard label="可用信号源" value={String(signalCatalog?.sources?.length ?? 0)} />
+      <MetricCard label="实盘状态" value={highlightedLiveSession?.health.status ?? "--"} tone={highlightedLiveSession?.health.status === "ready" ? "accent" : undefined} />
+    </div>
+  );
+}

--- a/web/console/src/components/layout/MainContent.tsx
+++ b/web/console/src/components/layout/MainContent.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { MonitorStage } from '../../pages/MonitorStage';
+import { StrategyStage } from '../../pages/StrategyStage';
+import { AccountStage } from '../../pages/AccountStage';
+import { useUIStore } from '../../store/useUIStore';
+
+interface MainContentProps {
+  actions: any;
+  dockContent: React.ReactNode;
+  strategies: any[];
+  quickLiveAccountId: string;
+}
+
+export function MainContent({ actions, dockContent, strategies, quickLiveAccountId }: MainContentProps) {
+  const sidebarTab = useUIStore(s => s.sidebarTab);
+  const setSidebarTab = useUIStore(s => s.setSidebarTab);
+  const dockTab = useUIStore(s => s.dockTab);
+  const setDockTab = useUIStore(s => s.setDockTab);
+
+  return (
+    <div className="h-full relative overflow-hidden">
+      {sidebarTab === 'monitor' && (
+        <MonitorStage
+          syncLiveOrder={actions.syncLiveOrder}
+          dockTab={dockTab}
+          onDockTabChange={setDockTab}
+          dockContent={dockContent}
+        />
+      )}
+      {sidebarTab === 'strategy' && (
+        <StrategyStage 
+          createStrategy={actions.createStrategy} 
+          saveStrategyParameters={actions.saveStrategyParameters} 
+        />
+      )}
+      {sidebarTab === 'account' && (
+        <AccountStage 
+          logout={actions.logout}
+          openLiveAccountModal={actions.openLiveAccountModal}
+          openLiveBindingModal={() => actions.openLiveBindingModal(quickLiveAccountId)}
+          openLiveSessionModal={(s) => actions.openLiveSessionModal(s ?? null, quickLiveAccountId, strategies)}
+          openMonitorStage={() => setSidebarTab('monitor')}
+          launchLiveFlow={actions.launchLiveFlow}
+          stopLiveFlow={actions.stopLiveFlow}
+          runLiveSessionAction={actions.runLiveSessionAction}
+          dispatchLiveSessionIntent={actions.dispatchLiveSessionIntent}
+          syncLiveSession={actions.syncLiveSession}
+          deleteLiveSession={actions.deleteLiveSession}
+          syncLiveAccount={actions.syncLiveAccount}
+          jumpToSignalRuntimeSession={actions.jumpToSignalRuntimeSession}
+          runLiveNextAction={actions.runLiveNextAction}
+          selectQuickLiveAccount={actions.selectQuickLiveAccount}
+          bindAccountSignalSource={actions.bindAccountSignalSource}
+          unbindAccountSignalSource={actions.unbindAccountSignalSource}
+          bindStrategySignalSource={actions.bindStrategySignalSource}
+          unbindStrategySignalSource={actions.unbindStrategySignalSource}
+          updateRuntimePolicy={actions.updateRuntimePolicy}
+          createSignalRuntimeSession={actions.createSignalRuntimeSession}
+          deleteSignalRuntimeSession={(id) => actions.deleteSignalRuntimeSession(id, null)}
+          runSignalRuntimeAction={actions.runSignalRuntimeAction}
+        />
+      )}
+    </div>
+  );
+}

--- a/web/console/src/components/layout/SystemStatusMenu.tsx
+++ b/web/console/src/components/layout/SystemStatusMenu.tsx
@@ -1,0 +1,129 @@
+import React, { useState, useRef, useMemo } from 'react';
+import { useUIStore } from '../../store/useUIStore';
+import { useTradingStore } from '../../store/useTradingStore';
+import { useClickOutside } from '../../hooks/useClickOutside';
+import { formatTime } from '../../utils/format';
+
+interface SystemStatusMenuProps {
+  setError: (valOrUpdater: string | null | ((prev: string | null) => string | null)) => void;
+}
+
+export function SystemStatusMenu({ setError }: SystemStatusMenuProps) {
+  const [systemLogOpen, setSystemLogOpen] = useState(false);
+  const systemLogRef = useRef<HTMLDivElement>(null);
+  
+  const authSession = useUIStore(s => s.authSession);
+  const error = useUIStore(s => s.error);
+  const systemLogs = useUIStore(s => s.systemLogs);
+  const clearSystemLogs = useUIStore(s => s.clearSystemLogs);
+  const alerts = useTradingStore(s => s.alerts);
+
+  const recentAlerts = useMemo(
+    () => [...alerts].sort((left, right) => Date.parse(right.eventTime ?? "") - Date.parse(left.eventTime ?? "")).slice(0, 6),
+    [alerts]
+  );
+
+  useClickOutside(systemLogRef, () => {
+    if (systemLogOpen) setSystemLogOpen(false);
+  });
+
+  return (
+    <div className="relative" ref={systemLogRef}>
+      <button
+        type="button"
+        className="flex items-center space-x-2 px-2 py-1 rounded transition-colors hover:bg-white/5"
+        onClick={() => setSystemLogOpen((current) => !current)}
+        title={error || "打开最近日志"}
+      >
+        <span className={!authSession?.token || error ? "w-2 h-2 rounded-full bg-rose-500" : "w-2 h-2 rounded-full bg-emerald-500"} />
+        <span className="text-zinc-400 text-xs truncate max-w-[220px]">
+          {!authSession?.token ? "需要登录" : error ? `连接异常` : "运行正常"}
+        </span>
+      </button>
+
+      {systemLogOpen && (
+        <div className="absolute right-0 top-full mt-2 w-[420px] max-w-[80vw] p-3 rounded-2xl border border-white/10 bg-zinc-950/90 backdrop-blur-2xl shadow-2xl z-50">
+          <div className="flex items-start justify-between gap-3 mb-3">
+            <div>
+              <p className="text-[10px] text-zinc-500 uppercase tracking-wider mb-1">System Logs</p>
+              <p className="text-sm text-zinc-100 font-medium">最近状态与告警</p>
+            </div>
+            <div className="flex items-center gap-2">
+              {error ? (
+                <button
+                  type="button"
+                  className="px-2 py-1 text-[11px] rounded-lg text-rose-300 hover:bg-rose-500/10 transition-colors"
+                  onClick={() => setError(null)}
+                >
+                  清除当前错误
+                </button>
+              ) : null}
+              <button
+                type="button"
+                className="px-2 py-1 text-[11px] rounded-lg text-zinc-400 hover:bg-white/5 transition-colors"
+                onClick={clearSystemLogs}
+              >
+                清空记录
+              </button>
+            </div>
+          </div>
+
+          <div className="space-y-2 max-h-[360px] overflow-y-auto pr-1">
+            {error ? (
+              <div className="rounded-xl border border-rose-500/20 bg-rose-500/10 px-3 py-2">
+                <div className="text-[11px] text-rose-300 font-semibold">当前错误</div>
+                <div className="text-xs text-zinc-200 mt-1">{error}</div>
+              </div>
+            ) : (
+              <div className="rounded-xl border border-emerald-500/20 bg-emerald-500/10 px-3 py-2">
+                <div className="text-[11px] text-emerald-300 font-semibold">当前状态</div>
+                <div className="text-xs text-zinc-200 mt-1">运行正常</div>
+              </div>
+            )}
+
+            {systemLogs.length > 0 ? (
+              <div className="rounded-xl border border-white/5 bg-white/5 p-2">
+                <div className="text-[11px] text-zinc-400 font-semibold px-1 pb-2">最近状态记录</div>
+                <div className="space-y-2">
+                  {systemLogs.map((item) => (
+                    <div key={item.id} className="px-2 py-2 rounded-lg bg-black/10 border border-white/5">
+                      <div className="flex items-center justify-between gap-3">
+                        <span className={`text-[11px] font-semibold ${item.level === 'error' ? 'text-rose-300' : 'text-emerald-300'}`}>
+                          {item.level === 'error' ? '异常' : '恢复'}
+                        </span>
+                        <span className="text-[11px] text-zinc-500">{formatTime(item.createdAt)}</span>
+                      </div>
+                      <div className="text-xs text-zinc-200 mt-1">{item.message}</div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ) : null}
+
+            <div className="rounded-xl border border-white/5 bg-white/5 p-2">
+              <div className="text-[11px] text-zinc-400 font-semibold px-1 pb-2">最近告警</div>
+              {recentAlerts.length > 0 ? (
+                <div className="space-y-2">
+                  {recentAlerts.map((alert) => (
+                    <div key={alert.id} className="px-2 py-2 rounded-lg bg-black/10 border border-white/5">
+                      <div className="flex items-center justify-between gap-3">
+                        <span className={`text-[11px] font-semibold ${alert.level === 'critical' ? 'text-rose-300' : alert.level === 'warning' ? 'text-amber-300' : 'text-zinc-300'}`}>
+                          {alert.level === 'critical' ? '严重' : alert.level === 'warning' ? '警告' : '信息'}
+                        </span>
+                        <span className="text-[11px] text-zinc-500">{formatTime(alert.eventTime ?? "")}</span>
+                      </div>
+                      <div className="text-xs text-zinc-100 mt-1">{alert.title}</div>
+                      <div className="text-xs text-zinc-400 mt-1">{alert.detail}</div>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <div className="px-2 py-3 text-xs text-zinc-500">最近没有告警</div>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/console/src/components/layout/UserMenu.tsx
+++ b/web/console/src/components/layout/UserMenu.tsx
@@ -1,0 +1,95 @@
+import React, { useRef } from 'react';
+import { LogOut, ChevronDown } from 'lucide-react';
+import { useUIStore } from '../../store/useUIStore';
+import { useClickOutside } from '../../hooks/useClickOutside';
+import { formatTime } from '../../utils/format';
+
+interface UserMenuProps {
+  actions: any;
+  setSidebarTab: (tab: 'monitor' | 'strategy' | 'account') => void;
+  setActiveSettingsModal: (modal: "telegram" | "live-account" | "live-binding" | "live-session" | null) => void;
+  quickLiveAccountId: string;
+}
+
+export function UserMenu({ actions, setSidebarTab, setActiveSettingsModal, quickLiveAccountId }: UserMenuProps) {
+  const authSession = useUIStore(s => s.authSession);
+  const settingsMenuOpen = useUIStore(s => s.settingsMenuOpen);
+  const setSettingsMenuOpen = useUIStore(s => s.setSettingsMenuOpen);
+  const userMenuRef = useRef<HTMLDivElement>(null);
+
+  useClickOutside(userMenuRef, () => {
+    if (settingsMenuOpen) setSettingsMenuOpen(false);
+  });
+
+  if (!authSession) {
+    return <div className="text-zinc-500 text-xs">需要登录</div>;
+  }
+
+  return (
+    <div className="relative" ref={userMenuRef}>
+      <button
+        type="button"
+        className="flex items-center space-x-2 px-3 py-1.5 rounded-xl hover:bg-white/10 transition-colors text-zinc-200"
+        onClick={() => setSettingsMenuOpen(!settingsMenuOpen)}
+      >
+        <div className="w-6 h-6 rounded-lg bg-emerald-500/20 flex items-center justify-center text-emerald-400 font-bold uppercase text-[10px]">
+          {authSession.username.slice(0, 2)}
+        </div>
+        <span className="text-sm font-medium">{authSession.username}</span>
+        <ChevronDown size={14} className={`text-zinc-500 transition-transform ${settingsMenuOpen ? 'rotate-180' : ''}`} />
+      </button>
+
+      {settingsMenuOpen && (
+        <div className="absolute right-0 top-full mt-2 w-56 p-2 rounded-2xl border border-white/10 bg-zinc-950/80 backdrop-blur-2xl shadow-2xl z-50">
+          <div className="px-3 py-2 border-b border-white/5 mb-2">
+            <p className="text-[10px] text-zinc-500 uppercase tracking-wider mb-1">身份与会话</p>
+            <p className="text-xs text-zinc-200 font-medium truncate">{authSession.username}</p>
+            <p className="text-[10px] text-zinc-500 mt-1 italic">
+              {authSession.expiresAt ? `有效期至 ${formatTime(authSession.expiresAt)}` : "已登录"}
+            </p>
+          </div>
+          
+          <div className="space-y-1">
+            <button
+              className="w-full text-left px-3 py-2 text-xs text-emerald-300 hover:bg-emerald-500/10 rounded-lg transition-colors"
+              onClick={() => { setSidebarTab('monitor'); setSettingsMenuOpen(false); }}
+            >
+              打开监控台
+            </button>
+            <button
+              className="w-full text-left px-3 py-2 text-xs text-zinc-300 hover:bg-white/5 rounded-lg transition-colors"
+              onClick={() => { actions.openLiveAccountModal(); setSettingsMenuOpen(false); }}
+            >
+              新建账户
+            </button>
+            <button
+              className="w-full text-left px-3 py-2 text-xs text-zinc-300 hover:bg-white/5 rounded-lg transition-colors"
+              onClick={() => { 
+                actions.openLiveBindingModal(quickLiveAccountId); 
+                setSettingsMenuOpen(false); 
+              }}
+            >
+              绑定账户
+            </button>
+            <button
+              className="w-full text-left px-3 py-2 text-xs text-zinc-300 hover:bg-white/5 rounded-lg transition-colors"
+              onClick={() => { setActiveSettingsModal("telegram"); setSettingsMenuOpen(false); }}
+            >
+              Telegram 通知
+            </button>
+          </div>
+
+          <div className="mt-2 pt-2 border-t border-white/5">
+            <button
+              className="w-full flex items-center px-3 py-2 text-xs text-rose-400 hover:bg-rose-500/10 rounded-lg transition-colors"
+              onClick={() => { actions.logout(); setSettingsMenuOpen(false); }}
+            >
+              <LogOut size={14} className="mr-2" />
+              退出登录
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/console/src/components/ui/ActionButton.tsx
+++ b/web/console/src/components/ui/ActionButton.tsx
@@ -1,13 +1,13 @@
 export function ActionButton(props: {
   label: string;
   disabled?: boolean;
-  variant?: "ghost";
+  variant?: "ghost" | "danger";
   onClick: () => void;
 }) {
   return (
     <button
       type="button"
-      className={`action-button ${props.variant === "ghost" ? "action-button-ghost" : ""}`}
+      className={`action-button ${props.variant === "ghost" ? "action-button-ghost" : ""} ${props.variant === "danger" ? "action-button-danger" : ""}`}
       disabled={props.disabled}
       onClick={props.onClick}
     >

--- a/web/console/src/hooks/useClickOutside.ts
+++ b/web/console/src/hooks/useClickOutside.ts
@@ -1,0 +1,34 @@
+import { useEffect, RefObject } from 'react';
+
+/**
+ * Hook that alerts clicks outside of the passed ref(s)
+ */
+export function useClickOutside(
+  refs: RefObject<HTMLElement | null> | RefObject<HTMLElement | null>[],
+  handler: () => void
+) {
+  useEffect(() => {
+    const listener = (event: MouseEvent | TouchEvent) => {
+      const target = event.target as Node;
+      
+      const refsArray = Array.isArray(refs) ? refs : [refs];
+      
+      // Check if the click was inside any of the provided refs
+      const isInside = refsArray.some(ref => ref.current && ref.current.contains(target));
+      
+      if (isInside) {
+        return;
+      }
+
+      handler();
+    };
+
+    document.addEventListener('mousedown', listener);
+    document.addEventListener('touchstart', listener);
+
+    return () => {
+      document.removeEventListener('mousedown', listener);
+      document.removeEventListener('touchstart', listener);
+    };
+  }, [refs, handler]);
+}

--- a/web/console/src/layouts/WorkbenchLayout.tsx
+++ b/web/console/src/layouts/WorkbenchLayout.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Activity, Briefcase, Settings, Bell, ListOrdered, Wallet, CreditCard } from 'lucide-react';
+import { Activity, Briefcase, Settings } from 'lucide-react';
 
 export interface WorkbenchLayoutProps {
   sidebarTab: 'monitor' | 'strategy' | 'account';
@@ -70,9 +70,9 @@ export function WorkbenchLayout({
         </header>
 
         {/* Middle Area: Main Stage + Right Side Panel */}
-        <div className={`flex flex-row w-full min-h-0 relative ${sidebarTab !== 'monitor' ? 'flex-1' : ''}`}>
+        <div className="flex flex-row w-full min-h-0 relative flex-1">
           {/* Main Stage (Charts, etc.) */}
-          <main className="flex-1 relative overflow-hidden bg-zinc-950/50">
+          <main className="flex-1 min-h-0 relative overflow-hidden bg-zinc-950/50">
             {mainStageContent}
           </main>
           
@@ -84,40 +84,6 @@ export function WorkbenchLayout({
           )}
         </div>
 
-        {/* Bottom Dock (Tabs + Content) */}
-        {sidebarTab === 'monitor' && (
-          <section className="flex-1 border-t border-white/5 bg-zinc-900/60 backdrop-blur-xl flex flex-col min-h-0">
-            <div className="h-10 flex items-center px-4 border-b border-white/5 space-x-6 text-xs text-zinc-500">
-              <DockTab 
-                icon={<ListOrdered size={14} />} 
-                label="全部订单" 
-                active={dockTab === 'orders'} 
-                onClick={() => onDockTabChange('orders')} 
-              />
-              <DockTab 
-                icon={<Wallet size={14} />} 
-                label="持仓" 
-                active={dockTab === 'positions'} 
-                onClick={() => onDockTabChange('positions')} 
-              />
-              <DockTab 
-                icon={<CreditCard size={14} />} 
-                label="成交明细" 
-                active={dockTab === 'fills'} 
-                onClick={() => onDockTabChange('fills')} 
-              />
-              <DockTab 
-                icon={<Bell size={14} />} 
-                label="异常告警" 
-                active={dockTab === 'alerts'} 
-                onClick={() => onDockTabChange('alerts')} 
-              />
-            </div>
-            <div className="flex-1 overflow-y-auto p-2">
-              {dockContent}
-            </div>
-          </section>
-        )}
       </div>
     </div>
   );
@@ -138,22 +104,6 @@ function SidebarItem({ icon, label, active, onClick }: { icon: React.ReactNode, 
       <div className="absolute left-14 px-3 py-1.5 bg-zinc-800 text-zinc-200 text-xs rounded-lg shadow-xl opacity-0 pointer-events-none group-hover:opacity-100 transition-opacity whitespace-nowrap z-50 border border-white/10">
         {label}
       </div>
-    </button>
-  );
-}
-
-function DockTab({ icon, label, active, onClick }: { icon: React.ReactNode, label: string, active: boolean, onClick: () => void }) {
-  return (
-    <button 
-      className={`flex items-center space-x-1.5 h-full border-b-2 transition-colors ${
-        active 
-          ? 'border-emerald-400 text-zinc-200' 
-          : 'border-transparent hover:text-zinc-300'
-      }`}
-      onClick={onClick}
-    >
-      {icon}
-      <span>{label}</span>
     </button>
   );
 }

--- a/web/console/src/pages/AccountStage.tsx
+++ b/web/console/src/pages/AccountStage.tsx
@@ -12,7 +12,6 @@ import {
   strategyLabel, 
   deriveLiveSessionExecutionSummary, 
   deriveLiveSessionHealth, 
-  deriveLiveSessionFlow,
   deriveLiveNextAction,
   deriveHighlightedLiveSession,
   deriveRuntimeMarketSnapshot,
@@ -45,13 +44,14 @@ interface AccountStageProps {
   openLiveAccountModal: () => void;
   openLiveBindingModal: () => void;
   openLiveSessionModal: (session?: LiveSession | null) => void;
+  openMonitorStage: () => void;
   launchLiveFlow: (account: AccountRecord) => void;
+  stopLiveFlow: (accountId: string) => void;
   runLiveSessionAction: (id: string, action: "start" | "stop") => void;
   dispatchLiveSessionIntent: (id: string) => void;
   syncLiveSession: (id: string) => void;
   deleteLiveSession: (id: string) => Promise<void>;
   syncLiveAccount: (id: string) => void;
-  syncLiveOrder: (id: string) => void;
   jumpToSignalRuntimeSession: (id: string) => void;
   runLiveNextAction: (account: AccountRecord, nextAction: LiveNextAction, runtime: SignalRuntimeSession | null) => void;
   selectQuickLiveAccount: (id: string) => void;
@@ -65,18 +65,42 @@ interface AccountStageProps {
   runSignalRuntimeAction: (id: string, action: "start" | "stop") => void;
 }
 
+function statusLabelZh(status: string): string {
+  switch (String(status).trim().toLowerCase()) {
+    case "ready":
+      return "就绪";
+    case "watch":
+      return "关注";
+    case "warning":
+      return "预警";
+    case "blocked":
+      return "阻塞";
+    case "neutral":
+      return "未激活";
+    case "active":
+      return "运行中";
+    case "error":
+      return "异常";
+    case "idle":
+      return "空闲";
+    default:
+      return status || "--";
+  }
+}
+
 export function AccountStage({
   logout,
   openLiveAccountModal,
   openLiveBindingModal,
   openLiveSessionModal,
+  openMonitorStage,
   launchLiveFlow,
+  stopLiveFlow,
   runLiveSessionAction,
   dispatchLiveSessionIntent,
   syncLiveSession,
   deleteLiveSession,
   syncLiveAccount,
-  syncLiveOrder,
   jumpToSignalRuntimeSession,
   runLiveNextAction,
   selectQuickLiveAccount,
@@ -106,7 +130,6 @@ export function AccountStage({
   const liveSessionAction = useUIStore(s => s.liveSessionAction);
   const liveSessionDeleteAction = useUIStore(s => s.liveSessionDeleteAction);
   const liveAccountSyncAction = useUIStore(s => s.liveAccountSyncAction);
-  const liveSyncAction = useUIStore(s => s.liveSyncAction);
   const liveFlowAction = useUIStore(s => s.liveFlowAction);
   const liveBindAction = useUIStore(s => s.liveBindAction);
   const signalBindingAction = useUIStore(s => s.signalBindingAction);
@@ -140,26 +163,6 @@ export function AccountStage({
     [liveSessions, orders, fills, positions]
   );
 
-  const highlightedLiveRuntime =
-    highlightedLiveSession?.session
-      ? signalRuntimeSessions.find((item) => item.id === String(highlightedLiveSession.session.state?.signalRuntimeSessionId ?? "")) ??
-        signalRuntimeSessions.find(
-          (item) =>
-            item.accountId === highlightedLiveSession.session.accountId &&
-            item.strategyId === highlightedLiveSession.session.strategyId
-        ) ??
-        null
-      : null;
-
-  const highlightedLiveSessionFlow = useMemo(
-    () =>
-      highlightedLiveSession
-        ? deriveLiveSessionFlow(highlightedLiveSession.session, highlightedLiveSession.execution)
-        : [],
-    [highlightedLiveSession]
-  );
-
-  const monitorMode = highlightedLiveSession?.session ? "LIVE" : "--";
   const strategyIds = useMemo(() => new Set(strategies.map((item) => item.id)), [strategies]);
   const validLiveSessions = useMemo(
     () => liveSessions.filter((item) => strategyIds.has(item.strategyId)),
@@ -167,12 +170,21 @@ export function AccountStage({
   );
 
   const primaryLiveSession = highlightedLiveSession?.session ?? null;
-  const primaryLiveRuntimeState = getRecord(highlightedLiveRuntime?.state);
-  const primaryLiveRuntimeSummary = getRecord(primaryLiveRuntimeState.lastEventSummary);
-  const primaryLiveSessionMarket = deriveRuntimeMarketSnapshot(
-    getRecord(primaryLiveRuntimeState.sourceStates),
-    primaryLiveRuntimeSummary
-  );
+  const primaryLiveSessionIntent = getRecord(primaryLiveSession?.state?.lastStrategyIntent);
+  const primaryLiveAccount = primaryLiveSession ? liveAccounts.find(a => a.id === primaryLiveSession.accountId) || null : null;
+  const primaryLiveBindings = primaryLiveSession ? accountSignalBindingMap[primaryLiveSession.accountId] || [] : [];
+  const primaryLiveRuntimeSessions = primaryLiveSession ? signalRuntimeSessions.filter(s => s.accountId === primaryLiveSession.accountId) : [];
+  const primaryLiveRuntime =
+    primaryLiveSession
+      ? signalRuntimeSessions.find((item) => item.id === String(primaryLiveSession.state?.signalRuntimeSessionId ?? "")) ??
+        signalRuntimeSessions.find(
+          (item) =>
+            item.accountId === primaryLiveSession.accountId &&
+            item.strategyId === primaryLiveSession.strategyId
+        ) ??
+        null
+      : null;
+  const primaryLiveRuntimeState = getRecord(primaryLiveRuntime?.state);
   const primaryLiveSessionRuntimeReadiness = deriveRuntimeReadiness(
     primaryLiveRuntimeState,
     deriveRuntimeSourceSummary(getRecord(primaryLiveRuntimeState.sourceStates), runtimePolicy),
@@ -181,21 +193,12 @@ export function AccountStage({
       requireOrderBook: false
     }
   );
-  const primaryLiveSessionIntent = getRecord(primaryLiveSession?.state?.lastStrategyIntent);
-  const primaryLiveSessionSignalBarDecision = getRecord(primaryLiveSession?.state?.lastStrategyEvaluationSignalBarDecision);
-  const primaryLiveExecutionSummary = highlightedLiveSession?.execution ?? deriveLiveSessionExecutionSummary(null, orders, fills, positions);
-  const primaryLiveSessionTimeline = getList(primaryLiveSession?.state?.timeline);
-  
-  const primaryLiveAccount = primaryLiveSession ? liveAccounts.find(a => a.id === primaryLiveSession.accountId) || null : null;
-  const primaryLiveBindings = primaryLiveSession ? accountSignalBindingMap[primaryLiveSession.accountId] || [] : [];
-  const primaryLiveRuntimeSessions = primaryLiveSession ? signalRuntimeSessions.filter(s => s.accountId === primaryLiveSession.accountId) : [];
-  
   const primaryLiveDispatchPreview = deriveLiveDispatchPreview(
     primaryLiveSession,
     primaryLiveAccount,
     primaryLiveBindings,
     primaryLiveRuntimeSessions,
-    highlightedLiveRuntime,
+    primaryLiveRuntime,
     primaryLiveSessionRuntimeReadiness,
     primaryLiveSessionIntent
   );
@@ -219,59 +222,7 @@ export function AccountStage({
   const selectedSignalRuntimeSubscriptions = Array.isArray(selectedSignalRuntimeState.subscriptions)
     ? (selectedSignalRuntimeState.subscriptions as Array<Record<string, unknown>>)
     : [];
-  const [expandedLiveSection, setExpandedLiveSection] = useState<string>("执行与分发");
   const [expandedAccountId, setExpandedAccountId] = useState<string | null>(null);
-
-  const primaryLiveSummaryItems = primaryLiveSession ? [
-    { label: "运行环境", value: `${String(primaryLiveSession.state?.signalRuntimeStatus ?? "--")} · ${formatTime(String(primaryLiveSession.state?.lastSignalRuntimeEventAt ?? ""))}` },
-    { label: "就绪预检", value: `${primaryLiveSessionRuntimeReadiness.status} · ${primaryLiveSessionRuntimeReadiness.reason}` },
-    { label: "信号意图", value: `${String(primaryLiveSessionIntent.action ?? "无")} · ${String(primaryLiveSessionIntent.side ?? "--")} · ${formatMaybeNumber(primaryLiveSessionIntent.priceHint)}` },
-    { label: "指令分发", value: `${String(primaryLiveSession?.state?.dispatchMode ?? "--")} · 冷却 ${String(primaryLiveSession?.state?.dispatchCooldownSeconds ?? "--")}s` },
-    { label: "恢复状态", value: `${String(primaryLiveSession?.state?.positionRecoveryStatus ?? "--")} / ${String(primaryLiveSession?.state?.protectionRecoveryStatus ?? "--")}` },
-    { label: "执行汇总", value: `订单 ${primaryLiveExecutionSummary.orderCount} · 成交 ${primaryLiveExecutionSummary.fillCount} · ${String(primaryLiveExecutionSummary.latestOrder?.status ?? "--")}` },
-  ] : [];
-
-  const primaryLiveSections = primaryLiveSession ? [
-    {
-      title: "运行与行情",
-      items: [
-        { label: "行情数据", value: `${formatMaybeNumber(primaryLiveSessionMarket.tradePrice)} · ${formatMaybeNumber(primaryLiveSessionMarket.bestBid)} / ${formatMaybeNumber(primaryLiveSessionMarket.bestAsk)}` },
-        { label: "数据同步", value: `${String(primaryLiveSession?.state?.lastSyncedOrderStatus ?? "--")} · ${formatTime(String(primaryLiveSession?.state?.lastSyncedAt ?? ""))} · 错误 ${String(primaryLiveSession?.state?.lastSyncError ?? "--")}` },
-        { label: "自动分发", value: `最后触发 ${formatTime(String(primaryLiveSession?.state?.lastDispatchedAt ?? ""))} · 最后错误 ${String(primaryLiveSession?.state?.lastAutoDispatchError ?? "--")}` },
-        { label: "时间线", value: buildTimelineNotes(primaryLiveSessionTimeline).slice(0, 2).join(" · ") || "--" },
-      ],
-    },
-    {
-      title: "信号与意图",
-      items: [
-        { label: "意图预览", value: `数量 ${formatMaybeNumber(primaryLiveSessionIntent.quantity)} · 报价源 ${String(primaryLiveSessionIntent.priceSource ?? "--")} · 信号种类 ${String(primaryLiveSessionIntent.signalKind ?? "--")}` },
-        { label: "意图上下文", value: `价差 ${formatMaybeNumber(primaryLiveSessionIntent.spreadBps)} bps · 偏置 ${String(primaryLiveSessionIntent.liquidityBias ?? "--")} · ma20 ${formatMaybeNumber(primaryLiveSessionIntent.ma20)} · atr14 ${formatMaybeNumber(primaryLiveSessionIntent.atr14)}` },
-        { label: "信号过滤", value: `周期 ${String(primaryLiveSessionSignalBarDecision.timeframe ?? "--")} · sma5 ${formatMaybeNumber(primaryLiveSessionSignalBarDecision.sma5)} · 多头 ${boolLabel(primaryLiveSessionSignalBarDecision.longEarlyReversalReady)} · 空头 ${boolLabel(primaryLiveSessionSignalBarDecision.shortEarlyReversalReady)}` },
-        { label: "信号备注", value: String(primaryLiveSessionSignalBarDecision.reason ?? "--") },
-      ],
-    },
-    {
-      title: "执行与分发",
-      items: [
-        { label: "执行配置", value: `${String(getRecord(primaryLiveSession?.state?.lastExecutionProfile).executionProfile ?? "--")} · ${String(getRecord(primaryLiveSession?.state?.lastExecutionProfile).orderType ?? "--")} · TIF ${String(getRecord(primaryLiveSession?.state?.lastExecutionProfile).timeInForce ?? "--")} · 只减仓 ${boolLabel(getRecord(primaryLiveSession?.state?.lastExecutionProfile).reduceOnly)}` },
-        { label: "执行遥测", value: `${String(getRecord(primaryLiveSession?.state?.lastExecutionTelemetry).decision ?? "--")} · 价差 ${formatMaybeNumber(getRecord(getRecord(primaryLiveSession?.state?.lastExecutionTelemetry).book).spreadBps)} bps · 盘口不平衡 ${formatMaybeNumber(getRecord(getRecord(primaryLiveSession?.state?.lastExecutionTelemetry).book).bookImbalance)}` },
-        { label: "分发状态", value: `${String(getRecord(primaryLiveSession?.state?.lastExecutionDispatch).status ?? "--")} · ${String(getRecord(primaryLiveSession?.state?.lastExecutionDispatch).executionMode ?? "--")} · 备选方案 ${boolLabel(getRecord(primaryLiveSession?.state?.lastExecutionDispatch).fallback)}` },
-        { label: "成交分析", value: `预期价格 ${formatMaybeNumber(getRecord(primaryLiveSession?.state?.lastExecutionDispatch).expectedPrice)} · 滑点偏移 ${formatMaybeNumber(getRecord(primaryLiveSession?.state?.lastExecutionDispatch).priceDriftBps)} bps` },
-        { label: "执行统计", value: `方案数 ${String(getRecord(primaryLiveSession?.state?.executionEventStats).proposalCount ?? "--")} · Maker ${String(getRecord(primaryLiveSession?.state?.executionEventStats).makerRestingDecisionCount ?? "--")} · 备选 ${String(getRecord(primaryLiveSession?.state?.executionEventStats).fallbackDispatchCount ?? "--")} · 平均偏移 ${formatMaybeNumber(getRecord(primaryLiveSession?.state?.executionEventStats).avgPriceDriftBps)} bps` },
-        { label: "分发预览", value: `${primaryLiveDispatchPreview.reason} · ${primaryLiveDispatchPreview.detail}` },
-        { label: "最终指令", value: `${String(primaryLiveDispatchPreview.payload.side ?? "--")} ${formatMaybeNumber(primaryLiveDispatchPreview.payload.quantity)} ${String(primaryLiveDispatchPreview.payload.symbol ?? "--")} · ${String(primaryLiveDispatchPreview.payload.type ?? "--")} @ ${formatMaybeNumber(primaryLiveDispatchPreview.payload.price)}` },
-      ],
-    },
-    {
-      title: "恢复与仓位",
-      items: [
-        { label: "恢复详情", value: `${String(primaryLiveSession?.state?.lastRecoveryStatus ?? "--")} · 仓位恢复 ${String(primaryLiveSession?.state?.positionRecoveryStatus ?? "--")} · 保护恢复 ${String(primaryLiveSession?.state?.protectionRecoveryStatus ?? "--")}` },
-        { label: "恢复统计", value: `最后尝试 ${formatTime(String(primaryLiveSession?.state?.lastRecoveryAttemptAt ?? primaryLiveSession?.state?.lastProtectionRecoveryAt ?? ""))} · 保护订单 ${String(primaryLiveSession?.state?.recoveredProtectionCount ?? "--")} · 止损 ${String(primaryLiveSession?.state?.recoveredStopOrderCount ?? "--")} · 止盈 ${String(primaryLiveSession?.state?.recoveredTakeProfitOrderCount ?? "--")}` },
-        { label: "策略持仓", value: `${String(primaryLiveExecutionSummary.position?.side ?? "平仓")} · ${formatMaybeNumber(primaryLiveExecutionSummary.position?.quantity)} @ ${formatMaybeNumber(primaryLiveExecutionSummary.position?.entryPrice)} · 标记价 ${formatMaybeNumber(primaryLiveExecutionSummary.position?.markPrice)}` },
-        { label: "已恢复持仓", value: `${String(getRecord(primaryLiveSession?.state?.recoveredPosition).side ?? "平仓")} · ${formatMaybeNumber(getRecord(primaryLiveSession?.state?.recoveredPosition).quantity)} @ ${formatMaybeNumber(getRecord(primaryLiveSession?.state?.recoveredPosition).entryPrice)}` },
-      ],
-    },
-  ] : [];
 
   const hasConfiguredAccount = liveAccounts.some((account) => account.status === "CONFIGURED" || account.status === "READY");
   const hasSignalBinding = liveAccounts.some((account) => (accountSignalBindingMap[account.id] ?? []).length > 0);
@@ -301,18 +252,14 @@ export function AccountStage({
     {
       key: "session",
       title: "创建会话",
-      detail: hasLiveSession ? "已有实盘策略会话" : "选择账户 + 策略 + 交易对创建会话",
-      status: !hasRunningRuntime ? "pending" : hasLiveSession ? "done" : "current",
-    },
-    {
-      key: "monitor",
-      title: "启动监控",
-      detail: hasRunningLiveSession ? "已有运行中的会话" : "启动会话并开始监控 / 干预",
-      status: !hasLiveSession ? "pending" : hasRunningLiveSession ? "done" : "current",
+      detail: hasRunningLiveSession
+        ? "已有运行中的实盘会话，可转到监控台盯盘"
+        : hasLiveSession
+          ? "已有实盘策略会话，启动后进入监控台"
+          : "选择账户 + 策略 + 交易对创建会话",
+      status: !hasRunningRuntime ? "pending" : hasRunningLiveSession ? "done" : "current",
     },
   ];
-
-  const syncableLiveOrders = orders.filter((item) => item.metadata?.executionMode === "live" && item.status === "ACCEPTED");
 
   function setActiveSettingsModal(modal: ActiveSettingsModal) {
     useUIStore.getState().setActiveSettingsModal(modal);
@@ -325,7 +272,7 @@ export function AccountStage({
           <p className="eyebrow">交易主控</p>
           <h2>先准备账户，再接通信号，然后创建并启动实盘会话</h2>
           <p className="hero-copy">
-            这页不是给你同时看所有对象的。按顺序完成账户、信号源、运行时、实盘会话四步后，再进入监控和人工干预。
+            这页只负责把链路搭起来。按顺序完成账户准备、信号接通和实盘会话创建后，再进入监控台处理运行状态与人工干预。
           </p>
         </div>
         <div className="hero-side hero-account-toolbar">
@@ -394,7 +341,7 @@ export function AccountStage({
           </div>
         </div>
         <div className="live-grid">
-          <div className="backtest-list live-grid-span-2">
+          <div className="live-grid-span-2">
             {liveAccounts.length > 0 ? (
               <div className="live-card-list">
                 {liveAccounts.map((account) => {
@@ -417,6 +364,11 @@ export function AccountStage({
                     requireTick: bindings.some((item) => item.streamType === "trade_tick"),
                     requireOrderBook: bindings.some((item) => item.streamType === "order_book"),
                   });
+                  const hasRunningRuntime = runtimeSessionsForAccount.some((item) => item.status === "RUNNING");
+                  const hasRunningLiveSession = validLiveSessions.some(
+                    (item) => item.accountId === account.id && item.status === "RUNNING"
+                  );
+                  const isLiveFlowRunning = hasRunningRuntime || hasRunningLiveSession;
                   const livePreflight = deriveLivePreflightSummary(
                     account,
                     bindings,
@@ -443,10 +395,10 @@ export function AccountStage({
                         </div>
                         <div className="live-account-status">
                           <StatusPill tone={runtimeReadinessTone(activeRuntimeReadiness.status)}>
-                            {activeRuntimeReadiness.status}
+                            {`环境：${statusLabelZh(activeRuntimeReadiness.status)}`}
                           </StatusPill>
                           <StatusPill tone={runtimeReadinessTone(livePreflight.status)}>
-                            {livePreflight.status}
+                            {`预检：${statusLabelZh(livePreflight.status)}`}
                           </StatusPill>
                         </div>
                       </div>
@@ -492,7 +444,12 @@ export function AccountStage({
                       </div>
                       <div className="inline-actions live-account-actions">
                         <ActionButton
-                          label={liveFlowAction === account.id ? "启动中..." : "启动实盘流程"}
+                          label={
+                            liveFlowAction === account.id
+                              ? isLiveFlowRunning ? "停止中..." : "启动中..."
+                              : isLiveFlowRunning ? "停止实盘流程" : "启动实盘流程"
+                          }
+                          variant={isLiveFlowRunning ? "danger" : undefined}
                           disabled={
                             liveFlowAction !== null ||
                             liveBindAction ||
@@ -502,7 +459,13 @@ export function AccountStage({
                             liveSessionCreateAction ||
                             liveSessionLaunchAction
                           }
-                          onClick={() => launchLiveFlow(account)}
+                          onClick={() => {
+                            if (isLiveFlowRunning) {
+                              stopLiveFlow(account.id);
+                              return;
+                            }
+                            launchLiveFlow(account);
+                          }}
                         />
                         <ActionButton
                           label={accountDetailOpen ? "收起详情" : "查看详情"}
@@ -1234,129 +1197,22 @@ export function AccountStage({
             ) : (
               <div className="empty-state empty-state-compact">暂无有效实盘会话</div>
             )}
-          </div>
-        </div>
-      </section>
-
-      <section id="monitoring" className="panel panel-session">
-        <div className="panel-header">
-          <div>
-            <p className="panel-kicker">Monitoring</p>
-            <h3>第四步：监控与人工干预</h3>
-          </div>
-        </div>
-        <div className="live-grid">
-          {highlightedLiveSession ? (
-            <div className="session-card session-card-primary">
-              <div className="session-card-header">
-                <div>
-                  <p className="panel-kicker">Primary Session</p>
-                  <h4>当前优先处理会话</h4>
-                </div>
-                <StatusPill tone={liveSessionHealthTone(highlightedLiveSession.health.status)}>
-                  {highlightedLiveSession.health.status}
-                </StatusPill>
-              </div>
-              <div className="live-account-meta">
-                <span title="会话 ID">{shrink(highlightedLiveSession.session.id)}</span>
-                <span title="账户 ID">{highlightedLiveSession.session.accountId}</span>
-                <span title="策略 ID">{highlightedLiveSession.session.strategyId}</span>
-                <span title="信号周期">{String(highlightedLiveSession.session.state?.signalTimeframe ?? "--")}</span>
-              </div>
-              <div className="backtest-notes">
-                <div className="note-item">健康状态: {highlightedLiveSession.health.detail}</div>
-                <div className="backtest-grid-notes">
-                   <div className="note-item">恢复状态: {String(highlightedLiveSession.session.state?.positionRecoveryStatus ?? "--")}</div>
-                   <div className="note-item">保护恢复: {String(highlightedLiveSession.session.state?.protectionRecoveryStatus ?? "--")} ({String(highlightedLiveSession.session.state?.recoveredProtectionCount ?? "--")})</div>
-                   <div className="note-item">执行统计: 订单 {highlightedLiveSession.execution.orderCount} · 成交 {highlightedLiveSession.execution.fillCount}</div>
-                   <div className="note-item">最后订单: {String(highlightedLiveSession.execution.latestOrder?.status ?? "--")} · {String(highlightedLiveSession.execution.latestOrder?.side ?? "--")} @ {formatMaybeNumber(highlightedLiveSession.execution.latestOrder?.price)}</div>
-                   <div className="note-item">当前持仓: {String(highlightedLiveSession.execution.position?.side ?? "平仓")} · {formatMaybeNumber(highlightedLiveSession.execution.position?.quantity)} @ {formatMaybeNumber(highlightedLiveSession.execution.position?.entryPrice)}</div>
-                </div>
-              </div>
-              <div className="flow-row">
-                {highlightedLiveSessionFlow.map((step) => (
-                  <div key={step.key} className="flow-step">
-                    <StatusPill tone={step.status}>{step.label}</StatusPill>
-                    <span>{step.detail}</span>
+            <div className="panel-compact bg-white/5 rounded-2xl p-5 border border-white/5 mt-6">
+              <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                <div className="space-y-2">
+                  <p className="text-[10px] font-bold uppercase tracking-[0.3em] text-zinc-500">Next</p>
+                  <div>
+                    <h4 className="text-sm font-semibold text-zinc-100">运行中状态已经移到监控台</h4>
+                    <p className="text-xs text-zinc-400">
+                      完成账户、信号源和实盘会话配置后，到监控台查看当前优先处理会话、执行状态和人工干预入口。
+                    </p>
                   </div>
-                ))}
-              </div>
-            </div>
-          ) : (
-            <div className="backtest-list">
-              <div className="empty-state empty-state-compact">当前没有可优先处理的运行中实盘会话</div>
-            </div>
-          )}
-          <div className="backtest-list">
-            <h4>当前会话监控细节</h4>
-            {primaryLiveSession ? (
-              <div className="live-detail-layout">
-                <div className="live-summary-grid">
-                  {primaryLiveSummaryItems.map((item) => (
-                    <div key={item.label} className="detail-item">
-                      <span>{item.label}</span>
-                      <strong>{item.value}</strong>
-                    </div>
-                  ))}
                 </div>
-                <div className="live-section-grid">
-                  {primaryLiveSections.map((section) => (
-                    <section key={section.title} className="live-section-card">
-                      <button
-                        type="button"
-                        className="live-section-toggle"
-                        onClick={() => setExpandedLiveSection((current) => current === section.title ? "" : section.title)}
-                      >
-                        <div>
-                          <h5>{section.title}</h5>
-                          <span>{expandedLiveSection === section.title ? "收起详情" : "点击查看详情"}</span>
-                        </div>
-                        <strong>{expandedLiveSection === section.title ? "−" : "+"}</strong>
-                      </button>
-                      {expandedLiveSection === section.title ? (
-                        <div className="live-section-items">
-                          {section.items.map((item) => (
-                            <div key={`${section.title}-${item.label}`} className="detail-item detail-item-compact">
-                              <span>{item.label}</span>
-                              <strong>{item.value}</strong>
-                            </div>
-                          ))}
-                        </div>
-                      ) : null}
-                    </section>
-                  ))}
+                <div className="session-actions">
+                  <ActionButton label="打开监控台" onClick={openMonitorStage} />
                 </div>
               </div>
-            ) : (
-              <div className="empty-state empty-state-compact">启动并选中一个实盘会话后，这里会显示监控细节</div>
-            )}
-          </div>
-        </div>
-        <div className="live-grid">
-          <div className="backtest-list live-grid-span-2">
-            <h4>待同步的实盘订单</h4>
-            {syncableLiveOrders.length > 0 ? (
-              <SimpleTable
-                columns={["订单", "账户", "代码", "方向", "数量", "状态", "操作"]}
-                rows={syncableLiveOrders.map((order) => [
-                  shrink(order.id),
-                  order.accountId,
-                  order.symbol,
-                  order.side,
-                  formatMaybeNumber(order.quantity),
-                  order.status,
-                  <ActionButton
-                    key={order.id}
-                    label={liveSyncAction === order.id ? "Syncing..." : "Sync"}
-                    disabled={liveSyncAction !== null}
-                    onClick={() => syncLiveOrder(order.id)}
-                  />,
-                ])}
-                emptyMessage="暂无已接受的实盘订单"
-              />
-            ) : (
-              <div className="empty-state empty-state-compact">暂无已接受的实盘订单</div>
-            )}
+            </div>
           </div>
         </div>
       </section>

--- a/web/console/src/pages/MonitorStage.tsx
+++ b/web/console/src/pages/MonitorStage.tsx
@@ -1,19 +1,37 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useUIStore } from '../store/useUIStore';
 import { useTradingStore } from '../store/useTradingStore';
+import { ActionButton } from '../components/ui/ActionButton';
+import { SimpleTable } from '../components/ui/SimpleTable';
+import { StatusPill } from '../components/ui/StatusPill';
 import { SignalMonitorChart } from '../components/charts/SignalMonitorChart';
 import { formatMoney, formatSigned, formatMaybeNumber, formatTime, shrink } from '../utils/format';
 import { 
   getRecord, 
+  getList,
   mapChartCandlesToSignalBarCandles, 
   derivePrimarySignalBarState, 
   deriveRuntimeMarketSnapshot, 
   deriveSessionMarkers, 
   derivePaperSessionExecutionSummary,
-  deriveHighlightedLiveSession
+  deriveHighlightedLiveSession,
+  deriveLiveDispatchPreview,
+  deriveLiveSessionFlow,
+  deriveRuntimeReadiness,
+  deriveRuntimeSourceSummary,
+  buildTimelineNotes,
+  boolLabel,
+  liveSessionHealthTone
 } from '../utils/derivation';
 
-export function MonitorStage() {
+type MonitorStageProps = {
+  syncLiveOrder: (id: string) => void;
+  dockTab: 'orders' | 'positions' | 'fills' | 'alerts';
+  onDockTabChange: (tab: 'orders' | 'positions' | 'fills' | 'alerts') => void;
+  dockContent: React.ReactNode;
+};
+
+export function MonitorStage({ syncLiveOrder, dockTab, onDockTabChange, dockContent }: MonitorStageProps) {
   const liveSessions = useTradingStore(s => s.liveSessions);
   const orders = useTradingStore(s => s.orders);
   const fills = useTradingStore(s => s.fills);
@@ -22,6 +40,9 @@ export function MonitorStage() {
   const monitorCandles = useTradingStore(s => s.monitorCandles);
   const summaries = useTradingStore(s => s.summaries);
   const runtimePolicy = useTradingStore(s => s.runtimePolicy);
+  const accounts = useTradingStore(s => s.accounts);
+  const accountSignalBindingMap = useTradingStore(s => s.accountSignalBindingMap);
+  const liveSyncAction = useUIStore(s => s.liveSyncAction);
 
   // Re-calculating derived state locally to keep App clean
   const highlightedLiveSession = useMemo(
@@ -61,9 +82,94 @@ export function MonitorStage() {
   const monitorSummary =
     monitorSession ? summaries.find((item) => item.accountId === monitorSession.accountId) ?? null : null;
   const monitorMarkers = deriveSessionMarkers(monitorSession, orders, fills);
+  const monitorFlow = useMemo(
+    () =>
+      highlightedLiveSession
+        ? deriveLiveSessionFlow(highlightedLiveSession.session, highlightedLiveSession.execution)
+        : [],
+    [highlightedLiveSession]
+  );
+  const primaryLiveAccount = monitorSession ? accounts.find((item) => item.id === monitorSession.accountId) ?? null : null;
+  const primaryLiveBindings = monitorSession ? accountSignalBindingMap[monitorSession.accountId] ?? [] : [];
+  const primaryLiveRuntimeSessions = monitorSession
+    ? signalRuntimeSessions.filter((item) => item.accountId === monitorSession.accountId)
+    : [];
+  const monitorRuntimeReadiness = deriveRuntimeReadiness(
+    highlightedLiveRuntimeState,
+    deriveRuntimeSourceSummary(getRecord(highlightedLiveRuntimeState.sourceStates), runtimePolicy),
+    {
+      requireTick: true,
+      requireOrderBook: false,
+    }
+  );
+  const monitorIntent = getRecord(monitorSession?.state?.lastStrategyIntent);
+  const monitorSignalBarDecision = getRecord(monitorSession?.state?.lastStrategyEvaluationSignalBarDecision);
+  const monitorTimeline = getList(monitorSession?.state?.timeline);
+  const monitorDispatchPreview = deriveLiveDispatchPreview(
+    monitorSession,
+    primaryLiveAccount,
+    primaryLiveBindings,
+    primaryLiveRuntimeSessions,
+    highlightedLiveRuntime,
+    monitorRuntimeReadiness,
+    monitorIntent
+  );
+  const syncableLiveOrders = orders.filter((item) => item.metadata?.executionMode === "live" && item.status === "ACCEPTED");
+  const [expandedLiveSection, setExpandedLiveSection] = useState<string>("执行与分发");
+
+  const monitorSummaryItems = monitorSession ? [
+    { label: "运行环境", value: `${String(monitorSession.state?.signalRuntimeStatus ?? "--")} · ${formatTime(String(monitorSession.state?.lastSignalRuntimeEventAt ?? ""))}` },
+    { label: "就绪预检", value: `${monitorRuntimeReadiness.status} · ${monitorRuntimeReadiness.reason}` },
+    { label: "信号意图", value: `${String(monitorIntent.action ?? "无")} · ${String(monitorIntent.side ?? "--")} · ${formatMaybeNumber(monitorIntent.priceHint)}` },
+    { label: "指令分发", value: `${String(monitorSession.state?.dispatchMode ?? "--")} · 冷却 ${String(monitorSession.state?.dispatchCooldownSeconds ?? "--")}s` },
+    { label: "恢复状态", value: `${String(monitorSession.state?.positionRecoveryStatus ?? "--")} / ${String(monitorSession.state?.protectionRecoveryStatus ?? "--")}` },
+    { label: "执行汇总", value: `订单 ${monitorExecutionSummary.orderCount} · 成交 ${monitorExecutionSummary.fillCount} · ${String(monitorExecutionSummary.latestOrder?.status ?? "--")}` },
+  ] : [];
+
+  const monitorSections = monitorSession ? [
+    {
+      title: "运行与行情",
+      items: [
+        { label: "行情数据", value: `${formatMaybeNumber(monitorMarket.tradePrice)} · ${formatMaybeNumber(monitorMarket.bestBid)} / ${formatMaybeNumber(monitorMarket.bestAsk)}` },
+        { label: "数据同步", value: `${String(monitorSession.state?.lastSyncedOrderStatus ?? "--")} · ${formatTime(String(monitorSession.state?.lastSyncedAt ?? ""))} · 错误 ${String(monitorSession.state?.lastSyncError ?? "--")}` },
+        { label: "自动分发", value: `最后触发 ${formatTime(String(monitorSession.state?.lastDispatchedAt ?? ""))} · 最后错误 ${String(monitorSession.state?.lastAutoDispatchError ?? "--")}` },
+        { label: "时间线", value: buildTimelineNotes(monitorTimeline).slice(0, 2).join(" · ") || "--" },
+      ],
+    },
+    {
+      title: "信号与意图",
+      items: [
+        { label: "意图预览", value: `数量 ${formatMaybeNumber(monitorIntent.quantity)} · 报价源 ${String(monitorIntent.priceSource ?? "--")} · 信号种类 ${String(monitorIntent.signalKind ?? "--")}` },
+        { label: "意图上下文", value: `价差 ${formatMaybeNumber(monitorIntent.spreadBps)} bps · 偏置 ${String(monitorIntent.liquidityBias ?? "--")} · ma20 ${formatMaybeNumber(monitorIntent.ma20)} · atr14 ${formatMaybeNumber(monitorIntent.atr14)}` },
+        { label: "信号过滤", value: `周期 ${String(monitorSignalBarDecision.timeframe ?? "--")} · sma5 ${formatMaybeNumber(monitorSignalBarDecision.sma5)} · 多头 ${boolLabel(monitorSignalBarDecision.longEarlyReversalReady)} · 空头 ${boolLabel(monitorSignalBarDecision.shortEarlyReversalReady)}` },
+        { label: "信号备注", value: String(monitorSignalBarDecision.reason ?? "--") },
+      ],
+    },
+    {
+      title: "执行与分发",
+      items: [
+        { label: "执行配置", value: `${String(getRecord(monitorSession.state?.lastExecutionProfile).executionProfile ?? "--")} · ${String(getRecord(monitorSession.state?.lastExecutionProfile).orderType ?? "--")} · TIF ${String(getRecord(monitorSession.state?.lastExecutionProfile).timeInForce ?? "--")} · 只减仓 ${boolLabel(getRecord(monitorSession.state?.lastExecutionProfile).reduceOnly)}` },
+        { label: "执行遥测", value: `${String(getRecord(monitorSession.state?.lastExecutionTelemetry).decision ?? "--")} · 价差 ${formatMaybeNumber(getRecord(getRecord(monitorSession.state?.lastExecutionTelemetry).book).spreadBps)} bps · 盘口不平衡 ${formatMaybeNumber(getRecord(getRecord(monitorSession.state?.lastExecutionTelemetry).book).bookImbalance)}` },
+        { label: "分发状态", value: `${String(getRecord(monitorSession.state?.lastExecutionDispatch).status ?? "--")} · ${String(getRecord(monitorSession.state?.lastExecutionDispatch).executionMode ?? "--")} · 备选方案 ${boolLabel(getRecord(monitorSession.state?.lastExecutionDispatch).fallback)}` },
+        { label: "成交分析", value: `预期价格 ${formatMaybeNumber(getRecord(monitorSession.state?.lastExecutionDispatch).expectedPrice)} · 滑点偏移 ${formatMaybeNumber(getRecord(monitorSession.state?.lastExecutionDispatch).priceDriftBps)} bps` },
+        { label: "执行统计", value: `方案数 ${String(getRecord(monitorSession.state?.executionEventStats).proposalCount ?? "--")} · Maker ${String(getRecord(monitorSession.state?.executionEventStats).makerRestingDecisionCount ?? "--")} · 备选 ${String(getRecord(monitorSession.state?.executionEventStats).fallbackDispatchCount ?? "--")} · 平均偏移 ${formatMaybeNumber(getRecord(monitorSession.state?.executionEventStats).avgPriceDriftBps)} bps` },
+        { label: "分发预览", value: `${monitorDispatchPreview.reason} · ${monitorDispatchPreview.detail}` },
+        { label: "最终指令", value: `${String(monitorDispatchPreview.payload.side ?? "--")} ${formatMaybeNumber(monitorDispatchPreview.payload.quantity)} ${String(monitorDispatchPreview.payload.symbol ?? "--")} · ${String(monitorDispatchPreview.payload.type ?? "--")} @ ${formatMaybeNumber(monitorDispatchPreview.payload.price)}` },
+      ],
+    },
+    {
+      title: "恢复与仓位",
+      items: [
+        { label: "恢复详情", value: `${String(monitorSession.state?.lastRecoveryStatus ?? "--")} · 仓位恢复 ${String(monitorSession.state?.positionRecoveryStatus ?? "--")} · 保护恢复 ${String(monitorSession.state?.protectionRecoveryStatus ?? "--")}` },
+        { label: "恢复统计", value: `最后尝试 ${formatTime(String(monitorSession.state?.lastRecoveryAttemptAt ?? monitorSession.state?.lastProtectionRecoveryAt ?? ""))} · 保护订单 ${String(monitorSession.state?.recoveredProtectionCount ?? "--")} · 止损 ${String(monitorSession.state?.recoveredStopOrderCount ?? "--")} · 止盈 ${String(monitorSession.state?.recoveredTakeProfitOrderCount ?? "--")}` },
+        { label: "策略持仓", value: `${String(monitorExecutionSummary.position?.side ?? "平仓")} · ${formatMaybeNumber(monitorExecutionSummary.position?.quantity)} @ ${formatMaybeNumber(monitorExecutionSummary.position?.entryPrice)} · 标记价 ${formatMaybeNumber(monitorExecutionSummary.position?.markPrice)}` },
+        { label: "已恢复持仓", value: `${String(getRecord(monitorSession.state?.recoveredPosition).side ?? "平仓")} · ${formatMaybeNumber(getRecord(monitorSession.state?.recoveredPosition).quantity)} @ ${formatMaybeNumber(getRecord(monitorSession.state?.recoveredPosition).entryPrice)}` },
+      ],
+    },
+  ] : [];
 
   return (
-    <div className="flex flex-col p-4 bg-zinc-950/20">
+    <div className="h-full overflow-y-auto p-4 space-y-4 bg-zinc-950/20">
       <section id="monitor" className="panel panel-market panel-compact monitor-panel-main w-full">
         <div className="panel-header">
           <div>
@@ -128,6 +234,162 @@ export function MonitorStage() {
           <div className="note-item">
             最新成交：{formatMaybeNumber(monitorExecutionSummary.latestFill?.price)} · 手续费 {formatMaybeNumber(monitorExecutionSummary.latestFill?.fee)} · {formatTime(String(monitorExecutionSummary.latestFill?.createdAt ?? ""))}
           </div>
+        </div>
+      </section>
+
+      <section id="monitoring-detail" className="panel panel-session">
+        <div className="panel-header">
+          <div>
+            <p className="panel-kicker">Monitoring</p>
+            <h3>运行监控与人工干预</h3>
+          </div>
+        </div>
+        <div className="live-grid">
+          {highlightedLiveSession ? (
+            <div className="session-card session-card-primary">
+              <div className="session-card-header">
+                <div>
+                  <p className="panel-kicker">Primary Session</p>
+                  <h4>当前优先处理会话</h4>
+                </div>
+                <StatusPill tone={liveSessionHealthTone(highlightedLiveSession.health.status)}>
+                  {highlightedLiveSession.health.status}
+                </StatusPill>
+              </div>
+              <div className="live-account-meta">
+                <span title="会话 ID">{shrink(highlightedLiveSession.session.id)}</span>
+                <span title="账户 ID">{highlightedLiveSession.session.accountId}</span>
+                <span title="策略 ID">{highlightedLiveSession.session.strategyId}</span>
+                <span title="信号周期">{String(highlightedLiveSession.session.state?.signalTimeframe ?? "--")}</span>
+              </div>
+              <div className="backtest-notes">
+                <div className="note-item">健康状态: {highlightedLiveSession.health.detail}</div>
+                <div className="backtest-grid-notes">
+                  <div className="note-item">恢复状态: {String(highlightedLiveSession.session.state?.positionRecoveryStatus ?? "--")}</div>
+                  <div className="note-item">保护恢复: {String(highlightedLiveSession.session.state?.protectionRecoveryStatus ?? "--")} ({String(highlightedLiveSession.session.state?.recoveredProtectionCount ?? "--")})</div>
+                  <div className="note-item">执行统计: 订单 {highlightedLiveSession.execution.orderCount} · 成交 {highlightedLiveSession.execution.fillCount}</div>
+                  <div className="note-item">最后订单: {String(highlightedLiveSession.execution.latestOrder?.status ?? "--")} · {String(highlightedLiveSession.execution.latestOrder?.side ?? "--")} @ {formatMaybeNumber(highlightedLiveSession.execution.latestOrder?.price)}</div>
+                  <div className="note-item">当前持仓: {String(highlightedLiveSession.execution.position?.side ?? "平仓")} · {formatMaybeNumber(highlightedLiveSession.execution.position?.quantity)} @ {formatMaybeNumber(highlightedLiveSession.execution.position?.entryPrice)}</div>
+                </div>
+              </div>
+              <div className="flow-row">
+                {monitorFlow.map((step) => (
+                  <div key={step.key} className="flow-step">
+                    <StatusPill tone={step.status}>{step.label}</StatusPill>
+                    <span>{step.detail}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ) : (
+            <div className="backtest-list">
+              <div className="empty-state empty-state-compact">当前没有可优先处理的运行中实盘会话</div>
+            </div>
+          )}
+          <div className="backtest-list">
+            <h4>当前会话监控细节</h4>
+            {monitorSession ? (
+              <div className="live-detail-layout">
+                <div className="live-summary-grid">
+                  {monitorSummaryItems.map((item) => (
+                    <div key={item.label} className="detail-item">
+                      <span>{item.label}</span>
+                      <strong>{item.value}</strong>
+                    </div>
+                  ))}
+                </div>
+                <div className="live-section-grid">
+                  {monitorSections.map((section) => (
+                    <section key={section.title} className="live-section-card">
+                      <button
+                        type="button"
+                        className="live-section-toggle"
+                        onClick={() => setExpandedLiveSection((current) => current === section.title ? "" : section.title)}
+                      >
+                        <div>
+                          <h5>{section.title}</h5>
+                          <span>{expandedLiveSection === section.title ? "收起详情" : "点击查看详情"}</span>
+                        </div>
+                        <strong>{expandedLiveSection === section.title ? "−" : "+"}</strong>
+                      </button>
+                      {expandedLiveSection === section.title ? (
+                        <div className="live-section-items">
+                          {section.items.map((item) => (
+                            <div key={`${section.title}-${item.label}`} className="detail-item detail-item-compact">
+                              <span>{item.label}</span>
+                              <strong>{item.value}</strong>
+                            </div>
+                          ))}
+                        </div>
+                      ) : null}
+                    </section>
+                  ))}
+                </div>
+              </div>
+            ) : (
+              <div className="empty-state empty-state-compact">启动并选中一个实盘会话后，这里会显示监控细节</div>
+            )}
+          </div>
+        </div>
+        <div className="live-grid">
+          <div className="backtest-list live-grid-span-2">
+            <h4>待同步的实盘订单</h4>
+            {syncableLiveOrders.length > 0 ? (
+              <SimpleTable
+                columns={["订单", "账户", "代码", "方向", "数量", "状态", "操作"]}
+                rows={syncableLiveOrders.map((order) => [
+                  shrink(order.id),
+                  order.accountId,
+                  order.symbol,
+                  order.side,
+                  formatMaybeNumber(order.quantity),
+                  order.status,
+                  <ActionButton
+                    key={order.id}
+                    label={liveSyncAction === order.id ? "Syncing..." : "Sync"}
+                    disabled={liveSyncAction !== null}
+                    onClick={() => syncLiveOrder(order.id)}
+                  />,
+                ])}
+                emptyMessage="暂无已接受的实盘订单"
+              />
+            ) : (
+              <div className="empty-state empty-state-compact">暂无已接受的实盘订单</div>
+            )}
+          </div>
+        </div>
+      </section>
+
+      <section id="runtime-records" className="panel panel-session">
+        <div className="panel-header">
+          <div>
+            <p className="panel-kicker">Records</p>
+            <h3>订单、持仓、成交与告警</h3>
+          </div>
+        </div>
+        <div className="flex flex-wrap gap-2 mb-4">
+          {[
+            { key: 'orders', label: '全部订单' },
+            { key: 'positions', label: '持仓' },
+            { key: 'fills', label: '成交明细' },
+            { key: 'alerts', label: '异常告警' },
+          ].map((tab) => (
+            <button
+              key={tab.key}
+              type="button"
+              className={`px-3 py-2 rounded-xl text-xs border transition-colors ${
+                dockTab === tab.key
+                  ? 'border-emerald-400/40 bg-emerald-500/10 text-emerald-300'
+                  : 'border-white/5 bg-white/5 text-zinc-400 hover:text-zinc-200 hover:bg-white/10'
+              }`}
+              onClick={() => onDockTabChange(tab.key as 'orders' | 'positions' | 'fills' | 'alerts')}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+        <div className="panel-compact bg-white/5 rounded-2xl p-3 border border-white/5 overflow-x-auto">
+          {dockContent}
         </div>
       </section>
     </div>

--- a/web/console/src/store/useUIStore.ts
+++ b/web/console/src/store/useUIStore.ts
@@ -9,6 +9,13 @@ import { resolveUpdater } from './helpers';
 type SidebarTab = "monitor" | "strategy" | "account";
 type DockTab = "orders" | "positions" | "fills" | "alerts";
 
+export type SystemLogEntry = {
+  id: string;
+  level: "error" | "info";
+  message: string;
+  createdAt: string;
+};
+
 const CONSOLE_NAV_STORAGE_KEY = "bktrader-console-nav";
 const DEFAULT_SIDEBAR_TAB: SidebarTab = "monitor";
 const DEFAULT_DOCK_TAB: DockTab = "orders";
@@ -61,6 +68,8 @@ export interface useUIStoreState {
   setLoading: (valOrUpdater: boolean | ((prev: boolean) => boolean)) => void;
   error: string | null;
   setError: (valOrUpdater: string | null | ((prev: string | null) => string | null)) => void;
+  systemLogs: SystemLogEntry[];
+  clearSystemLogs: () => void;
   authSession: AuthSession | null;
   setAuthSession: (valOrUpdater: AuthSession | null | ((prev: AuthSession | null) => AuthSession | null)) => void;
   loginForm: LoginForm;
@@ -183,7 +192,36 @@ export const useUIStore = create<useUIStoreState>((set) => ({
   loading: true,
   setLoading: (valOrUpdater) => set((state) => ({ loading: resolveUpdater(valOrUpdater, state.loading) })),
   error: null,
-  setError: (valOrUpdater) => set((state) => ({ error: resolveUpdater(valOrUpdater, state.error) })),
+  setError: (valOrUpdater) => set((state) => {
+    const nextError = resolveUpdater(valOrUpdater, state.error);
+    if (nextError === state.error) {
+      return { error: nextError };
+    }
+
+    const nextLogs = [...state.systemLogs];
+    if (nextError) {
+      nextLogs.unshift({
+        id: `error:${Date.now()}:${Math.random().toString(36).slice(2, 8)}`,
+        level: "error",
+        message: nextError,
+        createdAt: new Date().toISOString(),
+      });
+    } else if (state.error) {
+      nextLogs.unshift({
+        id: `info:${Date.now()}:${Math.random().toString(36).slice(2, 8)}`,
+        level: "info",
+        message: "连接已恢复正常",
+        createdAt: new Date().toISOString(),
+      });
+    }
+
+    return {
+      error: nextError,
+      systemLogs: nextLogs.slice(0, 40),
+    };
+  }),
+  systemLogs: [],
+  clearSystemLogs: () => set({ systemLogs: [] }),
   authSession: readStoredAuthSession(),
   setAuthSession: (valOrUpdater) => set((state) => ({ authSession: resolveUpdater(valOrUpdater, state.authSession) })),
   loginForm: { username: "admin", password: "" },

--- a/web/console/src/styles.css
+++ b/web/console/src/styles.css
@@ -516,8 +516,8 @@ a {
 
 .workflow-grid {
   display: grid;
-  grid-template-columns: repeat(5, minmax(0, 1fr));
-  gap: 10px;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
 }
 
 .workflow-card {
@@ -1163,6 +1163,12 @@ a {
   color: var(--ink);
   border: 1px solid var(--line);
   box-shadow: none;
+}
+
+.action-button-danger {
+  background: linear-gradient(135deg, rgba(176, 74, 55, 0.95), rgba(138, 47, 29, 1));
+  color: white;
+  box-shadow: 0 6px 16px rgba(176, 74, 55, 0.18);
 }
 
 .chart-shell {


### PR DESCRIPTION
## 目的
_这次改动要解决什么问题 / 实现了什么功能_

- 调整前端控制台的信息架构：账户页只保留配置流，监控内容迁入监控台
- 取消监控台上下拆分和底部 dock，改为单页滚动的信息流
- 增强账户页可用性：状态标签中文化、启动/停止实盘流程按钮联动、工作流卡片均分
- 顶部“运行正常/连接异常”增加最近状态与告警查看入口
- 新增日志查看台建设计划文档，作为后续逐步建设的执行蓝图

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [x] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [ ] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main)
- [ ] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？
- [ ] DB migration 是否具备向下兼容幂等性？
- [ ] 配置字段有没有无意被混改？

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

- 本地执行：`cd web/console && npm run build`
- 结果：构建通过
- 额外说明：顶部状态区现已支持打开最近状态与告警面板；日志查看台完整页面已写入计划文档，后续按计划逐步实现