### PR TITLE
[codex] research zero-initial reentry window semantics

### DIFF
--- a/research/20260419_zero_initial_reentry_window.md
+++ b/research/20260419_zero_initial_reentry_window.md
@@ -1,0 +1,109 @@
+# 2026-04-19 Zero-Initial Reentry Window Research
+
+Scope: research-only experiment on a separate branch. No `internal/service` live or replay code was changed.
+
+## Question
+
+Current canonical zero-initial semantics still creates a persistent zero-notional position after `Initial` breakout, then manages that synthetic position with `SL/PT` exits.
+
+This experiment tests an alternative research-only semantic:
+
+- `dir2_zero_initial=true`
+- `Initial` breakout does **not** create a persistent position
+- breakout only opens a reentry window for:
+  - the current signal bar
+  - the next signal bar
+- if no reentry signal appears inside that window, state resets and the engine waits for a fresh breakout again
+
+Implemented as `--zero-initial-mode reentry_window` in `research/ma_filter_backtest.py`.
+
+## Important Caveat
+
+The reentry trigger remains the existing `reclaim` rule:
+
+- long: `high >= prev_low_1 + 0.1 * ATR`
+- short: `low <= prev_high_1`
+
+That means this experiment is **not** "breakout must wait until the next signal bar". It is:
+
+- breakout opens a current+next-bar reentry window
+- reentry can still happen inside the same signal bar if `reP` is already satisfied
+
+So this experiment isolates one thing only:
+
+- remove the long-lived zero-notional synthetic position
+- keep reentry as the first real exposure
+
+## Config
+
+Shared config for the comparisons below:
+
+- `dir2_zero_initial=true`
+- `stop_mode=atr`
+- `stop_loss_atr=0.05`
+- `profit_protect_atr=1.0`
+- `reentry_anchor_levels=wick`
+- `reentry_trigger_mode=reclaim`
+- `max_trades_per_bar=4`
+- `reentry_size_schedule=[0.10, 0.05, 0.025]`
+
+## BTC 1D Q1 2026
+
+Data:
+
+- `BTC_1min_Q1.csv`
+- window: `2026-01-01` to `2026-03-31`
+- filter: `SMA5 hard`
+- early reversal gate: `0.06 ATR`
+
+| Scenario | Final Balance | Return | Max DD | Trade Pairs | Entry Reasons |
+|---|---:|---:|---:|---:|---|
+| Baseline `position` | 101,656.40 | 1.66% | -0.33% | 52 | `Initial:10`, `PT-Reentry:18`, `SL-Reentry:25` |
+| Variant `reentry_window` | 106,203.96 | 6.20% | -0.33% | 44 | `Zero-Initial-Reentry:10`, `PT-Reentry:18`, `SL-Reentry:17` |
+
+Delta, `reentry_window - position`:
+
+- Final balance: `+4,547.56`
+- Return: `+4.55 pp`
+- Max drawdown: `+0.00 pp` (no material change)
+- Trade pairs: `-8`
+
+## ETH 4H Q1 2026
+
+Data:
+
+- `ETH_1min_Q1.csv`
+- derived signal file: `research/ETH_4H_Q1_signals.csv`
+- window: `2026-01-01` to `2026-03-31`
+- filter: `SMA20 hard`
+- no early reversal gate
+
+| Scenario | Final Balance | Return | Max DD | Trade Pairs | Entry Reasons |
+|---|---:|---:|---:|---:|---|
+| Baseline `position` | 101,447.67 | 1.45% | -1.77% | 392 | `Initial:50`, `PT-Reentry:83`, `SL-Reentry:260` |
+| Variant `reentry_window` | 108,023.66 | 8.02% | -0.79% | 356 | `Zero-Initial-Reentry:50`, `PT-Reentry:83`, `SL-Reentry:224` |
+
+Delta, `reentry_window - position`:
+
+- Final balance: `+6,575.99`
+- Return: `+6.58 pp`
+- Max drawdown: `+0.98 pp` improvement
+- Trade pairs: `-36`
+
+## Initial Read
+
+On both sampled runs, replacing the persistent zero-notional synthetic `Initial` position with a short-lived reentry window improved returns and reduced churn.
+
+The most likely reason is:
+
+- baseline zero-initial creates many long-lived synthetic positions
+- those synthetic positions then consume `SL/PT` management cycles even though no real exposure exists yet
+- the windowed variant delays real exposure until a reentry trigger actually appears, which removes a class of synthetic exit noise
+
+## Next Step
+
+If we want to treat this as a canonical candidate rather than a one-off idea, the next research step should be:
+
+1. run the same comparison on longer BTC / ETH windows
+2. decide whether same-bar reclaim should remain allowed for zero-initial windows
+3. only then consider porting the semantic into Go replay/live together

--- a/research/20260419_zero_initial_reentry_window_enhanced.md
+++ b/research/20260419_zero_initial_reentry_window_enhanced.md
@@ -1,0 +1,80 @@
+# 2026-04-19 Zero-Initial Reentry Window, Enhanced Baseline
+
+Scope: research-only experiment on a separate branch. No `internal/service` live or replay code was changed.
+
+## Question
+
+Evaluate the same `zero_initial_mode=reentry_window` idea against the current enhanced ETH `4h` baseline, instead of the simplified `ma_filter_backtest.py` path.
+
+This isolates one semantic change:
+
+- `dir2_zero_initial=true`
+- breakout does **not** create a long-lived zero-notional synthetic position
+- breakout only opens a reentry window for:
+  - the current signal bar
+  - the next signal bar
+- if no reentry appears inside that window, state resets and the engine waits for a fresh breakout again
+
+Enhanced path used: `research/backTest.py:run_backtest_enhanced()`.
+
+## Shared Setup
+
+- Data: `/Users/wuyaocheng/Downloads/bkTrader/ETH_1min_Q1.csv`
+- Window: `2026-01-01` to `2026-03-31`
+- Signal timeframe: `4h`
+- Initial balance: `100000.0`
+- Slippage: `0.0005`
+- `dir2_zero_initial=true`
+- `stop_mode='atr'`
+- `stop_loss_atr=0.05`
+- `profit_protect_atr=1.0`
+- `max_trades_per_bar=4`
+- `reentry_size_schedule=[0.10, 0.05, 0.025]`
+- `trailing_stop_atr=0.3`
+- `delayed_trailing_activation=0.5`
+- `long_reentry_atr=0.1`
+- `short_reentry_atr=0.0`
+- `reentry_anchor_levels='wick'`
+- `reentry_trigger_mode='reclaim'`
+
+## Important Caveat
+
+This compare is apples-to-apples on the current codebase, data, and parameters.
+
+It does **not** exactly reproduce the older archived note that reported `34.35%` for ETH `4h` Q1. On current `origin/main`-based code in this branch, the same enhanced baseline reproduces at `31.77%`.
+
+That archive drift matters for historical comparison, but it does not invalidate this experiment because both scenarios below run on the same current engine.
+
+## ETH 4H Q1 2026
+
+| Scenario | Final Balance | Return | Max DD | Trades | Win Rate | Sharpe | Entry Reasons | Exit Reasons |
+|---|---:|---:|---:|---:|---:|---:|---|---|
+| Baseline `position` | 131,774.05 | 31.77% | -0.12% | 299 | 80.60% | 16.67 | `Initial:68`, `PT-Reentry:3`, `SL-Reentry:367` | `PT:3`, `SL:432` |
+| Variant `reentry_window` | 144,458.56 | 44.46% | -0.12% | 348 | 83.05% | 17.42 | `Zero-Initial-Reentry:65`, `PT-Reentry:3`, `SL-Reentry:356` | `PT:3`, `SL:421` |
+
+Delta, `reentry_window - position`:
+
+- Final balance: `+12,684.51`
+- Return: `+12.68 pp`
+- Max drawdown: `+0.00 pp` (no material change)
+- Trades: `+49`
+- Win rate: `+2.44 pp`
+- Sharpe: `+0.75`
+
+## Read
+
+On the current enhanced ETH `4h` baseline, replacing the persistent zero-notional `Initial` position with a current+next-bar reentry window materially improved returns without increasing drawdown.
+
+The main behavioral shift is:
+
+- baseline keeps a synthetic position alive and spends many bars managing its `SL/PT`
+- `reentry_window` waits for the first actual reentry trigger before creating exposure
+- the trade mix shifts from `Initial` entries into `Zero-Initial-Reentry` entries, while downstream `SL-Reentry` remains the dominant path
+
+## Next Step
+
+If this semantic is a serious candidate for canonical strategy behavior, the next research step should be:
+
+1. rerun the same enhanced compare on BTC `1d` and ETH `1d`
+2. decide whether same-bar `reclaim` should remain allowed after a breakout opens the window
+3. only then consider replay/live alignment work

--- a/research/20260419_zero_initial_reentry_window_enhanced.md
+++ b/research/20260419_zero_initial_reentry_window_enhanced.md
@@ -61,15 +61,53 @@ Delta, `reentry_window - position`:
 - Win rate: `+2.44 pp`
 - Sharpe: `+0.75`
 
+## BTC 1D Q1 2026
+
+| Scenario | Final Balance | Return | Max DD | Trades | Win Rate | Sharpe | Entry Reasons | Exit Reasons |
+|---|---:|---:|---:|---:|---:|---:|---|---|
+| Baseline `position` | 117,616.10 | 17.62% | -0.17% | 78 | 83.33% | 20.47 | `Initial:15`, `SL-Reentry:97` | `SL:112` |
+| Variant `reentry_window` | 123,531.85 | 23.53% | -0.17% | 86 | 84.88% | 21.37 | `Zero-Initial-Reentry:15`, `SL-Reentry:90` | `SL:105` |
+
+Delta, `reentry_window - position`:
+
+- Final balance: `+5,915.75`
+- Return: `+5.92 pp`
+- Max drawdown: `+0.00 pp` (no material change)
+- Trades: `+8`
+- Win rate: `+1.55 pp`
+- Sharpe: `+0.90`
+
+## ETH 1D Q1 2026
+
+| Scenario | Final Balance | Return | Max DD | Trades | Win Rate | Sharpe | Entry Reasons | Exit Reasons |
+|---|---:|---:|---:|---:|---:|---:|---|---|
+| Baseline `position` | 121,632.54 | 21.63% | -0.04% | 54 | 98.15% | 26.24 | `Initial:16`, `SL-Reentry:67` | `SL:83` |
+| Variant `reentry_window` | 131,336.73 | 31.34% | -0.04% | 63 | 98.41% | 27.89 | `Zero-Initial-Reentry:16`, `SL-Reentry:60` | `SL:76` |
+
+Delta, `reentry_window - position`:
+
+- Final balance: `+9,704.20`
+- Return: `+9.70 pp`
+- Max drawdown: `+0.00 pp` (no material change)
+- Trades: `+9`
+- Win rate: `+0.26 pp`
+- Sharpe: `+1.65`
+
 ## Read
 
-On the current enhanced ETH `4h` baseline, replacing the persistent zero-notional `Initial` position with a current+next-bar reentry window materially improved returns without increasing drawdown.
+Across the three enhanced Q1 runs completed so far, replacing the persistent zero-notional `Initial` position with a current+next-bar reentry window improved returns without increasing drawdown.
 
 The main behavioral shift is:
 
 - baseline keeps a synthetic position alive and spends many bars managing its `SL/PT`
 - `reentry_window` waits for the first actual reentry trigger before creating exposure
 - the trade mix shifts from `Initial` entries into `Zero-Initial-Reentry` entries, while downstream `SL-Reentry` remains the dominant path
+
+Current enhanced Q1 deltas:
+
+- `ETH 4h`: `+12.68 pp`
+- `BTC 1d`: `+5.92 pp`
+- `ETH 1d`: `+9.70 pp`
 
 ## Next Step
 

--- a/research/backTest.py
+++ b/research/backTest.py
@@ -83,6 +83,13 @@ def _normalize_reentry_trigger_mode(reentry_trigger_mode):
     raise ValueError(f"未知重入触发模式: {reentry_trigger_mode}")
 
 
+def _normalize_zero_initial_mode(zero_initial_mode):
+    normalized = str(zero_initial_mode).lower().strip()
+    if normalized in ('position', 'reentry_window'):
+        return normalized
+    raise ValueError(f"未知 zero_initial_mode: {zero_initial_mode}")
+
+
 def _reentry_triggered(side, trigger_mode, high_value, low_value, close_value, prev_close_value, re_p, confirm=False):
     mode = _normalize_reentry_trigger_mode(trigger_mode)
     if mode == 'pullback':
@@ -1393,7 +1400,8 @@ def run_backtest_enhanced(df_1min, df_4h, initial_balance=100000.0,
                           cooldown_bars=6,
                           reentry_mode='default',
                           reentry_anchor_levels='wick',
-                          reentry_trigger_mode='reclaim'):
+                          reentry_trigger_mode='reclaim',
+                          zero_initial_mode='position'):
     """
     增强版 1min 回测引擎，在原始引擎基础上新增：
 
@@ -1422,6 +1430,7 @@ def run_backtest_enhanced(df_1min, df_4h, initial_balance=100000.0,
     REENTRY_SIZE_SCHEDULE = _normalize_reentry_sizes(reentry_size_schedule)
     PROFIT_PROTECT = profit_protect_atr
     stop_mode = 'structural' if dir3_structural_sl and stop_mode is None else (stop_mode or 'atr')
+    zero_initial_mode = _normalize_zero_initial_mode(zero_initial_mode)
 
     # 根据 reentry_mode 调整 schedule
     if reentry_mode == 'fixed':
@@ -1435,6 +1444,8 @@ def run_backtest_enhanced(df_1min, df_4h, initial_balance=100000.0,
     REENTRY_TIMEOUT = 1
     last_exit_reason = None
     last_exit_side = None
+    pending_zero_initial_side = None
+    pending_zero_initial_bar_index = -999
 
     # 熔断状态
     circuit_breaker_until = -999  # bar index until which trading is paused
@@ -1446,6 +1457,7 @@ def run_backtest_enhanced(df_1min, df_4h, initial_balance=100000.0,
     if reentry_mode != 'default': label_parts.append(f"Re:{reentry_mode}")
     if reentry_anchor_levels != 'wick': label_parts.append(f"ReAnchor:{reentry_anchor_levels}")
     if reentry_trigger_mode != 'reclaim': label_parts.append(f"ReTrigger:{reentry_trigger_mode}")
+    if dir2_zero_initial and zero_initial_mode != 'position': label_parts.append(f"ZeroInit:{zero_initial_mode}")
     label_parts.append(f"ReATR:{long_reentry_atr}/{short_reentry_atr}")
     label = " | ".join(label_parts) if label_parts else "Enhanced"
 
@@ -1473,6 +1485,8 @@ def run_backtest_enhanced(df_1min, df_4h, initial_balance=100000.0,
 
         if i - last_exit_bar_index > REENTRY_TIMEOUT:
             last_exit_side = None
+        if i - pending_zero_initial_bar_index > REENTRY_TIMEOUT:
+            pending_zero_initial_side = None
 
         while current_idx < total_steps:
             bar = window.iloc[current_idx]
@@ -1492,22 +1506,28 @@ def run_backtest_enhanced(df_1min, df_4h, initial_balance=100000.0,
                     re_p = _resolve_reentry_price(sig, 'long', reentry_anchor_levels, long_reentry_atr)
                     if trades_in_bar == 0 and sig['prev_high_2'] > sig['prev_high_1']:
                         if bar['high'] >= sig['prev_high_2']:
-                            entry_p = max(bar['open'], sig['prev_high_2']) * (1 + SLIPPAGE)
-                            notional_value = balance * CASH_USAGE_INITIAL
-                            initial_sl = _resolve_stop_price('long', entry_p, sig, stop_mode, stop_loss_atr)
-                            position = {
-                                'side': 'long', 'entry_p': entry_p,
-                                'sl': initial_sl, 'protected': False,
-                                'notional': notional_value,
-                                'hwm': entry_p,  # high water mark
-                            }
-                            balance -= notional_value * COMMISSION
-                            trade_logs.append({'time': bar_time, 'type': 'BUY', 'price': entry_p,
-                                               'reason': 'Initial', 'notional': notional_value, 'bal': balance})
-                            trades_in_bar += 1
-                            executed = True
+                            if dir2_zero_initial and zero_initial_mode == 'reentry_window':
+                                pending_zero_initial_side = 'long'
+                                pending_zero_initial_bar_index = i
+                            else:
+                                entry_p = max(bar['open'], sig['prev_high_2']) * (1 + SLIPPAGE)
+                                notional_value = balance * CASH_USAGE_INITIAL
+                                initial_sl = _resolve_stop_price('long', entry_p, sig, stop_mode, stop_loss_atr)
+                                position = {
+                                    'side': 'long', 'entry_p': entry_p,
+                                    'sl': initial_sl, 'protected': False,
+                                    'notional': notional_value,
+                                    'hwm': entry_p,  # high water mark
+                                }
+                                balance -= notional_value * COMMISSION
+                                trade_logs.append({'time': bar_time, 'type': 'BUY', 'price': entry_p,
+                                                   'reason': 'Initial', 'notional': notional_value, 'bal': balance})
+                                trades_in_bar += 1
+                                executed = True
 
-                    elif last_exit_side == 'long' and (i - last_exit_bar_index <= REENTRY_TIMEOUT):
+                    has_exit_reentry_window = last_exit_side == 'long' and (i - last_exit_bar_index <= REENTRY_TIMEOUT)
+                    has_zero_initial_window = pending_zero_initial_side == 'long' and (i - pending_zero_initial_bar_index <= REENTRY_TIMEOUT)
+                    if has_exit_reentry_window or has_zero_initial_window:
                         prev_close = prev_bar['close'] if prev_bar is not None else None
                         is_triggered, entry_p_raw = _reentry_triggered(
                             'long',
@@ -1521,9 +1541,11 @@ def run_backtest_enhanced(df_1min, df_4h, initial_balance=100000.0,
                         )
 
                         if is_triggered:
-                            reason = 'SL-Reentry' if last_exit_reason == 'SL' else 'PT-Reentry'
+                            reason = 'Zero-Initial-Reentry'
+                            if has_exit_reentry_window:
+                                reason = 'SL-Reentry' if last_exit_reason == 'SL' else 'PT-Reentry'
                             if trades_in_bar < MAX_TRADES_PER_BAR:
-                                current_reentry_size = _get_reentry_size(trades_in_bar, REENTRY_SIZE_SCHEDULE)
+                                current_reentry_size = REENTRY_SIZE_SCHEDULE[0] if (has_zero_initial_window and not has_exit_reentry_window) else _get_reentry_size(trades_in_bar, REENTRY_SIZE_SCHEDULE)
                                 notional_value = balance * current_reentry_size
                                 entry_price = entry_p_raw * (1 + SLIPPAGE)
                                 reentry_sl = _resolve_stop_price('long', entry_price, sig, stop_mode, stop_loss_atr)
@@ -1538,28 +1560,37 @@ def run_backtest_enhanced(df_1min, df_4h, initial_balance=100000.0,
                                                    'reason': reason, 'notional': notional_value, 'bal': balance})
                                 trades_in_bar += 1
                                 executed = True
-                            last_exit_side = None
+                            if has_exit_reentry_window:
+                                last_exit_side = None
+                            if has_zero_initial_window:
+                                pending_zero_initial_side = None
 
                 elif short_regime_ready:
                     re_p = _resolve_reentry_price(sig, 'short', reentry_anchor_levels, short_reentry_atr)
                     if trades_in_bar == 0 and sig['prev_low_2'] < sig['prev_low_1']:
                         if bar['low'] <= sig['prev_low_2']:
-                            entry_p = min(bar['open'], sig['prev_low_2']) * (1 - SLIPPAGE)
-                            notional_value = balance * CASH_USAGE_INITIAL
-                            initial_sl = _resolve_stop_price('short', entry_p, sig, stop_mode, stop_loss_atr)
-                            position = {
-                                'side': 'short', 'entry_p': entry_p,
-                                'sl': initial_sl, 'protected': False,
-                                'notional': notional_value,
-                                'lwm': entry_p,  # low water mark
-                            }
-                            balance -= notional_value * COMMISSION
-                            trade_logs.append({'time': bar_time, 'type': 'SHORT', 'price': entry_p,
-                                               'reason': 'Initial', 'notional': notional_value, 'bal': balance})
-                            trades_in_bar += 1
-                            executed = True
+                            if dir2_zero_initial and zero_initial_mode == 'reentry_window':
+                                pending_zero_initial_side = 'short'
+                                pending_zero_initial_bar_index = i
+                            else:
+                                entry_p = min(bar['open'], sig['prev_low_2']) * (1 - SLIPPAGE)
+                                notional_value = balance * CASH_USAGE_INITIAL
+                                initial_sl = _resolve_stop_price('short', entry_p, sig, stop_mode, stop_loss_atr)
+                                position = {
+                                    'side': 'short', 'entry_p': entry_p,
+                                    'sl': initial_sl, 'protected': False,
+                                    'notional': notional_value,
+                                    'lwm': entry_p,  # low water mark
+                                }
+                                balance -= notional_value * COMMISSION
+                                trade_logs.append({'time': bar_time, 'type': 'SHORT', 'price': entry_p,
+                                                   'reason': 'Initial', 'notional': notional_value, 'bal': balance})
+                                trades_in_bar += 1
+                                executed = True
 
-                    elif last_exit_side == 'short' and (i - last_exit_bar_index <= REENTRY_TIMEOUT):
+                    has_exit_reentry_window = last_exit_side == 'short' and (i - last_exit_bar_index <= REENTRY_TIMEOUT)
+                    has_zero_initial_window = pending_zero_initial_side == 'short' and (i - pending_zero_initial_bar_index <= REENTRY_TIMEOUT)
+                    if has_exit_reentry_window or has_zero_initial_window:
                         prev_close = prev_bar['close'] if prev_bar is not None else None
                         is_triggered, entry_p_raw = _reentry_triggered(
                             'short',
@@ -1573,9 +1604,11 @@ def run_backtest_enhanced(df_1min, df_4h, initial_balance=100000.0,
                         )
 
                         if is_triggered:
-                            reason = 'SL-Reentry' if last_exit_reason == 'SL' else 'PT-Reentry'
+                            reason = 'Zero-Initial-Reentry'
+                            if has_exit_reentry_window:
+                                reason = 'SL-Reentry' if last_exit_reason == 'SL' else 'PT-Reentry'
                             if trades_in_bar < MAX_TRADES_PER_BAR:
-                                current_reentry_size = _get_reentry_size(trades_in_bar, REENTRY_SIZE_SCHEDULE)
+                                current_reentry_size = REENTRY_SIZE_SCHEDULE[0] if (has_zero_initial_window and not has_exit_reentry_window) else _get_reentry_size(trades_in_bar, REENTRY_SIZE_SCHEDULE)
                                 notional_value = balance * current_reentry_size
                                 entry_price = entry_p_raw * (1 - SLIPPAGE)
                                 reentry_sl = _resolve_stop_price('short', entry_price, sig, stop_mode, stop_loss_atr)
@@ -1590,7 +1623,10 @@ def run_backtest_enhanced(df_1min, df_4h, initial_balance=100000.0,
                                                    'reason': reason, 'notional': notional_value, 'bal': balance})
                                 trades_in_bar += 1
                                 executed = True
-                            last_exit_side = None
+                            if has_exit_reentry_window:
+                                last_exit_side = None
+                            if has_zero_initial_window:
+                                pending_zero_initial_side = None
 
                 current_idx += 1
 

--- a/research/ma_filter_backtest.py
+++ b/research/ma_filter_backtest.py
@@ -105,6 +105,7 @@ def run_ma_filter_backtest(
     early_reversal_band_atr: float = 0.15,
     reentry_anchor_levels: str = "wick",
     reentry_trigger_mode: str = "reclaim",
+    zero_initial_mode: str = "position",
 ) -> pd.DataFrame:
     df_signal = apply_reentry_anchor_levels(df_signal, reentry_anchor_levels)
     balance = initial_balance
@@ -119,6 +120,11 @@ def run_ma_filter_backtest(
     reentry_timeout = 1
     last_exit_reason = None
     last_exit_side = None
+    zero_initial_mode = str(zero_initial_mode).lower().strip()
+    if zero_initial_mode not in {"position", "reentry_window"}:
+        raise ValueError(f"unsupported zero_initial_mode: {zero_initial_mode}")
+    pending_zero_initial_side = None
+    pending_zero_initial_bar_index = -999
 
     print(
         "🚀 Regime filter回测 | "
@@ -137,7 +143,8 @@ def run_ma_filter_backtest(
         f"EarlyReversalEnabled:{enable_early_reversal_gate} | "
         f"EarlyReversalBandATR:{early_reversal_band_atr} | "
         f"ReentryAnchor:{reentry_anchor_levels} | "
-        f"ReentryTrigger:{reentry_trigger_mode}"
+        f"ReentryTrigger:{reentry_trigger_mode} | "
+        f"ZeroInitialMode:{zero_initial_mode}"
     )
 
     for i in range(len(df_signal) - 1):
@@ -154,6 +161,8 @@ def run_ma_filter_backtest(
         current_idx = 0
         if i - last_exit_bar_index > reentry_timeout:
             last_exit_side = None
+        if i - pending_zero_initial_bar_index > reentry_timeout:
+            pending_zero_initial_side = None
 
         while current_idx < len(window):
             bar = window.iloc[current_idx]
@@ -203,22 +212,26 @@ def run_ma_filter_backtest(
                 if long_allowed or long_early_reversal:
                     re_p = _resolve_reentry_price(sig, "long", reentry_anchor_levels, reentry_atr)
                     if trades_in_bar == 0 and sig["prev_high_2"] > sig["prev_high_1"] and bar["high"] >= sig["prev_high_2"]:
-                        entry = max(bar["open"], sig["prev_high_2"]) * (1 + fixed_slippage)
-                        notional = balance * cash_usage_initial
-                        position = {
-                            "side": "long",
-                            "entry_p": entry,
-                            "sl": _resolve_stop_price("long", entry, sig, stop_mode, stop_loss_atr),
-                            "protected": False,
-                            "notional": notional,
-                        }
-                        balance -= notional * commission
-                        trade_logs.append(
-                            {"time": bar_time, "type": "BUY", "price": entry, "reason": "Initial", "notional": notional, "bal": balance}
-                        )
-                        trades_in_bar += 1
-                        current_idx += 1
-                        continue
+                        if dir2_zero_initial and zero_initial_mode == "reentry_window":
+                            pending_zero_initial_side = "long"
+                            pending_zero_initial_bar_index = i
+                        else:
+                            entry = max(bar["open"], sig["prev_high_2"]) * (1 + fixed_slippage)
+                            notional = balance * cash_usage_initial
+                            position = {
+                                "side": "long",
+                                "entry_p": entry,
+                                "sl": _resolve_stop_price("long", entry, sig, stop_mode, stop_loss_atr),
+                                "protected": False,
+                                "notional": notional,
+                            }
+                            balance -= notional * commission
+                            trade_logs.append(
+                                {"time": bar_time, "type": "BUY", "price": entry, "reason": "Initial", "notional": notional, "bal": balance}
+                            )
+                            trades_in_bar += 1
+                            current_idx += 1
+                            continue
 
                     prev_close = prev_bar["close"] if prev_bar is not None else None
                     is_reentry_triggered, entry_p_raw = _reentry_triggered(
@@ -230,9 +243,14 @@ def run_ma_filter_backtest(
                         prev_close,
                         re_p,
                     )
-                    if last_exit_side == "long" and is_reentry_triggered and (i - last_exit_bar_index <= reentry_timeout):
-                        reason = "SL-Reentry" if last_exit_reason == "SL" else "PT-Reentry"
-                        if (reason == "SL-Reentry" and trades_in_bar < max_trades_per_bar) or reason == "PT-Reentry":
+                    has_exit_reentry_window = last_exit_side == "long" and (i - last_exit_bar_index <= reentry_timeout)
+                    has_zero_initial_window = pending_zero_initial_side == "long" and (i - pending_zero_initial_bar_index <= reentry_timeout)
+                    if is_reentry_triggered and (has_exit_reentry_window or has_zero_initial_window):
+                        reason = "Zero-Initial-Reentry"
+                        if has_exit_reentry_window:
+                            reason = "SL-Reentry" if last_exit_reason == "SL" else "PT-Reentry"
+                        allow_entry = reason == "Zero-Initial-Reentry" or reason == "PT-Reentry" or (reason == "SL-Reentry" and trades_in_bar < max_trades_per_bar)
+                        if allow_entry:
                             size_index = trades_in_bar
                             reentry_size = reentry_sizes[min(size_index, len(reentry_sizes) - 1)]
                             notional = balance * reentry_size
@@ -251,28 +269,33 @@ def run_ma_filter_backtest(
                             if reason == "SL-Reentry":
                                 trades_in_bar += 1
                         last_exit_side = None
+                        pending_zero_initial_side = None
                         current_idx += 1
                         continue
 
                 if short_allowed or short_early_reversal:
                     re_p = _resolve_reentry_price(sig, "short", reentry_anchor_levels, 0.0)
                     if trades_in_bar == 0 and sig["prev_low_2"] < sig["prev_low_1"] and bar["low"] <= sig["prev_low_2"]:
-                        entry = min(bar["open"], sig["prev_low_2"]) * (1 - fixed_slippage)
-                        notional = balance * cash_usage_initial
-                        position = {
-                            "side": "short",
-                            "entry_p": entry,
-                            "sl": _resolve_stop_price("short", entry, sig, stop_mode, stop_loss_atr),
-                            "protected": False,
-                            "notional": notional,
-                        }
-                        balance -= notional * commission
-                        trade_logs.append(
-                            {"time": bar_time, "type": "SHORT", "price": entry, "reason": "Initial", "notional": notional, "bal": balance}
-                        )
-                        trades_in_bar += 1
-                        current_idx += 1
-                        continue
+                        if dir2_zero_initial and zero_initial_mode == "reentry_window":
+                            pending_zero_initial_side = "short"
+                            pending_zero_initial_bar_index = i
+                        else:
+                            entry = min(bar["open"], sig["prev_low_2"]) * (1 - fixed_slippage)
+                            notional = balance * cash_usage_initial
+                            position = {
+                                "side": "short",
+                                "entry_p": entry,
+                                "sl": _resolve_stop_price("short", entry, sig, stop_mode, stop_loss_atr),
+                                "protected": False,
+                                "notional": notional,
+                            }
+                            balance -= notional * commission
+                            trade_logs.append(
+                                {"time": bar_time, "type": "SHORT", "price": entry, "reason": "Initial", "notional": notional, "bal": balance}
+                            )
+                            trades_in_bar += 1
+                            current_idx += 1
+                            continue
 
                     prev_close = prev_bar["close"] if prev_bar is not None else None
                     is_reentry_triggered, entry_p_raw = _reentry_triggered(
@@ -284,9 +307,14 @@ def run_ma_filter_backtest(
                         prev_close,
                         re_p,
                     )
-                    if last_exit_side == "short" and is_reentry_triggered and (i - last_exit_bar_index <= reentry_timeout):
-                        reason = "SL-Reentry" if last_exit_reason == "SL" else "PT-Reentry"
-                        if (reason == "SL-Reentry" and trades_in_bar < max_trades_per_bar) or reason == "PT-Reentry":
+                    has_exit_reentry_window = last_exit_side == "short" and (i - last_exit_bar_index <= reentry_timeout)
+                    has_zero_initial_window = pending_zero_initial_side == "short" and (i - pending_zero_initial_bar_index <= reentry_timeout)
+                    if is_reentry_triggered and (has_exit_reentry_window or has_zero_initial_window):
+                        reason = "Zero-Initial-Reentry"
+                        if has_exit_reentry_window:
+                            reason = "SL-Reentry" if last_exit_reason == "SL" else "PT-Reentry"
+                        allow_entry = reason == "Zero-Initial-Reentry" or reason == "PT-Reentry" or (reason == "SL-Reentry" and trades_in_bar < max_trades_per_bar)
+                        if allow_entry:
                             size_index = trades_in_bar
                             reentry_size = reentry_sizes[min(size_index, len(reentry_sizes) - 1)]
                             notional = balance * reentry_size
@@ -305,6 +333,7 @@ def run_ma_filter_backtest(
                             if reason == "SL-Reentry":
                                 trades_in_bar += 1
                         last_exit_side = None
+                        pending_zero_initial_side = None
                         current_idx += 1
                         continue
 
@@ -390,6 +419,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--reentry-size-schedule", default="0.10,0.20")
     parser.add_argument("--reentry-anchor-levels", choices=["wick", "body"], default="wick")
     parser.add_argument("--reentry-trigger-mode", choices=["reclaim", "pullback"], default="reclaim")
+    parser.add_argument("--zero-initial-mode", choices=["position", "reentry_window"], default="position")
     parser.add_argument("--profit-protect-atr", type=float, default=1.0)
     parser.add_argument("--disable-zero-initial", action="store_true")
     parser.add_argument("--filter-kind", choices=["sma", "ema"], default="ema")
@@ -433,6 +463,7 @@ def main() -> None:
         early_reversal_band_atr=args.early_reversal_band_atr,
         reentry_anchor_levels=args.reentry_anchor_levels,
         reentry_trigger_mode=args.reentry_trigger_mode,
+        zero_initial_mode=args.zero_initial_mode,
     )
 
     result = {
@@ -440,6 +471,7 @@ def main() -> None:
         "breakout_levels": args.breakout_levels,
         "reentry_anchor_levels": args.reentry_anchor_levels,
         "reentry_trigger_mode": args.reentry_trigger_mode,
+        "zero_initial_mode": args.zero_initial_mode,
         "window": {"start": args.start, "end": args.end},
         "filter_kind": args.filter_kind,
         "filter_period": args.filter_period,


### PR DESCRIPTION
## 目的
这次改动把 `dir2_zero_initial` 的一条 research-only 备选语义补成了可重复回测的实验路径，并把结论写清楚：

- 当前 canonical 语义是 `Initial` breakout 后创建一个长期存在的 zero-notional synthetic position，再一路走 `SL/PT` 管理
- 这次新增的备选语义是 `zero_initial_mode=reentry_window`
- 在该语义下，breakout 只打开“当前 signal bar + 下一根 signal bar”的 reentry window
- 如果窗口内没有 reentry，状态直接回到 flat，重新等待下一次 breakout

这次 PR 只涉及 `research/` 脚本和研究记录，不涉及 `internal/service` live/replay 主链。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [x] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main)
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？
- [x] DB migration 是否具备向下兼容幂等性？
- [x] 配置字段有没有无意被混改？

说明：以上检查项在本 PR 范围内均不涉及；本 PR 不改 live、dispatch、部署或数据库。

## 具体改动
- 在 `research/ma_filter_backtest.py` 中新增 `zero_initial_mode`，支持：
  - `position`: 保持当前 canonical 行为
  - `reentry_window`: breakout 只打开当前+下一根 signal bar 的 reentry 窗口
- 在 `research/backTest.py` 的 enhanced 引擎中补齐同样的 `zero_initial_mode` 语义，确保可以和当前 enhanced baseline 做 apples-to-apples 对比
- 新增两份研究记录：
  - `research/20260419_zero_initial_reentry_window.md`
  - `research/20260419_zero_initial_reentry_window_enhanced.md`

## 研究结论
在当前 `origin/main` 口径的 enhanced baseline 上，这个 research-only 变体在 Q1 样本里表现一致更好，且没有带来更差的回撤：

- `ETH 4h`: `31.77% -> 44.46%`，`+12.68 pp`
- `BTC 1d`: `17.62% -> 23.53%`，`+5.92 pp`
- `ETH 1d`: `21.63% -> 31.34%`，`+9.70 pp`

当前观察到的主要行为差异是：
- baseline 会长期管理 zero-notional synthetic initial position
- `reentry_window` 会把首次真实暴露延后到第一笔 reentry trigger 出现时
- trade mix 从 `Initial` 转移到 `Zero-Initial-Reentry`，下游 `SL-Reentry` 仍然是主路径

## 关于历史 34.35% 的说明
归档研究里 `ETH 4h Q1` baseline 记录为 `34.35%`。在当前 `origin/main` 代码口径下，本 PR 复现实验得到的是 `31.77%`。

这里更像是研究脚本/环境后续有过漂移，而不是这次改动引入的新问题。此次 compare 的有效性不受影响，因为 baseline 和 variant 都运行在同一套当前代码、同一套参数、同一份数据上。

## 验证方式与测试证据
- [x] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

本地验证：
- `python3 -m py_compile research/backTest.py research/ma_filter_backtest.py`
- 使用当前 enhanced baseline 口径重跑：
  - `ETH 4h / 2026 Q1`
  - `BTC 1d / 2026 Q1`
  - `ETH 1d / 2026 Q1`
- 结果已记录在：
  - `research/20260419_zero_initial_reentry_window.md`
  - `research/20260419_zero_initial_reentry_window_enhanced.md`

## 影响
这次 PR 的目标是把 research 结论写清楚，给后续是否要修改 replay/live canonical 语义提供依据；它本身不改变任何生产交易路径。