### PR TITLE
build(ci): migrate all routines from ubuntu-latest to dedicated self-…

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   docker:
     name: Build and publish image
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, macOS, ARM64]
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   risk-checks:
     name: High Risk Defenses
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, macOS, ARM64]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -23,7 +23,7 @@ jobs:
 
   backend:
     name: Backend (Go)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, macOS, ARM64]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -54,7 +54,7 @@ jobs:
 
   frontend:
     name: Frontend (Vite)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, macOS, ARM64]
     defaults:
       run:
         working-directory: web/console
@@ -77,7 +77,7 @@ jobs:
 
   docker:
     name: Docker build validation
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, macOS, ARM64]
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
…hosted macOS node to bypass depleted github actions billing usage

## 目的
_这次改动要解决什么问题 / 实现了什么功能_

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [ ] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [ ] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main)
- [ ] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？
- [ ] DB migration 是否具备向下兼容幂等性？
- [ ] 配置字段有没有无意被混改？

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [ ] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩
