### PR TITLE
[codex] fix live fill ids and timestamps

### DIFF
--- a/db/migrations/015_fill_exchange_trade_time.sql
+++ b/db/migrations/015_fill_exchange_trade_time.sql
@@ -1,0 +1,2 @@
+alter table fills
+add column if not exists exchange_trade_time timestamptz;

--- a/db/migrations/016_fill_fallback_fingerprint.sql
+++ b/db/migrations/016_fill_fallback_fingerprint.sql
@@ -1,0 +1,5 @@
+alter table fills
+add column if not exists dedup_fallback_fingerprint text;
+
+create unique index if not exists idx_fills_order_fallback_fingerprint
+on fills (order_id, dedup_fallback_fingerprint);

--- a/internal/domain/models.go
+++ b/internal/domain/models.go
@@ -185,13 +185,14 @@ type Order struct {
 
 // Fill 成交记录，每笔成交关联一个订单。
 type Fill struct {
-	ID              string    `json:"id"`
-	OrderID         string    `json:"orderId"`
-	ExchangeTradeID string    `json:"exchangeTradeId,omitempty"`
-	Price           float64   `json:"price"`
-	Quantity        float64   `json:"quantity"`
-	Fee             float64   `json:"fee"` // 手续费
-	CreatedAt       time.Time `json:"createdAt"`
+	ID                string     `json:"id"`
+	OrderID           string     `json:"orderId"`
+	ExchangeTradeID   string     `json:"exchangeTradeId,omitempty"`
+	ExchangeTradeTime *time.Time `json:"exchangeTradeTime,omitempty"`
+	Price             float64    `json:"price"`
+	Quantity          float64    `json:"quantity"`
+	Fee               float64    `json:"fee"` // 手续费
+	CreatedAt         time.Time  `json:"createdAt"`
 }
 
 // Position 当前持仓，由成交记录聚合得出。

--- a/internal/domain/models.go
+++ b/internal/domain/models.go
@@ -2,7 +2,11 @@
 // 所有数据结构与具体存储层无关，可在内存和数据库间通用。
 package domain
 
-import "time"
+import (
+	"strconv"
+	"strings"
+	"time"
+)
 
 // Strategy 策略定义，包含名称、状态和描述信息。
 type Strategy struct {
@@ -189,10 +193,24 @@ type Fill struct {
 	OrderID           string     `json:"orderId"`
 	ExchangeTradeID   string     `json:"exchangeTradeId,omitempty"`
 	ExchangeTradeTime *time.Time `json:"exchangeTradeTime,omitempty"`
+	DedupFingerprint  string     `json:"-"`
 	Price             float64    `json:"price"`
 	Quantity          float64    `json:"quantity"`
 	Fee               float64    `json:"fee"` // 手续费
 	CreatedAt         time.Time  `json:"createdAt"`
+}
+
+func (f Fill) FallbackFingerprint() string {
+	tradeTime := ""
+	if f.ExchangeTradeTime != nil && !f.ExchangeTradeTime.IsZero() {
+		tradeTime = f.ExchangeTradeTime.UTC().Format(time.RFC3339Nano)
+	}
+	return strings.Join([]string{
+		strconv.FormatFloat(f.Price, 'f', -1, 64),
+		strconv.FormatFloat(f.Quantity, 'f', -1, 64),
+		strconv.FormatFloat(f.Fee, 'f', -1, 64),
+		tradeTime,
+	}, "|")
 }
 
 // Position 当前持仓，由成交记录聚合得出。

--- a/internal/service/backtest.go
+++ b/internal/service/backtest.go
@@ -3,6 +3,7 @@ package service
 import (
 	"bufio"
 	"encoding/csv"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -1685,6 +1686,9 @@ func parseFloatValue(value any) float64 {
 		return float64(v)
 	case int64:
 		return float64(v)
+	case json.Number:
+		parsed, _ := v.Float64()
+		return parsed
 	case string:
 		parsed, _ := strconv.ParseFloat(strings.TrimSpace(v), 64)
 		return parsed

--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -615,6 +615,7 @@ func buildLiveReconcileSyncResult(order domain.Order, payload map[string]any, tr
 				"source":          "binance-all-orders",
 				"exchangeOrderId": exchangeOrderID,
 				"clientOrderId":   clientOrderID,
+				"tradeTime":       syncedAt,
 				"executionMode":   "rest",
 			},
 		})

--- a/internal/service/live_registry.go
+++ b/internal/service/live_registry.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"bytes"
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
@@ -357,7 +358,7 @@ func (a binanceFuturesLiveAdapter) syncMockOrder(account domain.Account, order d
 				"exchange":        account.Exchange,
 				"adapterKey":      a.Key(),
 				"exchangeOrderId": exchangeOrderID,
-				"tradeId":         exchangeOrderID,
+				"tradeTime":       syncedAt.Format(time.RFC3339),
 				"executionMode":   "mock",
 			},
 		}},
@@ -527,6 +528,7 @@ func (a binanceFuturesLiveAdapter) syncRESTOrder(account domain.Account, order d
 				"adapterKey":      a.Key(),
 				"exchangeOrderId": normalizeBinanceOrderID(payload["orderId"], order.Metadata["exchangeOrderId"]),
 				"clientOrderId":   stringValue(payload["clientOrderId"]),
+				"tradeTime":       firstNonEmpty(parseBinanceMillisToRFC3339(payload["updateTime"]), time.Now().UTC().Format(time.RFC3339)),
 				"executionMode":   "rest",
 			},
 		})
@@ -638,7 +640,7 @@ func (a binanceFuturesLiveAdapter) fetchRESTTradeReports(account domain.Account,
 		return nil, err
 	}
 	var trades []map[string]any
-	if err := json.Unmarshal(payload, &trades); err != nil {
+	if err := unmarshalJSONUseNumber(payload, &trades); err != nil {
 		return nil, err
 	}
 	return a.tradeReportsFromBinanceTrades(account, trades, order.Metadata["exchangeOrderId"]), nil
@@ -660,7 +662,7 @@ func (a binanceFuturesLiveAdapter) fetchRESTTradeReportsForSymbol(account domain
 		return nil, err
 	}
 	var trades []map[string]any
-	if err := json.Unmarshal(payload, &trades); err != nil {
+	if err := unmarshalJSONUseNumber(payload, &trades); err != nil {
 		return nil, err
 	}
 	return a.tradeReportsFromBinanceTrades(account, trades, nil), nil
@@ -683,7 +685,7 @@ func (a binanceFuturesLiveAdapter) tradeReportsFromBinanceTrades(account domain.
 				"exchange":        account.Exchange,
 				"adapterKey":      a.Key(),
 				"exchangeOrderId": normalizeBinanceOrderID(trade["orderId"], fallbackOrderID),
-				"tradeId":         stringValue(trade["id"]),
+				"tradeId":         stringifyBinanceID(trade["id"]),
 				"commissionAsset": stringValue(trade["commissionAsset"]),
 				"realizedPnl":     parseFloatValue(trade["realizedPnl"]),
 				"maker":           trade["maker"],
@@ -1176,6 +1178,12 @@ func parseBinanceMillisToRFC3339(value any) string {
 		return ""
 	}
 	return time.UnixMilli(millis).UTC().Format(time.RFC3339)
+}
+
+func unmarshalJSONUseNumber(payload []byte, target any) error {
+	decoder := json.NewDecoder(bytes.NewReader(payload))
+	decoder.UseNumber()
+	return decoder.Decode(target)
 }
 
 func normalizeLiveExecutionMode(value any, sandbox bool) string {

--- a/internal/service/order.go
+++ b/internal/service/order.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -585,7 +586,6 @@ func buildLiveSyncSettlement(order domain.Order, syncResult LiveOrderSync) ([]do
 	fills := make([]domain.Fill, 0, len(syncResult.Fills))
 	lastFundingPnL := 0.0
 	lastPrice := order.Price
-	singleFillReport := len(syncResult.Fills) == 1
 	for _, report := range syncResult.Fills {
 		price := report.Price
 		if price <= 0 {
@@ -594,11 +594,12 @@ func buildLiveSyncSettlement(order domain.Order, syncResult LiveOrderSync) ([]do
 		lastPrice = price
 		lastFundingPnL = report.FundingPnL
 		fills = append(fills, domain.Fill{
-			OrderID:         order.ID,
-			ExchangeTradeID: resolveLiveFillTradeID(order, report, singleFillReport),
-			Price:           price,
-			Quantity:        report.Quantity,
-			Fee:             report.Fee - report.FundingPnL,
+			OrderID:           order.ID,
+			ExchangeTradeID:   resolveLiveFillTradeID(report),
+			ExchangeTradeTime: resolveLiveFillTradeTime(report),
+			Price:             price,
+			Quantity:          report.Quantity,
+			Fee:               report.Fee - report.FundingPnL,
 		})
 	}
 	return fills, lastFundingPnL, lastPrice
@@ -636,7 +637,11 @@ func (p *Platform) finalizeExecutedOrder(account domain.Account, order domain.Or
 		order.Metadata["acceptedAt"] = time.Now().UTC().Format(time.RFC3339)
 	}
 	if len(newFills) > 0 || strings.TrimSpace(stringValue(order.Metadata["lastFilledAt"])) == "" {
-		order.Metadata["lastFilledAt"] = time.Now().UTC().Format(time.RFC3339)
+		filledAt := time.Now().UTC()
+		if latestTradeTime := latestFillExchangeTradeTime(newFills); !latestTradeTime.IsZero() {
+			filledAt = latestTradeTime
+		}
+		order.Metadata["lastFilledAt"] = filledAt.Format(time.RFC3339)
 	}
 	updatedOrder, err := p.store.UpdateOrder(order)
 	if err != nil {
@@ -673,18 +678,23 @@ func (p *Platform) filterExistingExecutionFills(orderID string, fills []domain.F
 	}
 	seen := make(map[string]struct{}, len(existing)+len(fills))
 	for _, item := range existing {
-		if item.OrderID != orderID || strings.TrimSpace(item.ExchangeTradeID) == "" {
+		if item.OrderID != orderID {
 			continue
 		}
-		seen[buildFillDedupKey(item.OrderID, item.ExchangeTradeID)] = struct{}{}
+		key := buildFillDedupKey(item)
+		if key == "" {
+			continue
+		}
+		seen[key] = struct{}{}
 	}
 	filtered := make([]domain.Fill, 0, len(fills))
 	for _, fill := range fills {
-		if strings.TrimSpace(fill.ExchangeTradeID) == "" {
+		fill.OrderID = orderID
+		key := buildFillDedupKey(fill)
+		if key == "" {
 			filtered = append(filtered, fill)
 			continue
 		}
-		key := buildFillDedupKey(orderID, fill.ExchangeTradeID)
 		if _, exists := seen[key]; exists {
 			continue
 		}
@@ -694,26 +704,63 @@ func (p *Platform) filterExistingExecutionFills(orderID string, fills []domain.F
 	return filtered, nil
 }
 
-func buildFillDedupKey(orderID, exchangeTradeID string) string {
-	return strings.TrimSpace(orderID) + "|" + strings.TrimSpace(exchangeTradeID)
+func buildFillDedupKey(fill domain.Fill) string {
+	orderID := strings.TrimSpace(fill.OrderID)
+	if orderID == "" {
+		return ""
+	}
+	if exchangeTradeID := strings.TrimSpace(fill.ExchangeTradeID); exchangeTradeID != "" {
+		return orderID + "|trade|" + exchangeTradeID
+	}
+	return orderID + "|fallback|" + buildFallbackFillFingerprint(fill)
 }
 
-func resolveLiveFillTradeID(order domain.Order, report LiveFillReport, singleFillReport bool) string {
+func buildFallbackFillFingerprint(fill domain.Fill) string {
+	tradeTime := ""
+	if fill.ExchangeTradeTime != nil && !fill.ExchangeTradeTime.IsZero() {
+		tradeTime = fill.ExchangeTradeTime.UTC().Format(time.RFC3339Nano)
+	}
+	return strings.Join([]string{
+		formatFillKeyFloat(fill.Price),
+		formatFillKeyFloat(fill.Quantity),
+		formatFillKeyFloat(fill.Fee),
+		tradeTime,
+	}, "|")
+}
+
+func formatFillKeyFloat(value float64) string {
+	return strconv.FormatFloat(value, 'f', -1, 64)
+}
+
+func resolveLiveFillTradeID(report LiveFillReport) string {
 	metadata := mapValue(report.Metadata)
-	tradeID := strings.TrimSpace(firstNonEmpty(
-		stringValue(metadata["tradeId"]),
-		stringValue(metadata["exchangeTradeId"]),
+	return strings.TrimSpace(firstNonEmpty(
+		stringifyBinanceID(metadata["tradeId"]),
+		stringifyBinanceID(metadata["exchangeTradeId"]),
 	))
-	if tradeID != "" {
-		return tradeID
+}
+
+func resolveLiveFillTradeTime(report LiveFillReport) *time.Time {
+	metadata := mapValue(report.Metadata)
+	tradeTime := parseOptionalRFC3339(stringValue(metadata["tradeTime"]))
+	if tradeTime.IsZero() {
+		return nil
 	}
-	if singleFillReport {
-		return strings.TrimSpace(firstNonEmpty(
-			stringValue(metadata["exchangeOrderId"]),
-			stringValue(order.Metadata["exchangeOrderId"]),
-		))
+	resolved := tradeTime.UTC()
+	return &resolved
+}
+
+func latestFillExchangeTradeTime(fills []domain.Fill) time.Time {
+	var latest time.Time
+	for _, fill := range fills {
+		if fill.ExchangeTradeTime == nil || fill.ExchangeTradeTime.IsZero() {
+			continue
+		}
+		if fill.ExchangeTradeTime.After(latest) {
+			latest = fill.ExchangeTradeTime.UTC()
+		}
 	}
-	return ""
+	return latest
 }
 
 func (p *Platform) resolveLiveAdapterForAccount(account domain.Account) (LiveExecutionAdapter, map[string]any, error) {

--- a/internal/service/order.go
+++ b/internal/service/order.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 	"time"
 
@@ -690,6 +689,9 @@ func (p *Platform) filterExistingExecutionFills(orderID string, fills []domain.F
 	filtered := make([]domain.Fill, 0, len(fills))
 	for _, fill := range fills {
 		fill.OrderID = orderID
+		if strings.TrimSpace(fill.ExchangeTradeID) == "" && strings.TrimSpace(fill.DedupFingerprint) == "" {
+			fill.DedupFingerprint = fill.FallbackFingerprint()
+		}
 		key := buildFillDedupKey(fill)
 		if key == "" {
 			filtered = append(filtered, fill)
@@ -712,24 +714,11 @@ func buildFillDedupKey(fill domain.Fill) string {
 	if exchangeTradeID := strings.TrimSpace(fill.ExchangeTradeID); exchangeTradeID != "" {
 		return orderID + "|trade|" + exchangeTradeID
 	}
-	return orderID + "|fallback|" + buildFallbackFillFingerprint(fill)
-}
-
-func buildFallbackFillFingerprint(fill domain.Fill) string {
-	tradeTime := ""
-	if fill.ExchangeTradeTime != nil && !fill.ExchangeTradeTime.IsZero() {
-		tradeTime = fill.ExchangeTradeTime.UTC().Format(time.RFC3339Nano)
+	fingerprint := strings.TrimSpace(fill.DedupFingerprint)
+	if fingerprint == "" {
+		fingerprint = fill.FallbackFingerprint()
 	}
-	return strings.Join([]string{
-		formatFillKeyFloat(fill.Price),
-		formatFillKeyFloat(fill.Quantity),
-		formatFillKeyFloat(fill.Fee),
-		tradeTime,
-	}, "|")
-}
-
-func formatFillKeyFloat(value float64) string {
-	return strconv.FormatFloat(value, 'f', -1, 64)
+	return orderID + "|fallback|" + fingerprint
 }
 
 func resolveLiveFillTradeID(report LiveFillReport) string {

--- a/internal/service/order_test.go
+++ b/internal/service/order_test.go
@@ -2,19 +2,14 @@ package service
 
 import (
 	"testing"
+	"time"
 
 	"github.com/wuyaocheng/bktrader/internal/domain"
 	"github.com/wuyaocheng/bktrader/internal/store/memory"
 )
 
-func TestBuildLiveSyncSettlementFallsBackToExchangeOrderIDForSingleFill(t *testing.T) {
-	order := domain.Order{
-		ID:     "order-1",
-		Symbol: "BTCUSDT",
-		Metadata: map[string]any{
-			"exchangeOrderId": "exchange-order-1",
-		},
-	}
+func TestBuildLiveSyncSettlementKeepsExchangeTradeIDEmptyWithoutRealTradeID(t *testing.T) {
+	order := domain.Order{ID: "order-1", Symbol: "BTCUSDT"}
 
 	fills, _, _ := buildLiveSyncSettlement(order, LiveOrderSync{
 		Status: "FILLED",
@@ -24,6 +19,7 @@ func TestBuildLiveSyncSettlementFallsBackToExchangeOrderIDForSingleFill(t *testi
 			Fee:      1.23,
 			Metadata: map[string]any{
 				"exchangeOrderId": "exchange-order-1",
+				"tradeTime":       "2026-04-17T12:36:00Z",
 			},
 		}},
 	})
@@ -31,8 +27,11 @@ func TestBuildLiveSyncSettlementFallsBackToExchangeOrderIDForSingleFill(t *testi
 	if len(fills) != 1 {
 		t.Fatalf("expected one fill, got %d", len(fills))
 	}
-	if got := fills[0].ExchangeTradeID; got != "exchange-order-1" {
-		t.Fatalf("expected fallback exchange trade id to use exchange order id, got %q", got)
+	if got := fills[0].ExchangeTradeID; got != "" {
+		t.Fatalf("expected missing real trade id to stay empty, got %q", got)
+	}
+	if fills[0].ExchangeTradeTime == nil || fills[0].ExchangeTradeTime.Format(time.RFC3339) != "2026-04-17T12:36:00Z" {
+		t.Fatalf("expected exchange trade time to be captured, got %#v", fills[0].ExchangeTradeTime)
 	}
 }
 
@@ -107,5 +106,59 @@ func TestFinalizeExecutedOrderSkipsDuplicateExchangeTradeIDFills(t *testing.T) {
 	}
 	if position.Quantity != 0.1 {
 		t.Fatalf("expected duplicate sync to keep position quantity at 0.1, got %v", position.Quantity)
+	}
+}
+
+func TestFinalizeExecutedOrderSkipsDuplicateFallbackFillsWithoutExchangeTradeID(t *testing.T) {
+	store := memory.NewStore()
+	platform := NewPlatform(store)
+
+	account, err := store.GetAccount("live-main")
+	if err != nil {
+		t.Fatalf("get account failed: %v", err)
+	}
+
+	order, err := store.CreateOrder(domain.Order{
+		AccountID: account.ID,
+		Symbol:    "BTCUSDT",
+		Side:      "BUY",
+		Type:      "MARKET",
+		Quantity:  0.1,
+		Price:     68000,
+		Metadata:  map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("create order failed: %v", err)
+	}
+
+	tradeTime := time.Date(2026, 4, 17, 12, 36, 0, 0, time.UTC)
+	fill := domain.Fill{
+		OrderID:           order.ID,
+		Price:             68000,
+		Quantity:          0.1,
+		Fee:               1.23,
+		ExchangeTradeTime: &tradeTime,
+	}
+
+	filledOrder, err := platform.finalizeExecutedOrder(account, order, []domain.Fill{fill})
+	if err != nil {
+		t.Fatalf("first finalize failed: %v", err)
+	}
+	if _, err := platform.finalizeExecutedOrder(account, filledOrder, []domain.Fill{fill}); err != nil {
+		t.Fatalf("second finalize failed: %v", err)
+	}
+
+	fills, err := store.ListFills()
+	if err != nil {
+		t.Fatalf("list fills failed: %v", err)
+	}
+	orderFillCount := 0
+	for _, item := range fills {
+		if item.OrderID == order.ID {
+			orderFillCount++
+		}
+	}
+	if orderFillCount != 1 {
+		t.Fatalf("expected duplicate fallback sync to keep one fill, got %d", orderFillCount)
 	}
 }

--- a/internal/service/order_test.go
+++ b/internal/service/order_test.go
@@ -162,3 +162,115 @@ func TestFinalizeExecutedOrderSkipsDuplicateFallbackFillsWithoutExchangeTradeID(
 		t.Fatalf("expected duplicate fallback sync to keep one fill, got %d", orderFillCount)
 	}
 }
+
+func TestFinalizeExecutedOrderUsesExchangeTradeTimeForLastFilledAt(t *testing.T) {
+	store := memory.NewStore()
+	platform := NewPlatform(store)
+
+	account, _ := store.GetAccount("live-main")
+	order, err := store.CreateOrder(domain.Order{
+		AccountID: account.ID,
+		Symbol:    "BTCUSDT",
+		Side:      "BUY",
+		Type:      "MARKET",
+		Quantity:  0.1,
+		Price:     68000,
+		Metadata:  map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("create order failed: %v", err)
+	}
+
+	tradeTime := time.Date(2026, 4, 17, 12, 36, 0, 0, time.UTC)
+	filledOrder, err := platform.finalizeExecutedOrder(account, order, []domain.Fill{{
+		OrderID:           order.ID,
+		Price:             68000,
+		Quantity:          0.1,
+		Fee:               1.23,
+		ExchangeTradeTime: &tradeTime,
+	}})
+	if err != nil {
+		t.Fatalf("finalize failed: %v", err)
+	}
+
+	if got := stringValue(filledOrder.Metadata["lastFilledAt"]); got != tradeTime.Format(time.RFC3339) {
+		t.Fatalf("expected lastFilledAt to use exchange trade time, got %q", got)
+	}
+}
+
+func TestFinalizeExecutedOrderFallsBackToNowWhenExchangeTradeTimeMissing(t *testing.T) {
+	store := memory.NewStore()
+	platform := NewPlatform(store)
+
+	account, _ := store.GetAccount("live-main")
+	order, err := store.CreateOrder(domain.Order{
+		AccountID: account.ID,
+		Symbol:    "BTCUSDT",
+		Side:      "BUY",
+		Type:      "MARKET",
+		Quantity:  0.1,
+		Price:     68000,
+		Metadata:  map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("create order failed: %v", err)
+	}
+
+	before := time.Now().UTC().Add(-time.Second)
+	filledOrder, err := platform.finalizeExecutedOrder(account, order, []domain.Fill{{
+		OrderID:  order.ID,
+		Price:    68000,
+		Quantity: 0.1,
+		Fee:      1.23,
+	}})
+	after := time.Now().UTC().Add(time.Second)
+	if err != nil {
+		t.Fatalf("finalize failed: %v", err)
+	}
+
+	got := parseOptionalRFC3339(stringValue(filledOrder.Metadata["lastFilledAt"]))
+	if got.IsZero() || got.Before(before) || got.After(after) {
+		t.Fatalf("expected lastFilledAt to fall back to now, got %v", got)
+	}
+}
+
+func TestFinalizeExecutedOrderKeepsLastFilledAtOnDuplicateSync(t *testing.T) {
+	store := memory.NewStore()
+	platform := NewPlatform(store)
+
+	account, _ := store.GetAccount("live-main")
+	order, err := store.CreateOrder(domain.Order{
+		AccountID: account.ID,
+		Symbol:    "BTCUSDT",
+		Side:      "BUY",
+		Type:      "MARKET",
+		Quantity:  0.1,
+		Price:     68000,
+		Metadata:  map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("create order failed: %v", err)
+	}
+
+	firstTradeTime := time.Date(2026, 4, 17, 12, 36, 0, 0, time.UTC)
+	fill := domain.Fill{
+		OrderID:           order.ID,
+		Price:             68000,
+		Quantity:          0.1,
+		Fee:               1.23,
+		ExchangeTradeTime: &firstTradeTime,
+	}
+	filledOrder, err := platform.finalizeExecutedOrder(account, order, []domain.Fill{fill})
+	if err != nil {
+		t.Fatalf("first finalize failed: %v", err)
+	}
+
+	filledOrder, err = platform.finalizeExecutedOrder(account, filledOrder, []domain.Fill{fill})
+	if err != nil {
+		t.Fatalf("second finalize failed: %v", err)
+	}
+
+	if got := stringValue(filledOrder.Metadata["lastFilledAt"]); got != firstTradeTime.Format(time.RFC3339) {
+		t.Fatalf("expected duplicate sync to keep original lastFilledAt, got %q", got)
+	}
+}

--- a/internal/store/memory/store.go
+++ b/internal/store/memory/store.go
@@ -491,6 +491,16 @@ func (s *Store) CreateFill(fill domain.Fill) (domain.Fill, error) {
 				return item, nil
 			}
 		}
+	} else {
+		fill.DedupFingerprint = strings.TrimSpace(fill.DedupFingerprint)
+		if fill.DedupFingerprint == "" {
+			fill.DedupFingerprint = fill.FallbackFingerprint()
+		}
+		for _, item := range s.fills {
+			if item.OrderID == fill.OrderID && item.DedupFingerprint != "" && item.DedupFingerprint == fill.DedupFingerprint {
+				return item, nil
+			}
+		}
 	}
 	fill.ID = s.nextID("fill")
 	fill.CreatedAt = time.Now().UTC()

--- a/internal/store/memory/store.go
+++ b/internal/store/memory/store.go
@@ -494,6 +494,10 @@ func (s *Store) CreateFill(fill domain.Fill) (domain.Fill, error) {
 	}
 	fill.ID = s.nextID("fill")
 	fill.CreatedAt = time.Now().UTC()
+	if fill.ExchangeTradeTime != nil {
+		resolved := fill.ExchangeTradeTime.UTC()
+		fill.ExchangeTradeTime = &resolved
+	}
 	s.fills[fill.ID] = fill
 	return fill, nil
 }

--- a/internal/store/postgres/store.go
+++ b/internal/store/postgres/store.go
@@ -557,7 +557,7 @@ func (s *Store) UpdateOrder(order domain.Order) (domain.Order, error) {
 
 func (s *Store) ListFills() ([]domain.Fill, error) {
 	rows, err := s.db.Query(`
-		select id, order_id, exchange_trade_id, price, quantity, fee, created_at
+		select id, order_id, exchange_trade_id, exchange_trade_time, price, quantity, fee, created_at
 		from fills order by created_at asc
 	`)
 	if err != nil {
@@ -569,10 +569,15 @@ func (s *Store) ListFills() ([]domain.Fill, error) {
 	for rows.Next() {
 		var item domain.Fill
 		var exchangeTradeID sql.NullString
-		if err := rows.Scan(&item.ID, &item.OrderID, &exchangeTradeID, &item.Price, &item.Quantity, &item.Fee, &item.CreatedAt); err != nil {
+		var exchangeTradeTime sql.NullTime
+		if err := rows.Scan(&item.ID, &item.OrderID, &exchangeTradeID, &exchangeTradeTime, &item.Price, &item.Quantity, &item.Fee, &item.CreatedAt); err != nil {
 			return nil, err
 		}
 		item.ExchangeTradeID = exchangeTradeID.String
+		if exchangeTradeTime.Valid {
+			parsed := exchangeTradeTime.Time.UTC()
+			item.ExchangeTradeTime = &parsed
+		}
 		items = append(items, item)
 	}
 	return items, rows.Err()
@@ -585,29 +590,39 @@ func (s *Store) CreateFill(fill domain.Fill) (domain.Fill, error) {
 
 	if strings.TrimSpace(fill.ExchangeTradeID) == "" {
 		_, err := s.db.Exec(`
-			insert into fills (id, order_id, exchange_trade_id, price, quantity, fee, created_at)
-			values ($1, $2, $3, $4, $5, $6, $7)
-		`, fill.ID, fill.OrderID, nullIfEmpty(fill.ExchangeTradeID), fill.Price, fill.Quantity, fill.Fee, fill.CreatedAt)
+			insert into fills (id, order_id, exchange_trade_id, exchange_trade_time, price, quantity, fee, created_at)
+			values ($1, $2, $3, $4, $5, $6, $7, $8)
+		`, fill.ID, fill.OrderID, nullIfEmpty(fill.ExchangeTradeID), fill.ExchangeTradeTime, fill.Price, fill.Quantity, fill.Fee, fill.CreatedAt)
 		return fill, err
 	}
 
-	err := s.db.QueryRow(`
-		insert into fills (id, order_id, exchange_trade_id, price, quantity, fee, created_at)
-		values ($1, $2, $3, $4, $5, $6, $7)
+	row := s.db.QueryRow(`
+		insert into fills (id, order_id, exchange_trade_id, exchange_trade_time, price, quantity, fee, created_at)
+		values ($1, $2, $3, $4, $5, $6, $7, $8)
 		on conflict (order_id, exchange_trade_id) do update set
 			price = fills.price,
 			quantity = fills.quantity,
-			fee = fills.fee
-		returning id, order_id, exchange_trade_id, price, quantity, fee, created_at
-	`, fill.ID, fill.OrderID, fill.ExchangeTradeID, fill.Price, fill.Quantity, fill.Fee, fill.CreatedAt).Scan(
+			fee = fills.fee,
+			exchange_trade_time = coalesce(fills.exchange_trade_time, excluded.exchange_trade_time)
+		returning id, order_id, exchange_trade_id, exchange_trade_time, price, quantity, fee, created_at
+	`, fill.ID, fill.OrderID, fill.ExchangeTradeID, fill.ExchangeTradeTime, fill.Price, fill.Quantity, fill.Fee, fill.CreatedAt)
+	var exchangeTradeTime sql.NullTime
+	err := row.Scan(
 		&fill.ID,
 		&fill.OrderID,
 		&fill.ExchangeTradeID,
+		&exchangeTradeTime,
 		&fill.Price,
 		&fill.Quantity,
 		&fill.Fee,
 		&fill.CreatedAt,
 	)
+	if exchangeTradeTime.Valid {
+		parsed := exchangeTradeTime.Time.UTC()
+		fill.ExchangeTradeTime = &parsed
+	} else {
+		fill.ExchangeTradeTime = nil
+	}
 	return fill, err
 }
 

--- a/internal/store/postgres/store.go
+++ b/internal/store/postgres/store.go
@@ -557,7 +557,7 @@ func (s *Store) UpdateOrder(order domain.Order) (domain.Order, error) {
 
 func (s *Store) ListFills() ([]domain.Fill, error) {
 	rows, err := s.db.Query(`
-		select id, order_id, exchange_trade_id, exchange_trade_time, price, quantity, fee, created_at
+		select id, order_id, exchange_trade_id, exchange_trade_time, dedup_fallback_fingerprint, price, quantity, fee, created_at
 		from fills order by created_at asc
 	`)
 	if err != nil {
@@ -570,10 +570,12 @@ func (s *Store) ListFills() ([]domain.Fill, error) {
 		var item domain.Fill
 		var exchangeTradeID sql.NullString
 		var exchangeTradeTime sql.NullTime
-		if err := rows.Scan(&item.ID, &item.OrderID, &exchangeTradeID, &exchangeTradeTime, &item.Price, &item.Quantity, &item.Fee, &item.CreatedAt); err != nil {
+		var fallbackFingerprint sql.NullString
+		if err := rows.Scan(&item.ID, &item.OrderID, &exchangeTradeID, &exchangeTradeTime, &fallbackFingerprint, &item.Price, &item.Quantity, &item.Fee, &item.CreatedAt); err != nil {
 			return nil, err
 		}
 		item.ExchangeTradeID = exchangeTradeID.String
+		item.DedupFingerprint = fallbackFingerprint.String
 		if exchangeTradeTime.Valid {
 			parsed := exchangeTradeTime.Time.UTC()
 			item.ExchangeTradeTime = &parsed
@@ -587,36 +589,75 @@ func (s *Store) CreateFill(fill domain.Fill) (domain.Fill, error) {
 	now := time.Now().UTC()
 	fill.ID = fmt.Sprintf("fill-%d", now.UnixNano())
 	fill.CreatedAt = now
+	if strings.TrimSpace(fill.ExchangeTradeID) == "" {
+		fill.DedupFingerprint = strings.TrimSpace(fill.DedupFingerprint)
+		if fill.DedupFingerprint == "" {
+			fill.DedupFingerprint = fill.FallbackFingerprint()
+		}
+	}
 
 	if strings.TrimSpace(fill.ExchangeTradeID) == "" {
-		_, err := s.db.Exec(`
-			insert into fills (id, order_id, exchange_trade_id, exchange_trade_time, price, quantity, fee, created_at)
-			values ($1, $2, $3, $4, $5, $6, $7, $8)
-		`, fill.ID, fill.OrderID, nullIfEmpty(fill.ExchangeTradeID), fill.ExchangeTradeTime, fill.Price, fill.Quantity, fill.Fee, fill.CreatedAt)
+		row := s.db.QueryRow(`
+			insert into fills (id, order_id, exchange_trade_id, exchange_trade_time, dedup_fallback_fingerprint, price, quantity, fee, created_at)
+			values ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+			on conflict (order_id, dedup_fallback_fingerprint) do update set
+				price = fills.price,
+				quantity = fills.quantity,
+				fee = fills.fee,
+				exchange_trade_time = coalesce(fills.exchange_trade_time, excluded.exchange_trade_time)
+			returning id, order_id, exchange_trade_id, exchange_trade_time, dedup_fallback_fingerprint, price, quantity, fee, created_at
+		`, fill.ID, fill.OrderID, nullIfEmpty(fill.ExchangeTradeID), fill.ExchangeTradeTime, fill.DedupFingerprint, fill.Price, fill.Quantity, fill.Fee, fill.CreatedAt)
+		var (
+			exchangeTradeTime   sql.NullTime
+			fallbackFingerprint sql.NullString
+		)
+		err := row.Scan(
+			&fill.ID,
+			&fill.OrderID,
+			&fill.ExchangeTradeID,
+			&exchangeTradeTime,
+			&fallbackFingerprint,
+			&fill.Price,
+			&fill.Quantity,
+			&fill.Fee,
+			&fill.CreatedAt,
+		)
+		fill.DedupFingerprint = fallbackFingerprint.String
+		if exchangeTradeTime.Valid {
+			parsed := exchangeTradeTime.Time.UTC()
+			fill.ExchangeTradeTime = &parsed
+		} else {
+			fill.ExchangeTradeTime = nil
+		}
 		return fill, err
 	}
 
 	row := s.db.QueryRow(`
-		insert into fills (id, order_id, exchange_trade_id, exchange_trade_time, price, quantity, fee, created_at)
-		values ($1, $2, $3, $4, $5, $6, $7, $8)
+		insert into fills (id, order_id, exchange_trade_id, exchange_trade_time, dedup_fallback_fingerprint, price, quantity, fee, created_at)
+		values ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 		on conflict (order_id, exchange_trade_id) do update set
 			price = fills.price,
 			quantity = fills.quantity,
 			fee = fills.fee,
 			exchange_trade_time = coalesce(fills.exchange_trade_time, excluded.exchange_trade_time)
-		returning id, order_id, exchange_trade_id, exchange_trade_time, price, quantity, fee, created_at
-	`, fill.ID, fill.OrderID, fill.ExchangeTradeID, fill.ExchangeTradeTime, fill.Price, fill.Quantity, fill.Fee, fill.CreatedAt)
-	var exchangeTradeTime sql.NullTime
+		returning id, order_id, exchange_trade_id, exchange_trade_time, dedup_fallback_fingerprint, price, quantity, fee, created_at
+	`, fill.ID, fill.OrderID, fill.ExchangeTradeID, fill.ExchangeTradeTime, nil, fill.Price, fill.Quantity, fill.Fee, fill.CreatedAt)
+	var (
+		exchangeTradeTime   sql.NullTime
+		fallbackFingerprint sql.NullString
+	)
 	err := row.Scan(
 		&fill.ID,
 		&fill.OrderID,
 		&fill.ExchangeTradeID,
 		&exchangeTradeTime,
+		&fallbackFingerprint,
 		&fill.Price,
 		&fill.Quantity,
 		&fill.Fee,
 		&fill.CreatedAt,
 	)
+	fill.DedupFingerprint = fallbackFingerprint.String
 	if exchangeTradeTime.Valid {
 		parsed := exchangeTradeTime.Time.UTC()
 		fill.ExchangeTradeTime = &parsed

--- a/web/console/src/components/layout/DockContent.tsx
+++ b/web/console/src/components/layout/DockContent.tsx
@@ -168,14 +168,28 @@ export function DockContent({ dockTab, actions }: DockContentProps) {
   const positionCloseAction = useUIStore(s => s.positionCloseAction);
   const liveSyncAction = useUIStore(s => s.liveSyncAction);
   const openConfirmDialog = useUIStore(s => s.openConfirmDialog);
+  const orderById = new Map(orders.map((order) => [order.id, order] as const));
+  const duplicateFallbackFillCounts = fills
+    .filter((fill) => !(fill.exchangeTradeId ?? "").trim())
+    .reduce((counts, fill) => {
+      const key = [
+        fill.orderId,
+        String(fill.price),
+        String(fill.quantity),
+        String(fill.fee),
+        fill.exchangeTradeTime ?? "",
+      ].join("|");
+      counts.set(key, (counts.get(key) ?? 0) + 1);
+      return counts;
+    }, new Map<string, number>());
 
   return (
     <div className="h-full relative overflow-hidden">
       {dockTab === 'orders' && (
         <DockTable
-          columns={["ID", "策略版本", "Symbol", "Side", "Type", "数量", "价格", "交易所ID", "状态", "创建时间", "操作"]}
+          columns={["ID", "策略版本", "Symbol", "Side", "Type", "数量", "价格", "交易所订单ID", "状态", "创建时间", "操作"]}
           rows={orders.map((order) => {
-            const exchangeId = String(order.metadata?.exchangeTradeId ?? "--");
+            const exchangeId = String(order.metadata?.exchangeOrderId ?? "--");
             const isReconciled = !!(order.metadata?.orderLifecycle as any)?.synced;
             const isOrphan = order.status === "ACCEPTED" && (order.metadata?.orderLifecycle as any)?.reconciliationState === "orphaned";
 
@@ -249,17 +263,38 @@ export function DockContent({ dockTab, actions }: DockContentProps) {
       )}
       {dockTab === 'fills' && (
         <DockTable
-          columns={["ID", "策略版本", "Symbol", "价格", "数量", "侧向", "交易所成交ID", "成交时间"]}
-          rows={fills.map((fill) => [
-            <TruncatedValue key={`${fill.id}-id`} value={fill.id} display={fill.id.replace('fill-', '')} />,
-            fill.strategyVersion,
-            fill.symbol,
-            formatMaybeNumber(fill.price),
-            formatMaybeNumber(fill.quantity),
-            fill.side,
-            <TruncatedValue key={`${fill.id}-exid`} value={fill.exchangeTradeId ?? "--"} />,
-            formatTime(fill.createdAt),
-          ])}
+          columns={["ID", "策略版本", "Symbol", "侧向", "价格", "数量", "手续费", "交易所成交ID", "交易所成交时间", "本地入库时间", "同步提示"]}
+          rows={fills.map((fill) => {
+            const order = orderById.get(fill.orderId);
+            const duplicateKey = [
+              fill.orderId,
+              String(fill.price),
+              String(fill.quantity),
+              String(fill.fee),
+              fill.exchangeTradeTime ?? "",
+            ].join("|");
+            const suspiciousDuplicate = !(fill.exchangeTradeId ?? "").trim() && (duplicateFallbackFillCounts.get(duplicateKey) ?? 0) > 1;
+
+            return [
+              <TruncatedValue key={`${fill.id}-id`} value={fill.id} display={fill.id.replace('fill-', '')} />,
+              String(order?.metadata?.strategyVersionId ?? fill.strategyVersion ?? "--"),
+              order?.symbol ?? fill.symbol ?? "--",
+              order?.side ?? fill.side ?? "--",
+              formatMaybeNumber(fill.price),
+              formatMaybeNumber(fill.quantity),
+              formatMaybeNumber(fill.fee),
+              <TruncatedValue key={`${fill.id}-exid`} value={fill.exchangeTradeId ?? "--"} />,
+              formatTime(fill.exchangeTradeTime ?? ""),
+              formatTime(fill.createdAt),
+              suspiciousDuplicate ? (
+                <DockBadge key={`${fill.id}-dup`} tone="watch">疑似重复同步</DockBadge>
+              ) : (
+                <span key={`${fill.id}-ok`} className="text-[11px] text-[var(--bk-text-muted)]">
+                  --
+                </span>
+              ),
+            ];
+          })}
           emptyMessage="暂无成交记录"
         />
       )}

--- a/web/console/src/types/domain.ts
+++ b/web/console/src/types/domain.ts
@@ -77,13 +77,14 @@ export type Order = {
 export type Fill = {
   id: string;
   orderId: string;
-  strategyVersion: string;
-  symbol: string;
-  side: string;
+  strategyVersion?: string;
+  symbol?: string;
+  side?: string;
   price: number;
   quantity: number;
   fee: number;
   exchangeTradeId?: string;
+  exchangeTradeTime?: string;
   createdAt: string;
 };
 


### PR DESCRIPTION
## 目的
修复 live 订单同步链路中的成交 ID 与时间语义问题，避免 Binance `userTrades.id` 在链路中被转成科学计数法，并补齐无 `exchangeTradeId` 场景下从 service 到 DB 落库的幂等保护。同时把前端订单/成交列表的交易所 ID 与时间展示校正为正确语义。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [x] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main)
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？
- [x] DB migration 是否具备向下兼容幂等性？
- [x] 配置字段有没有无意被混改？

## 验证方式与测试证据
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

已执行：
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
- `cd web/console && ./node_modules/.bin/tsc --noEmit src/components/layout/DockContent.tsx --jsx react-jsx --esModuleInterop --skipLibCheck --target esnext --moduleResolution node --allowSyntheticDefaultImports`
- `cd web/console && npm run build`

## 变更说明
- 后端将 Binance `userTrades` 响应改为 `UseNumber` 解析，并把 `tradeId` 统一走字符串化 helper，避免 `exchangeTradeId` 出现科学计数法。
- `fills` 新增 `exchangeTradeTime` 字段与 migration，落库并回传交易所真实成交时间；没有真实成交 ID 的 fallback fill 不再拿 `exchangeOrderId` 冒充。
- 无 `exchangeTradeId` 的 fallback fill 现在会持久化 `dedup_fallback_fingerprint`，并在 Postgres 上通过唯一索引和 upsert 做 DB 级幂等；service 层仍保留前置过滤，sync/reconcile 重跑不会重复入账。
- `lastFilledAt` 补了测试，覆盖“有交易所时间 / 无交易所时间 / 重复 sync”三种场景。
- 前端订单列表改为展示 `exchangeOrderId`；成交列表拆分“交易所成交时间”和“本地入库时间”。“疑似重复同步” badge 的定位是历史/异常同步探测提示，不表示正常链路状态。
