### PR TITLE
feat: sync monitor k-line with active session runtime data

### DIFF
--- a/web/console/src/hooks/useDashboard.ts
+++ b/web/console/src/hooks/useDashboard.ts
@@ -151,21 +151,7 @@ export function useDashboard() {
     const range = chartOverrideRange ?? buildTimeRange(anchorDate, timeWindow);
     const { from, to } = range;
 
-    const monitorSessionForChart = liveSessionData[0] ?? null;
-    let selectedResolution = monitorResolution;
-    if (!selectedResolution) {
-      const monitorSignalTimeframe = String(monitorSessionForChart?.state?.signalTimeframe ?? "1d");
-      const normalizedMonitorSignalTimeframe = monitorSignalTimeframe.toLowerCase();
-      selectedResolution = normalizedMonitorSignalTimeframe === "5m" || normalizedMonitorSignalTimeframe === "5min" || normalizedMonitorSignalTimeframe === "5"
-        ? "5"
-        : normalizedMonitorSignalTimeframe === "4h"
-          ? "240"
-          : "1D";
-    }
-    
-    const monitorResolutionParam = selectedResolution;
-
-    const [snapshotData, candleData, monitorCandleData, annotationData] = await Promise.all([
+    const [snapshotData, candleData, annotationData] = await Promise.all([
       summaryData[0]?.accountId
         ? fetchJSON<AccountEquitySnapshot[]>(
             `/api/v1/account-equity-snapshots?accountId=${encodeURIComponent(summaryData[0].accountId)}`
@@ -173,9 +159,6 @@ export function useDashboard() {
         : Promise.resolve([]),
       fetchJSON<{ candles: ChartCandle[] }>(
         `/api/v1/chart/candles?symbol=BTCUSDT&resolution=1&from=${from}&to=${to}&limit=840`
-      ),
-      fetchJSON<{ candles: ChartCandle[] }>(
-        `/api/v1/chart/candles?symbol=BTCUSDT&resolution=${encodeURIComponent(monitorResolutionParam)}&limit=400`
       ),
       fetchJSON<ChartAnnotation[]>(
         `/api/v1/chart/annotations?symbol=BTCUSDT&from=${from}&to=${to}&limit=300`
@@ -200,7 +183,6 @@ export function useDashboard() {
     const normalizedSnapshots = Array.isArray(snapshotData) ? snapshotData : [];
     const normalizedAnnotations = Array.isArray(annotationData) ? annotationData : [];
     const normalizedCandles = Array.isArray(candleData?.candles) ? candleData.candles : [];
-    const normalizedMonitorCandles = Array.isArray(monitorCandleData?.candles) ? monitorCandleData.candles : [];
     const normalizedSignalCatalog = signalCatalogData && typeof signalCatalogData === "object" ? signalCatalogData : { sources: [], notes: [] };
     const normalizedBacktestOptions =
       backtestOptionsData && typeof backtestOptionsData === "object" ? backtestOptionsData : ({} as BacktestOptions);
@@ -212,7 +194,6 @@ export function useDashboard() {
     setFills(normalizedFills);
     setPositions(normalizedPositions);
     setSnapshots(normalizedSnapshots);
-    setMonitorCandles(normalizedMonitorCandles);
     setStrategies(normalizedStrategies);
     setSelectedStrategyId((current) => {
       if (current && normalizedStrategies.some((item) => item.id === current)) {

--- a/web/console/src/pages/MonitorStage.tsx
+++ b/web/console/src/pages/MonitorStage.tsx
@@ -6,7 +6,7 @@ import { formatMoney, formatSigned, formatMaybeNumber, formatTime, shrink } from
 import { 
   getRecord, 
   getList,
-  mapChartCandlesToSignalBarCandles, 
+  deriveSignalBarCandles,
   derivePrimarySignalBarState, 
   deriveRuntimeMarketSnapshot, 
   deriveSessionMarkers, 
@@ -46,14 +46,11 @@ export function MonitorStage({ syncLiveOrder, dockTab, onDockTabChange, dockCont
   const fills = useTradingStore(s => s.fills);
   const positions = useTradingStore(s => s.positions);
   const signalRuntimeSessions = useTradingStore(s => s.signalRuntimeSessions);
-  const monitorCandles = useTradingStore(s => s.monitorCandles);
   const summaries = useTradingStore(s => s.summaries);
   const runtimePolicy = useTradingStore(s => s.runtimePolicy);
   const monitorHealth = useTradingStore(s => s.monitorHealth);
   const accounts = useTradingStore(s => s.accounts);
   const strategySignalBindingMap = useTradingStore(s => s.strategySignalBindingMap);
-  const monitorResolution = useUIStore(s => s.monitorResolution);
-  const setMonitorResolution = useUIStore(s => s.setMonitorResolution);
   const liveSyncAction = useUIStore(s => s.liveSyncAction);
   const selectedSignalRuntimeId = useTradingStore(s => s.selectedSignalRuntimeId);
   const setSelectedSignalRuntimeId = useTradingStore(s => s.setSelectedSignalRuntimeId);
@@ -121,12 +118,12 @@ export function MonitorStage({ syncLiveOrder, dockTab, onDockTabChange, dockCont
   const monitorExecutionSummary = highlightedLiveSession?.execution ?? derivePaperSessionExecutionSummary(null, orders, fills, positions);
   const monitorRuntimeState = highlightedLiveSession?.session ? highlightedLiveRuntimeState : {};
   const monitorSessionState = getRecord(monitorSession?.state);
-  const monitorBars = mapChartCandlesToSignalBarCandles(
-    monitorCandles,
-    String(monitorSessionState.signalTimeframe ?? "1d")
-  );
+  const monitorBars = useMemo(() => {
+    return deriveSignalBarCandles(getRecord(highlightedLiveRuntimeState.sourceStates));
+  }, [highlightedLiveRuntimeState.sourceStates]);
+
   const monitorSignalState = derivePrimarySignalBarState(
-    getRecord(monitorRuntimeState.signalBarStates),
+    getRecord(highlightedLiveRuntimeState.signalBarStates),
     getRecord(monitorSessionState.lastStrategyEvaluationSignalBarStates)
   );
   const monitorMarket = deriveRuntimeMarketSnapshot(
@@ -203,6 +200,7 @@ export function MonitorStage({ syncLiveOrder, dockTab, onDockTabChange, dockCont
   return (
     <div className="h-full overflow-y-auto p-6 space-y-8 animate-in fade-in duration-500">
       {/* 1. 主监控区 - 彻底迁移至 Card 现代化体系 */}
+      {monitorSession ? (
       <Card className="border-[#d8cfba] bg-[var(--panel)] shadow-2xl rounded-[32px] overflow-hidden border-2">
          <CardHeader className="bg-white/40 border-b border-[#d8cfba]/50 px-8 py-5">
            <div className="flex items-center justify-between">
@@ -216,27 +214,6 @@ export function MonitorStage({ syncLiveOrder, dockTab, onDockTabChange, dockCont
                </div>
              </div>
              <div className="flex items-center gap-4">
-                <div className="flex items-center gap-1.5 px-3 py-1 bg-[#ebe5d5]/50 border border-[#d8cfba] rounded-2xl shadow-sm">
-                  {[
-                    { label: '5m', value: '5' },
-                    { label: '15m', value: '15' },
-                    { label: '1h', value: '60' },
-                    { label: '4h', value: '240' },
-                    { label: '1d', value: '1D' },
-                  ].map((tf) => (
-                    <button
-                      key={tf.label}
-                      onClick={() => setMonitorResolution(tf.value)}
-                      className={`px-2.5 py-1 rounded-lg text-[10px] uppercase font-black transition-all ${
-                        monitorResolution === tf.value
-                          ? 'bg-[#1f2328] text-white shadow-md scale-105'
-                          : 'text-[#687177] hover:bg-white/60 hover:text-[#1f2328]'
-                      }`}
-                    >
-                      {tf.label}
-                    </button>
-                  ))}
-                </div>
                 <Badge variant="outline" className="h-7 px-3 border-[#d8cfba] font-mono text-[10px] bg-white text-[#1f2328]">
                   {monitorMode}
                 </Badge>
@@ -273,7 +250,12 @@ export function MonitorStage({ syncLiveOrder, dockTab, onDockTabChange, dockCont
                 ))}
             </div>
          </CardContent>
-      </Card>
+      </Card>) : (
+        <div className="bg-[#fff8ea]/30 border-2 border-dashed border-[#d8cfba] rounded-[32px] p-20 flex flex-col items-center justify-center space-y-4 opacity-40">
+           <CandlestickChart className="size-12 text-[#687177]" />
+           <p className="text-sm font-black text-[#687177] uppercase tracking-wider italic">需选择活跃焦点会话以同步实时 K 线数据</p>
+        </div>
+      )}
 
       <div className="grid grid-cols-1 lg:grid-cols-12 gap-8">
         {/* 2. 交互与干预区 */}


### PR DESCRIPTION
## 目的\n同步主监控台 K 线与活跃焦点会话的数据。移除冗余的硬编码 BTCUSDT 请求，改为直接派生自运行时会话状态，确保显示效果与执行逻辑完全闭环一致。\n\n## 本次改动风险定级 (参照 agent-risk-model.md)\n- [x] **L2** - 高风险 (执行面板改动、核心数据流替换)\n\n## AI Agent 参与声明\n- [x] 这段属于由 LLM/Agent 生成的代码，我已经确切通读并检查了\n\n## 风险点 checklist\n- [x] `dispatchMode` 默认值有否变化？ -> 无\n- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？ -> 无\n\n## 验证方式与测试证据\n- 已通过 `tsc` 静态类型校验。\n- 移除了 `useDashboard.ts` 中的冗余 `BTCUSDT` 请求。\n- 重构了 `MonitorStage.tsx` 的数据派生逻辑，支持按需显示。