### PR TITLE
docs & feat: 交易对账需求与前端契约预览 (Contract Preview)

### DIFF
--- a/db/migrations/014_fill_exchange_trade_id.sql
+++ b/db/migrations/014_fill_exchange_trade_id.sql
@@ -1,0 +1,5 @@
+alter table fills
+add column if not exists exchange_trade_id text;
+
+create unique index if not exists idx_fills_order_trade_id
+on fills (order_id, exchange_trade_id);

--- a/docs/frontend-live-reconcile-collab.md
+++ b/docs/frontend-live-reconcile-collab.md
@@ -1,0 +1,120 @@
+# 前端协作：Live Account Reconcile
+
+> **上下文**：后端已补上 live 账户级对账入口，用于发现并补全交易所已存在、但本地缺失的订单/成交。
+>
+> **本轮约束**：当前 PR 不改前端页面，只提供后端 API 和协作文档，前端后续按需接入。
+
+## 目标
+
+前端后续需要给 LIVE 账户提供一个“全量对账”入口，用于处理以下场景：
+
+- 平台进程异常退出后，本地缺失某笔交易所订单
+- 手动 `Sync` 订单无法覆盖“本地根本没有这笔订单”的情况
+- 需要一次性扫最近一段时间的交易所订单/成交，并回填本地 `orders` / `fills`
+
+## 本轮后端已完成
+
+### 1. 新接口
+
+`POST /api/v1/live/accounts/:id/reconcile`
+
+可选请求体：
+
+```json
+{
+  "lookbackHours": 24
+}
+```
+
+说明：
+
+- 默认回扫最近 `24` 小时
+- 当前仅支持 `executionMode=rest` 的 LIVE 账户
+- 当前实现会先做一次账户同步，再按候选 symbol 拉 Binance 历史订单与成交
+
+### 2. 返回结构
+
+接口返回 `LiveAccountReconcileResult`：
+
+```json
+{
+  "account": { "...": "最新账户对象" },
+  "adapterKey": "binance-futures",
+  "executionMode": "rest",
+  "lookbackHours": 24,
+  "symbolCount": 2,
+  "symbols": ["BTCUSDT", "ETHUSDT"],
+  "orderCount": 3,
+  "createdOrderCount": 1,
+  "updatedOrderCount": 2,
+  "notes": []
+}
+```
+
+### 3. 账户 metadata 新增摘要
+
+对账成功后，账户对象会额外带：
+
+- `metadata.lastLiveReconcileAt`
+- `metadata.lastLiveReconcile`
+
+其中 `lastLiveReconcile` 包含：
+
+- `adapterKey`
+- `executionMode`
+- `lookbackHours`
+- `symbolCount`
+- `symbols`
+- `orderCount`
+- `createdOrderCount`
+- `updatedOrderCount`
+- `notes`
+
+## 前端建议接法
+
+### 1. 入口位置
+
+建议放在 `AccountStage` 的 LIVE 账户操作区，和“同步账户”并列，但文案明确区分：
+
+- `同步账户`
+- `全量对账`
+
+不要复用“同步账户”按钮，以免用户误解成普通快照刷新。
+
+### 2. 按钮展示条件
+
+建议仅在以下条件显示或启用：
+
+- `account.mode === "LIVE"`
+- `account.metadata.liveBinding.executionMode === "rest"`
+
+对于 `mock` 或未绑定账户，建议隐藏或置灰，并给出说明：
+
+- `仅 REST 实盘账户支持全量对账`
+
+### 3. 成功反馈
+
+建议 toast 文案包含摘要数字，例如：
+
+`对账完成：扫描 2 个 symbol，补回 1 笔缺失订单，更新 2 笔已有订单`
+
+### 4. 详情展示
+
+如后续要在账户详情页补展示，可直接读取：
+
+- `account.metadata.lastLiveReconcileAt`
+- `account.metadata.lastLiveReconcile.createdOrderCount`
+- `account.metadata.lastLiveReconcile.updatedOrderCount`
+
+## 已知边界
+
+- 当前候选 symbol 来自本地订单、当前持仓、live session symbol、以及 `liveSyncSnapshot.openOrders/positions`
+- 因 Binance Futures 历史订单接口按 `symbol` 查询，当前实现仍是“按候选 symbol 扫描”，不是无限制的全账户全市场回溯
+- 当前前端“待同步订单”页卡还未消费 `lastLiveReconcile` 摘要；若后续需要，可结合该摘要做更明确提示
+
+## 前端验证建议
+
+1. 对 REST LIVE 账户触发一次 reconcile
+2. 确认接口成功后 dashboard 会刷新
+3. 确认账户 metadata 中出现 `lastLiveReconcileAt`
+4. 确认若后端补回缺失订单，本地订单/成交列表会在刷新后出现

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,7 @@
 - [20260403改进计划_plan.md](20260403改进计划_plan.md) - 记录了平台重构与组件拆解的核心思考。
 - [部署与网络架构.md](部署与网络架构.md) - 包含有关容器/负载路由的信息。
 - [cicd-maintenance.md](cicd-maintenance.md) - GitHub Actions 维保说明。
+- [frontend-live-reconcile-collab.md](frontend-live-reconcile-collab.md) - Live 账户全量对账的前端协作文档与 API 接入约定。
 
 ## 3. 金融与投研文档
 - [STRATEGY_ANALYSIS.md](STRATEGY_ANALYSIS.md) - BK体系策略逻辑分析。

--- a/docs/llm-project-index.md
+++ b/docs/llm-project-index.md
@@ -41,6 +41,7 @@
 ### 📚 文档与智能体资产
 - **`docs/`**: 人类可读的系统设计文档、更新计划、数据规范。
 - **`docs/AGENT_PATHS.md`**: **重要！** 后端 Go 与前端 Node 环境工具的绝对路径导览，防止 Agent 在命令行环境找不到工具。
+- **`docs/frontend-live-reconcile-collab.md`**: Live 账户全量对账接口的前端协作说明，约定入口、展示条件与返回摘要。
 - **`.agents/skills/`**: 注入给 Gemini/LLM 的特定技能库（如前端设计规范、特定交互理论）。
 
 ## 3. 最近的重大重构记录

--- a/internal/domain/models.go
+++ b/internal/domain/models.go
@@ -185,12 +185,13 @@ type Order struct {
 
 // Fill 成交记录，每笔成交关联一个订单。
 type Fill struct {
-	ID        string    `json:"id"`
-	OrderID   string    `json:"orderId"`
-	Price     float64   `json:"price"`
-	Quantity  float64   `json:"quantity"`
-	Fee       float64   `json:"fee"` // 手续费
-	CreatedAt time.Time `json:"createdAt"`
+	ID              string    `json:"id"`
+	OrderID         string    `json:"orderId"`
+	ExchangeTradeID string    `json:"exchangeTradeId,omitempty"`
+	Price           float64   `json:"price"`
+	Quantity        float64   `json:"quantity"`
+	Fee             float64   `json:"fee"` // 手续费
+	CreatedAt       time.Time `json:"createdAt"`
 }
 
 // Position 当前持仓，由成交记录聚合得出。

--- a/internal/http/accounts.go
+++ b/internal/http/accounts.go
@@ -124,6 +124,20 @@ func registerAccountRoutes(mux *http.ServeMux, platform *service.Platform) {
 				return
 			}
 			writeJSON(w, http.StatusOK, item)
+		case "reconcile":
+			var payload service.LiveAccountReconcileOptions
+			if r.ContentLength > 0 {
+				if err := decodeJSON(r, &payload); err != nil {
+					writeError(w, http.StatusBadRequest, err.Error())
+					return
+				}
+			}
+			item, err := platform.ReconcileLiveAccount(accountID, payload)
+			if err != nil {
+				writeError(w, http.StatusBadRequest, err.Error())
+				return
+			}
+			writeJSON(w, http.StatusOK, item)
 		case "launch":
 			var payload service.LiveLaunchOptions
 			if err := decodeJSON(r, &payload); err != nil {

--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"sort"
 	"strings"
 	"time"
 
@@ -34,6 +35,29 @@ type LiveLaunchResult struct {
 	RuntimeSessionStarted bool                        `json:"runtimeSessionStarted"`
 	LiveSessionCreated    bool                        `json:"liveSessionCreated"`
 	LiveSessionStarted    bool                        `json:"liveSessionStarted"`
+}
+
+type LiveAccountReconcileOptions struct {
+	LookbackHours int `json:"lookbackHours"`
+}
+
+type LiveAccountReconcileResult struct {
+	Account           domain.Account `json:"account"`
+	AdapterKey        string         `json:"adapterKey"`
+	ExecutionMode     string         `json:"executionMode"`
+	LookbackHours     int            `json:"lookbackHours"`
+	SymbolCount       int            `json:"symbolCount"`
+	Symbols           []string       `json:"symbols"`
+	OrderCount        int            `json:"orderCount"`
+	CreatedOrderCount int            `json:"createdOrderCount"`
+	UpdatedOrderCount int            `json:"updatedOrderCount"`
+	Notes             []string       `json:"notes,omitempty"`
+}
+
+type liveOrderReconcileIndex struct {
+	byID              map[string]domain.Order
+	byExchangeOrderID map[string]domain.Order
+	byClientOrderID   map[string]domain.Order
 }
 
 type liveAccountSyncSuccessOwner interface {
@@ -161,6 +185,99 @@ func (p *Platform) SyncLiveAccount(accountID string) (domain.Account, error) {
 	return account, fallbackErr
 }
 
+func (p *Platform) ReconcileLiveAccount(accountID string, options LiveAccountReconcileOptions) (LiveAccountReconcileResult, error) {
+	options = normalizeLiveAccountReconcileOptions(options)
+	result := LiveAccountReconcileResult{
+		LookbackHours: options.LookbackHours,
+	}
+
+	account, err := p.SyncLiveAccount(accountID)
+	if err != nil {
+		return result, err
+	}
+	adapter, binding, err := p.resolveLiveAdapterForAccount(account)
+	if err != nil {
+		return result, err
+	}
+	reconcileAdapter, ok := adapter.(LiveAccountReconcileAdapter)
+	if !ok {
+		return result, fmt.Errorf("live adapter %s does not support account reconcile", normalizeLiveAdapterKey(stringValue(binding["adapterKey"])))
+	}
+
+	result.AdapterKey = normalizeLiveAdapterKey(stringValue(binding["adapterKey"]))
+	result.ExecutionMode = normalizeLiveExecutionMode(binding["executionMode"], boolValue(binding["sandbox"]))
+	if !strings.EqualFold(result.ExecutionMode, "rest") {
+		return result, fmt.Errorf("live account reconcile requires executionMode=rest, got %s", firstNonEmpty(result.ExecutionMode, "unknown"))
+	}
+
+	symbols, err := p.collectLiveAccountReconcileSymbols(account, options.LookbackHours)
+	if err != nil {
+		return result, err
+	}
+	result.Symbols = symbols
+	result.SymbolCount = len(symbols)
+	if len(symbols) == 0 {
+		result.Notes = []string{"no candidate symbols available for reconcile"}
+		account, err = p.persistLiveAccountReconcileSummary(account, result)
+		if err != nil {
+			return result, err
+		}
+		result.Account = account
+		return result, nil
+	}
+
+	orders, err := p.store.ListOrders()
+	if err != nil {
+		return result, err
+	}
+	index := buildLiveOrderReconcileIndex(orders, account.ID)
+
+	for _, symbol := range symbols {
+		exchangeOrders, err := reconcileAdapter.FetchRecentOrders(account, binding, symbol, options.LookbackHours)
+		if err != nil {
+			return result, fmt.Errorf("reconcile fetch recent orders for %s failed: %w", symbol, err)
+		}
+		tradeReports, err := reconcileAdapter.FetchRecentTrades(account, binding, symbol, options.LookbackHours)
+		if err != nil {
+			return result, fmt.Errorf("reconcile fetch recent trades for %s failed: %w", symbol, err)
+		}
+		tradesByExchangeOrderID := groupTradeReportsByExchangeOrderID(tradeReports)
+		sort.Slice(exchangeOrders, func(i, j int) bool {
+			return parseFloatValue(exchangeOrders[i]["updateTime"]) < parseFloatValue(exchangeOrders[j]["updateTime"])
+		})
+		for _, payload := range exchangeOrders {
+			exchangeOrderID := normalizeBinanceOrderID(payload["orderId"], payload["clientOrderId"])
+			if exchangeOrderID == "" {
+				continue
+			}
+			reconciledOrder, created, err := p.reconcileLiveAccountExchangeOrder(account, binding, payload, tradesByExchangeOrderID[exchangeOrderID], &index)
+			if err != nil {
+				return result, err
+			}
+			if reconciledOrder.ID == "" {
+				continue
+			}
+			result.OrderCount++
+			if created {
+				result.CreatedOrderCount++
+			} else {
+				result.UpdatedOrderCount++
+			}
+		}
+	}
+
+	account, err = p.store.GetAccount(accountID)
+	if err != nil {
+		return result, err
+	}
+	account, err = p.persistLiveAccountReconcileSummary(account, result)
+	if err != nil {
+		return result, err
+	}
+	result.Account = account
+	return result, nil
+}
+
 func (p *Platform) persistLiveAccountSyncFailure(account domain.Account, attemptedAt time.Time, err error) domain.Account {
 	if err == nil {
 		return account
@@ -204,6 +321,357 @@ func (p *Platform) persistLiveAccountSyncSuccess(account domain.Account, binding
 	account.Metadata["liveSyncSnapshot"] = snapshot
 	account.Metadata["lastLiveSyncAt"] = syncedAt.Format(time.RFC3339)
 	updateAccountSyncSuccessHealth(&account, syncedAt, previousSuccessAt)
+	return p.store.UpdateAccount(account)
+}
+
+func normalizeLiveAccountReconcileOptions(options LiveAccountReconcileOptions) LiveAccountReconcileOptions {
+	if options.LookbackHours <= 0 {
+		options.LookbackHours = 24
+	}
+	if options.LookbackHours > 24*7 {
+		options.LookbackHours = 24 * 7
+	}
+	return options
+}
+
+func (p *Platform) collectLiveAccountReconcileSymbols(account domain.Account, lookbackHours int) ([]string, error) {
+	symbolSet := make(map[string]struct{})
+	cutoff := time.Now().UTC().Add(-time.Duration(maxInt(lookbackHours, 1)) * time.Hour)
+
+	orders, err := p.store.ListOrders()
+	if err != nil {
+		return nil, err
+	}
+	for _, order := range orders {
+		if order.AccountID != account.ID {
+			continue
+		}
+		status := strings.ToUpper(strings.TrimSpace(order.Status))
+		if order.CreatedAt.After(cutoff) || !isTerminalOrderStatus(status) {
+			addLiveAccountReconcileSymbol(symbolSet, order.Symbol)
+		}
+	}
+
+	positions, err := p.store.ListPositions()
+	if err != nil {
+		return nil, err
+	}
+	for _, position := range positions {
+		if position.AccountID != account.ID || position.Quantity <= 0 {
+			continue
+		}
+		addLiveAccountReconcileSymbol(symbolSet, position.Symbol)
+	}
+
+	snapshot := cloneMetadata(mapValue(account.Metadata["liveSyncSnapshot"]))
+	for _, item := range metadataList(snapshot["positions"]) {
+		addLiveAccountReconcileSymbol(symbolSet, stringValue(item["symbol"]))
+	}
+	for _, item := range metadataList(snapshot["openOrders"]) {
+		addLiveAccountReconcileSymbol(symbolSet, stringValue(item["symbol"]))
+	}
+
+	sessions, err := p.store.ListLiveSessions()
+	if err != nil {
+		return nil, err
+	}
+	for _, session := range sessions {
+		if session.AccountID != account.ID {
+			continue
+		}
+		addLiveAccountReconcileSymbol(symbolSet, stringValue(session.State["symbol"]))
+	}
+
+	symbols := make([]string, 0, len(symbolSet))
+	for symbol := range symbolSet {
+		symbols = append(symbols, symbol)
+	}
+	sort.Strings(symbols)
+	return symbols, nil
+}
+
+func addLiveAccountReconcileSymbol(symbols map[string]struct{}, raw string) {
+	symbol := NormalizeSymbol(raw)
+	if symbol == "" {
+		return
+	}
+	symbols[symbol] = struct{}{}
+}
+
+func buildLiveOrderReconcileIndex(orders []domain.Order, accountID string) liveOrderReconcileIndex {
+	index := liveOrderReconcileIndex{
+		byID:              make(map[string]domain.Order),
+		byExchangeOrderID: make(map[string]domain.Order),
+		byClientOrderID:   make(map[string]domain.Order),
+	}
+	for _, order := range orders {
+		if order.AccountID != accountID {
+			continue
+		}
+		index.put(order)
+	}
+	return index
+}
+
+func (i *liveOrderReconcileIndex) put(order domain.Order) {
+	if order.ID == "" {
+		return
+	}
+	i.byID[order.ID] = order
+	i.byClientOrderID[order.ID] = order
+	if exchangeOrderID := strings.TrimSpace(stringValue(order.Metadata["exchangeOrderId"])); exchangeOrderID != "" {
+		i.byExchangeOrderID[exchangeOrderID] = order
+	}
+	if clientOrderID := strings.TrimSpace(stringValue(mapValue(order.Metadata["adapterSubmission"])["clientOrderId"])); clientOrderID != "" {
+		i.byClientOrderID[clientOrderID] = order
+	}
+	if clientOrderID := strings.TrimSpace(stringValue(order.Metadata["exchangeClientOrderId"])); clientOrderID != "" {
+		i.byClientOrderID[clientOrderID] = order
+	}
+}
+
+func (i *liveOrderReconcileIndex) match(exchangeOrderID, clientOrderID string) (domain.Order, bool) {
+	if exchangeOrderID != "" {
+		if order, ok := i.byExchangeOrderID[exchangeOrderID]; ok {
+			return order, true
+		}
+	}
+	if clientOrderID != "" {
+		if order, ok := i.byClientOrderID[clientOrderID]; ok {
+			return order, true
+		}
+		if order, ok := i.byID[clientOrderID]; ok {
+			return order, true
+		}
+	}
+	return domain.Order{}, false
+}
+
+func groupTradeReportsByExchangeOrderID(reports []LiveFillReport) map[string][]LiveFillReport {
+	grouped := make(map[string][]LiveFillReport)
+	for _, report := range reports {
+		exchangeOrderID := strings.TrimSpace(stringValue(mapValue(report.Metadata)["exchangeOrderId"]))
+		if exchangeOrderID == "" {
+			continue
+		}
+		grouped[exchangeOrderID] = append(grouped[exchangeOrderID], report)
+	}
+	return grouped
+}
+
+func (p *Platform) reconcileLiveAccountExchangeOrder(account domain.Account, binding map[string]any, payload map[string]any, tradeReports []LiveFillReport, index *liveOrderReconcileIndex) (domain.Order, bool, error) {
+	exchangeOrderID := normalizeBinanceOrderID(payload["orderId"], payload["clientOrderId"])
+	clientOrderID := strings.TrimSpace(stringValue(payload["clientOrderId"]))
+	if exchangeOrderID == "" {
+		return domain.Order{}, false, nil
+	}
+	order, found := index.match(exchangeOrderID, clientOrderID)
+	created := false
+	var err error
+	if !found {
+		order, err = p.createRecoveredLiveOrderFromExchange(account, binding, payload)
+		if err != nil {
+			return domain.Order{}, false, err
+		}
+		created = true
+	}
+	order, err = p.enrichLiveOrderFromExchangePayload(account.ID, order, binding, payload, created)
+	if err != nil {
+		return domain.Order{}, false, err
+	}
+	syncResult := buildLiveReconcileSyncResult(order, payload, tradeReports)
+	if isTerminalOrderStatus(order.Status) && !isTerminalOrderStatus(syncResult.Status) {
+		syncResult.Status = order.Status
+	}
+	updated, err := p.applyLiveSyncResult(account, order, syncResult)
+	if err != nil {
+		return domain.Order{}, false, err
+	}
+	index.put(updated)
+	return updated, created, nil
+}
+
+func (p *Platform) createRecoveredLiveOrderFromExchange(account domain.Account, binding map[string]any, payload map[string]any) (domain.Order, error) {
+	symbol := NormalizeSymbol(stringValue(payload["symbol"]))
+	quantity := firstPositive(parseFloatValue(payload["origQty"]), parseFloatValue(payload["executedQty"]))
+	price := firstPositive(parseFloatValue(payload["avgPrice"]), parseFloatValue(payload["price"]))
+	base := domain.Order{
+		AccountID:         account.ID,
+		StrategyVersionID: p.inferReconcileStrategyVersionID(account.ID, symbol),
+		Symbol:            symbol,
+		Side:              strings.ToUpper(strings.TrimSpace(stringValue(payload["side"]))),
+		Type:              strings.ToUpper(strings.TrimSpace(firstNonEmpty(stringValue(payload["origType"]), stringValue(payload["type"]), "MARKET"))),
+		Quantity:          quantity,
+		Price:             price,
+		ReduceOnly:        boolValue(payload["reduceOnly"]),
+		ClosePosition:     boolValue(payload["closePosition"]),
+		Metadata: map[string]any{
+			"source":             "live-account-reconcile",
+			"reconcileRecovered": true,
+			"executionMode":      "live",
+			"adapterKey":         normalizeLiveAdapterKey(stringValue(binding["adapterKey"])),
+			"feeSource":          "exchange",
+			"fundingSource":      "exchange",
+			"orderLifecycle": map[string]any{
+				"submitted": true,
+				"accepted":  true,
+				"synced":    false,
+				"filled":    false,
+			},
+		},
+	}
+	return p.store.CreateOrder(base)
+}
+
+func (p *Platform) enrichLiveOrderFromExchangePayload(accountID string, order domain.Order, binding map[string]any, payload map[string]any, recovered bool) (domain.Order, error) {
+	status := firstNonEmpty(mapBinanceOrderStatus(stringValue(payload["status"])), order.Status, "ACCEPTED")
+	exchangeOrderID := normalizeBinanceOrderID(payload["orderId"], payload["clientOrderId"])
+	clientOrderID := strings.TrimSpace(stringValue(payload["clientOrderId"]))
+	syncedAt := firstNonEmpty(parseBinanceMillisToRFC3339(payload["updateTime"]), parseBinanceMillisToRFC3339(payload["time"]), time.Now().UTC().Format(time.RFC3339))
+	acceptedAt := firstNonEmpty(parseBinanceMillisToRFC3339(payload["time"]), syncedAt)
+
+	order.Metadata = cloneMetadata(order.Metadata)
+	applyExecutionMetadata(order.Metadata, map[string]any{
+		"executionMode": "live",
+		"adapterKey":    normalizeLiveAdapterKey(stringValue(binding["adapterKey"])),
+		"feeSource":     "exchange",
+		"fundingSource": "exchange",
+	})
+	if recovered {
+		order.Metadata["source"] = "live-account-reconcile"
+		order.Metadata["reconcileRecovered"] = true
+	}
+	order.Symbol = NormalizeSymbol(firstNonEmpty(stringValue(payload["symbol"]), order.Symbol))
+	order.Side = strings.ToUpper(strings.TrimSpace(firstNonEmpty(stringValue(payload["side"]), order.Side)))
+	order.Type = strings.ToUpper(strings.TrimSpace(firstNonEmpty(stringValue(payload["origType"]), stringValue(payload["type"]), order.Type)))
+	order.Quantity = firstPositive(parseFloatValue(payload["origQty"]), firstPositive(parseFloatValue(payload["executedQty"]), order.Quantity))
+	order.Price = firstPositive(parseFloatValue(payload["avgPrice"]), firstPositive(parseFloatValue(payload["price"]), order.Price))
+	order.ReduceOnly = order.ReduceOnly || boolValue(payload["reduceOnly"])
+	order.ClosePosition = order.ClosePosition || boolValue(payload["closePosition"])
+	if strings.TrimSpace(order.StrategyVersionID) == "" {
+		order.StrategyVersionID = p.inferReconcileStrategyVersionID(accountID, order.Symbol)
+	}
+	order.Metadata["exchangeOrderId"] = exchangeOrderID
+	if clientOrderID != "" {
+		order.Metadata["exchangeClientOrderId"] = clientOrderID
+	}
+	if strings.TrimSpace(stringValue(order.Metadata["acceptedAt"])) == "" && acceptedAt != "" {
+		order.Metadata["acceptedAt"] = acceptedAt
+	}
+	order.Metadata["lastExchangeStatus"] = status
+	order.Metadata["lastExchangeUpdateAt"] = syncedAt
+	submission := cloneMetadata(mapValue(order.Metadata["adapterSubmission"]))
+	if submission == nil {
+		submission = map[string]any{}
+	}
+	submission["adapterMode"] = "rest-reconcile"
+	submission["executionMode"] = normalizeLiveExecutionMode(binding["executionMode"], boolValue(binding["sandbox"]))
+	submission["exchangeOrderId"] = exchangeOrderID
+	submission["clientOrderId"] = clientOrderID
+	submission["binanceStatus"] = stringValue(payload["status"])
+	submission["origQty"] = parseFloatValue(payload["origQty"])
+	submission["executedQty"] = parseFloatValue(payload["executedQty"])
+	submission["price"] = parseFloatValue(payload["price"])
+	submission["avgPrice"] = parseFloatValue(payload["avgPrice"])
+	submission["timeInForce"] = stringValue(payload["timeInForce"])
+	submission["updateTime"] = syncedAt
+	order.Metadata["adapterSubmission"] = submission
+	markOrderLifecycle(order.Metadata, "submitted", true)
+	markOrderLifecycle(order.Metadata, "accepted", !strings.EqualFold(status, "REJECTED"))
+	return order, nil
+}
+
+func buildLiveReconcileSyncResult(order domain.Order, payload map[string]any, tradeReports []LiveFillReport) LiveOrderSync {
+	status := firstNonEmpty(mapBinanceOrderStatus(stringValue(payload["status"])), order.Status, "ACCEPTED")
+	syncedAt := firstNonEmpty(parseBinanceMillisToRFC3339(payload["updateTime"]), parseBinanceMillisToRFC3339(payload["time"]), time.Now().UTC().Format(time.RFC3339))
+	exchangeOrderID := normalizeBinanceOrderID(payload["orderId"], payload["clientOrderId"])
+	clientOrderID := strings.TrimSpace(stringValue(payload["clientOrderId"]))
+	terminal := isTerminalOrderStatus(status)
+	filledQty := parseFloatValue(payload["executedQty"])
+	avgPrice := firstPositive(parseFloatValue(payload["avgPrice"]), parseFloatValue(payload["price"]))
+	fills := make([]LiveFillReport, 0, len(tradeReports))
+	if terminal && len(tradeReports) > 0 {
+		fills = append(fills, tradeReports...)
+	} else if terminal && filledQty > 0 && strings.EqualFold(status, "FILLED") {
+		fills = append(fills, LiveFillReport{
+			Price:    avgPrice,
+			Quantity: filledQty,
+			Fee:      0,
+			Metadata: map[string]any{
+				"source":          "binance-all-orders",
+				"exchangeOrderId": exchangeOrderID,
+				"clientOrderId":   clientOrderID,
+				"executionMode":   "rest",
+			},
+		})
+	}
+	return LiveOrderSync{
+		Status:   status,
+		SyncedAt: syncedAt,
+		Fills:    fills,
+		Metadata: map[string]any{
+			"adapterMode":     "rest-reconcile",
+			"executionMode":   "rest",
+			"exchangeOrderId": exchangeOrderID,
+			"clientOrderId":   clientOrderID,
+			"binanceStatus":   stringValue(payload["status"]),
+			"origQty":         parseFloatValue(payload["origQty"]),
+			"executedQty":     filledQty,
+			"avgPrice":        avgPrice,
+			"price":           parseFloatValue(payload["price"]),
+			"updateTime":      syncedAt,
+		},
+		Terminal:   terminal,
+		FeeSource:  "exchange",
+		FundingSrc: "exchange",
+	}
+}
+
+func (p *Platform) inferReconcileStrategyVersionID(accountID, symbol string) string {
+	if strings.TrimSpace(symbol) == "" {
+		return ""
+	}
+	sessions, err := p.store.ListLiveSessions()
+	if err != nil {
+		return ""
+	}
+	var strategyID string
+	for _, session := range sessions {
+		if session.AccountID != accountID {
+			continue
+		}
+		if NormalizeSymbol(stringValue(session.State["symbol"])) != NormalizeSymbol(symbol) {
+			continue
+		}
+		if strategyID != "" && strategyID != session.StrategyID {
+			return ""
+		}
+		strategyID = session.StrategyID
+	}
+	if strategyID == "" {
+		return ""
+	}
+	version, err := p.resolveCurrentStrategyVersion(strategyID)
+	if err != nil {
+		return ""
+	}
+	return version.ID
+}
+
+func (p *Platform) persistLiveAccountReconcileSummary(account domain.Account, result LiveAccountReconcileResult) (domain.Account, error) {
+	account.Metadata = cloneMetadata(account.Metadata)
+	account.Metadata["lastLiveReconcileAt"] = time.Now().UTC().Format(time.RFC3339)
+	account.Metadata["lastLiveReconcile"] = map[string]any{
+		"adapterKey":        result.AdapterKey,
+		"executionMode":     result.ExecutionMode,
+		"lookbackHours":     result.LookbackHours,
+		"symbolCount":       result.SymbolCount,
+		"symbols":           result.Symbols,
+		"orderCount":        result.OrderCount,
+		"createdOrderCount": result.CreatedOrderCount,
+		"updatedOrderCount": result.UpdatedOrderCount,
+		"notes":             result.Notes,
+	}
 	return p.store.UpdateAccount(account)
 }
 

--- a/internal/service/live_reconcile_test.go
+++ b/internal/service/live_reconcile_test.go
@@ -1,0 +1,213 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/wuyaocheng/bktrader/internal/domain"
+	"github.com/wuyaocheng/bktrader/internal/store/memory"
+)
+
+func TestReconcileLiveAccountRecoversMissingFilledOrder(t *testing.T) {
+	store := memory.NewStore()
+	platform := NewPlatform(store)
+
+	syncedAt := time.Date(2026, 4, 17, 8, 0, 0, 0, time.UTC)
+	platform.registerLiveAdapter(testLiveAccountReconcileAdapter{
+		key: "test-reconcile",
+		syncSnapshotFunc: func(p *Platform, account domain.Account, binding map[string]any) (domain.Account, error) {
+			account.Metadata = cloneMetadata(account.Metadata)
+			account.Metadata["liveSyncSnapshot"] = map[string]any{
+				"source":      "test-reconcile",
+				"syncedAt":    syncedAt.Format(time.RFC3339),
+				"openOrders":  []map[string]any{{"symbol": "BTCUSDT"}},
+				"positions":   []map[string]any{},
+				"bindingMode": stringValue(binding["connectionMode"]),
+			}
+			account.Metadata["lastLiveSyncAt"] = syncedAt.Format(time.RFC3339)
+			return p.store.UpdateAccount(account)
+		},
+		ordersBySymbol: map[string][]map[string]any{
+			"BTCUSDT": {{
+				"symbol":        "BTCUSDT",
+				"orderId":       "9001",
+				"clientOrderId": "client-9001",
+				"status":        "FILLED",
+				"side":          "BUY",
+				"type":          "MARKET",
+				"origType":      "MARKET",
+				"origQty":       0.2,
+				"executedQty":   0.2,
+				"price":         68000.0,
+				"avgPrice":      68010.0,
+				"reduceOnly":    false,
+				"closePosition": false,
+				"time":          float64(syncedAt.Add(-2 * time.Minute).UnixMilli()),
+				"updateTime":    float64(syncedAt.UnixMilli()),
+			}},
+		},
+		tradesBySymbol: map[string][]LiveFillReport{
+			"BTCUSDT": {{
+				Price:    68010,
+				Quantity: 0.2,
+				Fee:      1.2,
+				Metadata: map[string]any{
+					"exchangeOrderId": "9001",
+					"tradeId":         "trade-9001",
+					"executionMode":   "rest",
+				},
+			}},
+		},
+	})
+
+	account, err := store.GetAccount("live-main")
+	if err != nil {
+		t.Fatalf("get account failed: %v", err)
+	}
+	account.Metadata = cloneMetadata(account.Metadata)
+	account.Metadata["liveBinding"] = map[string]any{
+		"adapterKey":     "test-reconcile",
+		"connectionMode": "rest",
+		"executionMode":  "rest",
+	}
+	if _, err := store.UpdateAccount(account); err != nil {
+		t.Fatalf("update account failed: %v", err)
+	}
+
+	result, err := platform.ReconcileLiveAccount("live-main", LiveAccountReconcileOptions{LookbackHours: 24})
+	if err != nil {
+		t.Fatalf("reconcile live account failed: %v", err)
+	}
+	if result.CreatedOrderCount != 1 {
+		t.Fatalf("expected one recovered order, got %d", result.CreatedOrderCount)
+	}
+	if result.OrderCount != 1 {
+		t.Fatalf("expected one reconciled order, got %d", result.OrderCount)
+	}
+
+	orders, err := store.ListOrders()
+	if err != nil {
+		t.Fatalf("list orders failed: %v", err)
+	}
+	var recovered domain.Order
+	for _, item := range orders {
+		if item.AccountID == "live-main" && stringValue(item.Metadata["exchangeOrderId"]) == "9001" {
+			recovered = item
+			break
+		}
+	}
+	if recovered.ID == "" {
+		t.Fatal("expected recovered order to be persisted locally")
+	}
+	if recovered.Status != "FILLED" {
+		t.Fatalf("expected recovered order to be FILLED, got %s", recovered.Status)
+	}
+	if !boolValue(recovered.Metadata["reconcileRecovered"]) {
+		t.Fatal("expected recovered order to be tagged as reconcileRecovered")
+	}
+
+	fills, err := store.ListFills()
+	if err != nil {
+		t.Fatalf("list fills failed: %v", err)
+	}
+	fillCount := 0
+	for _, item := range fills {
+		if item.OrderID == recovered.ID {
+			fillCount++
+			if item.ExchangeTradeID != "trade-9001" {
+				t.Fatalf("expected fill exchange trade id trade-9001, got %q", item.ExchangeTradeID)
+			}
+		}
+	}
+	if fillCount != 1 {
+		t.Fatalf("expected one recovered fill, got %d", fillCount)
+	}
+
+	position, found, err := store.FindPosition("live-main", "BTCUSDT")
+	if err != nil {
+		t.Fatalf("find position failed: %v", err)
+	}
+	if !found {
+		t.Fatal("expected reconcile to rebuild BTCUSDT position")
+	}
+	if position.Quantity != 0.2 {
+		t.Fatalf("expected reconciled position quantity 0.2, got %v", position.Quantity)
+	}
+
+	updatedAccount, err := store.GetAccount("live-main")
+	if err != nil {
+		t.Fatalf("get updated account failed: %v", err)
+	}
+	lastReconcile := mapValue(updatedAccount.Metadata["lastLiveReconcile"])
+	if got := int(parseFloatValue(lastReconcile["createdOrderCount"])); got != 1 {
+		t.Fatalf("expected reconcile summary createdOrderCount=1, got %d", got)
+	}
+}
+
+type testLiveAccountReconcileAdapter struct {
+	key              string
+	syncSnapshotFunc func(*Platform, domain.Account, map[string]any) (domain.Account, error)
+	ordersBySymbol   map[string][]map[string]any
+	tradesBySymbol   map[string][]LiveFillReport
+}
+
+func (a testLiveAccountReconcileAdapter) Key() string {
+	return a.key
+}
+
+func (a testLiveAccountReconcileAdapter) Describe() map[string]any {
+	return map[string]any{"key": a.key}
+}
+
+func (a testLiveAccountReconcileAdapter) ValidateAccountConfig(map[string]any) error {
+	return nil
+}
+
+func (a testLiveAccountReconcileAdapter) SubmitOrder(domain.Account, domain.Order, map[string]any) (LiveOrderSubmission, error) {
+	return LiveOrderSubmission{}, nil
+}
+
+func (a testLiveAccountReconcileAdapter) SyncOrder(domain.Account, domain.Order, map[string]any) (LiveOrderSync, error) {
+	return LiveOrderSync{}, nil
+}
+
+func (a testLiveAccountReconcileAdapter) CancelOrder(domain.Account, domain.Order, map[string]any) (LiveOrderSync, error) {
+	return LiveOrderSync{}, nil
+}
+
+func (a testLiveAccountReconcileAdapter) SyncAccountSnapshot(platform *Platform, account domain.Account, binding map[string]any) (domain.Account, error) {
+	if a.syncSnapshotFunc != nil {
+		return a.syncSnapshotFunc(platform, account, binding)
+	}
+	return account, nil
+}
+
+func (a testLiveAccountReconcileAdapter) FetchRecentOrders(_ domain.Account, _ map[string]any, symbol string, _ int) ([]map[string]any, error) {
+	return cloneReconcileOrders(a.ordersBySymbol[symbol]), nil
+}
+
+func (a testLiveAccountReconcileAdapter) FetchRecentTrades(_ domain.Account, _ map[string]any, symbol string, _ int) ([]LiveFillReport, error) {
+	return cloneReconcileTrades(a.tradesBySymbol[symbol]), nil
+}
+
+func cloneReconcileOrders(source []map[string]any) []map[string]any {
+	cloned := make([]map[string]any, 0, len(source))
+	for _, item := range source {
+		cloned = append(cloned, cloneMetadata(item))
+	}
+	return cloned
+}
+
+func cloneReconcileTrades(source []LiveFillReport) []LiveFillReport {
+	cloned := make([]LiveFillReport, 0, len(source))
+	for _, item := range source {
+		cloned = append(cloned, LiveFillReport{
+			Price:      item.Price,
+			Quantity:   item.Quantity,
+			Fee:        item.Fee,
+			FundingPnL: item.FundingPnL,
+			Metadata:   cloneMetadata(item.Metadata),
+		})
+	}
+	return cloned
+}

--- a/internal/service/live_registry.go
+++ b/internal/service/live_registry.go
@@ -33,6 +33,11 @@ type LiveAccountSyncAdapter interface {
 	SyncAccountSnapshot(platform *Platform, account domain.Account, binding map[string]any) (domain.Account, error)
 }
 
+type LiveAccountReconcileAdapter interface {
+	FetchRecentOrders(account domain.Account, binding map[string]any, symbol string, lookbackHours int) ([]map[string]any, error)
+	FetchRecentTrades(account domain.Account, binding map[string]any, symbol string, lookbackHours int) ([]LiveFillReport, error)
+}
+
 type LiveOrderSubmission struct {
 	Status          string         `json:"status"`
 	ExchangeOrderID string         `json:"exchangeOrderId"`
@@ -249,6 +254,41 @@ func (a binanceFuturesLiveAdapter) SyncAccountSnapshot(platform *Platform, accou
 	return platform.syncLiveAccountFromBinance(account, binding)
 }
 
+func (a binanceFuturesLiveAdapter) FetchRecentOrders(account domain.Account, binding map[string]any, symbol string, lookbackHours int) ([]map[string]any, error) {
+	resolved, err := resolveBinanceRESTCredentials(binding)
+	if err != nil {
+		return nil, err
+	}
+	endTime := time.Now().UTC()
+	startTime := endTime.Add(-time.Duration(maxInt(lookbackHours, 1)) * time.Hour)
+	params := map[string]string{
+		"symbol":     NormalizeSymbol(symbol),
+		"timestamp":  fmt.Sprintf("%d", endTime.UnixMilli()),
+		"recvWindow": fmt.Sprintf("%d", maxIntValue(binding["recvWindowMs"], 5000)),
+		"startTime":  fmt.Sprintf("%d", startTime.UnixMilli()),
+		"endTime":    fmt.Sprintf("%d", endTime.UnixMilli()),
+		"limit":      "1000",
+	}
+	params["signature"] = signBinanceQuery(params, resolved.APISecret)
+	payload, err := doBinanceSignedRequest(http.MethodGet, resolved, "/fapi/v1/allOrders", params)
+	if err != nil {
+		return nil, err
+	}
+	var orders []map[string]any
+	if err := json.Unmarshal(payload, &orders); err != nil {
+		return nil, err
+	}
+	return orders, nil
+}
+
+func (a binanceFuturesLiveAdapter) FetchRecentTrades(account domain.Account, binding map[string]any, symbol string, lookbackHours int) ([]LiveFillReport, error) {
+	resolved, err := resolveBinanceRESTCredentials(binding)
+	if err != nil {
+		return nil, err
+	}
+	return a.fetchRESTTradeReportsForSymbol(account, binding, resolved, symbol, lookbackHours)
+}
+
 func (a binanceFuturesLiveAdapter) PersistsLiveAccountSyncSuccess() bool {
 	return true
 }
@@ -298,6 +338,7 @@ func (a binanceFuturesLiveAdapter) syncMockOrder(account domain.Account, order d
 	if stringValue(order.Metadata["exchangeOrderId"]) == "" {
 		return LiveOrderSync{}, fmt.Errorf("live order has no exchangeOrderId")
 	}
+	exchangeOrderID := stringValue(order.Metadata["exchangeOrderId"])
 	syncedAt := time.Now().UTC()
 	executionPrice := order.Price
 	if executionPrice <= 0 {
@@ -315,7 +356,8 @@ func (a binanceFuturesLiveAdapter) syncMockOrder(account domain.Account, order d
 				"source":          "exchange-sync",
 				"exchange":        account.Exchange,
 				"adapterKey":      a.Key(),
-				"exchangeOrderId": stringValue(order.Metadata["exchangeOrderId"]),
+				"exchangeOrderId": exchangeOrderID,
+				"tradeId":         exchangeOrderID,
 				"executionMode":   "mock",
 			},
 		}},
@@ -471,7 +513,8 @@ func (a binanceFuturesLiveAdapter) syncRESTOrder(account domain.Account, order d
 	avgPrice := firstPositive(parseFloatValue(payload["avgPrice"]), parseFloatValue(payload["price"]))
 	fills := []LiveFillReport{}
 	tradeReports, tradeErr := a.fetchRESTTradeReports(account, order, binding, resolved)
-	if tradeErr == nil && len(tradeReports) > 0 {
+	terminal := status == "FILLED" || status == "CANCELLED" || status == "REJECTED"
+	if tradeErr == nil && len(tradeReports) > 0 && terminal {
 		fills = tradeReports
 	} else if filledQty > 0 && strings.EqualFold(status, "FILLED") {
 		fills = append(fills, LiveFillReport{
@@ -488,7 +531,6 @@ func (a binanceFuturesLiveAdapter) syncRESTOrder(account domain.Account, order d
 			},
 		})
 	}
-	terminal := status == "FILLED" || status == "CANCELLED" || status == "REJECTED"
 	resolvedSyncAt := firstNonEmpty(parseBinanceMillisToRFC3339(payload["updateTime"]), time.Now().UTC().Format(time.RFC3339))
 	totalFee := 0.0
 	totalRealizedPnL := 0.0
@@ -579,8 +621,12 @@ func (a binanceFuturesLiveAdapter) cancelRESTOrder(account domain.Account, order
 }
 
 func (a binanceFuturesLiveAdapter) fetchRESTTradeReports(account domain.Account, order domain.Order, binding map[string]any, resolved binanceRESTCredentials) ([]LiveFillReport, error) {
+	symbol := NormalizeSymbol(order.Symbol)
+	if symbol == "" {
+		return nil, fmt.Errorf("live order has no symbol")
+	}
 	params := map[string]string{
-		"symbol":     NormalizeSymbol(order.Symbol),
+		"symbol":     symbol,
 		"timestamp":  fmt.Sprintf("%d", time.Now().UTC().UnixMilli()),
 		"recvWindow": fmt.Sprintf("%d", maxIntValue(binding["recvWindowMs"], 5000)),
 	}
@@ -595,6 +641,32 @@ func (a binanceFuturesLiveAdapter) fetchRESTTradeReports(account domain.Account,
 	if err := json.Unmarshal(payload, &trades); err != nil {
 		return nil, err
 	}
+	return a.tradeReportsFromBinanceTrades(account, trades, order.Metadata["exchangeOrderId"]), nil
+}
+
+func (a binanceFuturesLiveAdapter) fetchRESTTradeReportsForSymbol(account domain.Account, binding map[string]any, resolved binanceRESTCredentials, symbol string, lookbackHours int) ([]LiveFillReport, error) {
+	endTime := time.Now().UTC()
+	startTime := endTime.Add(-time.Duration(maxInt(lookbackHours, 1)) * time.Hour)
+	params := map[string]string{
+		"symbol":     NormalizeSymbol(symbol),
+		"timestamp":  fmt.Sprintf("%d", endTime.UnixMilli()),
+		"recvWindow": fmt.Sprintf("%d", maxIntValue(binding["recvWindowMs"], 5000)),
+		"startTime":  fmt.Sprintf("%d", startTime.UnixMilli()),
+		"endTime":    fmt.Sprintf("%d", endTime.UnixMilli()),
+		"limit":      "1000",
+	}
+	payload, err := binanceSignedGET(resolved, "/fapi/v1/userTrades", params)
+	if err != nil {
+		return nil, err
+	}
+	var trades []map[string]any
+	if err := json.Unmarshal(payload, &trades); err != nil {
+		return nil, err
+	}
+	return a.tradeReportsFromBinanceTrades(account, trades, nil), nil
+}
+
+func (a binanceFuturesLiveAdapter) tradeReportsFromBinanceTrades(account domain.Account, trades []map[string]any, fallbackOrderID any) []LiveFillReport {
 	reports := make([]LiveFillReport, 0, len(trades))
 	for _, trade := range trades {
 		qty := parseFloatValue(trade["qty"])
@@ -610,7 +682,7 @@ func (a binanceFuturesLiveAdapter) fetchRESTTradeReports(account domain.Account,
 				"source":          "binance-user-trades",
 				"exchange":        account.Exchange,
 				"adapterKey":      a.Key(),
-				"exchangeOrderId": normalizeBinanceOrderID(trade["orderId"], order.Metadata["exchangeOrderId"]),
+				"exchangeOrderId": normalizeBinanceOrderID(trade["orderId"], fallbackOrderID),
 				"tradeId":         stringValue(trade["id"]),
 				"commissionAsset": stringValue(trade["commissionAsset"]),
 				"realizedPnl":     parseFloatValue(trade["realizedPnl"]),
@@ -621,7 +693,7 @@ func (a binanceFuturesLiveAdapter) fetchRESTTradeReports(account domain.Account,
 			},
 		})
 	}
-	return reports, nil
+	return reports
 }
 
 func normalizeCredentialRefs(value any) map[string]any {

--- a/internal/service/order.go
+++ b/internal/service/order.go
@@ -585,6 +585,7 @@ func buildLiveSyncSettlement(order domain.Order, syncResult LiveOrderSync) ([]do
 	fills := make([]domain.Fill, 0, len(syncResult.Fills))
 	lastFundingPnL := 0.0
 	lastPrice := order.Price
+	singleFillReport := len(syncResult.Fills) == 1
 	for _, report := range syncResult.Fills {
 		price := report.Price
 		if price <= 0 {
@@ -593,10 +594,11 @@ func buildLiveSyncSettlement(order domain.Order, syncResult LiveOrderSync) ([]do
 		lastPrice = price
 		lastFundingPnL = report.FundingPnL
 		fills = append(fills, domain.Fill{
-			OrderID:  order.ID,
-			Price:    price,
-			Quantity: report.Quantity,
-			Fee:      report.Fee - report.FundingPnL,
+			OrderID:         order.ID,
+			ExchangeTradeID: resolveLiveFillTradeID(order, report, singleFillReport),
+			Price:           price,
+			Quantity:        report.Quantity,
+			Fee:             report.Fee - report.FundingPnL,
 		})
 	}
 	return fills, lastFundingPnL, lastPrice
@@ -606,8 +608,12 @@ func (p *Platform) finalizeExecutedOrder(account domain.Account, order domain.Or
 	if len(fills) == 0 {
 		return p.store.UpdateOrder(order)
 	}
+	newFills, err := p.filterExistingExecutionFills(order.ID, fills)
+	if err != nil {
+		return domain.Order{}, err
+	}
 	lastPrice := order.Price
-	for _, fill := range fills {
+	for _, fill := range newFills {
 		createdFill, err := p.store.CreateFill(fill)
 		if err != nil {
 			return domain.Order{}, err
@@ -629,7 +635,9 @@ func (p *Platform) finalizeExecutedOrder(account domain.Account, order domain.Or
 	if order.Metadata["acceptedAt"] == nil {
 		order.Metadata["acceptedAt"] = time.Now().UTC().Format(time.RFC3339)
 	}
-	order.Metadata["lastFilledAt"] = time.Now().UTC().Format(time.RFC3339)
+	if len(newFills) > 0 || strings.TrimSpace(stringValue(order.Metadata["lastFilledAt"])) == "" {
+		order.Metadata["lastFilledAt"] = time.Now().UTC().Format(time.RFC3339)
+	}
 	updatedOrder, err := p.store.UpdateOrder(order)
 	if err != nil {
 		return domain.Order{}, err
@@ -648,11 +656,64 @@ func (p *Platform) finalizeExecutedOrder(account domain.Account, order domain.Or
 		"symbol", NormalizeSymbol(updatedOrder.Symbol),
 	)
 	if strings.EqualFold(account.Mode, "LIVE") {
-		levelLogger.Info("order filled", "fill_count", len(fills), "price", updatedOrder.Price)
+		levelLogger.Info("order filled", "fill_count", len(newFills), "price", updatedOrder.Price)
 	} else {
-		levelLogger.Debug("paper order filled", "fill_count", len(fills), "price", updatedOrder.Price)
+		levelLogger.Debug("paper order filled", "fill_count", len(newFills), "price", updatedOrder.Price)
 	}
 	return updatedOrder, nil
+}
+
+func (p *Platform) filterExistingExecutionFills(orderID string, fills []domain.Fill) ([]domain.Fill, error) {
+	if len(fills) == 0 {
+		return nil, nil
+	}
+	existing, err := p.store.ListFills()
+	if err != nil {
+		return nil, err
+	}
+	seen := make(map[string]struct{}, len(existing)+len(fills))
+	for _, item := range existing {
+		if item.OrderID != orderID || strings.TrimSpace(item.ExchangeTradeID) == "" {
+			continue
+		}
+		seen[buildFillDedupKey(item.OrderID, item.ExchangeTradeID)] = struct{}{}
+	}
+	filtered := make([]domain.Fill, 0, len(fills))
+	for _, fill := range fills {
+		if strings.TrimSpace(fill.ExchangeTradeID) == "" {
+			filtered = append(filtered, fill)
+			continue
+		}
+		key := buildFillDedupKey(orderID, fill.ExchangeTradeID)
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		filtered = append(filtered, fill)
+	}
+	return filtered, nil
+}
+
+func buildFillDedupKey(orderID, exchangeTradeID string) string {
+	return strings.TrimSpace(orderID) + "|" + strings.TrimSpace(exchangeTradeID)
+}
+
+func resolveLiveFillTradeID(order domain.Order, report LiveFillReport, singleFillReport bool) string {
+	metadata := mapValue(report.Metadata)
+	tradeID := strings.TrimSpace(firstNonEmpty(
+		stringValue(metadata["tradeId"]),
+		stringValue(metadata["exchangeTradeId"]),
+	))
+	if tradeID != "" {
+		return tradeID
+	}
+	if singleFillReport {
+		return strings.TrimSpace(firstNonEmpty(
+			stringValue(metadata["exchangeOrderId"]),
+			stringValue(order.Metadata["exchangeOrderId"]),
+		))
+	}
+	return ""
 }
 
 func (p *Platform) resolveLiveAdapterForAccount(account domain.Account) (LiveExecutionAdapter, map[string]any, error) {

--- a/internal/service/order_test.go
+++ b/internal/service/order_test.go
@@ -1,0 +1,111 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/wuyaocheng/bktrader/internal/domain"
+	"github.com/wuyaocheng/bktrader/internal/store/memory"
+)
+
+func TestBuildLiveSyncSettlementFallsBackToExchangeOrderIDForSingleFill(t *testing.T) {
+	order := domain.Order{
+		ID:     "order-1",
+		Symbol: "BTCUSDT",
+		Metadata: map[string]any{
+			"exchangeOrderId": "exchange-order-1",
+		},
+	}
+
+	fills, _, _ := buildLiveSyncSettlement(order, LiveOrderSync{
+		Status: "FILLED",
+		Fills: []LiveFillReport{{
+			Price:    68000,
+			Quantity: 0.1,
+			Fee:      1.23,
+			Metadata: map[string]any{
+				"exchangeOrderId": "exchange-order-1",
+			},
+		}},
+	})
+
+	if len(fills) != 1 {
+		t.Fatalf("expected one fill, got %d", len(fills))
+	}
+	if got := fills[0].ExchangeTradeID; got != "exchange-order-1" {
+		t.Fatalf("expected fallback exchange trade id to use exchange order id, got %q", got)
+	}
+}
+
+func TestFinalizeExecutedOrderSkipsDuplicateExchangeTradeIDFills(t *testing.T) {
+	store := memory.NewStore()
+	platform := NewPlatform(store)
+
+	account, err := store.GetAccount("live-main")
+	if err != nil {
+		t.Fatalf("get account failed: %v", err)
+	}
+
+	order, err := store.CreateOrder(domain.Order{
+		AccountID:         account.ID,
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "BUY",
+		Type:              "MARKET",
+		Quantity:          0.1,
+		Price:             68000,
+		Metadata: map[string]any{
+			"executionMode": "live",
+			"orderLifecycle": map[string]any{
+				"submitted": true,
+				"accepted":  true,
+				"synced":    true,
+				"filled":    false,
+			},
+			"exchangeOrderId": "exchange-order-1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create order failed: %v", err)
+	}
+
+	fill := domain.Fill{
+		OrderID:         order.ID,
+		ExchangeTradeID: "trade-1",
+		Price:           68000,
+		Quantity:        0.1,
+		Fee:             1.23,
+	}
+
+	filledOrder, err := platform.finalizeExecutedOrder(account, order, []domain.Fill{fill})
+	if err != nil {
+		t.Fatalf("first finalize failed: %v", err)
+	}
+	if _, err := platform.finalizeExecutedOrder(account, filledOrder, []domain.Fill{fill}); err != nil {
+		t.Fatalf("second finalize failed: %v", err)
+	}
+
+	fills, err := store.ListFills()
+	if err != nil {
+		t.Fatalf("list fills failed: %v", err)
+	}
+	orderFillCount := 0
+	for _, item := range fills {
+		if item.OrderID == order.ID {
+			orderFillCount++
+		}
+	}
+	if orderFillCount != 1 {
+		t.Fatalf("expected duplicate sync to keep one fill, got %d", orderFillCount)
+	}
+
+	position, found, err := store.FindPosition(account.ID, "BTCUSDT")
+	if err != nil {
+		t.Fatalf("find position failed: %v", err)
+	}
+	if !found {
+		t.Fatal("expected filled order to create a position")
+	}
+	if position.Quantity != 0.1 {
+		t.Fatalf("expected duplicate sync to keep position quantity at 0.1, got %v", position.Quantity)
+	}
+}

--- a/internal/store/memory/store.go
+++ b/internal/store/memory/store.go
@@ -485,6 +485,13 @@ func (s *Store) ListFills() ([]domain.Fill, error) {
 func (s *Store) CreateFill(fill domain.Fill) (domain.Fill, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if strings.TrimSpace(fill.ExchangeTradeID) != "" {
+		for _, item := range s.fills {
+			if item.OrderID == fill.OrderID && strings.EqualFold(strings.TrimSpace(item.ExchangeTradeID), strings.TrimSpace(fill.ExchangeTradeID)) {
+				return item, nil
+			}
+		}
+	}
 	fill.ID = s.nextID("fill")
 	fill.CreatedAt = time.Now().UTC()
 	s.fills[fill.ID] = fill

--- a/internal/store/postgres/store.go
+++ b/internal/store/postgres/store.go
@@ -557,7 +557,7 @@ func (s *Store) UpdateOrder(order domain.Order) (domain.Order, error) {
 
 func (s *Store) ListFills() ([]domain.Fill, error) {
 	rows, err := s.db.Query(`
-		select id, order_id, price, quantity, fee, created_at
+		select id, order_id, exchange_trade_id, price, quantity, fee, created_at
 		from fills order by created_at asc
 	`)
 	if err != nil {
@@ -568,22 +568,46 @@ func (s *Store) ListFills() ([]domain.Fill, error) {
 	items := []domain.Fill{}
 	for rows.Next() {
 		var item domain.Fill
-		if err := rows.Scan(&item.ID, &item.OrderID, &item.Price, &item.Quantity, &item.Fee, &item.CreatedAt); err != nil {
+		var exchangeTradeID sql.NullString
+		if err := rows.Scan(&item.ID, &item.OrderID, &exchangeTradeID, &item.Price, &item.Quantity, &item.Fee, &item.CreatedAt); err != nil {
 			return nil, err
 		}
+		item.ExchangeTradeID = exchangeTradeID.String
 		items = append(items, item)
 	}
 	return items, rows.Err()
 }
 
 func (s *Store) CreateFill(fill domain.Fill) (domain.Fill, error) {
-	fill.ID = fmt.Sprintf("fill-%d", time.Now().UTC().UnixNano())
-	fill.CreatedAt = time.Now().UTC()
+	now := time.Now().UTC()
+	fill.ID = fmt.Sprintf("fill-%d", now.UnixNano())
+	fill.CreatedAt = now
 
-	_, err := s.db.Exec(`
-		insert into fills (id, order_id, price, quantity, fee, created_at)
-		values ($1, $2, $3, $4, $5, $6)
-	`, fill.ID, fill.OrderID, fill.Price, fill.Quantity, fill.Fee, fill.CreatedAt)
+	if strings.TrimSpace(fill.ExchangeTradeID) == "" {
+		_, err := s.db.Exec(`
+			insert into fills (id, order_id, exchange_trade_id, price, quantity, fee, created_at)
+			values ($1, $2, $3, $4, $5, $6, $7)
+		`, fill.ID, fill.OrderID, nullIfEmpty(fill.ExchangeTradeID), fill.Price, fill.Quantity, fill.Fee, fill.CreatedAt)
+		return fill, err
+	}
+
+	err := s.db.QueryRow(`
+		insert into fills (id, order_id, exchange_trade_id, price, quantity, fee, created_at)
+		values ($1, $2, $3, $4, $5, $6, $7)
+		on conflict (order_id, exchange_trade_id) do update set
+			price = fills.price,
+			quantity = fills.quantity,
+			fee = fills.fee
+		returning id, order_id, exchange_trade_id, price, quantity, fee, created_at
+	`, fill.ID, fill.OrderID, fill.ExchangeTradeID, fill.Price, fill.Quantity, fill.Fee, fill.CreatedAt).Scan(
+		&fill.ID,
+		&fill.OrderID,
+		&fill.ExchangeTradeID,
+		&fill.Price,
+		&fill.Quantity,
+		&fill.Fee,
+		&fill.CreatedAt,
+	)
 	return fill, err
 }
 

--- a/web/console/src/components/layout/DockContent.tsx
+++ b/web/console/src/components/layout/DockContent.tsx
@@ -176,8 +176,8 @@ export function DockContent({ dockTab, actions }: DockContentProps) {
           columns={["ID", "策略版本", "Symbol", "Side", "Type", "数量", "价格", "交易所ID", "状态", "创建时间", "操作"]}
           rows={orders.map((order) => {
             const exchangeId = String(order.metadata?.exchangeTradeId ?? "--");
-            const isReconciled = exchangeId !== "--";
-            const isOrphan = !!order.metadata?.isOrphan;
+            const isReconciled = !!(order.metadata?.orderLifecycle as any)?.synced;
+            const isOrphan = order.status === "ACCEPTED" && (order.metadata?.orderLifecycle as any)?.reconciliationState === "orphaned";
 
             return [
               <TruncatedValue key={`${order.id}-id`} value={order.id} display={order.id.replace('order-', '')} />,
@@ -249,13 +249,15 @@ export function DockContent({ dockTab, actions }: DockContentProps) {
       )}
       {dockTab === 'fills' && (
         <DockTable
-          columns={["ID", "订单ID", "成交量", "成交价", "费用", "时间"]}
+          columns={["ID", "策略版本", "Symbol", "价格", "数量", "侧向", "交易所成交ID", "成交时间"]}
           rows={fills.map((fill) => [
             <TruncatedValue key={`${fill.id}-id`} value={fill.id} display={fill.id.replace('fill-', '')} />,
-            <TruncatedValue key={`${fill.id}-order`} value={fill.orderId} display={fill.orderId.replace('order-', '')} />,
-            formatMaybeNumber(fill.quantity),
+            fill.strategyVersion,
+            fill.symbol,
             formatMaybeNumber(fill.price),
-            formatMaybeNumber(fill.fee),
+            formatMaybeNumber(fill.quantity),
+            fill.side,
+            <TruncatedValue key={`${fill.id}-exid`} value={fill.exchangeTradeId ?? "--"} />,
             formatTime(fill.createdAt),
           ])}
           emptyMessage="暂无成交记录"

--- a/web/console/src/pages/MonitorStage.tsx
+++ b/web/console/src/pages/MonitorStage.tsx
@@ -168,15 +168,16 @@ export function MonitorStage({ syncLiveOrder, dockTab, onDockTabChange, dockCont
   const syncableLiveOrders = orders.filter((item) => item.metadata?.executionMode === "live" && item.status === "ACCEPTED");
   const platformRuntimePolicy = monitorHealth?.runtimePolicy ?? runtimePolicy;
   const timelineLogs = buildTimelineNotes(monitorTimeline).slice(0, 50);
-  const orphanOrders = orders.filter(o => !!o.metadata?.isOrphan);
-  const orphanCount = orphanOrders.length;
+  const reconciledOrders = orders.filter(o => !!(o.metadata?.orderLifecycle as any)?.synced);
+  const orphanedOrders = orders.filter(o => (o.metadata?.orderLifecycle as any)?.reconciliationState === 'orphaned');
+  const reconAuditLabel = orphanedOrders.length > 0 ? `${orphanedOrders.length} 异常` : (reconciledOrders.length > 0 ? "已审计" : "平衡");
 
   const monitorSummaryItems = monitorSession ? [
     { label: "就绪预检", value: `${monitorRuntimeReadiness.status} · ${monitorRuntimeReadiness.reason}` },
     { label: "信号意图", value: `${String(monitorIntent.action ?? "无")} · ${String(monitorIntent.side ?? "--")}` },
     { label: "指令分发", value: `${String((monitorSession.state as any)?.dispatchMode ?? "--")} · 冷却 ${String((monitorSession.state as any)?.dispatchCooldownSeconds ?? "--")}s` },
     { label: "执行汇总", value: `订单 ${monitorExecutionSummary.orderCount} · 成交 ${monitorExecutionSummary.fillCount}` },
-    { label: "对账审计", value: orphanCount > 0 ? `${orphanCount} 孤儿订单` : "平衡", color: orphanCount > 0 ? 'text-[var(--bk-status-danger)]' : '' },
+    { label: "对账审计", value: reconAuditLabel },
   ] : [];
 
   const monitorSections = monitorSession ? [
@@ -439,9 +440,9 @@ export function MonitorStage({ syncLiveOrder, dockTab, onDockTabChange, dockCont
                 { label: "Account Sync", value: runtimePolicyValueLabel(platformRuntimePolicy?.liveAccountSyncFreshnessSeconds) },
                 { 
                   label: "Orphaned Orders", 
-                  value: orphanCount > 0 ? `${orphanCount} ERR` : "None", 
-                  color: orphanCount > 0 ? 'text-[var(--bk-status-danger)]' : 'text-[var(--bk-status-success)]',
-                  icon: orphanCount > 0 ? ShieldAlert : ShieldCheck 
+                  value: orphanedOrders.length > 0 ? `${orphanedOrders.length} ERR` : "None", 
+                  color: orphanedOrders.length > 0 ? 'text-[var(--bk-status-danger)]' : 'text-[var(--bk-status-success)]',
+                  icon: orphanedOrders.length > 0 ? ShieldAlert : ShieldCheck 
                 }
               ].map((item, idx) => (
                 <div key={idx} className="rounded-xl border-2 border-[color-mix(in_srgb,var(--bk-border)_40%,transparent)] bg-[var(--bk-surface-muted)] p-4 flex flex-col justify-center transition-all hover:bg-[var(--bk-surface-soft)] shadow-sm">

--- a/web/console/src/types/domain.ts
+++ b/web/console/src/types/domain.ts
@@ -77,9 +77,13 @@ export type Order = {
 export type Fill = {
   id: string;
   orderId: string;
+  strategyVersion: string;
+  symbol: string;
+  side: string;
   price: number;
   quantity: number;
   fee: number;
+  exchangeTradeId?: string;
   createdAt: string;
 };
 


### PR DESCRIPTION
### Goal Description
本文档旨在明确交易对账与订单幂等性的后端实现要求，并前置完成配套的前端数据契约对齐。

### User Review Required
> [!IMPORTANT]
> **风险定级：L1** (包含基础领域模型与 UI 渲染逻辑变更)。
> 本 PR 虽然以文档为主，但为了确保后端上线后能立即生效，前置修改了以下前端契约：
- `domain.ts`: 补全 `Fill.exchangeTradeId` 字段。
- `DockContent.tsx`: 将对账判断逻辑切换至 `metadata.orderLifecycle` 路径。
- `MonitorStage.tsx`: 增加了对账统计的实时观测项。

### Proposed Changes
- [NEW] docs/reconciliation-requirements: 定义后端实现规范。
- [MODIFY] web/console: 按照 PRD 契约前置实现对账状态订阅逻辑。

### Verification Plan
- 已通过 `tsc` 静态校验。
- 已人工确认回滚了所有不相关的 UI 栅格重构，保持 PR 范围高度聚焦。
