### PR TITLE
[codex] add 5m signal timeframe

### DIFF
--- a/internal/domain/models.go
+++ b/internal/domain/models.go
@@ -215,7 +215,7 @@ type BacktestRun struct {
 }
 
 // BacktestConfig 是平台级标准化回测配置。
-// signalTimeframe 表示策略信号周期，例如 4h / 1d。
+// signalTimeframe 表示策略信号周期，例如 5m / 4h / 1d。
 // executionDataSource 表示执行层数据源，例如 tick / 1min。
 type BacktestConfig struct {
 	SignalTimeframe     string         `json:"signalTimeframe"`

--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -1347,10 +1347,7 @@ func isLivePlanStepStale(nextPlannedEvent time.Time, signalTimeframe string, now
 	if nextPlannedEvent.IsZero() {
 		return true
 	}
-	resolution := "240"
-	if strings.EqualFold(strings.TrimSpace(signalTimeframe), "1d") {
-		resolution = "1D"
-	}
+	resolution := liveSignalResolution(signalTimeframe)
 	step := resolutionToDuration(resolution)
 	if step <= 0 {
 		step = 4 * time.Hour

--- a/internal/service/live_launch_templates.go
+++ b/internal/service/live_launch_templates.go
@@ -164,8 +164,10 @@ func (p *Platform) LiveLaunchTemplates() ([]LiveLaunchTemplate, error) {
 	}
 
 	return []LiveLaunchTemplate{
+		buildTemplate("BTCUSDT", "5m", 0.002),
 		buildTemplate("BTCUSDT", "4h", 0.002),
 		buildTemplate("BTCUSDT", "1d", 0.002),
+		buildTemplate("ETHUSDT", "5m", 0.100),
 		buildTemplate("ETHUSDT", "4h", 0.100),
 		buildTemplate("ETHUSDT", "1d", 0.100),
 	}, nil

--- a/internal/service/live_launch_templates_test.go
+++ b/internal/service/live_launch_templates_test.go
@@ -6,15 +6,15 @@ import (
 	"github.com/wuyaocheng/bktrader/internal/store/memory"
 )
 
-func TestLiveLaunchTemplatesExposeFourBinanceTestnetVariants(t *testing.T) {
+func TestLiveLaunchTemplatesExposeSixBinanceTestnetVariants(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
 
 	templates, err := platform.LiveLaunchTemplates()
 	if err != nil {
 		t.Fatalf("list live launch templates failed: %v", err)
 	}
-	if len(templates) != 4 {
-		t.Fatalf("expected 4 launch templates, got %d", len(templates))
+	if len(templates) != 6 {
+		t.Fatalf("expected 6 launch templates, got %d", len(templates))
 	}
 
 	expected := map[string]struct {
@@ -22,8 +22,10 @@ func TestLiveLaunchTemplatesExposeFourBinanceTestnetVariants(t *testing.T) {
 		timeframe string
 		quantity  float64
 	}{
+		"binance-testnet-btc-5m": {symbol: "BTCUSDT", timeframe: "5m", quantity: 0.002},
 		"binance-testnet-btc-4h": {symbol: "BTCUSDT", timeframe: "4h", quantity: 0.002},
 		"binance-testnet-btc-1d": {symbol: "BTCUSDT", timeframe: "1d", quantity: 0.002},
+		"binance-testnet-eth-5m": {symbol: "ETHUSDT", timeframe: "5m", quantity: 0.1},
 		"binance-testnet-eth-4h": {symbol: "ETHUSDT", timeframe: "4h", quantity: 0.1},
 		"binance-testnet-eth-1d": {symbol: "ETHUSDT", timeframe: "1d", quantity: 0.1},
 	}

--- a/internal/service/live_market_data.go
+++ b/internal/service/live_market_data.go
@@ -13,6 +13,7 @@ import (
 )
 
 const liveSignalWarmWindow = 400 * 24 * time.Hour
+const liveFastSignalWarmWindow = 7 * 24 * time.Hour
 const liveMinuteWarmWindow = 30 * 24 * time.Hour
 
 var fetchLiveCandleRange = fetchBinanceFuturesCandleRange
@@ -99,12 +100,17 @@ func (p *Platform) refreshLiveMarketSnapshot(symbol string) error {
 	end := time.Now().UTC().Truncate(time.Minute)
 	minuteStart := end.Add(-liveMinuteWarmWindow)
 	signalStart := end.Add(-liveSignalWarmWindow)
+	fastSignalStart := end.Add(-liveFastSignalWarmWindow)
 	minuteBars, err := fetchLiveCandleRange(normalizedSymbol, "1", minuteStart, end)
 	if err != nil {
 		return err
 	}
 	if len(minuteBars) == 0 {
 		return fmt.Errorf("no live market minute bars returned for %s", normalizedSymbol)
+	}
+	signal5M, err := p.syncStoredSignalBars(normalizedSymbol, "5m", fastSignalStart, end)
+	if err != nil {
+		return err
 	}
 	signal1D, err := p.syncStoredSignalBars(normalizedSymbol, "1d", signalStart, end)
 	if err != nil {
@@ -119,6 +125,7 @@ func (p *Platform) refreshLiveMarketSnapshot(symbol string) error {
 		Symbol:     normalizedSymbol,
 		MinuteBars: minuteBars,
 		SignalBars: map[string][]strategySignalBar{
+			"5m": signal5M,
 			"1d": signal1D,
 			"4h": signal4H,
 		},
@@ -127,6 +134,7 @@ func (p *Platform) refreshLiveMarketSnapshot(symbol string) error {
 	p.liveMarketMu.Unlock()
 	logger.Debug("live market snapshot refreshed",
 		"minute_bar_count", len(minuteBars),
+		"signal_5m_bar_count", len(signal5M),
 		"signal_1d_bar_count", len(signal1D),
 		"signal_4h_bar_count", len(signal4H),
 	)
@@ -209,8 +217,8 @@ func (p *Platform) ingestLiveSignalBarSummary(summary map[string]any, eventTime 
 	if !strings.EqualFold(stringValue(summary["streamType"]), "signal_bar") {
 		return nil
 	}
-	timeframe := strings.ToLower(strings.TrimSpace(stringValue(summary["timeframe"])))
-	if timeframe != "1d" && timeframe != "4h" {
+	timeframe := normalizeSignalBarInterval(stringValue(summary["timeframe"]))
+	if timeframe != "5m" && timeframe != "1d" && timeframe != "4h" {
 		return nil
 	}
 	symbol := NormalizeSymbol(stringValue(summary["symbol"]))
@@ -278,7 +286,9 @@ func strategySignalBarToStateEntry(bar strategySignalBar, symbol, timeframe stri
 }
 
 func liveSignalResolution(timeframe string) string {
-	switch strings.ToLower(strings.TrimSpace(timeframe)) {
+	switch normalizeSignalBarInterval(timeframe) {
+	case "5m":
+		return "5"
 	case "1d":
 		return "1D"
 	case "4h":

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -1358,6 +1358,16 @@ func TestEnsureLaunchLiveSessionCreatesDistinctSessionPerSymbolAndTimeframe(t *t
 	}
 }
 
+func TestIsLivePlanStepStaleUsesFiveMinuteTimeframe(t *testing.T) {
+	nextPlannedEvent := time.Date(2026, 4, 16, 12, 0, 0, 0, time.UTC)
+	if isLivePlanStepStale(nextPlannedEvent, "5m", nextPlannedEvent.Add(4*time.Minute+59*time.Second)) {
+		t.Fatal("expected 5m plan step to remain fresh before the next 5m boundary")
+	}
+	if !isLivePlanStepStale(nextPlannedEvent, "5m", nextPlannedEvent.Add(5*time.Minute+time.Second)) {
+		t.Fatal("expected 5m plan step to be stale after the next 5m boundary")
+	}
+}
+
 func TestShouldCancelLiveOrderForExecutionTimeout(t *testing.T) {
 	now := time.Date(2026, 4, 7, 8, 30, 0, 0, time.UTC)
 	order := domain.Order{

--- a/internal/service/paper.go
+++ b/internal/service/paper.go
@@ -1186,14 +1186,10 @@ func (p *Platform) resolvePaperSessionParameters(session domain.PaperSession, ve
 }
 
 func normalizePaperSignalTimeframe(value string) string {
-	value = strings.ToLower(strings.TrimSpace(value))
-	switch value {
-	case "4h", "1d":
-		return value
-	case "d", "1day":
-		return "1d"
-	case "240", "4hour":
-		return "4h"
+	normalized := normalizeSignalBarInterval(value)
+	switch normalized {
+	case "5m", "4h", "1d":
+		return normalized
 	default:
 		return "1d"
 	}

--- a/internal/service/signal_runtime_registry.go
+++ b/internal/service/signal_runtime_registry.go
@@ -157,6 +157,8 @@ func (p *Platform) SignalRuntimeAdapters() []map[string]any {
 func normalizeSignalBarInterval(value string) string {
 	value = strings.ToLower(strings.TrimSpace(value))
 	switch value {
+	case "5m", "5", "5min", "5minute":
+		return "5m"
 	case "1d", "d", "1day":
 		return "1d"
 	case "4h", "240", "4hour":

--- a/internal/service/signal_runtime_ws_test.go
+++ b/internal/service/signal_runtime_ws_test.go
@@ -10,7 +10,7 @@ import (
 func TestEnrichSignalRuntimeSummaryKeepsKlineEventsScopedByTimeframe(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
 
-	for _, timeframe := range []string{"1d", "4h"} {
+	for _, timeframe := range []string{"5m", "1d", "4h"} {
 		if _, err := platform.BindStrategySignalSource("strategy-bk-1d", map[string]any{
 			"sourceKey": "binance-kline",
 			"role":      "signal",
@@ -49,14 +49,28 @@ func TestEnrichSignalRuntimeSummaryKeepsKlineEventsScopedByTimeframe(t *testing.
 		t.Fatalf("expected 1d event to match 1d subscription, got %#v", event1d)
 	}
 
+	event5m := enrichSignalRuntimeSummary(session, map[string]any{
+		"event":     "kline",
+		"symbol":    "BTCUSDT",
+		"timeframe": "5m",
+		"barStart":  "1713074400000",
+	})
+	if got := stringValue(event5m["channel"]); got != "btcusdt@kline_5m" {
+		t.Fatalf("expected 5m event to match 5m subscription, got %#v", event5m)
+	}
+	if got := stringValue(event5m["timeframe"]); got != "5m" {
+		t.Fatalf("expected 5m event timeframe to remain 5m, got %#v", event5m)
+	}
+
 	sourceStates := map[string]any{}
 	sourceStates = mergeSignalSourceState(sourceStates, event1d, time.Date(2026, 4, 15, 0, 0, 0, 0, time.UTC))
 	sourceStates = mergeSignalSourceState(sourceStates, event4h, time.Date(2026, 4, 15, 0, 0, 1, 0, time.UTC))
-	if len(sourceStates) != 2 {
+	sourceStates = mergeSignalSourceState(sourceStates, event5m, time.Date(2026, 4, 15, 0, 0, 2, 0, time.UTC))
+	if len(sourceStates) != 3 {
 		t.Fatalf("expected distinct source-state entries per timeframe, got %#v", sourceStates)
 	}
 
-	for _, timeframe := range []string{"1d", "4h"} {
+	for _, timeframe := range []string{"5m", "1d", "4h"} {
 		key := signalBindingMatchKey("binance-kline", "signal", "BTCUSDT", map[string]any{"timeframe": timeframe})
 		entry := mapValue(sourceStates[key])
 		if entry == nil {

--- a/internal/service/signal_source_registry.go
+++ b/internal/service/signal_source_registry.go
@@ -84,10 +84,10 @@ func (p *Platform) registerBuiltInSignalSources() {
 		Roles:        []string{"signal"},
 		Environments: []string{"paper", "live"},
 		SymbolScope:  "multi_symbol",
-		Description:  "交易所原生 4h/1d K 线流，用于实时策略信号计算、MA20 和前两根 OHLC 状态。",
+		Description:  "交易所原生 5m/4h/1d K 线流，用于实时策略信号计算、MA20 和前两根 OHLC 状态。",
 		Metadata: map[string]any{
 			"stream":               "kline",
-			"supportedTimeframes":  []string{"4h", "1d"},
+			"supportedTimeframes":  []string{"5m", "4h", "1d"},
 			"preferForSignalState": true,
 		},
 	}})
@@ -211,7 +211,7 @@ func (p *Platform) SignalSourceCatalog() map[string]any {
 		"sources": sources,
 		"notes": []string{
 			"账户级信号源绑定支持多源并行，可同时绑定交易触发源和盘口特征源。",
-			"4h / 1d 策略信号建议直接绑定交易所 kline 源，而不是从 tick 聚合大周期 bar。",
+			"5m / 4h / 1d 策略信号建议直接绑定交易所 kline 源，而不是从 tick 聚合 signal bar。",
 			"paper/live 应优先绑定交易所 trade tick；order book 建议作为 feature 源单独接入。",
 			"跨市场套利可在单账户或多账户上并行绑定 Binance / OKX 等多个来源。",
 		},
@@ -224,7 +224,7 @@ func (p *Platform) SignalSourceTypes() []map[string]any {
 		{
 			"streamType":    "signal_bar",
 			"primaryRole":   "signal",
-			"description":   "交易所原生大周期 K 线流，适合作为 4h / 1d 策略信号源。",
+			"description":   "交易所原生 K 线流，适合作为 5m / 4h / 1d 策略信号源。",
 			"typicalInputs": []string{"open", "high", "low", "close", "volume", "interval", "barStart", "barEnd", "isClosed"},
 		},
 		{

--- a/internal/service/signal_source_registry_test.go
+++ b/internal/service/signal_source_registry_test.go
@@ -61,6 +61,42 @@ func TestBindStrategySignalSourceDoesNotDuplicateImplicitDefault1dKlineBinding(t
 	}
 }
 
+func TestBindStrategySignalSourceCanonicalizesFiveMinuteKlineBinding(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+
+	if _, err := platform.BindStrategySignalSource("strategy-bk-1d", map[string]any{
+		"sourceKey": "binance-kline",
+		"role":      "signal",
+		"symbol":    "BTCUSDT",
+		"options":   map[string]any{"timeframe": "5min"},
+	}); err != nil {
+		t.Fatalf("bind 5min kline failed: %v", err)
+	}
+
+	bindings, err := platform.ListStrategySignalBindings("strategy-bk-1d")
+	if err != nil {
+		t.Fatalf("list strategy bindings failed: %v", err)
+	}
+	if len(bindings) != 1 {
+		t.Fatalf("expected one 5m kline binding, got %#v", bindings)
+	}
+	if got := stringValue(bindings[0].Options["timeframe"]); got != "5m" {
+		t.Fatalf("expected canonicalized timeframe 5m, got %s", got)
+	}
+
+	plan, err := platform.BuildSignalRuntimePlan("live-main", "strategy-bk-1d")
+	if err != nil {
+		t.Fatalf("build runtime plan failed: %v", err)
+	}
+	subscriptions := metadataList(plan["subscriptions"])
+	if len(subscriptions) != 1 {
+		t.Fatalf("expected one 5m kline subscription, got %#v", subscriptions)
+	}
+	if got := stringValue(subscriptions[0]["channel"]); got != "btcusdt@kline_5m" {
+		t.Fatalf("expected 5m kline subscription, got %s", got)
+	}
+}
+
 func TestLegacyStrategyBindingWithoutTimeframeCanonicalizesToSingle1dBinding(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
 

--- a/internal/service/strategy.go
+++ b/internal/service/strategy.go
@@ -479,7 +479,7 @@ func (p *Platform) BacktestOptions() map[string]any {
 	}
 
 	return map[string]any{
-		"signalTimeframes":           []string{"4h", "1d"},
+		"signalTimeframes":           []string{"5m", "4h", "1d"},
 		"executionDataSources":       []string{"tick", "1min"},
 		"defaultSignalTimeframe":     "1d",
 		"defaultExecutionDataSource": "tick",
@@ -512,7 +512,7 @@ func (p *Platform) BacktestOptions() map[string]any {
 			"1min": minuteDatasets,
 		},
 		"notes": []string{
-			"4h 和 1d 用于策略信号周期。",
+			"5m 用于调试快速出信号，4h 和 1d 用于常规策略信号周期。",
 			"执行层测试可选 tick 或 1min。",
 			"回测模块聚焦单一执行源回放，不做 tick 与 1min 的结果对比分析。",
 		},
@@ -546,11 +546,11 @@ func NormalizeBacktestParameters(parameters map[string]any) (map[string]any, err
 	}
 	applyBacktestParameterAliases(normalized)
 
-	signalTimeframe := strings.ToLower(strings.TrimSpace(stringValue(normalized["signalTimeframe"])))
+	signalTimeframe := normalizeSignalBarInterval(stringValue(normalized["signalTimeframe"]))
 	if signalTimeframe == "" {
 		signalTimeframe = "1d"
 	}
-	if signalTimeframe != "4h" && signalTimeframe != "1d" {
+	if signalTimeframe != "5m" && signalTimeframe != "4h" && signalTimeframe != "1d" {
 		return nil, fmt.Errorf("unsupported signalTimeframe: %s", signalTimeframe)
 	}
 

--- a/internal/service/strategy_registry.go
+++ b/internal/service/strategy_registry.go
@@ -168,7 +168,7 @@ func (e bkStrategyEngine) Describe() map[string]any {
 	return map[string]any{
 		"key":                  e.Key(),
 		"name":                 "BK Default Strategy",
-		"supportedSignalBars":  []string{"4h", "1d"},
+		"supportedSignalBars":  []string{"5m", "4h", "1d"},
 		"supportedExecutions":  []string{"tick", "1min"},
 		"runtimeConsistency":   "canonical-execution-shared",
 		"backtestSlippageOnly": true,

--- a/internal/service/strategy_replay.go
+++ b/internal/service/strategy_replay.go
@@ -878,7 +878,7 @@ func buildStrategyReplayConfig(context StrategyExecutionContext) strategyReplayC
 		stopLossATR = 0.05
 	}
 	return strategyReplayConfig{
-		SignalTimeframe:      strings.ToLower(context.SignalTimeframe),
+		SignalTimeframe:      normalizeSignalBarInterval(context.SignalTimeframe),
 		ExecutionDataSource:  strings.ToLower(context.ExecutionDataSource),
 		Symbol:               normalizeBacktestSymbol(context.Symbol),
 		From:                 context.From,
@@ -938,10 +938,7 @@ func countFundingIntervals(entryTime, exitTime time.Time, intervalHours int) int
 }
 
 func buildSignalBars(minuteBars []candleBar, timeframe string) ([]strategySignalBar, error) {
-	resolution := "240"
-	if timeframe == "1d" {
-		resolution = "1D"
-	}
+	resolution := liveSignalResolution(timeframe)
 	step := resolutionToDuration(resolution)
 	if step <= 0 {
 		return nil, fmt.Errorf("unsupported signal timeframe: %s", timeframe)
@@ -997,7 +994,7 @@ func buildSignalBars(minuteBars []candleBar, timeframe string) ([]strategySignal
 }
 
 func strategySignalRegimeReady(sig strategySignalBar, timeframe string) (bool, bool) {
-	tf := strings.ToLower(strings.TrimSpace(timeframe))
+	tf := normalizeSignalBarInterval(timeframe)
 	if tf == "1d" {
 		if math.IsNaN(sig.ATR) || sig.ATR <= 0 {
 			return false, false
@@ -1022,7 +1019,13 @@ func strategySignalRegimeReady(sig strategySignalBar, timeframe string) (bool, b
 }
 
 func (p *Platform) loadStrategySignalBars(timeframe string) ([]strategySignalBar, error) {
-	switch strings.ToLower(timeframe) {
+	switch normalizeSignalBarInterval(timeframe) {
+	case "5m":
+		minuteBars, err := p.loadCandleBars()
+		if err != nil {
+			return nil, err
+		}
+		return buildSignalBars(minuteBars, "5m")
 	case "4h":
 		return readSignalBarsCSV("BTC_4H_Signals.csv")
 	case "1d":

--- a/internal/service/strategy_replay_test.go
+++ b/internal/service/strategy_replay_test.go
@@ -62,6 +62,52 @@ func TestNormalizeBacktestParametersPreservesExplicitZeroReentrySlots(t *testing
 	}
 }
 
+func TestNormalizeBacktestParametersCanonicalizesFiveMinuteSignalTimeframe(t *testing.T) {
+	normalized, err := NormalizeBacktestParameters(map[string]any{
+		"signalTimeframe":     "5min",
+		"executionDataSource": "1min",
+	})
+	if err != nil {
+		t.Fatalf("expected 5min signal timeframe to be supported, got %v", err)
+	}
+	if got := stringValue(normalized["signalTimeframe"]); got != "5m" {
+		t.Fatalf("expected canonicalized signalTimeframe 5m, got %s", got)
+	}
+}
+
+func TestBuildSignalBarsSupportsFiveMinuteAggregation(t *testing.T) {
+	minuteBars := make([]candleBar, 0, 12)
+	start := time.Date(2026, 4, 16, 0, 0, 0, 0, time.UTC)
+	for i := 0; i < 12; i++ {
+		price := 100.0 + float64(i)
+		minuteBars = append(minuteBars, candleBar{
+			Time:   start.Add(time.Duration(i) * time.Minute),
+			Open:   price,
+			High:   price + 1,
+			Low:    price - 1,
+			Close:  price + 0.5,
+			Volume: 10,
+		})
+	}
+
+	signals, err := buildSignalBars(minuteBars, "5m")
+	if err != nil {
+		t.Fatalf("build 5m signal bars failed: %v", err)
+	}
+	if len(signals) != 3 {
+		t.Fatalf("expected 3 aggregated 5m bars, got %d", len(signals))
+	}
+	if !signals[0].Time.Equal(start) {
+		t.Fatalf("expected first 5m bucket at %s, got %s", start, signals[0].Time)
+	}
+	if signals[0].Open != 100 || signals[0].Close != 104.5 || signals[0].Volume != 50 {
+		t.Fatalf("unexpected first 5m bar: %#v", signals[0])
+	}
+	if !signals[1].Time.Equal(start.Add(5 * time.Minute)) {
+		t.Fatalf("expected second 5m bucket at %s, got %s", start.Add(5*time.Minute), signals[1].Time)
+	}
+}
+
 func TestBuildStrategyReplayConfigUsesUpdatedBaselineDefaults(t *testing.T) {
 	cfg := buildStrategyReplayConfig(StrategyExecutionContext{
 		SignalTimeframe:     "1d",

--- a/web/console/src/hooks/useDashboard.ts
+++ b/web/console/src/hooks/useDashboard.ts
@@ -155,7 +155,12 @@ export function useDashboard() {
     let selectedResolution = monitorResolution;
     if (!selectedResolution) {
       const monitorSignalTimeframe = String(monitorSessionForChart?.state?.signalTimeframe ?? "1d");
-      selectedResolution = monitorSignalTimeframe.toLowerCase() === "4h" ? "240" : "1D";
+      const normalizedMonitorSignalTimeframe = monitorSignalTimeframe.toLowerCase();
+      selectedResolution = normalizedMonitorSignalTimeframe === "5m" || normalizedMonitorSignalTimeframe === "5min" || normalizedMonitorSignalTimeframe === "5"
+        ? "5"
+        : normalizedMonitorSignalTimeframe === "4h"
+          ? "240"
+          : "1D";
     }
     
     const monitorResolutionParam = selectedResolution;

--- a/web/console/src/modals/LiveSessionModal.tsx
+++ b/web/console/src/modals/LiveSessionModal.tsx
@@ -108,6 +108,7 @@ export function LiveSessionModal({
                 value={liveSessionForm.signalTimeframe}
                 onChange={(event) => setLiveSessionForm((current) => ({ ...current, signalTimeframe: event.target.value }))}
               >
+                <option value="5m">5m</option>
                 <option value="4h">4h</option>
                 <option value="1d">1d</option>
               </select>

--- a/web/console/src/pages/StrategySidePanel.tsx
+++ b/web/console/src/pages/StrategySidePanel.tsx
@@ -130,7 +130,7 @@ export function StrategySidePanel({ createBacktestRun }: StrategySidePanelProps)
                     <SelectValue placeholder="周期" />
                   </SelectTrigger>
                   <SelectContent className="bg-white border-[#d8cfba] rounded-xl">
-                    {(backtestOptions?.signalTimeframes ?? ["4h", "1d"]).map((item) => (
+                    {(backtestOptions?.signalTimeframes ?? ["5m", "4h", "1d"]).map((item) => (
                       <SelectItem key={item} value={item}>{item}</SelectItem>
                     ))}
                   </SelectContent>

--- a/web/console/src/pages/StrategyStage.tsx
+++ b/web/console/src/pages/StrategyStage.tsx
@@ -308,6 +308,7 @@ export function StrategyStage({ createStrategy, saveStrategyParameters }: Strate
                     <SelectValue placeholder="周期" />
                   </SelectTrigger>
                   <SelectContent className="bg-white border-[#d8cfba] rounded-xl">
+                    <SelectItem value="5m">5m</SelectItem>
                     <SelectItem value="4h">4h</SelectItem>
                     <SelectItem value="1d">1d</SelectItem>
                   </SelectContent>


### PR DESCRIPTION
## 目的
新增 5m 信号周期，方便调试时更快观察 K 线信号与策略评估结果，同时保留原有 4h / 1d 周期。

主要变化：
- `binance-kline` 信号源支持 `5m / 4h / 1d`，并将 `5` / `5min` / `5m` 归一化为 `5m`。
- Runtime 订阅支持 `@kline_5m`，source state / signal bar state 按 timeframe 继续隔离。
- 回测、paper、策略引擎能力声明加入 `5m`；5m signal bars 从 1min candles 聚合生成。
- live market cache 增加 5m 预热，使用 7 天窗口，避免按长周期窗口拉取过多 5m REST 数据。
- Live plan stale 判断按 `liveSignalResolution` 统一计算，5m 不再走 4h fallback。
- 前端策略编辑、回测侧栏、Live Session 弹窗可选择 `5m`；主监控图在 live session 为 5m 时默认拉 5min candles。
- 一键启动模板新增 BTCUSDT / ETHUSDT 的 5m testnet 模板。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [x] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

说明：本 PR 不修改下单、成交、仓位同步、`dispatchMode` 默认值或 mainnet 路由，但触碰了 `internal/service/live*.go` 的实盘行情缓存与计划过期判断，按项目规则标记为 L3 供人工重点审查。

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) — 无变化，仍为 `manual-review`
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？— 无
- [x] DB migration 是否具备向下兼容幂等性？— 未涉及 migration
- [x] 配置字段有没有无意被混改？— 未新增/修改环境配置字段

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

本地验证：
```bash
go test ./internal/service
go test ./...
go build ./cmd/platform-api
go build ./cmd/db-migrate
cd web/console && npm ci && npm run build
npm run build
```

pre-push hook 验证：
- graphify rebuilt: 1391 nodes, 2135 edges, 135 communities
- high risk defaults check passed
- environment safety check passed
- backend checks passed
- frontend build passed

## 注意事项
- 当前工作区存在未纳入本 PR 的 `research/` 本地改动，本提交未 stage / 未提交这些文件。
- `npm ci` 提示本机 Node `v20.6.1` 低于某依赖声明的 `^20.17.0 || >=22.9.0`，但安装与构建成功。
- Vite 输出 chunk size warning，属于既有构建体积提示，本 PR 未处理。