### PR TITLE
[codex] treat zero-quantity live positions as flat

### DIFF
--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -649,6 +649,41 @@ func TestResolveLiveSessionPositionSnapshotUsesVirtualPosition(t *testing.T) {
 	}
 }
 
+func TestResolveLiveSessionPositionSnapshotIgnoresZeroQuantityStoredPosition(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	if _, err := platform.store.SavePosition(domain.Position{
+		AccountID:         "live-main",
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "LONG",
+		Quantity:          0,
+		EntryPrice:        69000.0,
+		MarkPrice:         69010.0,
+	}); err != nil {
+		t.Fatalf("save zero-quantity position failed: %v", err)
+	}
+
+	session := domain.LiveSession{
+		AccountID: "live-main",
+		State: map[string]any{
+			"symbol": "BTCUSDT",
+		},
+	}
+	position, found, err := platform.resolveLiveSessionPositionSnapshot(session, "BTCUSDT")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if found {
+		t.Fatal("expected zero-quantity stored position not to be treated as found")
+	}
+	if boolValue(position["found"]) {
+		t.Fatal("expected returned snapshot to remain flat for zero-quantity stored position")
+	}
+	if got := parseFloatValue(position["quantity"]); got != 0 {
+		t.Fatalf("expected zero quantity snapshot, got %v", got)
+	}
+}
+
 func TestShouldAutoDispatchLiveIntentBlocksRepeatedVirtualInitialWithinCooldown(t *testing.T) {
 	now := time.Now().UTC()
 	intent := map[string]any{
@@ -4003,6 +4038,42 @@ func TestRefreshLiveSessionPositionContextClearsStaleLivePositionStateWithoutRea
 	}
 	if liveState := mapValue(updated.State["livePositionState"]); len(liveState) != 0 {
 		t.Fatalf("expected stale livePositionState to be cleared, got %+v", liveState)
+	}
+}
+
+func TestRefreshLiveSessionPositionContextTreatsZeroQuantityStoredPositionAsFlat(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	session, err := platform.CreateLiveSession("live-main", "strategy-bk-1d", map[string]any{
+		"symbol":          "BTCUSDT",
+		"signalTimeframe": "1d",
+	})
+	if err != nil {
+		t.Fatalf("create live session failed: %v", err)
+	}
+	if _, err := platform.store.SavePosition(domain.Position{
+		AccountID:         session.AccountID,
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "LONG",
+		Quantity:          0,
+		EntryPrice:        50000.0,
+		MarkPrice:         50010.0,
+	}); err != nil {
+		t.Fatalf("save zero-quantity position failed: %v", err)
+	}
+
+	updated, err := platform.refreshLiveSessionPositionContext(session, time.Date(2026, 4, 12, 8, 0, 0, 0, time.UTC), "test-zero-qty")
+	if err != nil {
+		t.Fatalf("refresh live session position context failed: %v", err)
+	}
+	if got := stringValue(updated.State["positionRecoveryStatus"]); got != "flat" {
+		t.Fatalf("expected flat recovery status for zero-quantity stored position, got %s", got)
+	}
+	if boolValue(updated.State["hasRecoveredPosition"]) {
+		t.Fatal("expected zero-quantity stored position not to count as recovered position")
+	}
+	if got := parseFloatValue(mapValue(updated.State["recoveredPosition"])["quantity"]); got != 0 {
+		t.Fatalf("expected recovered position snapshot quantity 0, got %v", got)
 	}
 }
 

--- a/internal/service/paper.go
+++ b/internal/service/paper.go
@@ -594,7 +594,7 @@ func (p *Platform) resolvePaperSessionPositionSnapshot(accountID, symbol string)
 	if err != nil {
 		return nil, false, err
 	}
-	if !found {
+	if !found || math.Abs(position.Quantity) <= 1e-9 {
 		return map[string]any{
 			"symbol":   NormalizeSymbol(symbol),
 			"found":    false,


### PR DESCRIPTION
## 目的
修复 live recovery / strategy evaluation 对“本地遗留 `positions` 记录存在，但 `quantity=0`”的误判。

当前 `FindPosition()` 只要查到记录就会返回 `found=true`，导致 recovery 反复打 `live-position-recovered`，同时 exit 评估又因为这条仓位缺少有效的 entry/side 风控上下文而落到 `position-unavailable`。线上表现就是：
- UI 能看到一笔 `quantity=0` 的仓位
- timeline 交替出现 `live-position-recovered` 与 `position-unavailable · risk-exit-watch`

这次修复把 `quantity<=0` 的仓位快照统一收敛为 `flat`，不再被 live 当成真实持仓上下文。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [x] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main)
  无变化。
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？
  无。
- [x] DB migration 是否具备向下兼容幂等性？
  无 DB migration。
- [x] 配置字段有没有无意被混改？
  无，仅统一 `quantity<=0` 持仓快照的解释语义。

## 验证方式与测试证据
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

已完成验证：
- `go test ./internal/service`
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`

新增覆盖点：
- `TestResolveLiveSessionPositionSnapshotIgnoresZeroQuantityStoredPosition`
- `TestRefreshLiveSessionPositionContextTreatsZeroQuantityStoredPositionAsFlat`

## 主要改动
- `resolvePaperSessionPositionSnapshot()` 现在把 `quantity<=0` 的遗留仓位记录视为 `found=false` / `flat`。
- live recovery 因为复用该快照逻辑，不再把 0 数量遗留仓位写成 `hasRecoveredPosition=true`，也不会继续沿用 exit 语境。
- 保留现有 virtual position 语义，不影响 `virtualPosition` 的 `reentry_window` / `position` 两种模式。

## 备注
这是对已合并 PR #78 后线上观察到的状态不一致修复，单独开新 PR，不叠到已合并分支上。