### PR TITLE
feat: add stop-loss-only silent watchdog fallback and session protection plan

### DIFF
--- a/docs/20260417-session-protection-and-manual-close-plan.md
+++ b/docs/20260417-session-protection-and-manual-close-plan.md
@@ -1,0 +1,45 @@
+# Session 停用保护与手动平仓后端接口规划
+
+## 背景
+用户反馈，当某个 `SignalRuntimeSession` 或 `LiveSession` 还在运行且带有关联此会话的未平仓头寸或活跃挂单时，如果被停用（Stop）或删除（Delete），会导致该头寸彻底失去被接管的机会并沦为“幽灵仓”。
+为解决此问题，后端接口需要增加持仓拦截判断。同时，在此契机下一并增加明确的、便于前端操作的订单全生命周期接管接口（例如单独点击某持仓直接一键强平）。
+
+## 规划细节
+
+### 1. 生命周期接口的安全锁改造
+我们将在会话删除和停用的主要入口挂载一个统一的前置预检函数，用于扫描并阻断破坏性的关闭动作。
+
+#### [NEW] internal/service/safety_checks.go (或在 `live.go` / `service.go` 中)
+- **增加核心检验方法**: `HasActivePositionsOrOrders(accountID, strategyID string) bool`
+  1. 向DB轮询 `ListPositions`: 找到 `Quantity > 0` 且归属当前 Account/Strategy的未平仓头寸。
+  2. 向DB轮询 `ListOrders`: 找到状态处于 `NEW`/`PARTIALLY_FILLED`/`ACCEPTED` 且归属当前的订单。
+
+#### [MODIFY] internal/service/live.go
+- **`StopLiveSession` 与 `DeleteLiveSession` 接口**： 
+  在最初步增加上述预检逻辑。如果存在活跃订单，立即返回 `fmt.Errorf("存在活动中的订单或未平仓头寸，无法直接停用/删除")` 以阻断请求。
+
+#### [MODIFY] internal/service/signal_runtime_sessions.go
+- **`StopSignalRuntimeSession` 与 `DeleteSignalRuntimeSession` 接口**： 
+  因为 `SignalRuntime` 统带下属 LiveSessions，因此查出属于该 Runtime 的 `LiveSession` 对应的 Account + Strategy 并抛给 `HasActivePositionsOrOrders`，有挂载持仓同样退回阻断。
+
+> [!WARNING] 
+> **硬退出后门支持 (Force Parameter)** 
+> 在上述涉及到停用或删除的所有 HTTP 接口方法签名中提供对查询参数的检测。如果 HTTP 请求的 URL 中带有 `?force=true`，则完全跳过上述 `HasActivePositionsOrOrders` 拦截器。此改动兼容由于断网或其他脏数据导致的极端情况下管理员强行清理节点的需求。
+
+---
+
+### 2. 订单管理与手动平仓管理接管
+后端平台当前原生支持通过 `POST /api/v1/orders` 手动下发市价单以完成平仓能力，但这极大要求前端完全拼凑好反身逻辑。此时我们将新增单独一键冲销平仓的语义化接管 API。
+
+#### [MODIFY] internal/service/order.go
+- **新增平仓业务方法**: `ClosePosition(positionID string) (domain.Order, error)`
+  根据 Position ID 获取仓位后，向内部引擎（`p.CreateOrder`）反身提交一笔：方向相反、数量等同 `pos.Quantity`、`Type: MARKET`、带有 `reduceOnly: true` (只减仓) 属性的全新订单。
+  此逻辑会让这笔接管单极其自然顺滑地汇聚到底层执行引擎与交易所，引发真正的清算且账册分毫不差。
+
+#### [MODIFY] internal/http/accounts.go (或 orders/positions路由)
+- 暴露一条新的前端友好的平仓提交点：**`POST /api/v1/positions/{id}/close`**，这会调用上述 `ClosePosition` 并将创建的平仓单结构体丢还给前端。
+
+#### [MODIFY] internal/http/orders.go
+- 新增查询指定订单明细路由：**`GET /api/v1/orders/{id}`**，方便前端页面或用户手动追踪刚刚发出的强平单或任何挂单。
+
+这套体系能够让系统的容错性变强，在操作层规避用户断头操作。随时可以开展编写任务。

--- a/internal/service/live_recovery.go
+++ b/internal/service/live_recovery.go
@@ -207,13 +207,11 @@ func (p *Platform) refreshLiveSessionPositionContext(session domain.LiveSession,
 				existingProposal := mapValue(state["lastExecutionProposal"])
 				existingReason := stringValue(existingProposal["reason"])
 
-				if existingReason != "sl-breached-fallback" && existingReason != "pt-breached-fallback" {
-					reason := "sl-breached-fallback"
-
+				if existingReason != "sl-breached-fallback" {
 					proposal := ExecutionProposal{
 						Action:            "risk-exit-fallback",
 						Role:              "exit",
-						Reason:            reason,
+						Reason:            "sl-breached-fallback",
 						Side:              exitSide,
 						Symbol:            stringValue(livePositionState["symbol"]),
 						Type:              "MARKET",
@@ -240,7 +238,7 @@ func (p *Platform) refreshLiveSessionPositionContext(session domain.LiveSession,
 					state["lastExecutionProposal"] = executionProposalMap
 					state["lastStrategyIntent"] = executionProposalMap
 					state["lastStrategyEvaluationStatus"] = "intent-ready"
-					markLiveWatchdogExitState(state, eventTime.UTC().Format(time.RFC3339), reason, "", "", "intent-ready")
+					markLiveWatchdogExitState(state, eventTime.UTC().Format(time.RFC3339), "sl-breached-fallback", "", "", "intent-ready")
 					state["positionRecoveryStatus"] = livePositionRecoveryStatusClosingPending
 				}
 			}
@@ -384,7 +382,7 @@ func isLiveWatchdogFallbackProposal(proposal map[string]any) bool {
 		return false
 	}
 	reason := strings.ToLower(strings.TrimSpace(stringValue(proposal["reason"])))
-	if reason != "sl-breached-fallback" && reason != "pt-breached-fallback" {
+	if reason != "sl-breached-fallback" {
 		return false
 	}
 	return strings.EqualFold(strings.TrimSpace(stringValue(proposal["signalKind"])), "recovery-watchdog")

--- a/internal/service/live_recovery.go
+++ b/internal/service/live_recovery.go
@@ -212,7 +212,7 @@ func (p *Platform) refreshLiveSessionPositionContext(session domain.LiveSession,
 			if breached {
 				existingProposal := mapValue(state["lastExecutionProposal"])
 				existingReason := stringValue(existingProposal["reason"])
-				
+
 				if existingReason != "sl-breached-fallback" && existingReason != "pt-breached-fallback" {
 					reason := "sl-breached-fallback"
 					if activeTrigger != stopLoss {

--- a/internal/service/live_recovery.go
+++ b/internal/service/live_recovery.go
@@ -196,25 +196,10 @@ func (p *Platform) refreshLiveSessionPositionContext(session domain.LiveSession,
 				exitSide = "BUY"
 			}
 
-			activeTrigger := stopLoss
-			if boolValue(livePositionState["protected"]) {
-				if side == "LONG" {
-					prevLow1 := parseFloatValue(livePositionState["prevLow1"])
-					if prevLow1 > activeTrigger {
-						activeTrigger = prevLow1
-					}
-				} else if side == "SHORT" {
-					prevHigh1 := parseFloatValue(livePositionState["prevHigh1"])
-					if prevHigh1 > 0 && prevHigh1 < activeTrigger {
-						activeTrigger = prevHigh1
-					}
-				}
-			}
-
 			breached := false
-			if side == "LONG" && marketPrice > 0 && marketPrice <= activeTrigger {
+			if side == "LONG" && marketPrice > 0 && marketPrice <= stopLoss {
 				breached = true
-			} else if side == "SHORT" && marketPrice > 0 && marketPrice >= activeTrigger {
+			} else if side == "SHORT" && marketPrice > 0 && marketPrice >= stopLoss {
 				breached = true
 			}
 
@@ -224,9 +209,6 @@ func (p *Platform) refreshLiveSessionPositionContext(session domain.LiveSession,
 
 				if existingReason != "sl-breached-fallback" && existingReason != "pt-breached-fallback" {
 					reason := "sl-breached-fallback"
-					if activeTrigger != stopLoss {
-						reason = "pt-breached-fallback"
-					}
 
 					proposal := ExecutionProposal{
 						Action:            "risk-exit-fallback",

--- a/internal/service/live_recovery.go
+++ b/internal/service/live_recovery.go
@@ -8,6 +8,8 @@ import (
 	"github.com/wuyaocheng/bktrader/internal/domain"
 )
 
+const livePositionRecoveryStatusClosingPending = "closing-pending"
+
 func (p *Platform) refreshLiveSessionProtectionState(session domain.LiveSession) (domain.LiveSession, error) {
 	account, err := p.store.GetAccount(session.AccountID)
 	if err != nil {
@@ -108,6 +110,7 @@ func (p *Platform) refreshLiveSessionPositionContext(session domain.LiveSession,
 	state["lastRecoveredPositionAt"] = eventTime.UTC().Format(time.RFC3339)
 	state["positionRecoverySource"] = firstNonEmpty(source, "live-position-refresh")
 	if !hasRealPositionContext && !hasVirtualPosition {
+		clearLiveWatchdogExitState(state)
 		clearLivePositionWatermarks(state)
 		delete(state, "livePositionState")
 		state["lastLivePositionState"] = map[string]any{}
@@ -119,6 +122,7 @@ func (p *Platform) refreshLiveSessionPositionContext(session domain.LiveSession,
 		return persistSnapshot(updated)
 	}
 	if hasVirtualPosition {
+		clearLiveWatchdogExitState(state)
 		state["positionRecoveryStatus"] = "monitoring-virtual-position"
 	}
 
@@ -173,7 +177,12 @@ func (p *Platform) refreshLiveSessionPositionContext(session domain.LiveSession,
 		state["positionRecoveryStatus"] = "protected-open-position"
 	}
 
-	if stringValue(state["positionRecoveryStatus"]) == "unprotected-open-position" {
+	watchdogExitPending := false
+	if hasRealPositionContext {
+		watchdogExitPending = syncLiveWatchdogExitState(state, eventTime)
+	}
+
+	if !watchdogExitPending && stringValue(state["positionRecoveryStatus"]) == "unprotected-open-position" {
 		stopLoss := parseFloatValue(livePositionState["stopLoss"])
 		entryPrice := parseFloatValue(livePositionState["entryPrice"])
 		quantity := math.Abs(parseFloatValue(positionSnapshot["quantity"]))
@@ -249,6 +258,8 @@ func (p *Platform) refreshLiveSessionPositionContext(session domain.LiveSession,
 					state["lastExecutionProposal"] = executionProposalMap
 					state["lastStrategyIntent"] = executionProposalMap
 					state["lastStrategyEvaluationStatus"] = "intent-ready"
+					markLiveWatchdogExitState(state, eventTime.UTC().Format(time.RFC3339), reason, "", "", "intent-ready")
+					state["positionRecoveryStatus"] = livePositionRecoveryStatusClosingPending
 				}
 			}
 		}
@@ -284,4 +295,144 @@ func firstMetadataOrEmpty(items []map[string]any) map[string]any {
 		return map[string]any{}
 	}
 	return cloneMetadata(items[0])
+}
+
+func syncLiveWatchdogExitState(state map[string]any, eventTime time.Time) bool {
+	if state == nil {
+		return false
+	}
+
+	pendingProposal := firstNonEmptyMapValue(state["lastExecutionProposal"], state["lastStrategyIntent"])
+	if isLiveWatchdogFallbackProposal(pendingProposal) {
+		markLiveWatchdogExitState(
+			state,
+			firstNonEmpty(stringValue(state["watchdogExitTriggeredAt"]), eventTime.UTC().Format(time.RFC3339)),
+			stringValue(pendingProposal["reason"]),
+			"",
+			"",
+			"intent-ready",
+		)
+		state["positionRecoveryStatus"] = livePositionRecoveryStatusClosingPending
+		return true
+	}
+
+	dispatchedIntent := cloneMetadata(mapValue(state["lastDispatchedIntent"]))
+	if isLiveWatchdogFallbackProposal(dispatchedIntent) {
+		orderID := stringValue(state["lastDispatchedOrderId"])
+		orderStatus := strings.ToUpper(strings.TrimSpace(firstNonEmpty(
+			stringValue(state["lastSyncedOrderStatus"]),
+			stringValue(state["lastDispatchedOrderStatus"]),
+		)))
+		if orderStatus == "" || !isTerminalOrderStatus(orderStatus) {
+			status := "dispatch-pending"
+			if orderID != "" {
+				status = "order-working"
+			}
+			markLiveWatchdogExitState(
+				state,
+				firstNonEmpty(stringValue(state["watchdogExitTriggeredAt"]), stringValue(state["lastDispatchedAt"]), eventTime.UTC().Format(time.RFC3339)),
+				stringValue(dispatchedIntent["reason"]),
+				orderID,
+				orderStatus,
+				status,
+			)
+			state["positionRecoveryStatus"] = livePositionRecoveryStatusClosingPending
+			return true
+		}
+		markLiveWatchdogExitState(
+			state,
+			firstNonEmpty(stringValue(state["watchdogExitTriggeredAt"]), stringValue(state["lastDispatchedAt"]), eventTime.UTC().Format(time.RFC3339)),
+			stringValue(dispatchedIntent["reason"]),
+			orderID,
+			orderStatus,
+			"retry-eligible",
+		)
+	}
+
+	if activeOrder, ok := activeLiveWatchdogExitOrder(metadataList(state["recoveredProtectionOrders"])); ok {
+		markLiveWatchdogExitState(
+			state,
+			firstNonEmpty(stringValue(state["watchdogExitTriggeredAt"]), stringValue(state["lastProtectionRecoveryAt"]), eventTime.UTC().Format(time.RFC3339)),
+			firstNonEmpty(stringValue(state["watchdogExitReason"]), "reduce-only-exit-order"),
+			liveWatchdogExitOrderID(activeOrder),
+			liveWatchdogExitOrderStatus(activeOrder),
+			"order-working",
+		)
+		state["positionRecoveryStatus"] = livePositionRecoveryStatusClosingPending
+		return true
+	}
+
+	return false
+}
+
+func markLiveWatchdogExitState(state map[string]any, triggeredAt, reason, orderID, orderStatus, status string) {
+	if state == nil {
+		return
+	}
+	if triggeredAt != "" {
+		state["watchdogExitTriggeredAt"] = triggeredAt
+	}
+	if reason != "" {
+		state["watchdogExitReason"] = reason
+	}
+	if orderID != "" {
+		state["watchdogExitOrderId"] = orderID
+	}
+	if orderStatus != "" {
+		state["watchdogExitOrderStatus"] = orderStatus
+	}
+	if status != "" {
+		state["watchdogExitStatus"] = status
+	}
+}
+
+func clearLiveWatchdogExitState(state map[string]any) {
+	if state == nil {
+		return
+	}
+	delete(state, "watchdogExitTriggeredAt")
+	delete(state, "watchdogExitReason")
+	delete(state, "watchdogExitOrderId")
+	delete(state, "watchdogExitOrderStatus")
+	delete(state, "watchdogExitStatus")
+}
+
+func isLiveWatchdogFallbackProposal(proposal map[string]any) bool {
+	if len(proposal) == 0 {
+		return false
+	}
+	reason := strings.ToLower(strings.TrimSpace(stringValue(proposal["reason"])))
+	if reason != "sl-breached-fallback" && reason != "pt-breached-fallback" {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(stringValue(proposal["signalKind"])), "recovery-watchdog")
+}
+
+func activeLiveWatchdogExitOrder(orders []map[string]any) (map[string]any, bool) {
+	for _, item := range orders {
+		order := cloneMetadata(item)
+		if len(order) == 0 {
+			continue
+		}
+		if !boolValue(order["reduceOnly"]) && !boolValue(order["closePosition"]) {
+			continue
+		}
+		if isStopProtectionOrder(order) || isTakeProfitProtectionOrder(order) {
+			continue
+		}
+		status := liveWatchdogExitOrderStatus(order)
+		if status != "" && isTerminalOrderStatus(status) {
+			continue
+		}
+		return order, true
+	}
+	return nil, false
+}
+
+func liveWatchdogExitOrderID(order map[string]any) string {
+	return firstNonEmpty(stringValue(order["orderId"]), stringValue(order["id"]), stringValue(order["clientOrderId"]))
+}
+
+func liveWatchdogExitOrderStatus(order map[string]any) string {
+	return strings.ToUpper(strings.TrimSpace(firstNonEmpty(stringValue(order["status"]), stringValue(order["orderStatus"]))))
 }

--- a/internal/service/live_recovery.go
+++ b/internal/service/live_recovery.go
@@ -172,6 +172,88 @@ func (p *Platform) refreshLiveSessionPositionContext(session domain.LiveSession,
 	if boolValue(livePositionState["protected"]) && len(metadataList(state["recoveredProtectionOrders"])) > 0 {
 		state["positionRecoveryStatus"] = "protected-open-position"
 	}
+
+	if stringValue(state["positionRecoveryStatus"]) == "unprotected-open-position" {
+		stopLoss := parseFloatValue(livePositionState["stopLoss"])
+		entryPrice := parseFloatValue(livePositionState["entryPrice"])
+		quantity := math.Abs(parseFloatValue(positionSnapshot["quantity"]))
+		side := strings.ToUpper(strings.TrimSpace(stringValue(livePositionState["side"])))
+
+		if quantity > 0 && stopLoss > 0 && entryPrice > 0 && side != "" {
+			var exitSide string
+			if side == "LONG" {
+				exitSide = "SELL"
+			} else {
+				exitSide = "BUY"
+			}
+
+			activeTrigger := stopLoss
+			if boolValue(livePositionState["protected"]) {
+				if side == "LONG" {
+					prevLow1 := parseFloatValue(livePositionState["prevLow1"])
+					if prevLow1 > activeTrigger {
+						activeTrigger = prevLow1
+					}
+				} else if side == "SHORT" {
+					prevHigh1 := parseFloatValue(livePositionState["prevHigh1"])
+					if prevHigh1 > 0 && prevHigh1 < activeTrigger {
+						activeTrigger = prevHigh1
+					}
+				}
+			}
+
+			breached := false
+			if side == "LONG" && marketPrice > 0 && marketPrice <= activeTrigger {
+				breached = true
+			} else if side == "SHORT" && marketPrice > 0 && marketPrice >= activeTrigger {
+				breached = true
+			}
+
+			if breached {
+				existingProposal := mapValue(state["lastExecutionProposal"])
+				existingReason := stringValue(existingProposal["reason"])
+				
+				if existingReason != "sl-breached-fallback" && existingReason != "pt-breached-fallback" {
+					reason := "sl-breached-fallback"
+					if activeTrigger != stopLoss {
+						reason = "pt-breached-fallback"
+					}
+
+					proposal := ExecutionProposal{
+						Action:            "risk-exit-fallback",
+						Role:              "exit",
+						Reason:            reason,
+						Side:              exitSide,
+						Symbol:            stringValue(livePositionState["symbol"]),
+						Type:              "MARKET",
+						Quantity:          quantity,
+						PriceHint:         marketPrice,
+						PriceSource:       "fallback-watchdog",
+						TimeInForce:       "GTC",
+						PostOnly:          false,
+						ReduceOnly:        true,
+						SignalKind:        "recovery-watchdog",
+						DecisionState:     "unprotected",
+						SignalBarStateKey: "",
+						SpreadBps:         0,
+						BestBid:           0,
+						BestAsk:           0,
+						ExecutionStrategy: "book-aware-v1",
+						Status:            "dispatchable",
+						Metadata: map[string]any{
+							"executionDecision": "direct-dispatch",
+							"livePositionState": cloneMetadata(livePositionState),
+						},
+					}
+					executionProposalMap := executionProposalToMap(proposal)
+					state["lastExecutionProposal"] = executionProposalMap
+					state["lastStrategyIntent"] = executionProposalMap
+					state["lastStrategyEvaluationStatus"] = "intent-ready"
+				}
+			}
+		}
+	}
+
 	updated, updateErr := p.store.UpdateLiveSessionState(refreshed.ID, state)
 	if updateErr != nil {
 		return domain.LiveSession{}, updateErr

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -2577,6 +2577,30 @@ func TestEvaluateLiveSignalDecisionDoesNotMutateOriginalSessionState(t *testing.
 	}
 }
 
+func testLiveRecoverySignalBarStates(symbol string, closePrice float64) map[string]any {
+	return map[string]any{
+		signalBindingMatchKey("binance-kline", "signal", symbol): map[string]any{
+			"symbol":    symbol,
+			"timeframe": "1d",
+			"ma20":      68000.0,
+			"atr14":     900.0,
+			"current": map[string]any{
+				"close": closePrice,
+				"high":  closePrice + 100.0,
+				"low":   closePrice - 100.0,
+			},
+			"prevBar1": map[string]any{
+				"high": 69800.0,
+				"low":  68800.0,
+			},
+			"prevBar2": map[string]any{
+				"high": 69700.0,
+				"low":  68700.0,
+			},
+		},
+	}
+}
+
 func TestRefreshLiveSessionPositionContextRebuildsLivePositionState(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
 	account, err := platform.store.GetAccount("live-main")
@@ -2659,6 +2683,149 @@ func TestRefreshLiveSessionPositionContextRebuildsLivePositionState(t *testing.T
 	}
 	if got := stringValue(updated.State["positionRecoveryStatus"]); got != "protected-open-position" {
 		t.Fatalf("expected protected-open-position, got %s", got)
+	}
+}
+
+func TestRefreshLiveSessionPositionContextDoesNotRetriggerWatchdogWhileExitOrderWorking(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	if _, err := platform.store.SavePosition(domain.Position{
+		AccountID:         "live-main",
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "LONG",
+		Quantity:          0.002,
+		EntryPrice:        69000,
+		MarkPrice:         68900,
+	}); err != nil {
+		t.Fatalf("save position failed: %v", err)
+	}
+
+	session, err := platform.CreateLiveSession("live-main", "strategy-bk-1d", map[string]any{
+		"symbol":          "BTCUSDT",
+		"signalTimeframe": "1d",
+	})
+	if err != nil {
+		t.Fatalf("create live session failed: %v", err)
+	}
+	state := cloneMetadata(session.State)
+	state["lastStrategyEvaluationSignalBarStates"] = testLiveRecoverySignalBarStates("BTCUSDT", 68900.0)
+	session, err = platform.store.UpdateLiveSessionState(session.ID, state)
+	if err != nil {
+		t.Fatalf("update live session state failed: %v", err)
+	}
+
+	firstRefreshAt := time.Date(2026, 4, 17, 3, 0, 0, 0, time.UTC)
+	updated, err := platform.refreshLiveSessionPositionContext(session, firstRefreshAt, "test-refresh")
+	if err != nil {
+		t.Fatalf("refresh live session position context failed: %v", err)
+	}
+	proposal := mapValue(updated.State["lastExecutionProposal"])
+	if !isLiveWatchdogFallbackProposal(proposal) {
+		t.Fatalf("expected watchdog fallback proposal, got %+v", proposal)
+	}
+	if got := stringValue(updated.State["watchdogExitStatus"]); got != "intent-ready" {
+		t.Fatalf("expected watchdog intent-ready status, got %s", got)
+	}
+
+	followupState := cloneMetadata(updated.State)
+	delete(followupState, "lastExecutionProposal")
+	delete(followupState, "lastStrategyIntent")
+	followupState["lastDispatchedIntent"] = cloneMetadata(proposal)
+	followupState["lastDispatchedAt"] = firstRefreshAt.Add(time.Second).Format(time.RFC3339)
+	followupState["lastDispatchedOrderId"] = "watchdog-order-1"
+	followupState["lastDispatchedOrderStatus"] = "NEW"
+	session, err = platform.store.UpdateLiveSessionState(session.ID, followupState)
+	if err != nil {
+		t.Fatalf("update live session state failed: %v", err)
+	}
+
+	refreshed, err := platform.refreshLiveSessionPositionContext(session, firstRefreshAt.Add(2*time.Second), "test-refresh")
+	if err != nil {
+		t.Fatalf("second refresh live session position context failed: %v", err)
+	}
+	if proposal := mapValue(refreshed.State["lastExecutionProposal"]); len(proposal) != 0 {
+		t.Fatalf("expected no duplicate watchdog proposal while exit order is working, got %+v", proposal)
+	}
+	if got := stringValue(refreshed.State["positionRecoveryStatus"]); got != livePositionRecoveryStatusClosingPending {
+		t.Fatalf("expected %s recovery status, got %s", livePositionRecoveryStatusClosingPending, got)
+	}
+	if got := stringValue(refreshed.State["watchdogExitOrderId"]); got != "watchdog-order-1" {
+		t.Fatalf("expected watchdog order id to be preserved, got %s", got)
+	}
+	if got := stringValue(refreshed.State["watchdogExitOrderStatus"]); got != "NEW" {
+		t.Fatalf("expected watchdog order status NEW, got %s", got)
+	}
+	if got := stringValue(refreshed.State["watchdogExitStatus"]); got != "order-working" {
+		t.Fatalf("expected watchdog order-working status, got %s", got)
+	}
+}
+
+func TestRefreshLiveSessionPositionContextTracksActiveReduceOnlyExitOrder(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	account, err := platform.store.GetAccount("live-main")
+	if err != nil {
+		t.Fatalf("get account failed: %v", err)
+	}
+	account.Metadata = cloneMetadata(account.Metadata)
+	account.Metadata["liveSyncSnapshot"] = map[string]any{
+		"openOrders": []map[string]any{
+			{
+				"symbol":     "BTCUSDT",
+				"origType":   "MARKET",
+				"type":       "MARKET",
+				"status":     "NEW",
+				"reduceOnly": true,
+				"orderId":    "watchdog-order-2",
+			},
+		},
+	}
+	if _, err := platform.store.UpdateAccount(account); err != nil {
+		t.Fatalf("update account failed: %v", err)
+	}
+	if _, err := platform.store.SavePosition(domain.Position{
+		AccountID:         "live-main",
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "LONG",
+		Quantity:          0.002,
+		EntryPrice:        69000,
+		MarkPrice:         68900,
+	}); err != nil {
+		t.Fatalf("save position failed: %v", err)
+	}
+
+	session, err := platform.CreateLiveSession("live-main", "strategy-bk-1d", map[string]any{
+		"symbol":          "BTCUSDT",
+		"signalTimeframe": "1d",
+	})
+	if err != nil {
+		t.Fatalf("create live session failed: %v", err)
+	}
+	state := cloneMetadata(session.State)
+	state["lastStrategyEvaluationSignalBarStates"] = testLiveRecoverySignalBarStates("BTCUSDT", 68900.0)
+	session, err = platform.store.UpdateLiveSessionState(session.ID, state)
+	if err != nil {
+		t.Fatalf("update live session state failed: %v", err)
+	}
+
+	updated, err := platform.refreshLiveSessionPositionContext(session, time.Date(2026, 4, 17, 4, 0, 0, 0, time.UTC), "test-refresh")
+	if err != nil {
+		t.Fatalf("refresh live session position context failed: %v", err)
+	}
+	if proposal := mapValue(updated.State["lastExecutionProposal"]); len(proposal) != 0 {
+		t.Fatalf("expected active reduce-only exit order to suppress duplicate watchdog proposal, got %+v", proposal)
+	}
+	if got := stringValue(updated.State["positionRecoveryStatus"]); got != livePositionRecoveryStatusClosingPending {
+		t.Fatalf("expected %s recovery status, got %s", livePositionRecoveryStatusClosingPending, got)
+	}
+	if got := stringValue(updated.State["watchdogExitOrderId"]); got != "watchdog-order-2" {
+		t.Fatalf("expected recovered watchdog order id, got %s", got)
+	}
+	if got := stringValue(updated.State["watchdogExitOrderStatus"]); got != "NEW" {
+		t.Fatalf("expected recovered watchdog order status NEW, got %s", got)
+	}
+	if got := stringValue(updated.State["watchdogExitStatus"]); got != "order-working" {
+		t.Fatalf("expected watchdog order-working status, got %s", got)
 	}
 }
 

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -2686,6 +2686,262 @@ func TestRefreshLiveSessionPositionContextRebuildsLivePositionState(t *testing.T
 	}
 }
 
+func TestRefreshLiveSessionPositionContextGeneratesLongWatchdogFallbackOnStopLossBreach(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	if _, err := platform.store.SavePosition(domain.Position{
+		AccountID:         "live-main",
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "LONG",
+		Quantity:          0.002,
+		EntryPrice:        69000,
+		MarkPrice:         68900,
+	}); err != nil {
+		t.Fatalf("save position failed: %v", err)
+	}
+
+	session, err := platform.CreateLiveSession("live-main", "strategy-bk-1d", map[string]any{
+		"symbol":          "BTCUSDT",
+		"signalTimeframe": "1d",
+	})
+	if err != nil {
+		t.Fatalf("create live session failed: %v", err)
+	}
+	state := cloneMetadata(session.State)
+	state["lastStrategyEvaluationSignalBarStates"] = testLiveRecoverySignalBarStates("BTCUSDT", 68900.0)
+	session, err = platform.store.UpdateLiveSessionState(session.ID, state)
+	if err != nil {
+		t.Fatalf("update live session state failed: %v", err)
+	}
+
+	updated, err := platform.refreshLiveSessionPositionContext(session, time.Date(2026, 4, 17, 2, 0, 0, 0, time.UTC), "test-refresh")
+	if err != nil {
+		t.Fatalf("refresh live session position context failed: %v", err)
+	}
+	proposal := executionProposalFromMap(mapValue(updated.State["lastExecutionProposal"]))
+	if proposal.Reason != "sl-breached-fallback" {
+		t.Fatalf("expected sl-breached-fallback reason, got %s", proposal.Reason)
+	}
+	if proposal.Side != "SELL" {
+		t.Fatalf("expected SELL exit side, got %s", proposal.Side)
+	}
+	if proposal.Type != "MARKET" || !proposal.ReduceOnly {
+		t.Fatalf("expected reduce-only MARKET fallback proposal, got type=%s reduceOnly=%t", proposal.Type, proposal.ReduceOnly)
+	}
+	if got := stringValue(updated.State["positionRecoveryStatus"]); got != livePositionRecoveryStatusClosingPending {
+		t.Fatalf("expected %s recovery status, got %s", livePositionRecoveryStatusClosingPending, got)
+	}
+}
+
+func TestRefreshLiveSessionPositionContextGeneratesShortWatchdogFallbackOnStopLossBreach(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	if _, err := platform.store.SavePosition(domain.Position{
+		AccountID:         "live-main",
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "SHORT",
+		Quantity:          0.002,
+		EntryPrice:        69000,
+		MarkPrice:         69100,
+	}); err != nil {
+		t.Fatalf("save position failed: %v", err)
+	}
+
+	session, err := platform.CreateLiveSession("live-main", "strategy-bk-1d", map[string]any{
+		"symbol":          "BTCUSDT",
+		"signalTimeframe": "1d",
+	})
+	if err != nil {
+		t.Fatalf("create live session failed: %v", err)
+	}
+	state := cloneMetadata(session.State)
+	state["lastStrategyEvaluationSignalBarStates"] = testLiveRecoverySignalBarStates("BTCUSDT", 69100.0)
+	session, err = platform.store.UpdateLiveSessionState(session.ID, state)
+	if err != nil {
+		t.Fatalf("update live session state failed: %v", err)
+	}
+
+	updated, err := platform.refreshLiveSessionPositionContext(session, time.Date(2026, 4, 17, 2, 5, 0, 0, time.UTC), "test-refresh")
+	if err != nil {
+		t.Fatalf("refresh live session position context failed: %v", err)
+	}
+	proposal := executionProposalFromMap(mapValue(updated.State["lastExecutionProposal"]))
+	if proposal.Reason != "sl-breached-fallback" {
+		t.Fatalf("expected sl-breached-fallback reason, got %s", proposal.Reason)
+	}
+	if proposal.Side != "BUY" {
+		t.Fatalf("expected BUY exit side, got %s", proposal.Side)
+	}
+	if proposal.Type != "MARKET" || !proposal.ReduceOnly {
+		t.Fatalf("expected reduce-only MARKET fallback proposal, got type=%s reduceOnly=%t", proposal.Type, proposal.ReduceOnly)
+	}
+}
+
+func TestRefreshLiveSessionPositionContextDoesNotGenerateWatchdogFallbackWithoutBreach(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	if _, err := platform.store.SavePosition(domain.Position{
+		AccountID:         "live-main",
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "LONG",
+		Quantity:          0.002,
+		EntryPrice:        69000,
+		MarkPrice:         68980,
+	}); err != nil {
+		t.Fatalf("save position failed: %v", err)
+	}
+
+	session, err := platform.CreateLiveSession("live-main", "strategy-bk-1d", map[string]any{
+		"symbol":          "BTCUSDT",
+		"signalTimeframe": "1d",
+	})
+	if err != nil {
+		t.Fatalf("create live session failed: %v", err)
+	}
+	state := cloneMetadata(session.State)
+	state["lastStrategyEvaluationSignalBarStates"] = testLiveRecoverySignalBarStates("BTCUSDT", 68980.0)
+	session, err = platform.store.UpdateLiveSessionState(session.ID, state)
+	if err != nil {
+		t.Fatalf("update live session state failed: %v", err)
+	}
+
+	updated, err := platform.refreshLiveSessionPositionContext(session, time.Date(2026, 4, 17, 2, 10, 0, 0, time.UTC), "test-refresh")
+	if err != nil {
+		t.Fatalf("refresh live session position context failed: %v", err)
+	}
+	if proposal := mapValue(updated.State["lastExecutionProposal"]); len(proposal) != 0 {
+		t.Fatalf("expected non-breach refresh to stay proposal-free, got %+v", proposal)
+	}
+	if got := stringValue(updated.State["positionRecoveryStatus"]); got != "unprotected-open-position" {
+		t.Fatalf("expected unprotected-open-position to remain, got %s", got)
+	}
+}
+
+func TestRefreshLiveSessionPositionContextKeepsExistingWatchdogFallbackIntent(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	if _, err := platform.store.SavePosition(domain.Position{
+		AccountID:         "live-main",
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "LONG",
+		Quantity:          0.002,
+		EntryPrice:        69000,
+		MarkPrice:         68900,
+	}); err != nil {
+		t.Fatalf("save position failed: %v", err)
+	}
+
+	session, err := platform.CreateLiveSession("live-main", "strategy-bk-1d", map[string]any{
+		"symbol":          "BTCUSDT",
+		"signalTimeframe": "1d",
+	})
+	if err != nil {
+		t.Fatalf("create live session failed: %v", err)
+	}
+	state := cloneMetadata(session.State)
+	state["lastStrategyEvaluationSignalBarStates"] = testLiveRecoverySignalBarStates("BTCUSDT", 68900.0)
+	existingProposal := executionProposalToMap(ExecutionProposal{
+		Action:            "risk-exit-fallback",
+		Role:              "exit",
+		Reason:            "sl-breached-fallback",
+		Side:              "SELL",
+		Symbol:            "BTCUSDT",
+		Type:              "MARKET",
+		Quantity:          0.002,
+		PriceHint:         68888.0,
+		PriceSource:       "fallback-watchdog",
+		TimeInForce:       "GTC",
+		ReduceOnly:        true,
+		SignalKind:        "recovery-watchdog",
+		DecisionState:     "unprotected",
+		ExecutionStrategy: "book-aware-v1",
+		Status:            "dispatchable",
+		Metadata: map[string]any{
+			"existingMarker": "keep-me",
+		},
+	})
+	state["lastExecutionProposal"] = existingProposal
+	state["lastStrategyIntent"] = cloneMetadata(existingProposal)
+	session, err = platform.store.UpdateLiveSessionState(session.ID, state)
+	if err != nil {
+		t.Fatalf("update live session state failed: %v", err)
+	}
+
+	updated, err := platform.refreshLiveSessionPositionContext(session, time.Date(2026, 4, 17, 2, 15, 0, 0, time.UTC), "test-refresh")
+	if err != nil {
+		t.Fatalf("refresh live session position context failed: %v", err)
+	}
+	proposal := mapValue(updated.State["lastExecutionProposal"])
+	if got := stringValue(mapValue(proposal["metadata"])["existingMarker"]); got != "keep-me" {
+		t.Fatalf("expected existing watchdog intent to stay in place, got marker %s", got)
+	}
+	if got := parseFloatValue(proposal["priceHint"]); got != 68888.0 {
+		t.Fatalf("expected existing watchdog intent priceHint to remain untouched, got %v", got)
+	}
+	if got := stringValue(updated.State["watchdogExitStatus"]); got != "intent-ready" {
+		t.Fatalf("expected intent-ready watchdog status, got %s", got)
+	}
+}
+
+func TestRefreshLiveSessionPositionContextDoesNotCrossProtectedBoundary(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	account, err := platform.store.GetAccount("live-main")
+	if err != nil {
+		t.Fatalf("get account failed: %v", err)
+	}
+	account.Metadata = cloneMetadata(account.Metadata)
+	account.Metadata["liveSyncSnapshot"] = map[string]any{
+		"openOrders": []map[string]any{
+			{
+				"symbol":        "BTCUSDT",
+				"origType":      "STOP_MARKET",
+				"reduceOnly":    true,
+				"closePosition": true,
+				"status":        "NEW",
+			},
+		},
+	}
+	if _, err := platform.store.UpdateAccount(account); err != nil {
+		t.Fatalf("update account failed: %v", err)
+	}
+	if _, err := platform.store.SavePosition(domain.Position{
+		AccountID:         "live-main",
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "LONG",
+		Quantity:          0.002,
+		EntryPrice:        69000,
+		MarkPrice:         68900,
+	}); err != nil {
+		t.Fatalf("save position failed: %v", err)
+	}
+
+	session, err := platform.CreateLiveSession("live-main", "strategy-bk-1d", map[string]any{
+		"symbol":          "BTCUSDT",
+		"signalTimeframe": "1d",
+	})
+	if err != nil {
+		t.Fatalf("create live session failed: %v", err)
+	}
+	state := cloneMetadata(session.State)
+	state["lastStrategyEvaluationSignalBarStates"] = testLiveRecoverySignalBarStates("BTCUSDT", 68900.0)
+	session, err = platform.store.UpdateLiveSessionState(session.ID, state)
+	if err != nil {
+		t.Fatalf("update live session state failed: %v", err)
+	}
+
+	updated, err := platform.refreshLiveSessionPositionContext(session, time.Date(2026, 4, 17, 2, 20, 0, 0, time.UTC), "test-refresh")
+	if err != nil {
+		t.Fatalf("refresh live session position context failed: %v", err)
+	}
+	if proposal := mapValue(updated.State["lastExecutionProposal"]); len(proposal) != 0 {
+		t.Fatalf("expected protected-open-position to suppress watchdog fallback, got %+v", proposal)
+	}
+	if got := stringValue(updated.State["positionRecoveryStatus"]); got != "protected-open-position" {
+		t.Fatalf("expected protected-open-position, got %s", got)
+	}
+}
+
 func TestRefreshLiveSessionPositionContextDoesNotRetriggerWatchdogWhileExitOrderWorking(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
 	if _, err := platform.store.SavePosition(domain.Position{


### PR DESCRIPTION
## 目的
为无保护头寸 (unprotected open positions) 引入 **stopLoss-only** 的「静默看门狗 (Silent Watchdog)」fallback，并把后续 Session 联防 / 手动平仓接管方案单独保留为规划文档。

## 本次已实现范围
1. 当恢复出的无保护持仓发生 `stopLoss` breach 时，生成 `reduceOnly + MARKET` 的 watchdog fallback intent。
2. 增加 watchdog 幂等/防重状态，避免在 pending proposal、已 dispatch intent、或已有 active reduce-only exit order 时重复灌出 fallback intent。
3. 补充回归测试，覆盖 LONG/SHORT breach、非 breach、不重复生成、已有 active exit order 抑制重复 proposal、以及 protected/unprotected 状态边界。

## 本次未实现但已规划
- Session 联防 / stop-delete 拦截
- force close / 手动平仓接管
- 更完整的 order detail / 后续执行面扩展

规划文档见：`docs/20260417-session-protection-and-manual-close-plan.md`

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [x] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？ -> 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？ -> 无
- [x] DB migration 是否具备向下兼容幂等性？ -> 不涉及
- [x] 配置字段有没有无意被混改？ -> 无

## 验证方式与测试证据
- [x] `go test ./...`
- [x] `go build ./cmd/platform-api`
- [x] `go build ./cmd/db-migrate`
- [x] watchdog fallback 回归测试：LONG/SHORT breach、non-breach、dedup、active exit order、protected/unprotected boundary