### PR TITLE
[codex] add breakout reentry research notes

### DIFF
--- a/research/20260416_breakout_reentry_experiments.md
+++ b/research/20260416_breakout_reentry_experiments.md
@@ -1,0 +1,232 @@
+# 2026-04-16 Breakout / Reentry Research Notes
+
+Scope: research-only backtests. No live execution or `internal/service` trading path was changed.
+
+## Shared Setup
+
+- Data: `BTC_1min_Clean.csv`
+- Window: `2020-01-01` to `2026-02-28`
+- Signal timeframe: `1D`
+- ATR period: `14`
+- Initial balance: `100000.0`
+- Slippage: `0.0005`
+- Stop: `atr`, `stop_loss_atr=0.05`
+- Max trades per bar: `4`
+- Reentry size schedule: `[0.10, 0.05, 0.025]`
+- Trailing stop: `trailing_stop_atr=0.3`
+- Delayed trailing activation: `0.5`
+
+## Experiment 1: Breakout Levels
+
+Question: compare original wick breakout levels with candle-body breakout levels.
+
+- Baseline `wick`: `prev_high_1/2 = high.shift(1/2)`, `prev_low_1/2 = low.shift(1/2)`.
+- Variant `body`: `prev_high_1/2 = max(open, close).shift(1/2)`, `prev_low_1/2 = min(open, close).shift(1/2)`.
+
+| Scenario | Final Balance | Return | Max DD | Trades | Win Rate | Sharpe | Buy Entries | Short Entries | Exit Reasons |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---|
+| `wick` baseline | 11,137,479.39 | 11037.48% | -0.17% | 1780 | 90.6% | 19.25 | 1319 | 1310 | `SL:1773, PT:7` |
+| `body` breakout | 1,637,453.76 | 1537.45% | -0.32% | 1871 | 67.3% | 12.72 | 1408 | 1332 | `SL:1853, PT:18` |
+
+Delta, `body - wick`:
+
+- Final balance: `-9,500,025.63`
+- Return: `-9500.03 pp`
+- Max DD: `-0.14 pp`
+- Trades: `+91`
+- Buy entries: `+89`
+- Short entries: `+22`
+
+Takeaway: body breakout increased triggering frequency but materially reduced trade quality. Keep baseline `wick` breakout as the default.
+
+## Experiment 2: Reentry Anchor Levels
+
+Question: keep baseline wick breakout, then change reentry anchor from wick low/high to candle-body low/high.
+
+- Baseline: long reentry at `prev_low_1 + 0.1ATR`; short reentry at `prev_high_1`.
+- Variant A: long reentry at `prev_body_low_1`; short reentry at `prev_body_high_1`.
+- Variant B: long reentry at `prev_body_low_1 + 0.1ATR`; short reentry at `prev_body_high_1 - 0.1ATR`.
+
+| Scenario | Final Balance | Return | Max DD | Trades | Win Rate | Sharpe | Buy Entries | Short Entries | Exit Reasons |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---|
+| Baseline wick reentry | 11,137,479.39 | 11037.48% | -0.17% | 1780 | 90.6% | 19.25 | 1319 | 1310 | `SL:1773, PT:7` |
+| Body reentry, no ATR offset | 3,738,242.29 | 3638.24% | -0.27% | 1779 | 81.6% | 16.30 | 1335 | 1289 | `SL:1778, PT:1` |
+| Body reentry, +/- 0.1ATR | 2,172,836.90 | 2072.84% | -0.28% | 1744 | 76.5% | 14.69 | 1308 | 1263 | `SL:1743, PT:1` |
+
+Delta vs baseline:
+
+| Scenario | Final Balance Delta | Return Delta | Max DD Delta | Trades Delta | Buy Entries Delta | Short Entries Delta |
+|---|---:|---:|---:|---:|---:|---:|
+| Body reentry, no ATR offset | -7,399,237.10 | -7399.24 pp | -0.10 pp | -1 | +16 | -21 |
+| Body reentry, +/- 0.1ATR | -8,964,642.49 | -8964.64 pp | -0.11 pp | -36 | -11 | -47 |
+
+Takeaway: both body reentry variants underperform the wick reentry baseline. The no-offset body reentry is less damaging than the +/- `0.1ATR` body variant, but neither improves the baseline.
+
+## Experiment 3: 2026 Q1 Tick-Derived 1min Reentry Check
+
+The previous `BTC_1min_Clean.csv` only covered through `2026-02-28`, so it is not used for this Q1 check. A new file was generated directly from raw tick data:
+
+- Output: `BTC_1min_Q1.csv`
+- Inputs:
+  - `dataset/archive/BTCUSDT-trades-2026-01/BTCUSDT-trades-2026-01.csv`
+  - `dataset/archive/BTCUSDT-trades-2026-02/BTCUSDT-trades-2026-02.csv`
+  - `dataset/archive/BTCUSDT-trades-2026-03/BTCUSDT-trades-2026-03.csv`
+- Range: `2026-01-01 00:00:00+00:00` to `2026-03-31 23:59:00+00:00`
+- Rows: `129600`, exactly `90 * 24 * 60`
+
+No `2025-12` BTC tick file was available locally, so this run generated 1D signals from Q1 data only. This means the first part of January is used for MA/ATR warmup; first trade appears on `2026-01-18`.
+
+Breakout remains baseline `wick`; only reentry anchor changes.
+
+| Scenario | Final Balance | Return | Max DD | Trades | Win Rate | Sharpe | Buy Entries | Short Entries | First Trade | Last Trade | Exit Reasons |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---|---|---|
+| Baseline wick reentry | 117,968.59 | 17.97% | -0.17% | 75 | 86.7% | 22.17 | 53 | 54 | `2026-01-18 23:46:00+00:00` | `2026-03-30 04:02:00+00:00` | `SL:75` |
+| Body reentry, no ATR offset | 113,693.77 | 13.69% | -0.19% | 73 | 82.2% | 20.95 | 51 | 54 | `2026-01-18 23:46:00+00:00` | `2026-03-30 19:50:00+00:00` | `SL:73` |
+| Body reentry, +/- 0.1ATR | 112,136.78 | 12.14% | -0.17% | 71 | 83.1% | 21.07 | 51 | 52 | `2026-01-18 23:46:00+00:00` | `2026-03-29 23:21:00+00:00` | `SL:71` |
+
+Delta vs baseline:
+
+| Scenario | Final Balance Delta | Return Delta | Max DD Delta | Trades Delta | Buy Entries Delta | Short Entries Delta |
+|---|---:|---:|---:|---:|---:|---:|
+| Body reentry, no ATR offset | -4,274.83 | -4.27 pp | -0.01 pp | -2 | -2 | 0 |
+| Body reentry, +/- 0.1ATR | -5,831.81 | -5.83 pp | 0.00 pp | -4 | -2 | -2 |
+
+Takeaway: on tick-derived 2026 Q1 1min data, body reentry still does not beat the baseline. The no-offset body reentry remains the better of the two body variants, but baseline wick reentry is still ahead.
+
+## Experiment 4: 2026 Q1 Tick-Derived 4h Reentry Check
+
+Data source remains `BTC_1min_Q1.csv`, generated from raw BTCUSDT 2026 Q1 tick files. For this run, 4h signal bars were aggregated from that 1min file:
+
+- Signal rows: `540`
+- Signal range: `2026-01-01 00:00:00+00:00` to `2026-03-31 20:00:00+00:00`
+- Valid ATR rows: `527`
+- Valid MA20 rows: `521`
+
+Breakout remains baseline `wick`; only reentry anchor changes.
+
+| Scenario | Final Balance | Return | Max DD | Trades | Win Rate | Sharpe | Buy Entries | Short Entries | First Trade | Last Trade | Exit Reasons |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---|---|---|
+| Baseline wick reentry | 119,672.92 | 19.67% | -0.10% | 272 | 82.0% | 16.75 | 169 | 222 | `2026-01-06 14:07:00+00:00` | `2026-03-31 11:18:00+00:00` | `SL:272` |
+| Body reentry, no ATR offset | 114,627.98 | 14.63% | -0.17% | 273 | 72.9% | 14.26 | 165 | 229 | `2026-01-06 14:07:00+00:00` | `2026-03-31 11:18:00+00:00` | `SL:273` |
+| Body reentry, +/- 0.1ATR | 112,325.22 | 12.33% | -0.17% | 256 | 67.6% | 13.56 | 160 | 210 | `2026-01-06 14:07:00+00:00` | `2026-03-31 11:18:00+00:00` | `SL:256` |
+
+Delta vs baseline:
+
+| Scenario | Final Balance Delta | Return Delta | Max DD Delta | Trades Delta | Buy Entries Delta | Short Entries Delta |
+|---|---:|---:|---:|---:|---:|---:|
+| Body reentry, no ATR offset | -5,044.94 | -5.04 pp | -0.07 pp | +1 | -4 | +7 |
+| Body reentry, +/- 0.1ATR | -7,347.70 | -7.35 pp | -0.07 pp | -16 | -9 | -12 |
+
+Takeaway: on 4h signals, baseline wick reentry remains ahead. The 4h baseline outperformed the 1D Q1 baseline (`19.67%` vs `17.97%`), but body reentry still did not show an edge.
+
+## Experiment 5: ETH 2026 Q1 Tick-Derived Reentry Check
+
+To mirror the BTC Q1 check, a new ETH 1min file was generated directly from raw tick data:
+
+- Output: `ETH_1min_Q1.csv`
+- Inputs:
+  - `dataset/archive/ETHUSDT-trades-2026-01/ETHUSDT-trades-2026-01.csv`
+  - `dataset/archive/ETHUSDT-trades-2026-02/ETHUSDT-trades-2026-02.zip`
+  - `dataset/archive/ETHUSDT-trades-2026-03/ETHUSDT-trades-2026-03.zip`
+- Range: `2026-01-01 00:00:00+00:00` to `2026-03-31 23:59:00+00:00`
+- Rows: `129600`, exactly `90 * 24 * 60`
+
+Breakout remains baseline `wick`; only reentry anchor changes.
+
+### ETH 1D Signals
+
+- Signal rows: `90`
+- Signal range: `2026-01-01 00:00:00+00:00` to `2026-03-31 00:00:00+00:00`
+- Valid ATR rows: `77`
+- Valid MA20 rows: `71`
+
+| Scenario | Final Balance | Return | Max DD | Trades | Win Rate | Sharpe | Buy Entries | Short Entries | First Trade | Last Trade | Exit Reasons |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---|---|---|
+| Baseline wick reentry | 122,151.87 | 22.15% | -0.04% | 55 | 98.2% | 26.32 | 45 | 38 | `2026-01-25 16:16:00+00:00` | `2026-03-30 19:11:00+00:00` | `SL:55` |
+| Body reentry, no ATR offset | 117,310.58 | 17.31% | -0.15% | 54 | 88.9% | 22.74 | 44 | 38 | `2026-01-25 16:16:00+00:00` | `2026-03-30 19:11:00+00:00` | `SL:54` |
+| Body reentry, +/- 0.1ATR | 115,563.18 | 15.56% | -0.10% | 51 | 92.2% | 23.09 | 44 | 34 | `2026-01-25 16:16:00+00:00` | `2026-03-30 19:11:00+00:00` | `SL:51` |
+
+Delta vs baseline:
+
+| Scenario | Final Balance Delta | Return Delta | Max DD Delta | Trades Delta | Buy Entries Delta | Short Entries Delta |
+|---|---:|---:|---:|---:|---:|---:|
+| Body reentry, no ATR offset | -4,841.30 | -4.84 pp | -0.12 pp | -1 | -1 | 0 |
+| Body reentry, +/- 0.1ATR | -6,588.70 | -6.59 pp | -0.06 pp | -4 | -1 | -4 |
+
+### ETH 4h Signals
+
+- Signal rows: `540`
+- Signal range: `2026-01-01 00:00:00+00:00` to `2026-03-31 20:00:00+00:00`
+- Valid ATR rows: `527`
+- Valid MA20 rows: `521`
+
+| Scenario | Final Balance | Return | Max DD | Trades | Win Rate | Sharpe | Buy Entries | Short Entries | First Trade | Last Trade | Exit Reasons |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---|---|---|
+| Baseline wick reentry | 134,354.23 | 34.35% | -0.08% | 305 | 86.2% | 17.66 | 175 | 263 | `2026-01-04 21:11:00+00:00` | `2026-03-31 14:43:00+00:00` | `SL:305` |
+| Body reentry, no ATR offset | 123,802.54 | 23.80% | -0.18% | 295 | 74.9% | 13.88 | 168 | 262 | `2026-01-04 21:11:00+00:00` | `2026-03-31 14:43:00+00:00` | `SL:295` |
+| Body reentry, +/- 0.1ATR | 119,278.25 | 19.28% | -0.23% | 292 | 67.5% | 12.43 | 175 | 249 | `2026-01-04 21:11:00+00:00` | `2026-03-31 14:43:00+00:00` | `SL:292` |
+
+Delta vs baseline:
+
+| Scenario | Final Balance Delta | Return Delta | Max DD Delta | Trades Delta | Buy Entries Delta | Short Entries Delta |
+|---|---:|---:|---:|---:|---:|---:|
+| Body reentry, no ATR offset | -10,551.69 | -10.55 pp | -0.10 pp | -10 | -7 | -1 |
+| Body reentry, +/- 0.1ATR | -15,075.98 | -15.08 pp | -0.15 pp | -13 | 0 | -14 |
+
+Takeaway: ETH also favors baseline wick reentry. The 4h ETH baseline is the strongest Q1 result in this batch (`34.35%`), while both body reentry variants underperform on 1D and 4h.
+
+## Experiment 6: True Pullback Reentry Trigger
+
+Previous reentry tests changed the anchor but kept the existing reclaim trigger:
+
+- Long reclaim: `bar.high >= re_p`
+- Short reclaim: `bar.low <= re_p`
+
+This experiment adds a true pullback trigger while leaving the default behavior unchanged:
+
+- Long pullback: `bar.low <= re_p`
+- Short pullback: `bar.high >= re_p`
+
+Baseline remains the existing reclaim mode with wick anchors. Variants use body anchors with pullback trigger.
+
+### BTC Pullback Reentry
+
+| Timeframe | Scenario | Final Balance | Return | Max DD | Trades | Win Rate | Sharpe | Buy Entries | Short Entries | Exit Reasons |
+|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---|
+| 1D | Baseline reclaim wick | 117,968.59 | 17.97% | -0.17% | 75 | 86.7% | 22.17 | 53 | 54 | `SL:75` |
+| 1D | Body pullback, no ATR offset | 99,791.60 | -0.21% | -0.25% | 11 | 9.1% | -1.19 | 16 | 15 | `SL:11` |
+| 1D | Body pullback, +/- 0.1ATR | 99,566.34 | -0.43% | -0.43% | 15 | 0.0% | -61.60 | 20 | 14 | `SL:15` |
+| 4h | Baseline reclaim wick | 119,672.92 | 19.67% | -0.10% | 272 | 82.0% | 16.75 | 169 | 222 | `SL:272` |
+| 4h | Body pullback, no ATR offset | 98,745.16 | -1.25% | -1.25% | 77 | 7.8% | -3.17 | 73 | 89 | `SL:77` |
+| 4h | Body pullback, +/- 0.1ATR | 98,252.06 | -1.75% | -1.75% | 103 | 3.9% | -6.67 | 89 | 105 | `SL:103` |
+
+BTC delta vs baseline:
+
+| Timeframe | Scenario | Return Delta | Max DD Delta | Trades Delta |
+|---|---|---:|---:|---:|
+| 1D | Body pullback, no ATR offset | -18.18 pp | -0.07 pp | -64 |
+| 1D | Body pullback, +/- 0.1ATR | -18.40 pp | -0.26 pp | -60 |
+| 4h | Body pullback, no ATR offset | -20.93 pp | -1.16 pp | -195 |
+| 4h | Body pullback, +/- 0.1ATR | -21.42 pp | -1.65 pp | -169 |
+
+### ETH Pullback Reentry
+
+| Timeframe | Scenario | Final Balance | Return | Max DD | Trades | Win Rate | Sharpe | Buy Entries | Short Entries | Exit Reasons |
+|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---|
+| 1D | Baseline reclaim wick | 122,151.87 | 22.15% | -0.04% | 55 | 98.2% | 26.32 | 45 | 38 | `SL:55` |
+| 1D | Body pullback, no ATR offset | 99,752.73 | -0.25% | -0.25% | 6 | 0.0% | -79.73 | 12 | 13 | `SL:6` |
+| 1D | Body pullback, +/- 0.1ATR | 99,499.79 | -0.50% | -0.50% | 15 | 0.0% | -107.78 | 16 | 19 | `SL:15` |
+| 4h | Baseline reclaim wick | 134,354.23 | 34.35% | -0.08% | 305 | 86.2% | 17.66 | 175 | 263 | `SL:305` |
+| 4h | Body pullback, no ATR offset | 98,466.71 | -1.53% | -1.53% | 81 | 4.9% | -10.60 | 65 | 112 | `SL:81` |
+| 4h | Body pullback, +/- 0.1ATR | 98,698.80 | -1.30% | -1.41% | 115 | 6.1% | -0.92 | 79 | 140 | `SL:115` |
+
+ETH delta vs baseline:
+
+| Timeframe | Scenario | Return Delta | Max DD Delta | Trades Delta |
+|---|---|---:|---:|---:|
+| 1D | Body pullback, no ATR offset | -22.40 pp | -0.21 pp | -49 |
+| 1D | Body pullback, +/- 0.1ATR | -22.65 pp | -0.46 pp | -40 |
+| 4h | Body pullback, no ATR offset | -35.89 pp | -1.45 pp | -224 |
+| 4h | Body pullback, +/- 0.1ATR | -35.66 pp | -1.33 pp | -190 |
+
+Takeaway: true pullback reentry performs substantially worse in this Q1 batch. It creates far fewer completed trades and much lower win rates under the current stop/trailing/reentry sizing setup. The existing reclaim-style reentry remains the better behavior for BTC and ETH on both 1D and 4h.

--- a/research/backTest.py
+++ b/research/backTest.py
@@ -12,6 +12,94 @@ def _normalize_utc_index(df):
     return normalized
 
 
+def attach_body_extrema_levels(df_signal):
+    prepared = df_signal.copy()
+    body_high = prepared[['open', 'close']].astype(float).max(axis=1)
+    body_low = prepared[['open', 'close']].astype(float).min(axis=1)
+    prepared['body_high'] = body_high
+    prepared['body_low'] = body_low
+    prepared['prev_body_high_1'] = body_high.shift(1)
+    prepared['prev_body_high_2'] = body_high.shift(2)
+    prepared['prev_body_low_1'] = body_low.shift(1)
+    prepared['prev_body_low_2'] = body_low.shift(2)
+    return prepared
+
+
+def apply_wick_breakout_levels(df_signal):
+    prepared = attach_body_extrema_levels(df_signal)
+    prepared['prev_high_1'] = prepared['high'].shift(1)
+    prepared['prev_high_2'] = prepared['high'].shift(2)
+    prepared['prev_low_1'] = prepared['low'].shift(1)
+    prepared['prev_low_2'] = prepared['low'].shift(2)
+    return prepared
+
+
+def apply_body_breakout_levels(df_signal):
+    prepared = attach_body_extrema_levels(df_signal)
+    prepared['prev_high_1'] = prepared['prev_body_high_1']
+    prepared['prev_high_2'] = prepared['prev_body_high_2']
+    prepared['prev_low_1'] = prepared['prev_body_low_1']
+    prepared['prev_low_2'] = prepared['prev_body_low_2']
+    return prepared
+
+
+def apply_breakout_levels(df_signal, breakout_levels='wick'):
+    normalized = str(breakout_levels).lower().strip()
+    if normalized == 'wick':
+        return apply_wick_breakout_levels(df_signal)
+    if normalized == 'body':
+        return apply_body_breakout_levels(df_signal)
+    raise ValueError(f"未知突破形态口径: {breakout_levels}")
+
+
+def apply_reentry_anchor_levels(df_signal, reentry_anchor_levels='wick'):
+    normalized = str(reentry_anchor_levels).lower().strip()
+    if normalized == 'wick':
+        return df_signal
+    if normalized == 'body':
+        return attach_body_extrema_levels(df_signal)
+    raise ValueError(f"未知重入口径: {reentry_anchor_levels}")
+
+
+def _resolve_reentry_price(sig, side, reentry_anchor_levels, reentry_atr):
+    normalized = str(reentry_anchor_levels).lower().strip()
+    if normalized == 'body':
+        anchor_key = 'prev_body_low_1' if side == 'long' else 'prev_body_high_1'
+    elif normalized == 'wick':
+        anchor_key = 'prev_low_1' if side == 'long' else 'prev_high_1'
+    else:
+        raise ValueError(f"未知重入口径: {reentry_anchor_levels}")
+
+    anchor = sig[anchor_key]
+    if side == 'long':
+        return anchor + (reentry_atr * sig['atr'])
+    return anchor - (reentry_atr * sig['atr'])
+
+
+def _normalize_reentry_trigger_mode(reentry_trigger_mode):
+    normalized = str(reentry_trigger_mode).lower().strip()
+    if normalized in ('reclaim', 'pullback'):
+        return normalized
+    raise ValueError(f"未知重入触发模式: {reentry_trigger_mode}")
+
+
+def _reentry_triggered(side, trigger_mode, high_value, low_value, close_value, prev_close_value, re_p, confirm=False):
+    mode = _normalize_reentry_trigger_mode(trigger_mode)
+    if mode == 'pullback':
+        if side == 'long':
+            return low_value <= re_p, re_p
+        return high_value >= re_p, re_p
+
+    if side == 'long':
+        if confirm:
+            return (prev_close_value is not None and not pd.isna(prev_close_value) and close_value > re_p and prev_close_value > re_p), close_value
+        return high_value >= re_p, re_p
+
+    if confirm:
+        return (prev_close_value is not None and not pd.isna(prev_close_value) and close_value < re_p and prev_close_value < re_p), close_value
+    return low_value <= re_p, re_p
+
+
 def _empty_tick_event_stream():
     return pd.DataFrame(
         {
@@ -170,8 +258,11 @@ def run_tick_full_scan_dual(df_4h, tick_file, current_bal,
                             tiered_protection=False,
                             max_drawdown_pct=None,
                             cooldown_bars=6,
-                            reentry_mode='default'):
+                            reentry_mode='default',
+                            reentry_anchor_levels='wick',
+                            reentry_trigger_mode='reclaim'):
     # Keep both signal windows and tick windows on the same UTC-aware contract.
+    df_4h = apply_reentry_anchor_levels(df_4h, reentry_anchor_levels)
     df_4h = _normalize_utc_index(df_4h)
 
     replay_start = df_4h.index[0]
@@ -219,6 +310,10 @@ def run_tick_full_scan_dual(df_4h, tick_file, current_bal,
         label_parts.append(f"CB:{max_drawdown_pct:.0%}")
     if reentry_mode != 'default':
         label_parts.append(f"Re:{reentry_mode}")
+    if reentry_anchor_levels != 'wick':
+        label_parts.append(f"ReAnchor:{reentry_anchor_levels}")
+    if reentry_trigger_mode != 'reclaim':
+        label_parts.append(f"ReTrigger:{reentry_trigger_mode}")
     label_parts.append(f"ReATR:{long_reentry_atr}/{short_reentry_atr}")
     label = " | ".join(label_parts) if label_parts else "TickEnhanced"
 
@@ -261,7 +356,7 @@ def run_tick_full_scan_dual(df_4h, tick_file, current_bal,
                 executed = False
 
                 if long_regime_ready:
-                    re_p = sig['prev_low_1'] + (long_reentry_atr * sig['atr'])
+                    re_p = _resolve_reentry_price(sig, 'long', reentry_anchor_levels, long_reentry_atr)
                     if trades_in_bar == 0 and sig['prev_high_2'] > sig['prev_high_1']:
                         if current_p >= sig['prev_high_2']:
                             entry_raw = max(current_p, sig['prev_high_2'])
@@ -288,15 +383,16 @@ def run_tick_full_scan_dual(df_4h, tick_file, current_bal,
                             trades_in_bar += 1
                             executed = True
                     elif last_exit_side == 'long' and (i - last_exit_bar_index <= REENTRY_TIMEOUT):
-                        is_triggered = False
-                        entry_p_raw = re_p
-                        if dir1_reentry_confirm:
-                            if not pd.isna(prev_p) and current_p > re_p and prev_p > re_p:
-                                is_triggered = True
-                                entry_p_raw = current_p
-                        else:
-                            if current_p >= re_p:
-                                is_triggered = True
+                        is_triggered, entry_p_raw = _reentry_triggered(
+                            'long',
+                            reentry_trigger_mode,
+                            current_p,
+                            current_p,
+                            current_p,
+                            prev_p,
+                            re_p,
+                            dir1_reentry_confirm,
+                        )
                         if is_triggered:
                             reason = 'SL-Reentry' if last_exit_reason == 'SL' else 'PT-Reentry'
                             if trades_in_bar < MAX_TRADES_PER_BAR:
@@ -326,7 +422,7 @@ def run_tick_full_scan_dual(df_4h, tick_file, current_bal,
                             last_exit_side = None
 
                 elif short_regime_ready:
-                    re_p = sig['prev_high_1'] - (short_reentry_atr * sig['atr'])
+                    re_p = _resolve_reentry_price(sig, 'short', reentry_anchor_levels, short_reentry_atr)
                     if trades_in_bar == 0 and sig['prev_low_2'] < sig['prev_low_1']:
                         if current_p <= sig['prev_low_2']:
                             entry_raw = min(current_p, sig['prev_low_2'])
@@ -353,15 +449,16 @@ def run_tick_full_scan_dual(df_4h, tick_file, current_bal,
                             trades_in_bar += 1
                             executed = True
                     elif last_exit_side == 'short' and (i - last_exit_bar_index <= REENTRY_TIMEOUT):
-                        is_triggered = False
-                        entry_p_raw = re_p
-                        if dir1_reentry_confirm:
-                            if not pd.isna(prev_p) and current_p < re_p and prev_p < re_p:
-                                is_triggered = True
-                                entry_p_raw = current_p
-                        else:
-                            if current_p <= re_p:
-                                is_triggered = True
+                        is_triggered, entry_p_raw = _reentry_triggered(
+                            'short',
+                            reentry_trigger_mode,
+                            current_p,
+                            current_p,
+                            current_p,
+                            prev_p,
+                            re_p,
+                            dir1_reentry_confirm,
+                        )
                         if is_triggered:
                             reason = 'SL-Reentry' if last_exit_reason == 'SL' else 'PT-Reentry'
                             if trades_in_bar < MAX_TRADES_PER_BAR:
@@ -680,8 +777,8 @@ def analyze_worst_month(trade_df):
     print(f"  · 月内最大瞬时回撤: {intra_month_dd:.2%}")
     print("!"*40)
 
-def generate_1d_signals(df_1min, atr_period=14):
-    print(f"正在聚合 1Min 数据生成 1D (日线) 信号数据... (ATR 周期: {atr_period})")
+def generate_1d_signals(df_1min, atr_period=14, breakout_levels='wick'):
+    print(f"正在聚合 1Min 数据生成 1D (日线) 信号数据... (ATR 周期: {atr_period}, 突破口径: {breakout_levels})")
     df_1d = df_1min.resample('1D').agg({
         'open': 'first',
         'high': 'max',
@@ -698,10 +795,7 @@ def generate_1d_signals(df_1min, atr_period=14):
     ranges = pd.concat([high_low, high_close, low_close], axis=1)
     true_range = np.max(ranges, axis=1)
     df_1d['atr'] = true_range.rolling(atr_period).mean()
-    df_1d['prev_high_1'] = df_1d['high'].shift(1)
-    df_1d['prev_high_2'] = df_1d['high'].shift(2)
-    df_1d['prev_low_1'] = df_1d['low'].shift(1)
-    df_1d['prev_low_2'] = df_1d['low'].shift(2)
+    df_1d = apply_breakout_levels(df_1d, breakout_levels)
     print("1D 信号生成完成，总行数: ", len(df_1d))
     return df_1d
 
@@ -768,13 +862,16 @@ def run_backtest_1min_granularity(df_1min, df_4h, initial_balance=100000.0,
                                   long_reentry_atr=0.1,
                                   short_reentry_atr=0.0,
                                   stop_mode=None,
-                                  profit_protect_atr=1.0):
+                                  profit_protect_atr=1.0,
+                                  reentry_anchor_levels='wick',
+                                  reentry_trigger_mode='reclaim'):
     """
     1min 颗粒度双向回测引擎
     df_1min: 包含 open, high, low, close 的标准化 1min 数据
     df_4h: 包含策略锚点(ma20, atr, prev_high_2 等)的 4H 数据
     """
     df_1min = _normalize_utc_index(df_1min)
+    df_4h = apply_reentry_anchor_levels(df_4h, reentry_anchor_levels)
     df_4h = _normalize_utc_index(df_4h)
 
     balance = initial_balance
@@ -803,6 +900,8 @@ def run_backtest_1min_granularity(df_1min, df_4h, initial_balance=100000.0,
         f"🚀 1min回测 | InitialSize:{CASH_USAGE_INITIAL:.0%} | "
         f"Stop:{stop_mode} | Reentry:{'Confirm' if dir1_reentry_confirm else 'Touch'} | "
         f"MaxTrades:{MAX_TRADES_PER_BAR} | ReentrySizes:{REENTRY_SIZE_SCHEDULE} | "
+        f"ReentryAnchor:{reentry_anchor_levels} | "
+        f"ReentryTrigger:{reentry_trigger_mode} | "
         f"ReentryATR(L/S):{long_reentry_atr}/{short_reentry_atr} | "
         f"Slippage:{SLIPPAGE}"
     )
@@ -839,7 +938,7 @@ def run_backtest_1min_granularity(df_1min, df_4h, initial_balance=100000.0,
                 
                 # 1. 多头逻辑 (MA20 之上)
                 if long_regime_ready:
-                    re_p = sig['prev_low_1'] + (long_reentry_atr * sig['atr'])
+                    re_p = _resolve_reentry_price(sig, 'long', reentry_anchor_levels, long_reentry_atr)
                     # 初始进场
                     if trades_in_bar == 0 and sig['prev_high_2'] > sig['prev_high_1']:
                         if bar['high'] >= sig['prev_high_2']:
@@ -860,16 +959,17 @@ def run_backtest_1min_granularity(df_1min, df_4h, initial_balance=100000.0,
                     # 重入逻辑
                     elif last_exit_side == 'long' and (i - last_exit_bar_index <= REENTRY_TIMEOUT):
                         # 改变点1：结构确认控制
-                        is_triggered = False
-                        entry_p_raw = re_p # default
-                        if dir1_reentry_confirm:
-                            if prev_bar is not None and bar['close'] > re_p and prev_bar['close'] > re_p:
-                                is_triggered = True
-                                entry_p_raw = bar['close']
-                        else:
-                            if bar['high'] >= re_p:
-                                is_triggered = True
-                                entry_p_raw = re_p
+                        prev_close = prev_bar['close'] if prev_bar is not None else None
+                        is_triggered, entry_p_raw = _reentry_triggered(
+                            'long',
+                            reentry_trigger_mode,
+                            bar['high'],
+                            bar['low'],
+                            bar['close'],
+                            prev_close,
+                            re_p,
+                            dir1_reentry_confirm,
+                        )
 
                         if is_triggered:
                             reason = 'SL-Reentry' if last_exit_reason == 'SL' else 'PT-Reentry'
@@ -892,7 +992,7 @@ def run_backtest_1min_granularity(df_1min, df_4h, initial_balance=100000.0,
 
                 # 2. 空头逻辑 (MA20 之下)
                 elif short_regime_ready:
-                    re_p = sig['prev_high_1'] - (short_reentry_atr * sig['atr'])
+                    re_p = _resolve_reentry_price(sig, 'short', reentry_anchor_levels, short_reentry_atr)
                     # 初始进场
                     if trades_in_bar == 0 and sig['prev_low_2'] < sig['prev_low_1']:
                         if bar['low'] <= sig['prev_low_2']:
@@ -913,16 +1013,17 @@ def run_backtest_1min_granularity(df_1min, df_4h, initial_balance=100000.0,
                     
                     # 空头重入
                     elif last_exit_side == 'short' and (i - last_exit_bar_index <= REENTRY_TIMEOUT):
-                        is_triggered = False
-                        entry_p_raw = re_p
-                        if dir1_reentry_confirm:
-                            if prev_bar is not None and bar['close'] < re_p and prev_bar['close'] < re_p:
-                                is_triggered = True
-                                entry_p_raw = bar['close']
-                        else:
-                            if bar['low'] <= re_p:
-                                is_triggered = True
-                                entry_p_raw = re_p
+                        prev_close = prev_bar['close'] if prev_bar is not None else None
+                        is_triggered, entry_p_raw = _reentry_triggered(
+                            'short',
+                            reentry_trigger_mode,
+                            bar['high'],
+                            bar['low'],
+                            bar['close'],
+                            prev_close,
+                            re_p,
+                            dir1_reentry_confirm,
+                        )
 
                         if is_triggered:
                             reason = 'SL-Reentry' if last_exit_reason == 'SL' else 'PT-Reentry'
@@ -1290,7 +1391,9 @@ def run_backtest_enhanced(df_1min, df_4h, initial_balance=100000.0,
                           tiered_protection=False,
                           max_drawdown_pct=None,
                           cooldown_bars=6,
-                          reentry_mode='default'):
+                          reentry_mode='default',
+                          reentry_anchor_levels='wick',
+                          reentry_trigger_mode='reclaim'):
     """
     增强版 1min 回测引擎，在原始引擎基础上新增：
 
@@ -1304,6 +1407,7 @@ def run_backtest_enhanced(df_1min, df_4h, initial_balance=100000.0,
     - reentry_mode: str, 'default'=原始递增, 'fixed'=固定大小, 'decreasing'=递减。
     """
     df_1min = _normalize_utc_index(df_1min)
+    df_4h = apply_reentry_anchor_levels(df_4h, reentry_anchor_levels)
     df_4h = _normalize_utc_index(df_4h)
 
     balance = initial_balance
@@ -1340,6 +1444,8 @@ def run_backtest_enhanced(df_1min, df_4h, initial_balance=100000.0,
     if tiered_protection: label_parts.append("TieredPT")
     if max_drawdown_pct: label_parts.append(f"CB:{max_drawdown_pct:.0%}")
     if reentry_mode != 'default': label_parts.append(f"Re:{reentry_mode}")
+    if reentry_anchor_levels != 'wick': label_parts.append(f"ReAnchor:{reentry_anchor_levels}")
+    if reentry_trigger_mode != 'reclaim': label_parts.append(f"ReTrigger:{reentry_trigger_mode}")
     label_parts.append(f"ReATR:{long_reentry_atr}/{short_reentry_atr}")
     label = " | ".join(label_parts) if label_parts else "Enhanced"
 
@@ -1383,7 +1489,7 @@ def run_backtest_enhanced(df_1min, df_4h, initial_balance=100000.0,
 
                 # 多头逻辑
                 if long_regime_ready:
-                    re_p = sig['prev_low_1'] + (long_reentry_atr * sig['atr'])
+                    re_p = _resolve_reentry_price(sig, 'long', reentry_anchor_levels, long_reentry_atr)
                     if trades_in_bar == 0 and sig['prev_high_2'] > sig['prev_high_1']:
                         if bar['high'] >= sig['prev_high_2']:
                             entry_p = max(bar['open'], sig['prev_high_2']) * (1 + SLIPPAGE)
@@ -1402,15 +1508,17 @@ def run_backtest_enhanced(df_1min, df_4h, initial_balance=100000.0,
                             executed = True
 
                     elif last_exit_side == 'long' and (i - last_exit_bar_index <= REENTRY_TIMEOUT):
-                        is_triggered = False
-                        entry_p_raw = re_p
-                        if dir1_reentry_confirm:
-                            if prev_bar is not None and bar['close'] > re_p and prev_bar['close'] > re_p:
-                                is_triggered = True
-                                entry_p_raw = bar['close']
-                        else:
-                            if bar['high'] >= re_p:
-                                is_triggered = True
+                        prev_close = prev_bar['close'] if prev_bar is not None else None
+                        is_triggered, entry_p_raw = _reentry_triggered(
+                            'long',
+                            reentry_trigger_mode,
+                            bar['high'],
+                            bar['low'],
+                            bar['close'],
+                            prev_close,
+                            re_p,
+                            dir1_reentry_confirm,
+                        )
 
                         if is_triggered:
                             reason = 'SL-Reentry' if last_exit_reason == 'SL' else 'PT-Reentry'
@@ -1433,7 +1541,7 @@ def run_backtest_enhanced(df_1min, df_4h, initial_balance=100000.0,
                             last_exit_side = None
 
                 elif short_regime_ready:
-                    re_p = sig['prev_high_1'] - (short_reentry_atr * sig['atr'])
+                    re_p = _resolve_reentry_price(sig, 'short', reentry_anchor_levels, short_reentry_atr)
                     if trades_in_bar == 0 and sig['prev_low_2'] < sig['prev_low_1']:
                         if bar['low'] <= sig['prev_low_2']:
                             entry_p = min(bar['open'], sig['prev_low_2']) * (1 - SLIPPAGE)
@@ -1452,15 +1560,17 @@ def run_backtest_enhanced(df_1min, df_4h, initial_balance=100000.0,
                             executed = True
 
                     elif last_exit_side == 'short' and (i - last_exit_bar_index <= REENTRY_TIMEOUT):
-                        is_triggered = False
-                        entry_p_raw = re_p
-                        if dir1_reentry_confirm:
-                            if prev_bar is not None and bar['close'] < re_p and prev_bar['close'] < re_p:
-                                is_triggered = True
-                                entry_p_raw = bar['close']
-                        else:
-                            if bar['low'] <= re_p:
-                                is_triggered = True
+                        prev_close = prev_bar['close'] if prev_bar is not None else None
+                        is_triggered, entry_p_raw = _reentry_triggered(
+                            'short',
+                            reentry_trigger_mode,
+                            bar['high'],
+                            bar['low'],
+                            bar['close'],
+                            prev_close,
+                            re_p,
+                            dir1_reentry_confirm,
+                        )
 
                         if is_triggered:
                             reason = 'SL-Reentry' if last_exit_reason == 'SL' else 'PT-Reentry'

--- a/research/ma_filter_backtest.py
+++ b/research/ma_filter_backtest.py
@@ -6,7 +6,11 @@ import pandas as pd
 
 from backTest import (
     _normalize_reentry_sizes,
+    _reentry_triggered,
+    _resolve_reentry_price,
     _resolve_stop_price,
+    apply_breakout_levels,
+    apply_reentry_anchor_levels,
     generate_1d_signals,
 )
 
@@ -99,7 +103,10 @@ def run_ma_filter_backtest(
     adx_threshold: float = 20.0,
     enable_early_reversal_gate: bool = False,
     early_reversal_band_atr: float = 0.15,
+    reentry_anchor_levels: str = "wick",
+    reentry_trigger_mode: str = "reclaim",
 ) -> pd.DataFrame:
+    df_signal = apply_reentry_anchor_levels(df_signal, reentry_anchor_levels)
     balance = initial_balance
     position = None
     trade_logs = []
@@ -128,7 +135,9 @@ def run_ma_filter_backtest(
         f"ADXEnabled:{enable_adx_filter} | "
         f"ADXThreshold:{adx_threshold} | "
         f"EarlyReversalEnabled:{enable_early_reversal_gate} | "
-        f"EarlyReversalBandATR:{early_reversal_band_atr}"
+        f"EarlyReversalBandATR:{early_reversal_band_atr} | "
+        f"ReentryAnchor:{reentry_anchor_levels} | "
+        f"ReentryTrigger:{reentry_trigger_mode}"
     )
 
     for i in range(len(df_signal) - 1):
@@ -149,6 +158,7 @@ def run_ma_filter_backtest(
         while current_idx < len(window):
             bar = window.iloc[current_idx]
             bar_time = window.index[current_idx]
+            prev_bar = window.iloc[current_idx - 1] if current_idx > 0 else None
 
             if not position:
                 long_allowed = True
@@ -191,7 +201,7 @@ def run_ma_filter_backtest(
                 )
 
                 if long_allowed or long_early_reversal:
-                    re_p = sig["prev_low_1"] + reentry_atr * sig["atr"]
+                    re_p = _resolve_reentry_price(sig, "long", reentry_anchor_levels, reentry_atr)
                     if trades_in_bar == 0 and sig["prev_high_2"] > sig["prev_high_1"] and bar["high"] >= sig["prev_high_2"]:
                         entry = max(bar["open"], sig["prev_high_2"]) * (1 + fixed_slippage)
                         notional = balance * cash_usage_initial
@@ -210,13 +220,23 @@ def run_ma_filter_backtest(
                         current_idx += 1
                         continue
 
-                    if last_exit_side == "long" and bar["high"] >= re_p and (i - last_exit_bar_index <= reentry_timeout):
+                    prev_close = prev_bar["close"] if prev_bar is not None else None
+                    is_reentry_triggered, entry_p_raw = _reentry_triggered(
+                        "long",
+                        reentry_trigger_mode,
+                        bar["high"],
+                        bar["low"],
+                        bar["close"],
+                        prev_close,
+                        re_p,
+                    )
+                    if last_exit_side == "long" and is_reentry_triggered and (i - last_exit_bar_index <= reentry_timeout):
                         reason = "SL-Reentry" if last_exit_reason == "SL" else "PT-Reentry"
                         if (reason == "SL-Reentry" and trades_in_bar < max_trades_per_bar) or reason == "PT-Reentry":
                             size_index = trades_in_bar
                             reentry_size = reentry_sizes[min(size_index, len(reentry_sizes) - 1)]
                             notional = balance * reentry_size
-                            entry = re_p * (1 + fixed_slippage)
+                            entry = entry_p_raw * (1 + fixed_slippage)
                             position = {
                                 "side": "long",
                                 "entry_p": entry,
@@ -235,7 +255,7 @@ def run_ma_filter_backtest(
                         continue
 
                 if short_allowed or short_early_reversal:
-                    re_p = sig["prev_high_1"]
+                    re_p = _resolve_reentry_price(sig, "short", reentry_anchor_levels, 0.0)
                     if trades_in_bar == 0 and sig["prev_low_2"] < sig["prev_low_1"] and bar["low"] <= sig["prev_low_2"]:
                         entry = min(bar["open"], sig["prev_low_2"]) * (1 - fixed_slippage)
                         notional = balance * cash_usage_initial
@@ -254,13 +274,23 @@ def run_ma_filter_backtest(
                         current_idx += 1
                         continue
 
-                    if last_exit_side == "short" and bar["low"] <= re_p and (i - last_exit_bar_index <= reentry_timeout):
+                    prev_close = prev_bar["close"] if prev_bar is not None else None
+                    is_reentry_triggered, entry_p_raw = _reentry_triggered(
+                        "short",
+                        reentry_trigger_mode,
+                        bar["high"],
+                        bar["low"],
+                        bar["close"],
+                        prev_close,
+                        re_p,
+                    )
+                    if last_exit_side == "short" and is_reentry_triggered and (i - last_exit_bar_index <= reentry_timeout):
                         reason = "SL-Reentry" if last_exit_reason == "SL" else "PT-Reentry"
                         if (reason == "SL-Reentry" and trades_in_bar < max_trades_per_bar) or reason == "PT-Reentry":
                             size_index = trades_in_bar
                             reentry_size = reentry_sizes[min(size_index, len(reentry_sizes) - 1)]
                             notional = balance * reentry_size
-                            entry = re_p * (1 - fixed_slippage)
+                            entry = entry_p_raw * (1 - fixed_slippage)
                             position = {
                                 "side": "short",
                                 "entry_p": entry,
@@ -333,13 +363,15 @@ def summarize_ledger(ledger: pd.DataFrame, initial_balance: float) -> dict:
     }
 
 
-def load_signal_frame(df_1min: pd.DataFrame, timeframe: str, signal_csv: Optional[str]) -> pd.DataFrame:
+def load_signal_frame(df_1min: pd.DataFrame, timeframe: str, signal_csv: Optional[str], breakout_levels: str) -> pd.DataFrame:
     timeframe = timeframe.lower().strip()
     if timeframe == "1d":
-        return generate_1d_signals(df_1min)
+        return generate_1d_signals(df_1min, breakout_levels=breakout_levels)
     if signal_csv:
-        return pd.read_csv(signal_csv, index_col=0, parse_dates=True)
-    return pd.read_csv("BTC_4H_Signals.csv", index_col=0, parse_dates=True)
+        df_signal = pd.read_csv(signal_csv, index_col=0, parse_dates=True)
+    else:
+        df_signal = pd.read_csv("BTC_4H_Signals.csv", index_col=0, parse_dates=True)
+    return df_signal if breakout_levels == "wick" else apply_breakout_levels(df_signal, breakout_levels)
 
 
 def parse_args() -> argparse.Namespace:
@@ -347,6 +379,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--one-min-csv", default="BTC_1min_Clean.csv")
     parser.add_argument("--signal-csv", default="")
     parser.add_argument("--timeframe", choices=["4h", "1d"], default="1d")
+    parser.add_argument("--breakout-levels", choices=["wick", "body"], default="wick")
     parser.add_argument("--start", default="2023-01-01")
     parser.add_argument("--end", default="2026-02-28")
     parser.add_argument("--initial-balance", type=float, default=100000.0)
@@ -355,6 +388,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--stop-mode", default="atr")
     parser.add_argument("--max-trades-per-bar", type=int, default=3)
     parser.add_argument("--reentry-size-schedule", default="0.10,0.20")
+    parser.add_argument("--reentry-anchor-levels", choices=["wick", "body"], default="wick")
+    parser.add_argument("--reentry-trigger-mode", choices=["reclaim", "pullback"], default="reclaim")
     parser.add_argument("--profit-protect-atr", type=float, default=1.0)
     parser.add_argument("--disable-zero-initial", action="store_true")
     parser.add_argument("--filter-kind", choices=["sma", "ema"], default="ema")
@@ -375,7 +410,7 @@ def main() -> None:
     reentry_sizes = [float(item) for item in args.reentry_size_schedule.split(",") if item.strip()]
 
     df_1min = pd.read_csv(args.one_min_csv, index_col=0, parse_dates=True).loc[args.start : args.end]
-    df_signal = load_signal_frame(df_1min, args.timeframe, args.signal_csv or None).loc[args.start : args.end]
+    df_signal = load_signal_frame(df_1min, args.timeframe, args.signal_csv or None, args.breakout_levels).loc[args.start : args.end]
     df_signal = ensure_filter_indicator(df_signal, args.filter_kind, args.filter_period, args.adx_period)
 
     ledger = run_ma_filter_backtest(
@@ -396,10 +431,15 @@ def main() -> None:
         adx_threshold=args.adx_threshold,
         enable_early_reversal_gate=args.enable_early_reversal_gate,
         early_reversal_band_atr=args.early_reversal_band_atr,
+        reentry_anchor_levels=args.reentry_anchor_levels,
+        reentry_trigger_mode=args.reentry_trigger_mode,
     )
 
     result = {
         "timeframe": args.timeframe,
+        "breakout_levels": args.breakout_levels,
+        "reentry_anchor_levels": args.reentry_anchor_levels,
+        "reentry_trigger_mode": args.reentry_trigger_mode,
         "window": {"start": args.start, "end": args.end},
         "filter_kind": args.filter_kind,
         "filter_period": args.filter_period,


### PR DESCRIPTION
## 目的
补充 breakout / reentry 研究脚本扩展与 2026-04-16 实验记录，承接此前本地未纳入 PR #55 的 `research/` 改动。

主要变化：
- `research/backTest.py` 增加 wick/body breakout levels、wick/body reentry anchor，以及 reclaim/pullback reentry trigger 的实验参数。
- `research/ma_filter_backtest.py` 扩展对应研究入口与实验组合。
- 新增 `research/20260416_breakout_reentry_experiments.md`，记录 BTC/ETH、1D/4h、baseline/body/pullback 等实验结果与结论。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [x] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

说明：本 PR 只涉及 `research/` 投研脚本和实验记录，不修改后端服务、前端控制台、实盘执行、dispatch 默认值、DB migration 或部署配置。

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) — 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？— 无
- [x] DB migration 是否具备向下兼容幂等性？— 未涉及 migration
- [x] 配置字段有没有无意被混改？— 未涉及配置字段

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

本地验证：
```bash
python3 -m py_compile research/backTest.py research/ma_filter_backtest.py
```

pre-push hook 验证：
- graphify rebuilt: 1391 nodes, 2135 edges, 135 communities
- high risk defaults check passed
- environment safety check passed
- changed-scope checks passed

## 注意事项
- PR #55 已在 research 提交前合并，因此本 PR 是追加 research 改动的 follow-up。
- 当前 branch head: `1d8e373 add breakout reentry research notes`。