### PR TITLE
[codex] align live reentry signal gate with replay

### DIFF
--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -2121,7 +2121,7 @@ func alignLivePlanStepToCurrentMarket(
 	if signalBarState == nil {
 		return nextPlannedEvent, nextPlannedPrice, nextPlannedSide, nextPlannedRole, nextPlannedReason
 	}
-	gate := evaluateSignalBarGate(signalBarState, "", "entry")
+	gate := evaluateSignalBarGate(signalBarState, "", "entry", "")
 	longReady := boolValue(gate["longReady"])
 	shortReady := boolValue(gate["shortReady"])
 	if longReady == shortReady {

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -66,7 +66,7 @@ func TestEvaluateSignalBarGateRequiresLongBreakoutAlignmentWithResearch(t *testi
 			"high": 69000.0,
 			"low":  67600.0,
 		},
-	}, "BUY", "entry")
+	}, "BUY", "entry", "")
 	if boolValue(gate["longStructureReady"]) != true {
 		t.Fatal("expected long structure to be ready")
 	}
@@ -98,7 +98,7 @@ func TestEvaluateSignalBarGateAllowsLongAfterBreakoutAlignmentWithResearch(t *te
 			"high": 69000.0,
 			"low":  67600.0,
 		},
-	}, "BUY", "entry")
+	}, "BUY", "entry", "")
 	if !boolValue(gate["longStructureReady"]) {
 		t.Fatal("expected long structure to be ready")
 	}
@@ -127,7 +127,7 @@ func TestEvaluateSignalBarGateDoesNotRequireOppositeBreakoutForExit(t *testing.T
 			"high": 69000.0,
 			"low":  67600.0,
 		},
-	}, "SELL", "exit")
+	}, "SELL", "exit", "")
 	if !boolValue(gate["ready"]) {
 		t.Fatalf("expected exit gate to stay ready, got reason=%s", stringValue(gate["reason"]))
 	}
@@ -185,6 +185,36 @@ func TestAlignLivePlanStepToCurrentMarketKeepsExitForVirtualPosition(t *testing.
 	}
 	if gotSide != "SELL" || gotRole != "exit" || gotReason != "SL" {
 		t.Fatalf("expected virtual position to preserve exit step, got side=%s role=%s reason=%s", gotSide, gotRole, gotReason)
+	}
+}
+
+func TestEvaluateSignalBarGateAllowsReentryWithoutInitialBreakout(t *testing.T) {
+	gate := evaluateSignalBarGate(map[string]any{
+		"timeframe": "1d",
+		"sma5":      68050.0,
+		"atr14":     900.0,
+		"current": map[string]any{
+			"close": 68100.0,
+			"high":  68900.0,
+			"low":   67800.0,
+		},
+		"prevBar1": map[string]any{
+			"high": 68850.0,
+			"low":  67750.0,
+		},
+		"prevBar2": map[string]any{
+			"high": 69000.0,
+			"low":  67600.0,
+		},
+	}, "BUY", "entry", "SL-Reentry")
+	if !boolValue(gate["longStructureReady"]) {
+		t.Fatal("expected long structure to be ready for reentry")
+	}
+	if boolValue(gate["longBreakoutReady"]) {
+		t.Fatal("expected initial breakout to remain not ready for reentry regression")
+	}
+	if !boolValue(gate["longReady"]) || !boolValue(gate["ready"]) {
+		t.Fatalf("expected reentry gate to stay ready without initial breakout, got %#v", gate)
 	}
 }
 
@@ -2638,7 +2668,7 @@ func TestEvaluateLiveSessionOnSignalRecordsVirtualExitForStaleExitStepWithVirtua
 	}
 }
 
-func TestEvaluateLiveSessionOnSignalKeepsReentryDispatchable(t *testing.T) {
+func TestEvaluateLiveSessionOnSignalKeepsReentryDispatchableWithoutInitialBreakout(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
 	if _, err := platform.BindStrategySignalSource("strategy-bk-1d", map[string]any{
 		"sourceKey": "binance-kline",
@@ -2739,7 +2769,7 @@ func TestEvaluateLiveSessionOnSignalKeepsReentryDispatchable(t *testing.T) {
 				"atr14":     900.0,
 				"current": map[string]any{
 					"close": 68100.0,
-					"high":  69010.0,
+					"high":  68900.0,
 					"low":   67800.0,
 				},
 				"prevBar1": map[string]any{

--- a/internal/service/signal_runtime_ws_test.go
+++ b/internal/service/signal_runtime_ws_test.go
@@ -349,7 +349,7 @@ func TestDeriveSignalBarStatesUsesOpenCurrentBarWithClosedHistory(t *testing.T) 
 	if stringValue(prevBar2["barStart"]) != base.Add(18*5*time.Minute).Format(time.RFC3339) {
 		t.Fatalf("expected prevBar2 to be second latest closed bar, got %#v", prevBar2)
 	}
-	gate := evaluateSignalBarGate(state, "BUY", "entry")
+	gate := evaluateSignalBarGate(state, "BUY", "entry", "")
 	if !boolValue(gate["ready"]) || !boolValue(gate["longReady"]) {
 		t.Fatalf("expected open current bar breakout to be actionable, got %#v", gate)
 	}

--- a/internal/service/strategy_registry.go
+++ b/internal/service/strategy_registry.go
@@ -212,7 +212,7 @@ func (e bkStrategyEngine) EvaluateSignal(context StrategySignalEvaluationContext
 	signalBarDecision := map[string]any{}
 	signalFilterReady := true
 	if signalBarState != nil {
-		signalBarDecision = evaluateSignalBarGate(signalBarState, context.NextPlannedSide, context.NextPlannedRole)
+		signalBarDecision = evaluateSignalBarGate(signalBarState, context.NextPlannedSide, context.NextPlannedRole, context.NextPlannedReason)
 		if value, ok := signalBarDecision["ready"].(bool); ok {
 			signalFilterReady = value
 		}
@@ -591,8 +591,9 @@ func pickSignalBarState(signalBarStates map[string]any, symbol, timeframe string
 	return nil, ""
 }
 
-func evaluateSignalBarGate(signalBarState map[string]any, nextSide, nextRole string) map[string]any {
+func evaluateSignalBarGate(signalBarState map[string]any, nextSide, nextRole, nextReason string) map[string]any {
 	role := strings.ToLower(strings.TrimSpace(nextRole))
+	reasonTag := normalizeStrategyReasonTag(nextReason)
 	timeframe := strings.ToLower(strings.TrimSpace(stringValue(signalBarState["timeframe"])))
 	if timeframe == "" {
 		timeframe = strings.ToLower(strings.TrimSpace(stringValue(mapValue(signalBarState["current"])["timeframe"])))
@@ -670,6 +671,10 @@ func evaluateSignalBarGate(signalBarState map[string]any, nextSide, nextRole str
 	shortBreakoutReady := lowPrice <= prevLow2 && prevLow2 > 0
 	longReady := longStructureReady && longBreakoutReady
 	shortReady := shortStructureReady && shortBreakoutReady
+	if role == "entry" && (reasonTag == "sl-reentry" || reasonTag == "pt-reentry") {
+		longReady = longStructureReady
+		shortReady = shortStructureReady
+	}
 	result["longStructureReady"] = longStructureReady
 	result["shortStructureReady"] = shortStructureReady
 	result["longEarlyReversalReady"] = longEarlyReversalReady


### PR DESCRIPTION
## 目的
修正 live `EvaluateSignal` 对 `SL-Reentry/PT-Reentry` 复用了 `Initial` breakout gate 的偏差。

当前 replay 主链里，`Initial` 依赖 `close > sma5/ma20` 加 `prevHigh2/prevLow2` breakout，而 `Reentry` 主要依赖方向语境和 `reP` 触发；但 live 之前会先把所有 entry step 都经过同一层 `signalBarGate`，导致 `SL-Reentry/PT-Reentry` 在未突破 `prevHigh2/prevLow2` 时被提前拦成 `signal-filter-not-ready`，与 replay 语义不一致。

这次改动只把 `SL/PT-Reentry` 的 signal gate 收回到结构过滤，保留后续 planned price / `reP` actionability 作为真正的 reentry 触发；`Initial` 和 stale bootstrap 仍保持原有 breakout 语义。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [x] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
这次只调整 live signal evaluator 对 `SL-Reentry/PT-Reentry` 的 gate 语义，没有改 execution strategy、dispatchMode 默认值、mainnet 路由或配置归一化。
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main)
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？
- [x] DB migration 是否具备向下兼容幂等性？
- [x] 配置字段有没有无意被混改？

## 验证方式与测试证据
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

本地验证：
- `gofmt -w internal/service/strategy_registry.go internal/service/live.go internal/service/live_test.go internal/service/signal_runtime_ws_test.go`
- `go test ./internal/service -run 'TestEvaluateSignalBarGateRequiresLongBreakoutAlignmentWithResearch|TestEvaluateSignalBarGateAllowsLongAfterBreakoutAlignmentWithResearch|TestEvaluateSignalBarGateAllowsReentryWithoutInitialBreakout|TestEvaluateLiveSessionOnSignalKeepsReentryDispatchableWithoutInitialBreakout'`
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`

关键回归点：
- 新增 gate 单元测试，确认 `SL-Reentry` 在结构成立但未突破 `prevHigh2` 时不再被当成 `Initial` 拦下。
- 新增 live 端到端测试，确认 `SL-Reentry` 在不满足 initial breakout 的场景下仍能生成 `dispatchable` proposal。
- 既有 `Initial` breakout 对齐测试保留通过，确保没有把 `Initial` 语义一起放松。

## AI 参与说明
本 PR 由 Codex 协助定位 live/replay 语义偏差、生成修复和补充回归测试，人类已复核改动范围与验证结果。