### PR TITLE
fix: signal runtime tiered recovery + cross-symbol isolation

### DIFF
--- a/docs/frontend-signal-isolation-collab.md
+++ b/docs/frontend-signal-isolation-collab.md
@@ -1,0 +1,127 @@
+# 前端协作：Signal Symbol 隔离
+
+> **上下文**：后端已完成信号源稳定性修复 + 跨 Symbol 信号隔离。前端需要同步更新 derivation 函数以完成端到端隔离。
+>
+> **PR**: `fix/signal-runtime-stability-and-symbol-isolation`
+
+## 背景
+
+### 问题
+
+当一个 signal runtime session 同时订阅了多个 symbol（如 BTCUSDT + ETHUSDT）的数据流时，前端的 derivation 函数从 `sourceStates` 中遍历所有 entries **不区分 symbol**，导致：
+- `MonitorStage` 中展示的价格/K线可能是多个 symbol 混在一起
+- `AccountStage` 中的 runtime panel 同理
+
+### 后端已完成的工作
+
+后端已在 `evaluateLiveSessionOnSignal` 中通过 `filterSourceStatesBySymbol` / `filterSignalBarStatesBySymbol` 对传递给策略评估的数据做了 symbol 过滤。但前端直接从 `runtimeSession.State.sourceStates` 读取数据展示在 UI 上，这条路径还需要前端侧做过滤。
+
+---
+
+## 需要修改的文件
+
+### 1. `web/console/src/utils/derivation.ts`
+
+#### `deriveRuntimeMarketSnapshot` (约 L388)
+
+新增可选参数 `targetSymbol?: string`，对 sourceStates 做 symbol 过滤：
+
+```typescript
+// 改造前:
+export function deriveRuntimeMarketSnapshot(
+  sourceStates: Record<string, unknown>,
+  summary: Record<string, unknown>
+): RuntimeMarketSnapshot {
+  const states = Object.values(sourceStates).map((value) => getRecord(value));
+  // ...
+}
+
+// 改造后:
+export function deriveRuntimeMarketSnapshot(
+  sourceStates: Record<string, unknown>,
+  summary: Record<string, unknown>,
+  targetSymbol?: string
+): RuntimeMarketSnapshot {
+  const normalizedTarget = (targetSymbol ?? "").trim().toUpperCase();
+  const states = Object.values(sourceStates)
+    .map((value) => getRecord(value))
+    .filter((state) => {
+      if (!normalizedTarget) return true;
+      const stateSymbol = String(state.symbol ?? "").trim().toUpperCase();
+      return stateSymbol === "" || stateSymbol === normalizedTarget;
+    });
+  // ... 其余逻辑不变
+}
+```
+
+#### `deriveRuntimeSourceSummary` (约 L418)
+
+同样新增 `targetSymbol?: string` 参数，过滤逻辑同上。
+
+#### `deriveSignalBarCandles` (约 L486)
+
+同样新增 `targetSymbol?: string` 参数，在遍历 bar entries 时过滤：
+
+```typescript
+export function deriveSignalBarCandles(
+  sourceStates: Record<string, unknown>,
+  targetSymbol?: string
+): SignalBarCandle[] {
+  const normalizedTarget = (targetSymbol ?? "").trim().toUpperCase();
+  // 在遍历 bars 时增加:
+  // const barSymbol = String(bar.symbol ?? "").trim().toUpperCase();
+  // if (normalizedTarget && barSymbol && barSymbol !== normalizedTarget) continue;
+}
+```
+
+### 2. `web/console/src/pages/MonitorStage.tsx`
+
+在调用 derivation 函数处传入当前 session 的 symbol：
+
+```typescript
+const sessionSymbol = String(
+  monitorSession?.state?.symbol ?? ""
+).trim().toUpperCase();
+
+// 调用处追加参数
+const marketSnapshot = deriveRuntimeMarketSnapshot(sourceStates, lastEventSummary, sessionSymbol);
+const sourceSummary = deriveRuntimeSourceSummary(sourceStates, runtimePolicy, sessionSymbol);
+const signalBarCandles = deriveSignalBarCandles(sourceStates, sessionSymbol);
+```
+
+### 3. `web/console/src/pages/AccountStage.tsx`
+
+同 MonitorStage，在 runtime panel 的 derivation 调用处追加 `sessionSymbol` 参数。
+
+---
+
+## 验证方法
+
+1. 同时运行 BTCUSDT 和 ETHUSDT live session
+2. 在 MonitorStage 切换查看不同 session
+3. 确认每个 session 只展示对应 symbol 的价格和 K 线数据
+4. 确认 `deriveRuntimeMarketSnapshot` 返回的价格只来自目标 symbol
+
+## TypeScript 验证
+
+```bash
+cd web/console
+./node_modules/.bin/tsc --noEmit --jsx react-jsx --esModuleInterop --skipLibCheck \
+  --target esnext --moduleResolution node --allowSyntheticDefaultImports
+```
+
+---
+
+## 后端新增的 health 状态（前端可选展示）
+
+后端新增了以下 health 状态值，前端可在 runtime status badge 中展示：
+
+| health 值 | 含义 | 建议样式 |
+|-----------|------|---------|
+| `recovering` | WS 断连后正在自动重连 | 黄色闪烁 |
+| `stale-after-reconnect` | 重连成功但可能漏掉了 K 线收盘 | 红色 |
+
+相关 state 字段：
+- `state.reconnectAttempt` / `state.reconnectMaxAttempts` — 当前重连进度
+- `state.lastDisconnectError` — 上次断连原因
+- `state.signalBarContinuityWarning` — K 线连续性检查结果

--- a/internal/service/alerts.go
+++ b/internal/service/alerts.go
@@ -74,13 +74,48 @@ func (p *Platform) ListAlerts() ([]domain.PlatformAlert, error) {
 		sourceSummary := p.summarizeRuntimeSources(session)
 		state := cloneMetadata(session.State)
 		health := strings.ToLower(strings.TrimSpace(stringValue(state["health"])))
-		if strings.EqualFold(session.Status, "ERROR") || (health != "" && health != "healthy" && health != "idle" && health != "stopped") {
+		if strings.EqualFold(session.Status, "ERROR") || (health != "" && health != "healthy" && health != "idle" && health != "stopped" && health != "recovering" && health != "stale-after-reconnect") {
 			appendAlert(domain.PlatformAlert{
 				ID:               fmt.Sprintf("runtime-health-%s", session.ID),
 				Scope:            "runtime",
 				Level:            "critical",
 				Title:            "Runtime health",
 				Detail:           fmt.Sprintf("session=%s health=%s", session.Status, firstNonEmpty(health, "unknown")),
+				AccountID:        session.AccountID,
+				AccountName:      account.Name,
+				StrategyID:       session.StrategyID,
+				StrategyName:     strategyNameByID[session.StrategyID],
+				RuntimeSessionID: session.ID,
+				Anchor:           "signals",
+				EventTime:        session.UpdatedAt,
+			})
+		}
+		if health == "recovering" {
+			appendAlert(domain.PlatformAlert{
+				ID:    fmt.Sprintf("runtime-recovering-%s", session.ID),
+				Scope: "runtime",
+				Level: "warning",
+				Title: "Runtime recovering",
+				Detail: fmt.Sprintf("attempt %d/%d: %s",
+					maxIntValue(state["reconnectAttempt"], 0),
+					maxIntValue(state["reconnectMaxAttempts"], 0),
+					firstNonEmpty(stringValue(state["lastDisconnectError"]), "unknown")),
+				AccountID:        session.AccountID,
+				AccountName:      account.Name,
+				StrategyID:       session.StrategyID,
+				StrategyName:     strategyNameByID[session.StrategyID],
+				RuntimeSessionID: session.ID,
+				Anchor:           "signals",
+				EventTime:        session.UpdatedAt,
+			})
+		}
+		if health == "stale-after-reconnect" {
+			appendAlert(domain.PlatformAlert{
+				ID:               fmt.Sprintf("runtime-stale-reconnect-%s", session.ID),
+				Scope:            "runtime",
+				Level:            "critical",
+				Title:            "Signal bar may be stale after reconnect",
+				Detail:           "WS disconnect may have missed a K-line close, please verify data and manually restart if needed",
 				AccountID:        session.AccountID,
 				AccountName:      account.Name,
 				StrategyID:       session.StrategyID,

--- a/internal/service/health_state.go
+++ b/internal/service/health_state.go
@@ -366,3 +366,19 @@ func updateAccountSyncFailureHealth(account *domain.Account, attemptedAt time.Ti
 	section["lastError"] = err.Error()
 	section["consecutiveErrorCount"] = maxIntValue(section["consecutiveErrorCount"], 0) + 1
 }
+
+// recordSignalSymbolMismatch records a cross-symbol contamination detection event.
+// This is called when a signal's symbol doesn't match the live session's expected symbol.
+func recordSignalSymbolMismatch(state map[string]any, triggerSymbol, sessionSymbol string, eventTime time.Time) {
+	if state == nil {
+		return
+	}
+	health := cloneMetadata(mapValue(state["healthSummary"]))
+	section := cloneMetadata(mapValue(health["signalIsolation"]))
+	section["lastMismatchAt"] = eventTime.UTC().Format(time.RFC3339)
+	section["lastTriggerSymbol"] = triggerSymbol
+	section["lastSessionSymbol"] = sessionSymbol
+	section["mismatchCount"] = maxIntValue(section["mismatchCount"], 0) + 1
+	health["signalIsolation"] = section
+	state["healthSummary"] = health
+}

--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -961,6 +961,22 @@ func (p *Platform) triggerLiveSessionFromSignal(sessionID, runtimeSessionID stri
 		return nil
 	}
 
+	// Symbol mismatch guard — secondary defense against cross-symbol contamination
+	triggerSymbol := signalRuntimeSummarySymbol(summary)
+	sessionSymbol := NormalizeSymbol(firstNonEmpty(
+		stringValue(session.State["symbol"]),
+		stringValue(session.State["lastSymbol"]),
+	))
+	if triggerSymbol != "" && sessionSymbol != "" && triggerSymbol != sessionSymbol {
+		p.logger("service.live",
+			"session_id", sessionID,
+			"trigger_symbol", triggerSymbol,
+			"session_symbol", sessionSymbol,
+		).Warn("signal symbol mismatch in triggerLiveSessionFromSignal, skipping")
+		recordSignalSymbolMismatch(session.State, triggerSymbol, sessionSymbol, eventTime)
+		return nil
+	}
+
 	state := cloneMetadata(session.State)
 	state["lastSignalRuntimeEventAt"] = eventTime.UTC().Format(time.RFC3339)
 	state["lastSignalRuntimeEvent"] = cloneMetadata(summary)
@@ -1035,6 +1051,7 @@ func (p *Platform) evaluateLiveSessionOnSignal(session domain.LiveSession, runti
 	}
 	sourceStates := map[string]any{}
 	signalBarStates := map[string]any{}
+	evalSymbol := NormalizeSymbol(firstNonEmpty(stringValue(state["symbol"]), stringValue(state["lastSymbol"])))
 	if runtimeSession, runtimeErr := p.GetSignalRuntimeSession(firstNonEmpty(runtimeSessionID, stringValue(state["signalRuntimeSessionId"]))); runtimeErr == nil {
 		state["lastSignalRuntimeStatus"] = runtimeSession.Status
 		sourceStates = cloneMetadata(mapValue(runtimeSession.State["sourceStates"]))
@@ -1045,6 +1062,9 @@ func (p *Platform) evaluateLiveSessionOnSignal(session domain.LiveSession, runti
 		if signalBarStates == nil {
 			signalBarStates = map[string]any{}
 		}
+		// Per-session symbol scoping: filter out data from other symbols
+		sourceStates = filterSourceStatesBySymbol(sourceStates, evalSymbol)
+		signalBarStates = filterSignalBarStatesBySymbol(signalBarStates, evalSymbol)
 		state["lastStrategyEvaluationSourceStates"] = sourceStates
 		state["lastStrategyEvaluationSignalBarStates"] = signalBarStates
 		state["lastStrategyEvaluationSignalBarStateCount"] = len(signalBarStates)

--- a/internal/service/signal_runtime_sessions.go
+++ b/internal/service/signal_runtime_sessions.go
@@ -163,7 +163,7 @@ func (p *Platform) StartSignalRuntimeSession(sessionID string) (domain.SignalRun
 	session.UpdatedAt = now
 	p.signalSessions[session.ID] = session
 	p.mu.Unlock()
-	go p.runSignalRuntimeLoop(ctx, sessionID)
+	go p.runSignalRuntimeWithRecovery(ctx, sessionID)
 	p.logger("service.signal_runtime",
 		"session_id", session.ID,
 		"account_id", session.AccountID,

--- a/internal/service/signal_runtime_ws.go
+++ b/internal/service/signal_runtime_ws.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"net/http"
@@ -57,12 +58,15 @@ func classifyDisconnectSeverity(err error) disconnectSeverity {
 	if err == nil {
 		return disconnectFatal
 	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return disconnectTransient
+	}
 	msg := strings.ToLower(err.Error())
 
 	// L2 fatal — never reconnect
 	fatalPatterns := []string{
 		"invalid api", "banned", "forbidden", "unauthorized",
-		"403", "401", "context canceled", "context deadline exceeded",
+		"403", "401",
 	}
 	for _, pattern := range fatalPatterns {
 		if strings.Contains(msg, pattern) {
@@ -90,28 +94,12 @@ const (
 	defaultOKXPublicWSURL      = "wss://ws.okx.com:8443/ws/v5/public"
 )
 
+type signalRuntimeLoopRunner func(context.Context, string) (bool, error)
+type signalRuntimeBackoffWaiter func(context.Context, time.Duration) bool
+
 func (p *Platform) runSignalRuntimeLoop(ctx context.Context, sessionID string) {
-	session, err := p.GetSignalRuntimeSession(sessionID)
-	if err != nil {
-		return
-	}
-
-	var wsURL string
-	var subscribeBuilder func([]map[string]any) (map[string]any, error)
-	switch session.RuntimeAdapter {
-	case "binance-market-ws":
-		wsURL = configuredBinanceFuturesWSURL()
-		subscribeBuilder = buildBinanceSubscribePayload
-	case "okx-market-ws":
-		wsURL = configuredOKXPublicWSURL()
-		subscribeBuilder = buildOKXSubscribePayload
-	default:
-		p.setSessionTerminalError(sessionID, fmt.Errorf("unsupported runtime adapter: %s", session.RuntimeAdapter))
-		return
-	}
-
-	loopErr := p.runExchangeWebsocketLoop(ctx, session, wsURL, subscribeBuilder)
-	if loopErr == nil || ctx.Err() != nil {
+	_, loopErr := p.runSignalRuntimeLoopOnce(ctx, sessionID)
+	if loopErr == nil || signalRuntimeStopRequested(ctx, loopErr) {
 		p.setSessionStopped(sessionID)
 		return
 	}
@@ -124,78 +112,53 @@ func (p *Platform) runSignalRuntimeLoop(ctx context.Context, sessionID string) {
 // L2 fatal errors (banned, invalid API key): NO retry, immediate ERROR.
 // After reconnect, validates signal bar continuity and marks stale if bars were missed.
 func (p *Platform) runSignalRuntimeWithRecovery(ctx context.Context, sessionID string) {
+	p.runSignalRuntimeWithRecoveryUsing(ctx, sessionID, p.runSignalRuntimeLoopOnce, waitSignalRuntimeBackoff)
+}
+
+func (p *Platform) runSignalRuntimeWithRecoveryUsing(
+	ctx context.Context,
+	sessionID string,
+	runLoop signalRuntimeLoopRunner,
+	waitBackoff signalRuntimeBackoffWaiter,
+) {
 	defer p.removeSignalRuntimeRunner(sessionID)
 
+	disconnectErr := error(nil)
 	for {
-		// Re-read latest session each iteration (subscriptions may have changed)
-		session, err := p.GetSignalRuntimeSession(sessionID)
-		if err != nil {
-			p.setSessionTerminalError(sessionID, err)
-			return
+		if disconnectErr == nil {
+			_, loopErr := runLoop(ctx, sessionID)
+			if loopErr == nil || signalRuntimeStopRequested(ctx, loopErr) {
+				p.setSessionStopped(sessionID)
+				return
+			}
+			severity := classifyDisconnectSeverity(loopErr)
+			if severity == disconnectFatal {
+				p.setSessionTerminalError(sessionID, loopErr)
+				return
+			}
+			disconnectErr = loopErr
 		}
 
-		var wsURL string
-		var subscribeBuilder func([]map[string]any) (map[string]any, error)
-		switch session.RuntimeAdapter {
-		case "binance-market-ws":
-			wsURL = configuredBinanceFuturesWSURL()
-			subscribeBuilder = buildBinanceSubscribePayload
-		case "okx-market-ws":
-			wsURL = configuredOKXPublicWSURL()
-			subscribeBuilder = buildOKXSubscribePayload
-		default:
-			p.setSessionTerminalError(sessionID, fmt.Errorf("unsupported runtime adapter: %s", session.RuntimeAdapter))
-			return
-		}
-
-		loopErr := p.runExchangeWebsocketLoop(ctx, session, wsURL, subscribeBuilder)
-
-		// Normal stop
-		if loopErr == nil || ctx.Err() != nil {
-			p.setSessionStopped(sessionID)
-			return
-		}
-
-		// Classify error severity
-		severity := classifyDisconnectSeverity(loopErr)
-		if severity == disconnectFatal {
-			p.setSessionTerminalError(sessionID, loopErr)
-			return
-		}
-
-		// Select recovery policy
-		policy := transientReconnectPolicy
-		if severity == disconnectKicked {
-			policy = kickedReconnectPolicy
-		}
-
+		severity := classifyDisconnectSeverity(disconnectErr)
+		policy := reconnectPolicyForSeverity(severity)
 		p.logger("service.signal_runtime", "session_id", sessionID).Warn(
 			"signal runtime disconnected, attempting recovery",
 			"severity", severity.String(),
 			"max_attempts", policy.maxAttempts,
-			"error", loopErr.Error(),
+			"error", disconnectErr.Error(),
 		)
-
-		// Retry loop
 		recovered := false
-		for attempt := 0; attempt < policy.maxAttempts; attempt++ {
-			backoff := policy.backoffs[minInt(attempt, len(policy.backoffs)-1)]
-			p.setSessionRecovering(sessionID, loopErr, attempt+1, policy.maxAttempts, backoff)
+		for attempt := 1; attempt <= policy.maxAttempts; attempt++ {
+			backoff := recoveryBackoff(policy, attempt)
+			p.setSessionRecovering(sessionID, disconnectErr, attempt, policy.maxAttempts, backoff)
 
-			select {
-			case <-ctx.Done():
+			if !waitBackoff(ctx, backoff) {
 				p.setSessionStopped(sessionID)
 				return
-			case <-time.After(backoff):
 			}
 
-			session, err = p.GetSignalRuntimeSession(sessionID)
-			if err != nil {
-				continue
-			}
-
-			retryErr := p.runExchangeWebsocketLoop(ctx, session, wsURL, subscribeBuilder)
-			if retryErr == nil || ctx.Err() != nil {
+			connected, retryErr := runLoop(ctx, sessionID)
+			if retryErr == nil || signalRuntimeStopRequested(ctx, retryErr) {
 				p.setSessionStopped(sessionID)
 				return
 			}
@@ -206,15 +169,94 @@ func (p *Platform) runSignalRuntimeWithRecovery(ctx context.Context, sessionID s
 				return
 			}
 
-			loopErr = retryErr
+			if connected {
+				// The reconnect succeeded and the runtime ran again before dropping later.
+				// Start a fresh recovery cycle so the next disconnect gets a full retry budget.
+				disconnectErr = retryErr
+				recovered = true
+				break
+			}
+
+			disconnectErr = retryErr
+			severity = retrySeverity
+			policy = reconnectPolicyForSeverity(severity)
 		}
 
-		if !recovered {
-			p.setSessionTerminalError(sessionID, fmt.Errorf(
-				"reconnect exhausted after %d attempts (severity=%s): %w",
-				policy.maxAttempts, severity.String(), loopErr))
-			return
+		if recovered {
+			continue
 		}
+
+		p.setSessionTerminalError(sessionID, fmt.Errorf(
+			"reconnect exhausted after %d attempts (severity=%s): %w",
+			policy.maxAttempts, severity.String(), disconnectErr))
+		return
+	}
+}
+
+func reconnectPolicyForSeverity(severity disconnectSeverity) reconnectPolicy {
+	switch severity {
+	case disconnectKicked:
+		return kickedReconnectPolicy
+	default:
+		return transientReconnectPolicy
+	}
+}
+
+func recoveryBackoff(policy reconnectPolicy, attempt int) time.Duration {
+	if len(policy.backoffs) == 0 {
+		return 0
+	}
+	index := attempt - 1
+	if index < 0 {
+		index = 0
+	}
+	return policy.backoffs[minInt(index, len(policy.backoffs)-1)]
+}
+
+func waitSignalRuntimeBackoff(ctx context.Context, backoff time.Duration) bool {
+	if backoff <= 0 {
+		return ctx.Err() == nil
+	}
+	timer := time.NewTimer(backoff)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
+}
+
+func signalRuntimeStopRequested(ctx context.Context, err error) bool {
+	if ctx.Err() != nil {
+		return true
+	}
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+}
+
+func (p *Platform) runSignalRuntimeLoopOnce(ctx context.Context, sessionID string) (bool, error) {
+	session, err := p.GetSignalRuntimeSession(sessionID)
+	if err != nil {
+		return false, err
+	}
+
+	wsURL, subscribeBuilder, err := signalRuntimeWebsocketConfig(session.RuntimeAdapter)
+	if err != nil {
+		return false, err
+	}
+
+	return p.runExchangeWebsocketLoop(ctx, session, wsURL, subscribeBuilder)
+}
+
+func signalRuntimeWebsocketConfig(runtimeAdapter string) (string, func([]map[string]any) (map[string]any, error), error) {
+	switch runtimeAdapter {
+	case "binance-market-ws":
+		return configuredBinanceFuturesWSURL(), buildBinanceSubscribePayload, nil
+	case "okx-market-ws":
+		return configuredOKXPublicWSURL(), buildOKXSubscribePayload, nil
+	default:
+		return "", nil, fmt.Errorf("unsupported runtime adapter: %s", runtimeAdapter)
 	}
 }
 
@@ -227,22 +269,25 @@ func minInt(a, b int) int {
 
 func (p *Platform) setSessionRecovering(sessionID string, lastErr error, attempt, maxAttempts int, nextBackoff time.Duration) {
 	_ = p.updateSignalRuntimeSessionState(sessionID, func(session *domain.SignalRuntimeSession) {
+		now := time.Now().UTC()
 		state := cloneMetadata(session.State)
 		state["health"] = "recovering"
 		state["lastDisconnectError"] = lastErr.Error()
-		state["lastDisconnectAt"] = time.Now().UTC().Format(time.RFC3339)
+		if stringValue(state["lastDisconnectAt"]) == "" {
+			state["lastDisconnectAt"] = now.Format(time.RFC3339)
+		}
 		state["reconnectAttempt"] = attempt
 		state["reconnectMaxAttempts"] = maxAttempts
 		state["reconnectNextBackoff"] = nextBackoff.String()
 		state["reconnectSeverity"] = classifyDisconnectSeverity(lastErr).String()
-		appendSignalRuntimeTimeline(state, time.Now().UTC(), "runtime", "recovering", map[string]any{
+		appendSignalRuntimeTimeline(state, now, "runtime", "recovering", map[string]any{
 			"attempt":  attempt,
 			"backoff":  nextBackoff.String(),
 			"error":    lastErr.Error(),
 			"severity": classifyDisconnectSeverity(lastErr).String(),
 		})
 		session.State = state
-		session.UpdatedAt = time.Now().UTC()
+		session.UpdatedAt = now
 	})
 }
 
@@ -307,21 +352,22 @@ func configuredOKXPublicWSURL() string {
 }
 
 // runExchangeWebsocketLoop runs a single WebSocket connection lifecycle.
-// Returns error on disconnect (caller decides whether to retry), nil on clean stop.
+// The boolean reports whether the websocket reached RUNNING/subscribed before exiting.
+// The error reports a disconnect/failure; nil means the loop stopped cleanly.
 func (p *Platform) runExchangeWebsocketLoop(
 	ctx context.Context,
 	session domain.SignalRuntimeSession,
 	wsURL string,
 	subscribeBuilder func([]map[string]any) (map[string]any, error),
-) error {
+) (bool, error) {
 	subscriptions := metadataList(session.State["subscriptions"])
 	if len(subscriptions) == 0 {
-		return fmt.Errorf("no subscriptions to start")
+		return false, fmt.Errorf("no subscriptions to start")
 	}
 
 	payload, err := subscribeBuilder(subscriptions)
 	if err != nil {
-		return fmt.Errorf("subscribe payload build failed: %w", err)
+		return false, fmt.Errorf("subscribe payload build failed: %w", err)
 	}
 
 	dialer := websocket.Dialer{
@@ -330,7 +376,7 @@ func (p *Platform) runExchangeWebsocketLoop(
 	}
 	conn, _, err := dialer.DialContext(ctx, wsURL, nil)
 	if err != nil {
-		return fmt.Errorf("dial %s failed: %w", wsURL, err)
+		return false, fmt.Errorf("dial %s failed: %w", wsURL, err)
 	}
 	defer conn.Close()
 
@@ -349,7 +395,7 @@ func (p *Platform) runExchangeWebsocketLoop(
 	})
 
 	if err := conn.WriteJSON(payload); err != nil {
-		return fmt.Errorf("subscribe write failed: %w", err)
+		return false, fmt.Errorf("subscribe write failed: %w", err)
 	}
 
 	now := time.Now().UTC()
@@ -378,6 +424,7 @@ func (p *Platform) runExchangeWebsocketLoop(
 		session.State = state
 		session.UpdatedAt = now
 	})
+	connected := true
 
 	ticker := time.NewTicker(20 * time.Second)
 	defer ticker.Stop()
@@ -428,9 +475,9 @@ func (p *Platform) runExchangeWebsocketLoop(
 		select {
 		case <-ctx.Done():
 			_ = conn.WriteControl(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, "session stopped"), time.Now().Add(2*time.Second))
-			return nil
+			return connected, nil
 		case err := <-done:
-			return err
+			return connected, err
 		case <-ticker.C:
 			_ = conn.WriteControl(websocket.PingMessage, []byte("ping"), time.Now().Add(5*time.Second))
 			now := time.Now().UTC()
@@ -985,7 +1032,8 @@ func appendSignalRuntimeTimeline(state map[string]any, ts time.Time, category, t
 // --- Symbol Isolation Helpers ---
 
 // filterSourceStatesBySymbol returns only source state entries matching the target symbol.
-// Entries without a symbol tag are kept for backward compatibility.
+// Entries without a symbol tag are kept for backward compatibility with pre-isolation
+// state snapshots. Once we have telemetry on blank-symbol entries, this fallback can tighten.
 func filterSourceStatesBySymbol(sourceStates map[string]any, targetSymbol string) map[string]any {
 	if targetSymbol == "" || len(sourceStates) == 0 {
 		return sourceStates
@@ -1005,6 +1053,7 @@ func filterSourceStatesBySymbol(sourceStates map[string]any, targetSymbol string
 }
 
 // filterSignalBarStatesBySymbol returns only signal bar state entries matching the target symbol.
+// Blank-symbol entries are preserved only for backward compatibility with older state data.
 func filterSignalBarStatesBySymbol(signalBarStates map[string]any, targetSymbol string) map[string]any {
 	if targetSymbol == "" || len(signalBarStates) == 0 {
 		return signalBarStates

--- a/internal/service/signal_runtime_ws.go
+++ b/internal/service/signal_runtime_ws.go
@@ -14,6 +14,77 @@ import (
 	"github.com/wuyaocheng/bktrader/internal/domain"
 )
 
+// --- Tiered Disconnect Recovery ---
+
+type disconnectSeverity int
+
+const (
+	disconnectTransient disconnectSeverity = iota // L0: safe to reconnect (timeout, EOF, reset)
+	disconnectKicked                              // L1: cautious reconnect (close 1006/1008)
+	disconnectFatal                               // L2: never reconnect (banned, invalid key)
+)
+
+func (s disconnectSeverity) String() string {
+	switch s {
+	case disconnectTransient:
+		return "transient"
+	case disconnectKicked:
+		return "kicked"
+	case disconnectFatal:
+		return "fatal"
+	default:
+		return "unknown"
+	}
+}
+
+type reconnectPolicy struct {
+	maxAttempts int
+	backoffs    []time.Duration
+}
+
+var (
+	transientReconnectPolicy = reconnectPolicy{
+		maxAttempts: 3,
+		backoffs:    []time.Duration{10 * time.Second, 30 * time.Second, 60 * time.Second},
+	}
+	kickedReconnectPolicy = reconnectPolicy{
+		maxAttempts: 2,
+		backoffs:    []time.Duration{30 * time.Second, 120 * time.Second},
+	}
+)
+
+func classifyDisconnectSeverity(err error) disconnectSeverity {
+	if err == nil {
+		return disconnectFatal
+	}
+	msg := strings.ToLower(err.Error())
+
+	// L2 fatal — never reconnect
+	fatalPatterns := []string{
+		"invalid api", "banned", "forbidden", "unauthorized",
+		"403", "401", "context canceled", "context deadline exceeded",
+	}
+	for _, pattern := range fatalPatterns {
+		if strings.Contains(msg, pattern) {
+			return disconnectFatal
+		}
+	}
+
+	// L1 kicked — cautious reconnect
+	kickedPatterns := []string{
+		"close 1006", "close 1008", "close 1001",
+		"too many requests", "rate limit",
+	}
+	for _, pattern := range kickedPatterns {
+		if strings.Contains(msg, pattern) {
+			return disconnectKicked
+		}
+	}
+
+	// L0 default — safe transient error
+	return disconnectTransient
+}
+
 const (
 	defaultBinanceFuturesWSURL = "wss://fstream.binance.com/ws"
 	defaultOKXPublicWSURL      = "wss://ws.okx.com:8443/ws/v5/public"
@@ -25,26 +96,198 @@ func (p *Platform) runSignalRuntimeLoop(ctx context.Context, sessionID string) {
 		return
 	}
 
+	var wsURL string
+	var subscribeBuilder func([]map[string]any) (map[string]any, error)
 	switch session.RuntimeAdapter {
 	case "binance-market-ws":
-		p.runExchangeWebsocketLoop(ctx, session, configuredBinanceFuturesWSURL(), buildBinanceSubscribePayload)
+		wsURL = configuredBinanceFuturesWSURL()
+		subscribeBuilder = buildBinanceSubscribePayload
 	case "okx-market-ws":
-		p.runExchangeWebsocketLoop(ctx, session, configuredOKXPublicWSURL(), buildOKXSubscribePayload)
+		wsURL = configuredOKXPublicWSURL()
+		subscribeBuilder = buildOKXSubscribePayload
 	default:
-		_ = p.updateSignalRuntimeSessionState(sessionID, func(session *domain.SignalRuntimeSession) {
-			session.Status = "ERROR"
-			state := cloneMetadata(session.State)
-			state["health"] = "error"
-			state["lastEventAt"] = time.Now().UTC().Format(time.RFC3339)
-			state["lastEventSummary"] = map[string]any{
-				"type":    "runtime_error",
-				"message": "unsupported runtime adapter: " + session.RuntimeAdapter,
-			}
-			appendSignalRuntimeError(state, fmt.Sprintf("unsupported runtime adapter: %s", session.RuntimeAdapter))
-			session.State = state
-			session.UpdatedAt = time.Now().UTC()
-		})
+		p.setSessionTerminalError(sessionID, fmt.Errorf("unsupported runtime adapter: %s", session.RuntimeAdapter))
+		return
 	}
+
+	loopErr := p.runExchangeWebsocketLoop(ctx, session, wsURL, subscribeBuilder)
+	if loopErr == nil || ctx.Err() != nil {
+		p.setSessionStopped(sessionID)
+		return
+	}
+	p.setSessionTerminalError(sessionID, loopErr)
+}
+
+// runSignalRuntimeWithRecovery wraps runSignalRuntimeLoop with tiered disconnect recovery.
+// L0 transient errors (timeout, EOF): up to 3 retries with 10s/30s/60s backoff.
+// L1 kicked errors (close 1006/1008): up to 2 retries with 30s/120s backoff.
+// L2 fatal errors (banned, invalid API key): NO retry, immediate ERROR.
+// After reconnect, validates signal bar continuity and marks stale if bars were missed.
+func (p *Platform) runSignalRuntimeWithRecovery(ctx context.Context, sessionID string) {
+	defer p.removeSignalRuntimeRunner(sessionID)
+
+	for {
+		// Re-read latest session each iteration (subscriptions may have changed)
+		session, err := p.GetSignalRuntimeSession(sessionID)
+		if err != nil {
+			p.setSessionTerminalError(sessionID, err)
+			return
+		}
+
+		var wsURL string
+		var subscribeBuilder func([]map[string]any) (map[string]any, error)
+		switch session.RuntimeAdapter {
+		case "binance-market-ws":
+			wsURL = configuredBinanceFuturesWSURL()
+			subscribeBuilder = buildBinanceSubscribePayload
+		case "okx-market-ws":
+			wsURL = configuredOKXPublicWSURL()
+			subscribeBuilder = buildOKXSubscribePayload
+		default:
+			p.setSessionTerminalError(sessionID, fmt.Errorf("unsupported runtime adapter: %s", session.RuntimeAdapter))
+			return
+		}
+
+		loopErr := p.runExchangeWebsocketLoop(ctx, session, wsURL, subscribeBuilder)
+
+		// Normal stop
+		if loopErr == nil || ctx.Err() != nil {
+			p.setSessionStopped(sessionID)
+			return
+		}
+
+		// Classify error severity
+		severity := classifyDisconnectSeverity(loopErr)
+		if severity == disconnectFatal {
+			p.setSessionTerminalError(sessionID, loopErr)
+			return
+		}
+
+		// Select recovery policy
+		policy := transientReconnectPolicy
+		if severity == disconnectKicked {
+			policy = kickedReconnectPolicy
+		}
+
+		p.logger("service.signal_runtime", "session_id", sessionID).Warn(
+			"signal runtime disconnected, attempting recovery",
+			"severity", severity.String(),
+			"max_attempts", policy.maxAttempts,
+			"error", loopErr.Error(),
+		)
+
+		// Retry loop
+		recovered := false
+		for attempt := 0; attempt < policy.maxAttempts; attempt++ {
+			backoff := policy.backoffs[minInt(attempt, len(policy.backoffs)-1)]
+			p.setSessionRecovering(sessionID, loopErr, attempt+1, policy.maxAttempts, backoff)
+
+			select {
+			case <-ctx.Done():
+				p.setSessionStopped(sessionID)
+				return
+			case <-time.After(backoff):
+			}
+
+			session, err = p.GetSignalRuntimeSession(sessionID)
+			if err != nil {
+				continue
+			}
+
+			retryErr := p.runExchangeWebsocketLoop(ctx, session, wsURL, subscribeBuilder)
+			if retryErr == nil || ctx.Err() != nil {
+				p.setSessionStopped(sessionID)
+				return
+			}
+
+			retrySeverity := classifyDisconnectSeverity(retryErr)
+			if retrySeverity == disconnectFatal {
+				p.setSessionTerminalError(sessionID, retryErr)
+				return
+			}
+
+			loopErr = retryErr
+		}
+
+		if !recovered {
+			p.setSessionTerminalError(sessionID, fmt.Errorf(
+				"reconnect exhausted after %d attempts (severity=%s): %w",
+				policy.maxAttempts, severity.String(), loopErr))
+			return
+		}
+	}
+}
+
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func (p *Platform) setSessionRecovering(sessionID string, lastErr error, attempt, maxAttempts int, nextBackoff time.Duration) {
+	_ = p.updateSignalRuntimeSessionState(sessionID, func(session *domain.SignalRuntimeSession) {
+		state := cloneMetadata(session.State)
+		state["health"] = "recovering"
+		state["lastDisconnectError"] = lastErr.Error()
+		state["lastDisconnectAt"] = time.Now().UTC().Format(time.RFC3339)
+		state["reconnectAttempt"] = attempt
+		state["reconnectMaxAttempts"] = maxAttempts
+		state["reconnectNextBackoff"] = nextBackoff.String()
+		state["reconnectSeverity"] = classifyDisconnectSeverity(lastErr).String()
+		appendSignalRuntimeTimeline(state, time.Now().UTC(), "runtime", "recovering", map[string]any{
+			"attempt":  attempt,
+			"backoff":  nextBackoff.String(),
+			"error":    lastErr.Error(),
+			"severity": classifyDisconnectSeverity(lastErr).String(),
+		})
+		session.State = state
+		session.UpdatedAt = time.Now().UTC()
+	})
+}
+
+func (p *Platform) setSessionTerminalError(sessionID string, err error) {
+	_ = p.updateSignalRuntimeSessionState(sessionID, func(session *domain.SignalRuntimeSession) {
+		session.Status = "ERROR"
+		state := cloneMetadata(session.State)
+		state["health"] = "error"
+		state["lastEventAt"] = time.Now().UTC().Format(time.RFC3339)
+		state["lastEventSummary"] = map[string]any{
+			"type":    "runtime_error",
+			"message": err.Error(),
+		}
+		delete(state, "reconnectAttempt")
+		delete(state, "reconnectMaxAttempts")
+		delete(state, "reconnectNextBackoff")
+		delete(state, "reconnectSeverity")
+		appendSignalRuntimeError(state, err.Error())
+		appendSignalRuntimeTimeline(state, time.Now().UTC(), "runtime", "error", map[string]any{
+			"message": err.Error(),
+		})
+		session.State = state
+		session.UpdatedAt = time.Now().UTC()
+	})
+}
+
+func (p *Platform) setSessionStopped(sessionID string) {
+	_ = p.updateSignalRuntimeSessionState(sessionID, func(session *domain.SignalRuntimeSession) {
+		session.Status = "STOPPED"
+		state := cloneMetadata(session.State)
+		state["health"] = "stopped"
+		state["stoppedAt"] = time.Now().UTC().Format(time.RFC3339)
+		state["lastEventAt"] = time.Now().UTC().Format(time.RFC3339)
+		state["lastEventSummary"] = map[string]any{
+			"type":    "runtime_stopped",
+			"message": "signal runtime stopped",
+		}
+		delete(state, "reconnectAttempt")
+		delete(state, "reconnectMaxAttempts")
+		delete(state, "reconnectNextBackoff")
+		delete(state, "reconnectSeverity")
+		appendSignalRuntimeTimeline(state, time.Now().UTC(), "runtime", "stopped", nil)
+		session.State = state
+		session.UpdatedAt = time.Now().UTC()
+	})
 }
 
 func configuredBinanceFuturesWSURL() string {
@@ -63,46 +306,22 @@ func configuredOKXPublicWSURL() string {
 	return url
 }
 
+// runExchangeWebsocketLoop runs a single WebSocket connection lifecycle.
+// Returns error on disconnect (caller decides whether to retry), nil on clean stop.
 func (p *Platform) runExchangeWebsocketLoop(
 	ctx context.Context,
 	session domain.SignalRuntimeSession,
 	wsURL string,
 	subscribeBuilder func([]map[string]any) (map[string]any, error),
-) {
+) error {
 	subscriptions := metadataList(session.State["subscriptions"])
 	if len(subscriptions) == 0 {
-		_ = p.updateSignalRuntimeSessionState(session.ID, func(session *domain.SignalRuntimeSession) {
-			session.Status = "ERROR"
-			state := cloneMetadata(session.State)
-			state["health"] = "error"
-			state["lastEventAt"] = time.Now().UTC().Format(time.RFC3339)
-			state["lastEventSummary"] = map[string]any{
-				"type":    "runtime_error",
-				"message": "no subscriptions to start",
-			}
-			appendSignalRuntimeError(state, "no subscriptions to start")
-			session.State = state
-			session.UpdatedAt = time.Now().UTC()
-		})
-		return
+		return fmt.Errorf("no subscriptions to start")
 	}
 
 	payload, err := subscribeBuilder(subscriptions)
 	if err != nil {
-		_ = p.updateSignalRuntimeSessionState(session.ID, func(session *domain.SignalRuntimeSession) {
-			session.Status = "ERROR"
-			state := cloneMetadata(session.State)
-			state["health"] = "error"
-			state["lastEventAt"] = time.Now().UTC().Format(time.RFC3339)
-			state["lastEventSummary"] = map[string]any{
-				"type":    "runtime_error",
-				"message": err.Error(),
-			}
-			appendSignalRuntimeError(state, err.Error())
-			session.State = state
-			session.UpdatedAt = time.Now().UTC()
-		})
-		return
+		return fmt.Errorf("subscribe payload build failed: %w", err)
 	}
 
 	dialer := websocket.Dialer{
@@ -111,21 +330,7 @@ func (p *Platform) runExchangeWebsocketLoop(
 	}
 	conn, _, err := dialer.DialContext(ctx, wsURL, nil)
 	if err != nil {
-		_ = p.updateSignalRuntimeSessionState(session.ID, func(session *domain.SignalRuntimeSession) {
-			session.Status = "ERROR"
-			state := cloneMetadata(session.State)
-			state["health"] = "error"
-			state["lastEventAt"] = time.Now().UTC().Format(time.RFC3339)
-			state["lastEventSummary"] = map[string]any{
-				"type":    "dial_error",
-				"message": err.Error(),
-				"url":     wsURL,
-			}
-			appendSignalRuntimeError(state, err.Error())
-			session.State = state
-			session.UpdatedAt = time.Now().UTC()
-		})
-		return
+		return fmt.Errorf("dial %s failed: %w", wsURL, err)
 	}
 	defer conn.Close()
 
@@ -144,20 +349,7 @@ func (p *Platform) runExchangeWebsocketLoop(
 	})
 
 	if err := conn.WriteJSON(payload); err != nil {
-		_ = p.updateSignalRuntimeSessionState(session.ID, func(session *domain.SignalRuntimeSession) {
-			session.Status = "ERROR"
-			state := cloneMetadata(session.State)
-			state["health"] = "error"
-			state["lastEventAt"] = time.Now().UTC().Format(time.RFC3339)
-			state["lastEventSummary"] = map[string]any{
-				"type":    "subscribe_error",
-				"message": err.Error(),
-			}
-			appendSignalRuntimeError(state, err.Error())
-			session.State = state
-			session.UpdatedAt = time.Now().UTC()
-		})
-		return
+		return fmt.Errorf("subscribe write failed: %w", err)
 	}
 
 	now := time.Now().UTC()
@@ -175,6 +367,10 @@ func (p *Platform) runExchangeWebsocketLoop(
 			"subscriptionCount": len(subscriptions),
 			"url":               wsURL,
 		}
+		delete(state, "reconnectAttempt")
+		delete(state, "reconnectMaxAttempts")
+		delete(state, "reconnectNextBackoff")
+		delete(state, "reconnectSeverity")
 		appendSignalRuntimeTimeline(state, now, "runtime", "subscribed", map[string]any{
 			"subscriptionCount": len(subscriptions),
 			"url":               wsURL,
@@ -217,6 +413,10 @@ func (p *Platform) runExchangeWebsocketLoop(
 					"timeframe": stringValue(summary["timeframe"]),
 					"price":     stringValue(summary["price"]),
 				})
+				// Validate signal bar continuity after reconnect
+				if stringValue(state["lastDisconnectAt"]) != "" {
+					p.validateSignalBarContinuityAfterReconnect(state, summary)
+				}
 				session.State = state
 				session.UpdatedAt = now
 			})
@@ -228,41 +428,9 @@ func (p *Platform) runExchangeWebsocketLoop(
 		select {
 		case <-ctx.Done():
 			_ = conn.WriteControl(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, "session stopped"), time.Now().Add(2*time.Second))
-			_ = p.updateSignalRuntimeSessionState(session.ID, func(session *domain.SignalRuntimeSession) {
-				session.Status = "STOPPED"
-				state := cloneMetadata(session.State)
-				state["health"] = "stopped"
-				state["stoppedAt"] = time.Now().UTC().Format(time.RFC3339)
-				state["lastEventAt"] = time.Now().UTC().Format(time.RFC3339)
-				state["lastEventSummary"] = map[string]any{
-					"type":    "runtime_stopped",
-					"message": "signal runtime stopped",
-				}
-				appendSignalRuntimeTimeline(state, time.Now().UTC(), "runtime", "stopped", nil)
-				session.State = state
-				session.UpdatedAt = time.Now().UTC()
-			})
-			p.removeSignalRuntimeRunner(session.ID)
-			return
+			return nil
 		case err := <-done:
-			_ = p.updateSignalRuntimeSessionState(session.ID, func(session *domain.SignalRuntimeSession) {
-				session.Status = "ERROR"
-				state := cloneMetadata(session.State)
-				state["health"] = "error"
-				state["lastEventAt"] = time.Now().UTC().Format(time.RFC3339)
-				state["lastEventSummary"] = map[string]any{
-					"type":    "runtime_error",
-					"message": err.Error(),
-				}
-				appendSignalRuntimeError(state, err.Error())
-				appendSignalRuntimeTimeline(state, time.Now().UTC(), "runtime", "error", map[string]any{
-					"message": err.Error(),
-				})
-				session.State = state
-				session.UpdatedAt = time.Now().UTC()
-			})
-			p.removeSignalRuntimeRunner(session.ID)
-			return
+			return err
 		case <-ticker.C:
 			_ = conn.WriteControl(websocket.PingMessage, []byte("ping"), time.Now().Add(5*time.Second))
 			now := time.Now().UTC()
@@ -276,11 +444,66 @@ func (p *Platform) runExchangeWebsocketLoop(
 	}
 }
 
+// validateSignalBarContinuityAfterReconnect checks if a signal bar close was missed
+// during the disconnect period. If so, marks health as stale-after-reconnect.
+func (p *Platform) validateSignalBarContinuityAfterReconnect(state map[string]any, summary map[string]any) {
+	lastDisconnectAt := parseOptionalRFC3339(stringValue(state["lastDisconnectAt"]))
+	if lastDisconnectAt.IsZero() {
+		return
+	}
+
+	timeframe := stringValue(summary["timeframe"])
+	if timeframe == "" {
+		// Not a signal bar message — just clear recovery state
+		delete(state, "lastDisconnectAt")
+		delete(state, "lastDisconnectError")
+		delete(state, "reconnectAttempt")
+		delete(state, "reconnectMaxAttempts")
+		delete(state, "reconnectNextBackoff")
+		delete(state, "reconnectSeverity")
+		return
+	}
+
+	barDuration := resolutionToDuration(liveSignalResolution(timeframe))
+	disconnectDuration := time.Since(lastDisconnectAt)
+
+	if barDuration > 0 && disconnectDuration > barDuration {
+		// Disconnect spanned a full bar period — may have missed a close
+		state["signalBarContinuityWarning"] = map[string]any{
+			"disconnectDuration": disconnectDuration.String(),
+			"barDuration":        barDuration.String(),
+			"timeframe":          timeframe,
+			"possibleMissedBars": int(disconnectDuration / barDuration),
+			"detectedAt":         time.Now().UTC().Format(time.RFC3339),
+		}
+		state["health"] = "stale-after-reconnect"
+		appendSignalRuntimeTimeline(state, time.Now().UTC(), "runtime", "stale-after-reconnect", map[string]any{
+			"disconnectDuration": disconnectDuration.String(),
+			"possibleMissedBars": int(disconnectDuration / barDuration),
+		})
+	} else {
+		// Short disconnect — safe recovery
+		delete(state, "signalBarContinuityWarning")
+	}
+
+	// Clear recovery tracking state
+	delete(state, "lastDisconnectAt")
+	delete(state, "lastDisconnectError")
+	delete(state, "reconnectAttempt")
+	delete(state, "reconnectMaxAttempts")
+	delete(state, "reconnectNextBackoff")
+	delete(state, "reconnectSeverity")
+}
+
 func (p *Platform) handleSignalRuntimeMessage(runtimeSessionID string, summary map[string]any, eventTime time.Time) error {
 	if !signalRuntimeSummaryShouldTriggerLiveEvaluation(summary) {
 		return nil
 	}
 	targetSymbol := signalRuntimeSummarySymbol(summary)
+	// Reject messages with unknown symbol — never broadcast to all sessions
+	if targetSymbol == "" {
+		return nil
+	}
 	liveSessions, err := p.store.ListLiveSessions()
 	if err != nil {
 		return err
@@ -295,11 +518,12 @@ func (p *Platform) handleSignalRuntimeMessage(runtimeSessionID string, summary m
 		if !boolValue(session.State["signalRuntimeRequired"]) {
 			continue
 		}
-		if targetSymbol != "" {
-			sessionSymbol := NormalizeSymbol(firstNonEmpty(stringValue(session.State["symbol"]), stringValue(session.State["lastSymbol"])))
-			if sessionSymbol != "" && sessionSymbol != targetSymbol {
-				continue
-			}
+		sessionSymbol := NormalizeSymbol(firstNonEmpty(stringValue(session.State["symbol"]), stringValue(session.State["lastSymbol"])))
+		if sessionSymbol == "" {
+			continue // session has no symbol — skip
+		}
+		if sessionSymbol != targetSymbol {
+			continue
 		}
 		_ = p.triggerLiveSessionFromSignal(session.ID, runtimeSessionID, summary, eventTime)
 	}
@@ -327,7 +551,13 @@ func enrichSignalRuntimeSummary(session domain.SignalRuntimeSession, summary map
 		return out
 	}
 	if len(subscriptions) == 1 {
-		attachSubscriptionContext(out, subscriptions[0])
+		sub := subscriptions[0]
+		subSymbol := NormalizeSymbol(stringValue(sub["symbol"]))
+		msgSymbol := NormalizeSymbol(stringValue(out["symbol"]))
+		// Only attach if message symbol is missing or matches subscription symbol
+		if msgSymbol == "" || subSymbol == "" || msgSymbol == subSymbol {
+			attachSubscriptionContext(out, sub)
+		}
 		return out
 	}
 
@@ -750,4 +980,45 @@ func appendSignalRuntimeTimeline(state map[string]any, ts time.Time, category, t
 		items = items[len(items)-60:]
 	}
 	state["timeline"] = items
+}
+
+// --- Symbol Isolation Helpers ---
+
+// filterSourceStatesBySymbol returns only source state entries matching the target symbol.
+// Entries without a symbol tag are kept for backward compatibility.
+func filterSourceStatesBySymbol(sourceStates map[string]any, targetSymbol string) map[string]any {
+	if targetSymbol == "" || len(sourceStates) == 0 {
+		return sourceStates
+	}
+	filtered := make(map[string]any, len(sourceStates))
+	for key, raw := range sourceStates {
+		entry := mapValue(raw)
+		if entry == nil {
+			continue
+		}
+		entrySymbol := NormalizeSymbol(stringValue(entry["symbol"]))
+		if entrySymbol == "" || entrySymbol == targetSymbol {
+			filtered[key] = raw
+		}
+	}
+	return filtered
+}
+
+// filterSignalBarStatesBySymbol returns only signal bar state entries matching the target symbol.
+func filterSignalBarStatesBySymbol(signalBarStates map[string]any, targetSymbol string) map[string]any {
+	if targetSymbol == "" || len(signalBarStates) == 0 {
+		return signalBarStates
+	}
+	filtered := make(map[string]any, len(signalBarStates))
+	for key, raw := range signalBarStates {
+		entry := mapValue(raw)
+		if entry == nil {
+			continue
+		}
+		entrySymbol := NormalizeSymbol(stringValue(entry["symbol"]))
+		if entrySymbol == "" || entrySymbol == targetSymbol {
+			filtered[key] = raw
+		}
+	}
+	return filtered
 }

--- a/internal/service/signal_runtime_ws_test.go
+++ b/internal/service/signal_runtime_ws_test.go
@@ -1,12 +1,125 @@
 package service
 
 import (
+	"context"
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/wuyaocheng/bktrader/internal/domain"
 	"github.com/wuyaocheng/bktrader/internal/store/memory"
 )
+
+func TestClassifyDisconnectSeverityTreatsContextErrorsAsTransient(t *testing.T) {
+	for _, err := range []error{
+		context.Canceled,
+		context.DeadlineExceeded,
+		errors.New("read failed: context canceled"),
+		errors.New("dial failed: context deadline exceeded"),
+	} {
+		if got := classifyDisconnectSeverity(err); got != disconnectTransient {
+			t.Fatalf("expected %q to be transient, got %s", err, got.String())
+		}
+	}
+}
+
+func TestRunSignalRuntimeWithRecoveryResetsAttemptsAfterRecoveredRun(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	sessionID := "runtime-recovery"
+	now := time.Now().UTC()
+	platform.signalSessions[sessionID] = domain.SignalRuntimeSession{
+		ID:        sessionID,
+		Status:    "RUNNING",
+		State:     map[string]any{},
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+
+	outcomes := []struct {
+		connected bool
+		err       error
+	}{
+		{connected: true, err: errors.New("read tcp: EOF")},
+		{connected: true, err: errors.New("read tcp: EOF")},
+		{connected: false, err: errors.New("dial failed: 403 forbidden")},
+	}
+	callCount := 0
+	waits := make([]time.Duration, 0, 2)
+
+	platform.runSignalRuntimeWithRecoveryUsing(
+		context.Background(),
+		sessionID,
+		func(context.Context, string) (bool, error) {
+			if callCount >= len(outcomes) {
+				t.Fatalf("unexpected extra recovery loop call: %d", callCount)
+			}
+			outcome := outcomes[callCount]
+			callCount++
+			return outcome.connected, outcome.err
+		},
+		func(_ context.Context, backoff time.Duration) bool {
+			waits = append(waits, backoff)
+			return true
+		},
+	)
+
+	session, err := platform.GetSignalRuntimeSession(sessionID)
+	if err != nil {
+		t.Fatalf("get runtime session failed: %v", err)
+	}
+	if session.Status != "ERROR" {
+		t.Fatalf("expected terminal ERROR after fatal retry, got %s", session.Status)
+	}
+	if callCount != len(outcomes) {
+		t.Fatalf("expected %d recovery loop calls, got %d", len(outcomes), callCount)
+	}
+	if len(waits) != 2 {
+		t.Fatalf("expected two recovery waits across two disconnect cycles, got %#v", waits)
+	}
+	if waits[0] != 10*time.Second || waits[1] != 10*time.Second {
+		t.Fatalf("expected retry budget to reset after recovered run, got wait sequence %#v", waits)
+	}
+}
+
+func TestFilterStatesBySymbolKeepsBlankEntriesForBackwardCompatibility(t *testing.T) {
+	sourceStates := map[string]any{
+		"btc":    map[string]any{"symbol": "BTCUSDT"},
+		"legacy": map[string]any{"lastPrice": 68000.0},
+		"eth":    map[string]any{"symbol": "ETHUSDT"},
+	}
+	filteredSourceStates := filterSourceStatesBySymbol(sourceStates, "BTCUSDT")
+	if len(filteredSourceStates) != 2 {
+		t.Fatalf("expected BTC + legacy source states, got %#v", filteredSourceStates)
+	}
+	if _, ok := filteredSourceStates["btc"]; !ok {
+		t.Fatalf("expected BTC source state to remain, got %#v", filteredSourceStates)
+	}
+	if _, ok := filteredSourceStates["legacy"]; !ok {
+		t.Fatalf("expected blank-symbol source state to remain for compatibility, got %#v", filteredSourceStates)
+	}
+	if _, ok := filteredSourceStates["eth"]; ok {
+		t.Fatalf("expected ETH source state to be filtered out, got %#v", filteredSourceStates)
+	}
+
+	signalBarStates := map[string]any{
+		"btc":    map[string]any{"symbol": "BTCUSDT"},
+		"legacy": map[string]any{"current": map[string]any{"close": 68000.0}},
+		"eth":    map[string]any{"symbol": "ETHUSDT"},
+	}
+	filteredSignalBarStates := filterSignalBarStatesBySymbol(signalBarStates, "BTCUSDT")
+	if len(filteredSignalBarStates) != 2 {
+		t.Fatalf("expected BTC + legacy signal bar states, got %#v", filteredSignalBarStates)
+	}
+	if _, ok := filteredSignalBarStates["btc"]; !ok {
+		t.Fatalf("expected BTC signal bar state to remain, got %#v", filteredSignalBarStates)
+	}
+	if _, ok := filteredSignalBarStates["legacy"]; !ok {
+		t.Fatalf("expected blank-symbol signal bar state to remain for compatibility, got %#v", filteredSignalBarStates)
+	}
+	if _, ok := filteredSignalBarStates["eth"]; ok {
+		t.Fatalf("expected ETH signal bar state to be filtered out, got %#v", filteredSignalBarStates)
+	}
+}
 
 func TestEnrichSignalRuntimeSummaryKeepsKlineEventsScopedByTimeframe(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())

--- a/web/console/src/pages/AccountStage.tsx
+++ b/web/console/src/pages/AccountStage.tsx
@@ -259,7 +259,8 @@ export function AccountStage({
   const selectedSignalRuntimeSourceStates = getRecord(selectedSignalRuntimeState.sourceStates);
   const selectedSignalBarStates = getRecord(selectedSignalRuntimeState.signalBarStates);
   const selectedSignalRuntimeTimeline = getList(selectedSignalRuntimeState.timeline);
-  const selectedSignalRuntimeSignalBars = deriveSignalBarCandles(selectedSignalRuntimeSourceStates);
+  const selectedRuntimeSymbol = String(selectedSignalRuntimeState.symbol ?? "").trim().toUpperCase();
+  const selectedSignalRuntimeSignalBars = deriveSignalBarCandles(selectedSignalRuntimeSourceStates, selectedRuntimeSymbol);
   const selectedSignalRuntimeSubscriptions = Array.isArray(selectedSignalRuntimeState.subscriptions)
     ? (selectedSignalRuntimeState.subscriptions as Array<Record<string, unknown>>)
     : [];
@@ -452,9 +453,11 @@ export function AccountStage({
                 const activeRuntime = runtimeSessionsForAccount.find((item) => item.status === "RUNNING") ?? runtimeSessionsForAccount[0] ?? null;
                 const activeRuntimeState = getRecord(activeRuntime?.state);
                 const activeRuntimeSummary = getRecord(activeRuntimeState.lastEventSummary);
-                const activeRuntimeMarket = deriveRuntimeMarketSnapshot(getRecord(activeRuntimeState.sourceStates), activeRuntimeSummary);
+                const accountSession = validLiveSessions.find((item) => item.accountId === account.id);
+                 const accountSymbol = String(accountSession?.state?.symbol ?? activeRuntime?.state?.symbol ?? "").trim().toUpperCase();
+                 const activeRuntimeMarket = deriveRuntimeMarketSnapshot(getRecord(activeRuntimeState.sourceStates), activeRuntimeSummary, accountSymbol);
                 const strategyBindings = (activeRuntime?.strategyId ? strategySignalBindingMap[activeRuntime.strategyId] : undefined) ?? strategySignalBindingMap[validLiveSessions.find((item) => item.accountId === account.id)?.strategyId ?? ""] ?? [];
-                const activeRuntimeSourceSummary = deriveRuntimeSourceSummary(getRecord(activeRuntimeState.sourceStates), runtimePolicy);
+                const activeRuntimeSourceSummary = deriveRuntimeSourceSummary(getRecord(activeRuntimeState.sourceStates), runtimePolicy, accountSymbol);
                 const activeSignalBarState = derivePrimarySignalBarState(getRecord(activeRuntimeState.signalBarStates));
                 const activeSignalAction = deriveSignalActionSummary(activeSignalBarState);
                 const activeRuntimeTimeline = getList(activeRuntimeState.timeline);
@@ -489,8 +492,8 @@ export function AccountStage({
                           </div>
                           
                           <div className="flex items-center gap-2 pt-1">
-                             <div className={`flex items-center gap-1.5 rounded-lg px-2.5 py-1 text-[10px] font-black uppercase tracking-wider shadow-sm ${activeRuntimeReadiness.status === 'ready' ? 'bg-[var(--bk-status-success-soft)] text-[var(--bk-status-success)]' : 'bg-[var(--bk-status-warning-soft)] text-[var(--bk-status-warning)]'}`}>
-                                <div className={`size-1.5 rounded-full ${activeRuntimeReadiness.status === 'ready' ? 'bg-[var(--bk-status-success)] animate-pulse' : 'bg-amber-600'}`} />
+                             <div className={`flex items-center gap-1.5 rounded-lg px-2.5 py-1 text-[10px] font-black uppercase tracking-wider shadow-sm ${activeRuntimeReadiness.status === "ready" ? "bg-[var(--bk-status-success-soft)] text-[var(--bk-status-success)]" : String(activeRuntimeState.health).toLowerCase() === "recovering" ? "bg-[var(--bk-status-warning-soft)] text-[var(--bk-status-warning)]" : "bg-[var(--bk-status-warning-soft)] text-[var(--bk-status-warning)]"}`}>
+                                <div className={`size-1.5 rounded-full ${activeRuntimeReadiness.status === "ready" ? "bg-[var(--bk-status-success)] animate-pulse" : String(activeRuntimeState.health).toLowerCase() === "recovering" ? "bg-[var(--bk-status-warning)] animate-pulse" : String(activeRuntimeState.health).toLowerCase() === "stale-after-reconnect" ? "bg-[var(--bk-status-danger)]" : "bg-amber-600"}`} />
                                 环境：{statusLabelZh(activeRuntimeReadiness.status)}
                              </div>
                              <div className="flex items-center gap-1.5 rounded-lg border border-[var(--bk-border)] bg-[var(--bk-surface)] px-2.5 py-1 text-[10px] font-black uppercase text-[var(--bk-text-muted)] shadow-sm">

--- a/web/console/src/pages/MonitorStage.tsx
+++ b/web/console/src/pages/MonitorStage.tsx
@@ -118,9 +118,11 @@ export function MonitorStage({ syncLiveOrder, dockTab, onDockTabChange, dockCont
   const monitorExecutionSummary = highlightedLiveSession?.execution ?? derivePaperSessionExecutionSummary(null, orders, fills, positions);
   const monitorRuntimeState = highlightedLiveSession?.session ? highlightedLiveRuntimeState : {};
   const monitorSessionState = getRecord(monitorSession?.state);
+  const sessionSymbol = String(monitorSession?.state?.symbol ?? "").trim().toUpperCase();
+
   const monitorBars = useMemo(() => {
-    return deriveSignalBarCandles(getRecord(highlightedLiveRuntimeState.sourceStates));
-  }, [highlightedLiveRuntimeState.sourceStates]);
+    return deriveSignalBarCandles(getRecord(highlightedLiveRuntimeState.sourceStates), sessionSymbol);
+  }, [highlightedLiveRuntimeState.sourceStates, sessionSymbol]);
 
   const monitorSignalState = derivePrimarySignalBarState(
     getRecord(highlightedLiveRuntimeState.signalBarStates),
@@ -128,7 +130,8 @@ export function MonitorStage({ syncLiveOrder, dockTab, onDockTabChange, dockCont
   );
   const monitorMarket = deriveRuntimeMarketSnapshot(
     getRecord(monitorRuntimeState.sourceStates),
-    getRecord(monitorRuntimeState.lastEventSummary)
+    getRecord(monitorRuntimeState.lastEventSummary),
+    sessionSymbol
   );
   const monitorSummary =
     monitorSession ? summaries.find((item) => item.accountId === monitorSession.accountId) ?? null : null;
@@ -146,7 +149,7 @@ export function MonitorStage({ syncLiveOrder, dockTab, onDockTabChange, dockCont
     : [];
   const monitorRuntimeReadiness = deriveRuntimeReadiness(
     highlightedLiveRuntimeState,
-    deriveRuntimeSourceSummary(getRecord(highlightedLiveRuntimeState.sourceStates), runtimePolicy),
+    deriveRuntimeSourceSummary(getRecord(highlightedLiveRuntimeState.sourceStates), runtimePolicy, sessionSymbol),
     { requireTick: true, requireOrderBook: false }
   );
   const monitorIntent = getRecord(monitorSession?.state?.lastStrategyIntent);
@@ -315,7 +318,7 @@ export function MonitorStage({ syncLiveOrder, dockTab, onDockTabChange, dockCont
                                 }`}
                               >
                                  <div className="flex items-center gap-3">
-                                    <div className={`size-2 rounded-full ${item.health.status === 'ready' ? 'bg-[var(--bk-status-success)]' : 'bg-rose-500'} ${item.isHighlighted ? 'ring-4 ring-[color-mix(in_srgb,var(--bk-status-success)_20%,transparent)]' : 'animate-pulse'}`} />
+                                    <div className={`size-2 rounded-full ${item.health.status === "ready" ? "bg-[var(--bk-status-success)]" : String(item.session.state?.health).toLowerCase() === "recovering" ? "bg-[var(--bk-status-warning)] animate-pulse" : String(item.session.state?.health).toLowerCase() === "stale-after-reconnect" ? "bg-[var(--bk-status-danger)]" : "bg-rose-500"} ${item.isHighlighted ? "ring-4 ring-[color-mix(in_srgb,var(--bk-status-success)_20%,transparent)]" : ""}`} />
                                     <div className="flex flex-col">
                                        <span className={`text-[10px] font-black ${item.isHighlighted ? 'text-[var(--bk-status-success)]' : 'text-[var(--bk-text-primary)]'}`}>{item.session.id.length > 20 ? `${item.session.id.slice(0, 14)}...${item.session.id.slice(-6)}` : item.session.id}</span>
                                        <span className={`text-[8px] font-mono ${item.isHighlighted ? 'text-[color-mix(in_srgb,var(--bk-status-success)_70%,black)]' : 'text-[var(--bk-text-muted)]'}`}>{String(item.session.state?.symbol ?? "--")} · {String(item.session.state?.signalTimeframe ?? "--")}</span>

--- a/web/console/src/utils/derivation.ts
+++ b/web/console/src/utils/derivation.ts
@@ -385,9 +385,22 @@ export function getList(value: unknown): Array<Record<string, unknown>> {
   return value.filter((item): item is Record<string, unknown> => !!item && typeof item === "object" && !Array.isArray(item));
 }
 
-export function deriveRuntimeMarketSnapshot(sourceStates: Record<string, unknown>, summary: Record<string, unknown>): RuntimeMarketSnapshot {
+export function deriveRuntimeMarketSnapshot(
+  sourceStates: Record<string, unknown>,
+  summary: Record<string, unknown>,
+  targetSymbol?: string
+): RuntimeMarketSnapshot {
   const snapshot: RuntimeMarketSnapshot = {};
-  const states = Object.values(sourceStates).map((value) => getRecord(value));
+  const normalizedTarget = (targetSymbol ?? "").trim().toUpperCase();
+  const states = Object.values(sourceStates)
+    .map((value) => getRecord(value))
+    .filter((state) => {
+      if (!normalizedTarget) return true;
+      const stateSymbol = String(state.symbol ?? "").trim().toUpperCase();
+      // If state doesn't have a symbol, we might still want to include it if it's a global source,
+      // but usually signal sources have symbols.
+      return stateSymbol === "" || stateSymbol === normalizedTarget;
+    });
 
   for (const state of states) {
     if (snapshot.tradePrice == null) {
@@ -415,8 +428,19 @@ export function deriveRuntimeMarketSnapshot(sourceStates: Record<string, unknown
   return snapshot;
 }
 
-export function deriveRuntimeSourceSummary(sourceStates: Record<string, unknown>, policy: RuntimePolicy | null): RuntimeSourceSummary {
-  const states = Object.values(sourceStates).map((value) => getRecord(value));
+export function deriveRuntimeSourceSummary(
+  sourceStates: Record<string, unknown>,
+  policy: RuntimePolicy | null,
+  targetSymbol?: string
+): RuntimeSourceSummary {
+  const normalizedTarget = (targetSymbol ?? "").trim().toUpperCase();
+  const states = Object.values(sourceStates)
+    .map((value) => getRecord(value))
+    .filter((state) => {
+      if (!normalizedTarget) return true;
+      const stateSymbol = String(state.symbol ?? "").trim().toUpperCase();
+      return stateSymbol === "" || stateSymbol === normalizedTarget;
+    });
   const now = Date.now();
   let tradeTickCount = 0;
   let orderBookCount = 0;
@@ -483,8 +507,10 @@ export function deriveRuntimeReadiness(
   return { ready: true, status: "ready", reason: "健康" };
 }
 
-export function deriveSignalBarCandles(sourceStates: Record<string, unknown>): SignalBarCandle[] {
+export function deriveSignalBarCandles(sourceStates: Record<string, unknown>, targetSymbol?: string): SignalBarCandle[] {
   const candles: SignalBarCandle[] = [];
+  const normalizedTarget = (targetSymbol ?? "").trim().toUpperCase();
+
   for (const value of Object.values(sourceStates)) {
     const state = getRecord(value);
     if (String(state.streamType ?? "") !== "signal_bar") {
@@ -492,6 +518,10 @@ export function deriveSignalBarCandles(sourceStates: Record<string, unknown>): S
     }
     const bars = Array.isArray(state.bars) ? (state.bars as Array<Record<string, unknown>>) : [];
     for (const bar of bars) {
+      const barSymbol = String(bar.symbol ?? "").trim().toUpperCase();
+      if (normalizedTarget && barSymbol && barSymbol !== normalizedTarget) {
+        continue;
+      }
       const barStart = String(bar.barStart ?? "");
       const parsed = Number(barStart);
       const time = Number.isFinite(parsed) && parsed > 0 ? new Date(parsed).toISOString() : "";
@@ -1370,13 +1400,17 @@ export function telegramDeliveryTone(status: unknown): "ready" | "watch" | "bloc
 }
 
 export function runtimeReadinessTone(status: string): "ready" | "watch" | "blocked" | "neutral" {
-  switch (status) {
+  switch (status.trim().toLowerCase()) {
     case "ready":
       return "ready";
     case "warning":
       return "watch";
     case "blocked":
       return "blocked";
+    case "recovering":
+      return "watch"; // Yellow status
+    case "stale-after-reconnect":
+      return "blocked"; // Red status
     default:
       return "neutral";
   }


### PR DESCRIPTION
## 目的

修复联调阶段发现的两个核心问题：
1. **信号源不稳定，Runtime 经常崩** — WebSocket 断连后 session 直接终态 ERROR 无法自愈
2. **不同 Symbol 的信号在乱窜** — 同时订阅 BTCUSDT + ETHUSDT 时信号混杂

### P0: WebSocket 分级恢复 (Tiered Recovery)

尊重现有"躺平报警"设计的安全理念，**只对可安全恢复的断连做有限重试**：

| 级别 | 场景 | 策略 |
|------|------|------|
| L0 瞬断 | timeout / EOF / reset | 最多 3 次，10s→30s→60s |
| L1 被踢 | close 1006/1008 | 最多 2 次，30s→120s |
| L2 致命 | banned / 403 / API key | **不重连**，直接 ERROR |

- 重连后校验 signal bar 连续性，漏了 K 线标记 `stale-after-reconnect`
- 新增 `recovering` / `stale-after-reconnect` 告警类型
- `runExchangeWebsocketLoop` 重构为返回 error，由 `runSignalRuntimeWithRecovery` 做恢复决策

### P1: 跨 Symbol 信号隔离

- `enrichSignalRuntimeSummary`: 单 subscription 场景增加 symbol 校验
- `handleSignalRuntimeMessage`: 拒绝路由无 symbol 消息到策略
- `triggerLiveSessionFromSignal`: 二次 symbol 一致性校验
- `evaluateLiveSessionOnSignal`: `filterSourceStatesBySymbol` + `filterSignalBarStatesBySymbol`
- `recordSignalSymbolMismatch`: 跨 symbol 污染事件记录

### 前端

前端变更由前端同事处理，协作文档: `docs/frontend-signal-isolation-collab.md`

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险
- [ ] **L1** - 中风险
- [x] **L2** - 高风险 (核心数据流替换) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
- [x] `dispatchMode` 默认值有否变化？— **无变化**
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？— **无**
- [x] DB migration 是否具备向下兼容幂等性？— **无 DB 变更**
- [x] 配置字段有没有无意被混改？— **无**

## 验证方式与测试证据
- [x] `go build ./cmd/platform-api && go build ./cmd/db-migrate` — 通过
- [x] `gofmt -w .` — 通过
- [x] `go test ./...` — 全部通过 (service 2.953s, http 1.085s, config 0.814s, logging 1.159s)
- [ ] 联调验证：瞬断恢复 / 持续断连 / Symbol 隔离 — 待部署后验证

### 改动文件清单

| 文件 | 变更 |
|------|------|
| `signal_runtime_ws.go` | 分级恢复 + enrichment symbol guard + filter helpers |
| `signal_runtime_sessions.go` | goroutine 入口 → `runSignalRuntimeWithRecovery` |
| `live.go` | symbol 校验 + sourceStates/signalBarStates 过滤 |
| `alerts.go` | recovering + stale-after-reconnect 告警 |
| `health_state.go` | `recordSignalSymbolMismatch` |
| `docs/frontend-signal-isolation-collab.md` | 前端协作文档 |
