### PR TITLE
[codex] clarify live exit diagnostics

### DIFF
--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -545,6 +545,79 @@ func TestEvaluateLiveExitStateTriggersSLForLong(t *testing.T) {
 	}
 }
 
+func TestEvaluateLiveExitStateUsesTrailingStopDiagnosticsForLong(t *testing.T) {
+	state := evaluateLiveExitState(map[string]any{
+		"profit_protect_atr":              1.0,
+		"stop_loss_atr":                   0.05,
+		"stop_mode":                       "atr",
+		"trailing_stop_atr":               0.3,
+		"delayed_trailing_activation_atr": 0.5,
+	}, map[string]any{
+		"found":      true,
+		"symbol":     "BTCUSDT",
+		"side":       "LONG",
+		"quantity":   0.002,
+		"entryPrice": 69000.0,
+	}, map[string]any{
+		"atr14": 900.0,
+		"current": map[string]any{
+			"close": 69600.0,
+		},
+		"prevBar1": map[string]any{
+			"high": 69700.0,
+			"low":  68800.0,
+		},
+		"prevBar2": map[string]any{
+			"high": 69650.0,
+			"low":  68700.0,
+		},
+	}, 69600.0, map[string]any{}, "SL")
+	if boolValue(state["ready"]) {
+		t.Fatal("expected trailing SL to remain untriggered while price stays above the tightened stop")
+	}
+	if got := stringValue(state["waitReason"]); got != "trailing-sl-not-triggered" {
+		t.Fatalf("expected trailing-sl-not-triggered, got %s", got)
+	}
+	if got := stringValue(state["targetPriceSource"]); got != "trailing-stop" {
+		t.Fatalf("expected targetPriceSource trailing-stop, got %s", got)
+	}
+	if !boolValue(state["trailingStopActive"]) {
+		t.Fatal("expected trailingStopActive to be surfaced in exit diagnostics")
+	}
+}
+
+func TestEvaluateLiveExitStateReportsMissingEntryPrice(t *testing.T) {
+	state := evaluateLiveExitState(map[string]any{
+		"profit_protect_atr": 1.0,
+		"stop_loss_atr":      0.05,
+		"stop_mode":          "atr",
+	}, map[string]any{
+		"found":    true,
+		"symbol":   "BTCUSDT",
+		"side":     "LONG",
+		"quantity": 0.002,
+	}, map[string]any{
+		"atr14": 900.0,
+		"current": map[string]any{
+			"close": 68940.0,
+		},
+		"prevBar1": map[string]any{
+			"high": 69500.0,
+			"low":  68800.0,
+		},
+		"prevBar2": map[string]any{
+			"high": 69400.0,
+			"low":  68700.0,
+		},
+	}, 68940.0, map[string]any{}, "SL")
+	if boolValue(state["ready"]) {
+		t.Fatal("expected exit state to stay blocked when entry price is unavailable")
+	}
+	if got := stringValue(state["waitReason"]); got != "position-unavailable-missing-entry-price" {
+		t.Fatalf("expected position-unavailable-missing-entry-price, got %s", got)
+	}
+}
+
 func TestAdjustLiveExecutionProposalForVirtualInitialWhenZeroInitialEnabled(t *testing.T) {
 	proposal := adjustLiveExecutionProposalForVirtualSemantics(domain.LiveSession{}, map[string]any{
 		"dir2_zero_initial": true,

--- a/internal/service/strategy_registry.go
+++ b/internal/service/strategy_registry.go
@@ -956,6 +956,31 @@ func evaluateLivePositionState(parameters map[string]any, currentPosition map[st
 	return deriveLivePositionState(parameters, currentPosition, signalBarState, marketPrice, watermarks)
 }
 
+func explainLivePositionUnavailable(currentPosition map[string]any, signalBarState map[string]any) string {
+	if !boolValue(currentPosition["found"]) && parseFloatValue(currentPosition["quantity"]) <= 0 && !boolValue(currentPosition["virtual"]) {
+		return "position-unavailable-no-active-position"
+	}
+	if entryPrice := parseFloatValue(currentPosition["entryPrice"]); entryPrice <= 0 {
+		return "position-unavailable-missing-entry-price"
+	}
+	if side := strings.TrimSpace(stringValue(currentPosition["side"])); side == "" {
+		return "position-unavailable-missing-side"
+	}
+	current := mapValue(signalBarState["current"])
+	if current == nil {
+		return "position-unavailable-missing-current-bar"
+	}
+	prevBar1 := mapValue(signalBarState["prevBar1"])
+	if prevBar1 == nil {
+		return "position-unavailable-missing-prev-bar-1"
+	}
+	prevBar2 := mapValue(signalBarState["prevBar2"])
+	if prevBar2 == nil {
+		return "position-unavailable-missing-prev-bar-2"
+	}
+	return "position-unavailable"
+}
+
 func deriveLivePositionState(parameters map[string]any, currentPosition map[string]any, signalBarState map[string]any, marketPrice float64, watermarks livePositionWatermarks) map[string]any {
 	if !boolValue(currentPosition["found"]) && parseFloatValue(currentPosition["quantity"]) <= 0 && !boolValue(currentPosition["virtual"]) {
 		return nil
@@ -986,16 +1011,35 @@ func deriveLivePositionState(parameters map[string]any, currentPosition map[stri
 	if stopLossATR <= 0 {
 		stopLossATR = 0.05
 	}
+	baseStopLoss := resolveStopPrice(side, entryPrice, sig, stopMode, stopLossATR)
 	stopLoss := parseFloatValue(currentPosition["stopLoss"])
 	if stopLoss <= 0 {
-		stopLoss = resolveStopPrice(side, entryPrice, sig, stopMode, stopLossATR)
+		stopLoss = baseStopLoss
+	}
+	stopLossSource := "initial-stop"
+	if baseStopLoss > 0 {
+		switch side {
+		case "long":
+			if stopLoss > baseStopLoss {
+				stopLossSource = "trailing-stop"
+			}
+		case "short":
+			if stopLoss < baseStopLoss {
+				stopLossSource = "trailing-stop"
+			}
+		}
 	}
 	hwm := firstPositive(watermarks.HWM, entryPrice)
 	lwm := firstPositive(watermarks.LWM, entryPrice)
 
 	// Calculate Trailing Stop Loss
+	trailingStopConfigured := parseFloatValue(parameters["trailing_stop_atr"])
+	trailingStopActive := false
+	trailingActivationArmed := false
+	trailingStopCandidate := 0.0
 	if trailingStopATR := parseFloatValue(parameters["trailing_stop_atr"]); trailingStopATR > 0 {
 		isActive := true
+		trailingActivationArmed = true
 		if delayedActivation := parseFloatValue(parameters["delayed_trailing_activation_atr"]); delayedActivation > 0 {
 			profitATR := 0.0
 			if sig.ATR > 0 {
@@ -1011,15 +1055,20 @@ func deriveLivePositionState(parameters map[string]any, currentPosition map[stri
 		}
 
 		if isActive && sig.ATR > 0 {
+			trailingStopActive = true
 			if side == "long" {
 				trailingSL := hwm - trailingStopATR*sig.ATR
+				trailingStopCandidate = trailingSL
 				if trailingSL > stopLoss {
 					stopLoss = trailingSL
+					stopLossSource = "trailing-stop"
 				}
 			} else if side == "short" {
 				trailingSL := lwm + trailingStopATR*sig.ATR
+				trailingStopCandidate = trailingSL
 				if trailingSL < stopLoss {
 					stopLoss = trailingSL
+					stopLossSource = "trailing-stop"
 				}
 			}
 		}
@@ -1040,20 +1089,26 @@ func deriveLivePositionState(parameters map[string]any, currentPosition map[stri
 		}
 	}
 	return map[string]any{
-		"found":                true,
-		"symbol":               NormalizeSymbol(stringValue(currentPosition["symbol"])),
-		"side":                 strings.ToUpper(side),
-		"entryPrice":           entryPrice,
-		"stopLoss":             stopLoss,
-		"protected":            protected,
-		"protectionTrigger":    protectionPrice,
-		"prevHigh1":            sig.PrevHigh1,
-		"prevLow1":             sig.PrevLow1,
-		"atr14":                sig.ATR,
-		"profitProtectATR":     profitProtectATR,
-		"hwm":                  hwm,
-		"lwm":                  lwm,
-		"watermarkPositionKey": watermarks.PositionKey,
+		"found":                   true,
+		"symbol":                  NormalizeSymbol(stringValue(currentPosition["symbol"])),
+		"side":                    strings.ToUpper(side),
+		"entryPrice":              entryPrice,
+		"baseStopLoss":            baseStopLoss,
+		"stopLoss":                stopLoss,
+		"stopLossSource":          stopLossSource,
+		"trailingStopConfigured":  trailingStopConfigured > 0,
+		"trailingStopActive":      trailingStopActive,
+		"trailingActivationArmed": trailingActivationArmed,
+		"trailingStopCandidate":   trailingStopCandidate,
+		"protected":               protected,
+		"protectionTrigger":       protectionPrice,
+		"prevHigh1":               sig.PrevHigh1,
+		"prevLow1":                sig.PrevLow1,
+		"atr14":                   sig.ATR,
+		"profitProtectATR":        profitProtectATR,
+		"hwm":                     hwm,
+		"lwm":                     lwm,
+		"watermarkPositionKey":    watermarks.PositionKey,
 	}
 }
 
@@ -1065,6 +1120,14 @@ func updateLivePositionWatermarks(sessionState map[string]any, currentPosition m
 func evaluateLiveExitState(parameters map[string]any, currentPosition map[string]any, signalBarState map[string]any, marketPrice float64, sessionState map[string]any, nextReason string) map[string]any {
 	watermarks := refreshLivePositionWatermarks(sessionState, currentPosition, marketPrice)
 	positionState := deriveLivePositionState(parameters, currentPosition, signalBarState, marketPrice, watermarks)
+	if len(positionState) == 0 {
+		waitReason := explainLivePositionUnavailable(currentPosition, signalBarState)
+		return map[string]any{
+			"ready":             false,
+			"waitReason":        waitReason,
+			"unavailableReason": waitReason,
+		}
+	}
 	return deriveLiveExitState(parameters, currentPosition, positionState, marketPrice, nextReason)
 }
 
@@ -1088,13 +1151,19 @@ func deriveLiveExitState(parameters map[string]any, currentPosition map[string]a
 		switch reasonTag {
 		case "sl":
 			state["targetPrice"] = stopLoss
+			state["targetPriceSource"] = firstNonEmpty(stringValue(positionState["stopLossSource"]), "initial-stop")
 			if marketPrice > 0 && stopLoss > 0 && marketPrice <= stopLoss {
 				state["ready"] = true
 			} else {
-				state["waitReason"] = "sl-not-triggered"
+				if strings.EqualFold(stringValue(positionState["stopLossSource"]), "trailing-stop") {
+					state["waitReason"] = "trailing-sl-not-triggered"
+				} else {
+					state["waitReason"] = "sl-not-triggered"
+				}
 			}
 		case "pt":
 			state["targetPrice"] = prevLow1
+			state["targetPriceSource"] = "structure-profit"
 			if !protected {
 				state["waitReason"] = "profit-protection-not-armed"
 			} else if marketPrice > 0 && prevLow1 > 0 && marketPrice <= prevLow1 {
@@ -1107,13 +1176,19 @@ func deriveLiveExitState(parameters map[string]any, currentPosition map[string]a
 		switch reasonTag {
 		case "sl":
 			state["targetPrice"] = stopLoss
+			state["targetPriceSource"] = firstNonEmpty(stringValue(positionState["stopLossSource"]), "initial-stop")
 			if marketPrice > 0 && stopLoss > 0 && marketPrice >= stopLoss {
 				state["ready"] = true
 			} else {
-				state["waitReason"] = "sl-not-triggered"
+				if strings.EqualFold(stringValue(positionState["stopLossSource"]), "trailing-stop") {
+					state["waitReason"] = "trailing-sl-not-triggered"
+				} else {
+					state["waitReason"] = "sl-not-triggered"
+				}
 			}
 		case "pt":
 			state["targetPrice"] = prevHigh1
+			state["targetPriceSource"] = "structure-profit"
 			if !protected {
 				state["waitReason"] = "profit-protection-not-armed"
 			} else if marketPrice > 0 && prevHigh1 > 0 && marketPrice >= prevHigh1 {


### PR DESCRIPTION
## 目的
这次改动聚焦 live exit 诊断可读性，帮助定位当前 `position-unavailable` 与移动止损日志过于模糊的问题。

具体包括：
- 将笼统的 `position-unavailable` 拆成更具体的缺因日志，如缺少 `entryPrice`、`side`、`current/prev` signal bar 等
- 在 `SL` 退出诊断里标明当前止损来源是 `initial-stop` 还是 `trailing-stop`
- 当 trailing stop 已生效但尚未触发时，使用更明确的 `trailing-sl-not-triggered` 等待原因

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [x] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
- [x] `dispatchMode` 默认值无变化
- [x] 不涉及 `mainnet` 凭证或路由硬编码
- [x] 不涉及 DB migration
- [x] 未混改策略默认参数或下单路径

## 验证方式与测试证据
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

本地已验证：
- `go test ./internal/service`
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`

新增回归覆盖：
- `TestEvaluateLiveExitStateUsesTrailingStopDiagnosticsForLong`
- `TestEvaluateLiveExitStateReportsMissingEntryPrice`

## 额外说明
这次 PR 只增强 live exit 诊断字段与日志语义，不改变 dispatch mode、下单触发、SL/PT 命中条件或 live session 生命周期。