### PR TITLE
[codex] persist logs across container restarts

### DIFF
--- a/cmd/platform-api/main.go
+++ b/cmd/platform-api/main.go
@@ -27,6 +27,17 @@ func main() {
 		_, _ = fmt.Fprintf(os.Stderr, "日志配置失败: %v\n", err)
 		os.Exit(1)
 	}
+	bootstrapResult, err := logging.BootstrapFromDisk(cfg.LogDir)
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "日志预热失败: %v\n", err)
+	} else if bootstrapResult.SystemRecovered > 0 || bootstrapResult.HTTPRecovered > 0 || bootstrapResult.SkippedLines > 0 {
+		slog.Info("log buffers preloaded from disk",
+			"log_dir", cfg.LogDir,
+			"system_logs", bootstrapResult.SystemRecovered,
+			"http_logs", bootstrapResult.HTTPRecovered,
+			"skipped_lines", bootstrapResult.SkippedLines,
+		)
+	}
 
 	slog.Info("platform-api starting",
 		"http_addr", cfg.HTTPAddr,

--- a/deployments/docker-compose.prod.yml
+++ b/deployments/docker-compose.prod.yml
@@ -5,8 +5,14 @@ services:
     restart: unless-stopped
     env_file:
       - ${APP_ENV_FILE:-/opt/bktrader/.env}
+    environment:
+      LOG_DIR: ${LOG_DIR:-/app/logs}
+      LOG_RETENTION_DAYS: ${LOG_RETENTION_DAYS:-7}
+      LOG_MAX_SIZE_MB: ${LOG_MAX_SIZE_MB:-100}
     ports:
       - "8080:8080"
+    volumes:
+      - ../logs:/app/logs
     depends_on:
       - postgres
       - redis

--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,5 @@ go 1.22
 require (
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/lib/pq v1.12.2 // indirect
+	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 )

--- a/go.sum
+++ b/go.sum
@@ -2,3 +2,5 @@ github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aN
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/lib/pq v1.12.2 h1:ajJNv84limnK3aPbDIhLtcjrUbqAw/5XNdkuI6KNe/Q=
 github.com/lib/pq v1.12.2/go.mod h1:/p+8NSbOcwzAEI7wiMXFlgydTwcgTr3OSKMsD2BitpA=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1 h1:bBRl1b0OH9s/DuPhuXpNl+VtCaJXFZ5/uEFST95x9zc=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYskCTPBJVb9jqSc=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,6 +14,9 @@ type Config struct {
 	LogLevel                       string // 日志级别（debug / info / warn / error）
 	LogFormat                      string // 日志格式（text / json）
 	LogAddSource                   bool   // 是否在日志中附带源码位置信息
+	LogDir                         string // 日志镜像落盘目录；为空时禁用日志持久化
+	LogRetentionDays               int    // 日志保留天数
+	LogMaxSizeMB                   int    // 单个日志文件滚动前的最大体积（MB）
 	HTTPAddr                       string // HTTP 监听地址
 	StoreBackend                   string // 存储后端类型（memory / postgres）
 	AutoMigrate                    bool   // 是否在启动时自动执行数据库迁移
@@ -70,6 +73,9 @@ func Load() Config {
 		LogLevel:                       getenv("LOG_LEVEL", "info"),
 		LogFormat:                      getenv("LOG_FORMAT", "text"),
 		LogAddSource:                   boolFromEnv("LOG_ADD_SOURCE", false),
+		LogDir:                         strings.TrimSpace(os.Getenv("LOG_DIR")),
+		LogRetentionDays:               intFromEnv("LOG_RETENTION_DAYS", 7),
+		LogMaxSizeMB:                   intFromEnv("LOG_MAX_SIZE_MB", 100),
 		HTTPAddr:                       getenv("HTTP_ADDR", ":8080"),
 		StoreBackend:                   getenv("STORE_BACKEND", "memory"),
 		AutoMigrate:                    boolFromEnv("AUTO_MIGRATE", false),
@@ -109,6 +115,12 @@ func (c Config) Validate() error {
 	case "", "text", "json":
 	default:
 		return fmt.Errorf("不支持的 LOG_FORMAT: %s（可选: text, json）", c.LogFormat)
+	}
+	if c.LogRetentionDays <= 0 {
+		return fmt.Errorf("LOG_RETENTION_DAYS 必须大于 0")
+	}
+	if c.LogMaxSizeMB <= 0 {
+		return fmt.Errorf("LOG_MAX_SIZE_MB 必须大于 0")
 	}
 	if c.HTTPAddr == "" {
 		return fmt.Errorf("HTTP_ADDR 不能为空")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -116,11 +116,13 @@ func (c Config) Validate() error {
 	default:
 		return fmt.Errorf("不支持的 LOG_FORMAT: %s（可选: text, json）", c.LogFormat)
 	}
-	if c.LogRetentionDays <= 0 {
-		return fmt.Errorf("LOG_RETENTION_DAYS 必须大于 0")
-	}
-	if c.LogMaxSizeMB <= 0 {
-		return fmt.Errorf("LOG_MAX_SIZE_MB 必须大于 0")
+	if strings.TrimSpace(c.LogDir) != "" {
+		if c.LogRetentionDays <= 0 {
+			return fmt.Errorf("LOG_RETENTION_DAYS 必须大于 0")
+		}
+		if c.LogMaxSizeMB <= 0 {
+			return fmt.Errorf("LOG_MAX_SIZE_MB 必须大于 0")
+		}
 	}
 	if c.HTTPAddr == "" {
 		return fmt.Errorf("HTTP_ADDR 不能为空")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -20,6 +20,7 @@ func TestConfigValidateAcceptsSupportedLoggingValues(t *testing.T) {
 		StoreBackend:     "memory",
 		LogLevel:         "debug",
 		LogFormat:        "json",
+		LogDir:           "/tmp/bktrader-logs",
 		LogRetentionDays: 7,
 		LogMaxSizeMB:     100,
 	}
@@ -28,10 +29,23 @@ func TestConfigValidateAcceptsSupportedLoggingValues(t *testing.T) {
 	}
 }
 
+func TestConfigValidateAllowsZeroPersistenceLimitsWhenLogDirDisabled(t *testing.T) {
+	cfg := Config{
+		HTTPAddr:         ":8080",
+		StoreBackend:     "memory",
+		LogRetentionDays: 0,
+		LogMaxSizeMB:     0,
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("expected disabled log persistence to skip retention validation, got %v", err)
+	}
+}
+
 func TestConfigValidateRejectsInvalidLogPersistenceLimits(t *testing.T) {
 	cfg := Config{
 		HTTPAddr:         ":8080",
 		StoreBackend:     "memory",
+		LogDir:           "/tmp/bktrader-logs",
 		LogRetentionDays: 0,
 		LogMaxSizeMB:     100,
 	}
@@ -42,6 +56,7 @@ func TestConfigValidateRejectsInvalidLogPersistenceLimits(t *testing.T) {
 	cfg = Config{
 		HTTPAddr:         ":8080",
 		StoreBackend:     "memory",
+		LogDir:           "/tmp/bktrader-logs",
 		LogRetentionDays: 7,
 		LogMaxSizeMB:     0,
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -16,13 +16,54 @@ func TestConfigValidateRejectsUnsupportedLoggingValues(t *testing.T) {
 
 func TestConfigValidateAcceptsSupportedLoggingValues(t *testing.T) {
 	cfg := Config{
-		HTTPAddr:     ":8080",
-		StoreBackend: "memory",
-		LogLevel:     "debug",
-		LogFormat:    "json",
+		HTTPAddr:         ":8080",
+		StoreBackend:     "memory",
+		LogLevel:         "debug",
+		LogFormat:        "json",
+		LogRetentionDays: 7,
+		LogMaxSizeMB:     100,
 	}
 	if err := cfg.Validate(); err != nil {
 		t.Fatalf("expected config to validate, got error: %v", err)
+	}
+}
+
+func TestConfigValidateRejectsInvalidLogPersistenceLimits(t *testing.T) {
+	cfg := Config{
+		HTTPAddr:         ":8080",
+		StoreBackend:     "memory",
+		LogRetentionDays: 0,
+		LogMaxSizeMB:     100,
+	}
+	if err := cfg.Validate(); err == nil {
+		t.Fatalf("expected invalid retention to fail validation")
+	}
+
+	cfg = Config{
+		HTTPAddr:         ":8080",
+		StoreBackend:     "memory",
+		LogRetentionDays: 7,
+		LogMaxSizeMB:     0,
+	}
+	if err := cfg.Validate(); err == nil {
+		t.Fatalf("expected invalid log max size to fail validation")
+	}
+}
+
+func TestLoadReadsLogPersistenceEnv(t *testing.T) {
+	t.Setenv("LOG_DIR", "/tmp/bktrader-logs")
+	t.Setenv("LOG_RETENTION_DAYS", "9")
+	t.Setenv("LOG_MAX_SIZE_MB", "64")
+
+	cfg := Load()
+	if cfg.LogDir != "/tmp/bktrader-logs" {
+		t.Fatalf("expected LOG_DIR to be loaded, got %q", cfg.LogDir)
+	}
+	if cfg.LogRetentionDays != 9 {
+		t.Fatalf("expected LOG_RETENTION_DAYS=9, got %d", cfg.LogRetentionDays)
+	}
+	if cfg.LogMaxSizeMB != 64 {
+		t.Fatalf("expected LOG_MAX_SIZE_MB=64, got %d", cfg.LogMaxSizeMB)
 	}
 }
 

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -13,6 +13,10 @@ import (
 
 // Configure 初始化全局默认日志器，统一接管结构化日志输出。
 func Configure(cfg config.Config) error {
+	if err := configureDiskMirror(cfg); err != nil {
+		return err
+	}
+
 	level, err := parseLevel(cfg.LogLevel)
 	if err != nil {
 		return err

--- a/internal/logging/persistence.go
+++ b/internal/logging/persistence.go
@@ -1,0 +1,315 @@
+package logging
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/wuyaocheng/bktrader/internal/config"
+	lumberjack "gopkg.in/natefinch/lumberjack.v2"
+)
+
+const (
+	systemLogMirrorFilename            = "system-log.jsonl"
+	httpRequestLogMirrorFilename       = "http-request-log.jsonl"
+	bootstrapTailReadBytes       int64 = 4 << 20
+)
+
+type BootstrapResult struct {
+	SystemRecovered int
+	HTTPRecovered   int
+	SkippedLines    int
+}
+
+type diskMirror struct {
+	mu         sync.Mutex
+	systemFile io.WriteCloser
+	httpFile   io.WriteCloser
+}
+
+var defaultDiskMirror diskMirror
+
+func configureDiskMirror(cfg config.Config) error {
+	return defaultDiskMirror.configure(cfg.LogDir, cfg.LogMaxSizeMB, cfg.LogRetentionDays)
+}
+
+func (m *diskMirror) configure(logDir string, maxSizeMB, retentionDays int) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.closeLocked()
+	if strings.TrimSpace(logDir) == "" {
+		return nil
+	}
+	if err := os.MkdirAll(logDir, 0o755); err != nil {
+		return fmt.Errorf("create log dir: %w", err)
+	}
+
+	m.systemFile = &lumberjack.Logger{
+		Filename:   filepath.Join(logDir, systemLogMirrorFilename),
+		MaxSize:    maxSizeMB,
+		MaxAge:     retentionDays,
+		MaxBackups: 0,
+		LocalTime:  false,
+		Compress:   false,
+	}
+	m.httpFile = &lumberjack.Logger{
+		Filename:   filepath.Join(logDir, httpRequestLogMirrorFilename),
+		MaxSize:    maxSizeMB,
+		MaxAge:     retentionDays,
+		MaxBackups: 0,
+		LocalTime:  false,
+		Compress:   false,
+	}
+	return nil
+}
+
+func (m *diskMirror) reset() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.closeLocked()
+}
+
+func (m *diskMirror) closeLocked() {
+	if m.systemFile != nil {
+		_ = m.systemFile.Close()
+		m.systemFile = nil
+	}
+	if m.httpFile != nil {
+		_ = m.httpFile.Close()
+		m.httpFile = nil
+	}
+}
+
+func (m *diskMirror) writeSystem(entry SystemLogEntry) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.systemFile == nil {
+		return nil
+	}
+	return writeJSONLine(m.systemFile, normalizePersistedSystemLog(entry))
+}
+
+func (m *diskMirror) writeHTTPRequest(entry HTTPRequestLogEntry) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.httpFile == nil {
+		return nil
+	}
+	return writeJSONLine(m.httpFile, normalizePersistedHTTPRequestLog(entry))
+}
+
+func BootstrapFromDisk(logDir string) (BootstrapResult, error) {
+	logDir = strings.TrimSpace(logDir)
+	if logDir == "" {
+		return BootstrapResult{}, nil
+	}
+	if _, err := os.Stat(logDir); err != nil {
+		if os.IsNotExist(err) {
+			return BootstrapResult{}, nil
+		}
+		return BootstrapResult{}, fmt.Errorf("stat log dir: %w", err)
+	}
+
+	systemEntries, skipped, err := loadPersistedTail[SystemLogEntry](filepath.Join(logDir, "system-log*.jsonl"), defaultSystemLogCapacity)
+	if err != nil {
+		return BootstrapResult{}, err
+	}
+	httpEntries, httpSkipped, err := loadPersistedTail[HTTPRequestLogEntry](filepath.Join(logDir, "http-request-log*.jsonl"), defaultHTTPRequestCapacity)
+	if err != nil {
+		return BootstrapResult{}, err
+	}
+	for _, entry := range systemEntries {
+		defaultSystemLogStore.add(entry)
+	}
+	for _, entry := range httpEntries {
+		defaultHTTPRequestStore.add(entry)
+	}
+	return BootstrapResult{
+		SystemRecovered: len(systemEntries),
+		HTTPRecovered:   len(httpEntries),
+		SkippedLines:    skipped + httpSkipped,
+	}, nil
+}
+
+func loadPersistedTail[T any](pattern string, limit int) ([]T, int, error) {
+	paths, err := filepath.Glob(pattern)
+	if err != nil {
+		return nil, 0, fmt.Errorf("glob log files: %w", err)
+	}
+	paths = filterExistingFiles(paths)
+	if len(paths) == 0 {
+		return nil, 0, nil
+	}
+	sort.Strings(paths)
+
+	reversedLines := make([]string, 0, limit)
+	for i := len(paths) - 1; i >= 0 && len(reversedLines) < limit; i-- {
+		lines, err := readTailLines(paths[i], limit-len(reversedLines))
+		if err != nil {
+			return nil, 0, fmt.Errorf("read persisted log %s: %w", paths[i], err)
+		}
+		for j := len(lines) - 1; j >= 0 && len(reversedLines) < limit; j-- {
+			reversedLines = append(reversedLines, lines[j])
+		}
+	}
+	reverseStrings(reversedLines)
+
+	items := make([]T, 0, len(reversedLines))
+	skipped := 0
+	for _, line := range reversedLines {
+		var item T
+		if err := json.Unmarshal([]byte(line), &item); err != nil {
+			skipped++
+			continue
+		}
+		items = append(items, item)
+	}
+	return items, skipped, nil
+}
+
+func filterExistingFiles(paths []string) []string {
+	out := make([]string, 0, len(paths))
+	for _, path := range paths {
+		info, err := os.Stat(path)
+		if err != nil || info.IsDir() {
+			continue
+		}
+		out = append(out, path)
+	}
+	return out
+}
+
+func readTailLines(path string, maxLines int) ([]string, error) {
+	if maxLines <= 0 {
+		return nil, nil
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	info, err := file.Stat()
+	if err != nil {
+		return nil, err
+	}
+	offset := info.Size() - bootstrapTailReadBytes
+	if offset < 0 {
+		offset = 0
+	}
+	if _, err := file.Seek(offset, io.SeekStart); err != nil {
+		return nil, err
+	}
+	payload, err := io.ReadAll(file)
+	if err != nil {
+		return nil, err
+	}
+	if offset > 0 {
+		if index := bytes.IndexByte(payload, '\n'); index >= 0 {
+			payload = payload[index+1:]
+		} else {
+			return nil, nil
+		}
+	}
+	rawLines := bytes.Split(payload, []byte{'\n'})
+	lines := make([]string, 0, len(rawLines))
+	for _, raw := range rawLines {
+		line := strings.TrimSpace(string(raw))
+		if line == "" {
+			continue
+		}
+		lines = append(lines, line)
+	}
+	if len(lines) > maxLines {
+		lines = lines[len(lines)-maxLines:]
+	}
+	return lines, nil
+}
+
+func reverseStrings(values []string) {
+	for left, right := 0, len(values)-1; left < right; left, right = left+1, right-1 {
+		values[left], values[right] = values[right], values[left]
+	}
+}
+
+func writeJSONLine(writer io.Writer, payload any) error {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	body = append(body, '\n')
+	_, err = writer.Write(body)
+	return err
+}
+
+func normalizePersistedSystemLog(entry SystemLogEntry) SystemLogEntry {
+	entry.CreatedAt = normalizeTime(entry.CreatedAt)
+	entry.Attributes = normalizePersistedMap(entry.Attributes)
+	return entry
+}
+
+func normalizePersistedHTTPRequestLog(entry HTTPRequestLogEntry) HTTPRequestLogEntry {
+	entry.CreatedAt = normalizeTime(entry.CreatedAt)
+	entry.Attributes = normalizePersistedMap(entry.Attributes)
+	return entry
+}
+
+func normalizePersistedMap(values map[string]any) map[string]any {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(values))
+	for key, value := range values {
+		out[key] = normalizePersistedValue(value)
+	}
+	return out
+}
+
+func normalizePersistedValue(value any) any {
+	switch typed := value.(type) {
+	case nil,
+		bool,
+		string,
+		float32,
+		float64,
+		int,
+		int8,
+		int16,
+		int32,
+		int64,
+		uint,
+		uint8,
+		uint16,
+		uint32,
+		uint64,
+		json.Number:
+		return typed
+	case time.Time:
+		return typed.UTC()
+	case []any:
+		out := make([]any, 0, len(typed))
+		for _, item := range typed {
+			out = append(out, normalizePersistedValue(item))
+		}
+		return out
+	case map[string]any:
+		return normalizePersistedMap(typed)
+	case error:
+		return typed.Error()
+	case fmt.Stringer:
+		return typed.String()
+	default:
+		if _, err := json.Marshal(typed); err == nil {
+			return typed
+		}
+		return fmt.Sprintf("%v", typed)
+	}
+}

--- a/internal/logging/persistence.go
+++ b/internal/logging/persistence.go
@@ -48,7 +48,7 @@ func (m *diskMirror) configure(logDir string, maxSizeMB, retentionDays int) erro
 	if strings.TrimSpace(logDir) == "" {
 		return nil
 	}
-	if err := os.MkdirAll(logDir, 0o755); err != nil {
+	if err := os.MkdirAll(logDir, 0o750); err != nil {
 		return fmt.Errorf("create log dir: %w", err)
 	}
 
@@ -126,11 +126,13 @@ func BootstrapFromDisk(logDir string) (BootstrapResult, error) {
 	if err != nil {
 		return BootstrapResult{}, err
 	}
+	// Bootstrap intentionally restores via store-only helpers so historical lines
+	// are not re-published to brokers or appended back into the mirror files.
 	for _, entry := range systemEntries {
-		defaultSystemLogStore.add(entry)
+		restoreSystemLog(entry)
 	}
 	for _, entry := range httpEntries {
-		defaultHTTPRequestStore.add(entry)
+		restoreHTTPRequest(entry)
 	}
 	return BootstrapResult{
 		SystemRecovered: len(systemEntries),
@@ -201,6 +203,8 @@ func readTailLines(path string, maxLines int) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
+	// Bootstrap only needs enough tail data to repopulate the in-memory buffers after restart.
+	// This 4MB window is a best-effort bound so startup stays predictable even for large log files.
 	offset := info.Size() - bootstrapTailReadBytes
 	if offset < 0 {
 		offset = 0

--- a/internal/logging/recovery_test.go
+++ b/internal/logging/recovery_test.go
@@ -170,6 +170,78 @@ func TestBootstrapFromDiskRestoresBuffersAndSequences(t *testing.T) {
 	}
 }
 
+func TestBootstrapFromDiskDoesNotRewritePersistedLogs(t *testing.T) {
+	ResetForTests()
+	t.Cleanup(ResetForTests)
+
+	dir := t.TempDir()
+	writeJSONLines(t, filepath.Join(dir, systemLogMirrorFilename), []SystemLogEntry{
+		{
+			ID:        "system-log-1",
+			Level:     "info",
+			Message:   "persisted system log",
+			CreatedAt: time.Date(2026, time.April, 17, 10, 0, 0, 0, time.UTC),
+		},
+	})
+	writeJSONLines(t, filepath.Join(dir, httpRequestLogMirrorFilename), []HTTPRequestLogEntry{
+		{
+			ID:         "http-log-1",
+			Level:      "info",
+			Message:    "persisted http log",
+			Method:     "GET",
+			Path:       "/readyz",
+			Status:     200,
+			DurationMs: 3,
+			CreatedAt:  time.Date(2026, time.April, 17, 10, 0, 1, 0, time.UTC),
+		},
+	})
+
+	cfg := config.Config{
+		AppName:          "bkTrader-test",
+		Environment:      "test",
+		LogLevel:         "info",
+		LogFormat:        "json",
+		LogDir:           dir,
+		LogRetentionDays: 7,
+		LogMaxSizeMB:     1,
+	}
+	if err := Configure(cfg); err != nil {
+		t.Fatalf("configure logger: %v", err)
+	}
+
+	systemBefore, err := os.ReadFile(filepath.Join(dir, systemLogMirrorFilename))
+	if err != nil {
+		t.Fatalf("read persisted system log before bootstrap: %v", err)
+	}
+	httpBefore, err := os.ReadFile(filepath.Join(dir, httpRequestLogMirrorFilename))
+	if err != nil {
+		t.Fatalf("read persisted http log before bootstrap: %v", err)
+	}
+
+	if _, err := BootstrapFromDisk(dir); err != nil {
+		t.Fatalf("first bootstrap from disk: %v", err)
+	}
+	if _, err := BootstrapFromDisk(dir); err != nil {
+		t.Fatalf("second bootstrap from disk: %v", err)
+	}
+
+	systemAfter, err := os.ReadFile(filepath.Join(dir, systemLogMirrorFilename))
+	if err != nil {
+		t.Fatalf("read persisted system log after bootstrap: %v", err)
+	}
+	httpAfter, err := os.ReadFile(filepath.Join(dir, httpRequestLogMirrorFilename))
+	if err != nil {
+		t.Fatalf("read persisted http log after bootstrap: %v", err)
+	}
+
+	if !bytes.Equal(systemBefore, systemAfter) {
+		t.Fatalf("expected bootstrap to avoid rewriting persisted system logs")
+	}
+	if !bytes.Equal(httpBefore, httpAfter) {
+		t.Fatalf("expected bootstrap to avoid rewriting persisted http logs")
+	}
+}
+
 func writeJSONLines[T any](t *testing.T, path string, entries []T) {
 	t.Helper()
 	var buffer bytes.Buffer

--- a/internal/logging/recovery_test.go
+++ b/internal/logging/recovery_test.go
@@ -1,0 +1,214 @@
+package logging
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/wuyaocheng/bktrader/internal/config"
+)
+
+func TestConfigurePersistsSystemAndHTTPRequestLogsToDisk(t *testing.T) {
+	ResetForTests()
+	t.Cleanup(ResetForTests)
+
+	dir := t.TempDir()
+	originalLogger := slog.Default()
+	t.Cleanup(func() {
+		slog.SetDefault(originalLogger)
+	})
+
+	cfg := config.Config{
+		AppName:          "bkTrader-test",
+		Environment:      "test",
+		LogLevel:         "debug",
+		LogFormat:        "json",
+		LogDir:           dir,
+		LogRetentionDays: 7,
+		LogMaxSizeMB:     1,
+	}
+	if err := Configure(cfg); err != nil {
+		t.Fatalf("configure logger: %v", err)
+	}
+
+	slog.Info("persistent system log", "component", "test.persistence", "attempt", 1)
+	RecordHTTPRequest(HTTPRequestLogEntry{
+		ID:         "http-log-7",
+		Level:      "info",
+		Message:    "http request completed",
+		Method:     "GET",
+		Path:       "/healthz",
+		Status:     200,
+		DurationMs: 12,
+		CreatedAt:  time.Date(2026, time.April, 17, 9, 0, 0, 0, time.UTC),
+		Attributes: map[string]any{
+			"component": "http",
+		},
+	})
+
+	systemEntries := readJSONLines[SystemLogEntry](t, filepath.Join(dir, systemLogMirrorFilename))
+	if len(systemEntries) == 0 {
+		t.Fatalf("expected system log mirror to contain entries")
+	}
+	foundSystem := false
+	for _, entry := range systemEntries {
+		if entry.Message != "persistent system log" {
+			continue
+		}
+		foundSystem = true
+		if entry.Level != "info" {
+			t.Fatalf("expected system log level info, got %q", entry.Level)
+		}
+		if got := stringValue(entry.Attributes["component"]); got != "test.persistence" {
+			t.Fatalf("expected mirrored component, got %q", got)
+		}
+	}
+	if !foundSystem {
+		t.Fatalf("expected persistent system log in mirrored file")
+	}
+
+	httpEntries := readJSONLines[HTTPRequestLogEntry](t, filepath.Join(dir, httpRequestLogMirrorFilename))
+	if len(httpEntries) != 1 {
+		t.Fatalf("expected exactly one persisted http request log, got %d", len(httpEntries))
+	}
+	if httpEntries[0].Path != "/healthz" {
+		t.Fatalf("expected mirrored http path /healthz, got %q", httpEntries[0].Path)
+	}
+}
+
+func TestBootstrapFromDiskRestoresBuffersAndSequences(t *testing.T) {
+	ResetForTests()
+	t.Cleanup(ResetForTests)
+
+	dir := t.TempDir()
+	writeJSONLines(t, filepath.Join(dir, systemLogMirrorFilename), []SystemLogEntry{
+		{
+			ID:        "system-log-41",
+			Level:     "warning",
+			Message:   "persisted warning",
+			CreatedAt: time.Date(2026, time.April, 17, 8, 0, 0, 0, time.UTC),
+			Attributes: map[string]any{
+				"component": "bootstrap",
+			},
+		},
+		{
+			ID:        "system-log-42",
+			Level:     "info",
+			Message:   "persisted info",
+			CreatedAt: time.Date(2026, time.April, 17, 8, 5, 0, 0, time.UTC),
+		},
+	})
+	writeJSONLines(t, filepath.Join(dir, httpRequestLogMirrorFilename), []HTTPRequestLogEntry{
+		{
+			ID:         "http-log-9",
+			Level:      "info",
+			Message:    "http request completed",
+			Method:     "GET",
+			Path:       "/api/v1/health",
+			Status:     200,
+			DurationMs: 4,
+			CreatedAt:  time.Date(2026, time.April, 17, 8, 10, 0, 0, time.UTC),
+		},
+	})
+
+	result, err := BootstrapFromDisk(dir)
+	if err != nil {
+		t.Fatalf("bootstrap from disk: %v", err)
+	}
+	if result.SystemRecovered != 2 {
+		t.Fatalf("expected 2 recovered system logs, got %d", result.SystemRecovered)
+	}
+	if result.HTTPRecovered != 1 {
+		t.Fatalf("expected 1 recovered http log, got %d", result.HTTPRecovered)
+	}
+	if result.SkippedLines != 0 {
+		t.Fatalf("expected no skipped lines, got %d", result.SkippedLines)
+	}
+
+	systemPage, err := ListSystemLogs(SystemLogQuery{Limit: 10})
+	if err != nil {
+		t.Fatalf("list system logs: %v", err)
+	}
+	if len(systemPage.Items) != 2 {
+		t.Fatalf("expected 2 system logs in memory, got %d", len(systemPage.Items))
+	}
+	if systemPage.Items[0].ID != "system-log-42" {
+		t.Fatalf("expected newest recovered system log first, got %q", systemPage.Items[0].ID)
+	}
+
+	httpEntry, ok := GetHTTPRequestLog("http-log-9")
+	if !ok {
+		t.Fatalf("expected recovered http request log to be queryable")
+	}
+	if httpEntry.Path != "/api/v1/health" {
+		t.Fatalf("expected recovered http request path, got %q", httpEntry.Path)
+	}
+
+	newSystem := RecordSystemLog(SystemLogEntry{
+		Message:   "new system log",
+		CreatedAt: time.Date(2026, time.April, 17, 8, 15, 0, 0, time.UTC),
+	})
+	if newSystem.ID != "system-log-43" {
+		t.Fatalf("expected recovered sequence to continue at system-log-43, got %q", newSystem.ID)
+	}
+
+	newHTTP := RecordHTTPRequest(HTTPRequestLogEntry{
+		Message:    "new http log",
+		Method:     "POST",
+		Path:       "/api/v1/orders",
+		Status:     201,
+		DurationMs: 6,
+		CreatedAt:  time.Date(2026, time.April, 17, 8, 20, 0, 0, time.UTC),
+	})
+	if newHTTP.ID != "http-log-10" {
+		t.Fatalf("expected recovered sequence to continue at http-log-10, got %q", newHTTP.ID)
+	}
+}
+
+func writeJSONLines[T any](t *testing.T, path string, entries []T) {
+	t.Helper()
+	var buffer bytes.Buffer
+	for _, entry := range entries {
+		line, err := json.Marshal(entry)
+		if err != nil {
+			t.Fatalf("marshal json line: %v", err)
+		}
+		buffer.Write(line)
+		buffer.WriteByte('\n')
+	}
+	if err := os.WriteFile(path, buffer.Bytes(), 0o644); err != nil {
+		t.Fatalf("write json lines: %v", err)
+	}
+}
+
+func readJSONLines[T any](t *testing.T, path string) []T {
+	t.Helper()
+	file, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open mirrored log file: %v", err)
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	items := make([]T, 0)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+		var item T
+		if err := json.Unmarshal(line, &item); err != nil {
+			t.Fatalf("decode mirrored log line: %v", err)
+		}
+		items = append(items, item)
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scan mirrored log file: %v", err)
+	}
+	return items
+}

--- a/internal/logging/store.go
+++ b/internal/logging/store.go
@@ -288,6 +288,14 @@ func GetHTTPRequestLog(id string) (HTTPRequestLogEntry, bool) {
 	return defaultHTTPRequestStore.get(strings.TrimSpace(id))
 }
 
+func restoreSystemLog(entry SystemLogEntry) SystemLogEntry {
+	return defaultSystemLogStore.add(entry)
+}
+
+func restoreHTTPRequest(entry HTTPRequestLogEntry) HTTPRequestLogEntry {
+	return defaultHTTPRequestStore.add(entry)
+}
+
 // ResetForTests 清理全局日志缓冲，仅供测试使用。
 func ResetForTests() {
 	defaultSystemLogStore.reset()

--- a/internal/logging/store.go
+++ b/internal/logging/store.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -239,6 +240,7 @@ func HTTPBroker() *Broker {
 
 func RecordSystemLog(entry SystemLogEntry) SystemLogEntry {
 	recorded := defaultSystemLogStore.add(entry)
+	_ = defaultDiskMirror.writeSystem(recorded)
 	defaultSystemBroker.Publish(StreamMessage{
 		ID:         recorded.ID,
 		Source:     "system",
@@ -253,6 +255,7 @@ func RecordSystemLog(entry SystemLogEntry) SystemLogEntry {
 
 func RecordHTTPRequest(entry HTTPRequestLogEntry) HTTPRequestLogEntry {
 	recorded := defaultHTTPRequestStore.add(entry)
+	_ = defaultDiskMirror.writeHTTPRequest(recorded)
 	defaultHTTPBroker.Publish(StreamMessage{
 		ID:         recorded.ID,
 		Source:     "http",
@@ -291,6 +294,7 @@ func ResetForTests() {
 	defaultHTTPRequestStore.reset()
 	defaultSystemBroker.reset()
 	defaultHTTPBroker.reset()
+	defaultDiskMirror.reset()
 }
 
 func newSystemCaptureHandler() slog.Handler {
@@ -349,6 +353,8 @@ func (s *systemLogStore) add(entry SystemLogEntry) SystemLogEntry {
 	entry.CreatedAt = normalizeTime(entry.CreatedAt)
 	if entry.ID == "" {
 		entry.ID = fmt.Sprintf("system-log-%d", s.sequence.Add(1))
+	} else {
+		bumpAtomicSequence(&s.sequence, entry.ID, "system-log-")
 	}
 	if len(entry.Attributes) == 0 {
 		entry.Attributes = nil
@@ -409,6 +415,8 @@ func (s *httpRequestLogStore) add(entry HTTPRequestLogEntry) HTTPRequestLogEntry
 	entry.Message = strings.TrimSpace(entry.Message)
 	if entry.ID == "" {
 		entry.ID = fmt.Sprintf("http-log-%d", s.sequence.Add(1))
+	} else {
+		bumpAtomicSequence(&s.sequence, entry.ID, "http-log-")
 	}
 	if len(entry.Attributes) == 0 {
 		entry.Attributes = nil
@@ -709,4 +717,24 @@ func firstNonEmpty(values ...string) string {
 		}
 	}
 	return ""
+}
+
+func bumpAtomicSequence(sequence *atomic.Int64, id, prefix string) {
+	raw := strings.TrimSpace(strings.TrimPrefix(id, prefix))
+	if raw == "" {
+		return
+	}
+	value, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || value <= 0 {
+		return
+	}
+	for {
+		current := sequence.Load()
+		if current >= value {
+			return
+		}
+		if sequence.CompareAndSwap(current, value) {
+			return
+		}
+	}
 }

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -15,8 +15,9 @@ if ! command -v docker >/dev/null 2>&1; then
   exit 127
 fi
 
-mkdir -p "$DEPLOY_PATH/deployments" "$DEPLOY_PATH/scripts"
+mkdir -p "$DEPLOY_PATH/deployments" "$DEPLOY_PATH/scripts" "$DEPLOY_PATH/logs"
 mkdir -p "$DOCKER_CONFIG_DIR"
+chmod 755 "$DEPLOY_PATH/logs"
 chmod 700 "$DOCKER_CONFIG_DIR"
 
 if [[ -n "${APP_ENV_FILE_CONTENT:-}" ]]; then

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -17,7 +17,7 @@ fi
 
 mkdir -p "$DEPLOY_PATH/deployments" "$DEPLOY_PATH/scripts" "$DEPLOY_PATH/logs"
 mkdir -p "$DOCKER_CONFIG_DIR"
-chmod 755 "$DEPLOY_PATH/logs"
+chmod 750 "$DEPLOY_PATH/logs"
 chmod 700 "$DOCKER_CONFIG_DIR"
 
 if [[ -n "${APP_ENV_FILE_CONTENT:-}" ]]; then


### PR DESCRIPTION
## 目的
解决 `docker-compose` 场景下容器重建后标准输出日志不可追溯、以及 Console 内存日志无法恢复的问题。根因是现有日志只保存在进程内 ring buffer 和容器 stdout 中，容器销毁后缺少可用于启动预热的持久化镜像。

本次改动：
- 为系统日志和 HTTP 请求日志增加 JSONL 文件镜像，并使用 `lumberjack` 做滚动控制
- 在 `platform-api` 启动阶段从持久化日志尾部预热 ring buffer，恢复 Console 可见历史日志
- 增加 `LOG_DIR` / `LOG_RETENTION_DAYS` / `LOG_MAX_SIZE_MB` 配置，并在生产 compose 与 deploy 脚本里挂载 `/app/logs`
- 补充落盘与恢复相关单元测试，覆盖恢复后 ID 续号行为

对使用者/运维的影响：
- 容器重建后，`/api/v1/logs/system` 和 Console 的系统日志可以恢复最近一段历史记录
- 宿主机日志目录可直接用于排查和备份，不再完全依赖容器 stdout
- 生产部署新增日志目录挂载与 3 个日志相关环境变量

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [x] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [ ] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main)
- [ ] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？
- [ ] DB migration 是否具备向下兼容幂等性？
- [x] 配置字段有没有无意被混改？

说明：本 PR 有意新增 `LOG_DIR`、`LOG_RETENTION_DAYS`、`LOG_MAX_SIZE_MB`，并调整了生产部署日志挂载；未触碰 live 执行策略、dispatch 默认行为或 mainnet 路由。

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

已执行：
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
- `git push -u origin codex/log-persistence` 时触发 pre-push harness checks，并自动重建了 `graphify-out`
