### PR TITLE
[codex] roll over flat exhausted live sessions

### DIFF
--- a/docs/20260418-live-plan-exhausted-troubleshooting.md
+++ b/docs/20260418-live-plan-exhausted-troubleshooting.md
@@ -55,9 +55,12 @@
 - `positionRecoveryStatus = flat`
 - `hasRecoveredPosition = false`
 - `hasRecoveredVirtualPosition = false`
-- 但 session 仍然是 `RUNNING`
+- session 仍然是 `RUNNING`
 
-则说明这条 session 已经失去继续运行的业务意义，应收口为完成或停止态。
+则需要继续区分两种情况：
+
+- 若同时还持续停留在旧的 `planIndex >= lastStrategyEvaluationPlanLength`，说明 exhausted plan 没有被正确收口或 rollover。
+- 若 `planIndex = 0` 且 `planLength = 0`，说明系统已经把旧 plan 清空，正在等待同一条 `RUNNING` session 进入下一轮 plan 周期。
 
 ## 3. `planLength` 与 `lastStrategyEvaluationPlanLength` 不一致意味着什么
 
@@ -79,17 +82,34 @@
 
 针对 `flat + no virtual position + no active orders + plan-exhausted`，系统现在会：
 
-1. 把 `planIndex` 收敛到当前 `len(plan)`
-2. 刷新 `planLength`
-3. 记录 `completedAt`
-4. 自动把 `live session` 收口为 `STOPPED`
-5. 清掉进程内的 live plan 缓存
+1. 把 `planIndex` 先收敛到当前 `len(plan)`
+2. 记录 `completedAt`
+3. 清掉进程内的 live plan 缓存
+4. 把当前 session 的 plan 状态重置为待下一轮构建
+5. 保持同一条 `live session` 继续 `RUNNING`
 
-因此修复后如果旧 session 已经耗尽，不会再无限期保持 `RUNNING` 并重复打印 exhausted 日志。
+下一次 runtime heartbeat 到来时，系统会基于当前市场重新构建一份新的 live plan，并继续做策略判断。
+
+### 修复后 rollover 前后的典型状态
+
+- 刚命中 exhausted：
+  - `lastStrategyEvaluationStatus = plan-exhausted`
+  - `completedAt` 已写入
+  - `lastPlanRolloverAt` 已写入
+- rollover 已调度、等待下一轮 plan：
+  - `planIndex = 0`
+  - `planLength = 0`
+  - `livePlans` 缓存已清空
+- 下一轮 plan 已生成：
+  - `planLength > 0`
+  - `completedAt` 被清除
+  - session 继续按新 plan 参与判断与开仓
+
+因此修复后如果旧 plan 已经耗尽，不需要人工手动 stop / restart / 新建 session 才能进入下一轮。
 
 ## 5. 仍然不开仓时怎么继续排查
 
-如果 session 已不再 `plan-exhausted`，但仍未开仓，下一步请看：
+如果 session 已不再长期卡在 `plan-exhausted`，但仍未开仓，下一步请看：
 
 - `lastStrategyDecision`
 - `lastExecutionProposal.status`
@@ -112,4 +132,4 @@
 
 适合在群里同步的简版结论：
 
-`这不是单纯“5m 没机会”，而是 live session 的当前 plan 已经耗尽；如果同时已经 flat 且无 virtual position，那它应被视为已完成并收口，而不是继续 RUNNING。`
+`这不是单纯“5m 没机会”，而是 live session 的当前 plan 已经耗尽；如果同时已经 flat 且无 virtual position，系统应自动 rollover 到下一轮 plan，而不是长期卡在同一份 exhausted plan 上。`

--- a/docs/20260418-live-plan-exhausted-troubleshooting.md
+++ b/docs/20260418-live-plan-exhausted-troubleshooting.md
@@ -1,0 +1,115 @@
+# Live Session `plan-exhausted` 排查手册
+
+本文用于排查以下典型现象：
+
+- `live session` 长时间保持 `RUNNING`
+- 运行日志持续出现 `strategy · plan-exhausted`
+- 5m / 4h / 1d runtime 仍在继续进事件，但 session 一直不开仓
+
+## 1. 先看 6 个关键字段
+
+优先观察目标 `live session.state` 中的以下字段：
+
+- `planLength`
+- `planIndex`
+- `lastStrategyEvaluationPlanLength`
+- `lastStrategyEvaluationRemaining`
+- `lastStrategyEvaluationStatus`
+- `positionRecoveryStatus`
+
+如果同时看到：
+
+- `lastStrategyEvaluationStatus = plan-exhausted`
+- `lastStrategyEvaluationRemaining = 0`
+- `planIndex >= lastStrategyEvaluationPlanLength`
+
+则说明当前评估链路已经没有可用的下一步计划，后续 heartbeat 不会再进入正常的策略决策与下单路径。
+
+## 2. 再判定 session 是否还有继续运行的理由
+
+继续看：
+
+- `hasRecoveredPosition`
+- `hasRecoveredVirtualPosition`
+- `lastDispatchedOrderStatus`
+- `lastSyncedOrderStatus`
+
+### A. 仍有真实仓位 / virtual 仓位
+
+这类 session 仍可能需要继续运行，用于：
+
+- 仓位状态监控
+- reduce-only 退出单跟踪
+- watchdog fallback 风控退出
+
+此时不应简单把 `RUNNING + plan-exhausted` 视为无害噪音，应该继续核查：
+
+- 是否存在活动中的退出单
+- `positionRecoveryStatus` 是否为 `protected-open-position` / `closing-pending`
+- `watchdogExitStatus` 是否卡在 `intent-ready` / `order-working`
+
+### B. 已经 `flat` 且无 virtual 仓位
+
+这时如果仍看到：
+
+- `positionRecoveryStatus = flat`
+- `hasRecoveredPosition = false`
+- `hasRecoveredVirtualPosition = false`
+- 但 session 仍然是 `RUNNING`
+
+则说明这条 session 已经失去继续运行的业务意义，应收口为完成或停止态。
+
+## 3. `planLength` 与 `lastStrategyEvaluationPlanLength` 不一致意味着什么
+
+常见异常组合：
+
+- `planLength = 918`
+- `lastStrategyEvaluationPlanLength = 914`
+- `planIndex = 922`
+
+这通常表示：
+
+- session state 中缓存的计划长度不是当前正在评估的那份 plan
+- 当前 plan 可能已重算或内存缓存已刷新
+- 但 `planIndex` 没有同步回收或钳正
+
+这种情况下，`planIndex` 可能已经落在当前 plan 之外，session 会稳定进入 `plan-exhausted`。
+
+## 4. 修复后的预期行为
+
+针对 `flat + no virtual position + no active orders + plan-exhausted`，系统现在会：
+
+1. 把 `planIndex` 收敛到当前 `len(plan)`
+2. 刷新 `planLength`
+3. 记录 `completedAt`
+4. 自动把 `live session` 收口为 `STOPPED`
+5. 清掉进程内的 live plan 缓存
+
+因此修复后如果旧 session 已经耗尽，不会再无限期保持 `RUNNING` 并重复打印 exhausted 日志。
+
+## 5. 仍然不开仓时怎么继续排查
+
+如果 session 已不再 `plan-exhausted`，但仍未开仓，下一步请看：
+
+- `lastStrategyDecision`
+- `lastExecutionProposal.status`
+- `lastExecutionProposal.reason`
+- `lastStrategyEvaluationSourceGate`
+- `lastStrategyEvaluationNextPlannedEventAt`
+
+可按以下顺序判断：
+
+1. `lastStrategyEvaluationStatus = waiting-source-states`
+   - 说明不是没信号，而是运行时依赖数据还没准备好。
+2. `lastStrategyEvaluationStatus = waiting-decision`
+   - 说明策略 gate 没放行，需看 `lastStrategyDecision.reason`。
+3. `lastStrategyEvaluationStatus = waiting-execution`
+   - 说明有意图，但执行层没有给出 `dispatchable` proposal。
+4. `lastStrategyEvaluationStatus = intent-ready`
+   - 说明已经具备派单条件，此时应继续排查 `dispatchMode`、订单状态与自动派单门控。
+
+## 6. 一句结论模板
+
+适合在群里同步的简版结论：
+
+`这不是单纯“5m 没机会”，而是 live session 的当前 plan 已经耗尽；如果同时已经 flat 且无 virtual position，那它应被视为已完成并收口，而不是继续 RUNNING。`

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,6 +14,7 @@
 - [llm-project-index.md](llm-project-index.md) - **推荐阅读：深入解读代码目录结构的索引层**。
 - [system-design.md](system-design.md) - 项目早期整体抽象架构。
 - [20260403改进计划_plan.md](20260403改进计划_plan.md) - 记录了平台重构与组件拆解的核心思考。
+- [20260418-live-plan-exhausted-troubleshooting.md](20260418-live-plan-exhausted-troubleshooting.md) - `live session` 长时间不下单且持续 `plan-exhausted` 时的定位手册。
 - [部署与网络架构.md](部署与网络架构.md) - 包含有关容器/负载路由的信息。
 - [cicd-maintenance.md](cicd-maintenance.md) - GitHub Actions 维保说明。
 - [frontend-live-reconcile-collab.md](frontend-live-reconcile-collab.md) - Live 账户全量对账的前端协作文档与 API 接入约定。

--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -1633,6 +1633,9 @@ func (p *Platform) StopLiveSessionWithForce(sessionID string, force bool) (domai
 		logger.Error("stop live session failed", "error", err)
 		return domain.LiveSession{}, err
 	}
+	p.mu.Lock()
+	delete(p.livePlans, session.ID)
+	p.mu.Unlock()
 	_, _ = p.stopLinkedLiveSignalRuntime(session)
 	p.logger("service.live",
 		"session_id", session.ID,
@@ -1730,8 +1733,7 @@ func (p *Platform) evaluateLiveSessionOnSignal(session domain.LiveSession, runti
 		appendTimelineEvent(state, "strategy", eventTime, "plan-exhausted", map[string]any{
 			"planLength": len(plan),
 		})
-		_, err := p.store.UpdateLiveSessionState(session.ID, state)
-		return err
+		return p.finalizeLiveSessionPlanExhausted(session, state, plan, eventTime)
 	}
 
 	sourceGate := map[string]any{
@@ -1967,6 +1969,37 @@ func (p *Platform) evaluateLiveSessionOnSignal(session domain.LiveSession, runti
 			"error": err.Error(),
 		})
 		_, _ = p.store.UpdateLiveSessionState(updatedSession.ID, state)
+		return err
+	}
+	return nil
+}
+
+func (p *Platform) finalizeLiveSessionPlanExhausted(session domain.LiveSession, state map[string]any, plan []paperPlannedOrder, eventTime time.Time) error {
+	if state == nil {
+		state = cloneMetadata(session.State)
+	}
+	state["planIndex"] = len(plan)
+	state["planLength"] = len(plan)
+	state["completedAt"] = eventTime.UTC().Format(time.RFC3339)
+
+	updatedSession, err := p.store.UpdateLiveSessionState(session.ID, state)
+	if err != nil {
+		return err
+	}
+	if !strings.EqualFold(updatedSession.Status, "RUNNING") {
+		return nil
+	}
+	if boolValue(updatedSession.State["hasRecoveredPosition"]) || boolValue(updatedSession.State["hasRecoveredVirtualPosition"]) {
+		return nil
+	}
+	if err := p.ensureNoActivePositionsOrOrders(updatedSession.AccountID, updatedSession.StrategyID); err != nil {
+		if errors.Is(err, ErrActivePositionsOrOrders) {
+			return nil
+		}
+		return err
+	}
+	_, err = p.StopLiveSessionWithForce(updatedSession.ID, false)
+	if err != nil && !errors.Is(err, ErrActivePositionsOrOrders) {
 		return err
 	}
 	return nil
@@ -2291,6 +2324,7 @@ func (p *Platform) ensureLiveExecutionPlan(session domain.LiveSession) (domain.L
 	state["fundingIntervalHours"] = semantics.FundingIntervalHours
 	state["planLength"] = len(plan)
 	state["planReadyAt"] = time.Now().UTC().Format(time.RFC3339)
+	delete(state, "completedAt")
 	if _, ok := state["planIndex"]; !ok {
 		state["planIndex"] = 0
 	}
@@ -2330,8 +2364,13 @@ func (p *Platform) reconcileLiveSessionPlanIndex(session domain.LiveSession, pla
 	}
 
 	state := cloneMetadata(session.State)
+	currentIndex := resolveLivePlanIndex(state)
 	symbol := NormalizeSymbol(firstNonEmpty(stringValue(state["symbol"]), stringValue(state["lastSymbol"])))
 	if symbol == "" {
+		if maxIntValue(state["planLength"], -1) != len(plan) {
+			state["planLength"] = len(plan)
+			return p.store.UpdateLiveSessionState(session.ID, state)
+		}
 		return session, nil
 	}
 
@@ -2340,11 +2379,19 @@ func (p *Platform) reconcileLiveSessionPlanIndex(session domain.LiveSession, pla
 		return domain.LiveSession{}, err
 	}
 
-	nextIndex, adjusted := reconcileLivePlanIndexWithPosition(plan, resolveLivePlanIndex(state), positionSnapshot, foundPosition)
-	if !adjusted {
+	nextIndex, adjusted := reconcileLivePlanIndexWithPosition(plan, currentIndex, positionSnapshot, foundPosition)
+	planLengthAdjusted := maxIntValue(state["planLength"], -1) != len(plan)
+	if !adjusted && !planLengthAdjusted {
 		return session, nil
 	}
 
+	state["planLength"] = len(plan)
+	if nextIndex < len(plan) {
+		delete(state, "completedAt")
+	}
+	if !adjusted {
+		return p.store.UpdateLiveSessionState(session.ID, state)
+	}
 	state["recoveredPosition"] = positionSnapshot
 	state["hasRecoveredPosition"] = foundPosition
 	state["hasRecoveredRealPosition"] = foundPosition
@@ -2362,11 +2409,24 @@ func reconcileLivePlanIndexWithPosition(plan []paperPlannedOrder, currentIndex i
 	if len(plan) == 0 || currentIndex < 0 {
 		return currentIndex, false
 	}
-	if currentIndex >= len(plan) {
-		currentIndex = len(plan) - 1
-	}
 	virtualFound := boolValue(position["virtual"])
-	if (!found && !virtualFound) || (parseFloatValue(position["quantity"]) <= 0 && !virtualFound) {
+	flatPosition := (!found && !virtualFound) || (parseFloatValue(position["quantity"]) <= 0 && !virtualFound)
+	normalizedIndex := false
+	if currentIndex > len(plan) {
+		if flatPosition {
+			return len(plan), true
+		}
+		currentIndex = len(plan) - 1
+		normalizedIndex = true
+	}
+	if currentIndex >= len(plan) {
+		if flatPosition {
+			return currentIndex, false
+		}
+		currentIndex = len(plan) - 1
+		normalizedIndex = true
+	}
+	if flatPosition {
 		if strings.EqualFold(plan[currentIndex].Role, "exit") {
 			for i := currentIndex; i >= 0; i-- {
 				if strings.EqualFold(plan[i].Role, "entry") {
@@ -2374,7 +2434,7 @@ func reconcileLivePlanIndexWithPosition(plan []paperPlannedOrder, currentIndex i
 				}
 			}
 		}
-		return currentIndex, false
+		return currentIndex, normalizedIndex
 	}
 	if strings.EqualFold(plan[currentIndex].Role, "entry") {
 		for i := currentIndex; i < len(plan); i++ {
@@ -2383,7 +2443,7 @@ func reconcileLivePlanIndexWithPosition(plan []paperPlannedOrder, currentIndex i
 			}
 		}
 	}
-	return currentIndex, false
+	return currentIndex, normalizedIndex
 }
 
 func resolveLivePlanIndex(state map[string]any) int {

--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -1998,10 +1998,35 @@ func (p *Platform) finalizeLiveSessionPlanExhausted(session domain.LiveSession, 
 		}
 		return err
 	}
-	_, err = p.StopLiveSessionWithForce(updatedSession.ID, false)
-	if err != nil && !errors.Is(err, ErrActivePositionsOrOrders) {
+	if err := p.rolloverLiveSessionPlan(updatedSession, eventTime); err != nil {
 		return err
 	}
+	return nil
+}
+
+func (p *Platform) rolloverLiveSessionPlan(session domain.LiveSession, eventTime time.Time) error {
+	state := cloneMetadata(session.State)
+	state["planIndex"] = 0
+	state["planLength"] = 0
+	state["lastPlanRolloverAt"] = eventTime.UTC().Format(time.RFC3339)
+	state["lastPlanRolloverReason"] = "plan-exhausted"
+	delete(state, "planReadyAt")
+	delete(state, "planIndexRecoveredFromPosition")
+	delete(state, "recoveredPlanIndex")
+	delete(state, "lastStrategyEvaluationNextPlannedEventAt")
+	delete(state, "lastStrategyEvaluationNextPlannedPrice")
+	delete(state, "lastStrategyEvaluationNextPlannedSide")
+	delete(state, "lastStrategyEvaluationNextPlannedRole")
+	delete(state, "lastStrategyEvaluationNextPlannedReason")
+	appendTimelineEvent(state, "strategy", eventTime, "plan-rollover-scheduled", map[string]any{
+		"reason": "plan-exhausted",
+	})
+	if _, err := p.store.UpdateLiveSessionState(session.ID, state); err != nil {
+		return err
+	}
+	p.mu.Lock()
+	delete(p.livePlans, session.ID)
+	p.mu.Unlock()
 	return nil
 }
 

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -1706,7 +1706,7 @@ func TestEnsureLiveExecutionPlanReconcilesExhaustedCachedPlanIndexToCompletionWh
 	}
 }
 
-func TestEvaluateLiveSessionOnSignalStopsFlatSessionWhenPlanExhausted(t *testing.T) {
+func TestEvaluateLiveSessionOnSignalRollsOverFlatSessionWhenPlanExhausted(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
 	session, err := platform.CreateLiveSession("live-main", "strategy-bk-1d", map[string]any{
 		"symbol":              "BTCUSDT",
@@ -1746,26 +1746,60 @@ func TestEvaluateLiveSessionOnSignalStopsFlatSessionWhenPlanExhausted(t *testing
 	if err != nil {
 		t.Fatalf("reload live session failed: %v", err)
 	}
-	if got := stopped.Status; got != "STOPPED" {
-		t.Fatalf("expected flat exhausted live session to auto-stop, got %s", got)
+	if got := stopped.Status; got != "RUNNING" {
+		t.Fatalf("expected flat exhausted live session to remain running for rollover, got %s", got)
 	}
 	if got := stringValue(stopped.State["lastStrategyEvaluationStatus"]); got != "plan-exhausted" {
 		t.Fatalf("expected lastStrategyEvaluationStatus=plan-exhausted, got %s", got)
 	}
-	if got := maxIntValue(stopped.State["planIndex"], -1); got != 2 {
-		t.Fatalf("expected completed plan index to be recorded before stop, got %d", got)
+	gotIndex, ok := toFloat64(stopped.State["planIndex"])
+	if !ok || int(gotIndex) != 0 {
+		t.Fatalf("expected rollover to reset planIndex, got %v", stopped.State["planIndex"])
 	}
-	if got := maxIntValue(stopped.State["planLength"], -1); got != 2 {
-		t.Fatalf("expected stopped session to persist current plan length, got %d", got)
+	gotLength, ok := toFloat64(stopped.State["planLength"])
+	if !ok || int(gotLength) != 0 {
+		t.Fatalf("expected rollover to clear current planLength, got %v", stopped.State["planLength"])
 	}
 	if got := stringValue(stopped.State["completedAt"]); got != eventTime.UTC().Format(time.RFC3339) {
 		t.Fatalf("expected completedAt to be recorded at exhaustion time, got %s", got)
+	}
+	if got := stringValue(stopped.State["lastPlanRolloverAt"]); got != eventTime.UTC().Format(time.RFC3339) {
+		t.Fatalf("expected lastPlanRolloverAt to be recorded, got %s", got)
+	}
+	if got := stringValue(stopped.State["lastPlanRolloverReason"]); got != "plan-exhausted" {
+		t.Fatalf("expected lastPlanRolloverReason=plan-exhausted, got %s", got)
 	}
 	platform.mu.Lock()
 	_, cached := platform.livePlans[session.ID]
 	platform.mu.Unlock()
 	if cached {
-		t.Fatal("expected cached live execution plan to be cleared when session auto-stops")
+		t.Fatal("expected cached live execution plan to be cleared when rollover is scheduled")
+	}
+
+	platform.mu.Lock()
+	platform.livePlans[session.ID] = []paperPlannedOrder{
+		{Role: "entry", Side: "BUY", Symbol: "BTCUSDT"},
+		{Role: "exit", Side: "SELL", Symbol: "BTCUSDT"},
+	}
+	platform.mu.Unlock()
+
+	rolledForward, plan, err := platform.ensureLiveExecutionPlan(stopped)
+	if err != nil {
+		t.Fatalf("ensure live execution plan after rollover failed: %v", err)
+	}
+	if len(plan) != 2 {
+		t.Fatalf("expected rollover to accept the fresh cached plan, got %d steps", len(plan))
+	}
+	gotIndex, ok = toFloat64(rolledForward.State["planIndex"])
+	if !ok || int(gotIndex) != 0 {
+		t.Fatalf("expected fresh cycle to start at planIndex 0, got %v", rolledForward.State["planIndex"])
+	}
+	gotLength, ok = toFloat64(rolledForward.State["planLength"])
+	if !ok || int(gotLength) != 2 {
+		t.Fatalf("expected fresh cycle to refresh planLength, got %v", rolledForward.State["planLength"])
+	}
+	if _, ok := rolledForward.State["completedAt"]; ok {
+		t.Fatal("expected completedAt to be cleared after fresh plan is available")
 	}
 }
 

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -1660,6 +1660,115 @@ func TestEnsureLiveExecutionPlanReconcilesCachedPlanIndexToExitWhenPositionExist
 	}
 }
 
+func TestEnsureLiveExecutionPlanReconcilesExhaustedCachedPlanIndexToCompletionWhenFlat(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	session, err := platform.CreateLiveSession("live-main", "strategy-bk-1d", map[string]any{
+		"symbol":              "BTCUSDT",
+		"signalTimeframe":     "1d",
+		"executionDataSource": "tick",
+		"dispatchMode":        "manual-review",
+	})
+	if err != nil {
+		t.Fatalf("create live session failed: %v", err)
+	}
+
+	updatedState := cloneMetadata(session.State)
+	updatedState["planIndex"] = 5
+	updatedState["planLength"] = 8
+	session, err = platform.store.UpdateLiveSessionState(session.ID, updatedState)
+	if err != nil {
+		t.Fatalf("update live session state failed: %v", err)
+	}
+
+	platform.mu.Lock()
+	platform.livePlans[session.ID] = []paperPlannedOrder{
+		{Role: "entry", Side: "BUY", Symbol: "BTCUSDT"},
+		{Role: "exit", Side: "SELL", Symbol: "BTCUSDT"},
+	}
+	platform.mu.Unlock()
+
+	reconciled, plan, err := platform.ensureLiveExecutionPlan(session)
+	if err != nil {
+		t.Fatalf("ensure live execution plan failed: %v", err)
+	}
+	if len(plan) != 2 {
+		t.Fatalf("expected cached live plan to be preserved, got %d steps", len(plan))
+	}
+	gotIndex, ok := toFloat64(reconciled.State["planIndex"])
+	if !ok || int(gotIndex) != len(plan) {
+		t.Fatalf("expected exhausted cached plan index to reconcile to completion marker, got %v", reconciled.State["planIndex"])
+	}
+	if got := maxIntValue(reconciled.State["planLength"], -1); got != len(plan) {
+		t.Fatalf("expected cached plan length to refresh to current plan length, got %d", got)
+	}
+	if !boolValue(reconciled.State["planIndexRecoveredFromPosition"]) {
+		t.Fatal("expected exhausted plan reconciliation to be recorded in session state")
+	}
+}
+
+func TestEvaluateLiveSessionOnSignalStopsFlatSessionWhenPlanExhausted(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	session, err := platform.CreateLiveSession("live-main", "strategy-bk-1d", map[string]any{
+		"symbol":              "BTCUSDT",
+		"signalTimeframe":     "1d",
+		"executionDataSource": "tick",
+		"dispatchMode":        "manual-review",
+	})
+	if err != nil {
+		t.Fatalf("create live session failed: %v", err)
+	}
+	if _, err := platform.store.UpdateLiveSessionStatus(session.ID, "RUNNING"); err != nil {
+		t.Fatalf("mark live session running failed: %v", err)
+	}
+
+	updatedState := cloneMetadata(session.State)
+	updatedState["planIndex"] = 7
+	session, err = platform.store.UpdateLiveSessionState(session.ID, updatedState)
+	if err != nil {
+		t.Fatalf("update live session state failed: %v", err)
+	}
+
+	platform.mu.Lock()
+	platform.livePlans[session.ID] = []paperPlannedOrder{
+		{Role: "entry", Side: "BUY", Symbol: "BTCUSDT"},
+		{Role: "exit", Side: "SELL", Symbol: "BTCUSDT"},
+	}
+	platform.mu.Unlock()
+
+	eventTime := time.Date(2026, 4, 18, 2, 0, 0, 0, time.UTC)
+	if err := platform.evaluateLiveSessionOnSignal(session, "", map[string]any{
+		"symbol": "BTCUSDT",
+	}, eventTime); err != nil {
+		t.Fatalf("evaluate live session failed: %v", err)
+	}
+
+	stopped, err := platform.store.GetLiveSession(session.ID)
+	if err != nil {
+		t.Fatalf("reload live session failed: %v", err)
+	}
+	if got := stopped.Status; got != "STOPPED" {
+		t.Fatalf("expected flat exhausted live session to auto-stop, got %s", got)
+	}
+	if got := stringValue(stopped.State["lastStrategyEvaluationStatus"]); got != "plan-exhausted" {
+		t.Fatalf("expected lastStrategyEvaluationStatus=plan-exhausted, got %s", got)
+	}
+	if got := maxIntValue(stopped.State["planIndex"], -1); got != 2 {
+		t.Fatalf("expected completed plan index to be recorded before stop, got %d", got)
+	}
+	if got := maxIntValue(stopped.State["planLength"], -1); got != 2 {
+		t.Fatalf("expected stopped session to persist current plan length, got %d", got)
+	}
+	if got := stringValue(stopped.State["completedAt"]); got != eventTime.UTC().Format(time.RFC3339) {
+		t.Fatalf("expected completedAt to be recorded at exhaustion time, got %s", got)
+	}
+	platform.mu.Lock()
+	_, cached := platform.livePlans[session.ID]
+	platform.mu.Unlock()
+	if cached {
+		t.Fatal("expected cached live execution plan to be cleared when session auto-stops")
+	}
+}
+
 func TestParseBinanceSymbolRules(t *testing.T) {
 	rules := parseBinanceSymbolRules(map[string]any{
 		"symbol": "BTCUSDT",


### PR DESCRIPTION
## 目的
修复 `flat` 的 `live session` 在执行计划已耗尽后仍卡在旧 plan 上的问题。修复后，session 不需要人工 stop / restart / 新建，就能自动 rollover 到下一轮 plan 并继续做策略判断。

本次改动包含两部分：
- 后端 rollover 修复：让 `flat + no virtual position + no active orders` 的 exhausted live session 自动清掉旧 plan、重置计划状态，并等待下一轮 plan 重建。
- 文档补充：新增 `docs/20260418-live-plan-exhausted-troubleshooting.md`，整理排查顺序、关键字段和结论模板。

根因总结：
- `evaluateLiveSessionOnSignal()` 在 `planIndex >= len(plan)` 时会直接进入 `plan-exhausted`。
- 之前 exhausted 后只是留下一个失效状态，session 既不继续构建新 plan，也不正确收口到下一轮周期。
- `reconcileLiveSessionPlanIndex()` 之前没有把“已跑穿且当前 plan 更短”的 `planIndex` 稳定落库回收，导致 `planLength` / `lastStrategyEvaluationPlanLength` / `planIndex` 之间可能持续漂移。
- `StopLiveSessionWithForce()` 之前不会清 `p.livePlans` 缓存，停掉后的 session 再启动时仍可能沿用旧 plan。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [x] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
- [ ] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main)
- [ ] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？
- [ ] DB migration 是否具备向下兼容幂等性？
- [ ] 配置字段有没有无意被混改？

补充说明：
- 本 PR 没有修改 `dispatchMode` 默认值，也没有放宽 `auto-dispatch` 门控。
- 改动只影响 live session 在 exhausted 且已 flat 时的 rollover 逻辑，以及 plan index / plan cache 一致性。
- 若 session 仍有真实仓位、virtual 仓位或活动订单，则不会 rollover，仓位恢复/watchdog 路径保持原行为。

## 验证方式与测试证据
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

本地验证：
- `gofmt -w internal/service/live.go internal/service/live_test.go`
- `go test ./internal/service -run 'TestEnsureLiveExecutionPlanReconcilesExhaustedCachedPlanIndexToCompletionWhenFlat|TestEvaluateLiveSessionOnSignalRollsOverFlatSessionWhenPlanExhausted|TestEnsureLiveExecutionPlanReconcilesCachedPlanIndexBackToEntryWhenPositionFlat|TestEnsureLiveExecutionPlanReconcilesCachedPlanIndexToExitWhenPositionExists'`
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
- `git push` 期间仓库 pre-push harness 已实际重建 `graphify-out/`

新增回归覆盖：
- exhausted cached plan index 在 `flat` 条件下会收敛到 completion marker
- `flat` exhausted live session 会自动安排 rollover，并在下一轮 fresh plan 可用时从 `planIndex=0` 继续运行
- 既有的 flat 回退到 entry / 持仓推进到 exit 的 reconciliation 行为保持不变

对使用者/值班影响：
- 不会再出现一条已 `flat` 的 exhausted live session 长期卡在旧 plan 上、却需要人工重新 launch 才能继续判断的状态。
- 排查时可直接参考新增文档中的字段清单、一句话结论模板，以及 rollover 前后的状态特征。