### PR TITLE
[codex] align live zero-initial defaults with reentry window research

### DIFF
--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -1785,7 +1785,9 @@ func (p *Platform) evaluateLiveSessionOnSignal(session domain.LiveSession, runti
 		return err
 	}
 
-	executionContext, decision, err := p.evaluateLiveSignalDecision(session, summary, sourceStates, signalBarStates, eventTime, nextPlannedEvent, nextPlannedPrice, nextPlannedSide, nextPlannedRole, nextPlannedReason)
+	evaluationSession := session
+	evaluationSession.State = cloneMetadata(state)
+	executionContext, decision, updatedDecisionState, err := p.evaluateLiveSignalDecision(evaluationSession, summary, sourceStates, signalBarStates, eventTime, nextPlannedEvent, nextPlannedPrice, nextPlannedSide, nextPlannedRole, nextPlannedReason)
 	if err != nil {
 		state["lastStrategyEvaluationStatus"] = "decision-error"
 		state["lastStrategyDecision"] = map[string]any{
@@ -1800,6 +1802,7 @@ func (p *Platform) evaluateLiveSessionOnSignal(session domain.LiveSession, runti
 		}
 		return err
 	}
+	state = updatedDecisionState
 
 	signalIntent := deriveLiveSignalIntent(decision, executionContext.Symbol)
 	var intent map[string]any
@@ -2030,18 +2033,18 @@ func (p *Platform) rolloverLiveSessionPlan(session domain.LiveSession, eventTime
 	return nil
 }
 
-func (p *Platform) evaluateLiveSignalDecision(session domain.LiveSession, summary map[string]any, sourceStates map[string]any, signalBarStates map[string]any, eventTime time.Time, nextPlannedEvent time.Time, nextPlannedPrice float64, nextPlannedSide, nextPlannedRole, nextPlannedReason string) (StrategyExecutionContext, StrategySignalDecision, error) {
+func (p *Platform) evaluateLiveSignalDecision(session domain.LiveSession, summary map[string]any, sourceStates map[string]any, signalBarStates map[string]any, eventTime time.Time, nextPlannedEvent time.Time, nextPlannedPrice float64, nextPlannedSide, nextPlannedRole, nextPlannedReason string) (StrategyExecutionContext, StrategySignalDecision, map[string]any, error) {
 	version, err := p.resolveCurrentStrategyVersion(session.StrategyID)
 	if err != nil {
-		return StrategyExecutionContext{}, StrategySignalDecision{}, err
+		return StrategyExecutionContext{}, StrategySignalDecision{}, cloneMetadata(session.State), err
 	}
 	parameters, err := p.resolveLiveSessionParameters(session, version)
 	if err != nil {
-		return StrategyExecutionContext{}, StrategySignalDecision{}, err
+		return StrategyExecutionContext{}, StrategySignalDecision{}, cloneMetadata(session.State), err
 	}
 	engine, engineKey, err := p.resolveStrategyEngine(version.ID, parameters)
 	if err != nil {
-		return StrategyExecutionContext{}, StrategySignalDecision{}, err
+		return StrategyExecutionContext{}, StrategySignalDecision{}, cloneMetadata(session.State), err
 	}
 	executionContext := StrategyExecutionContext{
 		StrategyEngineKey:   engineKey,
@@ -2059,14 +2062,17 @@ func (p *Platform) evaluateLiveSignalDecision(session domain.LiveSession, summar
 		return executionContext, StrategySignalDecision{
 			Action: "wait",
 			Reason: "engine-has-no-signal-evaluator",
-		}, nil
+		}, cloneMetadata(session.State), nil
 	}
 	currentPosition, _, err := p.resolveLiveSessionPositionSnapshot(session, executionContext.Symbol)
 	if err != nil {
-		return executionContext, StrategySignalDecision{}, err
+		return executionContext, StrategySignalDecision{}, cloneMetadata(session.State), err
 	}
-	nextPlannedEvent, nextPlannedPrice, nextPlannedSide, nextPlannedRole, nextPlannedReason = alignLivePlanStepToCurrentMarket(
+	updatedState, nextPlannedEvent, nextPlannedPrice, nextPlannedSide, nextPlannedRole, nextPlannedReason := prepareLivePlanStepForSignalEvaluation(
+		session.State,
+		executionContext.Parameters,
 		signalBarStates,
+		executionContext.Symbol,
 		executionContext.SignalTimeframe,
 		currentPosition,
 		eventTime,
@@ -2091,7 +2097,7 @@ func (p *Platform) evaluateLiveSignalDecision(session domain.LiveSession, summar
 		NextPlannedReason: nextPlannedReason,
 	})
 	if err != nil {
-		return executionContext, StrategySignalDecision{}, err
+		return executionContext, StrategySignalDecision{}, updatedState, err
 	}
 	if strings.TrimSpace(decision.Action) == "" {
 		decision.Action = "wait"
@@ -2099,7 +2105,7 @@ func (p *Platform) evaluateLiveSignalDecision(session domain.LiveSession, summar
 	if strings.TrimSpace(decision.Reason) == "" {
 		decision.Reason = "unspecified"
 	}
-	return executionContext, decision, nil
+	return executionContext, decision, updatedState, nil
 }
 
 func alignLivePlanStepToCurrentMarket(
@@ -2550,6 +2556,18 @@ func (p *Platform) resolveLiveSessionParameters(session domain.LiveSession, vers
 		"to",
 		"strategyEngine",
 		"fixed_slippage",
+		"stop_mode",
+		"stop_loss_atr",
+		"profit_protect_atr",
+		"long_reentry_atr",
+		"short_reentry_atr",
+		"reentry_size_schedule",
+		"trailing_stop_atr",
+		"delayed_trailing_activation_atr",
+		"reentry_decay_factor",
+		"max_trades_per_bar",
+		"dir2_zero_initial",
+		"zero_initial_mode",
 	} {
 		if value, ok := state[key]; ok {
 			parameters[key] = value
@@ -2653,7 +2671,8 @@ func adjustLiveExecutionProposalForVirtualSemantics(session domain.LiveSession, 
 	if _, ok := parameters["dir2_zero_initial"]; ok {
 		zeroInitial = boolValue(parameters["dir2_zero_initial"])
 	}
-	if strings.EqualFold(proposal.Role, "entry") && zeroInitial {
+	zeroInitialMode := resolveStrategyZeroInitialMode(zeroInitial, parameters["zero_initial_mode"])
+	if strings.EqualFold(proposal.Role, "entry") && zeroInitial && zeroInitialMode == strategyZeroInitialModePosition {
 		if reasonTag == "initial" || reasonTag == "livesignalbootstrap" {
 			proposal.Status = "virtual-initial"
 			proposal.Metadata = cloneMetadata(proposal.Metadata)

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -188,6 +188,129 @@ func TestAlignLivePlanStepToCurrentMarketKeepsExitForVirtualPosition(t *testing.
 	}
 }
 
+func TestPrepareLivePlanStepForSignalEvaluationUsesZeroInitialWindowAcrossTwoBars(t *testing.T) {
+	barStart := time.Date(2026, 4, 10, 0, 0, 0, 0, time.UTC)
+	signalStates := map[string]any{
+		signalBindingMatchKey("binance-kline", "signal", "BTCUSDT"): map[string]any{
+			"symbol":    "BTCUSDT",
+			"timeframe": "1d",
+			"ma20":      68000.0,
+			"atr14":     900.0,
+			"current": map[string]any{
+				"barStart": barStart.Format(time.RFC3339),
+				"close":    68100.0,
+				"high":     69010.0,
+				"low":      67800.0,
+			},
+			"prevBar1": map[string]any{
+				"high": 68850.0,
+				"low":  67750.0,
+			},
+			"prevBar2": map[string]any{
+				"high": 69000.0,
+				"low":  67600.0,
+			},
+		},
+	}
+	state, gotEvent, gotPrice, gotSide, gotRole, gotReason := prepareLivePlanStepForSignalEvaluation(
+		map[string]any{},
+		map[string]any{
+			"dir2_zero_initial": true,
+			"zero_initial_mode": "reentry_window",
+			"long_reentry_atr":  0.1,
+		},
+		signalStates,
+		"BTCUSDT",
+		"1d",
+		map[string]any{},
+		barStart.Add(2*time.Hour),
+		barStart.Add(-48*time.Hour),
+		68950.0,
+		"BUY",
+		"entry",
+		"Initial",
+	)
+	if gotRole != "entry" || gotReason != "Zero-Initial-Reentry" || gotSide != "BUY" {
+		t.Fatalf("expected zero initial reentry override, got side=%s role=%s reason=%s", gotSide, gotRole, gotReason)
+	}
+	if gotPrice != 67840.0 {
+		t.Fatalf("expected long reentry price 67840, got %.2f", gotPrice)
+	}
+	if gotEvent.IsZero() {
+		t.Fatal("expected planned event for zero initial window")
+	}
+	pending := mapValue(state[livePendingZeroInitialWindowStateKey])
+	if stringValue(pending["side"]) != "BUY" {
+		t.Fatalf("expected pending BUY window, got %+v", pending)
+	}
+
+	nextBarStart := barStart.Add(24 * time.Hour)
+	nextBarStates := map[string]any{
+		signalBindingMatchKey("binance-kline", "signal", "BTCUSDT"): map[string]any{
+			"symbol":    "BTCUSDT",
+			"timeframe": "1d",
+			"atr14":     900.0,
+			"current": map[string]any{
+				"barStart": nextBarStart.Format(time.RFC3339),
+				"close":    68200.0,
+				"high":     68800.0,
+				"low":      67820.0,
+			},
+			"prevBar1": map[string]any{
+				"high": 69010.0,
+				"low":  67800.0,
+			},
+			"prevBar2": map[string]any{
+				"high": 68850.0,
+				"low":  67750.0,
+			},
+		},
+	}
+	state, _, _, gotSide, gotRole, gotReason = prepareLivePlanStepForSignalEvaluation(
+		state,
+		map[string]any{
+			"dir2_zero_initial": true,
+			"zero_initial_mode": "reentry_window",
+			"long_reentry_atr":  0.1,
+		},
+		nextBarStates,
+		"BTCUSDT",
+		"1d",
+		map[string]any{},
+		nextBarStart.Add(2*time.Hour),
+		barStart.Add(-24*time.Hour),
+		68950.0,
+		"BUY",
+		"entry",
+		"Initial",
+	)
+	if gotRole != "entry" || gotReason != "Zero-Initial-Reentry" || gotSide != "BUY" {
+		t.Fatalf("expected pending zero initial window to remain active on next bar, got side=%s role=%s reason=%s", gotSide, gotRole, gotReason)
+	}
+
+	expiredState, _, _, _, _, _ := prepareLivePlanStepForSignalEvaluation(
+		state,
+		map[string]any{
+			"dir2_zero_initial": true,
+			"zero_initial_mode": "reentry_window",
+			"long_reentry_atr":  0.1,
+		},
+		nextBarStates,
+		"BTCUSDT",
+		"1d",
+		map[string]any{},
+		barStart.Add(49*time.Hour),
+		barStart.Add(-72*time.Hour),
+		68950.0,
+		"BUY",
+		"entry",
+		"Initial",
+	)
+	if pending := mapValue(expiredState[livePendingZeroInitialWindowStateKey]); len(pending) != 0 {
+		t.Fatalf("expected zero initial window to expire after next bar, got %+v", pending)
+	}
+}
+
 func TestEvaluateSignalBarGateAllowsReentryWithoutInitialBreakout(t *testing.T) {
 	gate := evaluateSignalBarGate(map[string]any{
 		"timeframe": "1d",
@@ -419,6 +542,7 @@ func TestEvaluateLiveExitStateTriggersSLForLong(t *testing.T) {
 func TestAdjustLiveExecutionProposalForVirtualInitialWhenZeroInitialEnabled(t *testing.T) {
 	proposal := adjustLiveExecutionProposalForVirtualSemantics(domain.LiveSession{}, map[string]any{
 		"dir2_zero_initial": true,
+		"zero_initial_mode": "position",
 	}, ExecutionProposal{
 		Role:   "entry",
 		Reason: "Initial",
@@ -432,6 +556,20 @@ func TestAdjustLiveExecutionProposalForVirtualInitialWhenZeroInitialEnabled(t *t
 	}
 	if !boolValue(proposal.Metadata["virtualPosition"]) {
 		t.Fatal("expected virtualPosition marker on proposal metadata")
+	}
+}
+
+func TestAdjustLiveExecutionProposalLeavesInitialDispatchableWhenZeroInitialWindowEnabled(t *testing.T) {
+	proposal := adjustLiveExecutionProposalForVirtualSemantics(domain.LiveSession{}, map[string]any{
+		"dir2_zero_initial": true,
+		"zero_initial_mode": "reentry_window",
+	}, ExecutionProposal{
+		Role:   "entry",
+		Reason: "Initial",
+		Status: "dispatchable",
+	})
+	if proposal.Status != "dispatchable" {
+		t.Fatalf("expected initial proposal to remain dispatchable under reentry window mode, got %s", proposal.Status)
 	}
 }
 
@@ -1263,6 +1401,27 @@ func TestNormalizeLiveSessionOverridesIncludesPositionSizing(t *testing.T) {
 	}
 }
 
+func TestNormalizeLiveSessionOverridesIncludesZeroInitialControls(t *testing.T) {
+	overrides := normalizeLiveSessionOverrides(map[string]any{
+		"dir2_zero_initial":               false,
+		"zero_initial_mode":               "position",
+		"trailing_stop_atr":               0.3,
+		"delayed_trailing_activation_atr": 0.5,
+	})
+	if boolValue(overrides["dir2_zero_initial"]) {
+		t.Fatal("expected dir2_zero_initial override to be preserved")
+	}
+	if got := stringValue(overrides["zero_initial_mode"]); got != "position" {
+		t.Fatalf("expected zero_initial_mode=position, got %s", got)
+	}
+	if got := parseFloatValue(overrides["trailing_stop_atr"]); got != 0.3 {
+		t.Fatalf("expected trailing_stop_atr=0.3, got %v", got)
+	}
+	if got := parseFloatValue(overrides["delayed_trailing_activation_atr"]); got != 0.5 {
+		t.Fatalf("expected delayed_trailing_activation_atr=0.5, got %v", got)
+	}
+}
+
 func TestCreateLiveSessionAppliesExecutionOverrides(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
 	session, err := platform.CreateLiveSession("live-main", "strategy-bk-1d", map[string]any{
@@ -1659,6 +1818,7 @@ func TestEnsureLiveExecutionPlanReconcilesCachedPlanIndexBackToEntryWhenPosition
 		"signalTimeframe":     "1d",
 		"executionDataSource": "tick",
 		"dispatchMode":        "manual-review",
+		"zero_initial_mode":   "position",
 	})
 	if err != nil {
 		t.Fatalf("create live session failed: %v", err)
@@ -1701,6 +1861,7 @@ func TestEnsureLiveExecutionPlanReconcilesCachedPlanIndexToExitWhenPositionExist
 		"signalTimeframe":     "1d",
 		"executionDataSource": "tick",
 		"dispatchMode":        "manual-review",
+		"zero_initial_mode":   "position",
 	})
 	if err != nil {
 		t.Fatalf("create live session failed: %v", err)
@@ -1752,6 +1913,7 @@ func TestEnsureLiveExecutionPlanReconcilesExhaustedCachedPlanIndexToCompletionWh
 		"signalTimeframe":     "1d",
 		"executionDataSource": "tick",
 		"dispatchMode":        "manual-review",
+		"zero_initial_mode":   "position",
 	})
 	if err != nil {
 		t.Fatalf("create live session failed: %v", err)
@@ -2401,6 +2563,7 @@ func TestEvaluateLiveSessionOnSignalRecordsVirtualInitialForZeroInitialStrategy(
 		"signalTimeframe":     "1d",
 		"executionDataSource": "tick",
 		"dispatchMode":        "manual-review",
+		"zero_initial_mode":   "position",
 	})
 	if err != nil {
 		t.Fatalf("create live session failed: %v", err)
@@ -2427,7 +2590,7 @@ func TestEvaluateLiveSessionOnSignalRecordsVirtualInitialForZeroInitialStrategy(
 		"role":               "trigger",
 		"symbol":             "BTCUSDT",
 		"subscriptionSymbol": "BTCUSDT",
-		"price":              69010.0,
+		"price":              68110.0,
 		"event":              "trade_tick",
 	}
 	err = platform.updateSignalRuntimeSessionState(runtimeSessionID, func(runtimeSession *domain.SignalRuntimeSession) {
@@ -2445,7 +2608,7 @@ func TestEvaluateLiveSessionOnSignalRecordsVirtualInitialForZeroInitialStrategy(
 				"streamType":  "trade_tick",
 				"lastEventAt": eventTime.UTC().Format(time.RFC3339),
 				"summary": map[string]any{
-					"price": 69010.0,
+					"price": 68110.0,
 				},
 			},
 			signalKey: map[string]any{
@@ -2506,6 +2669,155 @@ func TestEvaluateLiveSessionOnSignalRecordsVirtualInitialForZeroInitialStrategy(
 	}
 	if got := maxIntValue(updated.State["planIndex"], -1); got != 1 {
 		t.Fatalf("expected planIndex to advance after virtual initial, got %d", got)
+	}
+}
+
+func TestEvaluateLiveSessionOnSignalUsesZeroInitialReentryWindowInsteadOfVirtualInitial(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	if _, err := platform.BindStrategySignalSource("strategy-bk-1d", map[string]any{
+		"sourceKey": "binance-kline",
+		"role":      "signal",
+		"symbol":    "BTCUSDT",
+		"options":   map[string]any{"timeframe": "1d"},
+	}); err != nil {
+		t.Fatalf("bind strategy signal failed: %v", err)
+	}
+	if _, err := platform.BindStrategySignalSource("strategy-bk-1d", map[string]any{
+		"sourceKey": "binance-trade-tick",
+		"role":      "trigger",
+		"symbol":    "BTCUSDT",
+	}); err != nil {
+		t.Fatalf("bind strategy trigger failed: %v", err)
+	}
+	if _, err := platform.BindAccountSignalSource("live-main", map[string]any{
+		"sourceKey": "binance-kline",
+		"role":      "signal",
+		"symbol":    "BTCUSDT",
+		"options":   map[string]any{"timeframe": "1d"},
+	}); err != nil {
+		t.Fatalf("bind account signal failed: %v", err)
+	}
+	if _, err := platform.BindAccountSignalSource("live-main", map[string]any{
+		"sourceKey": "binance-trade-tick",
+		"role":      "trigger",
+		"symbol":    "BTCUSDT",
+	}); err != nil {
+		t.Fatalf("bind account trigger failed: %v", err)
+	}
+
+	session, err := platform.CreateLiveSession("live-main", "strategy-bk-1d", map[string]any{
+		"symbol":              "BTCUSDT",
+		"signalTimeframe":     "1d",
+		"executionDataSource": "tick",
+		"dispatchMode":        "manual-review",
+		"zero_initial_mode":   "reentry_window",
+	})
+	if err != nil {
+		t.Fatalf("create live session failed: %v", err)
+	}
+	runtimeSessionID := stringValue(session.State["signalRuntimeSessionId"])
+	if runtimeSessionID == "" {
+		t.Fatal("expected linked runtime session id")
+	}
+
+	eventTime := time.Date(2026, 4, 7, 9, 0, 0, 0, time.UTC)
+	platform.mu.Lock()
+	platform.livePlans[session.ID] = []paperPlannedOrder{{
+		EventTime: eventTime.Add(-48 * time.Hour),
+		Price:     69000.0,
+		Side:      "BUY",
+		Role:      "entry",
+		Reason:    "Initial",
+	}}
+	platform.mu.Unlock()
+
+	signalKey := signalBindingMatchKey("binance-kline", "signal", "BTCUSDT")
+	triggerKey := signalBindingMatchKey("binance-trade-tick", "trigger", "BTCUSDT")
+	summary := map[string]any{
+		"role":               "trigger",
+		"symbol":             "BTCUSDT",
+		"subscriptionSymbol": "BTCUSDT",
+		"price":              67845.0,
+		"event":              "trade_tick",
+	}
+	err = platform.updateSignalRuntimeSessionState(runtimeSessionID, func(runtimeSession *domain.SignalRuntimeSession) {
+		runtimeSession.Status = "RUNNING"
+		state := cloneMetadata(runtimeSession.State)
+		state["health"] = "healthy"
+		state["lastEventAt"] = eventTime.UTC().Format(time.RFC3339)
+		state["lastHeartbeatAt"] = eventTime.UTC().Format(time.RFC3339)
+		state["lastEventSummary"] = cloneMetadata(summary)
+		state["sourceStates"] = map[string]any{
+			triggerKey: map[string]any{
+				"sourceKey":   "binance-trade-tick",
+				"role":        "trigger",
+				"symbol":      "BTCUSDT",
+				"streamType":  "trade_tick",
+				"lastEventAt": eventTime.UTC().Format(time.RFC3339),
+				"summary": map[string]any{
+					"price": 67845.0,
+				},
+			},
+			signalKey: map[string]any{
+				"sourceKey":   "binance-kline",
+				"role":        "signal",
+				"symbol":      "BTCUSDT",
+				"streamType":  "signal_bar",
+				"lastEventAt": eventTime.UTC().Format(time.RFC3339),
+			},
+		}
+		state["signalBarStates"] = map[string]any{
+			signalKey: map[string]any{
+				"symbol":    "BTCUSDT",
+				"timeframe": "1d",
+				"ma20":      68000.0,
+				"atr14":     900.0,
+				"current": map[string]any{
+					"barStart": eventTime.Truncate(24 * time.Hour).Format(time.RFC3339),
+					"close":    68100.0,
+					"high":     69010.0,
+					"low":      67800.0,
+				},
+				"prevBar1": map[string]any{
+					"high": 68850.0,
+					"low":  67750.0,
+				},
+				"prevBar2": map[string]any{
+					"high": 69000.0,
+					"low":  67600.0,
+				},
+			},
+		}
+		runtimeSession.State = state
+		runtimeSession.UpdatedAt = eventTime
+	})
+	if err != nil {
+		t.Fatalf("update runtime state failed: %v", err)
+	}
+
+	if err := platform.evaluateLiveSessionOnSignal(session, runtimeSessionID, summary, eventTime); err != nil {
+		t.Fatalf("evaluate live session failed: %v", err)
+	}
+
+	updated, err := platform.store.GetLiveSession(session.ID)
+	if err != nil {
+		t.Fatalf("get updated live session failed: %v", err)
+	}
+	if got := stringValue(updated.State["lastDispatchedOrderStatus"]); got == liveOrderStatusVirtualInitial {
+		t.Fatalf("expected zero initial window mode to avoid virtual initial dispatch marker, got %s", got)
+	}
+	if virtualPosition := mapValue(updated.State["virtualPosition"]); len(virtualPosition) != 0 {
+		t.Fatalf("expected zero initial window mode to avoid virtual positions, got %+v", virtualPosition)
+	}
+	proposal := mapValue(updated.State["lastExecutionProposal"])
+	if got := stringValue(proposal["status"]); got != "dispatchable" {
+		t.Fatalf("expected dispatchable reentry proposal, got %s", got)
+	}
+	if got := stringValue(proposal["reason"]); got != "Zero-Initial-Reentry" {
+		t.Fatalf("expected Zero-Initial-Reentry proposal reason, got %s", got)
+	}
+	if pending := mapValue(updated.State[livePendingZeroInitialWindowStateKey]); stringValue(pending["side"]) != "BUY" {
+		t.Fatalf("expected pending BUY zero initial window in session state, got %+v", pending)
 	}
 }
 
@@ -3030,7 +3342,7 @@ func TestEvaluateLiveSignalDecisionDoesNotMutateOriginalSessionState(t *testing.
 		},
 	}
 
-	_, decision, err := platform.evaluateLiveSignalDecision(
+	_, decision, _, err := platform.evaluateLiveSignalDecision(
 		session,
 		summary,
 		sourceStates,

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -361,6 +361,12 @@ func TestBuildLiveExecutionPlanFromMarketDataAcceptsTickExecutionSource(t *testi
 	if err != nil {
 		t.Fatalf("resolve live session parameters failed: %v", err)
 	}
+	if !boolValue(parameters["dir2_zero_initial"]) {
+		t.Fatal("expected live session parameters to default dir2_zero_initial=true")
+	}
+	if got := stringValue(parameters["zero_initial_mode"]); got != strategyZeroInitialModeReentryWindow {
+		t.Fatalf("expected live session zero_initial_mode=%s, got %s", strategyZeroInitialModeReentryWindow, got)
+	}
 	engine, engineKey, err := platform.resolveStrategyEngine(version.ID, parameters)
 	if err != nil {
 		t.Fatalf("resolve strategy engine failed: %v", err)

--- a/internal/service/live_zero_initial.go
+++ b/internal/service/live_zero_initial.go
@@ -1,0 +1,185 @@
+package service
+
+import (
+	"strings"
+	"time"
+)
+
+const livePendingZeroInitialWindowStateKey = "pendingZeroInitialWindow"
+
+func prepareLivePlanStepForSignalEvaluation(
+	sessionState map[string]any,
+	parameters map[string]any,
+	signalBarStates map[string]any,
+	symbol string,
+	signalTimeframe string,
+	currentPosition map[string]any,
+	eventTime time.Time,
+	nextPlannedEvent time.Time,
+	nextPlannedPrice float64,
+	nextPlannedSide, nextPlannedRole, nextPlannedReason string,
+) (map[string]any, time.Time, float64, string, string, string) {
+	updatedState := cloneMetadata(sessionState)
+	if !strategyZeroInitialReentryWindowEnabled(parameters) {
+		alignedEvent, alignedPrice, alignedSide, alignedRole, alignedReason := alignLivePlanStepToCurrentMarket(
+			signalBarStates,
+			signalTimeframe,
+			currentPosition,
+			eventTime,
+			nextPlannedEvent,
+			nextPlannedPrice,
+			nextPlannedSide,
+			nextPlannedRole,
+			nextPlannedReason,
+		)
+		return updatedState, alignedEvent, alignedPrice, alignedSide, alignedRole, alignedReason
+	}
+
+	updatedState = refreshLiveZeroInitialWindowState(updatedState, signalBarStates, symbol, signalTimeframe, currentPosition, eventTime)
+	if updatedState, alignedEvent, alignedPrice, alignedSide, alignedRole, alignedReason, ok := liveZeroInitialWindowPlanStep(
+		updatedState,
+		parameters,
+		signalBarStates,
+		symbol,
+		signalTimeframe,
+		eventTime,
+	); ok {
+		return updatedState, alignedEvent, alignedPrice, alignedSide, alignedRole, alignedReason
+	}
+	if hasActiveLivePositionSnapshot(currentPosition) || !isLivePlanStepStale(nextPlannedEvent, signalTimeframe, eventTime) {
+		return updatedState, nextPlannedEvent, nextPlannedPrice, nextPlannedSide, nextPlannedRole, nextPlannedReason
+	}
+
+	signalBarState, _ := pickSignalBarState(signalBarStates, symbol, signalTimeframe)
+	if signalBarState == nil {
+		return updatedState, nextPlannedEvent, nextPlannedPrice, nextPlannedSide, nextPlannedRole, nextPlannedReason
+	}
+	gate := evaluateSignalBarGate(signalBarState, "", "entry", "")
+	longReady := boolValue(gate["longReady"])
+	shortReady := boolValue(gate["shortReady"])
+	if longReady == shortReady {
+		return updatedState, nextPlannedEvent, nextPlannedPrice, nextPlannedSide, nextPlannedRole, nextPlannedReason
+	}
+
+	current := mapValue(signalBarState["current"])
+	currentBarStart := parseOptionalRFC3339(stringValue(current["barStart"]))
+	if currentBarStart.IsZero() {
+		currentBarStart = eventTime.UTC()
+	}
+	step := resolutionToDuration(liveSignalResolution(signalTimeframe))
+	if step <= 0 {
+		step = 4 * time.Hour
+	}
+	side := "BUY"
+	if shortReady {
+		side = "SELL"
+	}
+	updatedState[livePendingZeroInitialWindowStateKey] = map[string]any{
+		"side":            side,
+		"symbol":          NormalizeSymbol(symbol),
+		"signalTimeframe": strings.ToLower(strings.TrimSpace(signalTimeframe)),
+		"armedAt":         eventTime.UTC().Format(time.RFC3339),
+		"signalBarStart":  currentBarStart.UTC().Format(time.RFC3339),
+		"expiresAt":       currentBarStart.UTC().Add(2 * step).Format(time.RFC3339),
+	}
+	updatedState, alignedEvent, alignedPrice, alignedSide, alignedRole, alignedReason, _ := liveZeroInitialWindowPlanStep(updatedState, parameters, signalBarStates, symbol, signalTimeframe, eventTime)
+	return updatedState, alignedEvent, alignedPrice, alignedSide, alignedRole, alignedReason
+}
+
+func refreshLiveZeroInitialWindowState(
+	sessionState map[string]any,
+	signalBarStates map[string]any,
+	symbol string,
+	signalTimeframe string,
+	currentPosition map[string]any,
+	eventTime time.Time,
+) map[string]any {
+	state := cloneMetadata(sessionState)
+	if state == nil {
+		state = map[string]any{}
+	}
+	if hasActiveLivePositionSnapshot(currentPosition) {
+		delete(state, livePendingZeroInitialWindowStateKey)
+		return state
+	}
+	pending := cloneMetadata(mapValue(state[livePendingZeroInitialWindowStateKey]))
+	if len(pending) == 0 {
+		return state
+	}
+	if pendingSymbol := NormalizeSymbol(stringValue(pending["symbol"])); pendingSymbol != "" && pendingSymbol != NormalizeSymbol(symbol) {
+		delete(state, livePendingZeroInitialWindowStateKey)
+		return state
+	}
+	if pendingTimeframe := strings.ToLower(strings.TrimSpace(stringValue(pending["signalTimeframe"]))); pendingTimeframe != "" &&
+		pendingTimeframe != strings.ToLower(strings.TrimSpace(signalTimeframe)) {
+		delete(state, livePendingZeroInitialWindowStateKey)
+		return state
+	}
+	expiresAt := parseOptionalRFC3339(stringValue(pending["expiresAt"]))
+	if !expiresAt.IsZero() && !eventTime.UTC().Before(expiresAt.UTC()) {
+		delete(state, livePendingZeroInitialWindowStateKey)
+		return state
+	}
+	if signalBarState, _ := pickSignalBarState(signalBarStates, symbol, signalTimeframe); signalBarState != nil {
+		current := mapValue(signalBarState["current"])
+		if currentBarStart := parseOptionalRFC3339(stringValue(current["barStart"])); !currentBarStart.IsZero() {
+			pendingBarStart := parseOptionalRFC3339(stringValue(pending["signalBarStart"]))
+			if !pendingBarStart.IsZero() && currentBarStart.UTC().Before(pendingBarStart.UTC()) {
+				delete(state, livePendingZeroInitialWindowStateKey)
+				return state
+			}
+		}
+	}
+	state[livePendingZeroInitialWindowStateKey] = pending
+	return state
+}
+
+func liveZeroInitialWindowPlanStep(
+	sessionState map[string]any,
+	parameters map[string]any,
+	signalBarStates map[string]any,
+	symbol string,
+	signalTimeframe string,
+	eventTime time.Time,
+) (map[string]any, time.Time, float64, string, string, string, bool) {
+	state := cloneMetadata(sessionState)
+	pending := cloneMetadata(mapValue(state[livePendingZeroInitialWindowStateKey]))
+	if len(pending) == 0 {
+		return state, time.Time{}, 0, "", "", "", false
+	}
+	side := strings.ToUpper(strings.TrimSpace(stringValue(pending["side"])))
+	if side == "" {
+		delete(state, livePendingZeroInitialWindowStateKey)
+		return state, time.Time{}, 0, "", "", "", false
+	}
+	signalBarState, _ := pickSignalBarState(signalBarStates, symbol, signalTimeframe)
+	if signalBarState == nil {
+		return state, time.Time{}, 0, "", "", "", false
+	}
+	price := resolveLiveReentryPlanPrice(parameters, signalBarState, side)
+	if price <= 0 {
+		return state, time.Time{}, 0, "", "", "", false
+	}
+	current := mapValue(signalBarState["current"])
+	plannedEvent := parseOptionalRFC3339(stringValue(current["barStart"]))
+	if plannedEvent.IsZero() {
+		plannedEvent = eventTime.UTC()
+	}
+	return state, plannedEvent.UTC(), price, side, "entry", "Zero-Initial-Reentry", true
+}
+
+func resolveLiveReentryPlanPrice(parameters map[string]any, signalBarState map[string]any, side string) float64 {
+	prevBar1 := mapValue(signalBarState["prevBar1"])
+	if prevBar1 == nil {
+		return 0
+	}
+	atr14 := parseFloatValue(signalBarState["atr14"])
+	switch strings.ToUpper(strings.TrimSpace(side)) {
+	case "BUY":
+		return parseFloatValue(prevBar1["low"]) + parseFloatValue(firstNonNil(parameters["long_reentry_atr"], 0.1))*atr14
+	case "SELL", "SHORT":
+		return parseFloatValue(prevBar1["high"]) + parseFloatValue(firstNonNil(parameters["short_reentry_atr"], 0.0))*atr14
+	default:
+		return 0
+	}
+}

--- a/internal/service/paper.go
+++ b/internal/service/paper.go
@@ -1175,8 +1175,16 @@ func (p *Platform) resolvePaperSessionParameters(session domain.PaperSession, ve
 		"stop_mode",
 		"stop_loss_atr",
 		"profit_protect_atr",
+		"long_reentry_atr",
+		"short_reentry_atr",
+		"reentry_size_schedule",
+		"trailing_stop_atr",
+		"delayed_trailing_activation_atr",
+		"reentry_decay_factor",
 		"max_trades_per_bar",
 		"fixed_slippage",
+		"dir2_zero_initial",
+		"zero_initial_mode",
 	} {
 		if value, ok := state[key]; ok {
 			parameters[key] = value
@@ -1229,14 +1237,33 @@ func normalizePaperSessionOverrides(overrides map[string]any) map[string]any {
 			}
 		case "strategyEngine":
 			normalized[key] = normalizeStrategyEngineKey(stringValue(value))
-		case "tradingFeeBps", "fundingRateBps", "fixed_slippage", "stop_loss_atr", "profit_protect_atr":
+		case "tradingFeeBps", "fundingRateBps", "fixed_slippage", "stop_loss_atr", "profit_protect_atr",
+			"long_reentry_atr", "short_reentry_atr", "trailing_stop_atr", "delayed_trailing_activation_atr",
+			"reentry_decay_factor":
 			normalized[key] = parseFloatValue(value)
 		case "fundingIntervalHours", "max_trades_per_bar":
 			normalized[key] = maxIntValue(value, 0)
+		case "dir2_zero_initial":
+			normalized[key] = boolValue(value)
 		case "stop_mode":
 			mode := strings.ToLower(strings.TrimSpace(stringValue(value)))
 			if mode != "" {
 				normalized[key] = mode
+			}
+		case "zero_initial_mode":
+			if mode := normalizeStrategyZeroInitialMode(stringValue(value)); mode != "" {
+				normalized[key] = mode
+			}
+		case "reentry_size_schedule":
+			switch schedule := value.(type) {
+			case []float64:
+				normalized[key] = append([]float64(nil), schedule...)
+			case []any:
+				normalized[key] = append([]any(nil), schedule...)
+			case []string:
+				normalized[key] = append([]string(nil), schedule...)
+			default:
+				normalized[key] = value
 			}
 		}
 	}

--- a/internal/service/strategy.go
+++ b/internal/service/strategy.go
@@ -647,6 +647,12 @@ func NormalizeBacktestParameters(parameters map[string]any) (map[string]any, err
 	normalized["executionDataSource"] = executionDataSource
 	normalized["symbol"] = symbol
 	normalized["strategyEngine"] = normalizeStrategyEngineKey(stringValue(normalized["strategyEngine"]))
+	dir2ZeroInitial := true
+	if _, ok := normalized["dir2_zero_initial"]; ok {
+		dir2ZeroInitial = boolValue(normalized["dir2_zero_initial"])
+	}
+	normalized["dir2_zero_initial"] = dir2ZeroInitial
+	normalized["zero_initial_mode"] = resolveStrategyZeroInitialMode(dir2ZeroInitial, normalized["zero_initial_mode"])
 	normalized["max_trades_per_bar"] = maxIntValue(normalized["max_trades_per_bar"], 3)
 	normalized["reentry_size_schedule"] = normalizeBacktestFloatSlice(normalized["reentry_size_schedule"], []float64{0.20, 0.10})
 	stopLossATR := parseFloatValue(normalized["stop_loss_atr"])
@@ -693,6 +699,8 @@ func applyBacktestParameterAliases(parameters map[string]any) {
 		"signal_timeframe":             "signalTimeframe",
 		"execution_data_source":        "executionDataSource",
 		"strategy_engine":              "strategyEngine",
+		"dir2ZeroInitial":              "dir2_zero_initial",
+		"zeroInitialMode":              "zero_initial_mode",
 		"maxTradesPerBar":              "max_trades_per_bar",
 		"reentrySizes":                 "reentry_size_schedule",
 		"stopLossATR":                  "stop_loss_atr",

--- a/internal/service/strategy_registry.go
+++ b/internal/service/strategy_registry.go
@@ -440,6 +440,8 @@ func classifyStrategySignalKind(action, reason, nextRole, nextReason string, cur
 			switch reasonTag {
 			case "initial":
 				return "initial-entry"
+			case "zero-initial-reentry":
+				return "zero-initial-reentry"
 			case "sl-reentry":
 				return "sl-reentry"
 			case "pt-reentry":
@@ -477,6 +479,17 @@ func classifyStrategySignalKind(action, reason, nextRole, nextReason string, cur
 				return "initial-entry-near"
 			}
 			return "initial-entry-watch"
+		case "zero-initial-reentry":
+			if nearEntry && reason == "bias-unfavorable" {
+				return "zero-initial-reentry-near-weak"
+			}
+			if nearEntry {
+				if favorableBias {
+					return "zero-initial-reentry-near-strong"
+				}
+				return "zero-initial-reentry-near"
+			}
+			return "zero-initial-reentry-watch"
 		case "sl-reentry":
 			if nearEntry && reason == "bias-unfavorable" {
 				return "sl-reentry-near-weak"
@@ -671,7 +684,7 @@ func evaluateSignalBarGate(signalBarState map[string]any, nextSide, nextRole, ne
 	shortBreakoutReady := lowPrice <= prevLow2 && prevLow2 > 0
 	longReady := longStructureReady && longBreakoutReady
 	shortReady := shortStructureReady && shortBreakoutReady
-	if role == "entry" && (reasonTag == "sl-reentry" || reasonTag == "pt-reentry") {
+	if role == "entry" && (reasonTag == "zero-initial-reentry" || reasonTag == "sl-reentry" || reasonTag == "pt-reentry") {
 		longReady = longStructureReady
 		shortReady = shortStructureReady
 	}
@@ -710,7 +723,7 @@ func isFavorableBiasForPlan(nextRole, nextReason, liquidityBias string) bool {
 	reasonTag := normalizeStrategyReasonTag(nextReason)
 	if role == "entry" {
 		switch reasonTag {
-		case "initial", "sl-reentry", "pt-reentry":
+		case "initial", "zero-initial-reentry", "sl-reentry", "pt-reentry":
 			return liquidityBias == "bid-heavy"
 		}
 	}

--- a/internal/service/strategy_replay.go
+++ b/internal/service/strategy_replay.go
@@ -58,6 +58,7 @@ type strategyReplayConfig struct {
 	InitialBalance       float64
 	Dir1ReentryConfirm   bool
 	Dir2ZeroInitial      bool
+	ZeroInitialMode      string
 	FixedSlippage        float64
 	StopLossATR          float64
 	MaxTradesPerBar      int
@@ -156,6 +157,7 @@ func (p *Platform) runStrategyReplayOnTick(cfg strategyReplayConfig, signals []s
 		if i-engine.lastExitBarIndex > 1 {
 			engine.lastExitSide = ""
 		}
+		engine.clearExpiredZeroInitialWindow(i)
 
 		for hasEvent && !nextEvent.Time.After(endT) {
 			current := nextEvent
@@ -168,35 +170,49 @@ func (p *Platform) runStrategyReplayOnTick(cfg strategyReplayConfig, signals []s
 					reP := sig.PrevLow1 + cfg.LongReentryATR*sig.ATR
 					if tradesInBar == 0 && sig.PrevHigh2 > sig.PrevHigh1 {
 						if current.Price >= sig.PrevHigh2 {
-							entry := math.Max(current.Price, sig.PrevHigh2) * (1 + cfg.FixedSlippage)
-							notional := engine.balance * initialUsage
-							stopLoss := resolveStopPrice("long", entry, sig, cfg.StopMode, cfg.StopLossATR)
-							engine.position = &strategyPosition{
-								Side:       "long",
-								EntryPrice: entry,
-								StopLoss:   stopLoss,
-								Protected:  false,
-								Notional:   notional,
-								Reason:     "Initial",
-								BarIndex:   i,
-								EntryTime:  current.Time,
-								HWM:        entry,
-								LWM:        entry,
+							if engine.zeroInitialReentryWindowEnabled() {
+								engine.armZeroInitialWindow("long", i)
+							} else {
+								entry := math.Max(current.Price, sig.PrevHigh2) * (1 + cfg.FixedSlippage)
+								notional := engine.balance * initialUsage
+								stopLoss := resolveStopPrice("long", entry, sig, cfg.StopMode, cfg.StopLossATR)
+								engine.position = &strategyPosition{
+									Side:       "long",
+									EntryPrice: entry,
+									StopLoss:   stopLoss,
+									Protected:  false,
+									Notional:   notional,
+									Reason:     "Initial",
+									BarIndex:   i,
+									EntryTime:  current.Time,
+									HWM:        entry,
+									LWM:        entry,
+								}
+								tradingFee := notional * commission
+								engine.balance -= tradingFee
+								engine.totalTradingFees += tradingFee
+								engine.appendTrade("BUY", current.Time, entry, "Initial", notional, 0, tradingFee, 0)
+								tradesInBar++
+								executed = true
 							}
-							tradingFee := notional * commission
-							engine.balance -= tradingFee
-							engine.totalTradingFees += tradingFee
-							engine.appendTrade("BUY", current.Time, entry, "Initial", notional, 0, tradingFee, 0)
-							tradesInBar++
-							executed = true
 						}
-					} else if engine.lastExitSide == "long" && i-engine.lastExitBarIndex <= 1 {
+					}
+					hasExitWindow := engine.lastExitSide == "long" && i-engine.lastExitBarIndex <= 1
+					hasZeroWindow := engine.hasZeroInitialWindow("long", i)
+					if hasExitWindow || hasZeroWindow {
 						if current.Price >= reP {
-							reason := "PT-Reentry"
-							if engine.lastExitReason == "SL" {
-								reason = "SL-Reentry"
+							reason := "Zero-Initial-Reentry"
+							size := getReentrySize(1, cfg.ReentrySizeSchedule)
+							effectiveTradesInBar := 0
+							ok := size > 0
+							if hasExitWindow {
+								reason = "PT-Reentry"
+								if engine.lastExitReason == "SL" {
+									reason = "SL-Reentry"
+								}
+								size, effectiveTradesInBar, ok = resolveReplayReentrySlot(tradesInBar, cfg.MaxTradesPerBar, cfg.ReentrySizeSchedule)
 							}
-							if size, effectiveTradesInBar, ok := resolveReplayReentrySlot(tradesInBar, cfg.MaxTradesPerBar, cfg.ReentrySizeSchedule); ok {
+							if ok {
 								notional := engine.balance * size
 								entry := reP * (1 + cfg.FixedSlippage)
 								stopLoss := resolveStopPrice("long", entry, sig, cfg.StopMode, cfg.StopLossATR)
@@ -216,45 +232,68 @@ func (p *Platform) runStrategyReplayOnTick(cfg strategyReplayConfig, signals []s
 								engine.balance -= tradingFee
 								engine.totalTradingFees += tradingFee
 								engine.appendTrade("BUY", current.Time, entry, reason, notional, 0, tradingFee, 0)
-								tradesInBar = effectiveTradesInBar + 1
+								if hasExitWindow {
+									tradesInBar = effectiveTradesInBar + 1
+								} else {
+									tradesInBar = 1
+								}
 								executed = true
 							}
-							engine.lastExitSide = ""
+							if hasExitWindow {
+								engine.lastExitSide = ""
+							}
+							if hasZeroWindow {
+								engine.clearZeroInitialWindow()
+							}
 						}
 					}
 				} else if shortRegimeReady {
 					reP := sig.PrevHigh1 + cfg.ShortReentryATR*sig.ATR
 					if tradesInBar == 0 && sig.PrevLow2 < sig.PrevLow1 {
 						if current.Price <= sig.PrevLow2 {
-							entry := math.Min(current.Price, sig.PrevLow2) * (1 - cfg.FixedSlippage)
-							notional := engine.balance * initialUsage
-							stopLoss := resolveStopPrice("short", entry, sig, cfg.StopMode, cfg.StopLossATR)
-							engine.position = &strategyPosition{
-								Side:       "short",
-								EntryPrice: entry,
-								StopLoss:   stopLoss,
-								Protected:  false,
-								Notional:   notional,
-								Reason:     "Initial",
-								BarIndex:   i,
-								EntryTime:  current.Time,
-								HWM:        entry,
-								LWM:        entry,
+							if engine.zeroInitialReentryWindowEnabled() {
+								engine.armZeroInitialWindow("short", i)
+							} else {
+								entry := math.Min(current.Price, sig.PrevLow2) * (1 - cfg.FixedSlippage)
+								notional := engine.balance * initialUsage
+								stopLoss := resolveStopPrice("short", entry, sig, cfg.StopMode, cfg.StopLossATR)
+								engine.position = &strategyPosition{
+									Side:       "short",
+									EntryPrice: entry,
+									StopLoss:   stopLoss,
+									Protected:  false,
+									Notional:   notional,
+									Reason:     "Initial",
+									BarIndex:   i,
+									EntryTime:  current.Time,
+									HWM:        entry,
+									LWM:        entry,
+								}
+								tradingFee := notional * commission
+								engine.balance -= tradingFee
+								engine.totalTradingFees += tradingFee
+								engine.appendTrade("SHORT", current.Time, entry, "Initial", notional, 0, tradingFee, 0)
+								tradesInBar++
+								executed = true
 							}
-							tradingFee := notional * commission
-							engine.balance -= tradingFee
-							engine.totalTradingFees += tradingFee
-							engine.appendTrade("SHORT", current.Time, entry, "Initial", notional, 0, tradingFee, 0)
-							tradesInBar++
-							executed = true
 						}
-					} else if engine.lastExitSide == "short" && i-engine.lastExitBarIndex <= 1 {
+					}
+					hasExitWindow := engine.lastExitSide == "short" && i-engine.lastExitBarIndex <= 1
+					hasZeroWindow := engine.hasZeroInitialWindow("short", i)
+					if hasExitWindow || hasZeroWindow {
 						if current.Price <= reP {
-							reason := "PT-Reentry"
-							if engine.lastExitReason == "SL" {
-								reason = "SL-Reentry"
+							reason := "Zero-Initial-Reentry"
+							size := getReentrySize(1, cfg.ReentrySizeSchedule)
+							effectiveTradesInBar := 0
+							ok := size > 0
+							if hasExitWindow {
+								reason = "PT-Reentry"
+								if engine.lastExitReason == "SL" {
+									reason = "SL-Reentry"
+								}
+								size, effectiveTradesInBar, ok = resolveReplayReentrySlot(tradesInBar, cfg.MaxTradesPerBar, cfg.ReentrySizeSchedule)
 							}
-							if size, effectiveTradesInBar, ok := resolveReplayReentrySlot(tradesInBar, cfg.MaxTradesPerBar, cfg.ReentrySizeSchedule); ok {
+							if ok {
 								notional := engine.balance * size
 								entry := reP * (1 - cfg.FixedSlippage)
 								stopLoss := resolveStopPrice("short", entry, sig, cfg.StopMode, cfg.StopLossATR)
@@ -274,10 +313,19 @@ func (p *Platform) runStrategyReplayOnTick(cfg strategyReplayConfig, signals []s
 								engine.balance -= tradingFee
 								engine.totalTradingFees += tradingFee
 								engine.appendTrade("SHORT", current.Time, entry, reason, notional, 0, tradingFee, 0)
-								tradesInBar = effectiveTradesInBar + 1
+								if hasExitWindow {
+									tradesInBar = effectiveTradesInBar + 1
+								} else {
+									tradesInBar = 1
+								}
 								executed = true
 							}
-							engine.lastExitSide = ""
+							if hasExitWindow {
+								engine.lastExitSide = ""
+							}
+							if hasZeroWindow {
+								engine.clearZeroInitialWindow()
+							}
 						}
 					}
 				}
@@ -403,6 +451,7 @@ func runStrategyReplayOnMinuteBars(cfg strategyReplayConfig, signals []strategyS
 		if i-engine.lastExitBarIndex > 1 {
 			engine.lastExitSide = ""
 		}
+		engine.clearExpiredZeroInitialWindow(i)
 
 		for currentIdx < windowEnd {
 			bar := minuteBars[currentIdx]
@@ -420,29 +469,36 @@ func runStrategyReplayOnMinuteBars(cfg strategyReplayConfig, signals []strategyS
 					reP := sig.PrevLow1 + cfg.LongReentryATR*sig.ATR
 					if tradesInBar == 0 && sig.PrevHigh2 > sig.PrevHigh1 {
 						if bar.High >= sig.PrevHigh2 {
-							entry := math.Max(bar.Open, sig.PrevHigh2) * (1 + cfg.FixedSlippage)
-							notional := engine.balance * initialUsage
-							stopLoss := resolveStopPrice("long", entry, sig, cfg.StopMode, cfg.StopLossATR)
-							engine.position = &strategyPosition{
-								Side:       "long",
-								EntryPrice: entry,
-								StopLoss:   stopLoss,
-								Protected:  false,
-								Notional:   notional,
-								Reason:     "Initial",
-								BarIndex:   i,
-								EntryTime:  bar.Time,
-								HWM:        entry,
-								LWM:        entry,
+							if engine.zeroInitialReentryWindowEnabled() {
+								engine.armZeroInitialWindow("long", i)
+							} else {
+								entry := math.Max(bar.Open, sig.PrevHigh2) * (1 + cfg.FixedSlippage)
+								notional := engine.balance * initialUsage
+								stopLoss := resolveStopPrice("long", entry, sig, cfg.StopMode, cfg.StopLossATR)
+								engine.position = &strategyPosition{
+									Side:       "long",
+									EntryPrice: entry,
+									StopLoss:   stopLoss,
+									Protected:  false,
+									Notional:   notional,
+									Reason:     "Initial",
+									BarIndex:   i,
+									EntryTime:  bar.Time,
+									HWM:        entry,
+									LWM:        entry,
+								}
+								tradingFee := notional * commission
+								engine.balance -= tradingFee
+								engine.totalTradingFees += tradingFee
+								engine.appendTrade("BUY", bar.Time, entry, "Initial", notional, 0, tradingFee, 0)
+								tradesInBar++
+								executed = true
 							}
-							tradingFee := notional * commission
-							engine.balance -= tradingFee
-							engine.totalTradingFees += tradingFee
-							engine.appendTrade("BUY", bar.Time, entry, "Initial", notional, 0, tradingFee, 0)
-							tradesInBar++
-							executed = true
 						}
-					} else if engine.lastExitSide == "long" && i-engine.lastExitBarIndex <= 1 {
+					}
+					hasExitWindow := engine.lastExitSide == "long" && i-engine.lastExitBarIndex <= 1
+					hasZeroWindow := engine.hasZeroInitialWindow("long", i)
+					if hasExitWindow || hasZeroWindow {
 						triggered := false
 						entryRaw := reP
 						if cfg.Dir1ReentryConfirm {
@@ -454,11 +510,18 @@ func runStrategyReplayOnMinuteBars(cfg strategyReplayConfig, signals []strategyS
 							triggered = true
 						}
 						if triggered {
-							reason := "PT-Reentry"
-							if engine.lastExitReason == "SL" {
-								reason = "SL-Reentry"
+							reason := "Zero-Initial-Reentry"
+							size := getReentrySize(1, cfg.ReentrySizeSchedule)
+							effectiveTradesInBar := 0
+							ok := size > 0
+							if hasExitWindow {
+								reason = "PT-Reentry"
+								if engine.lastExitReason == "SL" {
+									reason = "SL-Reentry"
+								}
+								size, effectiveTradesInBar, ok = resolveReplayReentrySlot(tradesInBar, cfg.MaxTradesPerBar, cfg.ReentrySizeSchedule)
 							}
-							if size, effectiveTradesInBar, ok := resolveReplayReentrySlot(tradesInBar, cfg.MaxTradesPerBar, cfg.ReentrySizeSchedule); ok {
+							if ok {
 								notional := engine.balance * size
 								entry := entryRaw * (1 + cfg.FixedSlippage)
 								stopLoss := resolveStopPrice("long", entry, sig, cfg.StopMode, cfg.StopLossATR)
@@ -478,39 +541,55 @@ func runStrategyReplayOnMinuteBars(cfg strategyReplayConfig, signals []strategyS
 								engine.balance -= tradingFee
 								engine.totalTradingFees += tradingFee
 								engine.appendTrade("BUY", bar.Time, entry, reason, notional, 0, tradingFee, 0)
-								tradesInBar = effectiveTradesInBar + 1
+								if hasExitWindow {
+									tradesInBar = effectiveTradesInBar + 1
+								} else {
+									tradesInBar = 1
+								}
 								executed = true
 							}
-							engine.lastExitSide = ""
+							if hasExitWindow {
+								engine.lastExitSide = ""
+							}
+							if hasZeroWindow {
+								engine.clearZeroInitialWindow()
+							}
 						}
 					}
 				} else if shortRegimeReady {
 					reP := sig.PrevHigh1 + cfg.ShortReentryATR*sig.ATR
 					if tradesInBar == 0 && sig.PrevLow2 < sig.PrevLow1 {
 						if bar.Low <= sig.PrevLow2 {
-							entry := math.Min(bar.Open, sig.PrevLow2) * (1 - cfg.FixedSlippage)
-							notional := engine.balance * initialUsage
-							stopLoss := resolveStopPrice("short", entry, sig, cfg.StopMode, cfg.StopLossATR)
-							engine.position = &strategyPosition{
-								Side:       "short",
-								EntryPrice: entry,
-								StopLoss:   stopLoss,
-								Protected:  false,
-								Notional:   notional,
-								Reason:     "Initial",
-								BarIndex:   i,
-								EntryTime:  bar.Time,
-								HWM:        entry,
-								LWM:        entry,
+							if engine.zeroInitialReentryWindowEnabled() {
+								engine.armZeroInitialWindow("short", i)
+							} else {
+								entry := math.Min(bar.Open, sig.PrevLow2) * (1 - cfg.FixedSlippage)
+								notional := engine.balance * initialUsage
+								stopLoss := resolveStopPrice("short", entry, sig, cfg.StopMode, cfg.StopLossATR)
+								engine.position = &strategyPosition{
+									Side:       "short",
+									EntryPrice: entry,
+									StopLoss:   stopLoss,
+									Protected:  false,
+									Notional:   notional,
+									Reason:     "Initial",
+									BarIndex:   i,
+									EntryTime:  bar.Time,
+									HWM:        entry,
+									LWM:        entry,
+								}
+								tradingFee := notional * commission
+								engine.balance -= tradingFee
+								engine.totalTradingFees += tradingFee
+								engine.appendTrade("SHORT", bar.Time, entry, "Initial", notional, 0, tradingFee, 0)
+								tradesInBar++
+								executed = true
 							}
-							tradingFee := notional * commission
-							engine.balance -= tradingFee
-							engine.totalTradingFees += tradingFee
-							engine.appendTrade("SHORT", bar.Time, entry, "Initial", notional, 0, tradingFee, 0)
-							tradesInBar++
-							executed = true
 						}
-					} else if engine.lastExitSide == "short" && i-engine.lastExitBarIndex <= 1 {
+					}
+					hasExitWindow := engine.lastExitSide == "short" && i-engine.lastExitBarIndex <= 1
+					hasZeroWindow := engine.hasZeroInitialWindow("short", i)
+					if hasExitWindow || hasZeroWindow {
 						triggered := false
 						entryRaw := reP
 						if cfg.Dir1ReentryConfirm {
@@ -522,11 +601,18 @@ func runStrategyReplayOnMinuteBars(cfg strategyReplayConfig, signals []strategyS
 							triggered = true
 						}
 						if triggered {
-							reason := "PT-Reentry"
-							if engine.lastExitReason == "SL" {
-								reason = "SL-Reentry"
+							reason := "Zero-Initial-Reentry"
+							size := getReentrySize(1, cfg.ReentrySizeSchedule)
+							effectiveTradesInBar := 0
+							ok := size > 0
+							if hasExitWindow {
+								reason = "PT-Reentry"
+								if engine.lastExitReason == "SL" {
+									reason = "SL-Reentry"
+								}
+								size, effectiveTradesInBar, ok = resolveReplayReentrySlot(tradesInBar, cfg.MaxTradesPerBar, cfg.ReentrySizeSchedule)
 							}
-							if size, effectiveTradesInBar, ok := resolveReplayReentrySlot(tradesInBar, cfg.MaxTradesPerBar, cfg.ReentrySizeSchedule); ok {
+							if ok {
 								notional := engine.balance * size
 								entry := entryRaw * (1 - cfg.FixedSlippage)
 								stopLoss := resolveStopPrice("short", entry, sig, cfg.StopMode, cfg.StopLossATR)
@@ -546,10 +632,19 @@ func runStrategyReplayOnMinuteBars(cfg strategyReplayConfig, signals []strategyS
 								engine.balance -= tradingFee
 								engine.totalTradingFees += tradingFee
 								engine.appendTrade("SHORT", bar.Time, entry, reason, notional, 0, tradingFee, 0)
-								tradesInBar = effectiveTradesInBar + 1
+								if hasExitWindow {
+									tradesInBar = effectiveTradesInBar + 1
+								} else {
+									tradesInBar = 1
+								}
 								executed = true
 							}
-							engine.lastExitSide = ""
+							if hasExitWindow {
+								engine.lastExitSide = ""
+							}
+							if hasZeroWindow {
+								engine.clearZeroInitialWindow()
+							}
 						}
 					}
 				}
@@ -596,30 +691,59 @@ func runStrategyReplayOnMinuteBars(cfg strategyReplayConfig, signals []strategyS
 }
 
 type strategyReplayEngine struct {
-	cfg              strategyReplayConfig
-	balance          float64
-	position         *strategyPosition
-	lastExitReason   string
-	lastExitSide     string
-	lastExitBarIndex int
-	currentBarIndex  int
-	tradesInBar      int
-	prevExecBar      *executionBar
-	equity           []float64
-	trades           []map[string]any
-	processedCount   int
-	totalTradingFees float64
-	totalFundingPnL  float64
+	cfg                        strategyReplayConfig
+	balance                    float64
+	position                   *strategyPosition
+	lastExitReason             string
+	lastExitSide               string
+	lastExitBarIndex           int
+	pendingZeroInitialSide     string
+	pendingZeroInitialBarIndex int
+	currentBarIndex            int
+	tradesInBar                int
+	prevExecBar                *executionBar
+	equity                     []float64
+	trades                     []map[string]any
+	processedCount             int
+	totalTradingFees           float64
+	totalFundingPnL            float64
 }
 
 func newStrategyReplayEngine(cfg strategyReplayConfig) *strategyReplayEngine {
 	return &strategyReplayEngine{
-		cfg:              cfg,
-		balance:          cfg.InitialBalance,
-		lastExitBarIndex: -999,
-		equity:           []float64{cfg.InitialBalance},
-		trades:           make([]map[string]any, 0, 128),
+		cfg:                        cfg,
+		balance:                    cfg.InitialBalance,
+		lastExitBarIndex:           -999,
+		pendingZeroInitialBarIndex: -999,
+		equity:                     []float64{cfg.InitialBalance},
+		trades:                     make([]map[string]any, 0, 128),
 	}
+}
+
+func (e *strategyReplayEngine) zeroInitialReentryWindowEnabled() bool {
+	return e.cfg.Dir2ZeroInitial && e.cfg.ZeroInitialMode == strategyZeroInitialModeReentryWindow
+}
+
+func (e *strategyReplayEngine) clearExpiredZeroInitialWindow(currentBarIndex int) {
+	if currentBarIndex-e.pendingZeroInitialBarIndex > 1 {
+		e.pendingZeroInitialSide = ""
+		e.pendingZeroInitialBarIndex = -999
+	}
+}
+
+func (e *strategyReplayEngine) armZeroInitialWindow(side string, currentBarIndex int) {
+	e.pendingZeroInitialSide = strings.ToLower(strings.TrimSpace(side))
+	e.pendingZeroInitialBarIndex = currentBarIndex
+}
+
+func (e *strategyReplayEngine) hasZeroInitialWindow(side string, currentBarIndex int) bool {
+	return strings.EqualFold(strings.TrimSpace(e.pendingZeroInitialSide), strings.TrimSpace(side)) &&
+		currentBarIndex-e.pendingZeroInitialBarIndex <= 1
+}
+
+func (e *strategyReplayEngine) clearZeroInitialWindow() {
+	e.pendingZeroInitialSide = ""
+	e.pendingZeroInitialBarIndex = -999
 }
 
 func (e *strategyReplayEngine) process(bar executionBar, signals []strategySignalBar) {
@@ -630,6 +754,7 @@ func (e *strategyReplayEngine) process(bar executionBar, signals []strategySigna
 		if e.currentBarIndex-e.lastExitBarIndex > 1 {
 			e.lastExitSide = ""
 		}
+		e.clearExpiredZeroInitialWindow(e.currentBarIndex)
 	}
 
 	if e.currentBarIndex >= len(signals)-1 {
@@ -661,26 +786,33 @@ func (e *strategyReplayEngine) tryEntry(bar executionBar, sig strategySignalBar)
 		reP := sig.PrevLow1 + e.cfg.LongReentryATR*sig.ATR
 		if e.tradesInBar == 0 && sig.PrevHigh2 > sig.PrevHigh1 {
 			if bar.High >= sig.PrevHigh2 {
-				entry := math.Max(bar.Open, sig.PrevHigh2) * (1 + e.cfg.FixedSlippage)
-				notional := e.balance * initialUsage
-				stopLoss := resolveStopPrice("long", entry, sig, e.cfg.StopMode, e.cfg.StopLossATR)
-				e.position = &strategyPosition{
-					Side:       "long",
-					EntryPrice: entry,
-					StopLoss:   stopLoss,
-					Protected:  false,
-					Notional:   notional,
-					Reason:     "Initial",
-					BarIndex:   e.currentBarIndex,
-					HWM:        entry,
-					LWM:        entry,
+				if e.zeroInitialReentryWindowEnabled() {
+					e.armZeroInitialWindow("long", e.currentBarIndex)
+				} else {
+					entry := math.Max(bar.Open, sig.PrevHigh2) * (1 + e.cfg.FixedSlippage)
+					notional := e.balance * initialUsage
+					stopLoss := resolveStopPrice("long", entry, sig, e.cfg.StopMode, e.cfg.StopLossATR)
+					e.position = &strategyPosition{
+						Side:       "long",
+						EntryPrice: entry,
+						StopLoss:   stopLoss,
+						Protected:  false,
+						Notional:   notional,
+						Reason:     "Initial",
+						BarIndex:   e.currentBarIndex,
+						HWM:        entry,
+						LWM:        entry,
+					}
+					e.balance -= notional * commission
+					e.tradesInBar++
+					e.appendTrade("BUY", bar.Time, entry, "Initial", notional, 0, notional*commission, 0)
+					return
 				}
-				e.balance -= notional * commission
-				e.tradesInBar++
-				e.appendTrade("BUY", bar.Time, entry, "Initial", notional, 0, notional*commission, 0)
-				return
 			}
-		} else if e.lastExitSide == "long" && e.currentBarIndex-e.lastExitBarIndex <= 1 {
+		}
+		hasExitWindow := e.lastExitSide == "long" && e.currentBarIndex-e.lastExitBarIndex <= 1
+		hasZeroWindow := e.hasZeroInitialWindow("long", e.currentBarIndex)
+		if hasExitWindow || hasZeroWindow {
 			triggered := false
 			entryRaw := reP
 			if e.cfg.Dir1ReentryConfirm {
@@ -692,11 +824,18 @@ func (e *strategyReplayEngine) tryEntry(bar executionBar, sig strategySignalBar)
 				triggered = true
 			}
 			if triggered {
-				reason := "PT-Reentry"
-				if e.lastExitReason == "SL" {
-					reason = "SL-Reentry"
+				reason := "Zero-Initial-Reentry"
+				size := getReentrySize(1, e.cfg.ReentrySizeSchedule)
+				effectiveTradesInBar := 0
+				ok := size > 0
+				if hasExitWindow {
+					reason = "PT-Reentry"
+					if e.lastExitReason == "SL" {
+						reason = "SL-Reentry"
+					}
+					size, effectiveTradesInBar, ok = resolveReplayReentrySlot(e.tradesInBar, e.cfg.MaxTradesPerBar, e.cfg.ReentrySizeSchedule)
 				}
-				if size, effectiveTradesInBar, ok := resolveReplayReentrySlot(e.tradesInBar, e.cfg.MaxTradesPerBar, e.cfg.ReentrySizeSchedule); ok {
+				if ok {
 					notional := e.balance * size
 					entry := entryRaw * (1 + e.cfg.FixedSlippage)
 					stopLoss := resolveStopPrice("long", entry, sig, e.cfg.StopMode, e.cfg.StopLossATR)
@@ -712,10 +851,19 @@ func (e *strategyReplayEngine) tryEntry(bar executionBar, sig strategySignalBar)
 						LWM:        entry,
 					}
 					e.balance -= notional * commission
-					e.tradesInBar = effectiveTradesInBar + 1
+					if hasExitWindow {
+						e.tradesInBar = effectiveTradesInBar + 1
+					} else {
+						e.tradesInBar = 1
+					}
 					e.appendTrade("BUY", bar.Time, entry, reason, notional, 0, notional*commission, 0)
 				}
-				e.lastExitSide = ""
+				if hasExitWindow {
+					e.lastExitSide = ""
+				}
+				if hasZeroWindow {
+					e.clearZeroInitialWindow()
+				}
 			}
 		}
 		return
@@ -725,26 +873,33 @@ func (e *strategyReplayEngine) tryEntry(bar executionBar, sig strategySignalBar)
 		reP := sig.PrevHigh1 + e.cfg.ShortReentryATR*sig.ATR
 		if e.tradesInBar == 0 && sig.PrevLow2 < sig.PrevLow1 {
 			if bar.Low <= sig.PrevLow2 {
-				entry := math.Min(bar.Open, sig.PrevLow2) * (1 - e.cfg.FixedSlippage)
-				notional := e.balance * initialUsage
-				stopLoss := resolveStopPrice("short", entry, sig, e.cfg.StopMode, e.cfg.StopLossATR)
-				e.position = &strategyPosition{
-					Side:       "short",
-					EntryPrice: entry,
-					StopLoss:   stopLoss,
-					Protected:  false,
-					Notional:   notional,
-					Reason:     "Initial",
-					BarIndex:   e.currentBarIndex,
-					HWM:        entry,
-					LWM:        entry,
+				if e.zeroInitialReentryWindowEnabled() {
+					e.armZeroInitialWindow("short", e.currentBarIndex)
+				} else {
+					entry := math.Min(bar.Open, sig.PrevLow2) * (1 - e.cfg.FixedSlippage)
+					notional := e.balance * initialUsage
+					stopLoss := resolveStopPrice("short", entry, sig, e.cfg.StopMode, e.cfg.StopLossATR)
+					e.position = &strategyPosition{
+						Side:       "short",
+						EntryPrice: entry,
+						StopLoss:   stopLoss,
+						Protected:  false,
+						Notional:   notional,
+						Reason:     "Initial",
+						BarIndex:   e.currentBarIndex,
+						HWM:        entry,
+						LWM:        entry,
+					}
+					e.balance -= notional * commission
+					e.tradesInBar++
+					e.appendTrade("SHORT", bar.Time, entry, "Initial", notional, 0, notional*commission, 0)
+					return
 				}
-				e.balance -= notional * commission
-				e.tradesInBar++
-				e.appendTrade("SHORT", bar.Time, entry, "Initial", notional, 0, notional*commission, 0)
-				return
 			}
-		} else if e.lastExitSide == "short" && e.currentBarIndex-e.lastExitBarIndex <= 1 {
+		}
+		hasExitWindow := e.lastExitSide == "short" && e.currentBarIndex-e.lastExitBarIndex <= 1
+		hasZeroWindow := e.hasZeroInitialWindow("short", e.currentBarIndex)
+		if hasExitWindow || hasZeroWindow {
 			triggered := false
 			entryRaw := reP
 			if e.cfg.Dir1ReentryConfirm {
@@ -756,11 +911,18 @@ func (e *strategyReplayEngine) tryEntry(bar executionBar, sig strategySignalBar)
 				triggered = true
 			}
 			if triggered {
-				reason := "PT-Reentry"
-				if e.lastExitReason == "SL" {
-					reason = "SL-Reentry"
+				reason := "Zero-Initial-Reentry"
+				size := getReentrySize(1, e.cfg.ReentrySizeSchedule)
+				effectiveTradesInBar := 0
+				ok := size > 0
+				if hasExitWindow {
+					reason = "PT-Reentry"
+					if e.lastExitReason == "SL" {
+						reason = "SL-Reentry"
+					}
+					size, effectiveTradesInBar, ok = resolveReplayReentrySlot(e.tradesInBar, e.cfg.MaxTradesPerBar, e.cfg.ReentrySizeSchedule)
 				}
-				if size, effectiveTradesInBar, ok := resolveReplayReentrySlot(e.tradesInBar, e.cfg.MaxTradesPerBar, e.cfg.ReentrySizeSchedule); ok {
+				if ok {
 					notional := e.balance * size
 					entry := entryRaw * (1 - e.cfg.FixedSlippage)
 					stopLoss := resolveStopPrice("short", entry, sig, e.cfg.StopMode, e.cfg.StopLossATR)
@@ -776,10 +938,19 @@ func (e *strategyReplayEngine) tryEntry(bar executionBar, sig strategySignalBar)
 						LWM:        entry,
 					}
 					e.balance -= notional * commission
-					e.tradesInBar = effectiveTradesInBar + 1
+					if hasExitWindow {
+						e.tradesInBar = effectiveTradesInBar + 1
+					} else {
+						e.tradesInBar = 1
+					}
 					e.appendTrade("SHORT", bar.Time, entry, reason, notional, 0, notional*commission, 0)
 				}
-				e.lastExitSide = ""
+				if hasExitWindow {
+					e.lastExitSide = ""
+				}
+				if hasZeroWindow {
+					e.clearZeroInitialWindow()
+				}
 			}
 		}
 	}
@@ -873,6 +1044,10 @@ func buildStrategyReplayConfig(context StrategyExecutionContext) strategyReplayC
 	if stopMode == "" {
 		stopMode = "atr"
 	}
+	dir2ZeroInitial := true
+	if _, ok := parameters["dir2_zero_initial"]; ok {
+		dir2ZeroInitial = boolValue(parameters["dir2_zero_initial"])
+	}
 	stopLossATR := parseFloatValue(parameters["stop_loss_atr"])
 	if stopLossATR <= 0 {
 		stopLossATR = 0.05
@@ -885,7 +1060,8 @@ func buildStrategyReplayConfig(context StrategyExecutionContext) strategyReplayC
 		To:                   context.To,
 		InitialBalance:       100000.0,
 		Dir1ReentryConfirm:   false,
-		Dir2ZeroInitial:      true,
+		Dir2ZeroInitial:      dir2ZeroInitial,
+		ZeroInitialMode:      resolveStrategyZeroInitialMode(dir2ZeroInitial, parameters["zero_initial_mode"]),
 		FixedSlippage:        strategyReplaySlippage(context, parameters),
 		StopLossATR:          stopLossATR,
 		MaxTradesPerBar:      maxIntValue(parameters["max_trades_per_bar"], 3),

--- a/internal/service/strategy_replay_test.go
+++ b/internal/service/strategy_replay_test.go
@@ -131,6 +131,65 @@ func TestBuildStrategyReplayConfigUsesUpdatedBaselineDefaults(t *testing.T) {
 	if cfg.ShortReentryATR != 0.0 {
 		t.Fatalf("expected short reentry atr 0.0, got %v", cfg.ShortReentryATR)
 	}
+	if cfg.ZeroInitialMode != strategyZeroInitialModeReentryWindow {
+		t.Fatalf("expected zero initial mode %s, got %s", strategyZeroInitialModeReentryWindow, cfg.ZeroInitialMode)
+	}
+}
+
+func TestRunStrategyReplayOnMinuteBarsUsesZeroInitialReentryWindowForLongEntries(t *testing.T) {
+	start := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	signals := []strategySignalBar{
+		{
+			Time:      start,
+			Close:     110,
+			MA5:       100,
+			MA20:      100,
+			ATR:       10,
+			PrevHigh1: 100,
+			PrevHigh2: 105,
+			PrevLow1:  95,
+			PrevLow2:  94,
+		},
+		{Time: start.Add(24 * time.Hour)},
+	}
+	minuteBars := []candleBar{
+		{Time: start.Add(time.Minute), Open: 105, High: 106, Low: 104, Close: 105},
+		{Time: start.Add(2 * time.Minute), Open: 106, High: 106, Low: 94, Close: 95},
+	}
+	cfg := strategyReplayConfig{
+		SignalTimeframe:     "1d",
+		ExecutionDataSource: "1min",
+		InitialBalance:      100000,
+		Dir2ZeroInitial:     true,
+		ZeroInitialMode:     strategyZeroInitialModeReentryWindow,
+		FixedSlippage:       0,
+		StopLossATR:         0.05,
+		MaxTradesPerBar:     4,
+		ReentrySizeSchedule: []float64{0.10, 0.05, 0.025},
+		LongReentryATR:      0.1,
+		ShortReentryATR:     0.0,
+		StopMode:            "atr",
+		ProfitProtectATR:    1.0,
+		TradingFeeRate:      0,
+	}
+
+	result, err := runStrategyReplayOnMinuteBars(cfg, signals, minuteBars)
+	if err != nil {
+		t.Fatalf("runStrategyReplayOnMinuteBars failed: %v", err)
+	}
+	trades, err := executionTradesFromResult(result)
+	if err != nil {
+		t.Fatalf("executionTradesFromResult failed: %v", err)
+	}
+	if len(trades) != 1 {
+		t.Fatalf("expected one execution trade, got %d", len(trades))
+	}
+	if got := stringValue(trades[0]["entryReason"]); got != "Zero-Initial-Reentry" {
+		t.Fatalf("expected Zero-Initial-Reentry entry reason, got %s", got)
+	}
+	if got := parseFloatValue(trades[0]["notional"]); got <= 0 {
+		t.Fatalf("expected positive notional for zero initial reentry window, got %v", got)
+	}
 }
 
 func TestResolveReplayReentrySlotCarriesInitialBudgetAcrossBars(t *testing.T) {

--- a/internal/service/strategy_replay_test.go
+++ b/internal/service/strategy_replay_test.go
@@ -75,6 +75,19 @@ func TestNormalizeBacktestParametersCanonicalizesFiveMinuteSignalTimeframe(t *te
 	}
 }
 
+func TestNormalizeBacktestParametersDefaultsZeroInitialToReentryWindow(t *testing.T) {
+	normalized, err := NormalizeBacktestParameters(map[string]any{})
+	if err != nil {
+		t.Fatalf("expected normalization to succeed, got %v", err)
+	}
+	if !boolValue(normalized["dir2_zero_initial"]) {
+		t.Fatal("expected dir2_zero_initial to default to true")
+	}
+	if got := stringValue(normalized["zero_initial_mode"]); got != strategyZeroInitialModeReentryWindow {
+		t.Fatalf("expected zero_initial_mode=%s, got %s", strategyZeroInitialModeReentryWindow, got)
+	}
+}
+
 func TestBuildSignalBarsSupportsFiveMinuteAggregation(t *testing.T) {
 	minuteBars := make([]candleBar, 0, 12)
 	start := time.Date(2026, 4, 16, 0, 0, 0, 0, time.UTC)
@@ -133,6 +146,9 @@ func TestBuildStrategyReplayConfigUsesUpdatedBaselineDefaults(t *testing.T) {
 	}
 	if cfg.ZeroInitialMode != strategyZeroInitialModeReentryWindow {
 		t.Fatalf("expected zero initial mode %s, got %s", strategyZeroInitialModeReentryWindow, cfg.ZeroInitialMode)
+	}
+	if !cfg.Dir2ZeroInitial {
+		t.Fatal("expected dir2 zero initial to remain enabled by default")
 	}
 }
 

--- a/internal/service/strategy_zero_initial.go
+++ b/internal/service/strategy_zero_initial.go
@@ -1,0 +1,40 @@
+package service
+
+import "strings"
+
+const (
+	strategyZeroInitialModePosition      = "position"
+	strategyZeroInitialModeReentryWindow = "reentry_window"
+)
+
+func normalizeStrategyZeroInitialMode(value string) string {
+	normalized := strings.ToLower(strings.TrimSpace(value))
+	normalized = strings.ReplaceAll(normalized, "-", "_")
+	switch normalized {
+	case "", strategyZeroInitialModePosition:
+		return strategyZeroInitialModePosition
+	case strategyZeroInitialModeReentryWindow:
+		return strategyZeroInitialModeReentryWindow
+	default:
+		return strategyZeroInitialModePosition
+	}
+}
+
+func resolveStrategyZeroInitialMode(enabled bool, raw any) string {
+	if !enabled {
+		return strategyZeroInitialModePosition
+	}
+	mode := normalizeStrategyZeroInitialMode(stringValue(raw))
+	if mode == strategyZeroInitialModePosition && strings.TrimSpace(stringValue(raw)) == "" {
+		return strategyZeroInitialModeReentryWindow
+	}
+	return mode
+}
+
+func strategyZeroInitialReentryWindowEnabled(parameters map[string]any) bool {
+	enabled := true
+	if _, ok := parameters["dir2_zero_initial"]; ok {
+		enabled = boolValue(parameters["dir2_zero_initial"])
+	}
+	return resolveStrategyZeroInitialMode(enabled, parameters["zero_initial_mode"]) == strategyZeroInitialModeReentryWindow
+}

--- a/internal/service/telemetry_test.go
+++ b/internal/service/telemetry_test.go
@@ -256,6 +256,7 @@ func prepareLiveDecisionTelemetryFixture(t *testing.T) (*Platform, domain.LiveSe
 		"signalTimeframe":     "1d",
 		"executionDataSource": "tick",
 		"dispatchMode":        "manual-review",
+		"zero_initial_mode":   "position",
 	})
 	if err != nil {
 		t.Fatalf("create live session failed: %v", err)


### PR DESCRIPTION
## 目的
将最新 research 结论收敛进 canonical live/replay 语义：`dir2_zero_initial` 不再默认生成长期存活的 zero-notional / virtual initial position，而是默认进入 `reentry_window` 语义，只打开当前 signal bar 与下一根 signal bar 的 `Zero-Initial-Reentry` 窗口。

同时把这层默认值从“运行时 fallback”补成“参数面显式默认”，确保重新走 CI / 重新起 live 后立刻按新语义生效，并且 session / parameter 快照可观测。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [x] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main)
  无变化，默认仍为 `manual-review`。
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？
  无。
- [x] DB migration 是否具备向下兼容幂等性？
  无 DB migration。
- [x] 配置字段有没有无意被混改？
  仅补齐 `dir2_zero_initial` / `zero_initial_mode` 及相关 reentry/trailing 参数的 session override 透传与默认值归一化。

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

已完成验证：
- `go test ./internal/service`
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`

关键覆盖点：
- replay 默认配置默认走 `Zero-Initial-Reentry` / `reentry_window`
- live stale-plan 对齐不再默认回退为长期 virtual initial
- legacy `zero_initial_mode=position` 仍保持原有 virtual-initial 语义
- `NormalizeBacktestParameters()` 与 live session parameter resolution 现在会显式产出 `dir2_zero_initial=true`、`zero_initial_mode=reentry_window`

## 主要改动
- 新增 `internal/service/strategy_zero_initial.go` 统一 zero-initial mode 解析与默认值逻辑。
- replay 主链新增 canonical `Zero-Initial-Reentry` window 语义，并保留显式 `position` 回退模式。
- live 新增 `pendingZeroInitialWindow` 状态机，stale plan 时优先转成 zero-initial reentry window，而不是 `LiveSignalBootstrap -> virtual initial`。
- `evaluateSignalBarGate()` 允许 `Zero-Initial-Reentry` 走 reentry gate，而不是 `Initial` breakout gate。
- live / paper session override 与 parameter resolution 现在会保留并显式默认 `dir2_zero_initial`、`zero_initial_mode` 及相关 reentry/trailing 参数。

## 备注
这次改动是对 PR #77 中 research 结论的 canonical 化，不包含部署/CI/CD 调整。