### PR TITLE
[codex] preserve virtual exits for stale live plans

### DIFF
--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -2111,7 +2111,7 @@ func alignLivePlanStepToCurrentMarket(
 	nextPlannedPrice float64,
 	nextPlannedSide, nextPlannedRole, nextPlannedReason string,
 ) (time.Time, float64, string, string, string) {
-	if boolValue(currentPosition["found"]) || parseFloatValue(currentPosition["quantity"]) > 0 {
+	if hasActiveLivePositionSnapshot(currentPosition) {
 		return nextPlannedEvent, nextPlannedPrice, nextPlannedSide, nextPlannedRole, nextPlannedReason
 	}
 	if !isLivePlanStepStale(nextPlannedEvent, signalTimeframe, eventTime) {

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -133,6 +133,61 @@ func TestEvaluateSignalBarGateDoesNotRequireOppositeBreakoutForExit(t *testing.T
 	}
 }
 
+func TestAlignLivePlanStepToCurrentMarketKeepsExitForVirtualPosition(t *testing.T) {
+	eventTime := time.Date(2026, 4, 10, 10, 0, 0, 0, time.UTC)
+	nextPlannedEvent := eventTime.Add(-48 * time.Hour)
+	signalStates := map[string]any{
+		signalBindingMatchKey("binance-kline", "signal", "BTCUSDT"): map[string]any{
+			"symbol":    "BTCUSDT",
+			"timeframe": "1d",
+			"ma20":      68000.0,
+			"atr14":     900.0,
+			"current": map[string]any{
+				"close": 68100.0,
+				"high":  69010.0,
+				"low":   67800.0,
+			},
+			"prevBar1": map[string]any{
+				"high": 68850.0,
+				"low":  67750.0,
+			},
+			"prevBar2": map[string]any{
+				"high": 69000.0,
+				"low":  67600.0,
+			},
+		},
+	}
+	currentPosition := map[string]any{
+		"id":         "virtual|session-1|signal-1",
+		"virtual":    true,
+		"symbol":     "BTCUSDT",
+		"side":       "LONG",
+		"entryPrice": 69000.0,
+		"quantity":   0.0,
+	}
+
+	gotEvent, gotPrice, gotSide, gotRole, gotReason := alignLivePlanStepToCurrentMarket(
+		signalStates,
+		"1d",
+		currentPosition,
+		eventTime,
+		nextPlannedEvent,
+		68950.0,
+		"SELL",
+		"exit",
+		"SL",
+	)
+	if !gotEvent.Equal(nextPlannedEvent.UTC()) {
+		t.Fatalf("expected stale exit event to stay unchanged, got %s", gotEvent.Format(time.RFC3339))
+	}
+	if gotPrice != 68950.0 {
+		t.Fatalf("expected planned price to stay unchanged, got %.2f", gotPrice)
+	}
+	if gotSide != "SELL" || gotRole != "exit" || gotReason != "SL" {
+		t.Fatalf("expected virtual position to preserve exit step, got side=%s role=%s reason=%s", gotSide, gotRole, gotReason)
+	}
+}
+
 func TestBuildLiveExecutionPlanFromMarketDataAcceptsTickExecutionSource(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
 
@@ -2421,6 +2476,165 @@ func TestEvaluateLiveSessionOnSignalRecordsVirtualInitialForZeroInitialStrategy(
 	}
 	if got := maxIntValue(updated.State["planIndex"], -1); got != 1 {
 		t.Fatalf("expected planIndex to advance after virtual initial, got %d", got)
+	}
+}
+
+func TestEvaluateLiveSessionOnSignalRecordsVirtualExitForStaleExitStepWithVirtualPosition(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	if _, err := platform.BindStrategySignalSource("strategy-bk-1d", map[string]any{
+		"sourceKey": "binance-kline",
+		"role":      "signal",
+		"symbol":    "BTCUSDT",
+		"options":   map[string]any{"timeframe": "1d"},
+	}); err != nil {
+		t.Fatalf("bind strategy signal failed: %v", err)
+	}
+	if _, err := platform.BindStrategySignalSource("strategy-bk-1d", map[string]any{
+		"sourceKey": "binance-trade-tick",
+		"role":      "trigger",
+		"symbol":    "BTCUSDT",
+	}); err != nil {
+		t.Fatalf("bind strategy trigger failed: %v", err)
+	}
+	if _, err := platform.BindAccountSignalSource("live-main", map[string]any{
+		"sourceKey": "binance-kline",
+		"role":      "signal",
+		"symbol":    "BTCUSDT",
+		"options":   map[string]any{"timeframe": "1d"},
+	}); err != nil {
+		t.Fatalf("bind account signal failed: %v", err)
+	}
+	if _, err := platform.BindAccountSignalSource("live-main", map[string]any{
+		"sourceKey": "binance-trade-tick",
+		"role":      "trigger",
+		"symbol":    "BTCUSDT",
+	}); err != nil {
+		t.Fatalf("bind account trigger failed: %v", err)
+	}
+
+	session, err := platform.CreateLiveSession("live-main", "strategy-bk-1d", map[string]any{
+		"symbol":              "BTCUSDT",
+		"signalTimeframe":     "1d",
+		"executionDataSource": "tick",
+		"dispatchMode":        "manual-review",
+	})
+	if err != nil {
+		t.Fatalf("create live session failed: %v", err)
+	}
+	state := cloneMetadata(session.State)
+	state["virtualPosition"] = map[string]any{
+		"id":         "virtual|session-1|signal-1",
+		"virtual":    true,
+		"symbol":     "BTCUSDT",
+		"side":       "LONG",
+		"entryPrice": 69000.0,
+		"stopLoss":   69050.0,
+		"quantity":   0.0,
+	}
+	session, err = platform.store.UpdateLiveSessionState(session.ID, state)
+	if err != nil {
+		t.Fatalf("update live session state failed: %v", err)
+	}
+
+	runtimeSessionID := stringValue(session.State["signalRuntimeSessionId"])
+	if runtimeSessionID == "" {
+		t.Fatal("expected linked runtime session id")
+	}
+
+	eventTime := time.Date(2026, 4, 10, 10, 0, 0, 0, time.UTC)
+	staleExitEvent := eventTime.Add(-48 * time.Hour)
+	platform.mu.Lock()
+	platform.livePlans[session.ID] = []paperPlannedOrder{{
+		EventTime: staleExitEvent,
+		Price:     68950.0,
+		Side:      "SELL",
+		Role:      "exit",
+		Reason:    "SL",
+	}}
+	platform.mu.Unlock()
+
+	signalKey := signalBindingMatchKey("binance-kline", "signal", "BTCUSDT")
+	triggerKey := signalBindingMatchKey("binance-trade-tick", "trigger", "BTCUSDT")
+	summary := map[string]any{
+		"role":               "trigger",
+		"symbol":             "BTCUSDT",
+		"subscriptionSymbol": "BTCUSDT",
+		"price":              68900.0,
+		"event":              "trade_tick",
+	}
+	err = platform.updateSignalRuntimeSessionState(runtimeSessionID, func(runtimeSession *domain.SignalRuntimeSession) {
+		runtimeSession.Status = "RUNNING"
+		runtimeState := cloneMetadata(runtimeSession.State)
+		runtimeState["health"] = "healthy"
+		runtimeState["lastEventAt"] = eventTime.UTC().Format(time.RFC3339)
+		runtimeState["lastHeartbeatAt"] = eventTime.UTC().Format(time.RFC3339)
+		runtimeState["lastEventSummary"] = cloneMetadata(summary)
+		runtimeState["sourceStates"] = map[string]any{
+			triggerKey: map[string]any{
+				"sourceKey":   "binance-trade-tick",
+				"role":        "trigger",
+				"symbol":      "BTCUSDT",
+				"streamType":  "trade_tick",
+				"lastEventAt": eventTime.UTC().Format(time.RFC3339),
+				"summary": map[string]any{
+					"price": 68900.0,
+				},
+			},
+			signalKey: map[string]any{
+				"sourceKey":   "binance-kline",
+				"role":        "signal",
+				"symbol":      "BTCUSDT",
+				"streamType":  "signal_bar",
+				"lastEventAt": eventTime.UTC().Format(time.RFC3339),
+			},
+		}
+		runtimeState["signalBarStates"] = map[string]any{
+			signalKey: map[string]any{
+				"symbol":    "BTCUSDT",
+				"timeframe": "1d",
+				"ma20":      68000.0,
+				"atr14":     900.0,
+				"current": map[string]any{
+					"close": 68100.0,
+					"high":  69010.0,
+					"low":   67800.0,
+				},
+				"prevBar1": map[string]any{
+					"high": 68850.0,
+					"low":  67750.0,
+				},
+				"prevBar2": map[string]any{
+					"high": 69000.0,
+					"low":  67600.0,
+				},
+			},
+		}
+		runtimeSession.State = runtimeState
+		runtimeSession.UpdatedAt = eventTime
+	})
+	if err != nil {
+		t.Fatalf("update runtime state failed: %v", err)
+	}
+
+	if err := platform.evaluateLiveSessionOnSignal(session, runtimeSessionID, summary, eventTime); err != nil {
+		t.Fatalf("evaluate live session failed: %v", err)
+	}
+
+	updated, err := platform.store.GetLiveSession(session.ID)
+	if err != nil {
+		t.Fatalf("get updated live session failed: %v", err)
+	}
+	if got := stringValue(updated.State["lastDispatchedOrderStatus"]); got != liveOrderStatusVirtualExit {
+		t.Fatalf("expected virtual exit dispatch marker, got %s", got)
+	}
+	if got := stringValue(updated.State["lastVirtualSignalType"]); got != "exit" {
+		t.Fatalf("expected lastVirtualSignalType=exit, got %s", got)
+	}
+	if virtualPosition := mapValue(updated.State["virtualPosition"]); len(virtualPosition) != 0 {
+		t.Fatalf("expected virtualPosition to be cleared after virtual exit, got %+v", virtualPosition)
+	}
+	if got := maxIntValue(updated.State["planIndex"], -1); got != 1 {
+		t.Fatalf("expected planIndex to advance after virtual exit, got %d", got)
 	}
 }
 


### PR DESCRIPTION
## 目的
这次 PR 不是在修 `plan-exhausted`；那部分已经在上一轮完成。

这次新增要解决的是 follow-up 问题：active `virtualPosition` 在 stale plan step 对齐时，会被错误打回 `LiveSignalBootstrap` entry，导致日志里反复出现 `bias-unfavorable` / `live-virtual-initial-recorded`，却很难看到 `live-virtual-exit-recorded`。

这次 PR 只做一件事：保证 active `virtualPosition` 在 stale step 对齐时继续保留 exit 语境，能够正常走到 `live-virtual-exit-recorded`。

根因上，之前 `alignLivePlanStepToCurrentMarket()` 只把真实仓位当成“有持仓”，没有把 active virtual position 算进去。这样一旦计划步过期，virtual exit 也会被误判成空仓，再被改写成 bootstrap entry。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [x] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main)
  本次未改默认值。
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？
  无。
- [x] DB migration 是否具备向下兼容幂等性？
  无 migration 改动。
- [x] 配置字段有没有无意被混改？
  无；仅调整 live stale-step 对齐语义并补充测试。

## 验证方式与测试证据
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

本地验证：
- `gofmt -w internal/service/live.go internal/service/live_test.go`
- `go test ./internal/service -run 'TestAlignLivePlanStepToCurrentMarketKeepsExitForVirtualPosition|TestEvaluateLiveSessionOnSignalRecordsVirtualInitialForZeroInitialStrategy|TestEvaluateLiveSessionOnSignalRecordsVirtualExitForStaleExitStepWithVirtualPosition|TestEvaluateLiveSessionOnSignalKeepsReentryDispatchable'`
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
- `git push` 时仓库 pre-push harness 重新执行了 graphify rebuild 与 backend checks

新增回归覆盖：
- active virtual position 遇到 stale exit step 时，不再被改回 bootstrap entry
- `evaluateLiveSessionOnSignal()` 在 virtual long + stale exit + SL 触发时，会写出 `virtual-exit`、清掉 `virtualPosition` 并推进 `planIndex`
- 原有 `zero-initial -> virtual-initial` 语义保持不变
- 原有 `reentry -> dispatchable` 语义保持不变