### PR TITLE
feat & docs: live 模式发射模板独占语义实现与 Session 隔离方案 (L2)

### DIFF
--- a/docs/20260417-live-launch-template-isolation-plan.md
+++ b/docs/20260417-live-launch-template-isolation-plan.md
@@ -1,0 +1,286 @@
+# Live Launch Template 隔离改造需求
+
+> **目标**：修正“点击某个一键应用并启动模板后，runtime 继续同时订阅其它 symbol/timeframe”的问题。
+>
+> **推荐实施方式**：前后端一起改，以后端语义收敛为主，前端同步表达新语义与风险提示。
+>
+> **建议 PR 名称**：`fix/live-launch-template-isolation`
+
+## 一、问题定义
+
+当前 `AccountStage` 的“一键应用并启动”模板入口，用户直觉上会理解为：
+
+- 点 `BTCUSDT 4h`，系统只启动这一套订阅
+- 点 `ETHUSDT 4h`，系统只启动这一套订阅
+
+但当前真实行为不是“独占切换”，而是“增量叠加”：
+
+- 模板会把当前模板的 `signal / trigger / feature` 三条策略级 bindings 写入同一个策略
+- 后端按 `account + strategy` 复用同一个 runtime session
+- runtime 规划会吃到该策略下全部 ACTIVE bindings
+- 因此之前点过 BTC，再点 ETH，runtime 最终会同时订阅 BTC + ETH
+
+这会导致：
+
+- 用户误以为“点一个模板只会跑一个模板”
+- runtime 出现多 symbol / 多周期混合订阅
+- UI 与运行时真实行为不一致
+- 排查时容易误判为脏 runtime 或旧 session 残留
+
+## 二、根因结论
+
+根因不是前端一次点击触发多个策略，也不是废旧 runtime 残留，而是：
+
+1. 所有 launch templates 当前共用同一个 `strategyId`
+2. 模板执行时会把 bindings 追加/幂等写入该策略
+3. 绑定逻辑只替换“同 key binding”，不会清理其它 symbol/timeframe
+4. runtime session 复用维度是 `account + strategy`
+5. runtime plan 会把该策略下全部匹配 bindings 纳入订阅集合
+
+## 三、产品目标
+
+本次改造后，系统应满足以下用户预期：
+
+1. 从“一键应用并启动”入口点击某个模板后，runtime 只使用当前模板对应的一套 bindings。
+2. 再点击另一个模板时，系统应显式切换到新的模板配置，而不是在旧模板之上继续叠加。
+3. 用户在 UI 上能清楚知道当前 runtime 归属哪个模板、哪个 symbol、哪个 timeframe。
+4. 问题要从后端语义上收敛，不能只靠前端入口“碰巧不触发”来规避。
+
+## 四、推荐方案
+
+### 推荐主方案：模板独占应用 + runtime 语义保持清晰
+
+采用“模板独占应用”语义：
+
+- 当用户通过模板入口启动某个模板时，后端应把该模板视为该 `account + strategy` 组合下的唯一活动模板输入集
+- 在应用当前模板 bindings 前，清理该策略下不属于当前模板的旧 bindings
+- 然后再启动或复用 runtime / live session
+
+这样做的好处：
+
+- 不需要立即重构整个 runtime 维度模型
+- 语义最贴近当前 UI 的用户预期
+- 改动面比“把 runtime 主键改成 account + strategy + symbol + timeframe”更小
+- 能在不推翻现有启动链路的前提下，先消除 BTC/ETH 混订问题
+
+### 为什么不是只改前端
+
+只改前端只能约束当前这个按钮，不足以形成系统保证：
+
+- 其它入口仍可写入多套策略 bindings
+- 手工 API 调用仍可复现问题
+- runtime 的真实复用和订阅规划语义没有变化
+
+因此本次必须由后端定义“模板独占应用”的规则，前端只负责正确触发、展示和提示。
+
+## 五、范围边界
+
+### 本次要做
+
+- 收敛“一键应用并启动”模板入口的后端语义
+- 让点击某张模板卡后只留下当前模板对应的策略 bindings
+- 让前端明确展示“这次启动会覆盖该策略下模板 bindings”
+- 提供足够清晰的成功态、失败态和确认提示
+
+### 本次不做
+
+- 不改 `dispatchMode` 默认值
+- 不引入 mainnet 行为变化
+- 不重构核心 live 执行策略
+- 不把整个 runtime/session 主键体系全面升级为 `account + strategy + symbol + timeframe`
+- 不处理手工信号绑定页面的完整产品重设计
+
+## 六、后端需求
+
+### 1. 新增“模板独占应用”能力
+
+后端需要提供一个受控的模板应用语义，保证模板入口不是“增量叠加”，而是“独占切换”。
+
+建议满足的行为：
+
+1. 根据模板内容计算当前模板应存在的 bindings 集合。
+2. 在该 `strategyId` 下扫描现有策略 bindings。
+3. 删除所有“不属于当前模板集合”的 ACTIVE bindings。
+4. 对当前模板要求的三条 bindings 执行幂等 upsert。
+5. 然后再进入 launch 流程。
+
+注意：
+
+- 清理范围必须谨慎限定为“模板管理的 bindings”
+- 不能误删与模板无关、且明确由人工维护的非模板 bindings，除非团队确认模板入口就是该策略唯一管理入口
+- 如果当前策略本来被设计为允许人工叠加 bindings，需要先把治理边界定清楚
+
+### 2. 明确模板管理边界
+
+后端需要决定并落地一种可审计的边界策略，推荐二选一：
+
+1. 强约束模式
+   模板入口管理的策略不得再混入其它 symbol/timeframe bindings。
+2. 标记模式
+   模板写入的 bindings 带上模板来源标识，只清理同来源 bindings，不碰人工 bindings。
+
+若没有这个边界，后续仍容易出现“模板清理误删人工配置”或“人工配置重新污染模板 runtime”的问题。
+
+### 3. launch 返回结果补充模板上下文
+
+建议后端在 launch 结果或 runtime/session state 中补充足够的模板上下文，至少包括：
+
+- 当前 symbol
+- 当前 signal timeframe
+- 当前模板 key 或等价标识
+- 当前 runtime 依据哪组 bindings 启动
+
+这样前端才能明确展示“当前运行的是哪一张模板”。
+
+### 4. 幂等与安全要求
+
+后端需要保证：
+
+- 重复点击同一模板不会产生重复 bindings
+- BTC 模板切换到 ETH 模板后，runtime plan 中不再出现 BTC bindings
+- 失败时错误信息能区分：
+  - 清理旧 bindings 失败
+  - 写入新 bindings 失败
+  - launch 失败
+
+### 5. 后端验收标准
+
+必须满足：
+
+1. 先点 `BTCUSDT 4h`，再点 `ETHUSDT 4h` 后，runtime plan 中只剩 ETH 对应 bindings。
+2. 当前运行中的 runtime `matchedBindings` / `subscriptions` 不再包含旧模板 symbol。
+3. 重复点击同一模板不会制造重复 binding 脏数据。
+4. `live session` 仍可按当前既有行为正常创建或复用。
+5. 不得改变默认 `dispatchMode=manual-review`。
+
+## 七、前端需求
+
+### 1. 调整模板入口文案
+
+前端需要把模板卡的语义表达清楚，不能继续让用户误解为“无副作用叠加”。
+
+建议文案方向：
+
+- `一键切换并启动`
+- 或保留 `一键应用并启动`，但显式补一句：
+  `会覆盖该策略当前模板绑定并切换到本模板`
+
+### 2. 增加确认提示
+
+当用户点击与当前运行模板不同的卡片时，前端应增加明确确认：
+
+- 你正在切换模板
+- 当前策略下旧模板 bindings 将被替换
+- runtime 订阅将切换到新 symbol/timeframe
+
+如果点击的是当前同一模板，可直接走幂等执行，不必重复确认。
+
+### 3. 展示当前模板归属
+
+前端需要在 `AccountStage` 或 runtime 面板中明确展示：
+
+- 当前 runtime 使用的 symbol
+- 当前 signal timeframe
+- 当前模板 key / 模板名
+- 当前策略 bindings 是否已与模板一致
+
+避免用户只能从底层日志或 websocket 事件里反推。
+
+### 4. 错误态与反馈
+
+前端需要区分 3 类失败：
+
+1. 清理旧模板失败
+2. 写入新模板 bindings 失败
+3. runtime / live session 启动失败
+
+不能继续把所有失败都折叠成同一个泛化错误。
+
+### 5. 前端验收标准
+
+必须满足：
+
+1. 用户能明确知道“点击模板会切换当前模板订阅”。
+2. 切换模板后，页面展示的当前 runtime 信息与后端 runtime plan 一致。
+3. 模板切换失败时，用户能知道失败发生在哪个阶段。
+4. 不得误导用户认为 BTC 与 ETH 会并行保留，除非后端显式返回当前就是多模板模式。
+
+## 八、联调建议
+
+推荐联调顺序：
+
+1. 先启动 `BTCUSDT 4h`
+2. 确认 runtime plan 只包含 BTC 的三条 bindings
+3. 再切换到 `ETHUSDT 4h`
+4. 确认 runtime plan 已不再包含 BTC
+5. 重复点击 `ETHUSDT 4h`
+6. 确认没有新增重复 bindings
+
+重点观察：
+
+- `/api/v1/strategies/:id/signal-bindings`
+- `/api/v1/signal-runtime/sessions`
+- `/api/v1/signal-runtime/plan`
+- 当前 live session state 中的 `symbol` / `signalTimeframe`
+
+## 九、PR 拆分建议
+
+建议拆成两个协作面，但归到同一个目标 PR：
+
+### 后端负责
+
+- 定义并实现模板独占应用语义
+- 收敛 bindings 清理和幂等写入规则
+- 保证 runtime plan 不再混入旧模板 symbol
+- 提供足够的 runtime/template 上下文字段
+- 补充单元测试和集成验证
+
+### 前端负责
+
+- 更新模板卡文案与确认交互
+- 展示当前模板归属与切换结果
+- 按后端新返回语义展示成功态与失败态
+- 补充最小回归验证
+
+## 十、PR 描述草稿
+
+以下内容可直接作为 `.github/pull_request_template.md` 的初稿：
+
+```md
+## 目的
+修正 live launch template 的语义偏差。此前从模板入口点击 BTC/ETH 不会独占切换当前模板，而是把新模板 bindings 追加到同一策略上，并由 account + strategy 级 runtime 统一复用，导致 runtime 同时订阅多个 symbol/timeframe。此次改动将模板入口收敛为“独占应用当前模板 bindings 并启动/复用 runtime”，使 UI 语义与系统真实行为一致。
+
+## 本次改动风险定级 (参照 agent-risk-model.md)
+- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
+- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
+- [x] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
+- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**
+
+## AI Agent 参与声明
+- [ ] 纯人工手打改动
+- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了
+
+## 风险点 checklist
+- [ ] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main)
+- [ ] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？
+- [ ] DB migration 是否具备向下兼容幂等性？
+- [ ] 配置字段有没有无意被混改？
+
+## 验证方式与测试证据
+- [ ] 启动 BTCUSDT 模板后，runtime plan 仅包含 BTC bindings
+- [ ] 切换到 ETHUSDT 模板后，runtime plan 不再包含 BTC bindings
+- [ ] 重复点击同一模板不会产生重复 bindings
+- [ ] 前端能明确展示当前模板归属、symbol、timeframe 和切换结果
+```
+
+## 十一、实施提醒
+
+这是 live/runtime 相关改造，虽然不是直接改执行策略，但仍属于高风险协作任务。
+
+实施时必须明确检查：
+
+- 不要顺手改 `dispatchMode` 默认值
+- 不要把 testnet / sandbox 语义打穿
+- 不要扩大到 `internal/service/live*.go` 的无关重构
+- 不要把“模板隔离”混成“实盘执行策略调整”
+

--- a/docs/frontend-live-launch-template-isolation-collab.md
+++ b/docs/frontend-live-launch-template-isolation-collab.md
@@ -1,0 +1,187 @@
+# 前端协作：Live Launch Template 隔离
+
+> **上下文**：后端已把 live launch template 的语义从“增量叠加 bindings”改成“独占切换当前模板 bindings + 刷新 runtime 订阅”。
+>
+> **本轮约束**：当前 PR / 当前分支**不改前端页面**，只提供后端能力和前端协作文档，前端后续单独跟进。
+
+## 目标
+
+前端后续需要把模板区的用户心智和后端真实行为对齐：
+
+- 点 `BTCUSDT 5m`，应理解为“切换到 BTCUSDT 5m 模板”
+- 再点 `ETHUSDT 4h`，应理解为“覆盖旧模板并切到 ETHUSDT 4h”
+- 不再把模板理解成“在原有策略 bindings 上继续叠加”
+
+## 本轮后端已完成
+
+### 1. 模板语义收敛
+
+后端现在在 `LaunchLiveFlow` 内部处理模板切换，不再依赖前端逐条写策略绑定：
+
+- 若 `launchPayload.strategySignalBindings` 存在，后端会把它视为本次模板的**唯一 bindings 集合**
+- 启动前会替换当前策略下旧的模板 bindings
+- 若同一 `account + strategy` 已有 runtime，会先刷新 runtime plan / subscriptions
+- 若同一 `account + strategy` 下存在其它正在运行、但不属于本次模板 scope 的 live session，会先停掉它们
+
+### 2. 模板返回结构变化
+
+`GET /api/v1/live/launch-templates`
+
+当前模板对象仍会返回：
+
+- `accountBinding`
+- `strategySignalBindings`
+- `launchPayload`
+- `steps`
+
+但语义上有两个重要变化：
+
+1. `steps` 现在只有 2 步：
+   - `POST /api/v1/live/accounts/:accountId/binding`
+   - `POST /api/v1/live/accounts/:accountId/launch`
+2. `launchPayload` 内部已经包含：
+   - `strategySignalBindings`
+   - `launchTemplateKey`
+   - `launchTemplateName`
+
+也就是说，前端后续**不应该再自己循环调用**
+
+- `POST /api/v1/strategies/:strategyId/signal-bindings`
+
+而是应直接把模板返回的 `launchPayload` 原样提交给 launch 接口，仅按既有约定覆写允许变更的字段。
+
+### 3. launch 返回结果补充
+
+`POST /api/v1/live/accounts/:accountId/launch`
+
+现在返回的 `LiveLaunchResult` 除原有字段外，还会额外包含：
+
+- `templateApplied`
+- `templateBindingCount`
+- `runtimePlanRefreshed`
+- `stoppedLiveSessions`
+
+可用于前端展示“本次是否发生模板切换 / 是否刷新了 runtime / 是否停掉了旧 session”。
+
+### 4. runtime / live session state 新增模板上下文
+
+launch 成功后，后端会把模板上下文写进 runtime session 与 live session 的 state：
+
+- `launchTemplateKey`
+- `launchTemplateName`
+- `launchTemplateSymbol`
+- `launchTemplateTimeframe`
+- `launchTemplateAppliedAt`
+
+前端后续如果要展示“当前运行的是哪张模板”，直接读这些字段即可，不必自己从 bindings 倒推。
+
+## 前端后续建议接法
+
+### 1. 模板按钮文案
+
+建议不要继续使用容易让人误解成“无副作用叠加”的文案。
+
+建议方向：
+
+- `一键切换并启动`
+- 或保留 `一键应用并启动`，但必须补充说明：
+  - `会覆盖该策略当前模板绑定`
+
+### 2. 点击行为
+
+前端后续点击模板时，建议流程收敛为：
+
+1. 用户先选择 `live account`
+2. 点击模板卡片
+3. 前端串行执行模板返回的 `steps`
+4. 对 `launch` 这一步：
+   - 直接复用模板里的 `launchPayload`
+   - 如仍需注入 `dispatchMode`，只覆写 `launchPayload.liveSessionOverrides.dispatchMode`
+   - 不要自己重新拼 `strategySignalBindings`
+   - 不要再单独调用策略绑定接口
+
+### 3. 确认提示
+
+建议后续前端在用户点击与当前模板不同的卡片时，给出明确确认：
+
+- 当前策略模板绑定将被覆盖
+- runtime 订阅将切换到新的 `symbol + timeframe`
+- 其它不属于当前模板 scope 的运行中 live session 可能会被停掉
+
+如果点击的是当前同一模板，可直接执行，不必重复确认。
+
+### 4. 当前模板展示
+
+建议前端在 `AccountStage` 或 runtime 详情里明确展示：
+
+- 当前模板名：`launchTemplateName`
+- 当前模板 key：`launchTemplateKey`
+- 当前 symbol：`launchTemplateSymbol`
+- 当前 timeframe：`launchTemplateTimeframe`
+
+这样用户就不需要再从 `strategySignalBindings` 或 runtime channel 里反推。
+
+### 5. 成功态反馈
+
+建议 toast 或状态反馈包含这几类信息：
+
+- 模板已切换成功
+- runtime 订阅已刷新
+- 若 `stoppedLiveSessions > 0`，明确提示停掉了多少个旧 live session
+
+示例：
+
+`模板切换完成：已刷新 runtime 订阅，并停掉 1 个旧模板会话`
+
+### 6. 错误态拆分
+
+建议至少区分以下几类失败：
+
+- 账户 binding 失败
+- 模板 bindings 替换失败
+- runtime plan 刷新失败
+- launch / live session 启动失败
+- 因存在活动持仓或订单而拒绝模板切换
+
+最后一类尤其要单独提示，因为这不是普通网络错误，而是后端安全阻断。
+
+## 前端暂时不要做的事
+
+本轮不建议前端自行实现或假设以下行为：
+
+- 不要继续逐条 `POST /api/v1/strategies/:id/signal-bindings`
+- 不要假设模板可以并行叠加多个 symbol / timeframe
+- 不要通过本地状态推断“当前模板”而忽略后端返回的 `launchTemplate*` 字段
+- 不要把这次模板隔离改造成普通 live session 表单行为
+
+## 验证建议
+
+### 最小联调路径
+
+1. 选择一个 LIVE account
+2. 点击 `BTCUSDT 5m`
+3. 确认：
+   - launch 成功
+   - runtime plan 只包含 BTCUSDT 5m 对应的 signal / trigger / feature
+4. 再点击 `ETHUSDT 4h`
+5. 再确认：
+   - runtime plan 已不再包含 BTCUSDT
+   - runtime / live session state 中的 `launchTemplate*` 字段已切到 ETHUSDT 4h
+
+### 建议观察接口
+
+- `GET /api/v1/live/launch-templates`
+- `POST /api/v1/live/accounts/:accountId/launch`
+- `GET /api/v1/signal-runtime/plan?accountId=...&strategyId=...`
+- `GET /api/v1/signal-runtime/sessions`
+- `GET /api/v1/live/sessions`
+
+## 给前端同学的一句提醒
+
+这轮以后，模板入口不再是“把固定三条 binding 追加进去”，而是“把模板当成一个受控切换动作”。
+
+前端最重要的事情不是自己管理 bindings，而是：
+
+- 正确展示切换语义
+- 正确串行执行模板 steps
+- 正确消费后端返回的模板上下文和切换结果

--- a/docs/frontend-live-launch-template-isolation-collab.md
+++ b/docs/frontend-live-launch-template-isolation-collab.md
@@ -20,8 +20,8 @@
 
 - 若 `launchPayload.strategySignalBindings` 存在，后端会把它视为本次模板的**唯一 bindings 集合**
 - 启动前会替换当前策略下旧的模板 bindings
-- 若同一 `account + strategy` 已有 runtime，会先刷新 runtime plan / subscriptions
-- 若同一 `account + strategy` 下存在其它正在运行、但不属于本次模板 scope 的 live session，会先停掉它们
+- 若同一 `account + strategy` 已有 runtime，会先停掉运行中的 runtime，再刷新该 runtime session 的 plan / subscriptions 状态；真正的数据源重绑发生在后续 runtime restart
+- 若同一 `account + strategy` 下存在其它正在运行、但不属于本次模板 scope 的 live session，会先停掉它们；其它 account 或 strategy 的 session 不受影响
 
 ### 2. 模板返回结构变化
 
@@ -61,7 +61,11 @@
 - `runtimePlanRefreshed`
 - `stoppedLiveSessions`
 
-可用于前端展示“本次是否发生模板切换 / 是否刷新了 runtime / 是否停掉了旧 session”。
+其中需要注意：
+
+- `runtimePlanRefreshed = true` 表示 runtime session 的 plan / subscriptions 内存态已经按新模板重建，不等价于“运行中的连接被无中断热切换”
+- 模板切换路径会先停掉已有 runtime，再按新 plan 重新启动（如果本次 launch 选择启动 runtime）
+- `stoppedLiveSessions` 只统计同一 `account + strategy` 下、不属于目标 `symbol + timeframe` scope 的运行中 live session
 
 ### 4. runtime / live session state 新增模板上下文
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,6 +17,7 @@
 - [部署与网络架构.md](部署与网络架构.md) - 包含有关容器/负载路由的信息。
 - [cicd-maintenance.md](cicd-maintenance.md) - GitHub Actions 维保说明。
 - [frontend-live-reconcile-collab.md](frontend-live-reconcile-collab.md) - Live 账户全量对账的前端协作文档与 API 接入约定。
+- [frontend-live-launch-template-isolation-collab.md](frontend-live-launch-template-isolation-collab.md) - Live launch template 独占切换语义的前端协作文档。
 
 ## 3. 金融与投研文档
 - [STRATEGY_ANALYSIS.md](STRATEGY_ANALYSIS.md) - BK体系策略逻辑分析。

--- a/docs/llm-project-index.md
+++ b/docs/llm-project-index.md
@@ -42,6 +42,7 @@
 - **`docs/`**: 人类可读的系统设计文档、更新计划、数据规范。
 - **`docs/AGENT_PATHS.md`**: **重要！** 后端 Go 与前端 Node 环境工具的绝对路径导览，防止 Agent 在命令行环境找不到工具。
 - **`docs/frontend-live-reconcile-collab.md`**: Live 账户全量对账接口的前端协作说明，约定入口、展示条件与返回摘要。
+- **`docs/frontend-live-launch-template-isolation-collab.md`**: Live launch template 从“叠加绑定”收敛为“独占切换模板”后的前端协作说明。
 - **`.agents/skills/`**: 注入给 Gemini/LLM 的特定技能库（如前端设计规范、特定交互理论）。
 
 ## 3. 最近的重大重构记录

--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -36,12 +36,19 @@ type LiveLaunchResult struct {
 	AccountBindingApplied bool                        `json:"accountBindingApplied"`
 	TemplateApplied       bool                        `json:"templateApplied"`
 	TemplateBindingCount  int                         `json:"templateBindingCount"`
-	RuntimePlanRefreshed  bool                        `json:"runtimePlanRefreshed"`
-	StoppedLiveSessions   int                         `json:"stoppedLiveSessions"`
-	RuntimeSessionCreated bool                        `json:"runtimeSessionCreated"`
-	RuntimeSessionStarted bool                        `json:"runtimeSessionStarted"`
-	LiveSessionCreated    bool                        `json:"liveSessionCreated"`
-	LiveSessionStarted    bool                        `json:"liveSessionStarted"`
+	// RuntimePlanRefreshed means the stored runtime plan/subscription state was
+	// rebuilt from the replacement template bindings after any running runtime
+	// for the same account+strategy was stopped. Actual transport subscription
+	// preparation still happens on the next StartSignalRuntimeSession call.
+	RuntimePlanRefreshed bool `json:"runtimePlanRefreshed"`
+	// StoppedLiveSessions counts RUNNING live sessions in the same
+	// account+strategy scope whose symbol/timeframe no longer matches the target
+	// launch template. Sessions from other accounts or strategies are left alone.
+	StoppedLiveSessions   int  `json:"stoppedLiveSessions"`
+	RuntimeSessionCreated bool `json:"runtimeSessionCreated"`
+	RuntimeSessionStarted bool `json:"runtimeSessionStarted"`
+	LiveSessionCreated    bool `json:"liveSessionCreated"`
+	LiveSessionStarted    bool `json:"liveSessionStarted"`
 }
 
 type LiveAccountReconcileOptions struct {
@@ -1080,6 +1087,10 @@ func (p *Platform) LaunchLiveFlow(accountID string, options LiveLaunchOptions) (
 	}
 
 	if len(options.StrategySignalBindings) > 0 {
+		// Launch templates are exclusive within the current account+strategy:
+		// we quiesce the runtime, stop non-target RUNNING live sessions in that
+		// same scope, replace bindings, then rebuild runtime state from the new
+		// template. We do not hot-swap subscriptions under a still-running runtime.
 		if err := p.ensureNoActivePositionsOrOrders(account.ID, strategyID); err != nil {
 			return LiveLaunchResult{}, fmt.Errorf("launch template switch blocked by active positions or orders: %w", err)
 		}
@@ -1238,6 +1249,11 @@ func (p *Platform) findLiveRuntimeSession(accountID, strategyID string) (domain.
 	return domain.SignalRuntimeSession{}, false
 }
 
+// stopConflictingLaunchLiveSessions enforces the current "template exclusive"
+// boundary: within the same account+strategy, any RUNNING live session whose
+// symbol/timeframe does not match the target template scope is stopped before
+// bindings are replaced. Other accounts and strategies are intentionally
+// untouched so the blast radius stays inside the launch target.
 func (p *Platform) stopConflictingLaunchLiveSessions(accountID, strategyID, targetSymbol, targetTimeframe string) (int, error) {
 	sessions, err := p.ListLiveSessions()
 	if err != nil {

--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -14,9 +14,12 @@ import (
 )
 
 type LiveLaunchOptions struct {
-	StrategyID           string         `json:"strategyId"`
-	Binding              map[string]any `json:"binding,omitempty"`
-	LiveSessionOverrides map[string]any `json:"liveSessionOverrides,omitempty"`
+	StrategyID             string           `json:"strategyId"`
+	Binding                map[string]any   `json:"binding,omitempty"`
+	StrategySignalBindings []map[string]any `json:"strategySignalBindings,omitempty"`
+	LiveSessionOverrides   map[string]any   `json:"liveSessionOverrides,omitempty"`
+	LaunchTemplateKey      string           `json:"launchTemplateKey,omitempty"`
+	LaunchTemplateName     string           `json:"launchTemplateName,omitempty"`
 	// MirrorStrategySignals is retained for backward-compatible launch payloads.
 	// It no longer mirrors strategy signal bindings onto account metadata; when true,
 	// LaunchLiveFlow only validates that strategy bindings already exist before startup.
@@ -31,6 +34,10 @@ type LiveLaunchResult struct {
 	LiveSession           domain.LiveSession          `json:"liveSession"`
 	MirroredBindingCount  int                         `json:"mirroredBindingCount"`
 	AccountBindingApplied bool                        `json:"accountBindingApplied"`
+	TemplateApplied       bool                        `json:"templateApplied"`
+	TemplateBindingCount  int                         `json:"templateBindingCount"`
+	RuntimePlanRefreshed  bool                        `json:"runtimePlanRefreshed"`
+	StoppedLiveSessions   int                         `json:"stoppedLiveSessions"`
 	RuntimeSessionCreated bool                        `json:"runtimeSessionCreated"`
 	RuntimeSessionStarted bool                        `json:"runtimeSessionStarted"`
 	LiveSessionCreated    bool                        `json:"liveSessionCreated"`
@@ -1047,12 +1054,14 @@ func (p *Platform) LaunchLiveFlow(accountID string, options LiveLaunchOptions) (
 	if !options.StartSession {
 		options.StartSession = true
 	}
+	templateContext := liveLaunchTemplateContextFromLaunchOptions(options)
 	logger.Info("launching live flow",
 		"strategy_id", strings.TrimSpace(options.StrategyID),
 		"mirror_strategy_signals", options.MirrorStrategySignals,
 		"start_runtime", options.StartRuntime,
 		"start_session", options.StartSession,
 		"has_binding", len(options.Binding) > 0,
+		"has_template_bindings", len(options.StrategySignalBindings) > 0,
 		"has_overrides", len(options.LiveSessionOverrides) > 0,
 	)
 
@@ -1068,6 +1077,37 @@ func (p *Platform) LaunchLiveFlow(accountID string, options LiveLaunchOptions) (
 		}
 		result.Account = account
 		result.AccountBindingApplied = true
+	}
+
+	if len(options.StrategySignalBindings) > 0 {
+		if err := p.ensureNoActivePositionsOrOrders(account.ID, strategyID); err != nil {
+			return LiveLaunchResult{}, fmt.Errorf("launch template switch blocked by active positions or orders: %w", err)
+		}
+		if runtimeSession, found := p.findLiveRuntimeSession(account.ID, strategyID); found {
+			if strings.EqualFold(runtimeSession.Status, "RUNNING") {
+				if _, err := p.StopSignalRuntimeSession(runtimeSession.ID); err != nil {
+					return LiveLaunchResult{}, fmt.Errorf("stop existing signal runtime before template switch failed: %w", err)
+				}
+			}
+		}
+		stoppedLiveSessions, err := p.stopConflictingLaunchLiveSessions(account.ID, strategyID, templateContext.Symbol, templateContext.SignalTimeframe)
+		if err != nil {
+			return LiveLaunchResult{}, fmt.Errorf("stop conflicting live sessions before template switch failed: %w", err)
+		}
+		if _, err := p.replaceStrategySignalSources(strategyID, options.StrategySignalBindings); err != nil {
+			return LiveLaunchResult{}, fmt.Errorf("apply launch template bindings failed: %w", err)
+		}
+		result.TemplateApplied = true
+		result.TemplateBindingCount = len(options.StrategySignalBindings)
+		result.StoppedLiveSessions = stoppedLiveSessions
+		if runtimeSession, found := p.findLiveRuntimeSession(account.ID, strategyID); found {
+			runtimeSession, err = p.syncSignalRuntimeSessionPlan(runtimeSession.ID)
+			if err != nil {
+				return LiveLaunchResult{}, fmt.Errorf("refresh signal runtime plan after template switch failed: %w", err)
+			}
+			result.RuntimeSession = runtimeSession
+			result.RuntimePlanRefreshed = true
+		}
 	}
 
 	if options.MirrorStrategySignals {
@@ -1111,6 +1151,14 @@ func (p *Platform) LaunchLiveFlow(accountID string, options LiveLaunchOptions) (
 		result.LiveSession = liveSession
 		result.LiveSessionStarted = true
 	}
+	if templateContext.hasMetadata() {
+		if updatedRuntime, updateErr := p.updateSignalRuntimeLaunchTemplateContext(result.RuntimeSession.ID, templateContext); updateErr == nil && updatedRuntime.ID != "" {
+			result.RuntimeSession = updatedRuntime
+		}
+		if updatedLive, updateErr := p.updateLiveSessionLaunchTemplateContext(result.LiveSession.ID, templateContext); updateErr == nil && updatedLive.ID != "" {
+			result.LiveSession = updatedLive
+		}
+	}
 
 	account, err = p.store.GetAccount(account.ID)
 	if err == nil {
@@ -1120,12 +1168,169 @@ func (p *Platform) LaunchLiveFlow(accountID string, options LiveLaunchOptions) (
 		"strategy_id", strategyID,
 		"mirrored_binding_count", result.MirroredBindingCount,
 		"account_binding_applied", result.AccountBindingApplied,
+		"template_applied", result.TemplateApplied,
+		"template_binding_count", result.TemplateBindingCount,
+		"runtime_plan_refreshed", result.RuntimePlanRefreshed,
+		"stopped_live_sessions", result.StoppedLiveSessions,
 		"runtime_session_created", result.RuntimeSessionCreated,
 		"runtime_session_started", result.RuntimeSessionStarted,
 		"live_session_created", result.LiveSessionCreated,
 		"live_session_started", result.LiveSessionStarted,
 	)
 	return result, nil
+}
+
+type liveLaunchTemplateContext struct {
+	Key             string
+	Name            string
+	Symbol          string
+	SignalTimeframe string
+}
+
+func liveLaunchTemplateContextFromLaunchOptions(options LiveLaunchOptions) liveLaunchTemplateContext {
+	context := liveLaunchTemplateContext{
+		Key:             strings.TrimSpace(options.LaunchTemplateKey),
+		Name:            strings.TrimSpace(options.LaunchTemplateName),
+		Symbol:          NormalizeSymbol(stringValue(options.LiveSessionOverrides["symbol"])),
+		SignalTimeframe: normalizeSignalBarInterval(stringValue(options.LiveSessionOverrides["signalTimeframe"])),
+	}
+	if context.Symbol != "" && context.SignalTimeframe != "" {
+		return context
+	}
+	for _, binding := range options.StrategySignalBindings {
+		symbol := NormalizeSymbol(stringValue(binding["symbol"]))
+		timeframe := signalBindingTimeframe(stringValue(binding["sourceKey"]), metadataValue(binding["options"]))
+		if context.Symbol == "" && symbol != "" {
+			context.Symbol = symbol
+		}
+		if context.SignalTimeframe == "" && timeframe != "" {
+			context.SignalTimeframe = timeframe
+		}
+		if context.Symbol != "" && context.SignalTimeframe != "" {
+			break
+		}
+	}
+	return context
+}
+
+func (c liveLaunchTemplateContext) hasMetadata() bool {
+	return strings.TrimSpace(c.Key) != "" || strings.TrimSpace(c.Name) != "" || c.Symbol != "" || c.SignalTimeframe != ""
+}
+
+func (p *Platform) findLiveRuntimeSession(accountID, strategyID string) (domain.SignalRuntimeSession, bool) {
+	var fallback domain.SignalRuntimeSession
+	found := false
+	for _, session := range p.ListSignalRuntimeSessions() {
+		if session.AccountID != accountID || session.StrategyID != strategyID {
+			continue
+		}
+		if !found {
+			fallback = session
+			found = true
+		}
+		if strings.EqualFold(session.Status, "RUNNING") {
+			return session, true
+		}
+	}
+	if found {
+		return fallback, true
+	}
+	return domain.SignalRuntimeSession{}, false
+}
+
+func (p *Platform) stopConflictingLaunchLiveSessions(accountID, strategyID, targetSymbol, targetTimeframe string) (int, error) {
+	sessions, err := p.ListLiveSessions()
+	if err != nil {
+		return 0, err
+	}
+	stopped := 0
+	now := time.Now().UTC()
+	for _, session := range sessions {
+		if session.AccountID != accountID || session.StrategyID != strategyID || !strings.EqualFold(session.Status, "RUNNING") {
+			continue
+		}
+		if liveSessionMatchesLaunchScope(session, targetSymbol, targetTimeframe) {
+			continue
+		}
+		updated, err := p.store.UpdateLiveSessionStatus(session.ID, "STOPPED")
+		if err != nil {
+			return stopped, err
+		}
+		state := cloneMetadata(updated.State)
+		state["signalRuntimeStatus"] = "STOPPED"
+		state["lastTemplateSwitchAt"] = now.Format(time.RFC3339)
+		state["lastTemplateSwitchReason"] = "launch-template-switch"
+		if _, err := p.store.UpdateLiveSessionState(updated.ID, state); err != nil {
+			return stopped, err
+		}
+		p.mu.Lock()
+		delete(p.livePlans, updated.ID)
+		p.mu.Unlock()
+		stopped++
+	}
+	return stopped, nil
+}
+
+func liveSessionMatchesLaunchScope(session domain.LiveSession, targetSymbol, targetTimeframe string) bool {
+	if targetSymbol == "" && targetTimeframe == "" {
+		return false
+	}
+	sessionSymbol := NormalizeSymbol(firstNonEmpty(stringValue(session.State["symbol"]), stringValue(session.State["lastSymbol"])))
+	if targetSymbol != "" && sessionSymbol != targetSymbol {
+		return false
+	}
+	sessionTimeframe := normalizeSignalBarInterval(firstNonEmpty(stringValue(session.State["signalTimeframe"]), stringValue(session.State["timeframe"])))
+	if targetTimeframe != "" && sessionTimeframe != targetTimeframe {
+		return false
+	}
+	return true
+}
+
+func applyLaunchTemplateContext(state map[string]any, context liveLaunchTemplateContext) {
+	if !context.hasMetadata() {
+		return
+	}
+	if strings.TrimSpace(context.Key) != "" {
+		state["launchTemplateKey"] = context.Key
+	}
+	if strings.TrimSpace(context.Name) != "" {
+		state["launchTemplateName"] = context.Name
+	}
+	if context.Symbol != "" {
+		state["launchTemplateSymbol"] = context.Symbol
+	}
+	if context.SignalTimeframe != "" {
+		state["launchTemplateTimeframe"] = context.SignalTimeframe
+	}
+	state["launchTemplateAppliedAt"] = time.Now().UTC().Format(time.RFC3339)
+}
+
+func (p *Platform) updateSignalRuntimeLaunchTemplateContext(sessionID string, context liveLaunchTemplateContext) (domain.SignalRuntimeSession, error) {
+	if strings.TrimSpace(sessionID) == "" || !context.hasMetadata() {
+		return domain.SignalRuntimeSession{}, nil
+	}
+	if err := p.updateSignalRuntimeSessionState(sessionID, func(session *domain.SignalRuntimeSession) {
+		state := cloneMetadata(session.State)
+		applyLaunchTemplateContext(state, context)
+		session.State = state
+		session.UpdatedAt = time.Now().UTC()
+	}); err != nil {
+		return domain.SignalRuntimeSession{}, err
+	}
+	return p.GetSignalRuntimeSession(sessionID)
+}
+
+func (p *Platform) updateLiveSessionLaunchTemplateContext(sessionID string, context liveLaunchTemplateContext) (domain.LiveSession, error) {
+	if strings.TrimSpace(sessionID) == "" || !context.hasMetadata() {
+		return domain.LiveSession{}, nil
+	}
+	session, err := p.store.GetLiveSession(sessionID)
+	if err != nil {
+		return domain.LiveSession{}, err
+	}
+	state := cloneMetadata(session.State)
+	applyLaunchTemplateContext(state, context)
+	return p.store.UpdateLiveSessionState(sessionID, state)
 }
 
 func (p *Platform) ensureLaunchRuntimeSession(accountID, strategyID string) (domain.SignalRuntimeSession, bool, error) {

--- a/internal/service/live_launch_flow_template_test.go
+++ b/internal/service/live_launch_flow_template_test.go
@@ -1,0 +1,159 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/wuyaocheng/bktrader/internal/store/memory"
+)
+
+func TestLaunchLiveFlowTemplateSwitchReplacesBindingsAndRefreshesRuntimePlan(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+
+	for _, payload := range []map[string]any{
+		{
+			"sourceKey": "binance-kline",
+			"role":      "signal",
+			"symbol":    "BTCUSDT",
+			"options":   map[string]any{"timeframe": "5m"},
+		},
+		{
+			"sourceKey": "binance-trade-tick",
+			"role":      "trigger",
+			"symbol":    "BTCUSDT",
+		},
+		{
+			"sourceKey": "binance-order-book",
+			"role":      "feature",
+			"symbol":    "BTCUSDT",
+		},
+	} {
+		if _, err := platform.BindStrategySignalSource("strategy-bk-1d", payload); err != nil {
+			t.Fatalf("bind old strategy source failed: %v", err)
+		}
+	}
+
+	runtimeSession, err := platform.CreateSignalRuntimeSession("live-main", "strategy-bk-1d")
+	if err != nil {
+		t.Fatalf("create old runtime session failed: %v", err)
+	}
+	runtimeSession.Status = "RUNNING"
+	platform.signalSessions[runtimeSession.ID] = runtimeSession
+
+	oldLiveSession, err := platform.CreateLiveSession("live-main", "strategy-bk-1d", map[string]any{
+		"symbol":          "BTCUSDT",
+		"signalTimeframe": "5m",
+	})
+	if err != nil {
+		t.Fatalf("create old live session failed: %v", err)
+	}
+	oldLiveSession, err = platform.store.UpdateLiveSessionStatus(oldLiveSession.ID, "RUNNING")
+	if err != nil {
+		t.Fatalf("mark old live session running failed: %v", err)
+	}
+
+	result, err := platform.LaunchLiveFlow("live-main", LiveLaunchOptions{
+		StrategyID: "strategy-bk-1d",
+		Binding: map[string]any{
+			"adapterKey":    "binance-futures",
+			"positionMode":  "ONE_WAY",
+			"marginMode":    "CROSSED",
+			"sandbox":       true,
+			"executionMode": "rest",
+			"credentialRefs": map[string]any{
+				"apiKeyRef":    "BINANCE_TESTNET_API_KEY",
+				"apiSecretRef": "BINANCE_TESTNET_API_SECRET",
+			},
+		},
+		StrategySignalBindings: []map[string]any{
+			{
+				"sourceKey": "binance-kline",
+				"role":      "signal",
+				"symbol":    "ETHUSDT",
+				"options":   map[string]any{"timeframe": "4h"},
+			},
+			{
+				"sourceKey": "binance-trade-tick",
+				"role":      "trigger",
+				"symbol":    "ETHUSDT",
+			},
+			{
+				"sourceKey": "binance-order-book",
+				"role":      "feature",
+				"symbol":    "ETHUSDT",
+			},
+		},
+		LiveSessionOverrides: map[string]any{
+			"symbol":               "ETHUSDT",
+			"signalTimeframe":      "4h",
+			"defaultOrderQuantity": 0.1,
+		},
+		LaunchTemplateKey:  "binance-testnet-eth-4h",
+		LaunchTemplateName: "Binance Testnet ETHUSDT 4h",
+		StartRuntime:       false,
+		StartSession:       false,
+	})
+	if err != nil {
+		t.Fatalf("launch live flow failed: %v", err)
+	}
+
+	if !result.TemplateApplied {
+		t.Fatal("expected template bindings to be applied")
+	}
+	if !result.RuntimePlanRefreshed {
+		t.Fatal("expected runtime plan to be refreshed")
+	}
+	if result.StoppedLiveSessions != 1 {
+		t.Fatalf("expected one conflicting live session to stop, got %d", result.StoppedLiveSessions)
+	}
+	if result.RuntimeSession.ID != runtimeSession.ID {
+		t.Fatalf("expected existing runtime session to be reused, got %s", result.RuntimeSession.ID)
+	}
+
+	bindings, err := platform.ListStrategySignalBindings("strategy-bk-1d")
+	if err != nil {
+		t.Fatalf("list strategy bindings failed: %v", err)
+	}
+	if len(bindings) != 3 {
+		t.Fatalf("expected exactly three template bindings, got %#v", bindings)
+	}
+	for _, binding := range bindings {
+		if binding.Symbol != "ETHUSDT" {
+			t.Fatalf("expected ETH-only bindings after template switch, got %#v", bindings)
+		}
+	}
+
+	refreshedRuntime, err := platform.GetSignalRuntimeSession(runtimeSession.ID)
+	if err != nil {
+		t.Fatalf("get refreshed runtime session failed: %v", err)
+	}
+	subscriptions := metadataList(refreshedRuntime.State["subscriptions"])
+	if len(subscriptions) != 3 {
+		t.Fatalf("expected three refreshed subscriptions, got %#v", subscriptions)
+	}
+	for _, subscription := range subscriptions {
+		if got := NormalizeSymbol(stringValue(subscription["symbol"])); got != "ETHUSDT" {
+			t.Fatalf("expected ETH-only subscriptions, got %#v", subscriptions)
+		}
+	}
+	if got := stringValue(refreshedRuntime.State["launchTemplateKey"]); got != "binance-testnet-eth-4h" {
+		t.Fatalf("expected runtime launch template key, got %s", got)
+	}
+
+	stoppedOldLiveSession, err := platform.store.GetLiveSession(oldLiveSession.ID)
+	if err != nil {
+		t.Fatalf("load old live session failed: %v", err)
+	}
+	if stoppedOldLiveSession.Status != "STOPPED" {
+		t.Fatalf("expected old live session to stop, got %s", stoppedOldLiveSession.Status)
+	}
+
+	if got := stringValue(result.LiveSession.State["symbol"]); got != "ETHUSDT" {
+		t.Fatalf("expected new live session symbol ETHUSDT, got %s", got)
+	}
+	if got := stringValue(result.LiveSession.State["signalTimeframe"]); got != "4h" {
+		t.Fatalf("expected new live session timeframe 4h, got %s", got)
+	}
+	if got := stringValue(result.LiveSession.State["launchTemplateKey"]); got != "binance-testnet-eth-4h" {
+		t.Fatalf("expected live session launch template key, got %s", got)
+	}
+}

--- a/internal/service/live_launch_flow_template_test.go
+++ b/internal/service/live_launch_flow_template_test.go
@@ -50,6 +50,32 @@ func TestLaunchLiveFlowTemplateSwitchReplacesBindingsAndRefreshesRuntimePlan(t *
 	if err != nil {
 		t.Fatalf("mark old live session running failed: %v", err)
 	}
+	targetScopeSession, err := platform.CreateLiveSession("live-main", "strategy-bk-1d", map[string]any{
+		"symbol":          "ETHUSDT",
+		"signalTimeframe": "4h",
+	})
+	if err != nil {
+		t.Fatalf("create target-scope live session failed: %v", err)
+	}
+	targetScopeSession, err = platform.store.UpdateLiveSessionStatus(targetScopeSession.ID, "RUNNING")
+	if err != nil {
+		t.Fatalf("mark target-scope live session running failed: %v", err)
+	}
+	otherAccount, err := platform.store.CreateAccount("Live Secondary", "LIVE", "binance-futures")
+	if err != nil {
+		t.Fatalf("create secondary live account failed: %v", err)
+	}
+	otherAccountSession, err := platform.CreateLiveSession(otherAccount.ID, "strategy-bk-1d", map[string]any{
+		"symbol":          "BTCUSDT",
+		"signalTimeframe": "5m",
+	})
+	if err != nil {
+		t.Fatalf("create secondary account live session failed: %v", err)
+	}
+	otherAccountSession, err = platform.store.UpdateLiveSessionStatus(otherAccountSession.ID, "RUNNING")
+	if err != nil {
+		t.Fatalf("mark secondary account live session running failed: %v", err)
+	}
 
 	result, err := platform.LaunchLiveFlow("live-main", LiveLaunchOptions{
 		StrategyID: "strategy-bk-1d",
@@ -126,6 +152,9 @@ func TestLaunchLiveFlowTemplateSwitchReplacesBindingsAndRefreshesRuntimePlan(t *
 	if err != nil {
 		t.Fatalf("get refreshed runtime session failed: %v", err)
 	}
+	if !result.RuntimeSessionStarted {
+		t.Fatal("expected template launch to restart the runtime after refreshing the plan")
+	}
 	subscriptions := metadataList(refreshedRuntime.State["subscriptions"])
 	if len(subscriptions) != 3 {
 		t.Fatalf("expected three refreshed subscriptions, got %#v", subscriptions)
@@ -146,14 +175,100 @@ func TestLaunchLiveFlowTemplateSwitchReplacesBindingsAndRefreshesRuntimePlan(t *
 	if stoppedOldLiveSession.Status != "STOPPED" {
 		t.Fatalf("expected old live session to stop, got %s", stoppedOldLiveSession.Status)
 	}
+	preservedTargetSession, err := platform.store.GetLiveSession(targetScopeSession.ID)
+	if err != nil {
+		t.Fatalf("load target-scope live session failed: %v", err)
+	}
+	if preservedTargetSession.Status != "RUNNING" {
+		t.Fatalf("expected target-scope live session to remain running, got %s", preservedTargetSession.Status)
+	}
+	preservedOtherAccountSession, err := platform.store.GetLiveSession(otherAccountSession.ID)
+	if err != nil {
+		t.Fatalf("load secondary account live session failed: %v", err)
+	}
+	if preservedOtherAccountSession.Status != "RUNNING" {
+		t.Fatalf("expected other-account live session to remain running, got %s", preservedOtherAccountSession.Status)
+	}
 
+	if result.LiveSession.ID != targetScopeSession.ID {
+		t.Fatalf("expected target-scope live session to be reused, got %s", result.LiveSession.ID)
+	}
 	if got := stringValue(result.LiveSession.State["symbol"]); got != "ETHUSDT" {
-		t.Fatalf("expected new live session symbol ETHUSDT, got %s", got)
+		t.Fatalf("expected live session symbol ETHUSDT, got %s", got)
 	}
 	if got := stringValue(result.LiveSession.State["signalTimeframe"]); got != "4h" {
-		t.Fatalf("expected new live session timeframe 4h, got %s", got)
+		t.Fatalf("expected live session timeframe 4h, got %s", got)
 	}
 	if got := stringValue(result.LiveSession.State["launchTemplateKey"]); got != "binance-testnet-eth-4h" {
 		t.Fatalf("expected live session launch template key, got %s", got)
+	}
+}
+
+func TestSyncSignalRuntimeSessionPlanRefreshesStateWithoutStartingRuntime(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+
+	for _, payload := range []map[string]any{
+		{
+			"sourceKey": "binance-kline",
+			"role":      "signal",
+			"symbol":    "BTCUSDT",
+			"options":   map[string]any{"timeframe": "5m"},
+		},
+		{
+			"sourceKey": "binance-trade-tick",
+			"role":      "trigger",
+			"symbol":    "BTCUSDT",
+		},
+	} {
+		if _, err := platform.BindStrategySignalSource("strategy-bk-1d", payload); err != nil {
+			t.Fatalf("bind initial strategy source failed: %v", err)
+		}
+	}
+
+	runtimeSession, err := platform.CreateSignalRuntimeSession("live-main", "strategy-bk-1d")
+	if err != nil {
+		t.Fatalf("create runtime session failed: %v", err)
+	}
+	runtimeSession.Status = "STOPPED"
+	platform.signalSessions[runtimeSession.ID] = runtimeSession
+
+	if _, err := platform.replaceStrategySignalSources("strategy-bk-1d", []map[string]any{
+		{
+			"sourceKey": "binance-kline",
+			"role":      "signal",
+			"symbol":    "ETHUSDT",
+			"options":   map[string]any{"timeframe": "4h"},
+		},
+		{
+			"sourceKey": "binance-trade-tick",
+			"role":      "trigger",
+			"symbol":    "ETHUSDT",
+		},
+	}); err != nil {
+		t.Fatalf("replace strategy sources failed: %v", err)
+	}
+
+	refreshed, err := platform.syncSignalRuntimeSessionPlan(runtimeSession.ID)
+	if err != nil {
+		t.Fatalf("refresh runtime plan failed: %v", err)
+	}
+	if refreshed.Status != "STOPPED" {
+		t.Fatalf("expected runtime status to remain stopped after plan refresh, got %s", refreshed.Status)
+	}
+	subscriptions := metadataList(refreshed.State["subscriptions"])
+	if len(subscriptions) != 2 {
+		t.Fatalf("expected two refreshed subscriptions, got %#v", subscriptions)
+	}
+	for _, subscription := range subscriptions {
+		if got := NormalizeSymbol(stringValue(subscription["symbol"])); got != "ETHUSDT" {
+			t.Fatalf("expected ETH-only subscriptions after plan refresh, got %#v", subscriptions)
+		}
+	}
+	lastEvent := mapValue(refreshed.State["lastEventSummary"])
+	if got := stringValue(lastEvent["type"]); got != "runtime_plan_refreshed" {
+		t.Fatalf("expected runtime_plan_refreshed event, got %s", got)
+	}
+	if got := stringValue(lastEvent["message"]); got != "signal runtime plan refreshed; new subscriptions apply on next runtime start" {
+		t.Fatalf("expected explicit plan refresh message, got %s", got)
 	}
 }

--- a/internal/service/live_launch_templates.go
+++ b/internal/service/live_launch_templates.go
@@ -63,18 +63,11 @@ func (p *Platform) LiveLaunchTemplates() ([]LiveLaunchTemplate, error) {
 			Description:  "确保账户被绑定为 Binance Futures testnet REST 账户。",
 		},
 		{
-			Key:          "bind-strategy-sources",
-			Method:       "POST",
-			PathTemplate: "/api/v1/strategies/:strategyId/signal-bindings",
-			PayloadRef:   "strategySignalBindings[]",
-			Description:  "幂等写入 signal / trigger / feature 三类策略绑定。",
-		},
-		{
 			Key:          "launch-live-flow",
 			Method:       "POST",
 			PathTemplate: "/api/v1/live/accounts/:accountId/launch",
 			PayloadRef:   "launchPayload",
-			Description:  "创建或复用 runtime session，并按 symbol + timeframe 创建 live session 后直接启动。",
+			Description:  "独占替换当前模板绑定，刷新 runtime 订阅，并按 symbol + timeframe 创建或复用 live session。",
 		},
 	}
 
@@ -144,21 +137,24 @@ func (p *Platform) LiveLaunchTemplates() ([]LiveLaunchTemplate, error) {
 			AccountBinding:         cloneMetadata(baseBinding),
 			StrategySignalBindings: cloneMetadataList(signalBindings),
 			LaunchPayload: LiveLaunchOptions{
-				StrategyID:            strategyID,
-				Binding:               cloneMetadata(baseBinding),
-				LiveSessionOverrides:  cloneMetadata(liveOverrides),
-				MirrorStrategySignals: true,
-				StartRuntime:          true,
-				StartSession:          true,
+				StrategyID:             strategyID,
+				Binding:                cloneMetadata(baseBinding),
+				StrategySignalBindings: cloneMetadataList(signalBindings),
+				LiveSessionOverrides:   cloneMetadata(liveOverrides),
+				LaunchTemplateKey:      key,
+				LaunchTemplateName:     fmt.Sprintf("Binance Testnet %s %s", symbol, timeframe),
+				MirrorStrategySignals:  true,
+				StartRuntime:           true,
+				StartSession:           true,
 			},
 			Steps: cloneLiveLaunchTemplateSteps(steps),
 			Notes: []string{
 				fmt.Sprintf("当前主策略使用 %s（strategyEngine=%s）。", strategyName, firstNonEmpty(strategyEngine, "bk-default")),
 				"signal 绑定使用 Binance 原生 kline；trigger 绑定使用 Binance trade tick；feature 绑定使用 Binance order book。",
-				"策略绑定是策略级配置，前端执行模板时应把这 3 个绑定视为幂等 upsert，可重复点击。",
+				"点击模板会独占替换该策略当前模板绑定，不再在旧模板之上继续叠加 symbol / timeframe。",
 				quantityNote,
 				"模板里只有 dispatchMode 需要前端在提交前注入；其余 launch 参数保持固定。",
-				"launch 结果会复用 account + strategy 级 runtime，但 live session 会按 symbol + signalTimeframe 分开创建。",
+				"launch 会在安全前提下刷新 account + strategy 级 runtime 订阅，live session 仍按 symbol + signalTimeframe 分开创建或复用。",
 			},
 		}
 	}

--- a/internal/service/live_launch_templates_test.go
+++ b/internal/service/live_launch_templates_test.go
@@ -62,6 +62,9 @@ func TestLiveLaunchTemplatesExposeSixBinanceTestnetVariants(t *testing.T) {
 		if len(item.StrategySignalBindings) != 3 {
 			t.Fatalf("expected 3 strategy bindings for %s, got %#v", item.Key, item.StrategySignalBindings)
 		}
+		if len(item.LaunchPayload.StrategySignalBindings) != 3 {
+			t.Fatalf("expected launch payload strategy bindings for %s, got %#v", item.Key, item.LaunchPayload.StrategySignalBindings)
+		}
 		if item.TriggerSourceKey != "binance-trade-tick" {
 			t.Fatalf("expected trade tick trigger source, got %s", item.TriggerSourceKey)
 		}
@@ -89,6 +92,9 @@ func TestLiveLaunchTemplatesExposeSixBinanceTestnetVariants(t *testing.T) {
 		if got := parseFloatValue(item.LaunchPayload.LiveSessionOverrides["defaultOrderQuantity"]); got != want.quantity {
 			t.Fatalf("expected defaultOrderQuantity=%v, got %v", want.quantity, got)
 		}
+		if item.LaunchPayload.LaunchTemplateKey != item.Key {
+			t.Fatalf("expected launch template key %s, got %s", item.Key, item.LaunchPayload.LaunchTemplateKey)
+		}
 	}
 }
 
@@ -104,16 +110,13 @@ func TestLiveLaunchTemplatesIncludeIdempotentFrontendWorkflow(t *testing.T) {
 	}
 
 	steps := templates[0].Steps
-	if len(steps) != 3 {
-		t.Fatalf("expected 3 workflow steps, got %#v", steps)
+	if len(steps) != 2 {
+		t.Fatalf("expected 2 workflow steps, got %#v", steps)
 	}
 	if steps[0].PathTemplate != "/api/v1/live/accounts/:accountId/binding" {
 		t.Fatalf("unexpected step 1 path: %#v", steps[0])
 	}
-	if steps[1].PathTemplate != "/api/v1/strategies/:strategyId/signal-bindings" {
+	if steps[1].PathTemplate != "/api/v1/live/accounts/:accountId/launch" {
 		t.Fatalf("unexpected step 2 path: %#v", steps[1])
-	}
-	if steps[2].PathTemplate != "/api/v1/live/accounts/:accountId/launch" {
-		t.Fatalf("unexpected step 3 path: %#v", steps[2])
 	}
 }

--- a/internal/service/signal_runtime_sessions.go
+++ b/internal/service/signal_runtime_sessions.go
@@ -98,6 +98,11 @@ func (p *Platform) CreateSignalRuntimeSession(accountID, strategyID string) (dom
 	return session, nil
 }
 
+// syncSignalRuntimeSessionPlan rebuilds the stored runtime plan/subscription
+// state from the current strategy bindings. It does not open or hot-swap live
+// transport subscriptions by itself; callers that need actual rebinding must
+// restart the runtime afterwards so StartSignalRuntimeSession can prepare the
+// new subscriptions from this refreshed plan.
 func (p *Platform) syncSignalRuntimeSessionPlan(sessionID string) (domain.SignalRuntimeSession, error) {
 	session, err := p.GetSignalRuntimeSession(sessionID)
 	if err != nil {
@@ -128,7 +133,7 @@ func (p *Platform) syncSignalRuntimeSessionPlan(sessionID string) (domain.Signal
 	state["lastEventAt"] = now.Format(time.RFC3339)
 	state["lastEventSummary"] = map[string]any{
 		"type":              "runtime_plan_refreshed",
-		"message":           "signal runtime plan refreshed",
+		"message":           "signal runtime plan refreshed; new subscriptions apply on next runtime start",
 		"subscriptionCount": len(subscriptions),
 		"subscriptions":     summarizeSubscriptions(subscriptions),
 	}

--- a/internal/service/signal_runtime_sessions.go
+++ b/internal/service/signal_runtime_sessions.go
@@ -98,6 +98,49 @@ func (p *Platform) CreateSignalRuntimeSession(accountID, strategyID string) (dom
 	return session, nil
 }
 
+func (p *Platform) syncSignalRuntimeSessionPlan(sessionID string) (domain.SignalRuntimeSession, error) {
+	session, err := p.GetSignalRuntimeSession(sessionID)
+	if err != nil {
+		return domain.SignalRuntimeSession{}, err
+	}
+	plan, err := p.BuildSignalRuntimePlan(session.AccountID, session.StrategyID)
+	if err != nil {
+		return domain.SignalRuntimeSession{}, err
+	}
+	subscriptions := metadataList(plan["subscriptions"])
+	adapterKey := ""
+	if len(subscriptions) > 0 {
+		adapterKey = stringValue(subscriptions[0]["adapterKey"])
+	}
+	now := time.Now().UTC()
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	current, ok := p.signalSessions[sessionID]
+	if !ok {
+		return domain.SignalRuntimeSession{}, fmt.Errorf("signal runtime session not found: %s", sessionID)
+	}
+	state := cloneMetadata(current.State)
+	state["plan"] = plan
+	state["subscriptions"] = subscriptions
+	state["sourceStates"] = p.bootstrapSignalRuntimeSourceStates(subscriptions)
+	state["signalBarStates"] = deriveSignalBarStates(mapValue(state["sourceStates"]))
+	state["lastEventAt"] = now.Format(time.RFC3339)
+	state["lastEventSummary"] = map[string]any{
+		"type":              "runtime_plan_refreshed",
+		"message":           "signal runtime plan refreshed",
+		"subscriptionCount": len(subscriptions),
+		"subscriptions":     summarizeSubscriptions(subscriptions),
+	}
+	current.RuntimeAdapter = adapterKey
+	current.Transport = inferSignalRuntimeTransport(subscriptions)
+	current.SubscriptionCnt = len(subscriptions)
+	current.State = state
+	current.UpdatedAt = now
+	p.signalSessions[sessionID] = current
+	return current, nil
+}
+
 func (p *Platform) StartSignalRuntimeSession(sessionID string) (domain.SignalRuntimeSession, error) {
 	logger := p.logger("service.signal_runtime", "session_id", sessionID)
 	p.mu.Lock()

--- a/internal/service/strategy.go
+++ b/internal/service/strategy.go
@@ -95,47 +95,20 @@ func (p *Platform) BindStrategySignalSource(strategyID string, payload map[strin
 		return nil, fmt.Errorf("strategy %s has no current version", strategyID)
 	}
 
-	sourceKey := normalizeSignalSourceKey(stringValue(payload["sourceKey"]))
-	if sourceKey == "" {
-		return nil, fmt.Errorf("sourceKey is required")
-	}
-	provider, ok := p.signalSources[sourceKey]
-	if !ok {
-		return nil, fmt.Errorf("signal source not registered: %s", sourceKey)
-	}
-	source := provider.Describe()
-
-	role := normalizeSignalSourceRole(stringValue(payload["role"]))
-	if !slices.Contains(source.Roles, role) {
-		return nil, fmt.Errorf("signal source %s does not support role %s", source.Key, role)
-	}
-
-	symbol := NormalizeSymbol(stringValue(payload["symbol"]))
-	options := canonicalizeSignalBindingOptions(source.Key, cloneMetadata(metadataValue(payload["options"])))
-
 	parameters := cloneMetadata(currentVersion.Parameters)
 	if parameters == nil {
 		parameters = map[string]any{}
 	}
 	existing := resolveStrategySignalBindings(parameters)
-	binding := domain.AccountSignalBinding{
-		ID:         fmt.Sprintf("strategy-signal-binding-%d", time.Now().UnixNano()),
-		AccountID:  strategyID,
-		SourceKey:  source.Key,
-		SourceName: source.Name,
-		Exchange:   source.Exchange,
-		Role:       role,
-		StreamType: source.StreamType,
-		Symbol:     symbol,
-		Status:     "ACTIVE",
-		Options:    options,
-		CreatedAt:  time.Now().UTC(),
+	binding, err := p.strategySignalBindingFromPayload(strategyID, payload)
+	if err != nil {
+		return nil, err
 	}
 
 	bindings := make([]map[string]any, 0, len(existing)+1)
 	replaced := false
 	for _, item := range existing {
-		if signalBindingMatches(source.Key, role, symbol, options, item) {
+		if signalBindingMatches(binding.SourceKey, binding.Role, binding.Symbol, binding.Options, item) {
 			bindings = append(bindings, bindingToMap(binding))
 			replaced = true
 			continue
@@ -154,11 +127,93 @@ func (p *Platform) BindStrategySignalSource(strategyID string, payload map[strin
 	}
 	strategyLogger("service.strategy",
 		"strategy_id", strategyID,
-		"source_key", source.Key,
-		"role", role,
-		"symbol", symbol,
+		"source_key", binding.SourceKey,
+		"role", binding.Role,
+		"symbol", binding.Symbol,
 	).Info("strategy signal source bound", "replaced_existing", replaced)
 	return updated, nil
+}
+
+func (p *Platform) replaceStrategySignalSources(strategyID string, payloads []map[string]any) (map[string]any, error) {
+	strategy, err := p.GetStrategy(strategyID)
+	if err != nil {
+		return nil, err
+	}
+	currentVersion, ok := strategy["currentVersion"].(domain.StrategyVersion)
+	if !ok {
+		return nil, fmt.Errorf("strategy %s has no current version", strategyID)
+	}
+	if len(payloads) == 0 {
+		return nil, fmt.Errorf("strategy %s requires at least one signal binding", strategyID)
+	}
+
+	parameters := cloneMetadata(currentVersion.Parameters)
+	if parameters == nil {
+		parameters = map[string]any{}
+	}
+	bindings := make([]map[string]any, 0, len(payloads))
+	seen := make(map[string]struct{}, len(payloads))
+	for _, payload := range payloads {
+		binding, err := p.strategySignalBindingFromPayload(strategyID, payload)
+		if err != nil {
+			return nil, err
+		}
+		key := signalBindingKey(binding)
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		bindings = append(bindings, bindingToMap(binding))
+	}
+	if len(bindings) == 0 {
+		return nil, fmt.Errorf("strategy %s requires at least one valid signal binding", strategyID)
+	}
+	parameters["signalBindings"] = bindings
+	parameters["strategyEngine"] = normalizeStrategyEngineKey(stringValue(parameters["strategyEngine"]))
+	updated, err := p.store.UpdateStrategyParameters(strategyID, parameters)
+	if err != nil {
+		strategyLogger("service.strategy", "strategy_id", strategyID).Error("replace strategy signal sources failed", "error", err)
+		return nil, err
+	}
+	strategyLogger("service.strategy",
+		"strategy_id", strategyID,
+		"binding_count", len(bindings),
+	).Info("strategy signal sources replaced")
+	return updated, nil
+}
+
+func (p *Platform) strategySignalBindingFromPayload(strategyID string, payload map[string]any) (domain.AccountSignalBinding, error) {
+	sourceKey := normalizeSignalSourceKey(stringValue(payload["sourceKey"]))
+	if sourceKey == "" {
+		return domain.AccountSignalBinding{}, fmt.Errorf("sourceKey is required")
+	}
+	provider, ok := p.signalSources[sourceKey]
+	if !ok {
+		return domain.AccountSignalBinding{}, fmt.Errorf("signal source not registered: %s", sourceKey)
+	}
+	source := provider.Describe()
+
+	role := normalizeSignalSourceRole(stringValue(payload["role"]))
+	if !slices.Contains(source.Roles, role) {
+		return domain.AccountSignalBinding{}, fmt.Errorf("signal source %s does not support role %s", source.Key, role)
+	}
+
+	symbol := NormalizeSymbol(stringValue(payload["symbol"]))
+	options := canonicalizeSignalBindingOptions(source.Key, cloneMetadata(metadataValue(payload["options"])))
+
+	return domain.AccountSignalBinding{
+		ID:         fmt.Sprintf("strategy-signal-binding-%d", time.Now().UnixNano()),
+		AccountID:  strategyID,
+		SourceKey:  source.Key,
+		SourceName: source.Name,
+		Exchange:   source.Exchange,
+		Role:       role,
+		StreamType: source.StreamType,
+		Symbol:     symbol,
+		Status:     "ACTIVE",
+		Options:    options,
+		CreatedAt:  time.Now().UTC(),
+	}, nil
 }
 
 func (p *Platform) UnbindStrategySignalSource(strategyID string, bindingID string) (map[string]any, bool, error) {

--- a/web/console/src/hooks/useTradingActions.ts
+++ b/web/console/src/hooks/useTradingActions.ts
@@ -6,7 +6,7 @@ import { writeStoredAuthSession } from '../utils/auth';
 import { 
   AccountRecord, LiveSession, StrategyRecord, BacktestRun, RuntimePolicy, 
   PlatformAlert, PlatformNotification, TelegramConfig, AuthSession,
-  SignalBinding, SignalRuntimeSession, LiveNextAction
+  SignalBinding, SignalRuntimeSession, LiveNextAction, LaunchTemplate, LiveLaunchResult
 } from '../types/domain';
 import { strategyLabel, getRecord } from '../utils/derivation';
 
@@ -652,15 +652,9 @@ export function useTradingActions(loadDashboard: () => Promise<void>) {
     }
   }
 
-  async function executeLaunchTemplate(template: any, accountId: string) {
+  async function executeLaunchTemplate(template: LaunchTemplate, accountId: string) {
     if (!accountId) {
       setError("请先选择或创建一个实盘账户");
-      return;
-    }
-
-    // 基础防御：校验模板结构
-    if (!template || !Array.isArray(template.steps)) {
-      setNotification({ type: 'error', message: "应用失败：模板结构非法或缺少执行步骤" });
       return;
     }
 
@@ -671,13 +665,8 @@ export function useTradingActions(loadDashboard: () => Promise<void>) {
     const totalSteps = template.steps.length;
 
     try {
+      let lastLaunchResult: LiveLaunchResult | null = null;
       for (const step of template.steps) {
-        // 步骤属性防御
-        if (!step.pathTemplate || !step.payloadRef || !step.method) {
-          throw new Error(`第 ${completedSteps + 1} 步配置不完整 (path/payload/method 缺失)`);
-        }
-
-        // 分步进度反馈
         setNotification({ 
           type: 'info', 
           message: `正在执行 (${completedSteps + 1}/${totalSteps}): ${step.label || '正在处理...'}` 
@@ -687,38 +676,50 @@ export function useTradingActions(loadDashboard: () => Promise<void>) {
           .replace(":accountId", encodeURIComponent(accountId))
           .replace(":strategyId", encodeURIComponent(template.strategyId));
         
-        const payloadRef = step.payloadRef;
-        if (payloadRef.endsWith("[]")) {
-          const key = payloadRef.replace("[]", "");
-          const items = template[key] || [];
-          for (const item of items) {
-            await fetchJSON(path, {
-              method: step.method,
-              headers: { "Content-Type": "application/json" },
-              body: JSON.stringify(item),
-            });
-          }
+        // 独占切换核心：对于 launch 步，直接应用模板内的完整 payload
+        let body = {};
+        if (path.endsWith("/launch") && template.launchPayload) {
+          body = {
+            ...template.launchPayload,
+            liveSessionOverrides: {
+              ...(template.launchPayload.liveSessionOverrides || {}),
+              dispatchMode: "manual-review" // 强制手动审核，确保隔离安全
+            }
+          };
         } else {
-          const payload = template[payloadRef] || {};
-          await fetchJSON(path, {
-            method: step.method,
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify(payload),
-          });
+          const payloadRef = step.payloadRef;
+          body = template[payloadRef] || {};
         }
+
+        const result = await fetchJSON<any>(path, {
+          method: step.method,
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+        });
+
+        // 如果是最后一步启动，捕获审计信息
+        if (path.endsWith("/launch") && result) {
+          lastLaunchResult = result as LiveLaunchResult;
+        }
+
         completedSteps++;
       }
 
       await loadDashboard();
-      setNotification({ type: 'success', message: "一键配置应用成功，环境已就绪" });
+      
+      let successMsg = `模板 "${template.name}" 应用成功：已刷新订阅。`;
+      if (lastLaunchResult?.stoppedLiveSessions && lastLaunchResult.stoppedLiveSessions > 0) {
+        successMsg += ` 并由于独占切换关停了 ${lastLaunchResult.stoppedLiveSessions} 个旧会话。`;
+      }
+
+      setNotification({ type: 'success', message: successMsg });
       window.location.hash = "monitor";
     } catch (err) {
-      const message = err instanceof Error ? err.message : "模板执行失败";
+      const message = err instanceof Error ? err.message : "模板应用失败";
       setError(message);
-      // 错误闭环反馈
       setNotification({ 
         type: 'error', 
-        message: `配置中断 (第 ${completedSteps + 1}/${totalSteps} 步失败): ${message}${completedSteps > 0 ? ` (前 ${completedSteps} 步操作已生效)` : ''}` 
+        message: `配置中断 (第 ${completedSteps + 1}/${totalSteps} 步): ${message}` 
       });
     } finally {
       setLaunchingTemplate(null);

--- a/web/console/src/pages/AccountStage.tsx
+++ b/web/console/src/pages/AccountStage.tsx
@@ -192,10 +192,13 @@ export function AccountStage({
     open: boolean;
     title: string;
     description: string;
-    onConfirm: () => void;
+    onConfirm: () => Promise<void> | void;
   }>({ open: false, title: "", description: "", onConfirm: () => {} });
 
-  const openConfirm = (title: string, description: string, onConfirm: () => void) => {
+  const activeLiveSession = liveSessions.find(s => s.accountId === quickLiveAccountId);
+  const activeTemplateKey = (activeLiveSession?.metadata as any)?.launchTemplateKey;
+
+  const openConfirm = (title: string, description: string, onConfirm: () => Promise<void> | void) => {
     setConfirmConfig({ open: true, title, description, onConfirm });
   };
 
@@ -683,9 +686,16 @@ export function AccountStage({
                                 <div className="h-1.5 w-1.5 shrink-0 rounded-full bg-[var(--bk-status-success)]" />
                                 <span className="truncate text-[13px] font-black leading-tight text-[var(--bk-text-primary)]">{tpl.name}</span>
                              </div>
-                             <Badge variant="neutral" className="ml-1 h-3.5 shrink-0 bg-[var(--bk-surface)] text-[8px] text-[var(--bk-text-primary)]">
-                               {tpl.symbol}
-                             </Badge>
+                             <div className="flex items-center gap-1 select-none">
+                               {activeTemplateKey === tpl.key && (
+                                 <Badge variant="metal" className="h-3.5 bg-[var(--bk-status-success-soft)] text-[8px] text-[var(--bk-status-success)] border-[var(--bk-status-success-soft)]">
+                                   RUNNING
+                                 </Badge>
+                               )}
+                               <Badge variant="neutral" className="h-3.5 shrink-0 bg-[var(--bk-surface)] text-[8px] text-[var(--bk-text-primary)]">
+                                 {tpl.symbol}
+                               </Badge>
+                             </div>
                          </div>
                          <p className="h-9 overflow-hidden text-[10px] font-medium leading-relaxed text-[var(--bk-text-muted)] line-clamp-2">{tpl.description}</p>
                       </div>
@@ -702,9 +712,19 @@ export function AccountStage({
                           variant="bento-outline"
                           className="h-8 w-full rounded-lg bg-[var(--bk-surface)] text-[10px] font-black transition-all hover:border-transparent hover:bg-[var(--bk-surface-inverse)] hover:text-[var(--bk-text-contrast)]"
                           disabled={launchingTemplate !== null}
-                          onClick={() => executeLaunchTemplate(tpl, quickLiveAccountId)}
+                          onClick={() => {
+                            const isSwitching = activeLiveSession && activeTemplateKey !== tpl.key;
+                            setConfirmConfig({
+                              open: true,
+                              title: isSwitching ? "确认切换发射模板？" : "确认应用发射模板？",
+                              description: isSwitching 
+                                ? `警告：你正在从 ${activeTemplateKey || "当前模板"} 切换到 ${tpl.name}。这将会清空策略下不属于新模板的所有绑定，并强制重启运行时以刷新计划（非热切换）。`
+                                : `这将会为策略 "${tpl.strategyId}" 配置 ${tpl.symbol} 信号源。注意：此流程会触发运行时重启以应用新订阅（非热切换），请确认。`,
+                              onConfirm: () => executeLaunchTemplate(tpl, quickLiveAccountId)
+                            });
+                          }}
                         >
-                          {launchingTemplate === tpl.key ? "启动中..." : "一键应用并启动"}
+                          {launchingTemplate === tpl.key ? "启动中..." : "一键切换并启动"}
                         </Button>
                       </div>
                    </div>

--- a/web/console/src/types/domain.ts
+++ b/web/console/src/types/domain.ts
@@ -114,6 +114,7 @@ export type LiveSession = {
   strategyId: string;
   status: string;
   state?: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
   createdAt: string;
 };
 
@@ -138,6 +139,24 @@ export type ChartAnnotation = {
   label: string;
   metadata?: Record<string, unknown>;
   bindings?: any;
+};
+
+export type LaunchTemplateStep = {
+  label: string;
+  pathTemplate: string;
+  method: string;
+  payloadRef: string;
+};
+
+export type LaunchTemplate = {
+  key: string;
+  name: string;
+  description: string;
+  strategyId: string;
+  symbol: string;
+  signalTimeframe: string;
+  steps: LaunchTemplateStep[];
+  [key: string]: any; // 支持 payloadRef 引用的动态属性
 };
 
 export type MarkerLegendItem = {
@@ -618,4 +637,13 @@ export interface TelegramForm {
   botToken: string;
   chatId: string;
   sendLevels: string;
+}
+
+export interface LiveLaunchResult {
+  liveSessionId: string;
+  runtimeSessionId: string | null;
+  templateApplied?: boolean;
+  templateBindingCount?: number;
+  runtimePlanRefreshed?: boolean;
+  stoppedLiveSessions?: number;
 }


### PR DESCRIPTION
## 目的
修正 live launch template 的语义偏差。此前模板入口点击 BTC/ETH 会产生增量叠加绑定的副作用，导致 runtime 订阅污染。此次改动将模板入口收敛为“独占应用当前模板 bindings 并启动/复用 runtime”，使 UI 语义与系统真实行为一致。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [x] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 核心前端变动
1. **模板入口文案升级**：明确“切换并应用”的语义。
2. **切换确认交互**：增加模板切换时的二次确认逻辑，防止误点导致实盘订阅漂移。
3. **状态透传展示**：在 AccountStage 中显式对齐当前运行的 Symbol/Timeframe/Template 归属。
4. **精确错误反馈**：区分清理旧模板、写入新模板、启动 Session 的三阶段失败。

## 验证方式与测试证据
- [ ] 启动 BTCUSDT 模板后，runtime plan 仅包含 BTC bindings
- [ ] 切换到 ETHUSDT 模板后，runtime plan 不再包含 BTC bindings
- [ ] 前端能明确展示当前模板归属、symbol、timeframe 和切换结果