### PR TITLE
[codex] align console signal binding flow with strategy runtime

### DIFF
--- a/web/console/src/components/layout/MainContent.tsx
+++ b/web/console/src/components/layout/MainContent.tsx
@@ -50,8 +50,6 @@ export function MainContent({ actions, dockContent, strategies, quickLiveAccount
           jumpToSignalRuntimeSession={actions.jumpToSignalRuntimeSession}
           runLiveNextAction={actions.runLiveNextAction}
           selectQuickLiveAccount={actions.selectQuickLiveAccount}
-          bindAccountSignalSource={actions.bindAccountSignalSource}
-          unbindAccountSignalSource={actions.unbindAccountSignalSource}
           bindStrategySignalSource={actions.bindStrategySignalSource}
           unbindStrategySignalSource={actions.unbindStrategySignalSource}
           updateRuntimePolicy={actions.updateRuntimePolicy}

--- a/web/console/src/hooks/useDashboard.ts
+++ b/web/console/src/hooks/useDashboard.ts
@@ -7,7 +7,7 @@ import {
   AccountSummary, AccountRecord, Order, Fill, Position, PaperSession, LiveSession, 
   StrategyRecord, BacktestRun, BacktestOptions, LiveAdapter, SignalSourceCatalog, 
   SignalSourceType, SignalRuntimeAdapter, SignalRuntimeSession, RuntimePolicy, 
-  PlatformAlert, PlatformNotification, TelegramConfig, AccountEquitySnapshot, 
+  PlatformAlert, PlatformNotification, TelegramConfig, AccountEquitySnapshot, PlatformHealthSnapshot,
   ChartCandle, ChartAnnotation, SignalBinding 
 } from '../types/domain';
 import { 
@@ -50,12 +50,11 @@ export function useDashboard() {
   const setSignalRuntimeAdapters = useTradingStore(s => s.setSignalRuntimeAdapters);
   const setSignalRuntimeSessions = useTradingStore(s => s.setSignalRuntimeSessions);
   const setRuntimePolicy = useTradingStore(s => s.setRuntimePolicy);
+  const setMonitorHealth = useTradingStore(s => s.setMonitorHealth);
   const setAlerts = useTradingStore(s => s.setAlerts);
   const setNotifications = useTradingStore(s => s.setNotifications);
   const setTelegramConfig = useTradingStore(s => s.setTelegramConfig);
-  const setAccountSignalBindingMap = useTradingStore(s => s.setAccountSignalBindingMap);
   const setStrategySignalBindingMap = useTradingStore(s => s.setStrategySignalBindingMap);
-  const setAccountSignalBindings = useTradingStore(s => s.setAccountSignalBindings);
   const setStrategySignalBindings = useTradingStore(s => s.setStrategySignalBindings);
   const setSignalRuntimePlan = useTradingStore(s => s.setSignalRuntimePlan);
   const setSelectedSignalRuntimeId = useTradingStore(s => s.setSelectedSignalRuntimeId);
@@ -80,6 +79,7 @@ export function useDashboard() {
       signalRuntimeAdapterData,
       signalRuntimeSessionData,
       runtimePolicyData,
+      monitorHealthData,
       alertData,
       notificationData,
       telegramConfigData,
@@ -100,17 +100,12 @@ export function useDashboard() {
       fetchJSON<SignalRuntimeAdapter[]>("/api/v1/signal-runtime/adapters"),
       fetchJSON<SignalRuntimeSession[]>("/api/v1/signal-runtime/sessions"),
       fetchJSON<RuntimePolicy>("/api/v1/runtime-policy"),
+      fetchJSON<PlatformHealthSnapshot>("/api/v1/monitor/health"),
       fetchJSON<PlatformAlert[]>("/api/v1/alerts"),
       fetchJSON<PlatformNotification[]>("/api/v1/notifications?includeAcked=true"),
       fetchJSON<TelegramConfig>("/api/v1/telegram/config"),
     ]);
 
-    const accountBindingEntries = await Promise.all(
-      accountData.map(async (account) => [
-        account.id,
-        await fetchJSON<SignalBinding[]>(`/api/v1/accounts/${account.id}/signal-bindings`),
-      ] as const)
-    );
     const strategyBindingEntries = await Promise.all(
       strategyData.map(async (strategy) => [
         strategy.id,
@@ -226,6 +221,7 @@ export function useDashboard() {
     setSignalRuntimeAdapters(normalizedSignalRuntimeAdapters);
     setSignalRuntimeSessions(normalizedSignalRuntimeSessions);
     setRuntimePolicy(runtimePolicyData);
+    setMonitorHealth(monitorHealthData);
     setAlerts(normalizedAlerts);
     setNotifications(normalizedNotifications);
     setTelegramConfig(telegramConfigData);
@@ -243,11 +239,11 @@ export function useDashboard() {
       orderBookFreshnessSeconds: String(runtimePolicyData.orderBookFreshnessSeconds ?? 10),
       signalBarFreshnessSeconds: String(runtimePolicyData.signalBarFreshnessSeconds ?? 30),
       runtimeQuietSeconds: String(runtimePolicyData.runtimeQuietSeconds ?? 30),
+      strategyEvaluationQuietSeconds: String(runtimePolicyData.strategyEvaluationQuietSeconds ?? 0),
+      liveAccountSyncFreshnessSeconds: String(runtimePolicyData.liveAccountSyncFreshnessSeconds ?? 0),
       paperStartReadinessTimeoutSeconds: String(runtimePolicyData.paperStartReadinessTimeoutSeconds ?? 5),
     });
-    setAccountSignalBindingMap(Object.fromEntries(accountBindingEntries));
     setStrategySignalBindingMap(Object.fromEntries(strategyBindingEntries));
-    setAccountSignalBindings(accountBindingEntries.flatMap((e) => e[1]));
     setStrategySignalBindings(strategyBindingEntries.flatMap((e) => e[1]));
     setSignalRuntimePlan(runtimePlanData);
     setSelectedSignalRuntimeId((current: string | null) => {

--- a/web/console/src/hooks/useTradingActions.ts
+++ b/web/console/src/hooks/useTradingActions.ts
@@ -47,7 +47,6 @@ export function useTradingActions(loadDashboard: () => Promise<void>) {
   const setRuntimePolicyForm = useUIStore(s => s.setRuntimePolicyForm);
   const setLiveAccountNotice = useUIStore(s => s.setLiveAccountNotice);
   const setLiveBindingNotice = useUIStore(s => s.setLiveBindingNotice);
-  const setAccountSignalForm = useUIStore(s => s.setAccountSignalForm);
   const setStrategySignalForm = useUIStore(s => s.setStrategySignalForm);
   const setSignalRuntimeForm = useUIStore(s => s.setSignalRuntimeForm);
   const setLiveAccountForm = useUIStore(s => s.setLiveAccountForm);
@@ -61,7 +60,6 @@ export function useTradingActions(loadDashboard: () => Promise<void>) {
   const liveBindingForm = useUIStore(s => s.liveBindingForm);
   const liveOrderForm = useUIStore(s => s.liveOrderForm);
   const liveSessionForm = useUIStore(s => s.liveSessionForm);
-  const accountSignalForm = useUIStore(s => s.accountSignalForm);
   const strategySignalForm = useUIStore(s => s.strategySignalForm);
   const signalRuntimeForm = useUIStore(s => s.signalRuntimeForm);
   const runtimePolicyForm = useUIStore(s => s.runtimePolicyForm);
@@ -86,7 +84,6 @@ export function useTradingActions(loadDashboard: () => Promise<void>) {
   const setRuntimePolicy = useTradingStore(s => s.setRuntimePolicy);
   const setTelegramConfig = useTradingStore(s => s.setTelegramConfig);
   const strategySignalBindingMap = useTradingStore(s => s.strategySignalBindingMap);
-  const accountSignalBindingMap = useTradingStore(s => s.accountSignalBindingMap);
   const signalRuntimeSessions = useTradingStore(s => s.signalRuntimeSessions);
 
   const strategyIds = useMemo(() => new Set(strategies.map((s: StrategyRecord) => s.id)), [strategies]);
@@ -104,7 +101,6 @@ export function useTradingActions(loadDashboard: () => Promise<void>) {
     setLiveBindingForm((current: any) => ({ ...current, accountId }));
     setLiveSessionForm((current: any) => ({ ...current, accountId }));
     useUIStore.getState().setLiveOrderForm((current: any) => ({ ...current, accountId }));
-    setAccountSignalForm((current: any) => ({ ...current, accountId }));
     setSignalRuntimeForm((current: any) => ({ ...current, accountId }));
   }
 
@@ -249,16 +245,6 @@ export function useTradingActions(loadDashboard: () => Promise<void>) {
       setError(err instanceof Error ? err.message : "Failed to stop live flow");
     } finally {
       setLiveFlowAction(null);
-    }
-  }
-
-  async function unbindAccountSignalSource(accountId: string, bindingId: string) {
-    try {
-      await fetchJSON(`/api/v1/accounts/${accountId}/signal-bindings?id=${encodeURIComponent(bindingId)}`, { method: "DELETE" });
-      await loadDashboard();
-      setError(null);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to unbind account signal source");
     }
   }
 
@@ -493,7 +479,7 @@ export function useTradingActions(loadDashboard: () => Promise<void>) {
     
     try {
       const strategyBindings = strategySignalBindingMap[strategyId] ?? [];
-      if ((accountSignalBindingMap[account.id] ?? []).length === 0 && strategyBindings.length === 0) {
+      if (strategyBindings.length === 0) {
         window.location.hash = "signals";
         throw new Error("Launch live flow needs strategy signal bindings before it can continue");
       }
@@ -583,32 +569,6 @@ export function useTradingActions(loadDashboard: () => Promise<void>) {
     }
   }
 
-  async function bindAccountSignalSource() {
-    if (!accountSignalForm.accountId || !accountSignalForm.sourceKey) {
-      setError("Account signal binding needs an account and source");
-      return;
-    }
-    setSignalBindingAction("account");
-    try {
-      await fetchJSON(`/api/v1/accounts/${accountSignalForm.accountId}/signal-bindings`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          sourceKey: accountSignalForm.sourceKey,
-          role: accountSignalForm.role,
-          symbol: accountSignalForm.symbol,
-          options: accountSignalForm.role === "signal" ? { timeframe: accountSignalForm.timeframe } : undefined,
-        }),
-      });
-      await loadDashboard();
-      setError(null);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to bind account signal source");
-    } finally {
-      setSignalBindingAction(null);
-    }
-  }
-
   async function bindStrategySignalSource() {
     if (!strategySignalForm.strategyId || !strategySignalForm.sourceKey) {
       setError("Strategy signal binding needs a strategy and source");
@@ -667,6 +627,8 @@ export function useTradingActions(loadDashboard: () => Promise<void>) {
         orderBookFreshnessSeconds: Math.max(0, Number(runtimePolicyForm.orderBookFreshnessSeconds) || 0),
         signalBarFreshnessSeconds: Math.max(0, Number(runtimePolicyForm.signalBarFreshnessSeconds) || 0),
         runtimeQuietSeconds: Math.max(0, Number(runtimePolicyForm.runtimeQuietSeconds) || 0),
+        strategyEvaluationQuietSeconds: Math.max(0, Number(runtimePolicyForm.strategyEvaluationQuietSeconds) || 0),
+        liveAccountSyncFreshnessSeconds: Math.max(0, Number(runtimePolicyForm.liveAccountSyncFreshnessSeconds) || 0),
         paperStartReadinessTimeoutSeconds: Math.max(0, Number(runtimePolicyForm.paperStartReadinessTimeoutSeconds) || 0),
       };
       const updated = await fetchJSON<RuntimePolicy>("/api/v1/runtime-policy", {
@@ -680,6 +642,12 @@ export function useTradingActions(loadDashboard: () => Promise<void>) {
         orderBookFreshnessSeconds: String(updated.orderBookFreshnessSeconds ?? payload.orderBookFreshnessSeconds),
         signalBarFreshnessSeconds: String(updated.signalBarFreshnessSeconds ?? payload.signalBarFreshnessSeconds),
         runtimeQuietSeconds: String(updated.runtimeQuietSeconds ?? payload.runtimeQuietSeconds),
+        strategyEvaluationQuietSeconds: String(
+          updated.strategyEvaluationQuietSeconds ?? payload.strategyEvaluationQuietSeconds
+        ),
+        liveAccountSyncFreshnessSeconds: String(
+          updated.liveAccountSyncFreshnessSeconds ?? payload.liveAccountSyncFreshnessSeconds
+        ),
         paperStartReadinessTimeoutSeconds: String(
           updated.paperStartReadinessTimeoutSeconds ?? payload.paperStartReadinessTimeoutSeconds
         ),
@@ -936,7 +904,6 @@ export function useTradingActions(loadDashboard: () => Promise<void>) {
         window.location.hash = "live";
         break;
       case "bind-signals":
-        useUIStore.getState().setAccountSignalForm((current) => ({ ...current, accountId: account.id }));
         useUIStore.getState().setSignalRuntimeForm((current) => ({ ...current, accountId: account.id }));
         window.location.hash = "signals";
         break;
@@ -972,11 +939,11 @@ export function useTradingActions(loadDashboard: () => Promise<void>) {
 
   return {
     createStrategy, saveStrategyParameters, createLiveAccount, bindLiveAccount,
-    stopLiveFlow, unbindAccountSignalSource, unbindStrategySignalSource,
+    stopLiveFlow, unbindStrategySignalSource,
     deleteSignalRuntimeSession, syncLiveOrder, syncLiveAccount, createLiveOrder,
     createLiveSession, saveLiveSession, createAndStartLiveSession, deleteLiveSession,
     launchLiveFlow, runLiveSessionAction, dispatchLiveSessionIntent, syncLiveSession,
-    bindAccountSignalSource, bindStrategySignalSource, createSignalRuntimeSession,
+    bindStrategySignalSource, createSignalRuntimeSession,
     updateRuntimePolicy, runSignalRuntimeAction, acknowledgeNotification,
     sendNotificationToTelegram, saveTelegramConfig, sendTelegramTest, createBacktestRun,
     selectQuickLiveAccount,
@@ -984,7 +951,7 @@ export function useTradingActions(loadDashboard: () => Promise<void>) {
     openLiveAccountModal, openLiveBindingModal, openLiveSessionModal,
     runLiveNextAction, jumpToSignalRuntimeSession,
     setLoginForm, setLiveAccountForm, setLiveBindingForm, setLiveSessionForm, 
-    setAccountSignalForm, setStrategySignalForm, setSignalRuntimeForm,
+    setStrategySignalForm, setSignalRuntimeForm,
     setTelegramForm,
     setLiveSessionLaunchAction, setLiveSessionAction, setLiveSessionError, setError
   };

--- a/web/console/src/pages/AccountStage.tsx
+++ b/web/console/src/pages/AccountStage.tsx
@@ -35,7 +35,9 @@ import {
   boolLabel,
   liveSessionHealthTone,
   getNumber,
-  technicalStatusLabel
+  technicalStatusLabel,
+  displaySignalBindingTimeframe,
+  runtimePolicyValueLabel
 } from '../utils/derivation';
 import { AccountRecord, LiveSession, SignalRuntimeSession, LiveNextAction, ActiveSettingsModal } from '../types/domain';
 
@@ -55,8 +57,6 @@ interface AccountStageProps {
   jumpToSignalRuntimeSession: (id: string) => void;
   runLiveNextAction: (account: AccountRecord, nextAction: LiveNextAction, runtime: SignalRuntimeSession | null) => void;
   selectQuickLiveAccount: (id: string) => void;
-  bindAccountSignalSource: () => void;
-  unbindAccountSignalSource: (accountId: string, bindingId: string) => void;
   bindStrategySignalSource: () => void;
   unbindStrategySignalSource: (strategyId: string, bindingId: string) => void;
   updateRuntimePolicy: () => void;
@@ -104,8 +104,6 @@ export function AccountStage({
   jumpToSignalRuntimeSession,
   runLiveNextAction,
   selectQuickLiveAccount,
-  bindAccountSignalSource,
-  unbindAccountSignalSource,
   bindStrategySignalSource,
   unbindStrategySignalSource,
   updateRuntimePolicy,
@@ -137,16 +135,14 @@ export function AccountStage({
   const liveSessionCreateAction = useUIStore(s => s.liveSessionCreateAction);
   const liveSessionLaunchAction = useUIStore(s => s.liveSessionLaunchAction);
   const signalRuntimeSessions = useTradingStore(s => s.signalRuntimeSessions);
-  const accountSignalBindingMap = useTradingStore(s => s.accountSignalBindingMap);
   const runtimePolicy = useTradingStore(s => s.runtimePolicy);
   const signalCatalog = useTradingStore(s => s.signalCatalog);
-  const accountSignalForm = useUIStore(s => s.accountSignalForm);
-  const setAccountSignalForm = useUIStore(s => s.setAccountSignalForm);
+  const strategySignalBindingMap = useTradingStore(s => s.strategySignalBindingMap);
   const strategySignalForm = useUIStore(s => s.strategySignalForm);
   const setStrategySignalForm = useUIStore(s => s.setStrategySignalForm);
   const signalSourceTypes = useTradingStore(s => s.signalSourceTypes);
-  const accountSignalBindings = useTradingStore(s => s.accountSignalBindings);
   const strategySignalBindings = useTradingStore(s => s.strategySignalBindings);
+  const monitorHealth = useTradingStore(s => s.monitorHealth);
   const runtimePolicyForm = useUIStore(s => s.runtimePolicyForm);
   const setRuntimePolicyForm = useUIStore(s => s.setRuntimePolicyForm);
   const runtimePolicyAction = useUIStore(s => s.runtimePolicyAction);
@@ -172,7 +168,7 @@ export function AccountStage({
   const primaryLiveSession = highlightedLiveSession?.session ?? null;
   const primaryLiveSessionIntent = getRecord(primaryLiveSession?.state?.lastStrategyIntent);
   const primaryLiveAccount = primaryLiveSession ? liveAccounts.find(a => a.id === primaryLiveSession.accountId) || null : null;
-  const primaryLiveBindings = primaryLiveSession ? accountSignalBindingMap[primaryLiveSession.accountId] || [] : [];
+  const primaryStrategyBindings = primaryLiveSession ? strategySignalBindingMap[primaryLiveSession.strategyId] ?? [] : [];
   const primaryLiveRuntimeSessions = primaryLiveSession ? signalRuntimeSessions.filter(s => s.accountId === primaryLiveSession.accountId) : [];
   const primaryLiveRuntime =
     primaryLiveSession
@@ -196,7 +192,7 @@ export function AccountStage({
   const primaryLiveDispatchPreview = deriveLiveDispatchPreview(
     primaryLiveSession,
     primaryLiveAccount,
-    primaryLiveBindings,
+    primaryStrategyBindings,
     primaryLiveRuntimeSessions,
     primaryLiveRuntime,
     primaryLiveSessionRuntimeReadiness,
@@ -225,10 +221,11 @@ export function AccountStage({
   const [expandedAccountId, setExpandedAccountId] = useState<string | null>(null);
 
   const hasConfiguredAccount = liveAccounts.some((account) => account.status === "CONFIGURED" || account.status === "READY");
-  const hasSignalBinding = liveAccounts.some((account) => (accountSignalBindingMap[account.id] ?? []).length > 0);
+  const hasSignalBinding = strategySignalBindings.length > 0;
   const hasRunningRuntime = signalRuntimeSessions.some((session) => session.status === "RUNNING");
   const hasLiveSession = validLiveSessions.length > 0;
   const hasRunningLiveSession = validLiveSessions.some((session) => session.status === "RUNNING");
+  const platformRuntimePolicy = monitorHealth?.runtimePolicy ?? runtimePolicy;
 
   const onboardingSteps = [
     {
@@ -240,7 +237,7 @@ export function AccountStage({
     {
       key: "signal",
       title: "接通信号",
-      detail: hasSignalBinding ? "已绑定信号源" : "为账户或策略绑定 signal source",
+      detail: hasSignalBinding ? "已配置策略级 signal bindings" : "先配置策略级 signal bindings",
       status: !hasConfiguredAccount ? "pending" : hasSignalBinding ? "done" : "current",
     },
     {
@@ -347,12 +344,17 @@ export function AccountStage({
                 {liveAccounts.map((account) => {
                   const binding = (account.metadata?.liveBinding as Record<string, unknown> | undefined) ?? {};
                   const syncSnapshot = getRecord(getRecord(account.metadata).liveSyncSnapshot);
-                  const bindings = accountSignalBindingMap[account.id] ?? [];
                   const runtimeSessionsForAccount = signalRuntimeSessions.filter((item) => item.accountId === account.id);
                   const activeRuntime = runtimeSessionsForAccount.find((item) => item.status === "RUNNING") ?? runtimeSessionsForAccount[0] ?? null;
                   const activeRuntimeState = getRecord(activeRuntime?.state);
                   const activeRuntimeSummary = getRecord(activeRuntimeState.lastEventSummary);
                   const activeRuntimeMarket = deriveRuntimeMarketSnapshot(getRecord(activeRuntimeState.sourceStates), activeRuntimeSummary);
+                  const strategyBindings =
+                    (activeRuntime?.strategyId ? strategySignalBindingMap[activeRuntime.strategyId] : undefined) ??
+                    strategySignalBindingMap[
+                      validLiveSessions.find((item) => item.accountId === account.id)?.strategyId ?? ""
+                    ] ??
+                    [];
                   const activeRuntimeSourceSummary = deriveRuntimeSourceSummary(
                     getRecord(activeRuntimeState.sourceStates),
                     runtimePolicy
@@ -361,8 +363,8 @@ export function AccountStage({
                   const activeSignalAction = deriveSignalActionSummary(activeSignalBarState);
                   const activeRuntimeTimeline = getList(activeRuntimeState.timeline);
                   const activeRuntimeReadiness = deriveRuntimeReadiness(activeRuntimeState, activeRuntimeSourceSummary, {
-                    requireTick: bindings.some((item) => item.streamType === "trade_tick"),
-                    requireOrderBook: bindings.some((item) => item.streamType === "order_book"),
+                    requireTick: strategyBindings.some((item) => item.streamType === "trade_tick"),
+                    requireOrderBook: strategyBindings.some((item) => item.streamType === "order_book"),
                   });
                   const hasRunningRuntime = runtimeSessionsForAccount.some((item) => item.status === "RUNNING");
                   const hasRunningLiveSession = validLiveSessions.some(
@@ -371,7 +373,7 @@ export function AccountStage({
                   const isLiveFlowRunning = hasRunningRuntime || hasRunningLiveSession;
                   const livePreflight = deriveLivePreflightSummary(
                     account,
-                    bindings,
+                    strategyBindings,
                     runtimeSessionsForAccount,
                     activeRuntime,
                     activeRuntimeReadiness
@@ -495,7 +497,7 @@ export function AccountStage({
                             </div>
                             <div className="detail-item detail-item-compact">
                               <span>来源与实例</span>
-                              <strong>{String(syncSnapshot.source ?? "--")} · {bindings.length} 绑定 · {runtimeSessionsForAccount.length} 实例</strong>
+                              <strong>{String(syncSnapshot.source ?? "--")} · {strategyBindings.length} 策略绑定 · {runtimeSessionsForAccount.length} 实例</strong>
                             </div>
                             <div className="detail-item detail-item-compact">
                               <span>指标</span>
@@ -565,55 +567,7 @@ export function AccountStage({
 
         <div className="live-grid">
           <div className="backtest-form session-form">
-            <h4>2.1 绑定账户信号源</h4>
-            <div className="form-grid">
-              <label className="form-field">
-                <span>账户</span>
-                <select value={accountSignalForm.accountId} onChange={(event) => setAccountSignalForm((current) => ({ ...current, accountId: event.target.value }))}>
-                  {liveAccounts.map((item) => (
-                    <option key={item.id} value={item.id}>
-                      {item.name} ({technicalStatusLabel(item.mode)})
-                    </option>
-                  ))}
-                </select>
-              </label>
-              <label className="form-field">
-                <span>信号源</span>
-                <select value={accountSignalForm.sourceKey} onChange={(event) => setAccountSignalForm((current) => ({ ...current, sourceKey: event.target.value }))}>
-                  {(signalCatalog?.sources ?? []).map((source) => (
-                    <option key={source.key} value={source.key}>
-                      {source.name}
-                    </option>
-                  ))}
-                </select>
-              </label>
-              <label className="form-field">
-                <span>角色</span>
-                <select value={accountSignalForm.role} onChange={(event) => setAccountSignalForm((current) => ({ ...current, role: event.target.value }))}>
-                  <option value="signal">信号 (Signal)</option>
-                  <option value="trigger">触发器 (Trigger)</option>
-                  <option value="feature">特征项 (Feature)</option>
-                </select>
-              </label>
-              <label className="form-field">
-                <span>信号周期</span>
-                <select value={accountSignalForm.timeframe} onChange={(event) => setAccountSignalForm((current) => ({ ...current, timeframe: event.target.value }))}>
-                  <option value="4h">4h</option>
-                  <option value="1d">1d</option>
-                </select>
-              </label>
-              <label className="form-field">
-                <span>交易对 (Symbol)</span>
-                <input value={accountSignalForm.symbol} onChange={(event) => setAccountSignalForm((current) => ({ ...current, symbol: event.target.value.toUpperCase() }))} />
-              </label>
-            </div>
-            <div className="backtest-actions">
-              <ActionButton label={signalBindingAction === "account" ? "绑定中..." : "执行账户绑定"} disabled={signalBindingAction !== null || !accountSignalForm.accountId} onClick={bindAccountSignalSource} />
-            </div>
-          </div>
-
-          <div className="backtest-form session-form">
-            <h4>2.2 绑定策略信号源</h4>
+            <h4>2.1 绑定策略信号源</h4>
             <div className="form-grid">
               <label className="form-field">
                 <span>绑定策略</span>
@@ -659,10 +613,35 @@ export function AccountStage({
               <ActionButton label={signalBindingAction === "strategy" ? "绑定中..." : "执行策略绑定"} disabled={signalBindingAction !== null || !strategySignalForm.strategyId} onClick={bindStrategySignalSource} />
             </div>
           </div>
+
+          <div className="backtest-list">
+            <h4>当前信号绑定结果</h4>
+            <div className="backtest-breakdown">
+              <h5>策略级别</h5>
+              <SimpleTable
+                columns={["信号源", "角色", "代码 (Symbol)", "周期", "交易所", "状态", "操作"]}
+                rows={strategySignalBindings.map((item) => [
+                  item.sourceName,
+                  item.role,
+                  item.symbol || "--",
+                  displaySignalBindingTimeframe(item),
+                  item.exchange,
+                  technicalStatusLabel(item.status),
+                  <ActionButton
+                    key={item.id}
+                    label="Unbind"
+                    variant="ghost"
+                    onClick={() => unbindStrategySignalSource(item.strategyId || "", item.id)}
+                  />
+                ])}
+                emptyMessage="暂无策略绑定信息"
+              />
+            </div>
+          </div>
         </div>
 
         <div className="live-grid">
-          <div className="backtest-list">
+          <div className="backtest-list live-grid-span-2">
             <h4>信号源目录与说明</h4>
             {signalCatalog?.sources?.length ? (
               <SimpleTable
@@ -693,55 +672,11 @@ export function AccountStage({
               ))}
             </div>
           </div>
-
-          <div className="backtest-list">
-            <h4>当前信号绑定结果</h4>
-            <div className="backtest-breakdown">
-              <h5>账户级别</h5>
-              <SimpleTable
-                columns={["信号源", "角色", "代码 (Symbol)", "交易所", "状态", "操作"]}
-                rows={accountSignalBindings.map((item) => [
-                  item.sourceName,
-                  item.role,
-                  item.symbol || "--",
-                  item.exchange,
-                  technicalStatusLabel(item.status),
-                  <ActionButton
-                    key={item.id}
-                    label="Unbind"
-                    variant="ghost"
-                    onClick={() => unbindAccountSignalSource(item.accountId || "", item.id)}
-                  />
-                ])}
-                emptyMessage="暂无账户绑定信息"
-              />
-            </div>
-            <div className="backtest-breakdown">
-              <h5>策略级别</h5>
-              <SimpleTable
-                columns={["信号源", "角色", "代码 (Symbol)", "交易所", "状态", "操作"]}
-                rows={strategySignalBindings.map((item) => [
-                  item.sourceName,
-                  item.role,
-                  item.symbol || "--",
-                  item.exchange,
-                  technicalStatusLabel(item.status),
-                  <ActionButton
-                    key={item.id}
-                    label="Unbind"
-                    variant="ghost"
-                    onClick={() => unbindStrategySignalSource(item.strategyId || "", item.id)}
-                  />
-                ])}
-                emptyMessage="暂无策略绑定信息"
-              />
-            </div>
-          </div>
         </div>
 
         <div className="live-grid">
           <div className="backtest-form session-form">
-            <h4>2.3 运行时策略</h4>
+            <h4>2.2 运行时策略</h4>
             <div className="form-grid">
               <label className="form-field">
                 <span>成交价格新鲜度 (秒)</span>
@@ -780,6 +715,30 @@ export function AccountStage({
                 />
               </label>
               <label className="form-field">
+                <span>策略评估静默期 (秒)</span>
+                <input
+                  value={runtimePolicyForm.strategyEvaluationQuietSeconds}
+                  onChange={(event) =>
+                    setRuntimePolicyForm((current) => ({
+                      ...current,
+                      strategyEvaluationQuietSeconds: event.target.value,
+                    }))
+                  }
+                />
+              </label>
+              <label className="form-field">
+                <span>账户同步新鲜度 (秒)</span>
+                <input
+                  value={runtimePolicyForm.liveAccountSyncFreshnessSeconds}
+                  onChange={(event) =>
+                    setRuntimePolicyForm((current) => ({
+                      ...current,
+                      liveAccountSyncFreshnessSeconds: event.target.value,
+                    }))
+                  }
+                />
+              </label>
+              <label className="form-field">
                 <span>模拟盘启动超时 (秒)</span>
                 <input
                   value={runtimePolicyForm.paperStartReadinessTimeoutSeconds}
@@ -801,17 +760,23 @@ export function AccountStage({
             </div>
             <div className="backtest-notes">
               <div className="note-item">
-                活跃策略: 成交价格 {runtimePolicy?.tradeTickFreshnessSeconds ?? "--"}秒 · 盘口 {runtimePolicy?.orderBookFreshnessSeconds ?? "--"}秒 ·
-                信号 K 线 {runtimePolicy?.signalBarFreshnessSeconds ?? "--"}秒
+                活跃策略: 成交价格 {runtimePolicyValueLabel(platformRuntimePolicy?.tradeTickFreshnessSeconds)} · 盘口 {runtimePolicyValueLabel(platformRuntimePolicy?.orderBookFreshnessSeconds)} ·
+                信号 K 线 {runtimePolicyValueLabel(platformRuntimePolicy?.signalBarFreshnessSeconds)}
               </div>
               <div className="note-item">
-                静默期 {runtimePolicy?.runtimeQuietSeconds ?? "--"}秒 · 模拟盘预检 {runtimePolicy?.paperStartReadinessTimeoutSeconds ?? "--"}秒
+                运行时静默 {runtimePolicyValueLabel(platformRuntimePolicy?.runtimeQuietSeconds)} · 策略评估静默 {runtimePolicyValueLabel(platformRuntimePolicy?.strategyEvaluationQuietSeconds)}
+              </div>
+              <div className="note-item">
+                账户同步新鲜度 {runtimePolicyValueLabel(platformRuntimePolicy?.liveAccountSyncFreshnessSeconds)} · 模拟盘预检 {runtimePolicyValueLabel(platformRuntimePolicy?.paperStartReadinessTimeoutSeconds)}
+              </div>
+              <div className="note-item">
+                表单支持显式保存 `0`，表示关闭对应阈值，而不是丢失该字段。
               </div>
             </div>
           </div>
 
           <div className="backtest-form session-form">
-            <h4>2.4 创建信号运行时</h4>
+            <h4>2.3 创建信号运行时</h4>
             <div className="form-grid">
               <label className="form-field">
                 <span>账户</span>
@@ -860,14 +825,14 @@ export function AccountStage({
               {signalRuntimePlan?.missingBindings ? (
                 getList(signalRuntimePlan.missingBindings).map((item, index) => (
                   <div key={index} className="note-item note-item-alert note-item-alert-warning">
-                    Missing: {String(item.sourceKey)} · {String(item.role)} · {String(item.symbol)} · {String(item.timeframe)}
+                    Missing: {String(item.sourceKey)} · {String(item.role)} · {String(item.symbol)} · {displaySignalBindingTimeframe(item)}
                   </div>
                 ))
               ) : null}
               {signalRuntimePlan?.matchedBindings ? (
                 getList(signalRuntimePlan.matchedBindings).map((item, index) => (
                   <div key={index} className="note-item">
-                  Matched: {String(item.sourceName)} · {String(item.role)} · {String(item.symbol)}
+                  Matched: {String(item.sourceName ?? item.sourceKey ?? "--")} · {String(item.role)} · {String(item.symbol)} · {displaySignalBindingTimeframe(item)}
                   </div>
                 ))
               ) : null}
@@ -876,7 +841,7 @@ export function AccountStage({
         </div>
 
         <div className="backtest-list mt-8 pt-8 border-t border-white/5">
-          <h4 className="text-sm font-medium text-emerald-400 mb-4">2.5 运行时会话与结果</h4>
+          <h4 className="text-sm font-medium text-emerald-400 mb-4">2.4 运行时会话与结果</h4>
             {signalRuntimeSessions.length > 0 ? (
               <>
                 <div className="table-wrap">

--- a/web/console/src/pages/MonitorStage.tsx
+++ b/web/console/src/pages/MonitorStage.tsx
@@ -21,7 +21,9 @@ import {
   deriveRuntimeSourceSummary,
   buildTimelineNotes,
   boolLabel,
-  liveSessionHealthTone
+  liveSessionHealthTone,
+  runtimePolicyValueLabel,
+  technicalStatusLabel
 } from '../utils/derivation';
 
 type MonitorStageProps = {
@@ -40,8 +42,9 @@ export function MonitorStage({ syncLiveOrder, dockTab, onDockTabChange, dockCont
   const monitorCandles = useTradingStore(s => s.monitorCandles);
   const summaries = useTradingStore(s => s.summaries);
   const runtimePolicy = useTradingStore(s => s.runtimePolicy);
+  const monitorHealth = useTradingStore(s => s.monitorHealth);
   const accounts = useTradingStore(s => s.accounts);
-  const accountSignalBindingMap = useTradingStore(s => s.accountSignalBindingMap);
+  const strategySignalBindingMap = useTradingStore(s => s.strategySignalBindingMap);
   const liveSyncAction = useUIStore(s => s.liveSyncAction);
 
   // Re-calculating derived state locally to keep App clean
@@ -90,7 +93,6 @@ export function MonitorStage({ syncLiveOrder, dockTab, onDockTabChange, dockCont
     [highlightedLiveSession]
   );
   const primaryLiveAccount = monitorSession ? accounts.find((item) => item.id === monitorSession.accountId) ?? null : null;
-  const primaryLiveBindings = monitorSession ? accountSignalBindingMap[monitorSession.accountId] ?? [] : [];
   const primaryLiveRuntimeSessions = monitorSession
     ? signalRuntimeSessions.filter((item) => item.accountId === monitorSession.accountId)
     : [];
@@ -108,7 +110,7 @@ export function MonitorStage({ syncLiveOrder, dockTab, onDockTabChange, dockCont
   const monitorDispatchPreview = deriveLiveDispatchPreview(
     monitorSession,
     primaryLiveAccount,
-    primaryLiveBindings,
+    monitorSession ? strategySignalBindingMap[monitorSession.strategyId] ?? [] : [],
     primaryLiveRuntimeSessions,
     highlightedLiveRuntime,
     monitorRuntimeReadiness,
@@ -116,6 +118,7 @@ export function MonitorStage({ syncLiveOrder, dockTab, onDockTabChange, dockCont
   );
   const syncableLiveOrders = orders.filter((item) => item.metadata?.executionMode === "live" && item.status === "ACCEPTED");
   const [expandedLiveSection, setExpandedLiveSection] = useState<string>("执行与分发");
+  const platformRuntimePolicy = monitorHealth?.runtimePolicy ?? runtimePolicy;
 
   const monitorSummaryItems = monitorSession ? [
     { label: "运行环境", value: `${String(monitorSession.state?.signalRuntimeStatus ?? "--")} · ${formatTime(String(monitorSession.state?.lastSignalRuntimeEventAt ?? ""))}` },
@@ -358,6 +361,114 @@ export function MonitorStage({ syncLiveOrder, dockTab, onDockTabChange, dockCont
             )}
           </div>
         </div>
+      </section>
+
+      <section id="platform-health" className="panel panel-session">
+        <div className="panel-header">
+          <div>
+            <p className="panel-kicker">Platform Health</p>
+            <h3>平台健康总览</h3>
+          </div>
+          <div className="range-box">
+            <span>{technicalStatusLabel(monitorHealth?.status ?? "--")}</span>
+            <span>{formatTime(String(monitorHealth?.generatedAt ?? ""))}</span>
+          </div>
+        </div>
+        {monitorHealth ? (
+          <>
+            <div className="detail-grid detail-grid-compact">
+              <div className="detail-item">
+                <span>平台状态</span>
+                <strong>{technicalStatusLabel(monitorHealth.status)}</strong>
+              </div>
+              <div className="detail-item">
+                <span>告警总数</span>
+                <strong>{String(monitorHealth.alertCounts.total ?? 0)}</strong>
+              </div>
+              <div className="detail-item">
+                <span>Critical / Warning</span>
+                <strong>{String(monitorHealth.alertCounts.critical ?? 0)} / {String(monitorHealth.alertCounts.warning ?? 0)}</strong>
+              </div>
+              <div className="detail-item">
+                <span>运行时静默阈值</span>
+                <strong>{runtimePolicyValueLabel(platformRuntimePolicy?.runtimeQuietSeconds)}</strong>
+              </div>
+              <div className="detail-item">
+                <span>策略评估静默阈值</span>
+                <strong>{runtimePolicyValueLabel(platformRuntimePolicy?.strategyEvaluationQuietSeconds)}</strong>
+              </div>
+              <div className="detail-item">
+                <span>账户同步阈值</span>
+                <strong>{runtimePolicyValueLabel(platformRuntimePolicy?.liveAccountSyncFreshnessSeconds)}</strong>
+              </div>
+            </div>
+            <div className="live-grid mt-4">
+              <div className="backtest-list">
+                <h4>Live Accounts</h4>
+                <SimpleTable
+                  columns={["账户", "状态", "同步年龄", "是否 stale", "运行时", "运行中实盘"]}
+                  rows={monitorHealth.liveAccounts.map((item) => [
+                    item.name,
+                    technicalStatusLabel(item.status),
+                    `${String(item.syncAgeSeconds ?? 0)}s`,
+                    item.syncStale ? "是" : "否",
+                    String(item.runtimeSessionCount ?? 0),
+                    String(item.runningLiveSessionCount ?? 0),
+                  ])}
+                  emptyMessage="暂无 live account 健康数据"
+                />
+              </div>
+              <div className="backtest-list">
+                <h4>Runtime Sessions</h4>
+                <SimpleTable
+                  columns={["策略", "状态", "健康", "静默", "最后事件", "最后心跳"]}
+                  rows={monitorHealth.runtimeSessions.map((item) => [
+                    item.strategyName || shrink(item.strategyId),
+                    technicalStatusLabel(item.status),
+                    technicalStatusLabel(item.health),
+                    item.quiet ? "是" : "否",
+                    formatTime(String(item.lastEventAt ?? "")),
+                    formatTime(String(item.lastHeartbeatAt ?? "")),
+                  ])}
+                  emptyMessage="暂无 runtime 健康数据"
+                />
+              </div>
+            </div>
+            <div className="live-grid mt-4">
+              <div className="backtest-list">
+                <h4>Live Sessions</h4>
+                <SimpleTable
+                  columns={["策略", "状态", "评估静默", "最后评估", "最后运行时事件", "同步状态"]}
+                  rows={monitorHealth.liveSessions.map((item) => [
+                    item.strategyName || shrink(item.strategyId),
+                    technicalStatusLabel(item.status),
+                    item.evaluationQuiet ? "是" : "否",
+                    formatTime(String(item.lastStrategyEvaluationAt ?? "")),
+                    formatTime(String(item.lastSignalRuntimeEventAt ?? "")),
+                    String(item.lastSyncedOrderStatus ?? "--"),
+                  ])}
+                  emptyMessage="暂无 live session 健康数据"
+                />
+              </div>
+              <div className="backtest-list">
+                <h4>健康备注</h4>
+                <div className="backtest-notes">
+                  <div className="note-item">
+                    `/api/v1/monitor/health` 现在作为平台级主摘要，alerts 列表继续保留做事件明细，不再和这里重复堆相同字段。
+                  </div>
+                  <div className="note-item">
+                    `syncStale` 和 `evaluationQuiet` 都已经直接展示，方便区分是账户同步老化还是策略评估静默。
+                  </div>
+                  <div className="note-item">
+                    阈值显示支持 `0 秒 (disabled)`，可以直观看出哪些健康门槛已被显式关闭。
+                  </div>
+                </div>
+              </div>
+            </div>
+          </>
+        ) : (
+          <div className="empty-state empty-state-compact">平台健康快照尚未加载</div>
+        )}
       </section>
 
       <section id="runtime-records" className="panel panel-session">

--- a/web/console/src/store/useTradingStore.ts
+++ b/web/console/src/store/useTradingStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import { AccountSummary, AccountRecord, Order, Fill, Position, AccountEquitySnapshot, StrategyRecord, BacktestRun, BacktestOptions, PaperSession, LiveSession, LiveAdapter, SignalSourceCatalog, SignalSourceType, SignalRuntimeAdapter, SignalRuntimeSession, RuntimePolicy, PlatformAlert, PlatformNotification, TelegramConfig, SignalBinding, ChartCandle, ChartAnnotation, MarkerDetail, ChartOverrideRange, SelectedSample, SourceFilter, EventFilter, TimeWindow, AuthSession } from '../types/domain';
+import { AccountSummary, AccountRecord, Order, Fill, Position, AccountEquitySnapshot, StrategyRecord, BacktestRun, BacktestOptions, PaperSession, LiveSession, LiveAdapter, SignalSourceCatalog, SignalSourceType, SignalRuntimeAdapter, SignalRuntimeSession, RuntimePolicy, PlatformAlert, PlatformNotification, TelegramConfig, SignalBinding, ChartCandle, ChartAnnotation, MarkerDetail, ChartOverrideRange, SelectedSample, SourceFilter, EventFilter, TimeWindow, AuthSession, PlatformHealthSnapshot } from '../types/domain';
 import { readStoredAuthSession } from '../utils/auth';
 import { resolveUpdater } from './helpers';
 
@@ -39,18 +39,16 @@ export interface useTradingStoreState {
   setSignalRuntimeSessions: (valOrUpdater: SignalRuntimeSession[] | ((prev: SignalRuntimeSession[]) => SignalRuntimeSession[])) => void;
   runtimePolicy: RuntimePolicy | null;
   setRuntimePolicy: (valOrUpdater: RuntimePolicy | null | ((prev: RuntimePolicy | null) => RuntimePolicy | null)) => void;
+  monitorHealth: PlatformHealthSnapshot | null;
+  setMonitorHealth: (valOrUpdater: PlatformHealthSnapshot | null | ((prev: PlatformHealthSnapshot | null) => PlatformHealthSnapshot | null)) => void;
   alerts: PlatformAlert[];
   setAlerts: (valOrUpdater: PlatformAlert[] | ((prev: PlatformAlert[]) => PlatformAlert[])) => void;
   notifications: PlatformNotification[];
   setNotifications: (valOrUpdater: PlatformNotification[] | ((prev: PlatformNotification[]) => PlatformNotification[])) => void;
   telegramConfig: TelegramConfig | null;
   setTelegramConfig: (valOrUpdater: TelegramConfig | null | ((prev: TelegramConfig | null) => TelegramConfig | null)) => void;
-  accountSignalBindings: SignalBinding[];
-  setAccountSignalBindings: (valOrUpdater: SignalBinding[] | ((prev: SignalBinding[]) => SignalBinding[])) => void;
   strategySignalBindings: SignalBinding[];
   setStrategySignalBindings: (valOrUpdater: SignalBinding[] | ((prev: SignalBinding[]) => SignalBinding[])) => void;
-  accountSignalBindingMap: Record<string, SignalBinding[]>;
-  setAccountSignalBindingMap: (valOrUpdater: Record<string, SignalBinding[]> | ((prev: Record<string, SignalBinding[]>) => Record<string, SignalBinding[]>)) => void;
   strategySignalBindingMap: Record<string, SignalBinding[]>;
   setStrategySignalBindingMap: (valOrUpdater: Record<string, SignalBinding[]> | ((prev: Record<string, SignalBinding[]>) => Record<string, SignalBinding[]>)) => void;
   signalRuntimePlan: Record<string, unknown> | null;
@@ -104,18 +102,16 @@ export const useTradingStore = create<useTradingStoreState>((set) => ({
   setSignalRuntimeSessions: (valOrUpdater) => set((state) => ({ signalRuntimeSessions: resolveUpdater(valOrUpdater, state.signalRuntimeSessions) })),
   runtimePolicy: null,
   setRuntimePolicy: (valOrUpdater) => set((state) => ({ runtimePolicy: resolveUpdater(valOrUpdater, state.runtimePolicy) })),
+  monitorHealth: null,
+  setMonitorHealth: (valOrUpdater) => set((state) => ({ monitorHealth: resolveUpdater(valOrUpdater, state.monitorHealth) })),
   alerts: [],
   setAlerts: (valOrUpdater) => set((state) => ({ alerts: resolveUpdater(valOrUpdater, state.alerts) })),
   notifications: [],
   setNotifications: (valOrUpdater) => set((state) => ({ notifications: resolveUpdater(valOrUpdater, state.notifications) })),
   telegramConfig: null,
   setTelegramConfig: (valOrUpdater) => set((state) => ({ telegramConfig: resolveUpdater(valOrUpdater, state.telegramConfig) })),
-  accountSignalBindings: [],
-  setAccountSignalBindings: (valOrUpdater) => set((state) => ({ accountSignalBindings: resolveUpdater(valOrUpdater, state.accountSignalBindings) })),
   strategySignalBindings: [],
   setStrategySignalBindings: (valOrUpdater) => set((state) => ({ strategySignalBindings: resolveUpdater(valOrUpdater, state.strategySignalBindings) })),
-  accountSignalBindingMap: {},
-  setAccountSignalBindingMap: (valOrUpdater) => set((state) => ({ accountSignalBindingMap: resolveUpdater(valOrUpdater, state.accountSignalBindingMap) })),
   strategySignalBindingMap: {},
   setStrategySignalBindingMap: (valOrUpdater) => set((state) => ({ strategySignalBindingMap: resolveUpdater(valOrUpdater, state.strategySignalBindingMap) })),
   signalRuntimePlan: null,

--- a/web/console/src/store/useUIStore.ts
+++ b/web/console/src/store/useUIStore.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand';
 import { 
   AccountSummary, AccountRecord, Order, Fill, Position, AccountEquitySnapshot, StrategyRecord, BacktestRun, BacktestOptions, PaperSession, LiveSession, LiveAdapter, SignalSourceCatalog, SignalSourceType, SignalRuntimeAdapter, SignalRuntimeSession, RuntimePolicy, PlatformAlert, PlatformNotification, TelegramConfig, SignalBinding, ChartCandle, ChartAnnotation, MarkerDetail, ChartOverrideRange, SelectedSample, SourceFilter, EventFilter, TimeWindow, AuthSession,
-  LoginForm, BacktestForm, PaperForm, LiveAccountForm, LiveBindingForm, LiveOrderForm, LiveSessionForm, AccountSignalForm, StrategySignalForm, StrategyCreateForm, StrategyEditorForm, SignalRuntimeForm, RuntimePolicyForm, TelegramForm
+  LoginForm, BacktestForm, PaperForm, LiveAccountForm, LiveBindingForm, LiveOrderForm, LiveSessionForm, StrategySignalForm, StrategyCreateForm, StrategyEditorForm, SignalRuntimeForm, RuntimePolicyForm, TelegramForm
 } from '../types/domain';
 import { readStoredAuthSession } from '../utils/auth';
 import { resolveUpdater } from './helpers';
@@ -146,8 +146,6 @@ export interface useUIStoreState {
   setLiveOrderForm: (valOrUpdater: LiveOrderForm | ((prev: LiveOrderForm) => LiveOrderForm)) => void;
   liveSessionForm: LiveSessionForm;
   setLiveSessionForm: (valOrUpdater: LiveSessionForm | ((prev: LiveSessionForm) => LiveSessionForm)) => void;
-  accountSignalForm: AccountSignalForm;
-  setAccountSignalForm: (valOrUpdater: AccountSignalForm | ((prev: AccountSignalForm) => AccountSignalForm)) => void;
   strategySignalForm: StrategySignalForm;
   setStrategySignalForm: (valOrUpdater: StrategySignalForm | ((prev: StrategySignalForm) => StrategySignalForm)) => void;
   strategyCreateForm: StrategyCreateForm;
@@ -298,8 +296,6 @@ export const useUIStore = create<useUIStoreState>((set) => ({
   setLiveOrderForm: (valOrUpdater) => set((state) => ({ liveOrderForm: resolveUpdater(valOrUpdater, state.liveOrderForm) })),
   liveSessionForm: { accountId: "", strategyId: "", signalTimeframe: "1d", executionDataSource: "tick", symbol: "BTCUSDT", defaultOrderQuantity: "0.001", executionEntryOrderType: "MARKET", executionEntryMaxSpreadBps: "8", executionEntryWideSpreadMode: "limit-maker", executionEntryTimeoutFallbackOrderType: "MARKET", executionPTExitOrderType: "LIMIT", executionPTExitTimeInForce: "GTX", executionPTExitPostOnly: true, executionPTExitTimeoutFallbackOrderType: "MARKET", executionSLExitOrderType: "MARKET", executionSLExitMaxSpreadBps: "999", dispatchMode: "manual-review", dispatchCooldownSeconds: "30", },
   setLiveSessionForm: (valOrUpdater) => set((state) => ({ liveSessionForm: resolveUpdater(valOrUpdater, state.liveSessionForm) })),
-  accountSignalForm: { accountId: "", sourceKey: "", role: "trigger", symbol: "BTCUSDT", timeframe: "1d", },
-  setAccountSignalForm: (valOrUpdater) => set((state) => ({ accountSignalForm: resolveUpdater(valOrUpdater, state.accountSignalForm) })),
   strategySignalForm: { strategyId: "", sourceKey: "", role: "trigger", symbol: "BTCUSDT", timeframe: "1d", },
   setStrategySignalForm: (valOrUpdater) => set((state) => ({ strategySignalForm: resolveUpdater(valOrUpdater, state.strategySignalForm) })),
   strategyCreateForm: { name: "", description: "", },
@@ -308,7 +304,15 @@ export const useUIStore = create<useUIStoreState>((set) => ({
   setStrategyEditorForm: (valOrUpdater) => set((state) => ({ strategyEditorForm: resolveUpdater(valOrUpdater, state.strategyEditorForm) })),
   signalRuntimeForm: { accountId: "", strategyId: "", },
   setSignalRuntimeForm: (valOrUpdater) => set((state) => ({ signalRuntimeForm: resolveUpdater(valOrUpdater, state.signalRuntimeForm) })),
-  runtimePolicyForm: { tradeTickFreshnessSeconds: "15", orderBookFreshnessSeconds: "10", signalBarFreshnessSeconds: "30", runtimeQuietSeconds: "30", paperStartReadinessTimeoutSeconds: "5", },
+  runtimePolicyForm: {
+    tradeTickFreshnessSeconds: "15",
+    orderBookFreshnessSeconds: "10",
+    signalBarFreshnessSeconds: "30",
+    runtimeQuietSeconds: "30",
+    strategyEvaluationQuietSeconds: "0",
+    liveAccountSyncFreshnessSeconds: "0",
+    paperStartReadinessTimeoutSeconds: "5",
+  },
   setRuntimePolicyForm: (valOrUpdater) => set((state) => ({ runtimePolicyForm: resolveUpdater(valOrUpdater, state.runtimePolicyForm) })),
   telegramForm: { enabled: false, botToken: "", chatId: "", sendLevels: "critical,warning", },
   setTelegramForm: (valOrUpdater) => set((state) => ({ telegramForm: resolveUpdater(valOrUpdater, state.telegramForm) })),

--- a/web/console/src/types/domain.ts
+++ b/web/console/src/types/domain.ts
@@ -208,9 +208,74 @@ export type SignalBinding = {
   role: string;
   streamType: string;
   symbol: string;
+  timeframe?: string;
   status: string;
   options?: Record<string, unknown>;
   createdAt: string;
+};
+
+export type PlatformHealthAlertCounts = {
+  total: number;
+  critical: number;
+  warning: number;
+  info: number;
+};
+
+export type PlatformHealthAccountSnapshot = {
+  id: string;
+  name: string;
+  exchange: string;
+  status: string;
+  lastLiveSyncAt?: string;
+  syncAgeSeconds: number;
+  syncStale: boolean;
+  runtimeSessionCount: number;
+  runningLiveSessionCount: number;
+  accountSync?: Record<string, unknown>;
+};
+
+export type PlatformHealthRuntimeSessionSnapshot = {
+  id: string;
+  accountId: string;
+  strategyId: string;
+  strategyName?: string;
+  status: string;
+  transport: string;
+  health: string;
+  lastEventAt?: string;
+  lastHeartbeatAt?: string;
+  quiet: boolean;
+  tradeTick?: Record<string, unknown>;
+  orderBook?: Record<string, unknown>;
+};
+
+export type PlatformHealthStrategySessionSnapshot = {
+  id: string;
+  mode: string;
+  accountId: string;
+  strategyId: string;
+  strategyName?: string;
+  status: string;
+  runtimeSessionId?: string;
+  lastSignalRuntimeEventAt?: string;
+  lastStrategyEvaluationAt?: string;
+  lastStrategyEvaluationStatus?: string;
+  lastSyncedOrderStatus?: string;
+  evaluationQuiet: boolean;
+  strategyIngress?: Record<string, unknown>;
+  execution?: Record<string, unknown>;
+  sourceGate?: Record<string, unknown>;
+};
+
+export type PlatformHealthSnapshot = {
+  generatedAt: string;
+  status: string;
+  alertCounts: PlatformHealthAlertCounts;
+  runtimePolicy: RuntimePolicy;
+  liveAccounts: PlatformHealthAccountSnapshot[];
+  runtimeSessions: PlatformHealthRuntimeSessionSnapshot[];
+  liveSessions: PlatformHealthStrategySessionSnapshot[];
+  paperSessions: PlatformHealthStrategySessionSnapshot[];
 };
 
 export type SignalRuntimeAdapter = {
@@ -355,6 +420,8 @@ export type RuntimePolicy = {
   orderBookFreshnessSeconds: number;
   signalBarFreshnessSeconds: number;
   runtimeQuietSeconds: number;
+  strategyEvaluationQuietSeconds: number;
+  liveAccountSyncFreshnessSeconds: number;
   paperStartReadinessTimeoutSeconds: number;
 };
 
@@ -532,6 +599,8 @@ export interface RuntimePolicyForm {
   orderBookFreshnessSeconds: string;
   signalBarFreshnessSeconds: string;
   runtimeQuietSeconds: string;
+  strategyEvaluationQuietSeconds: string;
+  liveAccountSyncFreshnessSeconds: string;
   paperStartReadinessTimeoutSeconds: string;
 }
 
@@ -541,4 +610,3 @@ export interface TelegramForm {
   chatId: string;
   sendLevels: string;
 }
-

--- a/web/console/src/utils/derivation.ts
+++ b/web/console/src/utils/derivation.ts
@@ -1468,3 +1468,30 @@ export function technicalStatusLabel(value: unknown): string {
   }
 }
 
+export function resolveSignalBindingTimeframe(binding: SignalBinding | Record<string, unknown> | null | undefined): string {
+  const record = getRecord(binding);
+  const topLevel = String(record.timeframe ?? "").trim().toLowerCase();
+  if (topLevel) {
+    return topLevel;
+  }
+  const fallback = String(getRecord(record.options).timeframe ?? "").trim().toLowerCase();
+  if (fallback) {
+    return fallback;
+  }
+  return "";
+}
+
+export function displaySignalBindingTimeframe(binding: SignalBinding | Record<string, unknown> | null | undefined): string {
+  return resolveSignalBindingTimeframe(binding) || "--";
+}
+
+export function runtimePolicyValueLabel(value: unknown): string {
+  const num = Number(value);
+  if (!Number.isFinite(num)) {
+    return "--";
+  }
+  if (num === 0) {
+    return "0 秒 (disabled)";
+  }
+  return `${Math.trunc(num)} 秒`;
+}


### PR DESCRIPTION
## 目的
对齐前端 signal binding 与后端新的运行时模型：移除账户级 signal binding 前端入口与状态链路，统一以策略级 binding 作为唯一配置入口；同时补齐 runtime policy 新字段与平台健康快照展示。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [x] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main)
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？
- [x] DB migration 是否具备向下兼容幂等性？
- [x] 配置字段有没有无意被混改？

说明：本 PR 不修改默认 `dispatchMode`，不涉及 mainnet、DB migration、部署或后端执行路径。

## 验证方式与测试证据
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

已验证：
- `cd web/console && npm run build`
- `cd web/console && npx tsc --noEmit`

## 变更摘要
- 删除账户级 signal binding 的前端入口、store 状态、action 和 dashboard 加载链路
- 将 live/runtime 相关预检与分发展示统一改为读取策略级 bindings
- 在 signal binding 列表和 runtime plan 摘要中稳定展示 `timeframe`
- 补齐 `strategyEvaluationQuietSeconds` / `liveAccountSyncFreshnessSeconds` 表单与类型
- 接入 `/api/v1/monitor/health`，新增平台健康总览
- 重新整理 `2.1 绑定策略信号源` 区域排版，避免空卡片布局
