### PR TITLE
Add session safety locks and manual close APIs

### DIFF
--- a/internal/domain/models.go
+++ b/internal/domain/models.go
@@ -177,6 +177,8 @@ type Order struct {
 	Status            string         `json:"status"` // NEW / FILLED / CANCELLED
 	Quantity          float64        `json:"quantity"`
 	Price             float64        `json:"price"`
+	ReduceOnly        bool           `json:"reduceOnly,omitempty"`
+	ClosePosition     bool           `json:"closePosition,omitempty"`
 	Metadata          map[string]any `json:"metadata"` // 扩展信息（执行模式、来源等）
 	CreatedAt         time.Time      `json:"createdAt"`
 }

--- a/internal/domain/order_flags.go
+++ b/internal/domain/order_flags.go
@@ -1,0 +1,43 @@
+package domain
+
+import "strings"
+
+func (o Order) EffectiveReduceOnly() bool {
+	return o.ReduceOnly || orderFlagValue(o.Metadata["reduceOnly"])
+}
+
+func (o Order) EffectiveClosePosition() bool {
+	return o.ClosePosition || orderFlagValue(o.Metadata["closePosition"])
+}
+
+func (o *Order) NormalizeExecutionFlags() {
+	if o == nil {
+		return
+	}
+	if o.Metadata == nil {
+		o.Metadata = map[string]any{}
+	}
+	if orderFlagValue(o.Metadata["reduceOnly"]) {
+		o.ReduceOnly = true
+	}
+	if orderFlagValue(o.Metadata["closePosition"]) {
+		o.ClosePosition = true
+	}
+	if o.ReduceOnly {
+		o.Metadata["reduceOnly"] = true
+	}
+	if o.ClosePosition {
+		o.Metadata["closePosition"] = true
+	}
+}
+
+func orderFlagValue(value any) bool {
+	switch typed := value.(type) {
+	case bool:
+		return typed
+	case string:
+		return strings.EqualFold(strings.TrimSpace(typed), "true")
+	default:
+		return false
+	}
+}

--- a/internal/http/accounts.go
+++ b/internal/http/accounts.go
@@ -237,4 +237,23 @@ func registerAccountRoutes(mux *http.ServeMux, platform *service.Platform) {
 		writeJSON(w, http.StatusOK, items)
 	})
 
+	mux.HandleFunc("/api/v1/positions/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		path := strings.TrimPrefix(r.URL.Path, "/api/v1/positions/")
+		parts := strings.Split(strings.Trim(path, "/"), "/")
+		if len(parts) != 2 || parts[1] != "close" {
+			writeError(w, http.StatusNotFound, "position route not found")
+			return
+		}
+		item, err := platform.ClosePosition(parts[0])
+		if err != nil {
+			writeError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		writeJSON(w, http.StatusOK, item)
+	})
+
 }

--- a/internal/http/live.go
+++ b/internal/http/live.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"errors"
 	"net/http"
 	"strings"
 
@@ -427,7 +428,11 @@ func registerLiveRoutes(mux *http.ServeMux, platform *service.Platform) {
 				writeError(w, http.StatusNotFound, "live session route not found")
 				return
 			}
-			if err := platform.DeleteLiveSession(parts[0]); err != nil {
+			if err := platform.DeleteLiveSessionWithForce(parts[0], queryFlagEnabled(r, "force")); err != nil {
+				if errors.Is(err, service.ErrActivePositionsOrOrders) {
+					writeError(w, http.StatusBadRequest, err.Error())
+					return
+				}
 				writeError(w, http.StatusBadRequest, err.Error())
 				return
 			}
@@ -454,8 +459,12 @@ func registerLiveRoutes(mux *http.ServeMux, platform *service.Platform) {
 			}
 			writeJSON(w, http.StatusOK, item)
 		case "stop":
-			item, err := platform.StopLiveSession(sessionID)
+			item, err := platform.StopLiveSessionWithForce(sessionID, queryFlagEnabled(r, "force"))
 			if err != nil {
+				if errors.Is(err, service.ErrActivePositionsOrOrders) {
+					writeError(w, http.StatusBadRequest, err.Error())
+					return
+				}
 				writeError(w, http.StatusInternalServerError, err.Error())
 				return
 			}

--- a/internal/http/orders.go
+++ b/internal/http/orders.go
@@ -29,6 +29,8 @@ func registerOrderRoutes(mux *http.ServeMux, platform *service.Platform) {
 				Type              string         `json:"type"`
 				Quantity          float64        `json:"quantity"`
 				Price             float64        `json:"price"`
+				ReduceOnly        bool           `json:"reduceOnly"`
+				ClosePosition     bool           `json:"closePosition"`
 				Metadata          map[string]any `json:"metadata"`
 			}
 			if err := decodeJSON(r, &payload); err != nil {
@@ -52,6 +54,8 @@ func registerOrderRoutes(mux *http.ServeMux, platform *service.Platform) {
 				Type:              payload.Type,
 				Quantity:          payload.Quantity,
 				Price:             payload.Price,
+				ReduceOnly:        payload.ReduceOnly,
+				ClosePosition:     payload.ClosePosition,
 				Metadata:          payload.Metadata,
 			}
 			item, err := platform.CreateOrder(order)

--- a/internal/http/orders.go
+++ b/internal/http/orders.go
@@ -66,13 +66,26 @@ func registerOrderRoutes(mux *http.ServeMux, platform *service.Platform) {
 	})
 
 	mux.HandleFunc("/api/v1/orders/", func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost {
-			w.WriteHeader(http.StatusMethodNotAllowed)
-			return
-		}
 		path := strings.TrimPrefix(r.URL.Path, "/api/v1/orders/")
 		parts := strings.Split(strings.Trim(path, "/"), "/")
-		if len(parts) != 2 {
+		if len(parts) == 1 {
+			if r.Method != http.MethodGet {
+				w.WriteHeader(http.StatusMethodNotAllowed)
+				return
+			}
+			item, err := platform.GetOrder(parts[0])
+			if err != nil {
+				writeError(w, http.StatusNotFound, err.Error())
+				return
+			}
+			writeJSON(w, http.StatusOK, item)
+			return
+		}
+		if r.Method != http.MethodPost || len(parts) != 2 {
+			if r.Method != http.MethodPost {
+				w.WriteHeader(http.StatusMethodNotAllowed)
+				return
+			}
 			writeError(w, http.StatusNotFound, "order route not found")
 			return
 		}

--- a/internal/http/router.go
+++ b/internal/http/router.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"net/http"
 	"runtime/debug"
+	"strconv"
 	"time"
 
 	"github.com/wuyaocheng/bktrader/internal/config"
@@ -205,4 +206,13 @@ func writeError(w http.ResponseWriter, status int, message string) {
 	writeJSON(w, status, map[string]any{
 		"error": message,
 	})
+}
+
+func queryFlagEnabled(r *http.Request, key string) bool {
+	raw := r.URL.Query().Get(key)
+	if raw == "" {
+		return false
+	}
+	enabled, err := strconv.ParseBool(raw)
+	return err == nil && enabled
 }

--- a/internal/http/session_safety_test.go
+++ b/internal/http/session_safety_test.go
@@ -1,0 +1,106 @@
+package http
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/wuyaocheng/bktrader/internal/domain"
+	"github.com/wuyaocheng/bktrader/internal/service"
+	"github.com/wuyaocheng/bktrader/internal/store/memory"
+)
+
+func TestLiveSessionStopRouteRespectsForceQuery(t *testing.T) {
+	store := memory.NewStore()
+	platform := service.NewPlatform(store)
+	if _, err := store.SavePosition(domain.Position{
+		AccountID:         "live-main",
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "LONG",
+		Quantity:          0.002,
+		EntryPrice:        69000,
+		MarkPrice:         69100,
+	}); err != nil {
+		t.Fatalf("save position failed: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	registerLiveRoutes(mux, platform)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/live/sessions/live-session-main/stop", nil)
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for blocked stop, got %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodPost, "/api/v1/live/sessions/live-session-main/stop?force=true", nil)
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 for forced stop, got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestPositionCloseAndOrderDetailRoutes(t *testing.T) {
+	store := memory.NewStore()
+	platform := service.NewPlatform(store)
+	account, err := platform.CreateAccount("Paper HTTP", "PAPER", "binance-futures")
+	if err != nil {
+		t.Fatalf("create account failed: %v", err)
+	}
+	position, err := store.SavePosition(domain.Position{
+		AccountID:         account.ID,
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "LONG",
+		Quantity:          0.1,
+		EntryPrice:        68000,
+		MarkPrice:         68100,
+	})
+	if err != nil {
+		t.Fatalf("save position failed: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	registerAccountRoutes(mux, platform)
+	registerOrderRoutes(mux, platform)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/positions/"+position.ID+"/close", nil)
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 for position close, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	var closed domain.Order
+	if err := json.NewDecoder(rec.Body).Decode(&closed); err != nil {
+		t.Fatalf("decode close position response failed: %v", err)
+	}
+	if closed.ID == "" {
+		t.Fatal("expected created close order id")
+	}
+	if !serviceBool(closed.Metadata["reduceOnly"]) {
+		t.Fatal("expected reduceOnly metadata on close order")
+	}
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/orders/"+closed.ID, nil)
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 for order detail, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	var detail domain.Order
+	if err := json.NewDecoder(rec.Body).Decode(&detail); err != nil {
+		t.Fatalf("decode order detail response failed: %v", err)
+	}
+	if detail.ID != closed.ID {
+		t.Fatalf("expected fetched order %s, got %s", closed.ID, detail.ID)
+	}
+}
+
+func serviceBool(value any) bool {
+	typed, ok := value.(bool)
+	return ok && typed
+}

--- a/internal/http/signals.go
+++ b/internal/http/signals.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"errors"
 	"net/http"
 	"strings"
 
@@ -277,7 +278,11 @@ func registerSignalRoutes(mux *http.ServeMux, platform *service.Platform) {
 				}
 				writeJSON(w, http.StatusOK, item)
 			case http.MethodDelete:
-				if err := platform.DeleteSignalRuntimeSession(parts[0]); err != nil {
+				if err := platform.DeleteSignalRuntimeSessionWithForce(parts[0], queryFlagEnabled(r, "force")); err != nil {
+					if errors.Is(err, service.ErrActivePositionsOrOrders) {
+						writeError(w, http.StatusBadRequest, err.Error())
+						return
+					}
 					writeError(w, http.StatusNotFound, err.Error())
 					return
 				}
@@ -306,7 +311,7 @@ func registerSignalRoutes(mux *http.ServeMux, platform *service.Platform) {
 			}
 			writeJSON(w, http.StatusOK, item)
 		case "stop":
-			item, err := platform.StopSignalRuntimeSession(sessionID)
+			item, err := platform.StopSignalRuntimeSessionWithForce(sessionID, queryFlagEnabled(r, "force"))
 			if err != nil {
 				writeError(w, http.StatusBadRequest, err.Error())
 				return

--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -50,7 +50,20 @@ func (p *Platform) ListLiveSessions() ([]domain.LiveSession, error) {
 }
 
 func (p *Platform) DeleteLiveSession(sessionID string) error {
+	return p.DeleteLiveSessionWithForce(sessionID, false)
+}
+
+func (p *Platform) DeleteLiveSessionWithForce(sessionID string, force bool) error {
 	p.logger("service.live", "session_id", sessionID).Info("deleting live session")
+	session, err := p.store.GetLiveSession(sessionID)
+	if err != nil {
+		return err
+	}
+	if !force {
+		if err := p.ensureNoActivePositionsOrOrders(session.AccountID, session.StrategyID); err != nil {
+			return err
+		}
+	}
 	return p.store.DeleteLiveSession(sessionID)
 }
 
@@ -909,7 +922,22 @@ func (p *Platform) resolveLivePositionStrategyVersionID(accountID, symbol string
 }
 
 func (p *Platform) StopLiveSession(sessionID string) (domain.LiveSession, error) {
+	return p.StopLiveSessionWithForce(sessionID, false)
+}
+
+func (p *Platform) StopLiveSessionWithForce(sessionID string, force bool) (domain.LiveSession, error) {
 	logger := p.logger("service.live", "session_id", sessionID)
+	existing, err := p.store.GetLiveSession(sessionID)
+	if err != nil {
+		logger.Error("load live session before stop failed", "error", err)
+		return domain.LiveSession{}, err
+	}
+	if !force {
+		if err := p.ensureNoActivePositionsOrOrders(existing.AccountID, existing.StrategyID); err != nil {
+			logger.Warn("stop live session blocked by active positions or orders", "error", err)
+			return domain.LiveSession{}, err
+		}
+	}
 	session, err := p.store.UpdateLiveSessionStatus(sessionID, "STOPPED")
 	if err != nil {
 		logger.Error("stop live session failed", "error", err)

--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -1521,7 +1521,11 @@ func (p *Platform) ensureLiveExecutionPlan(session domain.LiveSession) (domain.L
 	p.mu.Lock()
 	if plan, ok := p.livePlans[session.ID]; ok {
 		p.mu.Unlock()
-		return session, plan, nil
+		reconciled, err := p.reconcileLiveSessionPlanIndex(session, plan, time.Now().UTC(), "live-plan-cache-reconcile")
+		if err != nil {
+			return domain.LiveSession{}, nil, err
+		}
+		return reconciled, plan, nil
 	}
 	p.mu.Unlock()
 
@@ -1608,6 +1612,40 @@ func (p *Platform) ensureLiveExecutionPlan(session domain.LiveSession) (domain.L
 		return domain.LiveSession{}, nil, err
 	}
 	return updatedSession, plan, nil
+}
+
+func (p *Platform) reconcileLiveSessionPlanIndex(session domain.LiveSession, plan []paperPlannedOrder, recoveredAt time.Time, source string) (domain.LiveSession, error) {
+	if len(plan) == 0 || strings.TrimSpace(session.ID) == "" {
+		return session, nil
+	}
+
+	state := cloneMetadata(session.State)
+	symbol := NormalizeSymbol(firstNonEmpty(stringValue(state["symbol"]), stringValue(state["lastSymbol"])))
+	if symbol == "" {
+		return session, nil
+	}
+
+	positionSnapshot, foundPosition, err := p.resolveLiveSessionPositionSnapshot(session, symbol)
+	if err != nil {
+		return domain.LiveSession{}, err
+	}
+
+	nextIndex, adjusted := reconcileLivePlanIndexWithPosition(plan, resolveLivePlanIndex(state), positionSnapshot, foundPosition)
+	if !adjusted {
+		return session, nil
+	}
+
+	state["recoveredPosition"] = positionSnapshot
+	state["hasRecoveredPosition"] = foundPosition
+	state["hasRecoveredRealPosition"] = foundPosition
+	state["hasRecoveredVirtualPosition"] = boolValue(positionSnapshot["virtual"])
+	state["lastRecoveredPositionAt"] = recoveredAt.UTC().Format(time.RFC3339)
+	state["positionRecoverySource"] = firstNonEmpty(source, "live-plan-cache-reconcile")
+	state["planIndex"] = nextIndex
+	state["planIndexRecoveredFromPosition"] = true
+	state["recoveredPlanIndex"] = nextIndex
+
+	return p.store.UpdateLiveSessionState(session.ID, state)
 }
 
 func reconcileLivePlanIndexWithPosition(plan []paperPlannedOrder, currentIndex int, position map[string]any, found bool) (int, bool) {

--- a/internal/service/live_execution.go
+++ b/internal/service/live_execution.go
@@ -336,6 +336,7 @@ func buildLiveOrderFromExecutionProposal(session domain.LiveSession, strategyVer
 		Type:              orderType,
 		Quantity:          quantity,
 		Price:             price,
+		ReduceOnly:        proposal.ReduceOnly,
 		Metadata: map[string]any{
 			"source":             "live-session-intent",
 			"liveSessionId":      session.ID,

--- a/internal/service/live_registry.go
+++ b/internal/service/live_registry.go
@@ -377,10 +377,10 @@ func (a binanceFuturesLiveAdapter) submitRESTOrder(account domain.Account, order
 	if orderType != "MARKET" && timeInForce != "" {
 		params["timeInForce"] = timeInForce
 	}
-	if boolValue(normalizedOrder.Metadata["reduceOnly"]) {
+	if normalizedOrder.EffectiveReduceOnly() {
 		params["reduceOnly"] = "true"
 	}
-	if boolValue(normalizedOrder.Metadata["closePosition"]) {
+	if normalizedOrder.EffectiveClosePosition() {
 		params["closePosition"] = "true"
 	}
 	params["signature"] = signBinanceQuery(params, resolved.APISecret)
@@ -722,6 +722,7 @@ func resolveBinanceRESTCredentials(binding map[string]any) (binanceRESTCredentia
 func (a binanceFuturesLiveAdapter) normalizeRESTOrder(order domain.Order, creds binanceRESTCredentials) (domain.Order, binanceSymbolRules, error) {
 	normalized := order
 	normalized.Metadata = cloneMetadata(order.Metadata)
+	normalized.NormalizeExecutionFlags()
 	rules, err := fetchBinanceSymbolRules(creds, NormalizeSymbol(order.Symbol))
 	if err != nil {
 		return domain.Order{}, binanceSymbolRules{}, err
@@ -736,6 +737,9 @@ func (a binanceFuturesLiveAdapter) normalizeRESTOrder(order domain.Order, creds 
 	}
 	if rules.MinQty > 0 && rawQuantity > 0 && rawQuantity < rules.MinQty {
 		quantityAdjustments = append(quantityAdjustments, "min_qty")
+	}
+	if normalized.EffectiveReduceOnly() && baseQuantity > rawQuantity {
+		return domain.Order{}, binanceSymbolRules{}, fmt.Errorf("reduce-only order quantity %.12f is below minQty %.12f for %s", rawQuantity, rules.MinQty, rules.Symbol)
 	}
 	normalized.Quantity = baseQuantity
 	if normalized.Quantity <= 0 {
@@ -756,6 +760,9 @@ func (a binanceFuturesLiveAdapter) normalizeRESTOrder(order domain.Order, creds 
 		}
 	}
 	if requiredQty := requiredBinanceQuantityForMinNotional(normalized.Quantity, firstPositive(normalized.Price, priceReference), rules); requiredQty > normalized.Quantity {
+		if normalized.EffectiveReduceOnly() {
+			return domain.Order{}, binanceSymbolRules{}, fmt.Errorf("reduce-only order quantity %.12f does not satisfy minNotional %.12f for %s", normalized.Quantity, rules.MinNotional, rules.Symbol)
+		}
 		normalized.Quantity = requiredQty
 		quantityAdjustments = append(quantityAdjustments, "min_notional")
 	}

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -1019,6 +1019,9 @@ func TestBuildLiveOrderFromExecutionProposalUsesExecutionFields(t *testing.T) {
 	if !boolValue(order.Metadata["reduceOnly"]) {
 		t.Fatal("expected reduceOnly metadata")
 	}
+	if !order.ReduceOnly {
+		t.Fatal("expected reduceOnly formal field")
+	}
 }
 
 func TestBuildLiveOrderUsesProposalQuantityOverSessionDefault(t *testing.T) {

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -1564,6 +1564,99 @@ func TestShouldAdvanceLivePlanForOrderStatus(t *testing.T) {
 	}
 }
 
+func TestEnsureLiveExecutionPlanReconcilesCachedPlanIndexBackToEntryWhenPositionFlat(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	session, err := platform.CreateLiveSession("live-main", "strategy-bk-1d", map[string]any{
+		"symbol":              "BTCUSDT",
+		"signalTimeframe":     "1d",
+		"executionDataSource": "tick",
+		"dispatchMode":        "manual-review",
+	})
+	if err != nil {
+		t.Fatalf("create live session failed: %v", err)
+	}
+
+	updatedState := cloneMetadata(session.State)
+	updatedState["planIndex"] = 1
+	session, err = platform.store.UpdateLiveSessionState(session.ID, updatedState)
+	if err != nil {
+		t.Fatalf("update live session state failed: %v", err)
+	}
+
+	platform.mu.Lock()
+	platform.livePlans[session.ID] = []paperPlannedOrder{
+		{Role: "entry", Side: "BUY", Symbol: "BTCUSDT"},
+		{Role: "exit", Side: "SELL", Symbol: "BTCUSDT"},
+	}
+	platform.mu.Unlock()
+
+	reconciled, plan, err := platform.ensureLiveExecutionPlan(session)
+	if err != nil {
+		t.Fatalf("ensure live execution plan failed: %v", err)
+	}
+	if len(plan) != 2 {
+		t.Fatalf("expected cached live plan to be preserved, got %d steps", len(plan))
+	}
+	gotIndex, ok := toFloat64(reconciled.State["planIndex"])
+	if !ok || int(gotIndex) != 0 {
+		t.Fatalf("expected cached plan index to roll back to entry when position is flat, got %v", reconciled.State["planIndex"])
+	}
+	if !boolValue(reconciled.State["planIndexRecoveredFromPosition"]) {
+		t.Fatal("expected cached plan reconciliation to be recorded in session state")
+	}
+}
+
+func TestEnsureLiveExecutionPlanReconcilesCachedPlanIndexToExitWhenPositionExists(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	session, err := platform.CreateLiveSession("live-main", "strategy-bk-1d", map[string]any{
+		"symbol":              "BTCUSDT",
+		"signalTimeframe":     "1d",
+		"executionDataSource": "tick",
+		"dispatchMode":        "manual-review",
+	})
+	if err != nil {
+		t.Fatalf("create live session failed: %v", err)
+	}
+
+	if _, err := platform.store.SavePosition(domain.Position{
+		AccountID:         session.AccountID,
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "LONG",
+		Quantity:          0.01,
+		EntryPrice:        68000,
+		MarkPrice:         68100,
+	}); err != nil {
+		t.Fatalf("save position failed: %v", err)
+	}
+
+	updatedState := cloneMetadata(session.State)
+	updatedState["planIndex"] = 0
+	session, err = platform.store.UpdateLiveSessionState(session.ID, updatedState)
+	if err != nil {
+		t.Fatalf("update live session state failed: %v", err)
+	}
+
+	platform.mu.Lock()
+	platform.livePlans[session.ID] = []paperPlannedOrder{
+		{Role: "entry", Side: "BUY", Symbol: "BTCUSDT"},
+		{Role: "exit", Side: "SELL", Symbol: "BTCUSDT"},
+	}
+	platform.mu.Unlock()
+
+	reconciled, _, err := platform.ensureLiveExecutionPlan(session)
+	if err != nil {
+		t.Fatalf("ensure live execution plan failed: %v", err)
+	}
+	gotIndex, ok := toFloat64(reconciled.State["planIndex"])
+	if !ok || int(gotIndex) != 1 {
+		t.Fatalf("expected cached plan index to advance to exit when position exists, got %v", reconciled.State["planIndex"])
+	}
+	if !boolValue(reconciled.State["hasRecoveredPosition"]) {
+		t.Fatal("expected recovered position to be captured during cached plan reconciliation")
+	}
+}
+
 func TestParseBinanceSymbolRules(t *testing.T) {
 	rules := parseBinanceSymbolRules(map[string]any{
 		"symbol": "BTCUSDT",

--- a/internal/service/order.go
+++ b/internal/service/order.go
@@ -33,27 +33,30 @@ func (p *Platform) ClosePosition(positionID string) (domain.Order, error) {
 	if err != nil {
 		return domain.Order{}, err
 	}
+	return p.CreateOrder(buildClosePositionOrder(position))
+}
+
+func buildClosePositionOrder(position domain.Position) domain.Order {
 	closeSide := "SELL"
 	if strings.EqualFold(strings.TrimSpace(position.Side), "SHORT") {
 		closeSide = "BUY"
 	}
-	order := domain.Order{
+	return domain.Order{
 		AccountID:         position.AccountID,
 		StrategyVersionID: position.StrategyVersionID,
 		Symbol:            NormalizeSymbol(position.Symbol),
 		Side:              closeSide,
 		Type:              "MARKET",
 		Quantity:          position.Quantity,
-		Price:             position.MarkPrice,
 		ReduceOnly:        true,
 		Metadata: map[string]any{
 			"source":       "manual-position-close",
 			"positionId":   position.ID,
 			"markPrice":    position.MarkPrice,
+			"priceHint":    position.MarkPrice,
 			"manualAction": "close-position",
 		},
 	}
-	return p.CreateOrder(order)
 }
 
 // CreateOrder 创建订单。对于 PAPER 模式账户，订单会被立即执行（模拟成交），
@@ -160,7 +163,7 @@ func (p *Platform) validateReduceOnlyOrder(account domain.Account, order domain.
 		return nil
 	}
 	symbol := NormalizeSymbol(order.Symbol)
-	position, found, err := p.store.FindPosition(account.ID, symbol)
+	position, found, err := p.resolveReduceOnlyTargetPosition(account.ID, order)
 	if err != nil {
 		return err
 	}
@@ -181,6 +184,55 @@ func (p *Platform) validateReduceOnlyOrder(account domain.Account, order domain.
 		return fmt.Errorf("reduce-only order quantity %.12f exceeds open position quantity %.12f for %s", order.Quantity, position.Quantity, symbol)
 	}
 	return nil
+}
+
+func (p *Platform) resolveReduceOnlyTargetPosition(accountID string, order domain.Order) (domain.Position, bool, error) {
+	symbol := NormalizeSymbol(order.Symbol)
+	positions, err := p.store.ListPositions()
+	if err != nil {
+		return domain.Position{}, false, err
+	}
+	candidates := make([]domain.Position, 0)
+	for _, item := range positions {
+		if strings.TrimSpace(item.AccountID) != strings.TrimSpace(accountID) {
+			continue
+		}
+		if NormalizeSymbol(item.Symbol) != symbol || item.Quantity <= 0 {
+			continue
+		}
+		candidates = append(candidates, item)
+	}
+	if len(candidates) == 0 {
+		return domain.Position{}, false, nil
+	}
+	if positionID := strings.TrimSpace(stringValue(mapValue(order.Metadata)["positionId"])); positionID != "" {
+		for _, item := range candidates {
+			if item.ID == positionID {
+				return item, true, nil
+			}
+		}
+		return domain.Position{}, false, fmt.Errorf("reduce-only order target position %s is not open for %s", positionID, symbol)
+	}
+	if strategyVersionID := strings.TrimSpace(order.StrategyVersionID); strategyVersionID != "" {
+		versionMatches := make([]domain.Position, 0, len(candidates))
+		for _, item := range candidates {
+			if strings.EqualFold(strings.TrimSpace(item.StrategyVersionID), strategyVersionID) {
+				versionMatches = append(versionMatches, item)
+			}
+		}
+		switch len(versionMatches) {
+		case 0:
+			return domain.Position{}, false, fmt.Errorf("reduce-only order requires an open %s position for strategy version %s", symbol, strategyVersionID)
+		case 1:
+			return versionMatches[0], true, nil
+		default:
+			return domain.Position{}, false, fmt.Errorf("reduce-only order for %s is ambiguous across %d open positions for strategy version %s; specify positionId", symbol, len(versionMatches), strategyVersionID)
+		}
+	}
+	if len(candidates) == 1 {
+		return candidates[0], true, nil
+	}
+	return domain.Position{}, false, fmt.Errorf("reduce-only order for %s is ambiguous across %d open positions; specify strategyVersionId or positionId", symbol, len(candidates))
 }
 
 func (p *Platform) executeCreatedOrder(account domain.Account, order domain.Order) (domain.Order, error) {

--- a/internal/service/order.go
+++ b/internal/service/order.go
@@ -28,6 +28,43 @@ func (p *Platform) GetOrder(orderID string) (domain.Order, error) {
 	return domain.Order{}, fmt.Errorf("order not found: %s", orderID)
 }
 
+func (p *Platform) ClosePosition(positionID string) (domain.Order, error) {
+	positions, err := p.store.ListPositions()
+	if err != nil {
+		return domain.Order{}, err
+	}
+	for _, item := range positions {
+		if item.ID != positionID {
+			continue
+		}
+		if item.Quantity <= 0 {
+			return domain.Order{}, fmt.Errorf("position has no quantity to close: %s", positionID)
+		}
+		closeSide := "SELL"
+		if strings.EqualFold(strings.TrimSpace(item.Side), "SHORT") {
+			closeSide = "BUY"
+		}
+		order := domain.Order{
+			AccountID:         item.AccountID,
+			StrategyVersionID: item.StrategyVersionID,
+			Symbol:            NormalizeSymbol(item.Symbol),
+			Side:              closeSide,
+			Type:              "MARKET",
+			Quantity:          item.Quantity,
+			Price:             item.MarkPrice,
+			Metadata: map[string]any{
+				"reduceOnly":   true,
+				"source":       "manual-position-close",
+				"positionId":   item.ID,
+				"markPrice":    item.MarkPrice,
+				"manualAction": "close-position",
+			},
+		}
+		return p.CreateOrder(order)
+	}
+	return domain.Order{}, fmt.Errorf("position not found: %s", positionID)
+}
+
 // CreateOrder 创建订单。对于 PAPER 模式账户，订单会被立即执行（模拟成交），
 // 生成 fill 记录、更新持仓、捕获净值快照。
 func (p *Platform) CreateOrder(order domain.Order) (domain.Order, error) {

--- a/internal/service/order.go
+++ b/internal/service/order.go
@@ -29,45 +29,37 @@ func (p *Platform) GetOrder(orderID string) (domain.Order, error) {
 }
 
 func (p *Platform) ClosePosition(positionID string) (domain.Order, error) {
-	positions, err := p.store.ListPositions()
+	position, _, err := p.resolveClosePositionTarget(positionID)
 	if err != nil {
 		return domain.Order{}, err
 	}
-	for _, item := range positions {
-		if item.ID != positionID {
-			continue
-		}
-		if item.Quantity <= 0 {
-			return domain.Order{}, fmt.Errorf("position has no quantity to close: %s", positionID)
-		}
-		closeSide := "SELL"
-		if strings.EqualFold(strings.TrimSpace(item.Side), "SHORT") {
-			closeSide = "BUY"
-		}
-		order := domain.Order{
-			AccountID:         item.AccountID,
-			StrategyVersionID: item.StrategyVersionID,
-			Symbol:            NormalizeSymbol(item.Symbol),
-			Side:              closeSide,
-			Type:              "MARKET",
-			Quantity:          item.Quantity,
-			Price:             item.MarkPrice,
-			Metadata: map[string]any{
-				"reduceOnly":   true,
-				"source":       "manual-position-close",
-				"positionId":   item.ID,
-				"markPrice":    item.MarkPrice,
-				"manualAction": "close-position",
-			},
-		}
-		return p.CreateOrder(order)
+	closeSide := "SELL"
+	if strings.EqualFold(strings.TrimSpace(position.Side), "SHORT") {
+		closeSide = "BUY"
 	}
-	return domain.Order{}, fmt.Errorf("position not found: %s", positionID)
+	order := domain.Order{
+		AccountID:         position.AccountID,
+		StrategyVersionID: position.StrategyVersionID,
+		Symbol:            NormalizeSymbol(position.Symbol),
+		Side:              closeSide,
+		Type:              "MARKET",
+		Quantity:          position.Quantity,
+		Price:             position.MarkPrice,
+		ReduceOnly:        true,
+		Metadata: map[string]any{
+			"source":       "manual-position-close",
+			"positionId":   position.ID,
+			"markPrice":    position.MarkPrice,
+			"manualAction": "close-position",
+		},
+	}
+	return p.CreateOrder(order)
 }
 
 // CreateOrder 创建订单。对于 PAPER 模式账户，订单会被立即执行（模拟成交），
 // 生成 fill 记录、更新持仓、捕获净值快照。
 func (p *Platform) CreateOrder(order domain.Order) (domain.Order, error) {
+	order.NormalizeExecutionFlags()
 	logger := p.logger("service.order",
 		"account_id", order.AccountID,
 		"strategy_version_id", order.StrategyVersionID,
@@ -99,6 +91,9 @@ func (p *Platform) prepareOrderAccount(order domain.Order) (domain.Account, erro
 }
 
 func (p *Platform) preflightOrderExecution(account domain.Account, order domain.Order) error {
+	if err := p.validateReduceOnlyOrder(account, order); err != nil {
+		return err
+	}
 	if account.Mode != "LIVE" {
 		return nil
 	}
@@ -113,6 +108,77 @@ func (p *Platform) preflightOrderExecution(account domain.Account, order domain.
 	}
 	if _, _, err := p.ensureLiveRuntimeReady(account, order); err != nil {
 		return err
+	}
+	return nil
+}
+
+func (p *Platform) resolveClosePositionTarget(positionID string) (domain.Position, domain.Account, error) {
+	position, found, err := p.findPositionByID(positionID)
+	if err != nil {
+		return domain.Position{}, domain.Account{}, err
+	}
+	if !found {
+		return domain.Position{}, domain.Account{}, fmt.Errorf("position not found: %s", positionID)
+	}
+	account, err := p.store.GetAccount(position.AccountID)
+	if err != nil {
+		return domain.Position{}, domain.Account{}, err
+	}
+	if strings.EqualFold(strings.TrimSpace(account.Mode), "LIVE") {
+		if _, err := p.SyncLiveAccount(account.ID); err != nil {
+			return domain.Position{}, domain.Account{}, err
+		}
+		position, found, err = p.findPositionByID(positionID)
+		if err != nil {
+			return domain.Position{}, domain.Account{}, err
+		}
+		if !found {
+			return domain.Position{}, domain.Account{}, fmt.Errorf("position not found: %s", positionID)
+		}
+	}
+	if position.Quantity <= 0 {
+		return domain.Position{}, domain.Account{}, fmt.Errorf("position has no quantity to close: %s", positionID)
+	}
+	return position, account, nil
+}
+
+func (p *Platform) findPositionByID(positionID string) (domain.Position, bool, error) {
+	positions, err := p.store.ListPositions()
+	if err != nil {
+		return domain.Position{}, false, err
+	}
+	for _, item := range positions {
+		if item.ID == positionID {
+			return item, true, nil
+		}
+	}
+	return domain.Position{}, false, nil
+}
+
+func (p *Platform) validateReduceOnlyOrder(account domain.Account, order domain.Order) error {
+	if !order.EffectiveReduceOnly() && !order.EffectiveClosePosition() {
+		return nil
+	}
+	symbol := NormalizeSymbol(order.Symbol)
+	position, found, err := p.store.FindPosition(account.ID, symbol)
+	if err != nil {
+		return err
+	}
+	if !found || position.Quantity <= 0 {
+		return fmt.Errorf("reduce-only order requires an open position for %s", symbol)
+	}
+	expectedSide := "SELL"
+	if strings.EqualFold(strings.TrimSpace(position.Side), "SHORT") {
+		expectedSide = "BUY"
+	}
+	if !strings.EqualFold(strings.TrimSpace(order.Side), expectedSide) {
+		return fmt.Errorf("reduce-only order side %s does not reduce %s position on %s", order.Side, position.Side, symbol)
+	}
+	if order.Quantity <= 0 {
+		return fmt.Errorf("reduce-only order quantity must be positive for %s", symbol)
+	}
+	if order.Quantity-position.Quantity > 1e-9 {
+		return fmt.Errorf("reduce-only order quantity %.12f exceeds open position quantity %.12f for %s", order.Quantity, position.Quantity, symbol)
 	}
 	return nil
 }

--- a/internal/service/safety_checks.go
+++ b/internal/service/safety_checks.go
@@ -1,0 +1,82 @@
+package service
+
+import (
+	"errors"
+	"strings"
+)
+
+var ErrActivePositionsOrOrders = errors.New("active positions or orders exist")
+
+type activePositionsOrOrdersError struct{}
+
+func (activePositionsOrOrdersError) Error() string {
+	return "存在活动中的订单或未平仓头寸，无法直接停用/删除"
+}
+
+func (activePositionsOrOrdersError) Unwrap() error {
+	return ErrActivePositionsOrOrders
+}
+
+func (p *Platform) HasActivePositionsOrOrders(accountID, strategyID string) (bool, error) {
+	positions, err := p.store.ListPositions()
+	if err != nil {
+		return false, err
+	}
+	for _, item := range positions {
+		if strings.TrimSpace(item.AccountID) != strings.TrimSpace(accountID) || item.Quantity <= 0 {
+			continue
+		}
+		matches, matchErr := p.matchesStrategyVersionToStrategy(item.StrategyVersionID, strategyID)
+		if matchErr != nil {
+			return false, matchErr
+		}
+		if matches {
+			return true, nil
+		}
+	}
+
+	orders, err := p.store.ListOrders()
+	if err != nil {
+		return false, err
+	}
+	for _, item := range orders {
+		if strings.TrimSpace(item.AccountID) != strings.TrimSpace(accountID) {
+			continue
+		}
+		switch strings.ToUpper(strings.TrimSpace(item.Status)) {
+		case "NEW", "PARTIALLY_FILLED", "ACCEPTED":
+		default:
+			continue
+		}
+		matches, matchErr := p.matchesStrategyVersionToStrategy(item.StrategyVersionID, strategyID)
+		if matchErr != nil {
+			return false, matchErr
+		}
+		if matches {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (p *Platform) ensureNoActivePositionsOrOrders(accountID, strategyID string) error {
+	active, err := p.HasActivePositionsOrOrders(accountID, strategyID)
+	if err != nil {
+		return err
+	}
+	if active {
+		return activePositionsOrOrdersError{}
+	}
+	return nil
+}
+
+func (p *Platform) matchesStrategyVersionToStrategy(strategyVersionID, strategyID string) (bool, error) {
+	if strings.TrimSpace(strategyVersionID) == "" || strings.TrimSpace(strategyID) == "" {
+		return false, nil
+	}
+	resolvedStrategyID, err := p.resolveStrategyIDFromVersionID(strategyVersionID)
+	if err != nil {
+		return false, err
+	}
+	return strings.EqualFold(strings.TrimSpace(resolvedStrategyID), strings.TrimSpace(strategyID)), nil
+}

--- a/internal/service/safety_checks_test.go
+++ b/internal/service/safety_checks_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -179,6 +180,9 @@ func TestClosePositionCreatesReduceOnlyMarketOrder(t *testing.T) {
 	if order.Type != "MARKET" {
 		t.Fatalf("expected MARKET close order, got %s", order.Type)
 	}
+	if !order.ReduceOnly {
+		t.Fatal("expected close order to set the formal ReduceOnly field")
+	}
 	if !boolValue(order.Metadata["reduceOnly"]) {
 		t.Fatal("expected close order to be reduceOnly")
 	}
@@ -192,5 +196,236 @@ func TestClosePositionCreatesReduceOnlyMarketOrder(t *testing.T) {
 		t.Fatalf("find position failed: %v", err)
 	} else if exists {
 		t.Fatal("expected close order to flatten the paper position")
+	}
+}
+
+func TestResolveClosePositionTargetRefreshesLivePositionBeforeSubmitting(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	position, err := platform.store.SavePosition(domain.Position{
+		AccountID:         "live-main",
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "LONG",
+		Quantity:          0.25,
+		EntryPrice:        68000,
+		MarkPrice:         68100,
+	})
+	if err != nil {
+		t.Fatalf("save position failed: %v", err)
+	}
+
+	platform.registerLiveAdapter(testLiveAccountSyncAdapter{
+		key: "test-close-refresh",
+		syncSnapshotFunc: func(p *Platform, account domain.Account, binding map[string]any) (domain.Account, error) {
+			refreshed, found, err := p.findPositionByID(position.ID)
+			if err != nil {
+				return domain.Account{}, err
+			}
+			if !found {
+				return domain.Account{}, errors.New("position disappeared during refresh")
+			}
+			refreshed.Quantity = 0.1
+			refreshed.MarkPrice = 68200
+			if _, err := p.store.SavePosition(refreshed); err != nil {
+				return domain.Account{}, err
+			}
+			return account, nil
+		},
+	})
+
+	account, err := platform.store.GetAccount("live-main")
+	if err != nil {
+		t.Fatalf("get live account failed: %v", err)
+	}
+	account.Status = "READY"
+	account.Metadata = cloneMetadata(account.Metadata)
+	account.Metadata["liveBinding"] = map[string]any{
+		"adapterKey":     "test-close-refresh",
+		"connectionMode": "mock",
+		"executionMode":  "mock",
+	}
+	if _, err := platform.store.UpdateAccount(account); err != nil {
+		t.Fatalf("update live account failed: %v", err)
+	}
+
+	target, _, err := platform.resolveClosePositionTarget(position.ID)
+	if err != nil {
+		t.Fatalf("resolveClosePositionTarget failed: %v", err)
+	}
+	if target.Quantity != 0.1 {
+		t.Fatalf("expected refreshed close quantity 0.1, got %v", target.Quantity)
+	}
+	if target.MarkPrice != 68200 {
+		t.Fatalf("expected refreshed close markPrice 68200, got %v", target.MarkPrice)
+	}
+}
+
+func TestResolveClosePositionTargetFailsWhenPositionDisappearsAfterRefresh(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	position, err := platform.store.SavePosition(domain.Position{
+		AccountID:         "live-main",
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "LONG",
+		Quantity:          0.25,
+		EntryPrice:        68000,
+		MarkPrice:         68100,
+	})
+	if err != nil {
+		t.Fatalf("save position failed: %v", err)
+	}
+
+	platform.registerLiveAdapter(testLiveAccountSyncAdapter{
+		key: "test-close-disappear",
+		syncSnapshotFunc: func(p *Platform, account domain.Account, binding map[string]any) (domain.Account, error) {
+			if err := p.store.DeletePosition(position.ID); err != nil {
+				return domain.Account{}, err
+			}
+			return account, nil
+		},
+	})
+
+	account, err := platform.store.GetAccount("live-main")
+	if err != nil {
+		t.Fatalf("get live account failed: %v", err)
+	}
+	account.Status = "READY"
+	account.Metadata = cloneMetadata(account.Metadata)
+	account.Metadata["liveBinding"] = map[string]any{
+		"adapterKey":     "test-close-disappear",
+		"connectionMode": "mock",
+		"executionMode":  "mock",
+	}
+	if _, err := platform.store.UpdateAccount(account); err != nil {
+		t.Fatalf("update live account failed: %v", err)
+	}
+
+	if _, _, err := platform.resolveClosePositionTarget(position.ID); err == nil || !strings.Contains(err.Error(), "position not found") {
+		t.Fatalf("expected refreshed close target lookup to fail after position disappears, got %v", err)
+	}
+}
+
+func TestCreateOrderReduceOnlyFormalFieldPreventsReverseOpen(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	account, err := platform.CreateAccount("Paper ReduceOnly", "PAPER", "binance-futures")
+	if err != nil {
+		t.Fatalf("create account failed: %v", err)
+	}
+	if _, err := platform.store.SavePosition(domain.Position{
+		AccountID:         account.ID,
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "LONG",
+		Quantity:          0.25,
+		EntryPrice:        68000,
+		MarkPrice:         68100,
+	}); err != nil {
+		t.Fatalf("save position failed: %v", err)
+	}
+
+	order, err := platform.CreateOrder(domain.Order{
+		AccountID:         account.ID,
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "SELL",
+		Type:              "MARKET",
+		Quantity:          0.1,
+		ReduceOnly:        true,
+	})
+	if err != nil {
+		t.Fatalf("CreateOrder reduce-only failed: %v", err)
+	}
+	if !order.ReduceOnly {
+		t.Fatal("expected returned order to preserve ReduceOnly field")
+	}
+	if !boolValue(order.Metadata["reduceOnly"]) {
+		t.Fatal("expected returned order metadata to preserve reduceOnly")
+	}
+	position, found, err := platform.store.FindPosition(account.ID, "BTCUSDT")
+	if err != nil {
+		t.Fatalf("find position failed: %v", err)
+	}
+	if !found {
+		t.Fatal("expected partial reduce-only execution to leave a remaining position")
+	}
+	if position.Side != "LONG" || position.Quantity != 0.15 {
+		t.Fatalf("expected remaining LONG 0.15 after partial reduce-only close, got side=%s qty=%v", position.Side, position.Quantity)
+	}
+}
+
+func TestCreateOrderReduceOnlyRejectsOversizedQuantity(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	account, err := platform.CreateAccount("Paper ReduceOnly Oversize", "PAPER", "binance-futures")
+	if err != nil {
+		t.Fatalf("create account failed: %v", err)
+	}
+	if _, err := platform.store.SavePosition(domain.Position{
+		AccountID:         account.ID,
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "LONG",
+		Quantity:          0.25,
+		EntryPrice:        68000,
+		MarkPrice:         68100,
+	}); err != nil {
+		t.Fatalf("save position failed: %v", err)
+	}
+
+	if _, err := platform.CreateOrder(domain.Order{
+		AccountID:         account.ID,
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "SELL",
+		Type:              "MARKET",
+		Quantity:          0.5,
+		ReduceOnly:        true,
+	}); err == nil || !strings.Contains(err.Error(), "exceeds open position quantity") {
+		t.Fatalf("expected oversized reduce-only order to be rejected, got %v", err)
+	}
+
+	position, found, err := platform.store.FindPosition(account.ID, "BTCUSDT")
+	if err != nil {
+		t.Fatalf("find position failed: %v", err)
+	}
+	if !found || position.Side != "LONG" || position.Quantity != 0.25 {
+		t.Fatalf("expected original LONG 0.25 position to remain untouched, got found=%t side=%s qty=%v", found, position.Side, position.Quantity)
+	}
+}
+
+func TestNormalizeRESTOrderRejectsReduceOnlyQuantityExpansion(t *testing.T) {
+	adapter := binanceFuturesLiveAdapter{}
+	creds := binanceRESTCredentials{BaseURL: "https://example.test"}
+	cacheKey := creds.BaseURL + "|BTCUSDT"
+	binanceSymbolRulesCacheMu.Lock()
+	previous, existed := binanceSymbolRulesCache[cacheKey]
+	binanceSymbolRulesCacheMu.Unlock()
+	t.Cleanup(func() {
+		binanceSymbolRulesCacheMu.Lock()
+		defer binanceSymbolRulesCacheMu.Unlock()
+		if existed {
+			binanceSymbolRulesCache[cacheKey] = previous
+		} else {
+			delete(binanceSymbolRulesCache, cacheKey)
+		}
+	})
+	binanceSymbolRulesCacheMu.Lock()
+	binanceSymbolRulesCache[cacheKey] = binanceSymbolRules{
+		Symbol:      "BTCUSDT",
+		TickSize:    0.1,
+		StepSize:    0.001,
+		MinQty:      0.001,
+		MaxQty:      1000,
+		MinNotional: 100,
+		UpdatedAt:   time.Now().UTC(),
+	}
+	binanceSymbolRulesCacheMu.Unlock()
+
+	if _, _, err := adapter.normalizeRESTOrder(domain.Order{
+		Symbol:     "BTCUSDT",
+		Type:       "MARKET",
+		Quantity:   0.0005,
+		ReduceOnly: true,
+	}, creds); err == nil || !strings.Contains(err.Error(), "reduce-only order quantity") {
+		t.Fatalf("expected reduce-only REST normalization to reject quantity expansion, got %v", err)
 	}
 }

--- a/internal/service/safety_checks_test.go
+++ b/internal/service/safety_checks_test.go
@@ -1,0 +1,196 @@
+package service
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/wuyaocheng/bktrader/internal/domain"
+	"github.com/wuyaocheng/bktrader/internal/store/memory"
+)
+
+func TestHasActivePositionsOrOrdersMatchesStrategyScopedExposure(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	if _, err := platform.store.SavePosition(domain.Position{
+		AccountID:         "live-main",
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "LONG",
+		Quantity:          0.002,
+		EntryPrice:        69000,
+		MarkPrice:         69100,
+	}); err != nil {
+		t.Fatalf("save position failed: %v", err)
+	}
+
+	active, err := platform.HasActivePositionsOrOrders("live-main", "strategy-bk-1d")
+	if err != nil {
+		t.Fatalf("HasActivePositionsOrOrders returned error: %v", err)
+	}
+	if !active {
+		t.Fatal("expected active exposure to be detected")
+	}
+
+	active, err = platform.HasActivePositionsOrOrders("live-main", "strategy-does-not-exist")
+	if err != nil {
+		t.Fatalf("HasActivePositionsOrOrders for unrelated strategy returned error: %v", err)
+	}
+	if active {
+		t.Fatal("expected unrelated strategy lookup to stay inactive")
+	}
+}
+
+func TestStopLiveSessionWithForceRequiresForceWhenExposureExists(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	if _, err := platform.store.SavePosition(domain.Position{
+		AccountID:         "live-main",
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "LONG",
+		Quantity:          0.002,
+		EntryPrice:        69000,
+		MarkPrice:         69100,
+	}); err != nil {
+		t.Fatalf("save position failed: %v", err)
+	}
+
+	if _, err := platform.StopLiveSessionWithForce("live-session-main", false); !errors.Is(err, ErrActivePositionsOrOrders) {
+		t.Fatalf("expected active exposure error, got %v", err)
+	}
+	session, err := platform.store.GetLiveSession("live-session-main")
+	if err != nil {
+		t.Fatalf("get live session failed: %v", err)
+	}
+	if session.Status != "READY" {
+		t.Fatalf("expected blocked stop to leave session READY, got %s", session.Status)
+	}
+
+	session, err = platform.StopLiveSessionWithForce("live-session-main", true)
+	if err != nil {
+		t.Fatalf("force stop live session failed: %v", err)
+	}
+	if session.Status != "STOPPED" {
+		t.Fatalf("expected STOPPED after force stop, got %s", session.Status)
+	}
+}
+
+func TestDeleteLiveSessionWithForceRequiresForceWhenExposureExists(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	if _, err := platform.store.CreateOrder(domain.Order{
+		AccountID:         "live-main",
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "SELL",
+		Type:              "LIMIT",
+		Quantity:          0.002,
+		Price:             70000,
+	}); err != nil {
+		t.Fatalf("seed order failed: %v", err)
+	}
+
+	if err := platform.DeleteLiveSessionWithForce("live-session-main", false); !errors.Is(err, ErrActivePositionsOrOrders) {
+		t.Fatalf("expected active exposure error, got %v", err)
+	}
+	if _, err := platform.store.GetLiveSession("live-session-main"); err != nil {
+		t.Fatalf("expected live session to remain after blocked delete, got %v", err)
+	}
+
+	if err := platform.DeleteLiveSessionWithForce("live-session-main", true); err != nil {
+		t.Fatalf("force delete live session failed: %v", err)
+	}
+	if _, err := platform.store.GetLiveSession("live-session-main"); err == nil {
+		t.Fatal("expected live session to be deleted after force delete")
+	}
+}
+
+func TestSignalRuntimeSessionForceActionsRespectSafetyLock(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	runtime := domain.SignalRuntimeSession{
+		ID:         "signal-runtime-test",
+		AccountID:  "live-main",
+		StrategyID: "strategy-bk-1d",
+		Status:     "RUNNING",
+		State:      map[string]any{},
+		CreatedAt:  time.Now().UTC(),
+		UpdatedAt:  time.Now().UTC(),
+	}
+	platform.signalSessions[runtime.ID] = runtime
+	if _, err := platform.store.SavePosition(domain.Position{
+		AccountID:         "live-main",
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "LONG",
+		Quantity:          0.002,
+		EntryPrice:        69000,
+		MarkPrice:         69100,
+	}); err != nil {
+		t.Fatalf("save position failed: %v", err)
+	}
+
+	if _, err := platform.StopSignalRuntimeSessionWithForce(runtime.ID, false); !errors.Is(err, ErrActivePositionsOrOrders) {
+		t.Fatalf("expected active exposure error for stop, got %v", err)
+	}
+	stopped, err := platform.StopSignalRuntimeSessionWithForce(runtime.ID, true)
+	if err != nil {
+		t.Fatalf("force stop signal runtime session failed: %v", err)
+	}
+	if stopped.Status != "STOPPED" {
+		t.Fatalf("expected STOPPED status after force stop, got %s", stopped.Status)
+	}
+
+	platform.signalSessions[runtime.ID] = runtime
+	if err := platform.DeleteSignalRuntimeSessionWithForce(runtime.ID, false); !errors.Is(err, ErrActivePositionsOrOrders) {
+		t.Fatalf("expected active exposure error for delete, got %v", err)
+	}
+	if err := platform.DeleteSignalRuntimeSessionWithForce(runtime.ID, true); err != nil {
+		t.Fatalf("force delete signal runtime session failed: %v", err)
+	}
+	if _, err := platform.GetSignalRuntimeSession(runtime.ID); err == nil {
+		t.Fatal("expected signal runtime session to be deleted after force delete")
+	}
+}
+
+func TestClosePositionCreatesReduceOnlyMarketOrder(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	account, err := platform.CreateAccount("Paper Close", "PAPER", "binance-futures")
+	if err != nil {
+		t.Fatalf("create account failed: %v", err)
+	}
+	position, err := platform.store.SavePosition(domain.Position{
+		AccountID:         account.ID,
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "LONG",
+		Quantity:          0.25,
+		EntryPrice:        68000,
+		MarkPrice:         68100,
+	})
+	if err != nil {
+		t.Fatalf("save position failed: %v", err)
+	}
+
+	order, err := platform.ClosePosition(position.ID)
+	if err != nil {
+		t.Fatalf("ClosePosition failed: %v", err)
+	}
+	if order.Side != "SELL" {
+		t.Fatalf("expected SELL side for closing LONG position, got %s", order.Side)
+	}
+	if order.Type != "MARKET" {
+		t.Fatalf("expected MARKET close order, got %s", order.Type)
+	}
+	if !boolValue(order.Metadata["reduceOnly"]) {
+		t.Fatal("expected close order to be reduceOnly")
+	}
+	if got := stringValue(order.Metadata["positionId"]); got != position.ID {
+		t.Fatalf("expected close order to reference position %s, got %s", position.ID, got)
+	}
+	if got := stringValue(order.Status); got != "FILLED" {
+		t.Fatalf("expected paper close order to be FILLED, got %s", got)
+	}
+	if _, exists, err := platform.store.FindPosition(account.ID, "BTCUSDT"); err != nil {
+		t.Fatalf("find position failed: %v", err)
+	} else if exists {
+		t.Fatal("expected close order to flatten the paper position")
+	}
+}

--- a/internal/service/safety_checks_test.go
+++ b/internal/service/safety_checks_test.go
@@ -189,6 +189,9 @@ func TestClosePositionCreatesReduceOnlyMarketOrder(t *testing.T) {
 	if got := stringValue(order.Metadata["positionId"]); got != position.ID {
 		t.Fatalf("expected close order to reference position %s, got %s", position.ID, got)
 	}
+	if got := parseFloatValue(order.Metadata["priceHint"]); got != 68100 {
+		t.Fatalf("expected close order to preserve priceHint 68100, got %v", got)
+	}
 	if got := stringValue(order.Status); got != "FILLED" {
 		t.Fatalf("expected paper close order to be FILLED, got %s", got)
 	}
@@ -196,6 +199,31 @@ func TestClosePositionCreatesReduceOnlyMarketOrder(t *testing.T) {
 		t.Fatalf("find position failed: %v", err)
 	} else if exists {
 		t.Fatal("expected close order to flatten the paper position")
+	}
+}
+
+func TestBuildClosePositionOrderUsesMetadataPriceHintForMarketClose(t *testing.T) {
+	order := buildClosePositionOrder(domain.Position{
+		ID:                "position-test-close",
+		AccountID:         "account-test-close",
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "LONG",
+		Quantity:          0.25,
+		MarkPrice:         68100,
+	})
+
+	if order.Type != "MARKET" {
+		t.Fatalf("expected MARKET close order, got %s", order.Type)
+	}
+	if order.Price != 0 {
+		t.Fatalf("expected close MARKET order to leave explicit price empty, got %v", order.Price)
+	}
+	if got := parseFloatValue(order.Metadata["priceHint"]); got != 68100 {
+		t.Fatalf("expected close MARKET order priceHint 68100, got %v", got)
+	}
+	if got := parseFloatValue(order.Metadata["markPrice"]); got != 68100 {
+		t.Fatalf("expected close MARKET order markPrice metadata 68100, got %v", got)
 	}
 }
 
@@ -350,6 +378,98 @@ func TestCreateOrderReduceOnlyFormalFieldPreventsReverseOpen(t *testing.T) {
 	}
 	if position.Side != "LONG" || position.Quantity != 0.15 {
 		t.Fatalf("expected remaining LONG 0.15 after partial reduce-only close, got side=%s qty=%v", position.Side, position.Quantity)
+	}
+}
+
+func TestResolveReduceOnlyTargetPositionScopesSharedSymbolByStrategyVersionOrPositionID(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	account, err := platform.CreateAccount("Paper Shared Symbol", "PAPER", "binance-futures")
+	if err != nil {
+		t.Fatalf("create account failed: %v", err)
+	}
+	fourHour, err := platform.store.SavePosition(domain.Position{
+		AccountID:         account.ID,
+		StrategyVersionID: "strategy-version-bk-4h-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "LONG",
+		Quantity:          0.05,
+		EntryPrice:        68000,
+		MarkPrice:         68100,
+	})
+	if err != nil {
+		t.Fatalf("save 4h position failed: %v", err)
+	}
+	oneDay, err := platform.store.SavePosition(domain.Position{
+		AccountID:         account.ID,
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "LONG",
+		Quantity:          0.25,
+		EntryPrice:        68200,
+		MarkPrice:         68300,
+	})
+	if err != nil {
+		t.Fatalf("save 1d position failed: %v", err)
+	}
+
+	position, found, err := platform.resolveReduceOnlyTargetPosition(account.ID, domain.Order{
+		AccountID:         account.ID,
+		StrategyVersionID: oneDay.StrategyVersionID,
+		Symbol:            "BTCUSDT",
+		Side:              "SELL",
+		ReduceOnly:        true,
+	})
+	if err != nil {
+		t.Fatalf("resolveReduceOnlyTargetPosition by strategyVersionID failed: %v", err)
+	}
+	if !found || position.ID != oneDay.ID {
+		t.Fatalf("expected strategy-scoped reduce-only target %s, got found=%t id=%s", oneDay.ID, found, position.ID)
+	}
+
+	position, found, err = platform.resolveReduceOnlyTargetPosition(account.ID, domain.Order{
+		AccountID:  account.ID,
+		Symbol:     "BTCUSDT",
+		Side:       "SELL",
+		ReduceOnly: true,
+		Metadata: map[string]any{
+			"positionId": fourHour.ID,
+		},
+	})
+	if err != nil {
+		t.Fatalf("resolveReduceOnlyTargetPosition by positionId failed: %v", err)
+	}
+	if !found || position.ID != fourHour.ID {
+		t.Fatalf("expected position-scoped reduce-only target %s, got found=%t id=%s", fourHour.ID, found, position.ID)
+	}
+}
+
+func TestResolveReduceOnlyTargetPositionRejectsAmbiguousSharedSymbolWithoutIdentity(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	account, err := platform.CreateAccount("Paper Shared Symbol Ambiguous", "PAPER", "binance-futures")
+	if err != nil {
+		t.Fatalf("create account failed: %v", err)
+	}
+	for _, strategyVersionID := range []string{"strategy-version-bk-4h-v010", "strategy-version-bk-1d-v010"} {
+		if _, err := platform.store.SavePosition(domain.Position{
+			AccountID:         account.ID,
+			StrategyVersionID: strategyVersionID,
+			Symbol:            "BTCUSDT",
+			Side:              "LONG",
+			Quantity:          0.1,
+			EntryPrice:        68000,
+			MarkPrice:         68100,
+		}); err != nil {
+			t.Fatalf("seed position for %s failed: %v", strategyVersionID, err)
+		}
+	}
+
+	if _, _, err := platform.resolveReduceOnlyTargetPosition(account.ID, domain.Order{
+		AccountID:  account.ID,
+		Symbol:     "BTCUSDT",
+		Side:       "SELL",
+		ReduceOnly: true,
+	}); err == nil || !strings.Contains(err.Error(), "ambiguous") {
+		t.Fatalf("expected ambiguous shared-symbol reduce-only lookup to be rejected, got %v", err)
 	}
 }
 

--- a/internal/service/signal_runtime_sessions.go
+++ b/internal/service/signal_runtime_sessions.go
@@ -176,7 +176,22 @@ func (p *Platform) StartSignalRuntimeSession(sessionID string) (domain.SignalRun
 }
 
 func (p *Platform) StopSignalRuntimeSession(sessionID string) (domain.SignalRuntimeSession, error) {
+	return p.StopSignalRuntimeSessionWithForce(sessionID, false)
+}
+
+func (p *Platform) StopSignalRuntimeSessionWithForce(sessionID string, force bool) (domain.SignalRuntimeSession, error) {
 	logger := p.logger("service.signal_runtime", "session_id", sessionID)
+	existing, err := p.GetSignalRuntimeSession(sessionID)
+	if err != nil {
+		logger.Warn("signal runtime session not found")
+		return domain.SignalRuntimeSession{}, err
+	}
+	if !force {
+		if err := p.ensureNoActivePositionsOrOrders(existing.AccountID, existing.StrategyID); err != nil {
+			logger.Warn("stop signal runtime session blocked by active positions or orders", "error", err)
+			return domain.SignalRuntimeSession{}, err
+		}
+	}
 	p.mu.Lock()
 	session, ok := p.signalSessions[sessionID]
 	if !ok {
@@ -292,6 +307,19 @@ func strategySignalBarsToRuntimeHistory(bars []strategySignalBar, symbol, timefr
 }
 
 func (p *Platform) DeleteSignalRuntimeSession(sessionID string) error {
+	return p.DeleteSignalRuntimeSessionWithForce(sessionID, false)
+}
+
+func (p *Platform) DeleteSignalRuntimeSessionWithForce(sessionID string, force bool) error {
+	existing, err := p.GetSignalRuntimeSession(sessionID)
+	if err != nil {
+		return err
+	}
+	if !force {
+		if err := p.ensureNoActivePositionsOrOrders(existing.AccountID, existing.StrategyID); err != nil {
+			return err
+		}
+	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	cancel, running := p.signalRun[sessionID]

--- a/internal/store/memory/store.go
+++ b/internal/store/memory/store.go
@@ -437,6 +437,7 @@ func (s *Store) ListOrders() ([]domain.Order, error) {
 	defer s.mu.RUnlock()
 	items := make([]domain.Order, 0, len(s.orders))
 	for _, item := range s.orders {
+		item.NormalizeExecutionFlags()
 		items = append(items, item)
 	}
 	sort.Slice(items, func(i, j int) bool { return items[i].CreatedAt.Before(items[j].CreatedAt) })
@@ -446,6 +447,7 @@ func (s *Store) ListOrders() ([]domain.Order, error) {
 func (s *Store) CreateOrder(order domain.Order) (domain.Order, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	order.NormalizeExecutionFlags()
 	order.ID = s.nextID("order")
 	order.Status = "NEW"
 	order.CreatedAt = time.Now().UTC()
@@ -459,6 +461,7 @@ func (s *Store) CreateOrder(order domain.Order) (domain.Order, error) {
 func (s *Store) UpdateOrder(order domain.Order) (domain.Order, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	order.NormalizeExecutionFlags()
 	existing, ok := s.orders[order.ID]
 	if !ok {
 		return domain.Order{}, fmt.Errorf("order not found: %s", order.ID)

--- a/internal/store/postgres/store.go
+++ b/internal/store/postgres/store.go
@@ -510,12 +510,14 @@ func (s *Store) ListOrders() ([]domain.Order, error) {
 		if len(metadataRaw) > 0 {
 			_ = json.Unmarshal(metadataRaw, &item.Metadata)
 		}
+		item.NormalizeExecutionFlags()
 		items = append(items, item)
 	}
 	return items, rows.Err()
 }
 
 func (s *Store) CreateOrder(order domain.Order) (domain.Order, error) {
+	order.NormalizeExecutionFlags()
 	order.ID = fmt.Sprintf("order-%d", time.Now().UTC().UnixNano())
 	order.Status = "NEW"
 	order.CreatedAt = time.Now().UTC()
@@ -532,6 +534,7 @@ func (s *Store) CreateOrder(order domain.Order) (domain.Order, error) {
 }
 
 func (s *Store) UpdateOrder(order domain.Order) (domain.Order, error) {
+	order.NormalizeExecutionFlags()
 	if order.Metadata == nil {
 		order.Metadata = map[string]any{}
 	}


### PR DESCRIPTION
## 目的
为 session protection / manual close 的第一阶段打底，并补齐 live session 在人工接管后的状态收敛：
- 为 `live session` 与 `signal runtime session` 的 `stop/delete` 增加活动订单/未平仓头寸安全锁，默认在仍有 exposure 时阻断；支持 `force=true` 显式绕过。
- 新增 `POST /api/v1/positions/{id}/close`，提供 reduce-only 的手动平仓入口。
- 新增 `GET /api/v1/orders/{id}`，补齐订单详情查询能力。
- 新增 live cached plan 与真实/虚拟仓位的回对齐逻辑，避免手动接管、手动取消订单、或交易所侧状态变化后 `planIndex` 与实际持仓脱节，导致后续错误地停留在 exit 或重新开仓判断失真。
- 补强 manual close 的执行硬约束：`reduceOnly` / `closePosition` 现在是订单模型里的正式字段并在执行链路中被显式识别；`ClosePosition()` 在 LIVE 账户会先 refresh 最新持仓再下单；reduce-only 订单会阻断无仓、方向错误、超量平仓，以及 REST 规范化阶段为了 `minQty` / `minNotional` 偷偷放大数量的情况。
- 跟进 review 的非阻塞建议：reduce-only 校验不再默认把 `account + symbol` 当作唯一目标，而是优先按 `positionId` / `strategyVersionId` 精确定位，并在共享 symbol 场景下显式拒绝歧义；manual close 的 `MARKET` 单不再把 `markPrice` 写进显式 `Price` 字段，而是仅作为 `priceHint` / `markPrice` metadata 传递。
- 这次改动只是把 manual close / reduce-only 入口的定位语义收紧；并不意味着系统已经完整支持“同账户、同 symbol、多策略/多周期并存持仓”的全局模型，这部分仍需后续单独设计。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [x] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [ ] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main)
- [ ] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？
- [ ] DB migration 是否具备向下兼容幂等性？
- [ ] 配置字段有没有无意被混改？

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

本地验证：
- `gofmt -w .`
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`

补充测试覆盖：
- `internal/service/safety_checks_test.go`
- `internal/http/session_safety_test.go`
- `internal/service/live_test.go`
