### PR TITLE
feat(ui): strategy console modernization & backtest lab integration

### DIFF
--- a/web/console/src/App.tsx
+++ b/web/console/src/App.tsx
@@ -108,11 +108,7 @@ export default function App() {
             quickLiveAccountId={quickLiveAccountId} 
           />
         }
-        sidePanelContent={
-          sidebarTab === 'strategy' ? (
-            <StrategySidePanel createBacktestRun={actions.createBacktestRun} />
-          ) : null
-        }
+        sidePanelContent={null}
         mainStageContent={mainStageContent}
         dockContent={dockContent}
       />

--- a/web/console/src/hooks/useTradingActions.ts
+++ b/web/console/src/hooks/useTradingActions.ts
@@ -1036,6 +1036,7 @@ export function useTradingActions(loadDashboard: () => Promise<void>) {
 
   function jumpToSignalRuntimeSession(sessionId: string) {
     setSelectedSignalRuntimeId(sessionId);
+    useUIStore.getState().setSidebarTab("monitor");
     window.location.hash = "signals";
   }
 

--- a/web/console/src/pages/AccountStage.tsx
+++ b/web/console/src/pages/AccountStage.tsx
@@ -145,6 +145,7 @@ export function AccountStage({
   const orders = useTradingStore(s => s.orders);
   const fills = useTradingStore(s => s.fills);
   const positions = useTradingStore(s => s.positions);
+  const summaries = useTradingStore(s => s.summaries);
   const liveSessionForm = useUIStore(s => s.liveSessionForm);
   const liveBindingForm = useUIStore(s => s.liveBindingForm);
   const quickLiveAccountId = liveSessionForm.accountId || liveBindingForm.accountId || liveAccounts[0]?.id || "";
@@ -441,6 +442,7 @@ export function AccountStage({
               {liveAccounts.map((account) => {
                 const binding = (account.metadata?.liveBinding as Record<string, unknown> | undefined) ?? {};
                 const syncSnapshot = getRecord(getRecord(account.metadata).liveSyncSnapshot);
+                const summary = summaries.find(s => s.accountId === account.id);
                 const runtimeSessionsForAccount = signalRuntimeSessions.filter((item) => item.accountId === account.id);
                 const activeRuntime = runtimeSessionsForAccount.find((item) => item.status === "RUNNING") ?? runtimeSessionsForAccount[0] ?? null;
                 const activeRuntimeState = getRecord(activeRuntime?.state);
@@ -492,24 +494,21 @@ export function AccountStage({
                           </div>
                        </div>
 
-                       {/* 中间：高密集指标矩阵 (Metrics Matrix) */}
                        <div className="flex-1 bg-white/40 p-6 flex flex-col justify-center border-r border-[#d8cfba]/30">
                           <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
                              <div className="p-3.5 bg-white/50 rounded-2xl border border-[#d8cfba]/40 hover:bg-white hover:border-[#1f2328] transition-all shadow-sm">
-                                <span className="text-[9px] text-[#687177] uppercase font-black tracking-widest block mb-1.5 opacity-60">Latest Price</span>
+                                <span className="text-[9px] text-[#687177] uppercase font-black tracking-widest block mb-1.5 opacity-60">Net Equity</span>
+                                <p className="text-xl font-mono font-black text-[#0e6d60] tracking-tighter tabular-nums">{summary ? formatMaybeNumber(summary.netEquity) : "--"}</p>
+                             </div>
+                             <div className="p-3.5 bg-white/50 rounded-2xl border border-[#d8cfba]/40 hover:bg-white hover:border-[#1f2328] transition-all shadow-sm">
+                                <span className="text-[9px] text-[#687177] uppercase font-black tracking-widest block mb-1.5 opacity-60">Unrealized PnL</span>
+                                <p className={`text-xl font-mono font-black tracking-tighter tabular-nums ${summary && summary.unrealizedPnl >= 0 ? 'text-[#0e6d60]' : 'text-rose-600'}`}>
+                                  {summary ? (summary.unrealizedPnl > 0 ? "+" : "") + formatMaybeNumber(summary.unrealizedPnl) : "--"}
+                                </p>
+                             </div>
+                             <div className="p-3.5 bg-white/50 rounded-2xl border border-[#d8cfba]/40 hover:bg-white hover:border-[#1f2328] transition-all shadow-sm">
+                                <span className="text-[9px] text-[#687177] uppercase font-black tracking-widest block mb-1.5 opacity-60">Market Price</span>
                                 <p className="text-xl font-mono font-black text-[#1f2328] tracking-tighter tabular-nums">{formatMaybeNumber(activeRuntimeMarket.tradePrice)}</p>
-                             </div>
-                             <div className="p-3.5 bg-white/50 rounded-2xl border border-[#d8cfba]/40 hover:bg-white hover:border-[#1f2328] transition-all shadow-sm">
-                                <span className="text-[9px] text-[#687177] uppercase font-black tracking-widest block mb-1.5 opacity-60">Heartbeat</span>
-                                <p className="text-[11px] font-mono text-[#1f2328] font-bold uppercase">{formatTime(String(activeRuntimeState.lastHeartbeatAt ?? ""))}</p>
-                             </div>
-                             <div className="p-3.5 bg-white/50 rounded-2xl border border-[#d8cfba]/40 hover:bg-white hover:border-[#1f2328] transition-all shadow-sm">
-                                <span className="text-[9px] text-[#687177] uppercase font-black tracking-widest block mb-1.5 opacity-60">Signal Bias</span>
-                                <div className="mt-1">
-                                  <Badge className={`h-5.5 px-2 text-[10px] font-black tracking-widest uppercase ${signalActionTone(activeSignalAction.bias, activeSignalAction.state) === 'ready' ? 'bg-[#0e6d60]' : 'bg-rose-600'}`}>
-                                    {String(activeSignalAction.bias || "--")}
-                                  </Badge>
-                                </div>
                              </div>
                              <div className="p-3.5 bg-white/50 rounded-2xl border border-[#d8cfba]/40 hover:bg-white hover:border-[#1f2328] transition-all shadow-sm">
                                 <span className="text-[9px] text-[#687177] uppercase font-black tracking-widest block mb-1.5 opacity-60">Next Advice</span>
@@ -558,9 +557,26 @@ export function AccountStage({
 
                     {accountDetailOpen && (
                       <div className="px-5 pb-5 pt-4 border-t border-[#d8cfba]/50 bg-white/50 animate-in slide-in-from-top-2 duration-300">
-                        <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+                        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-8">
                            <div className="space-y-4">
-                              <h5 className="text-[10px] font-black text-[#687177] uppercase tracking-widest border-l-2 border-[#d8cfba] pl-2">资产快照与同步 / SNAPSHOT</h5>
+                              <h5 className="text-[10px] font-black text-[#687177] uppercase tracking-widest border-l-2 border-[#d8cfba] pl-2">资产分布与保证金 / ASSETS</h5>
+                              <div className="grid grid-cols-3 gap-3">
+                                 <div className="p-3 rounded-2xl bg-white border border-[#d8cfba] text-center shadow-sm">
+                                    <span className="block text-[8px] text-[#687177] font-black uppercase mb-1">Wallet</span>
+                                    <strong className="text-sm text-[#1f2328] tabular-nums">{summary ? formatMaybeNumber(summary.walletBalance) : "--"}</strong>
+                                 </div>
+                                 <div className="p-3 rounded-2xl bg-white border border-[#d8cfba] text-center shadow-sm">
+                                    <span className="block text-[8px] text-[#687177] font-black uppercase mb-1">Margin</span>
+                                    <strong className="text-sm text-[#1f2328] tabular-nums">{summary ? formatMaybeNumber(summary.marginBalance) : "--"}</strong>
+                                 </div>
+                                 <div className="p-3 rounded-2xl bg-white border border-[#d8cfba] text-center shadow-sm">
+                                    <span className="block text-[8px] text-[#687177] font-black uppercase mb-1">Available</span>
+                                    <strong className="text-sm text-[#1f2328] tabular-nums">{summary ? formatMaybeNumber(summary.availableBalance) : "--"}</strong>
+                                 </div>
+                              </div>
+                           </div>
+                           <div className="space-y-4">
+                              <h5 className="text-[10px] font-black text-[#687177] uppercase tracking-widest border-l-2 border-[#d8cfba] pl-2">账户同步状态 / SNAPSHOT</h5>
                               <div className="grid grid-cols-3 gap-3">
                                  <div className="p-3 rounded-2xl bg-white border border-[#d8cfba] text-center shadow-sm">
                                     <span className="block text-[8px] text-[#687177] font-black uppercase mb-1">Orders</span>

--- a/web/console/src/pages/MonitorStage.tsx
+++ b/web/console/src/pages/MonitorStage.tsx
@@ -52,10 +52,23 @@ export function MonitorStage({ syncLiveOrder, dockTab, onDockTabChange, dockCont
   const monitorResolution = useUIStore(s => s.monitorResolution);
   const setMonitorResolution = useUIStore(s => s.setMonitorResolution);
   const liveSyncAction = useUIStore(s => s.liveSyncAction);
-
+  const selectedSignalRuntimeId = useTradingStore(s => s.selectedSignalRuntimeId);
   const highlightedLiveSession = useMemo(
-    () => deriveHighlightedLiveSession(liveSessions, orders, fills, positions),
-    [liveSessions, orders, fills, positions]
+    () => {
+      // 优先展示手动选中的运行时会话对应的实盘会话
+      if (selectedSignalRuntimeId) {
+        const sessionWithRuntime = liveSessions.find(s => 
+          s.id === selectedSignalRuntimeId || // 直接 ID 匹配
+          String(s.state?.signalRuntimeSessionId) === selectedSignalRuntimeId // 关联 ID 匹配
+        );
+        if (sessionWithRuntime) {
+          return deriveHighlightedLiveSession([sessionWithRuntime], orders, fills, positions);
+        }
+      }
+      // 回退到原有的自动高亮逻辑
+      return deriveHighlightedLiveSession(liveSessions, orders, fills, positions);
+    },
+    [liveSessions, orders, fills, positions, selectedSignalRuntimeId]
   );
 
   const highlightedLiveRuntime =

--- a/web/console/src/pages/StrategyStage.tsx
+++ b/web/console/src/pages/StrategyStage.tsx
@@ -1,8 +1,8 @@
 import React, { useMemo, useState } from 'react';
 import { useUIStore } from '../store/useUIStore';
 import { useTradingStore } from '../store/useTradingStore';
-import { formatTime } from '../utils/format';
-import { strategyLabel, getRecord } from '../utils/derivation';
+import { formatTime, formatPercent, formatSigned, formatMaybeNumber } from '../utils/format';
+import { strategyLabel, getRecord, getNumber, buildSampleKey, buildSampleRange } from '../utils/derivation';
 import { Card, CardHeader, CardTitle, CardContent, CardDescription } from '../components/ui/card';
 import { Button } from '../components/ui/button';
 import { Input } from '../components/ui/input';
@@ -30,14 +30,39 @@ import {
   TooltipProvider, 
   TooltipTrigger 
 } from '../components/ui/tooltip';
-import { HelpCircle, Plus, Save, RotateCcw, Layout, FileJson, List, Info } from 'lucide-react';
+import { Separator } from '../components/ui/separator';
+import { SampleCard } from '../components/ui/SampleCard';
+import { API_BASE } from '../utils/api';
+import { ExecutionTrade, ReplaySample } from '../types/domain';
+import { 
+  HelpCircle, 
+  Plus, 
+  Save, 
+  RotateCcw, 
+  Layout, 
+  FileJson, 
+  List, 
+  Info, 
+  FlaskConical, 
+  Play, 
+  History, 
+  BarChart4, 
+  Maximize2, 
+  FileDown, 
+  Database,
+  Clock,
+  ArrowRight,
+  AlertTriangle
+} from 'lucide-react';
 
 interface StrategyStageProps {
   createStrategy: () => void;
   saveStrategyParameters: () => void;
+  createBacktestRun: () => Promise<void>;
 }
 
-export function StrategyStage({ createStrategy, saveStrategyParameters }: StrategyStageProps) {
+export function StrategyStage({ createStrategy, saveStrategyParameters, createBacktestRun }: StrategyStageProps) {
+  // Strategy States
   const strategies = useTradingStore(s => s.strategies);
   const signalRuntimeAdapters = useTradingStore(s => s.signalRuntimeAdapters);
   const strategyCreateForm = useUIStore(s => s.strategyCreateForm);
@@ -49,326 +74,656 @@ export function StrategyStage({ createStrategy, saveStrategyParameters }: Strate
   const selectedStrategyId = useTradingStore(s => s.selectedStrategyId);
   const setSelectedStrategyId = useTradingStore(s => s.setSelectedStrategyId);
 
-  // Derived states
-  const strategyOptions = useMemo(
-    () =>
-      strategies.map((strategy) => ({
-        value: strategy.id,
-        label: strategyLabel(strategy),
-      })),
-    [strategies]
-  );
+  // Backtest States (Migrated from SidePanel)
+  const backtestForm = useUIStore(s => s.backtestForm);
+  const setBacktestForm = useUIStore(s => s.setBacktestForm);
+  const backtestAction = useUIStore(s => s.backtestAction);
+  const backtestOptions = useTradingStore(s => s.backtestOptions);
+  const backtests = useTradingStore(s => s.backtests);
+  const selectedBacktestId = useUIStore(s => s.selectedBacktestId);
+  const setSelectedBacktestId = useUIStore(s => s.setSelectedBacktestId);
+  const setChartOverrideRange = useUIStore(s => s.setChartOverrideRange);
+  const setFocusNonce = useUIStore(s => s.setFocusNonce);
+  const selectedSample = useUIStore(s => s.selectedSample);
+  const setSelectedSample = useUIStore(s => s.setSelectedSample);
+  const setSourceFilter = useUIStore(s => s.setSourceFilter);
+  const setEventFilter = useUIStore(s => s.setEventFilter);
 
+  // Derived states
   const selectedStrategy =
     strategies.find((item) => item.id === (selectedStrategyId || strategyEditorForm.strategyId)) ?? strategies[0] ?? null;
   const selectedStrategyVersion = selectedStrategy?.currentVersion ?? null;
   const selectedStrategyParameters = getRecord(selectedStrategyVersion?.parameters);
 
+  const selectedBacktest =
+    backtests.find((item) => item.id === selectedBacktestId) ??
+    (backtests.length > 0 ? backtests[backtests.length - 1] : null);
+  const latestBacktestSummary = (selectedBacktest?.resultSummary ?? {}) as Record<string, unknown>;
+  
+  const latestReplaySkippedSamples = Array.isArray(latestBacktestSummary.replayLedgerSkippedSamples)
+    ? (latestBacktestSummary.replayLedgerSkippedSamples as ReplaySample[])
+    : [];
+  const latestReplayCompletedSamples = Array.isArray(latestBacktestSummary.replayLedgerCompletedSamples)
+    ? (latestBacktestSummary.replayLedgerCompletedSamples as ReplaySample[])
+    : [];
+
+  const selectedExecutionSymbols = backtestOptions?.supportedSymbols?.[backtestForm.executionDataSource] ?? [];
+  const selectedSymbolAvailable =
+    selectedExecutionSymbols.length === 0 || selectedExecutionSymbols.includes(backtestForm.symbol.trim().toUpperCase());
+
   return (
-    <div className="p-8 space-y-8 animate-in fade-in duration-500">
-      {/* 顶部统计与导航 */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h2 className="text-3xl font-black text-[#1f2328] tracking-tight">策略主舞台</h2>
-          <p className="text-[#687177] text-sm mt-1">管理交易逻辑的核心引擎与参数矩阵</p>
+    <div className="absolute inset-0 overflow-y-auto p-8 space-y-8 bg-[#f3f0e7]">
+      {/* 顶部总控 - 参照 AccountStage 范式 */}
+      <Card className="border-[#d8cfba] bg-[var(--panel)] shadow-sm rounded-[24px] overflow-hidden">
+        <div className="py-3 px-6 flex flex-col md:flex-row items-center justify-between gap-4">
+           <div className="flex items-center gap-6 overflow-hidden">
+              <div className="shrink-0">
+                <p className="text-[#0e6d60] text-[9px] font-black uppercase tracking-widest font-mono mb-0.5">Strategy Control Center</p>
+                <h2 className="text-lg font-black text-[#1f2328] tracking-tight whitespace-nowrap">策略库与开发实验室</h2>
+              </div>
+              
+              <Separator orientation="vertical" className="h-8 bg-[#d8cfba]/40 hidden lg:block" />
+              
+              <div className="hidden lg:flex items-center gap-4 h-8 px-3 rounded-xl bg-[#fffbf2]/50 border border-[#d8cfba]/50">
+                <div className="flex items-center gap-1.5">
+                  <span className="text-[9px] font-black text-[#687177] uppercase opacity-40">Active:</span>
+                  <span className="text-[10px] font-black text-[#1f2328]">{strategies.length} 策略</span>
+                </div>
+                <Separator orientation="vertical" className="h-3 bg-[#d8cfba]/40" />
+                <div className="flex items-center gap-1.5">
+                  <span className="text-[9px] font-black text-[#687177] uppercase opacity-40">Engines:</span>
+                  <span className="text-[10px] font-black text-[#1f2328]">{signalRuntimeAdapters.length} 适配器</span>
+                </div>
+              </div>
+           </div>
+           
+           <div className="flex items-center gap-2">
+              <div className="flex items-center p-1 rounded-xl bg-white/40 border border-[#d8cfba]/20">
+                <Button 
+                   variant="ghost" 
+                   size="sm" 
+                   className="h-8 px-4 text-[10px] font-black text-[#1f2328] rounded-lg hover:bg-white shadow-none"
+                   onClick={() => document.getElementById('new-strategy-section')?.scrollIntoView({ behavior: 'smooth' })}
+                >
+                  创建新策略
+                </Button>
+                <Separator orientation="vertical" className="h-4 bg-[#d8cfba]/30 mx-1" />
+                <Button 
+                   variant="ghost" 
+                   size="sm" 
+                   className="h-8 px-4 text-[10px] font-black text-[#1f2328] rounded-lg hover:bg-white shadow-none"
+                   onClick={() => document.getElementById('backtest-lab-section')?.scrollIntoView({ behavior: 'smooth' })}
+                >
+                  进入实验室
+                </Button>
+              </div>
+           </div>
         </div>
-        <div className="flex items-center gap-3 bg-[#ebe5d5]/50 px-4 py-2 rounded-2xl border border-[#d8cfba]">
-          <div className="flex flex-col items-end">
-            <span className="text-[10px] text-[#687177] uppercase font-bold tracking-widest">Active Pool</span>
-            <span className="text-sm font-black text-[#1f2328]">{strategies.length} 策略 · {signalRuntimeAdapters.length} 引擎</span>
-          </div>
-          <Layout className="text-[#1f2328]/20 size-8" />
-        </div>
-      </div>
+      </Card>
 
       <div className="grid grid-cols-1 lg:grid-cols-12 gap-8">
-        {/* 左侧：策略字典 (Table) */}
-        <Card className="lg:col-span-8 border-[#d8cfba] bg-[var(--panel)] shadow-xl rounded-[32px] overflow-hidden">
-          <CardHeader className="border-b border-[#d8cfba]/50 bg-white/30 px-8 py-6">
-            <div className="flex items-center justify-between">
-              <div className="flex items-center gap-3">
-                <div className="p-2 bg-[#ebe5d5] rounded-xl">
-                  <List className="size-5 text-[#1f2328]" />
-                </div>
-                <CardTitle className="text-xl font-bold text-[#1f2328]">策略目录</CardTitle>
+        {/* 左侧：策略字典 (Archive) */}
+        <Card className="lg:col-span-8 border-[#d8cfba] bg-[var(--panel)] shadow-[var(--shadow)] rounded-[24px] overflow-hidden">
+          <CardHeader className="pb-4">
+            <div className="flex items-center gap-2">
+              <div>
+                <p className="text-[#0e6d60] text-[10px] font-bold uppercase tracking-widest font-mono">Strategy Portfolio</p>
+                <CardTitle className="text-lg font-black text-[#1f2328]">策略目录</CardTitle>
               </div>
             </div>
           </CardHeader>
           <CardContent className="p-0">
-            <Table>
-              <TableHeader className="bg-[#ebe5d5]/30">
-                <TableRow className="hover:bg-transparent border-[#d8cfba]/50">
-                  <TableHead className="px-8 h-12 text-[11px] uppercase font-black text-[#687177]">策略名称</TableHead>
-                  <TableHead className="h-12 text-[11px] uppercase font-black text-[#687177]">版本</TableHead>
-                  <TableHead className="h-12 text-[11px] uppercase font-black text-[#687177]">信号周期</TableHead>
-                  <TableHead className="h-12 text-[11px] uppercase font-black text-[#687177]">数据源</TableHead>
-                  <TableHead className="h-12 text-[11px] uppercase font-black text-[#687177]">运行引擎</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {strategies.length > 0 ? (
-                  strategies.map((strategy) => {
-                    const parameters = getRecord(strategy.currentVersion?.parameters);
-                    const isSelected = strategy.id === selectedStrategy?.id;
-                    return (
-                      <TableRow 
-                        key={strategy.id} 
-                        className={`group cursor-pointer border-[#d8cfba]/30 transition-all ${isSelected ? 'bg-white shadow-inner' : 'hover:bg-white/50'}`}
-                        onClick={() => setSelectedStrategyId(strategy.id)}
-                      >
-                        <TableCell className="px-8 py-4">
-                          <div className="flex flex-col">
-                            <span className="font-bold text-[#1f2328]">{strategy.name}</span>
-                            <span className="text-[10px] text-[#687177] font-mono">{strategy.id}</span>
-                          </div>
-                        </TableCell>
-                        <TableCell>
-                          <Badge variant="outline" className="font-mono text-[10px] bg-white border-[#d8cfba]">
-                            v{strategy.currentVersion?.version ?? "--"}
-                          </Badge>
-                        </TableCell>
-                        <TableCell className="text-xs font-medium text-[#687177]">
-                          {String(parameters.signalTimeframe ?? strategy.currentVersion?.signalTimeframe ?? "--")}
-                        </TableCell>
-                        <TableCell className="text-xs font-mono text-[#0e6d60]">
-                          {String(parameters.executionDataSource ?? parameters.executionTimeframe ?? strategy.currentVersion?.executionTimeframe ?? "--")}
-                        </TableCell>
-                        <TableCell>
-                          <span className="text-xs font-bold text-[#1f2328]/70">
-                            {String(parameters.strategyEngine ?? "bk-default")}
-                          </span>
-                        </TableCell>
-                      </TableRow>
-                    );
-                  })
-                ) : (
-                  <TableRow>
-                    <TableCell colSpan={5} className="h-40 text-center text-[#687177] italic">暂无策略数据</TableCell>
+            <div className="overflow-x-auto">
+              <Table>
+                <TableHeader className="bg-[#f8f6f0] border-y border-[#d8cfba]">
+                  <TableRow className="hover:bg-transparent">
+                    <TableHead className="px-6 h-10 text-[10px] uppercase font-black text-[#687177]">策略名称 / ID</TableHead>
+                    <TableHead className="h-10 text-[10px] uppercase font-black text-[#687177]">版本</TableHead>
+                    <TableHead className="h-10 text-[10px] uppercase font-black text-[#687177]">信号周期</TableHead>
+                    <TableHead className="h-10 text-[10px] uppercase font-black text-[#687177]">运行引擎</TableHead>
                   </TableRow>
-                )}
-              </TableBody>
-            </Table>
+                </TableHeader>
+                <TableBody className="divide-y divide-[#d8cfba]/50">
+                  {strategies.length > 0 ? (
+                    strategies.map((strategy) => {
+                      const params = getRecord(strategy.currentVersion?.parameters);
+                      const isSelected = strategy.id === selectedStrategy?.id;
+                      return (
+                        <TableRow 
+                          key={strategy.id} 
+                          className={`group cursor-pointer transition-all duration-200 ${isSelected ? 'bg-white shadow-inner relative z-10' : 'bg-[#fff8ea] hover:bg-white'}`}
+                          onClick={() => setSelectedStrategyId(strategy.id)}
+                        >
+                          <TableCell className="px-6 py-4">
+                            <div className="flex items-center gap-3">
+                               <div className={`w-1 h-8 rounded-full transition-all ${isSelected ? 'bg-[#0e6d60]' : 'bg-transparent group-hover:bg-[#d8cfba]'}`} />
+                               <div className="flex flex-col min-w-0">
+                                 <span className="font-black text-[#1f2328] text-sm tabular-nums tracking-tight truncate">{strategy.name}</span>
+                                 <span className="text-[9px] text-[#687177] font-mono opacity-60 uppercase truncate">{strategy.id}</span>
+                               </div>
+                            </div>
+                          </TableCell>
+                          <TableCell>
+                            <Badge variant="outline" className={`text-[10px] h-4.5 border-[#d8cfba] font-bold ${isSelected ? 'bg-[#1f2328] text-white border-transparent' : 'bg-white text-[#687177]'}`}>
+                              v{strategy.currentVersion?.version ?? "1"}
+                            </Badge>
+                          </TableCell>
+                          <TableCell className="text-xs font-black text-[#1f2328]/70 font-mono">
+                            {String(params.signalTimeframe ?? strategy.currentVersion?.signalTimeframe ?? "--")}
+                          </TableCell>
+                          <TableCell>
+                             <div className="flex items-center gap-1.5 px-2 py-0.5 rounded-md bg-white border border-[#d8cfba]/50 w-fit">
+                               <div className="size-1 rounded-full bg-[#0e6d60]" />
+                               <span className="text-[10px] font-black text-[#1f2328] uppercase">{String(params.strategyEngine ?? "bk-default")}</span>
+                             </div>
+                          </TableCell>
+                        </TableRow>
+                      );
+                    })
+                  ) : (
+                    <TableRow>
+                      <TableCell colSpan={4} className="h-40 text-center text-[11px] font-medium text-[#687177] italic">暂无策略数据</TableCell>
+                    </TableRow>
+                  )}
+                </TableBody>
+              </Table>
+            </div>
           </CardContent>
         </Card>
-
-        {/* 右侧：版本摘要 (Details) */}
-        <Card className="lg:col-span-4 border-[#d8cfba] bg-[var(--panel)] shadow-xl rounded-[32px] overflow-hidden flex flex-col">
-          <CardHeader className="border-b border-[#d8cfba]/50 bg-white/30 px-6 py-6">
-            <div className="flex items-center gap-3">
-              <div className="p-2 bg-[#ebe5d5] rounded-xl">
-                <Info className="size-5 text-[#1f2328]" />
+ 
+        {/* 右侧：版本摘要 (Details) - 参照 AccountStage 细节卡片 */}
+        <Card className="lg:col-span-4 border-[#d8cfba] bg-[var(--panel)] shadow-[var(--shadow)] rounded-[24px] overflow-hidden flex flex-col">
+          <CardHeader className="pb-4">
+            <div className="flex items-center gap-2">
+              <div>
+                <p className="text-[#0e6d60] text-[10px] font-bold uppercase tracking-widest font-mono">Summary</p>
+                <CardTitle className="text-lg font-black text-[#1f2328]">当前版本摘要</CardTitle>
               </div>
-              <CardTitle className="text-lg font-bold text-[#1f2328]">当前版本摘要</CardTitle>
             </div>
           </CardHeader>
-          <CardContent className="p-6 flex-1">
+          <CardContent className="p-6 space-y-6 flex-1">
             {selectedStrategy ? (
-              <div className="space-y-4">
-                <div className="bg-white/50 rounded-[20px] border border-[#d8cfba]/50 p-5 space-y-4">
-                  <div className="flex justify-between items-start">
-                    <div className="space-y-1">
-                      <span className="text-[10px] text-[#687177] uppercase font-bold">策略描述</span>
-                      <p className="text-xs text-[#1f2328] font-medium leading-relaxed">
-                        {selectedStrategy.description || "暂无描述内容"}
-                      </p>
-                    </div>
+              <>
+                <div className="space-y-4">
+                  <div className="grid grid-cols-2 gap-3">
+                     <div className="p-3.5 bg-white border border-[#d8cfba]/60 rounded-2xl shadow-sm">
+                        <span className="block text-[8px] font-black text-[#687177] uppercase tracking-widest mb-1.5 opacity-60">Signal Source</span>
+                        <p className="text-xs font-black text-[#1f2328] truncate">{String(selectedStrategyParameters.executionDataSource ?? "--")}</p>
+                     </div>
+                     <div className="p-3.5 bg-white border border-[#d8cfba]/60 rounded-2xl shadow-sm">
+                        <span className="block text-[8px] font-black text-[#687177] uppercase tracking-widest mb-1.5 opacity-60">Engine Type</span>
+                        <p className="text-xs font-black text-[#1f2328] uppercase">{String(selectedStrategyParameters.strategyEngine ?? "bk-default")}</p>
+                     </div>
                   </div>
-                  
-                  <div className="h-px bg-[#d8cfba]/30 w-full" />
-
-                  <div className="grid grid-cols-2 gap-4">
-                    <div className="space-y-1">
-                      <span className="text-[10px] text-[#687177] uppercase font-bold">创建时间</span>
-                      <p className="text-xs text-[#1f2328] font-mono">{formatTime(selectedStrategy.createdAt)}</p>
-                    </div>
-                    <div className="space-y-1">
-                      <span className="text-[10px] text-[#687177] uppercase font-bold">运行引擎</span>
-                      <p className="text-xs text-[#1f2328] font-bold">{String(selectedStrategyParameters.strategyEngine ?? "bk-default")}</p>
-                    </div>
-                    <div className="space-y-1">
-                      <span className="text-[10px] text-[#687177] uppercase font-bold">信号周期</span>
-                      <p className="text-xs text-[#1f2328] font-bold">{String(selectedStrategyParameters.signalTimeframe ?? selectedStrategyVersion?.signalTimeframe ?? "--")}</p>
-                    </div>
-                    <div className="space-y-1">
-                      <span className="text-[10px] text-[#687177] uppercase font-bold">执行源</span>
-                      <p className="text-xs text-[#1f2328] font-mono text-[#0e6d60]">{String(selectedStrategyParameters.executionDataSource ?? selectedStrategyVersion?.executionTimeframe ?? "--")}</p>
-                    </div>
+ 
+                  <div className="bg-[#fff8ea] border border-[#d8cfba] p-4 rounded-2xl shadow-inner space-y-3">
+                     <div className="flex items-center gap-2 pb-2 border-b border-[#d8cfba]/40">
+                       <Info size={14} className="text-[#0e6d60]" />
+                       <span className="text-[9px] font-black text-[#0e6d60] uppercase tracking-widest">Metadata</span>
+                     </div>
+                     <div className="grid grid-cols-1 gap-2.5">
+                       <div className="flex justify-between items-center text-[11px]">
+                         <span className="text-[#687177] font-medium">创建时间</span>
+                         <span className="font-mono font-bold text-[#1f2328]">{formatTime(selectedStrategy.createdAt).split(' ')[0]}</span>
+                       </div>
+                       <div className="flex justify-between items-center text-[11px]">
+                         <span className="text-[#687177] font-medium">最后编译版本</span>
+                         <Badge variant="outline" className="h-4 text-[9px] font-black border-[#d8cfba]">v{selectedStrategyVersion?.version ?? "1"}</Badge>
+                       </div>
+                     </div>
                   </div>
                 </div>
-
-                <div className="p-4 rounded-2xl bg-[#fff8ea] border border-[#d8cfba] flex gap-3">
-                  <HelpCircle className="size-4 text-[#1f2328]/40 shrink-0 mt-0.5" />
-                  <p className="text-[10px] text-[#687177] leading-relaxed italic">
-                    警告：当前版本为“开发热更新”模式。直接编辑参数将立即同步至所有运行中进程，可能导致实盘逻辑突跳。请在低频或空仓期间进行操作。
-                  </p>
+ 
+                <div className="flex-1 min-h-[80px] p-4 bg-white/40 border border-[#d8cfba] rounded-2xl border-dashed">
+                   <p className="text-[10px] font-black text-[#687177] uppercase tracking-widest mb-2 opacity-60">Description</p>
+                   <p className="text-xs text-[#1f2328] leading-relaxed font-medium">
+                     {selectedStrategy.description || "暂无描述内容"}
+                   </p>
                 </div>
-              </div>
+              </>
             ) : (
-              <div className="h-full flex flex-col items-center justify-center space-y-3 opacity-40">
-                <RotateCcw className="size-10 animate-spin-slow" />
-                <p className="text-sm font-medium">请在左侧选择策略</p>
+              <div className="flex-1 flex flex-col items-center justify-center space-y-3 text-[#d8cfba]">
+                <RotateCcw className="size-10 animate-spin-slow opacity-20" />
+                <p className="text-xs font-black uppercase tracking-widest">请选择策略</p>
               </div>
             )}
           </CardContent>
+          {selectedStrategy && (
+            <div className="p-4 bg-amber-50 mx-6 mb-6 rounded-xl border border-amber-200">
+               <div className="flex gap-2">
+                 <AlertTriangle size={12} className="text-amber-600 shrink-0 mt-0.5" />
+                 <p className="text-[9px] text-amber-800 leading-normal font-medium italic">
+                    警告：热更新模式已启用。编辑参数将立即波及所有运行中的反射引擎。
+                 </p>
+               </div>
+            </div>
+          )}
         </Card>
       </div>
 
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
-        {/* 下排左侧：创建新策略 */}
-        <Card className="border-[#d8cfba] bg-[var(--panel)] shadow-xl rounded-[32px] overflow-hidden">
-          <CardHeader className="border-b border-[#d8cfba]/50 bg-white/30 px-8 py-6">
-            <div className="flex items-center gap-3">
-              <div className="p-2 bg-[#ebe5d5] rounded-xl">
-                <Plus className="size-5 text-[#1f2328]" />
+      <div id="new-strategy-section" className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+        {/* 开发区左侧：建立新策略 - 风格对齐 AccountStage 的 Modal 样式 */}
+        <Card className="border-[#d8cfba] bg-[var(--panel)] shadow-[var(--shadow)] rounded-[24px] overflow-hidden">
+          <CardHeader className="pb-4">
+            <div className="flex items-center gap-2">
+              <div className="p-1.5 bg-[#ebe5d5] rounded-lg">
+                <Plus className="size-4 text-[#1f2328]" />
               </div>
-              <CardTitle className="text-xl font-bold text-[#1f2328]">创建新策略</CardTitle>
+              <CardTitle className="text-lg font-black text-[#1f2328]">建立新策略</CardTitle>
             </div>
           </CardHeader>
-          <CardContent className="p-8 space-y-6">
-            <div className="grid grid-cols-1 gap-6">
-              <div className="space-y-2">
-                <Label className="text-sm font-black text-[#1f2328] ml-1">策略名称</Label>
+          <CardContent className="p-6 space-y-5">
+            <div className="space-y-4">
+              <div className="space-y-1.5">
+                <Label className="text-[11px] font-black text-[#687177] ml-1 uppercase tracking-wider">Strategy Name</Label>
                 <Input 
                   value={strategyCreateForm.name}
                   onChange={(e) => setStrategyCreateForm(prev => ({ ...prev, name: e.target.value }))}
-                  placeholder="例如：BK 4H Runner"
-                  className="h-11 rounded-xl border-[#d8cfba] bg-white/50 focus:bg-white transition-all shadow-sm"
+                  placeholder="例如：BK-TREND-01"
+                  className="h-10 rounded-xl border-[#d8cfba] bg-white text-xs font-bold focus:ring-2 focus:ring-[#0e6d60]/10 transition-all shadow-sm"
                 />
               </div>
-              <div className="space-y-2">
-                <Label className="text-sm font-black text-[#1f2328] ml-1">策略说明</Label>
+              <div className="space-y-1.5">
+                <Label className="text-[11px] font-black text-[#687177] ml-1 uppercase tracking-wider">Internal Description</Label>
                 <Input 
                   value={strategyCreateForm.description}
                   onChange={(e) => setStrategyCreateForm(prev => ({ ...prev, description: e.target.value }))}
-                  placeholder="记录这条策略的用途、市场和执行方式"
-                  className="h-11 rounded-xl border-[#d8cfba] bg-white/50 focus:bg-white transition-all shadow-sm"
+                  placeholder="描述逻辑边界或执行目的"
+                  className="h-10 rounded-xl border-[#d8cfba] bg-white text-xs font-medium focus:ring-2 focus:ring-[#0e6d60]/10 transition-all shadow-sm"
                 />
               </div>
             </div>
             <Button 
-              className="w-full h-12 rounded-xl bg-[#1f2328] hover:bg-[#2f353c] text-white font-bold text-base transition-all shadow-lg active:scale-95 disabled:opacity-50"
+              className="w-full h-11 bg-[#1f2328] hover:bg-[#2f353c] text-white font-black text-xs rounded-xl shadow-md transition-all active:scale-95 disabled:opacity-50"
               disabled={strategyCreateAction || !strategyCreateForm.name.trim()}
               onClick={createStrategy}
             >
-              <Plus className="size-4 mr-2" />
-              {strategyCreateAction ? "正在构建环境..." : "建立该策略"}
+              {strategyCreateAction ? "正在注入逻辑..." : "确认并提交策略库"}
             </Button>
           </CardContent>
         </Card>
-
-        {/* 下排右侧：策略参数编辑库 */}
-        <Card className="border-[#d8cfba] bg-[var(--panel)] shadow-xl rounded-[32px] overflow-hidden">
-          <CardHeader className="border-b border-[#d8cfba]/50 bg-white/30 px-8 py-6">
-            <div className="flex items-center justify-between">
-              <div className="flex items-center gap-3">
-                <div className="p-2 bg-[#ebe5d5] rounded-xl">
-                  <FileJson className="size-5 text-[#1f2328]" />
-                </div>
-                <CardTitle className="text-xl font-bold text-[#1f2328]">配置编辑器</CardTitle>
+ 
+        {/* 开发区右侧：参数反射编辑器 (Refl Editor) */}
+        <Card className="border-[#d8cfba] bg-[var(--panel)] shadow-[var(--shadow)] rounded-[24px] overflow-hidden flex flex-col">
+          <CardHeader className="pb-4 flex flex-row items-center justify-between">
+            <div className="flex items-center gap-2">
+              <div className="p-1.5 bg-[#ebe5d5] rounded-lg">
+                <FileJson className="size-4 text-[#1f2328]" />
               </div>
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger>
-                    <Button variant="ghost" size="icon" className="rounded-full hover:bg-white/50">
-                      <HelpCircle className="size-4 text-[#687177]" />
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent className="bg-[#1f2328] text-white border-0 rounded-lg p-2 text-[10px]">
-                    直接修改 JSON 参数将同步至 Runtime 反射引擎
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
+              <CardTitle className="text-lg font-black text-[#1f2328]">参数反射编辑器</CardTitle>
             </div>
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger>
+                  <Button variant="ghost" size="icon" className="h-8 w-8 rounded-xl hover:bg-white/50">
+                    <HelpCircle className="size-4 text-[#687177]" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent className="bg-[#1f2328] text-white p-3 text-[10px] rounded-xl border-0 shadow-2xl w-64">
+                   热更新模式下，保存参数将通过反射引擎立即更新至对应的运行实例，建议在生产运行前进行参数校验。
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
           </CardHeader>
-          <CardContent className="p-8 space-y-6">
+          <CardContent className="p-6 space-y-5 flex-1 flex flex-col">
             <div className="grid grid-cols-2 gap-4">
-              <div className="space-y-2">
-                <Label className="text-sm font-black text-[#1f2328]">运行引擎</Label>
+              <div className="space-y-1.5">
+                <Label className="text-[11px] font-black text-[#687177] ml-1 uppercase tracking-wider">Engine</Label>
                 <Select 
                   value={strategyEditorForm.strategyEngine}
                   onValueChange={(val: any) => setStrategyEditorForm(prev => ({ ...prev, strategyEngine: val }))}
                 >
-                  <SelectTrigger className="h-11 rounded-xl border-[#d8cfba] bg-white/50">
+                  <SelectTrigger className="h-10 rounded-xl border-[#d8cfba] bg-white text-xs font-black">
                     <SelectValue placeholder="选择引擎" />
                   </SelectTrigger>
-                  <SelectContent className="bg-white border-[#d8cfba] rounded-xl">
+                  <SelectContent className="bg-white border-[#d8cfba] rounded-xl shadow-2xl">
                     {[...new Set(["bk-default", ...strategies.map((item) => String(getRecord(item.currentVersion?.parameters).strategyEngine || "bk-default"))])].map((engineKey) => (
                       <SelectItem key={engineKey} value={engineKey}>{engineKey}</SelectItem>
                     ))}
                   </SelectContent>
                 </Select>
               </div>
-              <div className="space-y-2">
-                <Label className="text-sm font-black text-[#1f2328]">信号周期</Label>
+              <div className="space-y-1.5">
+                <Label className="text-[11px] font-black text-[#687177] ml-1 uppercase tracking-wider">Timeframe</Label>
                 <Select 
                   value={strategyEditorForm.signalTimeframe}
                   onValueChange={(val: any) => setStrategyEditorForm(prev => ({ ...prev, signalTimeframe: val }))}
                 >
-                  <SelectTrigger className="h-11 rounded-xl border-[#d8cfba] bg-white/50">
+                  <SelectTrigger className="h-10 rounded-xl border-[#d8cfba] bg-white text-xs font-black">
                     <SelectValue placeholder="周期" />
                   </SelectTrigger>
-                  <SelectContent className="bg-white border-[#d8cfba] rounded-xl">
+                  <SelectContent className="bg-white border-[#d8cfba] rounded-xl shadow-2xl">
                     <SelectItem value="5m">5m</SelectItem>
+                    <SelectItem value="1h">1h</SelectItem>
                     <SelectItem value="4h">4h</SelectItem>
                     <SelectItem value="1d">1d</SelectItem>
                   </SelectContent>
                 </Select>
               </div>
             </div>
-
-            <div className="space-y-2">
-              <div className="flex items-center justify-between ml-1">
-                <Label className="text-sm font-black text-[#1f2328]">参数 JSON (Advanced)</Label>
-                <Badge variant="outline" className="text-[9px] border-[#d8cfba] uppercase text-[#687177]">Raw Edit</Badge>
+ 
+            <div className="space-y-2 flex-1 flex flex-col">
+              <div className="flex items-center justify-between">
+                 <Label className="text-[11px] font-black text-[#687177] ml-1 uppercase tracking-wider">Parameters Schema</Label>
+                 <Button 
+                   variant="ghost" 
+                   size="sm" 
+                   className="h-6 px-2 text-[9px] font-black text-[#0e6d60]"
+                   onClick={() => {
+                     try { setStrategyEditorForm(prev => ({ ...prev, parametersJson: JSON.stringify(JSON.parse(prev.parametersJson), null, 2) })) } catch (e) {}
+                   }}
+                 >
+                   格式化 JSON
+                 </Button>
               </div>
-              <Textarea 
-                rows={10}
-                value={strategyEditorForm.parametersJson}
-                onChange={(e) => setStrategyEditorForm(prev => ({ ...prev, parametersJson: e.target.value }))}
-                className="font-mono text-xs rounded-2xl border-[#d8cfba] bg-[#fffbf2]/80 focus:bg-white transition-all shadow-inner leading-relaxed"
-                placeholder='{"stop_loss_atr":0.05,"profit_protect_atr":1.0}'
-              />
+              <div className="relative flex-1 group">
+                 <div className="absolute left-0 top-0 bottom-0 w-8 bg-[#f3f0e7]/30 border-r border-[#d8cfba]/40 rounded-l-2xl flex flex-col items-center pt-3 pointer-events-none opacity-40">
+                    {[1,2,3,4,5,6,7].map(n => <span key={n} className="text-[8px] font-mono leading-relaxed">{n}</span>)}
+                 </div>
+                 <Textarea 
+                   value={strategyEditorForm.parametersJson}
+                   onChange={(e) => setStrategyEditorForm(prev => ({ ...prev, parametersJson: e.target.value }))}
+                   className="w-full h-full min-h-[160px] pl-10 pr-4 py-3 font-mono text-[11px] rounded-2xl border-[#d8cfba] bg-[#fffbf2]/40 focus:bg-white focus:ring-2 focus:ring-[#d8cfba]/40 transition-all shadow-inner leading-relaxed resize-none"
+                   placeholder='{"key": "value"}'
+                 />
+              </div>
             </div>
-
-            <div className="flex gap-4">
-              <Button 
-                className="flex-1 h-12 rounded-xl bg-[#0e6d60] hover:bg-[#128071] text-white font-bold shadow-lg transition-all active:scale-95"
-                disabled={strategySaveAction || !strategyEditorForm.strategyId}
-                onClick={saveStrategyParameters}
-              >
-                <Save className="size-4 mr-2" />
-                {strategySaveAction ? "提交变更中..." : "保存反射参数"}
-              </Button>
-              <Button 
-                variant="outline"
-                className="h-12 px-6 rounded-xl border-[#d8cfba] hover:bg-white text-[#1f2328] font-bold"
-                onClick={() => {
-                  if (!selectedStrategy) return;
-                  const currentParameters = getRecord(selectedStrategy.currentVersion?.parameters);
-                  setStrategyEditorForm({
-                    strategyId: selectedStrategy.id,
-                    strategyEngine: String(currentParameters.strategyEngine ?? "bk-default"),
-                    signalTimeframe: String(
-                      currentParameters.signalTimeframe ??
-                        selectedStrategy.currentVersion?.signalTimeframe ??
-                        "1d"
-                    ),
-                    executionDataSource: String(
-                      currentParameters.executionDataSource ??
-                        currentParameters.executionTimeframe ??
-                        selectedStrategy.currentVersion?.executionTimeframe ??
-                        "tick"
-                    ),
-                    parametersJson: JSON.stringify(currentParameters, null, 2),
-                  });
-                }}
-              >
-                <RotateCcw className="size-4" />
-              </Button>
+ 
+            <div className="flex gap-3 pt-2">
+               <Button 
+                 className="flex-1 h-11 bg-[#0e6d60] hover:bg-[#0a5a4f] text-white font-black text-xs rounded-xl shadow-md transition-transform active:scale-95"
+                 disabled={strategySaveAction || !strategyEditorForm.strategyId}
+                 onClick={saveStrategyParameters}
+               >
+                 <Save size={14} className="mr-2" />
+                 {strategySaveAction ? "正在提交同步..." : "保存反射参数"}
+               </Button>
+               <Button 
+                 variant="outline" 
+                 size="icon" 
+                 className="h-11 w-11 rounded-xl border-[#d8cfba] bg-white hover:bg-[#fff8ea]"
+                 onClick={() => {
+                    if (!selectedStrategy) return;
+                    const params = getRecord(selectedStrategy.currentVersion?.parameters);
+                    setStrategyEditorForm({
+                      strategyId: selectedStrategy.id,
+                      strategyEngine: String(params.strategyEngine ?? "bk-default"),
+                      signalTimeframe: String(params.signalTimeframe ?? selectedStrategy.currentVersion?.signalTimeframe ?? "1d"),
+                      executionDataSource: String(params.executionDataSource ?? "tick"),
+                      parametersJson: JSON.stringify(params, null, 2),
+                    });
+                 }}
+               >
+                 <RotateCcw size={16} />
+               </Button>
             </div>
           </CardContent>
         </Card>
       </div>
+ 
+      {/* 底部：回测实验室 (Backtest Research Lab) - 全新整合版 */}
+      <Card id="backtest-lab-section" className="border-[#d8cfba] bg-[var(--panel)] shadow-[var(--shadow)] rounded-[24px] overflow-hidden">
+        <CardHeader className="pb-6">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <div className="p-2 bg-[#ebe5d5] rounded-xl">
+                 <FlaskConical size={20} className="text-[#1f2328]" />
+              </div>
+              <div>
+                <p className="text-[#0e6d60] text-[10px] font-bold uppercase tracking-widest font-mono">Research Lab</p>
+                <CardTitle className="text-xl font-black text-[#1f2328]">回测控制台与回放审计</CardTitle>
+              </div>
+            </div>
+            <div className="flex items-center gap-4">
+               <Badge variant="outline" className="h-6 border-[#d8cfba] bg-white text-[#1f2328] font-black tabular-nums">
+                 {backtests.length} RUNS RECORDED
+               </Badge>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent className="p-0 border-t border-[#d8cfba]/40 bg-[#fffbf2]/30">
+          <div className="grid grid-cols-1 lg:grid-cols-12 min-h-[520px]">
+            {/* 左侧：参数配置 (Lab Config) */}
+            <div className="lg:col-span-3 p-6 space-y-6 border-r border-[#d8cfba]/40 bg-white/40">
+               <div className="space-y-4">
+                  <div className="space-y-1.5">
+                    <Label className="text-[10px] font-black text-[#687177] uppercase tracking-widest ml-1">Symbol</Label>
+                    <Input 
+                       value={backtestForm.symbol}
+                       onChange={(e) => setBacktestForm(curr => ({ ...curr, symbol: e.target.value.toUpperCase() }))}
+                       placeholder="BTCUSDT"
+                       className={`h-10 rounded-xl font-mono font-black text-xs border-[#d8cfba] ${!selectedSymbolAvailable ? 'ring-2 ring-rose-500/20 border-rose-300' : ''}`}
+                    />
+                  </div>
+                  <div className="grid grid-cols-2 gap-3">
+                    <div className="space-y-1.5">
+                      <Label className="text-[10px] font-black text-[#687177] uppercase ml-1">Period</Label>
+                      <Select value={backtestForm.signalTimeframe} onValueChange={(val: any) => setBacktestForm(curr => ({ ...curr, signalTimeframe: val }))}>
+                        <SelectTrigger className="h-10 rounded-xl border-[#d8cfba] text-xs font-black"><SelectValue /></SelectTrigger>
+                        <SelectContent className="bg-white border-[#d8cfba] rounded-xl">
+                          {(backtestOptions?.signalTimeframes ?? ["5m", "4h", "1d"]).map((item) => <SelectItem key={item} value={item}>{item}</SelectItem>)}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                    <div className="space-y-1.5">
+                      <Label className="text-[10px] font-black text-[#687177] uppercase ml-1">Source</Label>
+                      <Select value={backtestForm.executionDataSource} onValueChange={(val: any) => setBacktestForm(curr => ({ ...curr, executionDataSource: val }))}>
+                        <SelectTrigger className="h-10 rounded-xl border-[#d8cfba] text-xs font-black"><SelectValue /></SelectTrigger>
+                        <SelectContent className="bg-white border-[#d8cfba] rounded-xl">
+                          {(backtestOptions?.executionDataSources ?? ["tick", "1min"]).map((item) => <SelectItem key={item} value={item}>{item}</SelectItem>)}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                  </div>
+                  <div className="grid grid-cols-1 gap-3">
+                    <div className="space-y-1.5">
+                      <Label className="text-[10px] font-black text-[#687177] uppercase ml-1">Range From</Label>
+                      <Input value={backtestForm.from} onChange={(e) => setBacktestForm(curr => ({ ...curr, from: e.target.value }))} className="h-10 rounded-xl font-mono text-xs border-[#d8cfba]" />
+                    </div>
+                    <div className="space-y-1.5">
+                      <Label className="text-[10px] font-black text-[#687177] uppercase ml-1">Range To</Label>
+                      <Input value={backtestForm.to} onChange={(e) => setBacktestForm(curr => ({ ...curr, to: e.target.value }))} className="h-10 rounded-xl font-mono text-xs border-[#d8cfba]" />
+                    </div>
+                  </div>
+               </div>
+ 
+               <Button 
+                  className="w-full h-12 bg-[#1f2328] hover:bg-[#0e6d60] text-white font-black text-xs rounded-2xl shadow-lg transition-all active:scale-95 disabled:opacity-50"
+                  disabled={backtestAction || !selectedSymbolAvailable || !selectedStrategy}
+                  onClick={() => {
+                    const versionId = selectedStrategy?.currentVersion?.id ?? "";
+                    if (!versionId) return;
+                    setBacktestForm(curr => ({ ...curr, strategyVersionId: versionId }));
+                    createBacktestRun();
+                  }}
+               >
+                 <Play size={14} className="mr-2" />
+                 {backtestAction ? "正在计算路径..." : "启动压力测试"}
+               </Button>
+ 
+               {backtestOptions && (
+                 <div className="p-4 rounded-2xl bg-[#f3f0e7]/50 border border-[#d8cfba]/40 space-y-3">
+                    <div className="flex items-center gap-2 text-[10px] text-[#687177] font-black uppercase opacity-60">
+                       <Database size={12} /> <span>数据就绪状态</span>
+                    </div>
+                    <div className="space-y-2">
+                       {['tick', '1min'].map(type => (
+                         <div key={type} className="flex justify-between items-center text-[11px]">
+                           <span className="text-[#687177] font-medium">{type} Support</span>
+                           <Badge variant="outline" className={`h-4 text-[9px] font-black border-transparent uppercase ${backtestOptions.availability?.[type as 'tick'|'1min'] === 'ready' ? 'text-[#0e6d60]' : 'text-rose-600'}`}>
+                             {String(backtestOptions.availability?.[type as 'tick'|'1min'] ?? "unknown")}
+                           </Badge>
+                         </div>
+                       ))}
+                    </div>
+                 </div>
+               )}
+            </div>
+ 
+            {/* 中间：队列表格 (Lab History) */}
+            <div className="lg:col-span-5 border-r border-[#d8cfba]/40 flex flex-col min-w-0 bg-white/20">
+               <div className="p-4 border-b border-[#d8cfba]/40 bg-[#fff8ea]/50 flex items-center justify-between shrink-0">
+                  <div className="flex items-center gap-2">
+                    <History size={16} className="text-[#687177]" />
+                    <span className="text-[11px] font-black text-[#1f2328] uppercase tracking-widest">历史任务队列</span>
+                  </div>
+               </div>
+               <div className="flex-1 overflow-y-auto">
+                  <Table>
+                    <TableHeader className="bg-white/50 sticky top-0 z-10">
+                      <TableRow className="hover:bg-transparent border-[#d8cfba]/40">
+                        <TableHead className="px-5 h-10 text-[9px] uppercase font-black text-[#687177]">执行时间</TableHead>
+                        <TableHead className="h-10 text-[9px] uppercase font-black text-[#687177]">币种</TableHead>
+                        <TableHead className="h-10 text-[9px] uppercase font-black text-[#687177]">PnL (%)</TableHead>
+                        <TableHead className="h-10 text-[9px] uppercase font-black text-[#687177] pr-5 text-right">状态</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {backtests.length > 0 ? (
+                        backtests.slice().reverse().map((item) => {
+                          const isSelected = item.id === selectedBacktest?.id;
+                          const pnl = getNumber(item.resultSummary?.return);
+                          return (
+                            <TableRow 
+                              key={item.id} 
+                              className={`group cursor-pointer transition-all ${isSelected ? 'bg-white shadow-inner' : 'hover:bg-white/50'}`}
+                              onClick={() => setSelectedBacktestId(item.id)}
+                            >
+                              <TableCell className="px-5 py-3 text-[10px] font-mono text-[#687177]">
+                                {formatTime(item.createdAt).split(' ')[1]}
+                              </TableCell>
+                              <TableCell className="py-3 font-black text-[11px] text-[#1f2328]">
+                                {String(item.parameters?.symbol ?? "--")}
+                              </TableCell>
+                              <TableCell className={`py-3 font-mono font-black text-xs ${(pnl ?? 0) >= 0 ? 'text-[#0e6d60]' : 'text-rose-600'}`}>
+                                {pnl !== undefined ? (pnl > 0 ? "+" : "") + formatPercent(pnl) : "--"}
+                              </TableCell>
+                              <TableCell className="py-3 pr-5 text-right">
+                                <div className={`size-2 rounded-full inline-block ${item.status === 'COMPLETED' ? 'bg-[#0e6d60]' : 'bg-amber-500'}`} title={item.status} />
+                              </TableCell>
+                            </TableRow>
+                          );
+                        })
+                      ) : (
+                        <TableRow>
+                          <TableCell colSpan={4} className="h-64 text-center text-xs text-[#687177] italic opacity-40">队列为空，等待第一次实验</TableCell>
+                        </TableRow>
+                      )}
+                    </TableBody>
+                  </Table>
+               </div>
+            </div>
+ 
+            {/* 右侧：分析审计 (Auditor) */}
+            <div className="lg:col-span-4 p-6 flex flex-col bg-white/10 overflow-y-auto">
+               {selectedBacktest ? (
+                 <div className="space-y-8">
+                    <div className="flex items-center justify-between">
+                       <div className="flex items-center gap-2">
+                          <BarChart4 size={18} className="text-[#1f2328]" />
+                          <h4 className="text-sm font-black text-[#1f2328] uppercase tracking-wider">执行回放结果</h4>
+                       </div>
+                       <Badge className={`text-[9px] font-black h-5 ${selectedBacktest.status === 'COMPLETED' ? 'bg-[#1f2328]' : 'bg-rose-500'}`}>
+                         {selectedBacktest.status}
+                       </Badge>
+                    </div>
+ 
+                    <div className="grid grid-cols-2 gap-3">
+                       {[
+                         { label: "Trades", value: String(latestBacktestSummary.executionTradeCount ?? "--"), icon: Clock },
+                         { label: "Win Rate", value: formatPercent(latestBacktestSummary.executionWinRate), icon: Play },
+                         { label: "Total PnL", value: formatSigned(getNumber(latestBacktestSummary.executionRealizedPnL) ?? 0), color: (getNumber(latestBacktestSummary.executionRealizedPnL) ?? 0) >= 0 ? 'text-[#0e6d60]' : 'text-rose-600' },
+                         { label: "Max DD", value: formatPercent(latestBacktestSummary.maxDrawdown), color: 'text-amber-700' },
+                       ].map((stat, i) => (
+                         <div key={i} className="bg-white p-3.5 rounded-2xl border border-[#d8cfba]/40 shadow-sm">
+                           <span className="block text-[8px] font-black text-[#687177] uppercase mb-1.5 opacity-60 tracking-widest">{stat.label}</span>
+                           <strong className={`text-[13px] font-black block tabular-nums ${stat.color || 'text-[#1f2328]'}`}>{stat.value}</strong>
+                         </div>
+                       ))}
+                    </div>
+ 
+                    <div className="flex gap-2">
+                       <Button 
+                         variant="outline" 
+                         className="flex-1 h-10 border-[#d8cfba] bg-white hover:bg-[#fff8ea] rounded-xl text-[10px] font-black"
+                         disabled={!selectedBacktest?.parameters?.from || !selectedBacktest?.parameters?.to}
+                         onClick={() => {
+                            const from = Date.parse(String(selectedBacktest?.parameters?.from ?? ""));
+                            const to = Date.parse(String(selectedBacktest?.parameters?.to ?? ""));
+                            if (!Number.isFinite(from) || !Number.isFinite(to)) return;
+                            setChartOverrideRange({ from: Math.floor(from/1000), to: Math.floor(to/1000), label: "Bktr Range" });
+                            setFocusNonce((v) => v + 1);
+                         }}
+                       >
+                         <Maximize2 size={12} className="mr-2 opacity-50" /> 还原复现窗口
+                       </Button>
+                       <Button 
+                         variant="outline" 
+                         className="h-10 w-10 border-[#d8cfba] bg-white hover:bg-[#fff8ea] rounded-xl flex items-center justify-center p-0"
+                         onClick={() => window.open(`${API_BASE}/api/v1/backtests/${selectedBacktest.id}/execution-trades.csv`)}
+                       >
+                         <FileDown size={14} className="text-[#1f2328]" />
+                       </Button>
+                    </div>
+ 
+                    <div className="space-y-4">
+                       <div className="flex items-center gap-2 border-b border-[#d8cfba]/60 pb-2">
+                          <Database size={13} className="text-[#687177]" />
+                          <span className="text-[10px] font-black text-[#687177] uppercase tracking-widest">成交与观测样本审计</span>
+                       </div>
+                       
+                       <div className="grid grid-cols-1 gap-2.5 max-h-[300px] overflow-y-auto pr-2 custom-scrollbar">
+                          {latestReplayCompletedSamples.length > 0 && (
+                            <div className="space-y-2">
+                              {latestReplayCompletedSamples.map((sample, idx) => (
+                                <SampleCard 
+                                  key={`c-${idx}`} 
+                                  sample={sample} 
+                                  selected={selectedSample?.key === buildSampleKey("completed", idx, sample)} 
+                                  onSelect={() => {
+                                    const r = buildSampleRange(sample); if(!r) return;
+                                    setSelectedSample({ key: buildSampleKey("completed", idx, sample), sample });
+                                    setChartOverrideRange(r); setSourceFilter("backtest"); setEventFilter("all"); setFocusNonce(v => v+1);
+                                  }}
+                                />
+                              ))}
+                            </div>
+                          )}
+                          {latestReplaySkippedSamples.length > 0 && (
+                            <div className="space-y-2">
+                              {latestReplaySkippedSamples.map((sample, idx) => (
+                                <SampleCard 
+                                  key={`s-${idx}`} 
+                                  sample={sample} 
+                                  selected={selectedSample?.key === buildSampleKey("skipped", idx, sample)} 
+                                  onSelect={() => {
+                                    const r = buildSampleRange(sample); if(!r) return;
+                                    setSelectedSample({ key: buildSampleKey("skipped", idx, sample), sample });
+                                    setChartOverrideRange(r); setSourceFilter("backtest"); setEventFilter("all"); setFocusNonce(v => v+1);
+                                  }}
+                                />
+                              ))}
+                            </div>
+                          )}
+                          {(latestReplayCompletedSamples.length === 0 && latestReplaySkippedSamples.length === 0) && (
+                            <div className="p-8 text-center text-[10px] text-[#687177] italic bg-[#fff8ea]/40 rounded-2xl border border-dashed border-[#d8cfba]">
+                              未产生审计点
+                            </div>
+                          )}
+                       </div>
+                    </div>
+                 </div>
+               ) : (
+                 <div className="flex-1 flex flex-col items-center justify-center opacity-30">
+                    <BarChart4 size={40} className="mb-4" />
+                    <p className="text-xs font-black uppercase tracking-widest text-[#1f2328]">分析审计就绪</p>
+                 </div>
+               )}
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+      <div className="h-8 shrink-0" /> {/* Bottom Padding */}
     </div>
   );
 }

--- a/web/console/src/types/domain.ts
+++ b/web/console/src/types/domain.ts
@@ -9,6 +9,9 @@ export type AccountSummary = {
   unrealizedPnl: number;
   fees: number;
   netEquity: number;
+  walletBalance: number;
+  marginBalance: number;
+  availableBalance: number;
   exposureNotional: number;
   openPositionCount: number;
   updatedAt: string;


### PR DESCRIPTION
## 目的
重构 StrategyStage UI，应用 'Cream/Ivory' 奶油色现代视觉规范（参考 AccountStage），废弃侧边面板并整合整合 Backtest Lab 到主舞台以优化大屏工作流。

## 本次改动风险定级
- [x] **L2** - 高风险 (执行面板性改动、回测逻辑迁移)

## AI Agent 参与声明
- [x] 这段属于由 Antigravity 生成的代码，已通过本地 tsc 静态类型校验。

## 风险点 checklist
- [x] `dispatchMode` 默认值无变化。
- [x] 不存在直接调用 `mainnet` 凭证的硬编码。
- [x] 逻辑已通过 JSX 嵌套结构验证，确保 React 渲染闭环。

## 验证方式与测试证据
- [x] 在本地使用 tsc 完成了静态类型校验 (`./node_modules/.bin/tsc --noEmit src/pages/StrategyStage.tsx`)，修复了所有因重构产生的语法与类型错误。