### PR TITLE
[codex] add backend unified log APIs

### DIFF
--- a/internal/domain/logs.go
+++ b/internal/domain/logs.go
@@ -1,0 +1,50 @@
+package domain
+
+import "time"
+
+// EventCursor 定义事件查询游标的排序锚点。
+type EventCursor struct {
+	EventTime  time.Time
+	RecordedAt time.Time
+	ID         string
+}
+
+// StrategyDecisionEventQuery 定义策略决策事件的筛选与分页参数。
+type StrategyDecisionEventQuery struct {
+	AccountID        string
+	StrategyID       string
+	RuntimeSessionID string
+	LiveSessionID    string
+	DecisionEventID  string
+	From             time.Time
+	To               time.Time
+	Before           *EventCursor
+	Limit            int
+}
+
+// OrderExecutionEventQuery 定义订单执行事件的筛选与分页参数。
+type OrderExecutionEventQuery struct {
+	AccountID        string
+	StrategyID       string
+	RuntimeSessionID string
+	LiveSessionID    string
+	OrderID          string
+	DecisionEventID  string
+	From             time.Time
+	To               time.Time
+	Before           *EventCursor
+	Limit            int
+}
+
+// PositionAccountSnapshotQuery 定义仓位账户快照的筛选与分页参数。
+type PositionAccountSnapshotQuery struct {
+	AccountID       string
+	StrategyID      string
+	LiveSessionID   string
+	OrderID         string
+	DecisionEventID string
+	From            time.Time
+	To              time.Time
+	Before          *EventCursor
+	Limit           int
+}

--- a/internal/domain/logs.go
+++ b/internal/domain/logs.go
@@ -48,3 +48,59 @@ type PositionAccountSnapshotQuery struct {
 	Before          *EventCursor
 	Limit           int
 }
+
+// NormalizeEventRecordedAt 统一补齐事件排序用的 recordedAt 锚点。
+func NormalizeEventRecordedAt(recordedAt, eventTime time.Time) time.Time {
+	if recordedAt.IsZero() {
+		return eventTime.UTC()
+	}
+	return recordedAt.UTC()
+}
+
+// EventLessDesc 判断左事件是否应在倒序（最新优先）结果中排在右事件前。
+func EventLessDesc(leftTime, leftRecordedAt time.Time, leftID string, rightTime, rightRecordedAt time.Time, rightID string) bool {
+	leftTime = leftTime.UTC()
+	rightTime = rightTime.UTC()
+	switch {
+	case leftTime.After(rightTime):
+		return true
+	case leftTime.Before(rightTime):
+		return false
+	}
+	leftRecordedAt = NormalizeEventRecordedAt(leftRecordedAt, leftTime)
+	rightRecordedAt = NormalizeEventRecordedAt(rightRecordedAt, rightTime)
+	switch {
+	case leftRecordedAt.After(rightRecordedAt):
+		return true
+	case leftRecordedAt.Before(rightRecordedAt):
+		return false
+	default:
+		return leftID > rightID
+	}
+}
+
+// EventLessAsc 判断左事件是否应在正序（最旧优先）结果中排在右事件前。
+func EventLessAsc(leftTime, leftRecordedAt time.Time, leftID string, rightTime, rightRecordedAt time.Time, rightID string) bool {
+	return EventLessDesc(rightTime, rightRecordedAt, rightID, leftTime, leftRecordedAt, leftID)
+}
+
+// EventBeforeCursor 判断事件是否位于游标之前。
+func EventBeforeCursor(eventTime, recordedAt time.Time, id string, cursor EventCursor) bool {
+	eventTime = eventTime.UTC()
+	recordedAt = NormalizeEventRecordedAt(recordedAt, eventTime)
+	cursorRecordedAt := NormalizeEventRecordedAt(cursor.RecordedAt, cursor.EventTime)
+	switch {
+	case eventTime.Before(cursor.EventTime.UTC()):
+		return true
+	case eventTime.After(cursor.EventTime.UTC()):
+		return false
+	}
+	switch {
+	case recordedAt.Before(cursorRecordedAt):
+		return true
+	case recordedAt.After(cursorRecordedAt):
+		return false
+	default:
+		return id < cursor.ID
+	}
+}

--- a/internal/http/logs.go
+++ b/internal/http/logs.go
@@ -184,21 +184,33 @@ func registerLogRoutes(mux *http.ServeMux, platform *service.Platform) {
 			select {
 			case <-r.Context().Done():
 				return
-			case message := <-systemCh:
+			case message, ok := <-systemCh:
+				if !ok {
+					systemCh = nil
+					continue
+				}
 				if !matchesStreamSource(sourceFilter, message.Source) {
 					continue
 				}
 				if err := writeSSEMessage(w, flusher, message); err != nil {
 					return
 				}
-			case message := <-httpCh:
+			case message, ok := <-httpCh:
+				if !ok {
+					httpCh = nil
+					continue
+				}
 				if !matchesStreamSource(sourceFilter, message.Source) {
 					continue
 				}
 				if err := writeSSEMessage(w, flusher, message); err != nil {
 					return
 				}
-			case message := <-eventCh:
+			case message, ok := <-eventCh:
+				if !ok {
+					eventCh = nil
+					continue
+				}
 				if !matchesStreamSource(sourceFilter, message.Source) {
 					continue
 				}
@@ -457,7 +469,10 @@ func timelineEventsFromState(sessionType, sessionID, accountID, strategyID strin
 		if !ok {
 			continue
 		}
-		eventTime := parseTimelineTime(entry["time"])
+		eventTime, ok := parseTimelineTime(entry["time"])
+		if !ok {
+			continue
+		}
 		metadata := httpLogMapValue(entry["metadata"])
 		item := timelineStreamEvent{
 			SessionType: sessionType,
@@ -506,20 +521,20 @@ func hasTimelineKey(index map[string]map[string]struct{}, sessionType, sessionID
 	return exists
 }
 
-func parseTimelineTime(value any) time.Time {
+func parseTimelineTime(value any) (time.Time, bool) {
 	text := strings.TrimSpace(httpLogStringValue(value))
 	if text == "" {
-		return time.Now().UTC()
+		return time.Time{}, false
 	}
 	parsed, err := time.Parse(time.RFC3339, text)
 	if err == nil {
-		return parsed.UTC()
+		return parsed.UTC(), true
 	}
 	parsed, err = time.Parse(time.RFC3339Nano, text)
 	if err == nil {
-		return parsed.UTC()
+		return parsed.UTC(), true
 	}
-	return time.Now().UTC()
+	return time.Time{}, false
 }
 
 func timelineLevel(category, title string) string {

--- a/internal/http/logs.go
+++ b/internal/http/logs.go
@@ -146,6 +146,24 @@ func registerLogRoutes(mux *http.ServeMux, platform *service.Platform) {
 		writeJSON(w, http.StatusOK, page)
 	})
 
+	mux.HandleFunc("/api/v1/logs/http/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		id := strings.TrimSpace(strings.TrimPrefix(r.URL.Path, "/api/v1/logs/http/"))
+		if id == "" || strings.Contains(id, "/") {
+			writeError(w, http.StatusNotFound, "http log not found")
+			return
+		}
+		entry, ok := logging.GetHTTPRequestLog(id)
+		if !ok {
+			writeError(w, http.StatusNotFound, "http log not found")
+			return
+		}
+		writeJSON(w, http.StatusOK, entry)
+	})
+
 	mux.HandleFunc("/api/v1/logs/stream", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			w.WriteHeader(http.StatusMethodNotAllowed)

--- a/internal/http/logs.go
+++ b/internal/http/logs.go
@@ -1,0 +1,569 @@
+package http
+
+import (
+	"crypto/sha1"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/wuyaocheng/bktrader/internal/domain"
+	"github.com/wuyaocheng/bktrader/internal/logging"
+	"github.com/wuyaocheng/bktrader/internal/service"
+)
+
+const logStreamPollInterval = 2 * time.Second
+
+type streamSnapshotState struct {
+	alertIDs     map[string]struct{}
+	timelineKeys map[string]map[string]struct{}
+}
+
+type timelineStreamEvent struct {
+	ID          string         `json:"id"`
+	SessionType string         `json:"sessionType"`
+	SessionID   string         `json:"sessionId"`
+	AccountID   string         `json:"accountId,omitempty"`
+	StrategyID  string         `json:"strategyId,omitempty"`
+	Category    string         `json:"category,omitempty"`
+	Title       string         `json:"title"`
+	EventTime   time.Time      `json:"eventTime"`
+	Metadata    map[string]any `json:"metadata,omitempty"`
+}
+
+func registerLogRoutes(mux *http.ServeMux, platform *service.Platform) {
+	mux.HandleFunc("/api/v1/logs/events", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		query, err := parseUnifiedLogEventQuery(r)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		page, err := platform.ListLogEvents(query)
+		if err != nil {
+			if strings.Contains(err.Error(), "cursor") {
+				writeError(w, http.StatusBadRequest, err.Error())
+				return
+			}
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		writeJSON(w, http.StatusOK, page)
+	})
+
+	mux.HandleFunc("/api/v1/logs/system", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		from, err := parseOptionalTimeValue(r.URL.Query().Get("from"))
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid from")
+			return
+		}
+		to, err := parseOptionalTimeValue(r.URL.Query().Get("to"))
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid to")
+			return
+		}
+		limit, err := parseOptionalPositiveInt(r.URL.Query().Get("limit"))
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid limit")
+			return
+		}
+		page, err := logging.ListSystemLogs(logging.SystemLogQuery{
+			Level:     r.URL.Query().Get("level"),
+			Component: r.URL.Query().Get("component"),
+			From:      from,
+			To:        to,
+			Cursor:    r.URL.Query().Get("cursor"),
+			Limit:     limit,
+		})
+		if err != nil {
+			writeError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		writeJSON(w, http.StatusOK, page)
+	})
+
+	mux.HandleFunc("/api/v1/logs/http", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		from, err := parseOptionalTimeValue(r.URL.Query().Get("from"))
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid from")
+			return
+		}
+		to, err := parseOptionalTimeValue(r.URL.Query().Get("to"))
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid to")
+			return
+		}
+		limit, err := parseOptionalPositiveInt(r.URL.Query().Get("limit"))
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid limit")
+			return
+		}
+		status, err := parseOptionalPositiveInt(r.URL.Query().Get("status"))
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid status")
+			return
+		}
+		durationMinMs, err := parseOptionalInt64(r.URL.Query().Get("durationMinMs"))
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid durationMinMs")
+			return
+		}
+		durationMaxMs, err := parseOptionalInt64(r.URL.Query().Get("durationMaxMs"))
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid durationMaxMs")
+			return
+		}
+		page, err := logging.ListHTTPRequestLogs(logging.HTTPRequestLogQuery{
+			Level:         r.URL.Query().Get("level"),
+			Method:        r.URL.Query().Get("method"),
+			Path:          r.URL.Query().Get("path"),
+			Status:        status,
+			DurationMinMs: durationMinMs,
+			DurationMaxMs: durationMaxMs,
+			From:          from,
+			To:            to,
+			Cursor:        r.URL.Query().Get("cursor"),
+			Limit:         limit,
+		})
+		if err != nil {
+			writeError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		writeJSON(w, http.StatusOK, page)
+	})
+
+	mux.HandleFunc("/api/v1/logs/stream", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			writeError(w, http.StatusInternalServerError, "streaming unsupported")
+			return
+		}
+
+		sourceFilter := parseStreamSourceFilter(r.URL.Query().Get("source"))
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.Header().Set("Connection", "keep-alive")
+		w.Header().Set("X-Accel-Buffering", "no")
+
+		systemID, systemCh := logging.SystemBroker().Subscribe(64)
+		httpID, httpCh := logging.HTTPBroker().Subscribe(64)
+		eventID, eventCh := platform.SubscribeLogStream(64)
+		defer logging.SystemBroker().Unsubscribe(systemID)
+		defer logging.HTTPBroker().Unsubscribe(httpID)
+		defer platform.UnsubscribeLogStream(eventID)
+
+		_, _ = fmt.Fprint(w, ": connected\n\n")
+		flusher.Flush()
+
+		ticker := time.NewTicker(15 * time.Second)
+		pollTicker := time.NewTicker(logStreamPollInterval)
+		defer ticker.Stop()
+		defer pollTicker.Stop()
+
+		streamState := captureStreamSnapshot(platform)
+
+		for {
+			select {
+			case <-r.Context().Done():
+				return
+			case message := <-systemCh:
+				if !matchesStreamSource(sourceFilter, message.Source) {
+					continue
+				}
+				if err := writeSSEMessage(w, flusher, message); err != nil {
+					return
+				}
+			case message := <-httpCh:
+				if !matchesStreamSource(sourceFilter, message.Source) {
+					continue
+				}
+				if err := writeSSEMessage(w, flusher, message); err != nil {
+					return
+				}
+			case message := <-eventCh:
+				if !matchesStreamSource(sourceFilter, message.Source) {
+					continue
+				}
+				if err := writeSSEMessage(w, flusher, message); err != nil {
+					return
+				}
+			case <-ticker.C:
+				if _, err := fmt.Fprint(w, ": keepalive\n\n"); err != nil {
+					return
+				}
+				flusher.Flush()
+			case <-pollTicker.C:
+				nextState, messages, err := collectPolledStreamMessages(platform, streamState)
+				if err != nil {
+					continue
+				}
+				streamState = nextState
+				for _, message := range messages {
+					if !matchesStreamSource(sourceFilter, message.Source) {
+						continue
+					}
+					if err := writeSSEMessage(w, flusher, message); err != nil {
+						return
+					}
+				}
+			}
+		}
+	})
+}
+
+func parseUnifiedLogEventQuery(r *http.Request) (service.UnifiedLogEventQuery, error) {
+	from, err := parseOptionalTimeValue(r.URL.Query().Get("from"))
+	if err != nil {
+		return service.UnifiedLogEventQuery{}, fmt.Errorf("invalid from")
+	}
+	to, err := parseOptionalTimeValue(r.URL.Query().Get("to"))
+	if err != nil {
+		return service.UnifiedLogEventQuery{}, fmt.Errorf("invalid to")
+	}
+	limit, err := parseOptionalPositiveInt(r.URL.Query().Get("limit"))
+	if err != nil {
+		return service.UnifiedLogEventQuery{}, fmt.Errorf("invalid limit")
+	}
+	return service.UnifiedLogEventQuery{
+		Type:             r.URL.Query().Get("type"),
+		Level:            r.URL.Query().Get("level"),
+		AccountID:        r.URL.Query().Get("accountId"),
+		StrategyID:       r.URL.Query().Get("strategyId"),
+		RuntimeSessionID: r.URL.Query().Get("runtimeSessionId"),
+		LiveSessionID:    r.URL.Query().Get("liveSessionId"),
+		OrderID:          r.URL.Query().Get("orderId"),
+		DecisionEventID:  r.URL.Query().Get("decisionEventId"),
+		Cursor:           r.URL.Query().Get("cursor"),
+		From:             from,
+		To:               to,
+		Limit:            limit,
+	}, nil
+}
+
+func writeSSEMessage(w http.ResponseWriter, flusher http.Flusher, message logging.StreamMessage) error {
+	payload, err := json.Marshal(message)
+	if err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "event: %s\ndata: %s\n\n", message.Type, payload); err != nil {
+		return err
+	}
+	flusher.Flush()
+	return nil
+}
+
+func parseStreamSourceFilter(raw string) map[string]struct{} {
+	if strings.TrimSpace(raw) == "" {
+		return nil
+	}
+	out := make(map[string]struct{})
+	for _, item := range strings.Split(raw, ",") {
+		normalized := strings.ToLower(strings.TrimSpace(item))
+		if normalized == "" {
+			continue
+		}
+		out[normalized] = struct{}{}
+	}
+	return out
+}
+
+func matchesStreamSource(filters map[string]struct{}, source string) bool {
+	if len(filters) == 0 {
+		return true
+	}
+	_, ok := filters[strings.ToLower(strings.TrimSpace(source))]
+	return ok
+}
+
+func parseOptionalPositiveInt(raw string) (int, error) {
+	if strings.TrimSpace(raw) == "" {
+		return 0, nil
+	}
+	value, err := strconv.Atoi(strings.TrimSpace(raw))
+	if err != nil || value < 0 {
+		return 0, fmt.Errorf("invalid integer")
+	}
+	return value, nil
+}
+
+func parseOptionalInt64(raw string) (int64, error) {
+	if strings.TrimSpace(raw) == "" {
+		return 0, nil
+	}
+	value, err := strconv.ParseInt(strings.TrimSpace(raw), 10, 64)
+	if err != nil || value < 0 {
+		return 0, fmt.Errorf("invalid integer")
+	}
+	return value, nil
+}
+
+func parseOptionalTimeValue(raw string) (time.Time, error) {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return time.Time{}, nil
+	}
+	if unixValue, err := strconv.ParseInt(value, 10, 64); err == nil {
+		switch {
+		case len(value) >= 13:
+			return time.UnixMilli(unixValue).UTC(), nil
+		default:
+			return time.Unix(unixValue, 0).UTC(), nil
+		}
+	}
+	parsed, err := time.Parse(time.RFC3339, value)
+	if err == nil {
+		return parsed.UTC(), nil
+	}
+	parsed, err = time.Parse(time.RFC3339Nano, value)
+	if err == nil {
+		return parsed.UTC(), nil
+	}
+	return time.Time{}, fmt.Errorf("invalid time")
+}
+
+func captureStreamSnapshot(platform *service.Platform) streamSnapshotState {
+	state := streamSnapshotState{
+		alertIDs:     make(map[string]struct{}),
+		timelineKeys: make(map[string]map[string]struct{}),
+	}
+
+	if alerts, err := platform.ListAlerts(); err == nil {
+		for _, alert := range alerts {
+			if strings.TrimSpace(alert.ID) != "" {
+				state.alertIDs[alert.ID] = struct{}{}
+			}
+		}
+	}
+	for _, item := range snapshotLiveTimelines(platform) {
+		registerTimelineKey(state.timelineKeys, item.SessionType, item.SessionID, item.ID)
+	}
+	for _, item := range snapshotRuntimeTimelines(platform) {
+		registerTimelineKey(state.timelineKeys, item.SessionType, item.SessionID, item.ID)
+	}
+	return state
+}
+
+func collectPolledStreamMessages(platform *service.Platform, previous streamSnapshotState) (streamSnapshotState, []logging.StreamMessage, error) {
+	next := streamSnapshotState{
+		alertIDs:     make(map[string]struct{}),
+		timelineKeys: make(map[string]map[string]struct{}),
+	}
+	messages := make([]logging.StreamMessage, 0)
+
+	alerts, err := platform.ListAlerts()
+	if err != nil {
+		return previous, nil, err
+	}
+	newAlerts := make([]domain.PlatformAlert, 0)
+	for _, alert := range alerts {
+		if strings.TrimSpace(alert.ID) == "" {
+			continue
+		}
+		next.alertIDs[alert.ID] = struct{}{}
+		if _, seen := previous.alertIDs[alert.ID]; !seen {
+			newAlerts = append(newAlerts, alert)
+		}
+	}
+	sort.SliceStable(newAlerts, func(i, j int) bool {
+		if newAlerts[i].EventTime.Equal(newAlerts[j].EventTime) {
+			return newAlerts[i].ID < newAlerts[j].ID
+		}
+		return newAlerts[i].EventTime.Before(newAlerts[j].EventTime)
+	})
+	for _, alert := range newAlerts {
+		messages = append(messages, logging.StreamMessage{
+			ID:         alert.ID,
+			Source:     "alert",
+			Type:       "alert",
+			Level:      strings.ToLower(strings.TrimSpace(alert.Level)),
+			EventTime:  alert.EventTime.UTC(),
+			RecordedAt: alert.EventTime.UTC(),
+			Payload:    alert,
+		})
+	}
+
+	timelineEvents := append(snapshotLiveTimelines(platform), snapshotRuntimeTimelines(platform)...)
+	sort.SliceStable(timelineEvents, func(i, j int) bool {
+		if timelineEvents[i].EventTime.Equal(timelineEvents[j].EventTime) {
+			return timelineEvents[i].ID < timelineEvents[j].ID
+		}
+		return timelineEvents[i].EventTime.Before(timelineEvents[j].EventTime)
+	})
+	for _, item := range timelineEvents {
+		registerTimelineKey(next.timelineKeys, item.SessionType, item.SessionID, item.ID)
+		if hasTimelineKey(previous.timelineKeys, item.SessionType, item.SessionID, item.ID) {
+			continue
+		}
+		messages = append(messages, logging.StreamMessage{
+			ID:         item.ID,
+			Source:     "timeline",
+			Type:       "timeline",
+			Level:      timelineLevel(item.Category, item.Title),
+			EventTime:  item.EventTime.UTC(),
+			RecordedAt: item.EventTime.UTC(),
+			Payload:    item,
+		})
+	}
+	return next, messages, nil
+}
+
+func snapshotLiveTimelines(platform *service.Platform) []timelineStreamEvent {
+	sessions, err := platform.ListLiveSessions()
+	if err != nil {
+		return nil
+	}
+	items := make([]timelineStreamEvent, 0)
+	for _, session := range sessions {
+		items = append(items, timelineEventsFromState("live", session.ID, session.AccountID, session.StrategyID, session.State)...)
+	}
+	return items
+}
+
+func snapshotRuntimeTimelines(platform *service.Platform) []timelineStreamEvent {
+	sessions := platform.ListSignalRuntimeSessions()
+	items := make([]timelineStreamEvent, 0)
+	for _, session := range sessions {
+		items = append(items, timelineEventsFromState("runtime", session.ID, session.AccountID, session.StrategyID, session.State)...)
+	}
+	return items
+}
+
+func timelineEventsFromState(sessionType, sessionID, accountID, strategyID string, state map[string]any) []timelineStreamEvent {
+	rawItems, ok := state["timeline"].([]any)
+	if !ok || len(rawItems) == 0 {
+		return nil
+	}
+	items := make([]timelineStreamEvent, 0, len(rawItems))
+	for _, raw := range rawItems {
+		entry, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		eventTime := parseTimelineTime(entry["time"])
+		metadata := httpLogMapValue(entry["metadata"])
+		item := timelineStreamEvent{
+			SessionType: sessionType,
+			SessionID:   sessionID,
+			AccountID:   accountID,
+			StrategyID:  strategyID,
+			Category:    httpLogStringValue(entry["category"]),
+			Title:       httpLogStringValue(entry["title"]),
+			EventTime:   eventTime,
+			Metadata:    cloneMap(metadata),
+		}
+		item.ID = buildTimelineEventID(item)
+		items = append(items, item)
+	}
+	return items
+}
+
+func buildTimelineEventID(item timelineStreamEvent) string {
+	payload, _ := json.Marshal(map[string]any{
+		"sessionType": item.SessionType,
+		"sessionId":   item.SessionID,
+		"category":    item.Category,
+		"title":       item.Title,
+		"eventTime":   item.EventTime.UTC().Format(time.RFC3339Nano),
+		"metadata":    item.Metadata,
+	})
+	sum := sha1.Sum(payload)
+	return fmt.Sprintf("timeline-%s-%s-%x", item.SessionType, item.SessionID, sum[:6])
+}
+
+func registerTimelineKey(index map[string]map[string]struct{}, sessionType, sessionID, key string) {
+	composite := sessionType + ":" + sessionID
+	if _, ok := index[composite]; !ok {
+		index[composite] = make(map[string]struct{})
+	}
+	index[composite][key] = struct{}{}
+}
+
+func hasTimelineKey(index map[string]map[string]struct{}, sessionType, sessionID, key string) bool {
+	composite := sessionType + ":" + sessionID
+	items, ok := index[composite]
+	if !ok {
+		return false
+	}
+	_, exists := items[key]
+	return exists
+}
+
+func parseTimelineTime(value any) time.Time {
+	text := strings.TrimSpace(httpLogStringValue(value))
+	if text == "" {
+		return time.Now().UTC()
+	}
+	parsed, err := time.Parse(time.RFC3339, text)
+	if err == nil {
+		return parsed.UTC()
+	}
+	parsed, err = time.Parse(time.RFC3339Nano, text)
+	if err == nil {
+		return parsed.UTC()
+	}
+	return time.Now().UTC()
+}
+
+func timelineLevel(category, title string) string {
+	normalizedCategory := strings.ToLower(strings.TrimSpace(category))
+	normalizedTitle := strings.ToLower(strings.TrimSpace(title))
+	switch {
+	case normalizedCategory == "error":
+		return "critical"
+	case strings.Contains(normalizedTitle, "error"), strings.Contains(normalizedTitle, "fail"):
+		return "warning"
+	default:
+		return "info"
+	}
+}
+
+func httpLogMapValue(value any) map[string]any {
+	if item, ok := value.(map[string]any); ok {
+		return item
+	}
+	return nil
+}
+
+func httpLogStringValue(value any) string {
+	switch typed := value.(type) {
+	case string:
+		return strings.TrimSpace(typed)
+	case fmt.Stringer:
+		return strings.TrimSpace(typed.String())
+	default:
+		return ""
+	}
+}
+
+func cloneMap(input map[string]any) map[string]any {
+	if len(input) == 0 {
+		return nil
+	}
+	payload, err := json.Marshal(input)
+	if err != nil {
+		return map[string]any{}
+	}
+	var out map[string]any
+	if err := json.Unmarshal(payload, &out); err != nil {
+		return map[string]any{}
+	}
+	return out
+}

--- a/internal/http/logs_test.go
+++ b/internal/http/logs_test.go
@@ -247,3 +247,54 @@ func TestCollectPolledStreamMessagesDetectsAlertAndTimelineDeltas(t *testing.T) 
 		t.Fatalf("expected no duplicate messages on identical snapshot, got %#v", repeatMessages)
 	}
 }
+
+func TestCollectPolledStreamMessagesSkipsInvalidTimelineTimestamp(t *testing.T) {
+	store := memory.NewStore()
+	platform := service.NewPlatform(store)
+
+	previous := captureStreamSnapshot(platform)
+
+	account, err := store.CreateAccount("paper account", "PAPER", "BINANCE")
+	if err != nil {
+		t.Fatalf("create account: %v", err)
+	}
+	session, err := store.CreateLiveSession(account.ID, "strategy-1")
+	if err != nil {
+		t.Fatalf("create live session: %v", err)
+	}
+	_, err = store.UpdateLiveSessionState(session.ID, map[string]any{
+		"runner":       "strategy-engine",
+		"dispatchMode": "manual-review",
+		"timeline": []any{
+			map[string]any{
+				"time":     "not-a-timestamp",
+				"category": "strategy",
+				"title":    "decision",
+				"metadata": map[string]any{"symbol": "BTCUSDT"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("update live session state: %v", err)
+	}
+
+	next, messages, err := collectPolledStreamMessages(platform, previous)
+	if err != nil {
+		t.Fatalf("collect messages with invalid timestamp: %v", err)
+	}
+	for _, message := range messages {
+		if message.Source == "timeline" {
+			t.Fatalf("expected invalid timeline entries to be skipped, got %#v", message)
+		}
+	}
+
+	_, repeatMessages, err := collectPolledStreamMessages(platform, next)
+	if err != nil {
+		t.Fatalf("collect repeated messages with invalid timestamp: %v", err)
+	}
+	for _, message := range repeatMessages {
+		if message.Source == "timeline" {
+			t.Fatalf("expected invalid timeline entries to stay skipped, got %#v", message)
+		}
+	}
+}

--- a/internal/http/logs_test.go
+++ b/internal/http/logs_test.go
@@ -37,14 +37,18 @@ func TestLogRoutesExposeSystemAndHTTPRequestLogs(t *testing.T) {
 		Message:   "bootstrap recovered",
 		CreatedAt: base.Add(time.Minute),
 	})
-	logging.RecordHTTPRequest(logging.HTTPRequestLogEntry{
-		Level:      "error",
-		Message:    "http request failed",
-		Method:     http.MethodGet,
-		Path:       "/api/v1/live/sessions",
-		Status:     http.StatusServiceUnavailable,
-		DurationMs: 420,
-		CreatedAt:  base.Add(2 * time.Minute),
+	sensitiveRequestLog := logging.RecordHTTPRequest(logging.HTTPRequestLogEntry{
+		Level:        "error",
+		Message:      "http request failed",
+		Method:       http.MethodGet,
+		Path:         "/api/v1/live/sessions",
+		Query:        "token=abc123&mode=read",
+		RemoteAddr:   "10.1.2.3:443",
+		Status:       http.StatusServiceUnavailable,
+		DurationMs:   420,
+		PanicMessage: "panic: sensitive downstream error",
+		Stack:        "top-secret stack trace",
+		CreatedAt:    base.Add(2 * time.Minute),
 	})
 	logging.RecordHTTPRequest(logging.HTTPRequestLogEntry{
 		Level:      "info",
@@ -84,6 +88,33 @@ func TestLogRoutesExposeSystemAndHTTPRequestLogs(t *testing.T) {
 	}
 	if len(httpPage.Items) != 1 || httpPage.Items[0].Path != "/api/v1/live/sessions" {
 		t.Fatalf("unexpected http log page: %#v", httpPage.Items)
+	}
+	if httpPage.Items[0].Query != "token=REDACTED&mode=REDACTED" {
+		t.Fatalf("expected redacted query in list response, got %#v", httpPage.Items[0].Query)
+	}
+	if httpPage.Items[0].RemoteAddr != "10.1.x.x" {
+		t.Fatalf("expected masked remote addr in list response, got %#v", httpPage.Items[0].RemoteAddr)
+	}
+	if httpPage.Items[0].PanicMessage != "[redacted]" || httpPage.Items[0].Stack != "[redacted]" {
+		t.Fatalf("expected sensitive fields to be redacted in list response, got %#v", httpPage.Items[0])
+	}
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/logs/http/"+sensitiveRequestLog.ID, nil)
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 for http log detail, got %d", rec.Code)
+	}
+	var detail logging.HTTPRequestLogEntry
+	if err := json.NewDecoder(rec.Body).Decode(&detail); err != nil {
+		t.Fatalf("decode http log detail response: %v", err)
+	}
+	if detail.Query != "token=abc123&mode=read" || detail.RemoteAddr != "10.1.2.3:443" {
+		t.Fatalf("expected raw detail fields, got %#v", detail)
+	}
+	if detail.PanicMessage != "panic: sensitive downstream error" || detail.Stack != "top-secret stack trace" {
+		t.Fatalf("expected raw sensitive detail fields, got %#v", detail)
 	}
 }
 
@@ -186,6 +217,60 @@ func TestLogStreamEndpointWritesSSE(t *testing.T) {
 	}
 	if !strings.Contains(body, "watcher tripped") {
 		t.Fatalf("expected streamed payload in SSE output, got %q", body)
+	}
+}
+
+func TestLogStreamEndpointSanitizesHTTPRequestPayload(t *testing.T) {
+	logging.ResetForTests()
+	t.Cleanup(logging.ResetForTests)
+
+	platform := service.NewPlatform(memory.NewStore())
+	mux := http.NewServeMux()
+	registerLogRoutes(mux, platform)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/logs/stream?source=http", nil).WithContext(ctx)
+	rec := httptest.NewRecorder()
+	done := make(chan struct{})
+	go func() {
+		mux.ServeHTTP(rec, req)
+		close(done)
+	}()
+
+	time.Sleep(30 * time.Millisecond)
+	logging.RecordHTTPRequest(logging.HTTPRequestLogEntry{
+		Level:        "error",
+		Message:      "http request failed",
+		Method:       http.MethodPost,
+		Path:         "/api/v1/orders",
+		Query:        "token=abc123&account=live-main",
+		RemoteAddr:   "10.1.2.3:443",
+		Status:       http.StatusInternalServerError,
+		DurationMs:   88,
+		PanicMessage: "panic: exchange timeout",
+		Stack:        "top-secret stack trace",
+		CreatedAt:    time.Now().UTC(),
+	})
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for http stream handler to exit")
+	}
+
+	body := rec.Body.String()
+	if !strings.Contains(body, "event: http-request") {
+		t.Fatalf("expected http-request event in SSE output, got %q", body)
+	}
+	if strings.Contains(body, "abc123") || strings.Contains(body, "10.1.2.3:443") || strings.Contains(body, "top-secret stack trace") {
+		t.Fatalf("expected http SSE payload to stay redacted, got %q", body)
+	}
+	if !strings.Contains(body, "token=REDACTED\\u0026account=REDACTED") || !strings.Contains(body, "10.1.x.x") || !strings.Contains(body, "[redacted]") {
+		t.Fatalf("expected sanitized http SSE payload, got %q", body)
 	}
 }
 

--- a/internal/http/logs_test.go
+++ b/internal/http/logs_test.go
@@ -1,0 +1,249 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/wuyaocheng/bktrader/internal/domain"
+	"github.com/wuyaocheng/bktrader/internal/logging"
+	"github.com/wuyaocheng/bktrader/internal/service"
+	"github.com/wuyaocheng/bktrader/internal/store/memory"
+)
+
+func TestLogRoutesExposeSystemAndHTTPRequestLogs(t *testing.T) {
+	logging.ResetForTests()
+	t.Cleanup(logging.ResetForTests)
+
+	platform := service.NewPlatform(memory.NewStore())
+	mux := http.NewServeMux()
+	registerLogRoutes(mux, platform)
+
+	base := time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC)
+	logging.RecordSystemLog(logging.SystemLogEntry{
+		Level:     "error",
+		Message:   "bootstrap failed",
+		CreatedAt: base,
+		Attributes: map[string]any{
+			"component": "app.server",
+		},
+	})
+	logging.RecordSystemLog(logging.SystemLogEntry{
+		Level:     "info",
+		Message:   "bootstrap recovered",
+		CreatedAt: base.Add(time.Minute),
+	})
+	logging.RecordHTTPRequest(logging.HTTPRequestLogEntry{
+		Level:      "error",
+		Message:    "http request failed",
+		Method:     http.MethodGet,
+		Path:       "/api/v1/live/sessions",
+		Status:     http.StatusServiceUnavailable,
+		DurationMs: 420,
+		CreatedAt:  base.Add(2 * time.Minute),
+	})
+	logging.RecordHTTPRequest(logging.HTTPRequestLogEntry{
+		Level:      "info",
+		Message:    "http request completed",
+		Method:     http.MethodGet,
+		Path:       "/healthz",
+		Status:     http.StatusOK,
+		DurationMs: 12,
+		CreatedAt:  base.Add(3 * time.Minute),
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/logs/system?level=error&limit=10", nil)
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 for system logs, got %d", rec.Code)
+	}
+	var systemPage logging.SystemLogPage
+	if err := json.NewDecoder(rec.Body).Decode(&systemPage); err != nil {
+		t.Fatalf("decode system logs response: %v", err)
+	}
+	if len(systemPage.Items) != 1 || systemPage.Items[0].Message != "bootstrap failed" {
+		t.Fatalf("unexpected system log page: %#v", systemPage.Items)
+	}
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/logs/http?status=503&path=/api/v1/live&limit=10", nil)
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 for http logs, got %d", rec.Code)
+	}
+	var httpPage logging.HTTPRequestLogPage
+	if err := json.NewDecoder(rec.Body).Decode(&httpPage); err != nil {
+		t.Fatalf("decode http logs response: %v", err)
+	}
+	if len(httpPage.Items) != 1 || httpPage.Items[0].Path != "/api/v1/live/sessions" {
+		t.Fatalf("unexpected http log page: %#v", httpPage.Items)
+	}
+}
+
+func TestLogRoutesExposeUnifiedEvents(t *testing.T) {
+	store := memory.NewStore()
+	platform := service.NewPlatform(store)
+	mux := http.NewServeMux()
+	registerLogRoutes(mux, platform)
+
+	base := time.Date(2026, 4, 16, 11, 0, 0, 0, time.UTC)
+	if _, err := store.CreateStrategyDecisionEvent(domain.StrategyDecisionEvent{
+		ID:               "decision-1",
+		LiveSessionID:    "live-1",
+		RuntimeSessionID: "runtime-1",
+		AccountID:        "account-1",
+		StrategyID:       "strategy-1",
+		Action:           "wait",
+		Reason:           "blocked by gate",
+		SourceGateReady:  false,
+		MissingCount:     1,
+		EventTime:        base,
+		RecordedAt:       base,
+	}); err != nil {
+		t.Fatalf("seed decision event: %v", err)
+	}
+	if _, err := store.CreateOrderExecutionEvent(domain.OrderExecutionEvent{
+		ID:              "execution-1",
+		OrderID:         "order-1",
+		AccountID:       "account-1",
+		LiveSessionID:   "live-1",
+		DecisionEventID: "decision-1",
+		Status:          "FAILED",
+		EventType:       "submit",
+		Failed:          true,
+		EventTime:       base.Add(time.Minute),
+		RecordedAt:      base.Add(time.Minute),
+		Metadata: map[string]any{
+			"strategyId": "strategy-1",
+		},
+	}); err != nil {
+		t.Fatalf("seed order event: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/logs/events?type=order-execution&accountId=account-1&level=critical&limit=10", nil)
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 for unified events, got %d", rec.Code)
+	}
+	var page service.UnifiedLogEventPage
+	if err := json.NewDecoder(rec.Body).Decode(&page); err != nil {
+		t.Fatalf("decode unified log page: %v", err)
+	}
+	if len(page.Items) != 1 {
+		t.Fatalf("expected 1 unified event, got %d", len(page.Items))
+	}
+	if page.Items[0].ID != "execution-1" || page.Items[0].OrderID != "order-1" {
+		t.Fatalf("unexpected unified event: %#v", page.Items[0])
+	}
+}
+
+func TestLogStreamEndpointWritesSSE(t *testing.T) {
+	logging.ResetForTests()
+	t.Cleanup(logging.ResetForTests)
+
+	platform := service.NewPlatform(memory.NewStore())
+	mux := http.NewServeMux()
+	registerLogRoutes(mux, platform)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/logs/stream?source=system", nil).WithContext(ctx)
+	rec := httptest.NewRecorder()
+	done := make(chan struct{})
+	go func() {
+		mux.ServeHTTP(rec, req)
+		close(done)
+	}()
+
+	time.Sleep(30 * time.Millisecond)
+	logging.RecordSystemLog(logging.SystemLogEntry{
+		Level:     "warning",
+		Message:   "watcher tripped",
+		CreatedAt: time.Now().UTC(),
+	})
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for stream handler to exit")
+	}
+
+	body := rec.Body.String()
+	if !strings.Contains(body, "event: system-log") {
+		t.Fatalf("expected system-log event in SSE output, got %q", body)
+	}
+	if !strings.Contains(body, "watcher tripped") {
+		t.Fatalf("expected streamed payload in SSE output, got %q", body)
+	}
+}
+
+func TestCollectPolledStreamMessagesDetectsAlertAndTimelineDeltas(t *testing.T) {
+	store := memory.NewStore()
+	platform := service.NewPlatform(store)
+
+	previous := captureStreamSnapshot(platform)
+
+	account, err := store.CreateAccount("live account", "LIVE", "BINANCE")
+	if err != nil {
+		t.Fatalf("create live account: %v", err)
+	}
+	session, err := store.CreateLiveSession(account.ID, "strategy-1")
+	if err != nil {
+		t.Fatalf("create live session: %v", err)
+	}
+	_, err = store.UpdateLiveSessionState(session.ID, map[string]any{
+		"runner":       "strategy-engine",
+		"dispatchMode": "manual-review",
+		"timeline": []any{
+			map[string]any{
+				"time":     time.Date(2026, 4, 16, 12, 0, 0, 0, time.UTC).Format(time.RFC3339),
+				"category": "strategy",
+				"title":    "decision",
+				"metadata": map[string]any{"symbol": "BTCUSDT"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("update live session state: %v", err)
+	}
+
+	next, messages, err := collectPolledStreamMessages(platform, previous)
+	if err != nil {
+		t.Fatalf("collect polled stream messages: %v", err)
+	}
+	if len(messages) < 2 {
+		t.Fatalf("expected alert and timeline messages, got %#v", messages)
+	}
+	var alertCount, timelineCount int
+	for _, message := range messages {
+		switch message.Source {
+		case "alert":
+			alertCount++
+		case "timeline":
+			timelineCount++
+		}
+	}
+	if alertCount == 0 || timelineCount == 0 {
+		t.Fatalf("expected at least one alert and one timeline message, got alert=%d timeline=%d", alertCount, timelineCount)
+	}
+
+	_, repeatMessages, err := collectPolledStreamMessages(platform, next)
+	if err != nil {
+		t.Fatalf("collect repeated snapshot: %v", err)
+	}
+	if len(repeatMessages) != 0 {
+		t.Fatalf("expected no duplicate messages on identical snapshot, got %#v", repeatMessages)
+	}
+}

--- a/internal/http/router.go
+++ b/internal/http/router.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
@@ -30,6 +31,7 @@ func NewRouter(cfg config.Config, platform *service.Platform) http.Handler {
 	})
 
 	registerAuthRoutes(mux, cfg)
+	registerLogRoutes(mux, platform)
 
 	// 系统概览端点
 	mux.HandleFunc("/api/v1/overview", func(w http.ResponseWriter, _ *http.Request) {
@@ -124,14 +126,18 @@ func requestLogMiddleware(next http.Handler) http.Handler {
 		)
 
 		defer func() {
+			panicMessage := ""
+			stackTrace := ""
 			if recovered := recover(); recovered != nil {
 				recorder.statusCode = http.StatusInternalServerError
 				if !recorder.wroteHeader {
 					writeError(recorder, http.StatusInternalServerError, "internal server error")
 				}
+				panicMessage = fmt.Sprint(recovered)
+				stackTrace = string(debug.Stack())
 				logger.Error("http request panicked",
 					"panic", recovered,
-					"stack", string(debug.Stack()),
+					"stack", stackTrace,
 				)
 			}
 
@@ -149,6 +155,25 @@ func requestLogMiddleware(next http.Handler) http.Handler {
 				"bytes_written", recorder.bytesWrite,
 				"content_length", r.ContentLength,
 			)
+			logging.RecordHTTPRequest(logging.HTTPRequestLogEntry{
+				Level:         logging.HTTPLevel(recorder.statusCode).String(),
+				Message:       message,
+				Method:        r.Method,
+				Path:          r.URL.Path,
+				Query:         r.URL.RawQuery,
+				RemoteAddr:    r.RemoteAddr,
+				UserAgent:     r.UserAgent(),
+				Status:        recorder.statusCode,
+				DurationMs:    time.Since(start).Milliseconds(),
+				BytesWritten:  recorder.bytesWrite,
+				ContentLength: r.ContentLength,
+				PanicMessage:  panicMessage,
+				Stack:         stackTrace,
+				CreatedAt:     time.Now().UTC(),
+				Attributes: map[string]any{
+					"component": "http",
+				},
+			})
 		}()
 
 		next.ServeHTTP(recorder, r)

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -1,6 +1,7 @@
 package logging
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"os"
@@ -41,6 +42,8 @@ func Configure(cfg config.Config) error {
 		return fmt.Errorf("unsupported log format: %s", cfg.LogFormat)
 	}
 
+	handler = newMultiHandler(handler, newSystemCaptureHandler())
+
 	logger := slog.New(handler).With(
 		"app", cfg.AppName,
 		"env", cfg.Environment,
@@ -59,6 +62,58 @@ func HTTPLevel(status int) slog.Level {
 	default:
 		return slog.LevelInfo
 	}
+}
+
+type multiHandler struct {
+	handlers []slog.Handler
+}
+
+func newMultiHandler(handlers ...slog.Handler) slog.Handler {
+	filtered := make([]slog.Handler, 0, len(handlers))
+	for _, handler := range handlers {
+		if handler != nil {
+			filtered = append(filtered, handler)
+		}
+	}
+	return &multiHandler{handlers: filtered}
+}
+
+func (h *multiHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	for _, handler := range h.handlers {
+		if handler.Enabled(ctx, level) {
+			return true
+		}
+	}
+	return false
+}
+
+func (h *multiHandler) Handle(ctx context.Context, record slog.Record) error {
+	var firstErr error
+	for _, handler := range h.handlers {
+		if !handler.Enabled(ctx, record.Level) {
+			continue
+		}
+		if err := handler.Handle(ctx, record.Clone()); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+func (h *multiHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	handlers := make([]slog.Handler, 0, len(h.handlers))
+	for _, handler := range h.handlers {
+		handlers = append(handlers, handler.WithAttrs(attrs))
+	}
+	return &multiHandler{handlers: handlers}
+}
+
+func (h *multiHandler) WithGroup(name string) slog.Handler {
+	handlers := make([]slog.Handler, 0, len(h.handlers))
+	for _, handler := range h.handlers {
+		handlers = append(handlers, handler.WithGroup(name))
+	}
+	return &multiHandler{handlers: handlers}
 }
 
 func parseLevel(value string) (slog.Level, error) {

--- a/internal/logging/store.go
+++ b/internal/logging/store.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"net"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -17,6 +18,7 @@ const (
 	defaultHTTPRequestCapacity = 2048
 	defaultQueryLimit          = 100
 	maxQueryLimit              = 200
+	redactedText               = "[redacted]"
 )
 
 // SystemLogEntry 表示可供前端回看的系统日志记录。
@@ -258,7 +260,7 @@ func RecordHTTPRequest(entry HTTPRequestLogEntry) HTTPRequestLogEntry {
 		Level:      recorded.Level,
 		EventTime:  recorded.CreatedAt,
 		RecordedAt: recorded.CreatedAt,
-		Payload:    recorded,
+		Payload:    sanitizeHTTPRequestLogEntry(recorded),
 	})
 	return recorded
 }
@@ -277,6 +279,10 @@ func ListHTTPRequestLogs(query HTTPRequestLogQuery) (HTTPRequestLogPage, error) 
 		return HTTPRequestLogPage{}, err
 	}
 	return defaultHTTPRequestStore.query(query, cursor), nil
+}
+
+func GetHTTPRequestLog(id string) (HTTPRequestLogEntry, bool) {
+	return defaultHTTPRequestStore.get(strings.TrimSpace(id))
 }
 
 // ResetForTests 清理全局日志缓冲，仅供测试使用。
@@ -447,7 +453,7 @@ func (s *httpRequestLogStore) query(query HTTPRequestLogQuery, cursor *timeCurso
 		if !query.To.IsZero() && item.CreatedAt.After(query.To.UTC()) {
 			continue
 		}
-		out = append(out, item)
+		out = append(out, sanitizeHTTPRequestLogEntry(item))
 		if len(out) >= limit+1 {
 			break
 		}
@@ -463,6 +469,19 @@ func (s *httpRequestLogStore) query(query HTTPRequestLogQuery, cursor *timeCurso
 func (s *httpRequestLogStore) reset() {
 	s.sequence.Store(0)
 	s.buffer.reset()
+}
+
+func (s *httpRequestLogStore) get(id string) (HTTPRequestLogEntry, bool) {
+	if id == "" {
+		return HTTPRequestLogEntry{}, false
+	}
+	items := s.buffer.snapshot()
+	for i := len(items) - 1; i >= 0; i-- {
+		if items[i].ID == id {
+			return items[i], true
+		}
+	}
+	return HTTPRequestLogEntry{}, false
 }
 
 func normalizeLimit(limit int) int {
@@ -549,6 +568,76 @@ func normalizeTime(value time.Time) time.Time {
 		return time.Now().UTC()
 	}
 	return value.UTC()
+}
+
+func sanitizeHTTPRequestLogEntry(entry HTTPRequestLogEntry) HTTPRequestLogEntry {
+	entry.Query = redactQuery(entry.Query)
+	entry.RemoteAddr = maskRemoteAddr(entry.RemoteAddr)
+	entry.PanicMessage = redactSensitiveText(entry.PanicMessage)
+	entry.Stack = redactSensitiveText(entry.Stack)
+	return entry
+}
+
+func redactQuery(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	parts := strings.Split(raw, "&")
+	for i, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		key := part
+		if index := strings.Index(part, "="); index >= 0 {
+			key = part[:index]
+		}
+		key = strings.TrimSpace(key)
+		if key == "" {
+			parts[i] = redactedText
+			continue
+		}
+		parts[i] = key + "=REDACTED"
+	}
+	return strings.Join(parts, "&")
+}
+
+func maskRemoteAddr(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	host := raw
+	if parsedHost, _, err := net.SplitHostPort(raw); err == nil {
+		host = parsedHost
+	}
+	host = strings.Trim(host, "[]")
+	if ip := net.ParseIP(host); ip != nil {
+		if ipv4 := ip.To4(); ipv4 != nil {
+			return fmt.Sprintf("%d.%d.x.x", ipv4[0], ipv4[1])
+		}
+		parts := strings.Split(ip.String(), ":")
+		for len(parts) < 2 {
+			parts = append(parts, "*")
+		}
+		return parts[0] + ":" + parts[1] + ":*:*:*:*:*:*"
+	}
+	labels := strings.Split(host, ".")
+	if len(labels) > 1 && strings.TrimSpace(labels[0]) != "" {
+		return labels[0] + ".***"
+	}
+	if len(host) <= 2 {
+		return "*"
+	}
+	return host[:1] + "***"
+}
+
+func redactSensitiveText(raw string) string {
+	if strings.TrimSpace(raw) == "" {
+		return ""
+	}
+	return redactedText
 }
 
 func appendSlogAttr(target map[string]any, groups []string, attr slog.Attr) {

--- a/internal/logging/store.go
+++ b/internal/logging/store.go
@@ -1,0 +1,623 @@
+package logging
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+const (
+	defaultSystemLogCapacity   = 2048
+	defaultHTTPRequestCapacity = 2048
+	defaultQueryLimit          = 100
+	maxQueryLimit              = 200
+)
+
+// SystemLogEntry 表示可供前端回看的系统日志记录。
+type SystemLogEntry struct {
+	ID         string         `json:"id"`
+	Level      string         `json:"level"`
+	Message    string         `json:"message"`
+	CreatedAt  time.Time      `json:"createdAt"`
+	Attributes map[string]any `json:"attributes,omitempty"`
+}
+
+// HTTPRequestLogEntry 表示请求日志中间件采集到的结构化访问记录。
+type HTTPRequestLogEntry struct {
+	ID            string         `json:"id"`
+	Level         string         `json:"level"`
+	Message       string         `json:"message"`
+	Method        string         `json:"method"`
+	Path          string         `json:"path"`
+	Query         string         `json:"query,omitempty"`
+	RemoteAddr    string         `json:"remoteAddr,omitempty"`
+	UserAgent     string         `json:"userAgent,omitempty"`
+	Status        int            `json:"status"`
+	DurationMs    int64          `json:"durationMs"`
+	BytesWritten  int            `json:"bytesWritten"`
+	ContentLength int64          `json:"contentLength"`
+	PanicMessage  string         `json:"panicMessage,omitempty"`
+	Stack         string         `json:"stack,omitempty"`
+	CreatedAt     time.Time      `json:"createdAt"`
+	Attributes    map[string]any `json:"attributes,omitempty"`
+}
+
+// SystemLogQuery 定义系统日志检索条件。
+type SystemLogQuery struct {
+	Level     string
+	Component string
+	From      time.Time
+	To        time.Time
+	Cursor    string
+	Limit     int
+}
+
+// HTTPRequestLogQuery 定义请求日志检索条件。
+type HTTPRequestLogQuery struct {
+	Level         string
+	Method        string
+	Path          string
+	Status        int
+	DurationMinMs int64
+	DurationMaxMs int64
+	From          time.Time
+	To            time.Time
+	Cursor        string
+	Limit         int
+}
+
+// SystemLogPage 表示系统日志分页结果。
+type SystemLogPage struct {
+	Items      []SystemLogEntry `json:"items"`
+	NextCursor string           `json:"nextCursor,omitempty"`
+}
+
+// HTTPRequestLogPage 表示请求日志分页结果。
+type HTTPRequestLogPage struct {
+	Items      []HTTPRequestLogEntry `json:"items"`
+	NextCursor string                `json:"nextCursor,omitempty"`
+}
+
+// StreamMessage 表示 SSE 日志总线输出的统一消息。
+type StreamMessage struct {
+	ID         string    `json:"id,omitempty"`
+	Source     string    `json:"source"`
+	Type       string    `json:"type"`
+	Level      string    `json:"level,omitempty"`
+	EventTime  time.Time `json:"eventTime"`
+	RecordedAt time.Time `json:"recordedAt,omitempty"`
+	Payload    any       `json:"payload,omitempty"`
+}
+
+// Broker 提供轻量级的非阻塞发布订阅能力，避免慢客户端拖垮后端。
+type Broker struct {
+	mu     sync.Mutex
+	nextID int
+	subs   map[int]chan StreamMessage
+}
+
+func NewBroker() *Broker {
+	return &Broker{subs: make(map[int]chan StreamMessage)}
+}
+
+func (b *Broker) Subscribe(buffer int) (int, <-chan StreamMessage) {
+	if buffer <= 0 {
+		buffer = 32
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.nextID++
+	ch := make(chan StreamMessage, buffer)
+	b.subs[b.nextID] = ch
+	return b.nextID, ch
+}
+
+func (b *Broker) Unsubscribe(id int) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	ch, ok := b.subs[id]
+	if !ok {
+		return
+	}
+	delete(b.subs, id)
+	close(ch)
+}
+
+func (b *Broker) Publish(message StreamMessage) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for _, ch := range b.subs {
+		select {
+		case ch <- message:
+		default:
+			// 慢订阅者直接丢弃，避免背压传导到请求处理线程。
+		}
+	}
+}
+
+func (b *Broker) reset() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for id, ch := range b.subs {
+		delete(b.subs, id)
+		close(ch)
+	}
+	b.nextID = 0
+}
+
+type ringBuffer[T any] struct {
+	mu       sync.RWMutex
+	capacity int
+	items    []T
+	head     int
+	size     int
+}
+
+func newRingBuffer[T any](capacity int) *ringBuffer[T] {
+	if capacity < 1 {
+		capacity = 1
+	}
+	return &ringBuffer[T]{
+		capacity: capacity,
+		items:    make([]T, capacity),
+	}
+}
+
+func (r *ringBuffer[T]) append(item T) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.items[r.head] = item
+	r.head = (r.head + 1) % r.capacity
+	if r.size < r.capacity {
+		r.size++
+	}
+}
+
+func (r *ringBuffer[T]) snapshot() []T {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]T, 0, r.size)
+	start := r.head - r.size
+	if start < 0 {
+		start += r.capacity
+	}
+	for i := 0; i < r.size; i++ {
+		index := (start + i) % r.capacity
+		out = append(out, r.items[index])
+	}
+	return out
+}
+
+func (r *ringBuffer[T]) reset() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var zero T
+	for i := range r.items {
+		r.items[i] = zero
+	}
+	r.head = 0
+	r.size = 0
+}
+
+type systemLogStore struct {
+	sequence atomic.Int64
+	buffer   *ringBuffer[SystemLogEntry]
+}
+
+type httpRequestLogStore struct {
+	sequence atomic.Int64
+	buffer   *ringBuffer[HTTPRequestLogEntry]
+}
+
+type timeCursor struct {
+	Time string `json:"time"`
+	ID   string `json:"id"`
+}
+
+var (
+	defaultSystemLogStore   = &systemLogStore{buffer: newRingBuffer[SystemLogEntry](defaultSystemLogCapacity)}
+	defaultHTTPRequestStore = &httpRequestLogStore{buffer: newRingBuffer[HTTPRequestLogEntry](defaultHTTPRequestCapacity)}
+	defaultSystemBroker     = NewBroker()
+	defaultHTTPBroker       = NewBroker()
+)
+
+func SystemBroker() *Broker {
+	return defaultSystemBroker
+}
+
+func HTTPBroker() *Broker {
+	return defaultHTTPBroker
+}
+
+func RecordSystemLog(entry SystemLogEntry) SystemLogEntry {
+	recorded := defaultSystemLogStore.add(entry)
+	defaultSystemBroker.Publish(StreamMessage{
+		ID:         recorded.ID,
+		Source:     "system",
+		Type:       "system-log",
+		Level:      recorded.Level,
+		EventTime:  recorded.CreatedAt,
+		RecordedAt: recorded.CreatedAt,
+		Payload:    recorded,
+	})
+	return recorded
+}
+
+func RecordHTTPRequest(entry HTTPRequestLogEntry) HTTPRequestLogEntry {
+	recorded := defaultHTTPRequestStore.add(entry)
+	defaultHTTPBroker.Publish(StreamMessage{
+		ID:         recorded.ID,
+		Source:     "http",
+		Type:       "http-request",
+		Level:      recorded.Level,
+		EventTime:  recorded.CreatedAt,
+		RecordedAt: recorded.CreatedAt,
+		Payload:    recorded,
+	})
+	return recorded
+}
+
+func ListSystemLogs(query SystemLogQuery) (SystemLogPage, error) {
+	cursor, err := decodeTimeCursor(query.Cursor)
+	if err != nil {
+		return SystemLogPage{}, err
+	}
+	return defaultSystemLogStore.query(query, cursor), nil
+}
+
+func ListHTTPRequestLogs(query HTTPRequestLogQuery) (HTTPRequestLogPage, error) {
+	cursor, err := decodeTimeCursor(query.Cursor)
+	if err != nil {
+		return HTTPRequestLogPage{}, err
+	}
+	return defaultHTTPRequestStore.query(query, cursor), nil
+}
+
+// ResetForTests 清理全局日志缓冲，仅供测试使用。
+func ResetForTests() {
+	defaultSystemLogStore.reset()
+	defaultHTTPRequestStore.reset()
+	defaultSystemBroker.reset()
+	defaultHTTPBroker.reset()
+}
+
+func newSystemCaptureHandler() slog.Handler {
+	return &systemCaptureHandler{}
+}
+
+type systemCaptureHandler struct {
+	attrs  []slog.Attr
+	groups []string
+}
+
+func (h *systemCaptureHandler) Enabled(context.Context, slog.Level) bool {
+	return true
+}
+
+func (h *systemCaptureHandler) Handle(_ context.Context, record slog.Record) error {
+	attrs := make(map[string]any)
+	for _, attr := range h.attrs {
+		appendSlogAttr(attrs, h.groups, attr)
+	}
+	record.Attrs(func(attr slog.Attr) bool {
+		appendSlogAttr(attrs, h.groups, attr)
+		return true
+	})
+	RecordSystemLog(SystemLogEntry{
+		Level:      normalizeStoredLevel(record.Level.String()),
+		Message:    record.Message,
+		CreatedAt:  normalizeTime(record.Time),
+		Attributes: attrs,
+	})
+	return nil
+}
+
+func (h *systemCaptureHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &systemCaptureHandler{
+		attrs:  append(append([]slog.Attr{}, h.attrs...), attrs...),
+		groups: append([]string{}, h.groups...),
+	}
+}
+
+func (h *systemCaptureHandler) WithGroup(name string) slog.Handler {
+	if strings.TrimSpace(name) == "" {
+		return &systemCaptureHandler{
+			attrs:  append([]slog.Attr{}, h.attrs...),
+			groups: append([]string{}, h.groups...),
+		}
+	}
+	return &systemCaptureHandler{
+		attrs:  append([]slog.Attr{}, h.attrs...),
+		groups: append(append([]string{}, h.groups...), name),
+	}
+}
+
+func (s *systemLogStore) add(entry SystemLogEntry) SystemLogEntry {
+	entry.Level = normalizeStoredLevel(entry.Level)
+	entry.CreatedAt = normalizeTime(entry.CreatedAt)
+	if entry.ID == "" {
+		entry.ID = fmt.Sprintf("system-log-%d", s.sequence.Add(1))
+	}
+	if len(entry.Attributes) == 0 {
+		entry.Attributes = nil
+	}
+	s.buffer.append(entry)
+	return entry
+}
+
+func (s *systemLogStore) query(query SystemLogQuery, cursor *timeCursor) SystemLogPage {
+	items := s.buffer.snapshot()
+	limit := normalizeLimit(query.Limit)
+	level := normalizeLevelFilter(query.Level)
+	component := strings.TrimSpace(query.Component)
+	out := make([]SystemLogEntry, 0, limit+1)
+	for i := len(items) - 1; i >= 0; i-- {
+		item := items[i]
+		if cursor != nil && !isBeforeCursor(item.CreatedAt, item.ID, *cursor) {
+			continue
+		}
+		if level != "" && item.Level != level {
+			continue
+		}
+		if component != "" && strings.TrimSpace(stringValue(item.Attributes["component"])) != component {
+			continue
+		}
+		if !query.From.IsZero() && item.CreatedAt.Before(query.From.UTC()) {
+			continue
+		}
+		if !query.To.IsZero() && item.CreatedAt.After(query.To.UTC()) {
+			continue
+		}
+		out = append(out, item)
+		if len(out) >= limit+1 {
+			break
+		}
+	}
+	page := SystemLogPage{Items: out}
+	if len(out) > limit {
+		page.NextCursor = encodeTimeCursor(out[limit-1].CreatedAt, out[limit-1].ID)
+		page.Items = out[:limit]
+	}
+	return page
+}
+
+func (s *systemLogStore) reset() {
+	s.sequence.Store(0)
+	s.buffer.reset()
+}
+
+func (s *httpRequestLogStore) add(entry HTTPRequestLogEntry) HTTPRequestLogEntry {
+	entry.Level = normalizeStoredLevel(firstNonEmpty(entry.Level, HTTPLevel(entry.Status).String()))
+	entry.CreatedAt = normalizeTime(entry.CreatedAt)
+	entry.Method = strings.ToUpper(strings.TrimSpace(entry.Method))
+	entry.Path = strings.TrimSpace(entry.Path)
+	entry.Query = strings.TrimSpace(entry.Query)
+	entry.RemoteAddr = strings.TrimSpace(entry.RemoteAddr)
+	entry.UserAgent = strings.TrimSpace(entry.UserAgent)
+	entry.Message = strings.TrimSpace(entry.Message)
+	if entry.ID == "" {
+		entry.ID = fmt.Sprintf("http-log-%d", s.sequence.Add(1))
+	}
+	if len(entry.Attributes) == 0 {
+		entry.Attributes = nil
+	}
+	s.buffer.append(entry)
+	return entry
+}
+
+func (s *httpRequestLogStore) query(query HTTPRequestLogQuery, cursor *timeCursor) HTTPRequestLogPage {
+	items := s.buffer.snapshot()
+	limit := normalizeLimit(query.Limit)
+	level := normalizeLevelFilter(query.Level)
+	method := strings.ToUpper(strings.TrimSpace(query.Method))
+	path := strings.TrimSpace(query.Path)
+	out := make([]HTTPRequestLogEntry, 0, limit+1)
+	for i := len(items) - 1; i >= 0; i-- {
+		item := items[i]
+		if cursor != nil && !isBeforeCursor(item.CreatedAt, item.ID, *cursor) {
+			continue
+		}
+		if level != "" && item.Level != level {
+			continue
+		}
+		if method != "" && item.Method != method {
+			continue
+		}
+		if path != "" && !strings.Contains(item.Path, path) {
+			continue
+		}
+		if query.Status > 0 && item.Status != query.Status {
+			continue
+		}
+		if query.DurationMinMs > 0 && item.DurationMs < query.DurationMinMs {
+			continue
+		}
+		if query.DurationMaxMs > 0 && item.DurationMs > query.DurationMaxMs {
+			continue
+		}
+		if !query.From.IsZero() && item.CreatedAt.Before(query.From.UTC()) {
+			continue
+		}
+		if !query.To.IsZero() && item.CreatedAt.After(query.To.UTC()) {
+			continue
+		}
+		out = append(out, item)
+		if len(out) >= limit+1 {
+			break
+		}
+	}
+	page := HTTPRequestLogPage{Items: out}
+	if len(out) > limit {
+		page.NextCursor = encodeTimeCursor(out[limit-1].CreatedAt, out[limit-1].ID)
+		page.Items = out[:limit]
+	}
+	return page
+}
+
+func (s *httpRequestLogStore) reset() {
+	s.sequence.Store(0)
+	s.buffer.reset()
+}
+
+func normalizeLimit(limit int) int {
+	switch {
+	case limit <= 0:
+		return defaultQueryLimit
+	case limit > maxQueryLimit:
+		return maxQueryLimit
+	default:
+		return limit
+	}
+}
+
+func normalizeStoredLevel(level string) string {
+	switch strings.ToLower(strings.TrimSpace(level)) {
+	case "warn":
+		return "warning"
+	case "info", "warning", "error", "debug", "critical":
+		return strings.ToLower(strings.TrimSpace(level))
+	case "":
+		return "info"
+	default:
+		return strings.ToLower(strings.TrimSpace(level))
+	}
+}
+
+func normalizeLevelFilter(level string) string {
+	switch strings.ToLower(strings.TrimSpace(level)) {
+	case "", "all":
+		return ""
+	case "warn":
+		return "warning"
+	default:
+		return strings.ToLower(strings.TrimSpace(level))
+	}
+}
+
+func encodeTimeCursor(ts time.Time, id string) string {
+	payload, _ := json.Marshal(timeCursor{
+		Time: normalizeTime(ts).Format(time.RFC3339Nano),
+		ID:   id,
+	})
+	return base64.RawURLEncoding.EncodeToString(payload)
+}
+
+func decodeTimeCursor(raw string) (*timeCursor, error) {
+	if strings.TrimSpace(raw) == "" {
+		return nil, nil
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(raw)
+	if err != nil {
+		return nil, fmt.Errorf("invalid cursor")
+	}
+	var cursor timeCursor
+	if err := json.Unmarshal(payload, &cursor); err != nil {
+		return nil, fmt.Errorf("invalid cursor")
+	}
+	if strings.TrimSpace(cursor.ID) == "" {
+		return nil, fmt.Errorf("invalid cursor")
+	}
+	if _, err := time.Parse(time.RFC3339Nano, cursor.Time); err != nil {
+		return nil, fmt.Errorf("invalid cursor")
+	}
+	return &cursor, nil
+}
+
+func isBeforeCursor(ts time.Time, id string, cursor timeCursor) bool {
+	cursorTime, err := time.Parse(time.RFC3339Nano, cursor.Time)
+	if err != nil {
+		return false
+	}
+	switch {
+	case ts.Before(cursorTime):
+		return true
+	case ts.After(cursorTime):
+		return false
+	default:
+		return id < cursor.ID
+	}
+}
+
+func normalizeTime(value time.Time) time.Time {
+	if value.IsZero() {
+		return time.Now().UTC()
+	}
+	return value.UTC()
+}
+
+func appendSlogAttr(target map[string]any, groups []string, attr slog.Attr) {
+	if attr.Equal(slog.Attr{}) {
+		return
+	}
+	if attr.Value.Kind() == slog.KindGroup {
+		nextGroups := append([]string{}, groups...)
+		if attr.Key != "" {
+			nextGroups = append(nextGroups, attr.Key)
+		}
+		for _, child := range attr.Value.Group() {
+			appendSlogAttr(target, nextGroups, child)
+		}
+		return
+	}
+	if strings.TrimSpace(attr.Key) == "" {
+		return
+	}
+	key := attr.Key
+	if len(groups) > 0 {
+		key = strings.Join(append(append([]string{}, groups...), attr.Key), ".")
+	}
+	target[key] = slogValueToAny(attr.Value)
+}
+
+func slogValueToAny(value slog.Value) any {
+	switch value.Kind() {
+	case slog.KindString:
+		return value.String()
+	case slog.KindInt64:
+		return value.Int64()
+	case slog.KindUint64:
+		return value.Uint64()
+	case slog.KindFloat64:
+		return value.Float64()
+	case slog.KindBool:
+		return value.Bool()
+	case slog.KindDuration:
+		return value.Duration().Milliseconds()
+	case slog.KindTime:
+		return value.Time().UTC()
+	case slog.KindAny:
+		raw := value.Any()
+		if err, ok := raw.(error); ok {
+			return err.Error()
+		}
+		return raw
+	default:
+		return value.Any()
+	}
+}
+
+func stringValue(value any) string {
+	switch typed := value.(type) {
+	case string:
+		return typed
+	case fmt.Stringer:
+		return typed.String()
+	default:
+		return ""
+	}
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}

--- a/internal/service/logs.go
+++ b/internal/service/logs.go
@@ -231,13 +231,13 @@ func (p *Platform) queryStrategyDecisionEvents(query domain.StrategyDecisionEven
 		if !query.To.IsZero() && item.EventTime.After(query.To.UTC()) {
 			continue
 		}
-		if query.Before != nil && !eventComesBefore(item.EventTime, item.RecordedAt, item.ID, *query.Before) {
+		if query.Before != nil && !domain.EventBeforeCursor(item.EventTime, item.RecordedAt, item.ID, *query.Before) {
 			continue
 		}
 		filtered = append(filtered, item)
 	}
 	sort.SliceStable(filtered, func(i, j int) bool {
-		return eventPairLess(filtered[i].EventTime, filtered[i].RecordedAt, filtered[i].ID, filtered[j].EventTime, filtered[j].RecordedAt, filtered[j].ID)
+		return domain.EventLessDesc(filtered[i].EventTime, filtered[i].RecordedAt, filtered[i].ID, filtered[j].EventTime, filtered[j].RecordedAt, filtered[j].ID)
 	})
 	return limitStrategyDecisionEvents(filtered, query.Limit), nil
 }
@@ -276,13 +276,13 @@ func (p *Platform) queryOrderExecutionEvents(query domain.OrderExecutionEventQue
 		if !query.To.IsZero() && item.EventTime.After(query.To.UTC()) {
 			continue
 		}
-		if query.Before != nil && !eventComesBefore(item.EventTime, item.RecordedAt, item.ID, *query.Before) {
+		if query.Before != nil && !domain.EventBeforeCursor(item.EventTime, item.RecordedAt, item.ID, *query.Before) {
 			continue
 		}
 		filtered = append(filtered, item)
 	}
 	sort.SliceStable(filtered, func(i, j int) bool {
-		return eventPairLess(filtered[i].EventTime, filtered[i].RecordedAt, filtered[i].ID, filtered[j].EventTime, filtered[j].RecordedAt, filtered[j].ID)
+		return domain.EventLessDesc(filtered[i].EventTime, filtered[i].RecordedAt, filtered[i].ID, filtered[j].EventTime, filtered[j].RecordedAt, filtered[j].ID)
 	})
 	return limitOrderExecutionEvents(filtered, query.Limit), nil
 }
@@ -318,13 +318,13 @@ func (p *Platform) queryPositionAccountSnapshots(query domain.PositionAccountSna
 		if !query.To.IsZero() && item.EventTime.After(query.To.UTC()) {
 			continue
 		}
-		if query.Before != nil && !eventComesBefore(item.EventTime, item.RecordedAt, item.ID, *query.Before) {
+		if query.Before != nil && !domain.EventBeforeCursor(item.EventTime, item.RecordedAt, item.ID, *query.Before) {
 			continue
 		}
 		filtered = append(filtered, item)
 	}
 	sort.SliceStable(filtered, func(i, j int) bool {
-		return eventPairLess(filtered[i].EventTime, filtered[i].RecordedAt, filtered[i].ID, filtered[j].EventTime, filtered[j].RecordedAt, filtered[j].ID)
+		return domain.EventLessDesc(filtered[i].EventTime, filtered[i].RecordedAt, filtered[i].ID, filtered[j].EventTime, filtered[j].RecordedAt, filtered[j].ID)
 	})
 	return limitPositionSnapshots(filtered, query.Limit), nil
 }
@@ -345,7 +345,7 @@ func strategyDecisionToUnifiedLogEvent(item domain.StrategyDecisionEvent) Unifie
 		Title:            firstNonEmpty(strings.TrimSpace(item.Action), "strategy decision"),
 		Message:          firstNonEmpty(strings.TrimSpace(item.Reason), "strategy evaluation completed"),
 		EventTime:        item.EventTime.UTC(),
-		RecordedAt:       normalizeRecordedAt(item.RecordedAt, item.EventTime),
+		RecordedAt:       domain.NormalizeEventRecordedAt(item.RecordedAt, item.EventTime),
 		AccountID:        item.AccountID,
 		StrategyID:       item.StrategyID,
 		RuntimeSessionID: item.RuntimeSessionID,
@@ -381,7 +381,7 @@ func orderExecutionToUnifiedLogEvent(item domain.OrderExecutionEvent) UnifiedLog
 		Title:            firstNonEmpty(strings.TrimSpace(item.EventType), "order execution"),
 		Message:          firstNonEmpty(strings.TrimSpace(item.Status), strings.TrimSpace(item.Error), "order execution updated"),
 		EventTime:        item.EventTime.UTC(),
-		RecordedAt:       normalizeRecordedAt(item.RecordedAt, item.EventTime),
+		RecordedAt:       domain.NormalizeEventRecordedAt(item.RecordedAt, item.EventTime),
 		AccountID:        item.AccountID,
 		StrategyID:       strategyID,
 		RuntimeSessionID: item.RuntimeSessionID,
@@ -415,7 +415,7 @@ func positionSnapshotToUnifiedLogEvent(item domain.PositionAccountSnapshot) Unif
 		Title:           firstNonEmpty(strings.TrimSpace(item.Trigger), "position/account snapshot"),
 		Message:         firstNonEmpty(strings.TrimSpace(item.SyncStatus), "snapshot recorded"),
 		EventTime:       item.EventTime.UTC(),
-		RecordedAt:      normalizeRecordedAt(item.RecordedAt, item.EventTime),
+		RecordedAt:      domain.NormalizeEventRecordedAt(item.RecordedAt, item.EventTime),
 		AccountID:       item.AccountID,
 		StrategyID:      item.StrategyID,
 		LiveSessionID:   item.LiveSessionID,
@@ -516,55 +516,7 @@ func normalizeUnifiedLogLimit(limit int) int {
 }
 
 func unifiedLogEventLess(left, right UnifiedLogEvent) bool {
-	return eventPairLess(left.EventTime, left.RecordedAt, left.ID, right.EventTime, right.RecordedAt, right.ID)
-}
-
-func eventPairLess(leftTime, leftRecordedAt time.Time, leftID string, rightTime, rightRecordedAt time.Time, rightID string) bool {
-	leftTime = leftTime.UTC()
-	rightTime = rightTime.UTC()
-	switch {
-	case leftTime.After(rightTime):
-		return true
-	case leftTime.Before(rightTime):
-		return false
-	}
-	leftRecordedAt = normalizeRecordedAt(leftRecordedAt, leftTime)
-	rightRecordedAt = normalizeRecordedAt(rightRecordedAt, rightTime)
-	switch {
-	case leftRecordedAt.After(rightRecordedAt):
-		return true
-	case leftRecordedAt.Before(rightRecordedAt):
-		return false
-	default:
-		return leftID > rightID
-	}
-}
-
-func eventComesBefore(eventTime, recordedAt time.Time, id string, cursor domain.EventCursor) bool {
-	eventTime = eventTime.UTC()
-	recordedAt = normalizeRecordedAt(recordedAt, eventTime)
-	cursorRecordedAt := normalizeRecordedAt(cursor.RecordedAt, cursor.EventTime)
-	switch {
-	case eventTime.Before(cursor.EventTime.UTC()):
-		return true
-	case eventTime.After(cursor.EventTime.UTC()):
-		return false
-	}
-	switch {
-	case recordedAt.Before(cursorRecordedAt):
-		return true
-	case recordedAt.After(cursorRecordedAt):
-		return false
-	default:
-		return id < cursor.ID
-	}
-}
-
-func normalizeRecordedAt(recordedAt, eventTime time.Time) time.Time {
-	if recordedAt.IsZero() {
-		return eventTime.UTC()
-	}
-	return recordedAt.UTC()
+	return domain.EventLessDesc(left.EventTime, left.RecordedAt, left.ID, right.EventTime, right.RecordedAt, right.ID)
 }
 
 func limitStrategyDecisionEvents(items []domain.StrategyDecisionEvent, limit int) []domain.StrategyDecisionEvent {

--- a/internal/service/logs.go
+++ b/internal/service/logs.go
@@ -1,0 +1,596 @@
+package service
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"slices"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/wuyaocheng/bktrader/internal/domain"
+	"github.com/wuyaocheng/bktrader/internal/logging"
+)
+
+const (
+	defaultLogEventLimit = 100
+	maxLogEventLimit     = 200
+)
+
+// UnifiedLogEvent 表示后端统一聚合后的业务事件记录。
+type UnifiedLogEvent struct {
+	ID               string         `json:"id"`
+	Source           string         `json:"source"`
+	Type             string         `json:"type"`
+	Level            string         `json:"level"`
+	Title            string         `json:"title"`
+	Message          string         `json:"message"`
+	EventTime        time.Time      `json:"eventTime"`
+	RecordedAt       time.Time      `json:"recordedAt"`
+	AccountID        string         `json:"accountId,omitempty"`
+	StrategyID       string         `json:"strategyId,omitempty"`
+	RuntimeSessionID string         `json:"runtimeSessionId,omitempty"`
+	LiveSessionID    string         `json:"liveSessionId,omitempty"`
+	OrderID          string         `json:"orderId,omitempty"`
+	DecisionEventID  string         `json:"decisionEventId,omitempty"`
+	Metadata         map[string]any `json:"metadata,omitempty"`
+	Payload          any            `json:"payload,omitempty"`
+}
+
+// UnifiedLogEventPage 表示业务事件查询分页结果。
+type UnifiedLogEventPage struct {
+	Items      []UnifiedLogEvent `json:"items"`
+	NextCursor string            `json:"nextCursor,omitempty"`
+}
+
+// UnifiedLogEventQuery 定义统一业务事件接口的过滤条件。
+type UnifiedLogEventQuery struct {
+	Type             string
+	Level            string
+	AccountID        string
+	StrategyID       string
+	RuntimeSessionID string
+	LiveSessionID    string
+	OrderID          string
+	DecisionEventID  string
+	Cursor           string
+	From             time.Time
+	To               time.Time
+	Limit            int
+}
+
+type logEventCursor struct {
+	EventTime  string `json:"eventTime"`
+	RecordedAt string `json:"recordedAt"`
+	ID         string `json:"id"`
+}
+
+type strategyDecisionEventQueryReader interface {
+	QueryStrategyDecisionEvents(query domain.StrategyDecisionEventQuery) ([]domain.StrategyDecisionEvent, error)
+}
+
+type orderExecutionEventQueryReader interface {
+	QueryOrderExecutionEvents(query domain.OrderExecutionEventQuery) ([]domain.OrderExecutionEvent, error)
+}
+
+type positionAccountSnapshotQueryReader interface {
+	QueryPositionAccountSnapshots(query domain.PositionAccountSnapshotQuery) ([]domain.PositionAccountSnapshot, error)
+}
+
+func (p *Platform) SubscribeLogStream(buffer int) (int, <-chan logging.StreamMessage) {
+	if p.logBroker == nil {
+		p.logBroker = logging.NewBroker()
+	}
+	return p.logBroker.Subscribe(buffer)
+}
+
+func (p *Platform) UnsubscribeLogStream(id int) {
+	if p.logBroker == nil {
+		return
+	}
+	p.logBroker.Unsubscribe(id)
+}
+
+func (p *Platform) publishLogEvent(item UnifiedLogEvent) {
+	if p.logBroker == nil {
+		return
+	}
+	p.logBroker.Publish(logging.StreamMessage{
+		ID:         item.ID,
+		Source:     item.Source,
+		Type:       item.Type,
+		Level:      item.Level,
+		EventTime:  item.EventTime,
+		RecordedAt: item.RecordedAt,
+		Payload:    item,
+	})
+}
+
+func (p *Platform) ListLogEvents(query UnifiedLogEventQuery) (UnifiedLogEventPage, error) {
+	normalizedType := normalizeUnifiedLogEventType(query.Type)
+	levelFilter := normalizeUnifiedLogLevel(query.Level)
+	cursor, err := decodeLogEventCursor(query.Cursor)
+	if err != nil {
+		return UnifiedLogEventPage{}, err
+	}
+	limit := normalizeUnifiedLogLimit(query.Limit)
+	fetchLimit := limit + 1
+	if levelFilter != "" {
+		fetchLimit = min(limit*3+1, 600)
+	}
+
+	var merged []UnifiedLogEvent
+	if normalizedType == "" || normalizedType == "strategy-decision" {
+		items, err := p.queryStrategyDecisionEvents(domain.StrategyDecisionEventQuery{
+			AccountID:        strings.TrimSpace(query.AccountID),
+			StrategyID:       strings.TrimSpace(query.StrategyID),
+			RuntimeSessionID: strings.TrimSpace(query.RuntimeSessionID),
+			LiveSessionID:    strings.TrimSpace(query.LiveSessionID),
+			DecisionEventID:  strings.TrimSpace(query.DecisionEventID),
+			From:             query.From,
+			To:               query.To,
+			Before:           cursor,
+			Limit:            fetchLimit,
+		})
+		if err != nil {
+			return UnifiedLogEventPage{}, err
+		}
+		for _, item := range items {
+			event := strategyDecisionToUnifiedLogEvent(item)
+			if matchesUnifiedLogLevel(event.Level, levelFilter) {
+				merged = append(merged, event)
+			}
+		}
+	}
+	if normalizedType == "" || normalizedType == "order-execution" {
+		items, err := p.queryOrderExecutionEvents(domain.OrderExecutionEventQuery{
+			AccountID:        strings.TrimSpace(query.AccountID),
+			StrategyID:       strings.TrimSpace(query.StrategyID),
+			RuntimeSessionID: strings.TrimSpace(query.RuntimeSessionID),
+			LiveSessionID:    strings.TrimSpace(query.LiveSessionID),
+			OrderID:          strings.TrimSpace(query.OrderID),
+			DecisionEventID:  strings.TrimSpace(query.DecisionEventID),
+			From:             query.From,
+			To:               query.To,
+			Before:           cursor,
+			Limit:            fetchLimit,
+		})
+		if err != nil {
+			return UnifiedLogEventPage{}, err
+		}
+		for _, item := range items {
+			event := orderExecutionToUnifiedLogEvent(item)
+			if matchesUnifiedLogLevel(event.Level, levelFilter) {
+				merged = append(merged, event)
+			}
+		}
+	}
+	if normalizedType == "" || normalizedType == "position-account-snapshot" {
+		items, err := p.queryPositionAccountSnapshots(domain.PositionAccountSnapshotQuery{
+			AccountID:       strings.TrimSpace(query.AccountID),
+			StrategyID:      strings.TrimSpace(query.StrategyID),
+			LiveSessionID:   strings.TrimSpace(query.LiveSessionID),
+			OrderID:         strings.TrimSpace(query.OrderID),
+			DecisionEventID: strings.TrimSpace(query.DecisionEventID),
+			From:            query.From,
+			To:              query.To,
+			Before:          cursor,
+			Limit:           fetchLimit,
+		})
+		if err != nil {
+			return UnifiedLogEventPage{}, err
+		}
+		for _, item := range items {
+			event := positionSnapshotToUnifiedLogEvent(item)
+			if matchesUnifiedLogLevel(event.Level, levelFilter) {
+				merged = append(merged, event)
+			}
+		}
+	}
+
+	sort.SliceStable(merged, func(i, j int) bool {
+		return unifiedLogEventLess(merged[i], merged[j])
+	})
+	page := UnifiedLogEventPage{Items: merged}
+	if len(merged) > limit {
+		page.NextCursor = encodeLogEventCursor(merged[limit-1])
+		page.Items = slices.Clone(merged[:limit])
+	}
+	return page, nil
+}
+
+func (p *Platform) queryStrategyDecisionEvents(query domain.StrategyDecisionEventQuery) ([]domain.StrategyDecisionEvent, error) {
+	if reader, ok := p.store.(strategyDecisionEventQueryReader); ok {
+		return reader.QueryStrategyDecisionEvents(query)
+	}
+	items, err := p.store.ListStrategyDecisionEvents("")
+	if err != nil {
+		return nil, err
+	}
+	filtered := make([]domain.StrategyDecisionEvent, 0, len(items))
+	for _, item := range items {
+		if strings.TrimSpace(query.LiveSessionID) != "" && item.LiveSessionID != strings.TrimSpace(query.LiveSessionID) {
+			continue
+		}
+		if strings.TrimSpace(query.AccountID) != "" && item.AccountID != strings.TrimSpace(query.AccountID) {
+			continue
+		}
+		if strings.TrimSpace(query.StrategyID) != "" && item.StrategyID != strings.TrimSpace(query.StrategyID) {
+			continue
+		}
+		if strings.TrimSpace(query.RuntimeSessionID) != "" && item.RuntimeSessionID != strings.TrimSpace(query.RuntimeSessionID) {
+			continue
+		}
+		if strings.TrimSpace(query.DecisionEventID) != "" && item.ID != strings.TrimSpace(query.DecisionEventID) {
+			continue
+		}
+		if !query.From.IsZero() && item.EventTime.Before(query.From.UTC()) {
+			continue
+		}
+		if !query.To.IsZero() && item.EventTime.After(query.To.UTC()) {
+			continue
+		}
+		if query.Before != nil && !eventComesBefore(item.EventTime, item.RecordedAt, item.ID, *query.Before) {
+			continue
+		}
+		filtered = append(filtered, item)
+	}
+	sort.SliceStable(filtered, func(i, j int) bool {
+		return eventPairLess(filtered[i].EventTime, filtered[i].RecordedAt, filtered[i].ID, filtered[j].EventTime, filtered[j].RecordedAt, filtered[j].ID)
+	})
+	return limitStrategyDecisionEvents(filtered, query.Limit), nil
+}
+
+func (p *Platform) queryOrderExecutionEvents(query domain.OrderExecutionEventQuery) ([]domain.OrderExecutionEvent, error) {
+	if reader, ok := p.store.(orderExecutionEventQueryReader); ok {
+		return reader.QueryOrderExecutionEvents(query)
+	}
+	items, err := p.store.ListOrderExecutionEvents("")
+	if err != nil {
+		return nil, err
+	}
+	filtered := make([]domain.OrderExecutionEvent, 0, len(items))
+	for _, item := range items {
+		if strings.TrimSpace(query.AccountID) != "" && item.AccountID != strings.TrimSpace(query.AccountID) {
+			continue
+		}
+		if strings.TrimSpace(query.StrategyID) != "" && stringValue(item.Metadata["strategyId"]) != strings.TrimSpace(query.StrategyID) {
+			continue
+		}
+		if strings.TrimSpace(query.RuntimeSessionID) != "" && item.RuntimeSessionID != strings.TrimSpace(query.RuntimeSessionID) {
+			continue
+		}
+		if strings.TrimSpace(query.LiveSessionID) != "" && item.LiveSessionID != strings.TrimSpace(query.LiveSessionID) {
+			continue
+		}
+		if strings.TrimSpace(query.OrderID) != "" && item.OrderID != strings.TrimSpace(query.OrderID) {
+			continue
+		}
+		if strings.TrimSpace(query.DecisionEventID) != "" && item.DecisionEventID != strings.TrimSpace(query.DecisionEventID) {
+			continue
+		}
+		if !query.From.IsZero() && item.EventTime.Before(query.From.UTC()) {
+			continue
+		}
+		if !query.To.IsZero() && item.EventTime.After(query.To.UTC()) {
+			continue
+		}
+		if query.Before != nil && !eventComesBefore(item.EventTime, item.RecordedAt, item.ID, *query.Before) {
+			continue
+		}
+		filtered = append(filtered, item)
+	}
+	sort.SliceStable(filtered, func(i, j int) bool {
+		return eventPairLess(filtered[i].EventTime, filtered[i].RecordedAt, filtered[i].ID, filtered[j].EventTime, filtered[j].RecordedAt, filtered[j].ID)
+	})
+	return limitOrderExecutionEvents(filtered, query.Limit), nil
+}
+
+func (p *Platform) queryPositionAccountSnapshots(query domain.PositionAccountSnapshotQuery) ([]domain.PositionAccountSnapshot, error) {
+	if reader, ok := p.store.(positionAccountSnapshotQueryReader); ok {
+		return reader.QueryPositionAccountSnapshots(query)
+	}
+	items, err := p.store.ListPositionAccountSnapshots("")
+	if err != nil {
+		return nil, err
+	}
+	filtered := make([]domain.PositionAccountSnapshot, 0, len(items))
+	for _, item := range items {
+		if strings.TrimSpace(query.AccountID) != "" && item.AccountID != strings.TrimSpace(query.AccountID) {
+			continue
+		}
+		if strings.TrimSpace(query.StrategyID) != "" && item.StrategyID != strings.TrimSpace(query.StrategyID) {
+			continue
+		}
+		if strings.TrimSpace(query.LiveSessionID) != "" && item.LiveSessionID != strings.TrimSpace(query.LiveSessionID) {
+			continue
+		}
+		if strings.TrimSpace(query.OrderID) != "" && item.OrderID != strings.TrimSpace(query.OrderID) {
+			continue
+		}
+		if strings.TrimSpace(query.DecisionEventID) != "" && item.DecisionEventID != strings.TrimSpace(query.DecisionEventID) {
+			continue
+		}
+		if !query.From.IsZero() && item.EventTime.Before(query.From.UTC()) {
+			continue
+		}
+		if !query.To.IsZero() && item.EventTime.After(query.To.UTC()) {
+			continue
+		}
+		if query.Before != nil && !eventComesBefore(item.EventTime, item.RecordedAt, item.ID, *query.Before) {
+			continue
+		}
+		filtered = append(filtered, item)
+	}
+	sort.SliceStable(filtered, func(i, j int) bool {
+		return eventPairLess(filtered[i].EventTime, filtered[i].RecordedAt, filtered[i].ID, filtered[j].EventTime, filtered[j].RecordedAt, filtered[j].ID)
+	})
+	return limitPositionSnapshots(filtered, query.Limit), nil
+}
+
+func strategyDecisionToUnifiedLogEvent(item domain.StrategyDecisionEvent) UnifiedLogEvent {
+	level := "info"
+	if !item.SourceGateReady || item.MissingCount > 0 || item.StaleCount > 0 {
+		level = "warning"
+	}
+	if strings.Contains(strings.ToLower(strings.TrimSpace(item.Reason)), "error") || strings.Contains(strings.ToLower(strings.TrimSpace(item.DecisionState)), "error") {
+		level = "critical"
+	}
+	return UnifiedLogEvent{
+		ID:               item.ID,
+		Source:           "event",
+		Type:             "strategy-decision",
+		Level:            level,
+		Title:            firstNonEmpty(strings.TrimSpace(item.Action), "strategy decision"),
+		Message:          firstNonEmpty(strings.TrimSpace(item.Reason), "strategy evaluation completed"),
+		EventTime:        item.EventTime.UTC(),
+		RecordedAt:       normalizeRecordedAt(item.RecordedAt, item.EventTime),
+		AccountID:        item.AccountID,
+		StrategyID:       item.StrategyID,
+		RuntimeSessionID: item.RuntimeSessionID,
+		LiveSessionID:    item.LiveSessionID,
+		DecisionEventID:  item.ID,
+		Metadata: map[string]any{
+			"triggerType":     item.TriggerType,
+			"signalKind":      item.SignalKind,
+			"decisionState":   item.DecisionState,
+			"sourceGateReady": item.SourceGateReady,
+			"missingCount":    item.MissingCount,
+			"staleCount":      item.StaleCount,
+			"symbol":          item.Symbol,
+		},
+		Payload: item,
+	}
+}
+
+func orderExecutionToUnifiedLogEvent(item domain.OrderExecutionEvent) UnifiedLogEvent {
+	level := "info"
+	status := strings.ToLower(strings.TrimSpace(item.Status))
+	if item.Failed || strings.TrimSpace(item.Error) != "" || slices.Contains([]string{"failed", "error", "rejected", "expired"}, status) {
+		level = "critical"
+	} else if item.Fallback || slices.Contains([]string{"canceled", "cancelled"}, status) {
+		level = "warning"
+	}
+	strategyID := stringValue(item.Metadata["strategyId"])
+	return UnifiedLogEvent{
+		ID:               item.ID,
+		Source:           "event",
+		Type:             "order-execution",
+		Level:            level,
+		Title:            firstNonEmpty(strings.TrimSpace(item.EventType), "order execution"),
+		Message:          firstNonEmpty(strings.TrimSpace(item.Status), strings.TrimSpace(item.Error), "order execution updated"),
+		EventTime:        item.EventTime.UTC(),
+		RecordedAt:       normalizeRecordedAt(item.RecordedAt, item.EventTime),
+		AccountID:        item.AccountID,
+		StrategyID:       strategyID,
+		RuntimeSessionID: item.RuntimeSessionID,
+		LiveSessionID:    item.LiveSessionID,
+		OrderID:          item.OrderID,
+		DecisionEventID:  item.DecisionEventID,
+		Metadata: map[string]any{
+			"eventType":         item.EventType,
+			"status":            item.Status,
+			"symbol":            item.Symbol,
+			"side":              item.Side,
+			"orderType":         item.OrderType,
+			"executionStrategy": item.ExecutionStrategy,
+			"fallback":          item.Fallback,
+			"failed":            item.Failed,
+		},
+		Payload: item,
+	}
+}
+
+func positionSnapshotToUnifiedLogEvent(item domain.PositionAccountSnapshot) UnifiedLogEvent {
+	level := "info"
+	if strings.Contains(strings.ToLower(strings.TrimSpace(item.SyncStatus)), "error") || strings.Contains(strings.ToLower(strings.TrimSpace(item.SyncStatus)), "fail") {
+		level = "warning"
+	}
+	return UnifiedLogEvent{
+		ID:              item.ID,
+		Source:          "event",
+		Type:            "position-account-snapshot",
+		Level:           level,
+		Title:           firstNonEmpty(strings.TrimSpace(item.Trigger), "position/account snapshot"),
+		Message:         firstNonEmpty(strings.TrimSpace(item.SyncStatus), "snapshot recorded"),
+		EventTime:       item.EventTime.UTC(),
+		RecordedAt:      normalizeRecordedAt(item.RecordedAt, item.EventTime),
+		AccountID:       item.AccountID,
+		StrategyID:      item.StrategyID,
+		LiveSessionID:   item.LiveSessionID,
+		OrderID:         item.OrderID,
+		DecisionEventID: item.DecisionEventID,
+		Metadata: map[string]any{
+			"symbol":            item.Symbol,
+			"trigger":           item.Trigger,
+			"syncStatus":        item.SyncStatus,
+			"positionFound":     item.PositionFound,
+			"openPositionCount": item.OpenPositionCount,
+		},
+		Payload: item,
+	}
+}
+
+func encodeLogEventCursor(item UnifiedLogEvent) string {
+	payload, _ := json.Marshal(logEventCursor{
+		EventTime:  item.EventTime.UTC().Format(time.RFC3339Nano),
+		RecordedAt: item.RecordedAt.UTC().Format(time.RFC3339Nano),
+		ID:         item.ID,
+	})
+	return base64.RawURLEncoding.EncodeToString(payload)
+}
+
+func decodeLogEventCursor(raw string) (*domain.EventCursor, error) {
+	if strings.TrimSpace(raw) == "" {
+		return nil, nil
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(raw)
+	if err != nil {
+		return nil, fmt.Errorf("invalid cursor")
+	}
+	var cursor logEventCursor
+	if err := json.Unmarshal(payload, &cursor); err != nil {
+		return nil, fmt.Errorf("invalid cursor")
+	}
+	eventTime, err := time.Parse(time.RFC3339Nano, cursor.EventTime)
+	if err != nil {
+		return nil, fmt.Errorf("invalid cursor")
+	}
+	recordedAt, err := time.Parse(time.RFC3339Nano, cursor.RecordedAt)
+	if err != nil {
+		return nil, fmt.Errorf("invalid cursor")
+	}
+	if strings.TrimSpace(cursor.ID) == "" {
+		return nil, fmt.Errorf("invalid cursor")
+	}
+	return &domain.EventCursor{
+		EventTime:  eventTime.UTC(),
+		RecordedAt: recordedAt.UTC(),
+		ID:         cursor.ID,
+	}, nil
+}
+
+func normalizeUnifiedLogEventType(value string) string {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "", "all":
+		return ""
+	case "decision", "strategy-decision", "strategy_decision":
+		return "strategy-decision"
+	case "execution", "order-execution", "order_execution":
+		return "order-execution"
+	case "snapshot", "position-account-snapshot", "position_account_snapshot":
+		return "position-account-snapshot"
+	default:
+		return strings.ToLower(strings.TrimSpace(value))
+	}
+}
+
+func normalizeUnifiedLogLevel(value string) string {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "", "all":
+		return ""
+	case "warn":
+		return "warning"
+	default:
+		return strings.ToLower(strings.TrimSpace(value))
+	}
+}
+
+func matchesUnifiedLogLevel(level, filter string) bool {
+	if filter == "" {
+		return true
+	}
+	return strings.EqualFold(strings.TrimSpace(level), strings.TrimSpace(filter))
+}
+
+func normalizeUnifiedLogLimit(limit int) int {
+	switch {
+	case limit <= 0:
+		return defaultLogEventLimit
+	case limit > maxLogEventLimit:
+		return maxLogEventLimit
+	default:
+		return limit
+	}
+}
+
+func unifiedLogEventLess(left, right UnifiedLogEvent) bool {
+	return eventPairLess(left.EventTime, left.RecordedAt, left.ID, right.EventTime, right.RecordedAt, right.ID)
+}
+
+func eventPairLess(leftTime, leftRecordedAt time.Time, leftID string, rightTime, rightRecordedAt time.Time, rightID string) bool {
+	leftTime = leftTime.UTC()
+	rightTime = rightTime.UTC()
+	switch {
+	case leftTime.After(rightTime):
+		return true
+	case leftTime.Before(rightTime):
+		return false
+	}
+	leftRecordedAt = normalizeRecordedAt(leftRecordedAt, leftTime)
+	rightRecordedAt = normalizeRecordedAt(rightRecordedAt, rightTime)
+	switch {
+	case leftRecordedAt.After(rightRecordedAt):
+		return true
+	case leftRecordedAt.Before(rightRecordedAt):
+		return false
+	default:
+		return leftID > rightID
+	}
+}
+
+func eventComesBefore(eventTime, recordedAt time.Time, id string, cursor domain.EventCursor) bool {
+	eventTime = eventTime.UTC()
+	recordedAt = normalizeRecordedAt(recordedAt, eventTime)
+	cursorRecordedAt := normalizeRecordedAt(cursor.RecordedAt, cursor.EventTime)
+	switch {
+	case eventTime.Before(cursor.EventTime.UTC()):
+		return true
+	case eventTime.After(cursor.EventTime.UTC()):
+		return false
+	}
+	switch {
+	case recordedAt.Before(cursorRecordedAt):
+		return true
+	case recordedAt.After(cursorRecordedAt):
+		return false
+	default:
+		return id < cursor.ID
+	}
+}
+
+func normalizeRecordedAt(recordedAt, eventTime time.Time) time.Time {
+	if recordedAt.IsZero() {
+		return eventTime.UTC()
+	}
+	return recordedAt.UTC()
+}
+
+func limitStrategyDecisionEvents(items []domain.StrategyDecisionEvent, limit int) []domain.StrategyDecisionEvent {
+	if limit <= 0 || len(items) <= limit {
+		return items
+	}
+	return slices.Clone(items[:limit])
+}
+
+func limitOrderExecutionEvents(items []domain.OrderExecutionEvent, limit int) []domain.OrderExecutionEvent {
+	if limit <= 0 || len(items) <= limit {
+		return items
+	}
+	return slices.Clone(items[:limit])
+}
+
+func limitPositionSnapshots(items []domain.PositionAccountSnapshot, limit int) []domain.PositionAccountSnapshot {
+	if limit <= 0 || len(items) <= limit {
+		return items
+	}
+	return slices.Clone(items[:limit])
+}
+
+func min(left, right int) int {
+	if left < right {
+		return left
+	}
+	return right
+}

--- a/internal/service/logs_test.go
+++ b/internal/service/logs_test.go
@@ -1,0 +1,108 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/wuyaocheng/bktrader/internal/domain"
+	"github.com/wuyaocheng/bktrader/internal/store/memory"
+)
+
+func TestListLogEventsSupportsPaginationAndFilters(t *testing.T) {
+	store := memory.NewStore()
+	platform := NewPlatform(store)
+	base := time.Date(2026, 4, 16, 9, 0, 0, 0, time.UTC)
+
+	if _, err := store.CreateStrategyDecisionEvent(domain.StrategyDecisionEvent{
+		ID:               "decision-1",
+		LiveSessionID:    "live-1",
+		RuntimeSessionID: "runtime-1",
+		AccountID:        "account-1",
+		StrategyID:       "strategy-1",
+		Action:           "wait",
+		Reason:           "waiting for source gate",
+		SourceGateReady:  false,
+		MissingCount:     1,
+		EventTime:        base.Add(-3 * time.Minute),
+		RecordedAt:       base.Add(-3 * time.Minute),
+	}); err != nil {
+		t.Fatalf("create strategy decision event: %v", err)
+	}
+	if _, err := store.CreateOrderExecutionEvent(domain.OrderExecutionEvent{
+		ID:               "execution-1",
+		OrderID:          "order-1",
+		LiveSessionID:    "live-1",
+		DecisionEventID:  "decision-1",
+		RuntimeSessionID: "runtime-1",
+		AccountID:        "account-1",
+		Status:           "FAILED",
+		EventType:        "submit",
+		Failed:           true,
+		Error:            "exchange unavailable",
+		EventTime:        base.Add(-2 * time.Minute),
+		RecordedAt:       base.Add(-2 * time.Minute),
+		Metadata: map[string]any{
+			"strategyId": "strategy-1",
+		},
+	}); err != nil {
+		t.Fatalf("create order execution event: %v", err)
+	}
+	if _, err := store.CreatePositionAccountSnapshot(domain.PositionAccountSnapshot{
+		ID:              "snapshot-1",
+		LiveSessionID:   "live-2",
+		AccountID:       "account-2",
+		StrategyID:      "strategy-2",
+		Trigger:         "post-sync",
+		SyncStatus:      "ok",
+		EventTime:       base.Add(-1 * time.Minute),
+		RecordedAt:      base.Add(-1 * time.Minute),
+		DecisionEventID: "decision-2",
+	}); err != nil {
+		t.Fatalf("create position account snapshot: %v", err)
+	}
+
+	page, err := platform.ListLogEvents(UnifiedLogEventQuery{Limit: 2})
+	if err != nil {
+		t.Fatalf("list unified log events: %v", err)
+	}
+	if len(page.Items) != 2 {
+		t.Fatalf("expected 2 items on first page, got %d", len(page.Items))
+	}
+	if page.Items[0].ID != "snapshot-1" {
+		t.Fatalf("expected newest snapshot first, got %s", page.Items[0].ID)
+	}
+	if page.Items[1].ID != "execution-1" {
+		t.Fatalf("expected order execution second, got %s", page.Items[1].ID)
+	}
+	if page.NextCursor == "" {
+		t.Fatal("expected next cursor for truncated page")
+	}
+
+	nextPage, err := platform.ListLogEvents(UnifiedLogEventQuery{
+		Limit:  2,
+		Cursor: page.NextCursor,
+	})
+	if err != nil {
+		t.Fatalf("list next page: %v", err)
+	}
+	if len(nextPage.Items) != 1 || nextPage.Items[0].ID != "decision-1" {
+		t.Fatalf("expected older decision event on second page, got %#v", nextPage.Items)
+	}
+
+	filtered, err := platform.ListLogEvents(UnifiedLogEventQuery{
+		Type:      "order-execution",
+		AccountID: "account-1",
+		Level:     "critical",
+		Limit:     10,
+	})
+	if err != nil {
+		t.Fatalf("filter unified log events: %v", err)
+	}
+	if len(filtered.Items) != 1 {
+		t.Fatalf("expected 1 filtered item, got %d", len(filtered.Items))
+	}
+	item := filtered.Items[0]
+	if item.ID != "execution-1" || item.Level != "critical" || item.OrderID != "order-1" {
+		t.Fatalf("unexpected filtered item: %#v", item)
+	}
+}

--- a/internal/service/platform.go
+++ b/internal/service/platform.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/wuyaocheng/bktrader/internal/domain"
+	"github.com/wuyaocheng/bktrader/internal/logging"
 	"github.com/wuyaocheng/bktrader/internal/store"
 )
 
@@ -50,6 +51,7 @@ type Platform struct {
 	tickManifest        []tradeArchiveManifestEntry
 	runtimePolicy       RuntimePolicy
 	telegramConfig      domain.TelegramConfig
+	logBroker           *logging.Broker
 }
 
 type RuntimePolicy struct {
@@ -78,6 +80,7 @@ func NewPlatform(store store.Repository) *Platform {
 		executionStrategies: make(map[string]ExecutionStrategy),
 		signalSessions:      make(map[string]domain.SignalRuntimeSession),
 		liveMarketData:      make(map[string]liveMarketSnapshot),
+		logBroker:           logging.NewBroker(),
 		runtimePolicy: RuntimePolicy{
 			TradeTickFreshnessSeconds:      15,
 			OrderBookFreshnessSeconds:      10,

--- a/internal/service/telemetry.go
+++ b/internal/service/telemetry.go
@@ -71,7 +71,11 @@ func (p *Platform) recordStrategyDecisionEvent(
 			"fundingIntervalHours": executionContext.Semantics.FundingIntervalHours,
 		},
 	}
-	return p.store.CreateStrategyDecisionEvent(event)
+	recorded, err := p.store.CreateStrategyDecisionEvent(event)
+	if err == nil {
+		p.publishLogEvent(strategyDecisionToUnifiedLogEvent(recorded))
+	}
+	return recorded, err
 }
 
 func (p *Platform) recordLiveOrderExecutionEvent(order domain.Order, eventType string, eventTime time.Time, failed bool, eventErr error) error {
@@ -134,7 +138,10 @@ func (p *Platform) recordLiveOrderExecutionEvent(order domain.Order, eventType s
 		SymbolRules:       cloneMetadata(mapValue(dispatchSummary["symbolRules"])),
 		Metadata:          cloneMetadata(order.Metadata),
 	}
-	_, err := p.store.CreateOrderExecutionEvent(event)
+	recorded, err := p.store.CreateOrderExecutionEvent(event)
+	if err == nil {
+		p.publishLogEvent(orderExecutionToUnifiedLogEvent(recorded))
+	}
 	return err
 }
 
@@ -208,7 +215,10 @@ func (p *Platform) recordLivePositionAccountSnapshot(session domain.LiveSession,
 			"recoveredProtectionCount":    maxIntValue(state["recoveredProtectionCount"], 0),
 		},
 	}
-	_, err = p.store.CreatePositionAccountSnapshot(snapshot)
+	recorded, err := p.store.CreatePositionAccountSnapshot(snapshot)
+	if err == nil {
+		p.publishLogEvent(positionSnapshotToUnifiedLogEvent(recorded))
+	}
 	return err
 }
 

--- a/internal/store/memory/store.go
+++ b/internal/store/memory/store.go
@@ -744,10 +744,7 @@ func (s *Store) ListStrategyDecisionEvents(liveSessionID string) ([]domain.Strat
 		items = append(items, cloneJSONValue(item))
 	}
 	sort.Slice(items, func(i, j int) bool {
-		if items[i].EventTime.Equal(items[j].EventTime) {
-			return items[i].RecordedAt.Before(items[j].RecordedAt)
-		}
-		return items[i].EventTime.Before(items[j].EventTime)
+		return domain.EventLessAsc(items[i].EventTime, items[i].RecordedAt, items[i].ID, items[j].EventTime, items[j].RecordedAt, items[j].ID)
 	})
 	return items, nil
 }
@@ -780,10 +777,7 @@ func (s *Store) ListOrderExecutionEvents(orderID string) ([]domain.OrderExecutio
 		items = append(items, cloneJSONValue(item))
 	}
 	sort.Slice(items, func(i, j int) bool {
-		if items[i].EventTime.Equal(items[j].EventTime) {
-			return items[i].RecordedAt.Before(items[j].RecordedAt)
-		}
-		return items[i].EventTime.Before(items[j].EventTime)
+		return domain.EventLessAsc(items[i].EventTime, items[i].RecordedAt, items[i].ID, items[j].EventTime, items[j].RecordedAt, items[j].ID)
 	})
 	return items, nil
 }
@@ -816,10 +810,7 @@ func (s *Store) ListPositionAccountSnapshots(accountID string) ([]domain.Positio
 		items = append(items, cloneJSONValue(item))
 	}
 	sort.Slice(items, func(i, j int) bool {
-		if items[i].EventTime.Equal(items[j].EventTime) {
-			return items[i].RecordedAt.Before(items[j].RecordedAt)
-		}
-		return items[i].EventTime.Before(items[j].EventTime)
+		return domain.EventLessAsc(items[i].EventTime, items[i].RecordedAt, items[i].ID, items[j].EventTime, items[j].RecordedAt, items[j].ID)
 	})
 	return items, nil
 }
@@ -867,13 +858,13 @@ func (s *Store) QueryStrategyDecisionEvents(query domain.StrategyDecisionEventQu
 		if !query.To.IsZero() && item.EventTime.After(query.To.UTC()) {
 			continue
 		}
-		if query.Before != nil && !memoryEventComesBefore(item.EventTime, item.RecordedAt, item.ID, *query.Before) {
+		if query.Before != nil && !domain.EventBeforeCursor(item.EventTime, item.RecordedAt, item.ID, *query.Before) {
 			continue
 		}
 		items = append(items, cloneJSONValue(item))
 	}
 	sort.SliceStable(items, func(i, j int) bool {
-		return memoryEventLess(items[i].EventTime, items[i].RecordedAt, items[i].ID, items[j].EventTime, items[j].RecordedAt, items[j].ID)
+		return domain.EventLessDesc(items[i].EventTime, items[i].RecordedAt, items[i].ID, items[j].EventTime, items[j].RecordedAt, items[j].ID)
 	})
 	if query.Limit > 0 && len(items) > query.Limit {
 		items = items[:query.Limit]
@@ -910,13 +901,13 @@ func (s *Store) QueryOrderExecutionEvents(query domain.OrderExecutionEventQuery)
 		if !query.To.IsZero() && item.EventTime.After(query.To.UTC()) {
 			continue
 		}
-		if query.Before != nil && !memoryEventComesBefore(item.EventTime, item.RecordedAt, item.ID, *query.Before) {
+		if query.Before != nil && !domain.EventBeforeCursor(item.EventTime, item.RecordedAt, item.ID, *query.Before) {
 			continue
 		}
 		items = append(items, cloneJSONValue(item))
 	}
 	sort.SliceStable(items, func(i, j int) bool {
-		return memoryEventLess(items[i].EventTime, items[i].RecordedAt, items[i].ID, items[j].EventTime, items[j].RecordedAt, items[j].ID)
+		return domain.EventLessDesc(items[i].EventTime, items[i].RecordedAt, items[i].ID, items[j].EventTime, items[j].RecordedAt, items[j].ID)
 	})
 	if query.Limit > 0 && len(items) > query.Limit {
 		items = items[:query.Limit]
@@ -950,66 +941,18 @@ func (s *Store) QueryPositionAccountSnapshots(query domain.PositionAccountSnapsh
 		if !query.To.IsZero() && item.EventTime.After(query.To.UTC()) {
 			continue
 		}
-		if query.Before != nil && !memoryEventComesBefore(item.EventTime, item.RecordedAt, item.ID, *query.Before) {
+		if query.Before != nil && !domain.EventBeforeCursor(item.EventTime, item.RecordedAt, item.ID, *query.Before) {
 			continue
 		}
 		items = append(items, cloneJSONValue(item))
 	}
 	sort.SliceStable(items, func(i, j int) bool {
-		return memoryEventLess(items[i].EventTime, items[i].RecordedAt, items[i].ID, items[j].EventTime, items[j].RecordedAt, items[j].ID)
+		return domain.EventLessDesc(items[i].EventTime, items[i].RecordedAt, items[i].ID, items[j].EventTime, items[j].RecordedAt, items[j].ID)
 	})
 	if query.Limit > 0 && len(items) > query.Limit {
 		items = items[:query.Limit]
 	}
 	return items, nil
-}
-
-func memoryEventComesBefore(eventTime, recordedAt time.Time, id string, cursor domain.EventCursor) bool {
-	eventTime = eventTime.UTC()
-	recordedAt = normalizeMemoryRecordedAt(recordedAt, eventTime)
-	cursorRecordedAt := normalizeMemoryRecordedAt(cursor.RecordedAt, cursor.EventTime)
-	switch {
-	case eventTime.Before(cursor.EventTime.UTC()):
-		return true
-	case eventTime.After(cursor.EventTime.UTC()):
-		return false
-	}
-	switch {
-	case recordedAt.Before(cursorRecordedAt):
-		return true
-	case recordedAt.After(cursorRecordedAt):
-		return false
-	default:
-		return id < cursor.ID
-	}
-}
-
-func memoryEventLess(leftTime, leftRecordedAt time.Time, leftID string, rightTime, rightRecordedAt time.Time, rightID string) bool {
-	leftTime = leftTime.UTC()
-	rightTime = rightTime.UTC()
-	switch {
-	case leftTime.After(rightTime):
-		return true
-	case leftTime.Before(rightTime):
-		return false
-	}
-	leftRecordedAt = normalizeMemoryRecordedAt(leftRecordedAt, leftTime)
-	rightRecordedAt = normalizeMemoryRecordedAt(rightRecordedAt, rightTime)
-	switch {
-	case leftRecordedAt.After(rightRecordedAt):
-		return true
-	case leftRecordedAt.Before(rightRecordedAt):
-		return false
-	default:
-		return leftID > rightID
-	}
-}
-
-func normalizeMemoryRecordedAt(recordedAt, eventTime time.Time) time.Time {
-	if recordedAt.IsZero() {
-		return eventTime.UTC()
-	}
-	return recordedAt.UTC()
 }
 
 func stringValue(value any) string {

--- a/internal/store/memory/store.go
+++ b/internal/store/memory/store.go
@@ -841,6 +841,184 @@ func (s *Store) CreatePositionAccountSnapshot(snapshot domain.PositionAccountSna
 	return cloneJSONValue(snapshot), nil
 }
 
+func (s *Store) QueryStrategyDecisionEvents(query domain.StrategyDecisionEventQuery) ([]domain.StrategyDecisionEvent, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	items := make([]domain.StrategyDecisionEvent, 0, len(s.decisionEvents))
+	for _, item := range s.decisionEvents {
+		if strings.TrimSpace(query.LiveSessionID) != "" && item.LiveSessionID != strings.TrimSpace(query.LiveSessionID) {
+			continue
+		}
+		if strings.TrimSpace(query.AccountID) != "" && item.AccountID != strings.TrimSpace(query.AccountID) {
+			continue
+		}
+		if strings.TrimSpace(query.StrategyID) != "" && item.StrategyID != strings.TrimSpace(query.StrategyID) {
+			continue
+		}
+		if strings.TrimSpace(query.RuntimeSessionID) != "" && item.RuntimeSessionID != strings.TrimSpace(query.RuntimeSessionID) {
+			continue
+		}
+		if strings.TrimSpace(query.DecisionEventID) != "" && item.ID != strings.TrimSpace(query.DecisionEventID) {
+			continue
+		}
+		if !query.From.IsZero() && item.EventTime.Before(query.From.UTC()) {
+			continue
+		}
+		if !query.To.IsZero() && item.EventTime.After(query.To.UTC()) {
+			continue
+		}
+		if query.Before != nil && !memoryEventComesBefore(item.EventTime, item.RecordedAt, item.ID, *query.Before) {
+			continue
+		}
+		items = append(items, cloneJSONValue(item))
+	}
+	sort.SliceStable(items, func(i, j int) bool {
+		return memoryEventLess(items[i].EventTime, items[i].RecordedAt, items[i].ID, items[j].EventTime, items[j].RecordedAt, items[j].ID)
+	})
+	if query.Limit > 0 && len(items) > query.Limit {
+		items = items[:query.Limit]
+	}
+	return items, nil
+}
+
+func (s *Store) QueryOrderExecutionEvents(query domain.OrderExecutionEventQuery) ([]domain.OrderExecutionEvent, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	items := make([]domain.OrderExecutionEvent, 0, len(s.executionEvents))
+	for _, item := range s.executionEvents {
+		if strings.TrimSpace(query.AccountID) != "" && item.AccountID != strings.TrimSpace(query.AccountID) {
+			continue
+		}
+		if strings.TrimSpace(query.StrategyID) != "" && stringValue(item.Metadata["strategyId"]) != strings.TrimSpace(query.StrategyID) {
+			continue
+		}
+		if strings.TrimSpace(query.RuntimeSessionID) != "" && item.RuntimeSessionID != strings.TrimSpace(query.RuntimeSessionID) {
+			continue
+		}
+		if strings.TrimSpace(query.LiveSessionID) != "" && item.LiveSessionID != strings.TrimSpace(query.LiveSessionID) {
+			continue
+		}
+		if strings.TrimSpace(query.OrderID) != "" && item.OrderID != strings.TrimSpace(query.OrderID) {
+			continue
+		}
+		if strings.TrimSpace(query.DecisionEventID) != "" && item.DecisionEventID != strings.TrimSpace(query.DecisionEventID) {
+			continue
+		}
+		if !query.From.IsZero() && item.EventTime.Before(query.From.UTC()) {
+			continue
+		}
+		if !query.To.IsZero() && item.EventTime.After(query.To.UTC()) {
+			continue
+		}
+		if query.Before != nil && !memoryEventComesBefore(item.EventTime, item.RecordedAt, item.ID, *query.Before) {
+			continue
+		}
+		items = append(items, cloneJSONValue(item))
+	}
+	sort.SliceStable(items, func(i, j int) bool {
+		return memoryEventLess(items[i].EventTime, items[i].RecordedAt, items[i].ID, items[j].EventTime, items[j].RecordedAt, items[j].ID)
+	})
+	if query.Limit > 0 && len(items) > query.Limit {
+		items = items[:query.Limit]
+	}
+	return items, nil
+}
+
+func (s *Store) QueryPositionAccountSnapshots(query domain.PositionAccountSnapshotQuery) ([]domain.PositionAccountSnapshot, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	items := make([]domain.PositionAccountSnapshot, 0, len(s.liveSnapshots))
+	for _, item := range s.liveSnapshots {
+		if strings.TrimSpace(query.AccountID) != "" && item.AccountID != strings.TrimSpace(query.AccountID) {
+			continue
+		}
+		if strings.TrimSpace(query.StrategyID) != "" && item.StrategyID != strings.TrimSpace(query.StrategyID) {
+			continue
+		}
+		if strings.TrimSpace(query.LiveSessionID) != "" && item.LiveSessionID != strings.TrimSpace(query.LiveSessionID) {
+			continue
+		}
+		if strings.TrimSpace(query.OrderID) != "" && item.OrderID != strings.TrimSpace(query.OrderID) {
+			continue
+		}
+		if strings.TrimSpace(query.DecisionEventID) != "" && item.DecisionEventID != strings.TrimSpace(query.DecisionEventID) {
+			continue
+		}
+		if !query.From.IsZero() && item.EventTime.Before(query.From.UTC()) {
+			continue
+		}
+		if !query.To.IsZero() && item.EventTime.After(query.To.UTC()) {
+			continue
+		}
+		if query.Before != nil && !memoryEventComesBefore(item.EventTime, item.RecordedAt, item.ID, *query.Before) {
+			continue
+		}
+		items = append(items, cloneJSONValue(item))
+	}
+	sort.SliceStable(items, func(i, j int) bool {
+		return memoryEventLess(items[i].EventTime, items[i].RecordedAt, items[i].ID, items[j].EventTime, items[j].RecordedAt, items[j].ID)
+	})
+	if query.Limit > 0 && len(items) > query.Limit {
+		items = items[:query.Limit]
+	}
+	return items, nil
+}
+
+func memoryEventComesBefore(eventTime, recordedAt time.Time, id string, cursor domain.EventCursor) bool {
+	eventTime = eventTime.UTC()
+	recordedAt = normalizeMemoryRecordedAt(recordedAt, eventTime)
+	cursorRecordedAt := normalizeMemoryRecordedAt(cursor.RecordedAt, cursor.EventTime)
+	switch {
+	case eventTime.Before(cursor.EventTime.UTC()):
+		return true
+	case eventTime.After(cursor.EventTime.UTC()):
+		return false
+	}
+	switch {
+	case recordedAt.Before(cursorRecordedAt):
+		return true
+	case recordedAt.After(cursorRecordedAt):
+		return false
+	default:
+		return id < cursor.ID
+	}
+}
+
+func memoryEventLess(leftTime, leftRecordedAt time.Time, leftID string, rightTime, rightRecordedAt time.Time, rightID string) bool {
+	leftTime = leftTime.UTC()
+	rightTime = rightTime.UTC()
+	switch {
+	case leftTime.After(rightTime):
+		return true
+	case leftTime.Before(rightTime):
+		return false
+	}
+	leftRecordedAt = normalizeMemoryRecordedAt(leftRecordedAt, leftTime)
+	rightRecordedAt = normalizeMemoryRecordedAt(rightRecordedAt, rightTime)
+	switch {
+	case leftRecordedAt.After(rightRecordedAt):
+		return true
+	case leftRecordedAt.Before(rightRecordedAt):
+		return false
+	default:
+		return leftID > rightID
+	}
+}
+
+func normalizeMemoryRecordedAt(recordedAt, eventTime time.Time) time.Time {
+	if recordedAt.IsZero() {
+		return eventTime.UTC()
+	}
+	return recordedAt.UTC()
+}
+
+func stringValue(value any) string {
+	if text, ok := value.(string); ok {
+		return strings.TrimSpace(text)
+	}
+	return ""
+}
+
 func (s *Store) ListMarketBars(exchange, symbol, timeframe string, from, to int64, limit int) ([]domain.MarketBar, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()

--- a/internal/store/postgres/store.go
+++ b/internal/store/postgres/store.go
@@ -1216,6 +1216,256 @@ func (s *Store) ListPositionAccountSnapshots(accountID string) ([]domain.Positio
 	return items, rows.Err()
 }
 
+func (s *Store) QueryStrategyDecisionEvents(query domain.StrategyDecisionEventQuery) ([]domain.StrategyDecisionEvent, error) {
+	var builder strings.Builder
+	args := make([]any, 0, 12)
+	builder.WriteString(`
+		select
+			id, live_session_id, runtime_session_id, account_id, strategy_id, strategy_version_id, symbol,
+			trigger_type, action, reason, signal_kind, decision_state, intent_signature,
+			source_gate_ready, missing_count, stale_count, event_time, recorded_at,
+			trigger_summary, source_gate, source_states, signal_bar_states, position_snapshot,
+			decision_metadata, signal_intent, execution_proposal, evaluation_context
+		from strategy_decision_events
+		where 1 = 1
+	`)
+	appendQueryCondition(&builder, &args, "live_session_id = %s", strings.TrimSpace(query.LiveSessionID))
+	appendQueryCondition(&builder, &args, "account_id = %s", strings.TrimSpace(query.AccountID))
+	appendQueryCondition(&builder, &args, "strategy_id = %s", strings.TrimSpace(query.StrategyID))
+	appendQueryCondition(&builder, &args, "runtime_session_id = %s", strings.TrimSpace(query.RuntimeSessionID))
+	appendQueryCondition(&builder, &args, "id = %s", strings.TrimSpace(query.DecisionEventID))
+	appendQueryTimeCondition(&builder, &args, "event_time >= %s", query.From)
+	appendQueryTimeCondition(&builder, &args, "event_time <= %s", query.To)
+	appendEventCursorCondition(&builder, &args, query.Before)
+	builder.WriteString(" order by event_time desc, recorded_at desc, id desc")
+	appendLimitCondition(&builder, &args, query.Limit)
+
+	rows, err := s.db.Query(builder.String(), args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	items := make([]domain.StrategyDecisionEvent, 0)
+	for rows.Next() {
+		var item domain.StrategyDecisionEvent
+		var runtimeSessionID sql.NullString
+		var strategyVersionID sql.NullString
+		var triggerType sql.NullString
+		var signalKind sql.NullString
+		var decisionState sql.NullString
+		var intentSignature sql.NullString
+		var triggerSummaryRaw, sourceGateRaw, sourceStatesRaw, signalBarStatesRaw []byte
+		var positionSnapshotRaw, decisionMetadataRaw, signalIntentRaw, executionProposalRaw, evaluationContextRaw []byte
+		if err := rows.Scan(
+			&item.ID, &item.LiveSessionID, &runtimeSessionID, &item.AccountID, &item.StrategyID, &strategyVersionID, &item.Symbol,
+			&triggerType, &item.Action, &item.Reason, &signalKind, &decisionState, &intentSignature,
+			&item.SourceGateReady, &item.MissingCount, &item.StaleCount, &item.EventTime, &item.RecordedAt,
+			&triggerSummaryRaw, &sourceGateRaw, &sourceStatesRaw, &signalBarStatesRaw, &positionSnapshotRaw,
+			&decisionMetadataRaw, &signalIntentRaw, &executionProposalRaw, &evaluationContextRaw,
+		); err != nil {
+			return nil, err
+		}
+		item.RuntimeSessionID = runtimeSessionID.String
+		item.StrategyVersionID = strategyVersionID.String
+		item.TriggerType = triggerType.String
+		item.SignalKind = signalKind.String
+		item.DecisionState = decisionState.String
+		item.IntentSignature = intentSignature.String
+		item.TriggerSummary = unmarshalJSONMap(triggerSummaryRaw)
+		item.SourceGate = unmarshalJSONMap(sourceGateRaw)
+		item.SourceStates = unmarshalJSONMap(sourceStatesRaw)
+		item.SignalBarStates = unmarshalJSONMap(signalBarStatesRaw)
+		item.PositionSnapshot = unmarshalJSONMap(positionSnapshotRaw)
+		item.DecisionMetadata = unmarshalJSONMap(decisionMetadataRaw)
+		item.SignalIntent = unmarshalJSONMap(signalIntentRaw)
+		item.ExecutionProposal = unmarshalJSONMap(executionProposalRaw)
+		item.EvaluationContext = unmarshalJSONMap(evaluationContextRaw)
+		items = append(items, item)
+	}
+	return items, rows.Err()
+}
+
+func (s *Store) QueryOrderExecutionEvents(query domain.OrderExecutionEventQuery) ([]domain.OrderExecutionEvent, error) {
+	var builder strings.Builder
+	args := make([]any, 0, 14)
+	builder.WriteString(`
+		select
+			id, order_id, exchange_order_id, live_session_id, decision_event_id, runtime_session_id, account_id,
+			strategy_version_id, symbol, side, order_type, event_type, status,
+			execution_strategy, execution_decision, execution_mode,
+			quantity, price, expected_price, price_drift_bps, raw_quantity, normalized_quantity,
+			raw_price_reference, normalized_price, spread_bps, book_imbalance,
+			submit_latency_ms, sync_latency_ms, fill_latency_ms, event_time, recorded_at,
+			fallback, post_only, reduce_only, failed, error,
+			runtime_preflight, dispatch_summary, adapter_submission, adapter_sync, normalization, symbol_rules, metadata
+		from order_execution_events
+		where 1 = 1
+	`)
+	appendQueryCondition(&builder, &args, "account_id = %s", strings.TrimSpace(query.AccountID))
+	appendQueryCondition(&builder, &args, "live_session_id = %s", strings.TrimSpace(query.LiveSessionID))
+	appendQueryCondition(&builder, &args, "runtime_session_id = %s", strings.TrimSpace(query.RuntimeSessionID))
+	appendQueryCondition(&builder, &args, "order_id = %s", strings.TrimSpace(query.OrderID))
+	appendQueryCondition(&builder, &args, "decision_event_id = %s", strings.TrimSpace(query.DecisionEventID))
+	appendQueryTimeCondition(&builder, &args, "event_time >= %s", query.From)
+	appendQueryTimeCondition(&builder, &args, "event_time <= %s", query.To)
+	appendEventCursorCondition(&builder, &args, query.Before)
+	if strings.TrimSpace(query.StrategyID) != "" {
+		args = append(args, strings.TrimSpace(query.StrategyID))
+		builder.WriteString(fmt.Sprintf(" and coalesce(metadata->>'strategyId', '') = $%d", len(args)))
+	}
+	builder.WriteString(" order by event_time desc, recorded_at desc, id desc")
+	appendLimitCondition(&builder, &args, query.Limit)
+
+	rows, err := s.db.Query(builder.String(), args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	items := make([]domain.OrderExecutionEvent, 0)
+	for rows.Next() {
+		var item domain.OrderExecutionEvent
+		var exchangeOrderID, liveSessionID, decisionEventID, runtimeSessionID, strategyVersionID sql.NullString
+		var executionStrategy, executionDecision, executionMode, errText sql.NullString
+		var runtimePreflightRaw, dispatchSummaryRaw, adapterSubmissionRaw, adapterSyncRaw, normalizationRaw, symbolRulesRaw, metadataRaw []byte
+		if err := rows.Scan(
+			&item.ID, &item.OrderID, &exchangeOrderID, &liveSessionID, &decisionEventID, &runtimeSessionID, &item.AccountID,
+			&strategyVersionID, &item.Symbol, &item.Side, &item.OrderType, &item.EventType, &item.Status,
+			&executionStrategy, &executionDecision, &executionMode,
+			&item.Quantity, &item.Price, &item.ExpectedPrice, &item.PriceDriftBps, &item.RawQuantity, &item.NormalizedQty,
+			&item.RawPriceReference, &item.NormalizedPrice, &item.SpreadBps, &item.BookImbalance,
+			&item.SubmitLatencyMs, &item.SyncLatencyMs, &item.FillLatencyMs, &item.EventTime, &item.RecordedAt,
+			&item.Fallback, &item.PostOnly, &item.ReduceOnly, &item.Failed, &errText,
+			&runtimePreflightRaw, &dispatchSummaryRaw, &adapterSubmissionRaw, &adapterSyncRaw, &normalizationRaw, &symbolRulesRaw, &metadataRaw,
+		); err != nil {
+			return nil, err
+		}
+		item.ExchangeOrderID = exchangeOrderID.String
+		item.LiveSessionID = liveSessionID.String
+		item.DecisionEventID = decisionEventID.String
+		item.RuntimeSessionID = runtimeSessionID.String
+		item.StrategyVersionID = strategyVersionID.String
+		item.ExecutionStrategy = executionStrategy.String
+		item.ExecutionDecision = executionDecision.String
+		item.ExecutionMode = executionMode.String
+		item.Error = errText.String
+		item.RuntimePreflight = unmarshalJSONMap(runtimePreflightRaw)
+		item.DispatchSummary = unmarshalJSONMap(dispatchSummaryRaw)
+		item.AdapterSubmission = unmarshalJSONMap(adapterSubmissionRaw)
+		item.AdapterSync = unmarshalJSONMap(adapterSyncRaw)
+		item.Normalization = unmarshalJSONMap(normalizationRaw)
+		item.SymbolRules = unmarshalJSONMap(symbolRulesRaw)
+		item.Metadata = unmarshalJSONMap(metadataRaw)
+		items = append(items, item)
+	}
+	return items, rows.Err()
+}
+
+func (s *Store) QueryPositionAccountSnapshots(query domain.PositionAccountSnapshotQuery) ([]domain.PositionAccountSnapshot, error) {
+	var builder strings.Builder
+	args := make([]any, 0, 12)
+	builder.WriteString(`
+		select
+			id, live_session_id, decision_event_id, order_id, account_id, strategy_id, symbol, trigger, intent_signature,
+			position_found, position_side, position_quantity, entry_price, mark_price,
+			net_equity, available_balance, margin_balance, wallet_balance, exposure_notional, open_position_count,
+			sync_status, event_time, recorded_at,
+			position_snapshot, live_position_state, account_snapshot, account_summary, metadata
+		from position_account_snapshots
+		where 1 = 1
+	`)
+	appendQueryCondition(&builder, &args, "account_id = %s", strings.TrimSpace(query.AccountID))
+	appendQueryCondition(&builder, &args, "strategy_id = %s", strings.TrimSpace(query.StrategyID))
+	appendQueryCondition(&builder, &args, "live_session_id = %s", strings.TrimSpace(query.LiveSessionID))
+	appendQueryCondition(&builder, &args, "order_id = %s", strings.TrimSpace(query.OrderID))
+	appendQueryCondition(&builder, &args, "decision_event_id = %s", strings.TrimSpace(query.DecisionEventID))
+	appendQueryTimeCondition(&builder, &args, "event_time >= %s", query.From)
+	appendQueryTimeCondition(&builder, &args, "event_time <= %s", query.To)
+	appendEventCursorCondition(&builder, &args, query.Before)
+	builder.WriteString(" order by event_time desc, recorded_at desc, id desc")
+	appendLimitCondition(&builder, &args, query.Limit)
+
+	rows, err := s.db.Query(builder.String(), args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	items := make([]domain.PositionAccountSnapshot, 0)
+	for rows.Next() {
+		var item domain.PositionAccountSnapshot
+		var decisionEventID, orderID, intentSignature, positionSide, syncStatus sql.NullString
+		var positionSnapshotRaw, livePositionStateRaw, accountSnapshotRaw, accountSummaryRaw, metadataRaw []byte
+		if err := rows.Scan(
+			&item.ID, &item.LiveSessionID, &decisionEventID, &orderID, &item.AccountID, &item.StrategyID, &item.Symbol, &item.Trigger, &intentSignature,
+			&item.PositionFound, &positionSide, &item.PositionQuantity, &item.EntryPrice, &item.MarkPrice,
+			&item.NetEquity, &item.AvailableBalance, &item.MarginBalance, &item.WalletBalance, &item.ExposureNotional, &item.OpenPositionCount,
+			&syncStatus, &item.EventTime, &item.RecordedAt,
+			&positionSnapshotRaw, &livePositionStateRaw, &accountSnapshotRaw, &accountSummaryRaw, &metadataRaw,
+		); err != nil {
+			return nil, err
+		}
+		item.DecisionEventID = decisionEventID.String
+		item.OrderID = orderID.String
+		item.IntentSignature = intentSignature.String
+		item.PositionSide = positionSide.String
+		item.SyncStatus = syncStatus.String
+		item.PositionSnapshot = unmarshalJSONMap(positionSnapshotRaw)
+		item.LivePositionState = unmarshalJSONMap(livePositionStateRaw)
+		item.AccountSnapshot = unmarshalJSONMap(accountSnapshotRaw)
+		item.AccountSummary = unmarshalJSONMap(accountSummaryRaw)
+		item.Metadata = unmarshalJSONMap(metadataRaw)
+		items = append(items, item)
+	}
+	return items, rows.Err()
+}
+
+func appendQueryCondition(builder *strings.Builder, args *[]any, clause, value string) {
+	if value == "" {
+		return
+	}
+	*args = append(*args, value)
+	builder.WriteString(fmt.Sprintf(" and "+clause, fmt.Sprintf("$%d", len(*args))))
+}
+
+func appendQueryTimeCondition(builder *strings.Builder, args *[]any, clause string, value time.Time) {
+	if value.IsZero() {
+		return
+	}
+	*args = append(*args, value.UTC())
+	builder.WriteString(fmt.Sprintf(" and "+clause, fmt.Sprintf("$%d", len(*args))))
+}
+
+func appendEventCursorCondition(builder *strings.Builder, args *[]any, cursor *domain.EventCursor) {
+	if cursor == nil {
+		return
+	}
+	*args = append(*args, cursor.EventTime.UTC(), normalizeCursorRecordedAt(cursor.RecordedAt, cursor.EventTime), cursor.ID)
+	eventIdx := len(*args) - 2
+	recordedIdx := len(*args) - 1
+	idIdx := len(*args)
+	builder.WriteString(fmt.Sprintf(
+		" and (event_time < $%d or (event_time = $%d and recorded_at < $%d) or (event_time = $%d and recorded_at = $%d and id < $%d))",
+		eventIdx, eventIdx, recordedIdx, eventIdx, recordedIdx, idIdx,
+	))
+}
+
+func appendLimitCondition(builder *strings.Builder, args *[]any, limit int) {
+	if limit <= 0 {
+		return
+	}
+	*args = append(*args, limit)
+	builder.WriteString(fmt.Sprintf(" limit $%d", len(*args)))
+}
+
+func normalizeCursorRecordedAt(recordedAt, eventTime time.Time) time.Time {
+	if recordedAt.IsZero() {
+		return eventTime.UTC()
+	}
+	return recordedAt.UTC()
+}
+
 func (s *Store) CreatePositionAccountSnapshot(snapshot domain.PositionAccountSnapshot) (domain.PositionAccountSnapshot, error) {
 	if snapshot.ID == "" {
 		snapshot.ID = fmt.Sprintf("position-account-snapshot-%d", time.Now().UTC().UnixNano())

--- a/internal/store/postgres/store.go
+++ b/internal/store/postgres/store.go
@@ -1441,7 +1441,7 @@ func appendEventCursorCondition(builder *strings.Builder, args *[]any, cursor *d
 	if cursor == nil {
 		return
 	}
-	*args = append(*args, cursor.EventTime.UTC(), normalizeCursorRecordedAt(cursor.RecordedAt, cursor.EventTime), cursor.ID)
+	*args = append(*args, cursor.EventTime.UTC(), domain.NormalizeEventRecordedAt(cursor.RecordedAt, cursor.EventTime), cursor.ID)
 	eventIdx := len(*args) - 2
 	recordedIdx := len(*args) - 1
 	idIdx := len(*args)
@@ -1457,13 +1457,6 @@ func appendLimitCondition(builder *strings.Builder, args *[]any, limit int) {
 	}
 	*args = append(*args, limit)
 	builder.WriteString(fmt.Sprintf(" limit $%d", len(*args)))
-}
-
-func normalizeCursorRecordedAt(recordedAt, eventTime time.Time) time.Time {
-	if recordedAt.IsZero() {
-		return eventTime.UTC()
-	}
-	return recordedAt.UTC()
 }
 
 func (s *Store) CreatePositionAccountSnapshot(snapshot domain.PositionAccountSnapshot) (domain.PositionAccountSnapshot, error) {


### PR DESCRIPTION
## 目的
为日志查看台补齐后端统一日志能力：新增业务事件聚合查询、系统日志与 HTTP 请求日志查询，以及 SSE 实时流，先把后端观测面补完整，前端暂不改动。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [x] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
- [ ] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main)
- [ ] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？
- [ ] DB migration 是否具备向下兼容幂等性？
- [ ] 配置字段有没有无意被混改？

## 验证方式与测试证据
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

已执行验证：
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
- `/usr/local/opt/python@3.12/bin/python3.12 -c "from graphify.watch import _rebuild_code; from pathlib import Path; _rebuild_code(Path('.'))"`

## 改动说明
- 新增 `GET /api/v1/logs/events`，聚合 `StrategyDecisionEvent`、`OrderExecutionEvent`、`PositionAccountSnapshot`，支持 `limit/cursor`、时间范围和实体筛选。
- 新增 `GET /api/v1/logs/system` 与 `GET /api/v1/logs/http`，通过内存 ring buffer 暴露 `slog` 系统日志和请求日志留存。
- 新增 `GET /api/v1/logs/stream` SSE 通道，统一推送 system/http/business events，并补齐 alerts 与 runtime/live timeline 的增量流。
- 为 memory/postgres store 增加按游标限量查询，避免日志接口全量加载。
- 补充日志 API、SSE 和统一事件分页过滤测试。

## 用户/开发者影响
- 后端现在已经具备前端日志台后续接入所需的查询与实时流基础设施。
- 本 PR 不修改前端、不触碰 `internal/service/live*.go` 的高风险执行逻辑。