### PR TITLE
[codex] Fix live signal runtime scoping

### DIFF
--- a/internal/service/signal_runtime_ws.go
+++ b/internal/service/signal_runtime_ws.go
@@ -277,6 +277,10 @@ func (p *Platform) runExchangeWebsocketLoop(
 }
 
 func (p *Platform) handleSignalRuntimeMessage(runtimeSessionID string, summary map[string]any, eventTime time.Time) error {
+	if !signalRuntimeSummaryShouldTriggerLiveEvaluation(summary) {
+		return nil
+	}
+	targetSymbol := signalRuntimeSummarySymbol(summary)
 	liveSessions, err := p.store.ListLiveSessions()
 	if err != nil {
 		return err
@@ -291,9 +295,31 @@ func (p *Platform) handleSignalRuntimeMessage(runtimeSessionID string, summary m
 		if !boolValue(session.State["signalRuntimeRequired"]) {
 			continue
 		}
+		if targetSymbol != "" {
+			sessionSymbol := NormalizeSymbol(firstNonEmpty(stringValue(session.State["symbol"]), stringValue(session.State["lastSymbol"])))
+			if sessionSymbol != "" && sessionSymbol != targetSymbol {
+				continue
+			}
+		}
 		_ = p.triggerLiveSessionFromSignal(session.ID, runtimeSessionID, summary, eventTime)
 	}
 	return nil
+}
+
+func signalRuntimeSummaryShouldTriggerLiveEvaluation(summary map[string]any) bool {
+	role := strings.TrimSpace(stringValue(summary["role"]))
+	if role == "" || !strings.EqualFold(normalizeSignalSourceRole(role), "trigger") {
+		return false
+	}
+	streamType := strings.ToLower(strings.TrimSpace(stringValue(summary["streamType"])))
+	if streamType == "" {
+		streamType = inferStreamTypeFromEvent(strings.ToLower(strings.TrimSpace(stringValue(summary["event"]))))
+	}
+	return streamType == "" || streamType == "trade_tick" || streamType == "replay_tick"
+}
+
+func signalRuntimeSummarySymbol(summary map[string]any) string {
+	return NormalizeSymbol(firstNonEmpty(stringValue(summary["subscriptionSymbol"]), stringValue(summary["symbol"])))
 }
 
 func enrichSignalRuntimeSummary(session domain.SignalRuntimeSession, summary map[string]any) map[string]any {
@@ -462,18 +488,27 @@ func deriveSignalBarStates(sourceStates map[string]any) map[string]any {
 			continue
 		}
 		bars := normalizeSignalBarEntries(state["bars"])
+		if len(bars) == 0 {
+			continue
+		}
+		current := bars[len(bars)-1]
+		currentClosed := boolValue(current["isClosed"])
 		closed := make([]map[string]any, 0, len(bars))
 		for _, bar := range bars {
 			if boolValue(bar["isClosed"]) {
 				closed = append(closed, bar)
 			}
 		}
-		if len(closed) == 0 {
+		indicatorBars := closed
+		if !currentClosed {
+			indicatorBars = append(indicatorBars, current)
+		}
+		if len(indicatorBars) == 0 {
 			continue
 		}
-		closes := make([]float64, 0, len(closed))
-		trueRanges := make([]float64, 0, len(closed))
-		for i, bar := range closed {
+		closes := make([]float64, 0, len(indicatorBars))
+		trueRanges := make([]float64, 0, len(indicatorBars))
+		for i, bar := range indicatorBars {
 			closePrice := parseFloatValue(bar["close"])
 			high := parseFloatValue(bar["high"])
 			low := parseFloatValue(bar["low"])
@@ -482,28 +517,33 @@ func deriveSignalBarStates(sourceStates map[string]any) map[string]any {
 				trueRanges = append(trueRanges, high-low)
 				continue
 			}
-			prevClose := parseFloatValue(closed[i-1]["close"])
+			prevClose := parseFloatValue(indicatorBars[i-1]["close"])
 			highLow := high - low
 			highClose := math.Abs(high - prevClose)
 			lowClose := math.Abs(low - prevClose)
 			trueRanges = append(trueRanges, math.Max(highLow, math.Max(highClose, lowClose)))
 		}
 
-		last := closed[len(closed)-1]
+		previousClosed := closed
+		if currentClosed && len(previousClosed) > 0 {
+			previousClosed = previousClosed[:len(previousClosed)-1]
+		}
 		entry := map[string]any{
-			"symbol":    stringValue(last["symbol"]),
-			"timeframe": stringValue(last["timeframe"]),
-			"barCount":  len(closed),
-			"sma5":      rollingMean(closes, len(closed)-1, 5),
-			"ma20":      rollingMean(closes, len(closed)-1, 20),
-			"atr14":     rollingMean(trueRanges, len(closed)-1, 14),
-			"current":   cloneMetadata(last),
+			"symbol":         stringValue(current["symbol"]),
+			"timeframe":      stringValue(current["timeframe"]),
+			"barCount":       len(indicatorBars),
+			"closedBarCount": len(closed),
+			"currentClosed":  currentClosed,
+			"sma5":           rollingMean(closes, len(indicatorBars)-1, 5),
+			"ma20":           rollingMean(closes, len(indicatorBars)-1, 20),
+			"atr14":          rollingMean(trueRanges, len(indicatorBars)-1, 14),
+			"current":        cloneMetadata(current),
 		}
-		if len(closed) >= 2 {
-			entry["prevBar1"] = cloneMetadata(closed[len(closed)-2])
+		if len(previousClosed) >= 1 {
+			entry["prevBar1"] = cloneMetadata(previousClosed[len(previousClosed)-1])
 		}
-		if len(closed) >= 3 {
-			entry["prevBar2"] = cloneMetadata(closed[len(closed)-3])
+		if len(previousClosed) >= 2 {
+			entry["prevBar2"] = cloneMetadata(previousClosed[len(previousClosed)-2])
 		}
 		out[key] = entry
 	}

--- a/internal/service/signal_runtime_ws.go
+++ b/internal/service/signal_runtime_ws.go
@@ -308,14 +308,12 @@ func (p *Platform) handleSignalRuntimeMessage(runtimeSessionID string, summary m
 
 func signalRuntimeSummaryShouldTriggerLiveEvaluation(summary map[string]any) bool {
 	role := strings.TrimSpace(stringValue(summary["role"]))
-	if role == "" || !strings.EqualFold(normalizeSignalSourceRole(role), "trigger") {
-		return false
+	streamType := inferSignalRuntimeStreamType(summary)
+	if role != "" {
+		return strings.EqualFold(normalizeSignalSourceRole(role), "trigger") &&
+			(streamType == "" || streamType == "trade_tick" || streamType == "replay_tick")
 	}
-	streamType := strings.ToLower(strings.TrimSpace(stringValue(summary["streamType"])))
-	if streamType == "" {
-		streamType = inferStreamTypeFromEvent(strings.ToLower(strings.TrimSpace(stringValue(summary["event"]))))
-	}
-	return streamType == "" || streamType == "trade_tick" || streamType == "replay_tick"
+	return streamType == "trade_tick" || streamType == "replay_tick"
 }
 
 func signalRuntimeSummarySymbol(summary map[string]any) string {
@@ -334,8 +332,7 @@ func enrichSignalRuntimeSummary(session domain.SignalRuntimeSession, summary map
 	}
 
 	symbol := NormalizeSymbol(stringValue(out["symbol"]))
-	event := strings.ToLower(strings.TrimSpace(stringValue(out["event"])))
-	streamType := inferStreamTypeFromEvent(event)
+	streamType := inferSignalRuntimeStreamType(out)
 	for _, subscription := range subscriptions {
 		if !signalRuntimeSubscriptionMatchesSummary(subscription, out, symbol, streamType) {
 			continue
@@ -382,6 +379,29 @@ func inferStreamTypeFromEvent(event string) string {
 	case "depthupdate":
 		return "order_book"
 	case "kline":
+		return "signal_bar"
+	default:
+		return ""
+	}
+}
+
+func inferSignalRuntimeStreamType(summary map[string]any) string {
+	streamType := strings.ToLower(strings.TrimSpace(stringValue(summary["streamType"])))
+	if streamType != "" {
+		return streamType
+	}
+	if inferred := inferStreamTypeFromEvent(strings.ToLower(strings.TrimSpace(stringValue(summary["event"])))); inferred != "" {
+		return inferred
+	}
+	channel := strings.ToLower(strings.TrimSpace(stringValue(summary["channel"])))
+	switch {
+	case channel == "", channel == "message":
+		return ""
+	case strings.HasPrefix(channel, "trades"):
+		return "trade_tick"
+	case strings.HasPrefix(channel, "books"), strings.HasPrefix(channel, "book"):
+		return "order_book"
+	case strings.HasPrefix(channel, "candle"), strings.HasPrefix(channel, "kline"):
 		return "signal_bar"
 	default:
 		return ""

--- a/internal/service/signal_runtime_ws_test.go
+++ b/internal/service/signal_runtime_ws_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/wuyaocheng/bktrader/internal/domain"
 	"github.com/wuyaocheng/bktrader/internal/store/memory"
 )
 
@@ -137,6 +138,71 @@ func TestMergeSignalSourceStatePreservesSignalBarHistory(t *testing.T) {
 	}
 }
 
+func TestDeriveSignalBarStatesUsesOpenCurrentBarWithClosedHistory(t *testing.T) {
+	key := signalBindingMatchKey("binance-kline", "signal", "BTCUSDT", map[string]any{"timeframe": "5m"})
+	base := time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC)
+	bars := make([]any, 0, 21)
+	for i := 0; i < 20; i++ {
+		bars = append(bars, map[string]any{
+			"symbol":    "BTCUSDT",
+			"timeframe": "5m",
+			"barStart":  base.Add(time.Duration(i) * 5 * time.Minute).Format(time.RFC3339),
+			"open":      100 + float64(i),
+			"high":      101 + float64(i),
+			"low":       95 + float64(i),
+			"close":     100 + float64(i),
+			"volume":    1000 + float64(i),
+			"isClosed":  true,
+		})
+	}
+	currentStart := base.Add(20 * 5 * time.Minute).Format(time.RFC3339)
+	bars = append(bars, map[string]any{
+		"symbol":    "BTCUSDT",
+		"timeframe": "5m",
+		"barStart":  currentStart,
+		"open":      119.0,
+		"high":      130.0,
+		"low":       118.0,
+		"close":     125.0,
+		"volume":    1500.0,
+		"isClosed":  false,
+	})
+
+	states := deriveSignalBarStates(map[string]any{
+		key: map[string]any{
+			"sourceKey":  "binance-kline",
+			"role":       "signal",
+			"streamType": "signal_bar",
+			"symbol":     "BTCUSDT",
+			"timeframe":  "5m",
+			"bars":       bars,
+		},
+	})
+	state := mapValue(states[key])
+	if state == nil {
+		t.Fatalf("expected signal state from open current bar, got %#v", states)
+	}
+	if boolValue(state["currentClosed"]) {
+		t.Fatalf("expected current bar to remain marked open, got %#v", state)
+	}
+	current := mapValue(state["current"])
+	if stringValue(current["barStart"]) != currentStart {
+		t.Fatalf("expected open bar to be current, got %#v", current)
+	}
+	prevBar1 := mapValue(state["prevBar1"])
+	prevBar2 := mapValue(state["prevBar2"])
+	if stringValue(prevBar1["barStart"]) != base.Add(19*5*time.Minute).Format(time.RFC3339) {
+		t.Fatalf("expected prevBar1 to be latest closed bar, got %#v", prevBar1)
+	}
+	if stringValue(prevBar2["barStart"]) != base.Add(18*5*time.Minute).Format(time.RFC3339) {
+		t.Fatalf("expected prevBar2 to be second latest closed bar, got %#v", prevBar2)
+	}
+	gate := evaluateSignalBarGate(state, "BUY", "entry")
+	if !boolValue(gate["ready"]) || !boolValue(gate["longReady"]) {
+		t.Fatalf("expected open current bar breakout to be actionable, got %#v", gate)
+	}
+}
+
 func TestBootstrapSignalRuntimeSourceStatesUsesWarmMarketCache(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
 	signalBars := make([]strategySignalBar, 0, 4)
@@ -189,5 +255,101 @@ func TestBootstrapSignalRuntimeSourceStatesUsesWarmMarketCache(t *testing.T) {
 	}
 	if mapValue(signalState["prevBar2"]) == nil {
 		t.Fatalf("expected bootstrap state to include previous bars, got %#v", signalState)
+	}
+}
+
+func TestHandleSignalRuntimeMessageScopesTriggerByLiveSessionSymbol(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	for _, symbol := range []string{"BTCUSDT", "ETHUSDT"} {
+		if _, err := platform.BindStrategySignalSource("strategy-bk-1d", map[string]any{
+			"sourceKey": "binance-trade-tick",
+			"role":      "trigger",
+			"symbol":    symbol,
+		}); err != nil {
+			t.Fatalf("bind %s trigger failed: %v", symbol, err)
+		}
+	}
+
+	session, err := platform.CreateLiveSession("live-main", "strategy-bk-1d", map[string]any{
+		"symbol":              "BTCUSDT",
+		"signalTimeframe":     "1d",
+		"executionDataSource": "tick",
+	})
+	if err != nil {
+		t.Fatalf("create BTC live session failed: %v", err)
+	}
+	runtimeSessionID := stringValue(session.State["signalRuntimeSessionId"])
+	if runtimeSessionID == "" {
+		t.Fatal("expected linked runtime session id")
+	}
+	if _, err := platform.store.UpdateLiveSessionStatus(session.ID, "RUNNING"); err != nil {
+		t.Fatalf("mark live session running failed: %v", err)
+	}
+	eventTime := time.Date(2026, 4, 16, 12, 0, 0, 0, time.UTC)
+	if err := platform.updateSignalRuntimeSessionState(runtimeSessionID, func(runtimeSession *domain.SignalRuntimeSession) {
+		runtimeSession.Status = "RUNNING"
+		state := cloneMetadata(runtimeSession.State)
+		state["sourceStates"] = map[string]any{}
+		runtimeSession.State = state
+		runtimeSession.UpdatedAt = eventTime
+	}); err != nil {
+		t.Fatalf("update runtime state failed: %v", err)
+	}
+
+	if err := platform.handleSignalRuntimeMessage(runtimeSessionID, map[string]any{
+		"role":               "signal",
+		"streamType":         "signal_bar",
+		"symbol":             "BTCUSDT",
+		"subscriptionSymbol": "BTCUSDT",
+		"timeframe":          "1d",
+		"event":              "kline",
+	}, eventTime); err != nil {
+		t.Fatalf("handle BTC signal bar failed: %v", err)
+	}
+	updated, err := platform.store.GetLiveSession(session.ID)
+	if err != nil {
+		t.Fatalf("get live session after signal bar failed: %v", err)
+	}
+	if got := stringValue(updated.State["lastSignalRuntimeEventAt"]); got != "" {
+		t.Fatalf("expected signal bar to skip live evaluation, got last event at %s", got)
+	}
+
+	if err := platform.handleSignalRuntimeMessage(runtimeSessionID, map[string]any{
+		"role":               "trigger",
+		"streamType":         "trade_tick",
+		"symbol":             "ETHUSDT",
+		"subscriptionSymbol": "ETHUSDT",
+		"event":              "trade",
+		"price":              "3000",
+	}, eventTime); err != nil {
+		t.Fatalf("handle ETH trigger failed: %v", err)
+	}
+	updated, err = platform.store.GetLiveSession(session.ID)
+	if err != nil {
+		t.Fatalf("get updated live session failed: %v", err)
+	}
+	if got := stringValue(updated.State["lastSignalRuntimeEventAt"]); got != "" {
+		t.Fatalf("expected ETH trigger to skip BTC session, got last event at %s", got)
+	}
+	if timeline := metadataList(updated.State["timeline"]); len(timeline) != 0 {
+		t.Fatalf("expected ETH trigger to append no BTC timeline entries, got %#v", timeline)
+	}
+
+	if err := platform.handleSignalRuntimeMessage(runtimeSessionID, map[string]any{
+		"role":               "trigger",
+		"streamType":         "trade_tick",
+		"symbol":             "BTCUSDT",
+		"subscriptionSymbol": "BTCUSDT",
+		"event":              "trade",
+		"price":              "69000",
+	}, eventTime.Add(time.Second)); err != nil {
+		t.Fatalf("handle BTC trigger failed: %v", err)
+	}
+	updated, err = platform.store.GetLiveSession(session.ID)
+	if err != nil {
+		t.Fatalf("get updated live session after BTC trigger failed: %v", err)
+	}
+	if got := stringValue(updated.State["lastSignalRuntimeEventAt"]); got == "" {
+		t.Fatalf("expected BTC trigger to reach BTC session, got empty last event state")
 	}
 }

--- a/internal/service/signal_runtime_ws_test.go
+++ b/internal/service/signal_runtime_ws_test.go
@@ -83,6 +83,45 @@ func TestEnrichSignalRuntimeSummaryKeepsKlineEventsScopedByTimeframe(t *testing.
 	}
 }
 
+func TestEnrichSignalRuntimeSummaryInfersOKXTradesChannelAsTrigger(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	if _, err := platform.BindStrategySignalSource("strategy-bk-1d", map[string]any{
+		"sourceKey": "okx-order-book",
+		"role":      "feature",
+		"symbol":    "BTCUSDT",
+	}); err != nil {
+		t.Fatalf("bind okx order book failed: %v", err)
+	}
+	if _, err := platform.BindStrategySignalSource("strategy-bk-1d", map[string]any{
+		"sourceKey": "okx-trade-tick",
+		"role":      "trigger",
+		"symbol":    "BTCUSDT",
+	}); err != nil {
+		t.Fatalf("bind okx trigger failed: %v", err)
+	}
+
+	session, err := platform.CreateSignalRuntimeSession("live-main", "strategy-bk-1d")
+	if err != nil {
+		t.Fatalf("create runtime session failed: %v", err)
+	}
+
+	summary := enrichSignalRuntimeSummary(session, map[string]any{
+		"event":   "message",
+		"channel": "trades",
+		"symbol":  "BTCUSDT",
+		"price":   "68000",
+	})
+	if got := stringValue(summary["streamType"]); got != "trade_tick" {
+		t.Fatalf("expected okx trades message to infer trade_tick, got %#v", summary)
+	}
+	if got := stringValue(summary["role"]); got != "trigger" {
+		t.Fatalf("expected okx trades message to attach trigger role, got %#v", summary)
+	}
+	if !signalRuntimeSummaryShouldTriggerLiveEvaluation(summary) {
+		t.Fatalf("expected okx trades message to remain trigger-actionable, got %#v", summary)
+	}
+}
+
 func TestMergeSignalSourceStatePreservesSignalBarHistory(t *testing.T) {
 	sourceStates := map[string]any{}
 	first := map[string]any{


### PR DESCRIPTION
## 目的
修复共享 signal runtime 下 BTC/ETH 多 symbol 消息混入 live session 的问题：只有显式 trigger 消息会触发 live strategy evaluation，并且 trigger 会按 session 的 `symbol` 过滤，避免 ETH trigger 在 BTC session 中生成 `symbol-mismatch` decision 日志。

同时修正实时 K 线信号状态生成：当前未闭合 bar 也可以作为 `current` 参与突破判断，`prevBar1` / `prevBar2` 仍来自已闭合历史 bar，避免实时 bar 未闭合时误报 `missing-signal-bars` 导致闭环卡住。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [x] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) —— 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？—— 无
- [x] DB migration 是否具备向下兼容幂等性？—— 不涉及 DB migration
- [x] 配置字段有没有无意被混改？—— 无配置字段变化

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

本地验证已通过：

```bash
gofmt -w internal/service/signal_runtime_ws.go internal/service/signal_runtime_ws_test.go
go test ./internal/service -run 'TestDeriveSignalBarStatesUsesOpenCurrentBarWithClosedHistory|TestHandleSignalRuntimeMessageScopesTriggerByLiveSessionSymbol|TestEnrichSignalRuntimeSummaryKeepsKlineEventsScopedByTimeframe|TestMergeSignalSourceStatePreservesSignalBarHistory|TestBootstrapSignalRuntimeSourceStatesUsesWarmMarketCache'
go test ./...
go build ./cmd/platform-api
go build ./cmd/db-migrate
```

pre-push hook 已运行 graphify rebuild：`1397 nodes, 2144 edges, 135 communities`。