### PR TITLE
fix(health): suppress cascading stale/quiet alerts for dead runtime sessions

### DIFF
--- a/internal/service/alerts.go
+++ b/internal/service/alerts.go
@@ -90,37 +90,39 @@ func (p *Platform) ListAlerts() ([]domain.PlatformAlert, error) {
 				EventTime:        session.UpdatedAt,
 			})
 		}
-		if sourceSummary.staleCount > 0 {
-			appendAlert(domain.PlatformAlert{
-				ID:               fmt.Sprintf("runtime-stale-%s", session.ID),
-				Scope:            "runtime",
-				Level:            "warning",
-				Title:            "Stale sources",
-				Detail:           fmt.Sprintf("%d source state(s) outdated", sourceSummary.staleCount),
-				AccountID:        session.AccountID,
-				AccountName:      account.Name,
-				StrategyID:       session.StrategyID,
-				StrategyName:     strategyNameByID[session.StrategyID],
-				RuntimeSessionID: session.ID,
-				Anchor:           "signals",
-				EventTime:        sourceSummary.latestEventAt,
-			})
-		}
-		if p.runtimeSessionQuiet(state) {
-			appendAlert(domain.PlatformAlert{
-				ID:               fmt.Sprintf("runtime-quiet-%s", session.ID),
-				Scope:            "runtime",
-				Level:            "warning",
-				Title:            "Runtime quiet",
-				Detail:           fmt.Sprintf("no runtime events observed in the last %ds", p.runtimePolicy.RuntimeQuietSeconds),
-				AccountID:        session.AccountID,
-				AccountName:      account.Name,
-				StrategyID:       session.StrategyID,
-				StrategyName:     strategyNameByID[session.StrategyID],
-				RuntimeSessionID: session.ID,
-				Anchor:           "signals",
-				EventTime:        parseOptionalRFC3339(stringValue(state["lastEventAt"])),
-			})
+		if !strings.EqualFold(session.Status, "ERROR") && !strings.EqualFold(session.Status, "STOPPED") && health != "stopped" {
+			if sourceSummary.staleCount > 0 {
+				appendAlert(domain.PlatformAlert{
+					ID:               fmt.Sprintf("runtime-stale-%s", session.ID),
+					Scope:            "runtime",
+					Level:            "warning",
+					Title:            "Stale sources",
+					Detail:           fmt.Sprintf("%d source state(s) outdated", sourceSummary.staleCount),
+					AccountID:        session.AccountID,
+					AccountName:      account.Name,
+					StrategyID:       session.StrategyID,
+					StrategyName:     strategyNameByID[session.StrategyID],
+					RuntimeSessionID: session.ID,
+					Anchor:           "signals",
+					EventTime:        sourceSummary.latestEventAt,
+				})
+			}
+			if p.runtimeSessionQuiet(state) {
+				appendAlert(domain.PlatformAlert{
+					ID:               fmt.Sprintf("runtime-quiet-%s", session.ID),
+					Scope:            "runtime",
+					Level:            "warning",
+					Title:            "Runtime quiet",
+					Detail:           fmt.Sprintf("no runtime events observed in the last %ds", p.runtimePolicy.RuntimeQuietSeconds),
+					AccountID:        session.AccountID,
+					AccountName:      account.Name,
+					StrategyID:       session.StrategyID,
+					StrategyName:     strategyNameByID[session.StrategyID],
+					RuntimeSessionID: session.ID,
+					Anchor:           "signals",
+					EventTime:        parseOptionalRFC3339(stringValue(state["lastEventAt"])),
+				})
+			}
 		}
 	}
 


### PR DESCRIPTION
## What changed?
Suppressed secondary cascading alerts (`Stale sources` and `Runtime quiet`) when a `SignalRuntimeSession` has explicitly transitioned to `ERROR` or `STOPPED` state.

## Why?
When a legacy signal-runtime disconnects violently and transitions to `ERROR` (e.g. `signal-runtime-1776334634738...`), it is intentionally preserved in the system for RCA and diagnostic review. Since its sub-streams are fully detached, they naturally become stale and quiet. The periodic health monitor would endlessly spam the `Alerts` state with this legacy data.

By wrapping these specific evaluations in an explicit `session.Status` guard, we ensure the user still receives the vital `Runtime health` error but isn't drowned in meaningless consequence alarms.