### PR TITLE
[codex] fix live signal bar bootstrap

### DIFF
--- a/internal/service/signal_runtime_sessions.go
+++ b/internal/service/signal_runtime_sessions.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/wuyaocheng/bktrader/internal/domain"
@@ -137,6 +139,12 @@ func (p *Platform) StartSignalRuntimeSession(sessionID string) (domain.SignalRun
 	state := cloneMetadata(session.State)
 	state["plan"] = plan
 	state["subscriptions"] = subscriptions
+	sourceStates := cloneMetadata(mapValue(state["sourceStates"]))
+	if len(sourceStates) == 0 {
+		sourceStates = p.bootstrapSignalRuntimeSourceStates(subscriptions)
+	}
+	state["sourceStates"] = sourceStates
+	state["signalBarStates"] = deriveSignalBarStates(sourceStates)
 	session.RuntimeAdapter = adapterKey
 	session.Transport = inferSignalRuntimeTransport(subscriptions)
 	session.SubscriptionCnt = len(subscriptions)
@@ -204,6 +212,83 @@ func (p *Platform) StopSignalRuntimeSession(sessionID string) (domain.SignalRunt
 		"strategy_id", session.StrategyID,
 	).Info("signal runtime session stopped")
 	return session, nil
+}
+
+func (p *Platform) bootstrapSignalRuntimeSourceStates(subscriptions []map[string]any) map[string]any {
+	out := map[string]any{}
+	for _, subscription := range subscriptions {
+		if !strings.EqualFold(stringValue(subscription["streamType"]), "signal_bar") {
+			continue
+		}
+		symbol := NormalizeSymbol(stringValue(subscription["symbol"]))
+		timeframe := signalBindingTimeframe(stringValue(subscription["sourceKey"]), metadataValue(subscription["options"]))
+		if symbol == "" || timeframe == "" {
+			continue
+		}
+		snapshot, err := p.liveMarketSnapshot(symbol)
+		if err != nil {
+			continue
+		}
+		bars := snapshot.SignalBars[strings.ToLower(strings.TrimSpace(timeframe))]
+		if len(bars) == 0 {
+			continue
+		}
+		key := signalBindingMatchKey(
+			stringValue(subscription["sourceKey"]),
+			stringValue(subscription["role"]),
+			symbol,
+			map[string]any{"timeframe": timeframe},
+		)
+		out[key] = map[string]any{
+			"sourceKey":   stringValue(subscription["sourceKey"]),
+			"role":        stringValue(subscription["role"]),
+			"streamType":  stringValue(subscription["streamType"]),
+			"symbol":      symbol,
+			"timeframe":   timeframe,
+			"event":       "bootstrap",
+			"lastEventAt": "",
+			"summary": map[string]any{
+				"event":      "bootstrap",
+				"source":     "market-cache",
+				"symbol":     symbol,
+				"timeframe":  timeframe,
+				"streamType": stringValue(subscription["streamType"]),
+			},
+			"bars": strategySignalBarsToRuntimeHistory(bars, symbol, timeframe, 200),
+		}
+	}
+	return out
+}
+
+func strategySignalBarsToRuntimeHistory(bars []strategySignalBar, symbol, timeframe string, limit int) []any {
+	if len(bars) == 0 {
+		return nil
+	}
+	if limit > 0 && len(bars) > limit {
+		bars = bars[len(bars)-limit:]
+	}
+	step := resolutionToDuration(liveSignalResolution(timeframe))
+	if step <= 0 {
+		return nil
+	}
+	out := make([]any, 0, len(bars))
+	for _, bar := range bars {
+		start := bar.Time.UTC()
+		out = append(out, map[string]any{
+			"timeframe": strings.ToLower(strings.TrimSpace(timeframe)),
+			"symbol":    NormalizeSymbol(symbol),
+			"barStart":  strconv.FormatInt(start.UnixMilli(), 10),
+			"barEnd":    strconv.FormatInt(start.Add(step).UnixMilli(), 10),
+			"open":      bar.Open,
+			"high":      bar.High,
+			"low":       bar.Low,
+			"close":     bar.Close,
+			"volume":    bar.Volume,
+			"isClosed":  true,
+			"updatedAt": start.Format(time.RFC3339),
+		})
+	}
+	return out
 }
 
 func (p *Platform) DeleteSignalRuntimeSession(sessionID string) error {

--- a/internal/service/signal_runtime_ws.go
+++ b/internal/service/signal_runtime_ws.go
@@ -379,6 +379,7 @@ func mergeSignalSourceState(existing any, summary map[string]any, eventTime time
 	if strings.Trim(key, "|") == "" {
 		key = "unknown"
 	}
+	existingEntry := cloneMetadata(mapValue(stateMap[key]))
 	stateMap[key] = map[string]any{
 		"sourceKey":   stringValue(summary["sourceKey"]),
 		"role":        stringValue(summary["role"]),
@@ -391,7 +392,7 @@ func mergeSignalSourceState(existing any, summary map[string]any, eventTime time
 	}
 	if strings.EqualFold(stringValue(summary["streamType"]), "signal_bar") {
 		entry := cloneMetadata(mapValue(stateMap[key]))
-		entry["bars"] = mergeSignalBarHistory(entry["bars"], summary, eventTime, 200)
+		entry["bars"] = mergeSignalBarHistory(existingEntry["bars"], summary, eventTime, 200)
 		stateMap[key] = entry
 	}
 	return stateMap

--- a/internal/service/signal_runtime_ws_test.go
+++ b/internal/service/signal_runtime_ws_test.go
@@ -67,3 +67,113 @@ func TestEnrichSignalRuntimeSummaryKeepsKlineEventsScopedByTimeframe(t *testing.
 		}
 	}
 }
+
+func TestMergeSignalSourceStatePreservesSignalBarHistory(t *testing.T) {
+	sourceStates := map[string]any{}
+	first := map[string]any{
+		"sourceKey":          "binance-kline",
+		"role":               "signal",
+		"streamType":         "signal_bar",
+		"symbol":             "BTCUSDT",
+		"subscriptionSymbol": "BTCUSDT",
+		"timeframe":          "1d",
+		"barStart":           "1712966400000",
+		"barEnd":             "1713052800000",
+		"open":               "68000",
+		"high":               "69000",
+		"low":                "67500",
+		"close":              "68800",
+		"volume":             "1200",
+		"isClosed":           true,
+	}
+	second := map[string]any{
+		"sourceKey":          "binance-kline",
+		"role":               "signal",
+		"streamType":         "signal_bar",
+		"symbol":             "BTCUSDT",
+		"subscriptionSymbol": "BTCUSDT",
+		"timeframe":          "1d",
+		"barStart":           "1713052800000",
+		"barEnd":             "1713139200000",
+		"open":               "68800",
+		"high":               "69500",
+		"low":                "68200",
+		"close":              "69200",
+		"volume":             "1300",
+		"isClosed":           true,
+	}
+
+	sourceStates = mergeSignalSourceState(sourceStates, first, time.Date(2026, 4, 15, 0, 0, 0, 0, time.UTC))
+	sourceStates = mergeSignalSourceState(sourceStates, second, time.Date(2026, 4, 15, 0, 0, 1, 0, time.UTC))
+
+	key := signalBindingMatchKey("binance-kline", "signal", "BTCUSDT", map[string]any{"timeframe": "1d"})
+	entry := mapValue(sourceStates[key])
+	if entry == nil {
+		t.Fatalf("expected source state entry, got %#v", sourceStates)
+	}
+	bars := normalizeSignalBarEntries(entry["bars"])
+	if len(bars) != 2 {
+		t.Fatalf("expected two retained bars, got %#v", entry["bars"])
+	}
+	if got := stringValue(bars[0]["barStart"]); got != "1712966400000" {
+		t.Fatalf("expected first bar to be retained, got %#v", bars)
+	}
+	if got := stringValue(bars[1]["barStart"]); got != "1713052800000" {
+		t.Fatalf("expected second bar to be appended, got %#v", bars)
+	}
+}
+
+func TestBootstrapSignalRuntimeSourceStatesUsesWarmMarketCache(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	signalBars := make([]strategySignalBar, 0, 4)
+	base := time.Date(2026, 4, 12, 0, 0, 0, 0, time.UTC)
+	for i := 0; i < 4; i++ {
+		signalBars = append(signalBars, strategySignalBar{
+			Time:   base.Add(time.Duration(i) * 24 * time.Hour),
+			Open:   68000 + float64(i)*100,
+			High:   68500 + float64(i)*100,
+			Low:    67500 + float64(i)*100,
+			Close:  68200 + float64(i)*100,
+			Volume: 1000 + float64(i)*10,
+			MA5:    68050 + float64(i)*100,
+			MA20:   67000 + float64(i)*100,
+			ATR:    900 + float64(i)*10,
+		})
+	}
+	platform.liveMarketData["BTCUSDT"] = liveMarketSnapshot{
+		Symbol: "BTCUSDT",
+		SignalBars: map[string][]strategySignalBar{
+			"1d": signalBars,
+		},
+		UpdatedAt: time.Now().UTC(),
+	}
+
+	subscriptions := []map[string]any{{
+		"sourceKey":  "binance-kline",
+		"role":       "signal",
+		"streamType": "signal_bar",
+		"symbol":     "BTCUSDT",
+		"options":    map[string]any{"timeframe": "1d"},
+	}}
+
+	sourceStates := platform.bootstrapSignalRuntimeSourceStates(subscriptions)
+	key := signalBindingMatchKey("binance-kline", "signal", "BTCUSDT", map[string]any{"timeframe": "1d"})
+	entry := mapValue(sourceStates[key])
+	if entry == nil {
+		t.Fatalf("expected bootstrap source state, got %#v", sourceStates)
+	}
+	if got := len(normalizeSignalBarEntries(entry["bars"])); got != 4 {
+		t.Fatalf("expected warm cache bars to be copied, got %#v", entry["bars"])
+	}
+	if got := stringValue(entry["lastEventAt"]); got != "" {
+		t.Fatalf("expected bootstrap state to wait for live freshness, got %#v", entry)
+	}
+	signalBarStates := deriveSignalBarStates(sourceStates)
+	signalState := mapValue(signalBarStates[key])
+	if signalState == nil {
+		t.Fatalf("expected derived signal bar state, got %#v", signalBarStates)
+	}
+	if mapValue(signalState["prevBar2"]) == nil {
+		t.Fatalf("expected bootstrap state to include previous bars, got %#v", signalState)
+	}
+}


### PR DESCRIPTION
## 目的
修复 live/runtime 启动后持续出现“信号 K 线不足”的问题。

根因有两处：
- signal runtime 每次收到 `signal_bar` 事件时会先覆盖 source state，再写入 `bars`，导致历史 K 线被重置成单根，`prevBar1 / prevBar2` 长期缺失。
- signal runtime 启动时没有把已经预热好的 market cache 注入 `sourceStates / signalBarStates`，导致交易侧刚启动时不能复用 startup warmup 的历史 K 线。

本次改动让 runtime 启动时从 warm market cache bootstrap signal bar 历史，并修正 websocket 后续更新时保留历史 bars。这样启动会话后可以立刻派生 `current / prevBar1 / prevBar2 / sma5 / ma20 / atr14`，同时仍然要求真实 runtime source freshness 来通过实时预检。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [x] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) 未变化。
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？不存在。
- [x] DB migration 是否具备向下兼容幂等性？不涉及 DB migration。
- [x] 配置字段有没有无意被混改？未改配置字段。

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

已执行：
```bash
go test ./internal/service -run 'Test(EnrichSignalRuntimeSummaryKeepsKlineEventsScopedByTimeframe|MergeSignalSourceStatePreservesSignalBarHistory|BootstrapSignalRuntimeSourceStatesUsesWarmMarketCache)$'
go test ./...
go build ./cmd/platform-api
go build ./cmd/db-migrate
```

Push 前已执行 bktrader pre-push harness，graphify rebuild 完成且没有留下未提交 diff。