### PR TITLE
[codex] recover live entry price during sync

### DIFF
--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -901,10 +901,15 @@ func (p *Platform) syncLiveAccountFromBinance(account domain.Account, binding ma
 		}
 		riskKey := strings.ToUpper(strings.TrimSpace(stringValue(item["symbol"]))) + "|" + strings.ToUpper(strings.TrimSpace(stringValue(item["positionSide"])))
 		risk := positionRiskIndex[riskKey]
+		entryPrice := resolveRecoveredLiveEntryPrice(
+			parseFloatValue(item["entryPrice"]),
+			parseFloatValue(risk["entryPrice"]),
+			parseFloatValue(risk["breakEvenPrice"]),
+		)
 		openPositions = append(openPositions, map[string]any{
 			"symbol":           stringValue(item["symbol"]),
 			"positionAmt":      positionAmt,
-			"entryPrice":       parseFloatValue(item["entryPrice"]),
+			"entryPrice":       entryPrice,
 			"markPrice":        firstPositive(parseFloatValue(risk["markPrice"]), parseFloatValue(item["markPrice"])),
 			"unrealizedProfit": firstPositive(parseFloatValue(risk["unRealizedProfit"]), parseFloatValue(item["unrealizedProfit"])),
 			"liquidationPrice": parseFloatValue(risk["liquidationPrice"]),
@@ -1564,10 +1569,14 @@ func (p *Platform) reconcileLiveAccountPositions(account domain.Account, exchang
 			side = "SHORT"
 		}
 		quantity := math.Abs(positionAmt)
-		entryPrice := parseFloatValue(item["entryPrice"])
-		markPrice := firstPositive(parseFloatValue(item["markPrice"]), entryPrice)
 		strategyVersionID := p.resolveLivePositionStrategyVersionID(account.ID, symbol)
 		position := existingBySymbol[symbol]
+		entryPrice := resolveRecoveredLiveEntryPrice(
+			parseFloatValue(item["entryPrice"]),
+			parseFloatValue(item["breakEvenPrice"]),
+			position.EntryPrice,
+		)
+		markPrice := firstPositive(parseFloatValue(item["markPrice"]), entryPrice)
 		position.AccountID = account.ID
 		position.StrategyVersionID = firstNonEmpty(strategyVersionID, position.StrategyVersionID)
 		position.Symbol = symbol
@@ -1589,6 +1598,10 @@ func (p *Platform) reconcileLiveAccountPositions(account domain.Account, exchang
 		}
 	}
 	return nil
+}
+
+func resolveRecoveredLiveEntryPrice(primary, secondary, fallback float64) float64 {
+	return firstPositive(primary, firstPositive(secondary, fallback))
 }
 
 func (p *Platform) resolveLivePositionStrategyVersionID(accountID, symbol string) string {

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -4470,6 +4470,154 @@ func TestSyncLiveAccountDoesNotDoubleCountPersistedAdapterSuccessHealth(t *testi
 	}
 }
 
+func TestResolveRecoveredLiveEntryPriceFallsBackThroughRiskAndExistingValues(t *testing.T) {
+	if got := resolveRecoveredLiveEntryPrice(74500.0, 74400.0, 74300.0); got != 74500.0 {
+		t.Fatalf("expected primary entry price to win, got %v", got)
+	}
+	if got := resolveRecoveredLiveEntryPrice(0, 74400.0, 74300.0); got != 74400.0 {
+		t.Fatalf("expected secondary entry price fallback, got %v", got)
+	}
+	if got := resolveRecoveredLiveEntryPrice(0, 0, 74300.0); got != 74300.0 {
+		t.Fatalf("expected existing entry price fallback, got %v", got)
+	}
+}
+
+func TestReconcileLiveAccountPositionsFallsBackToBreakEvenPrice(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	account, err := platform.store.GetAccount("live-main")
+	if err != nil {
+		t.Fatalf("get account failed: %v", err)
+	}
+
+	err = platform.reconcileLiveAccountPositions(account, []map[string]any{
+		{
+			"symbol":         "BTCUSDT",
+			"positionAmt":    -0.002,
+			"entryPrice":     0.0,
+			"breakEvenPrice": 74512.34,
+			"markPrice":      74618.69,
+		},
+	})
+	if err != nil {
+		t.Fatalf("reconcile live account positions failed: %v", err)
+	}
+
+	position, found, err := platform.store.FindPosition("live-main", "BTCUSDT")
+	if err != nil {
+		t.Fatalf("find position failed: %v", err)
+	}
+	if !found {
+		t.Fatal("expected reconciled BTCUSDT position")
+	}
+	if position.Side != "SHORT" {
+		t.Fatalf("expected SHORT side, got %s", position.Side)
+	}
+	if position.EntryPrice != 74512.34 {
+		t.Fatalf("expected breakEvenPrice fallback to populate entry price, got %v", position.EntryPrice)
+	}
+}
+
+func TestReconcileLiveAccountPositionsPreservesExistingEntryPriceWhenSnapshotIsZero(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	if _, err := platform.store.SavePosition(domain.Position{
+		AccountID:         "live-main",
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "SHORT",
+		Quantity:          0.002,
+		EntryPrice:        74123.45,
+		MarkPrice:         74618.69,
+	}); err != nil {
+		t.Fatalf("save position failed: %v", err)
+	}
+	account, err := platform.store.GetAccount("live-main")
+	if err != nil {
+		t.Fatalf("get account failed: %v", err)
+	}
+
+	err = platform.reconcileLiveAccountPositions(account, []map[string]any{
+		{
+			"symbol":      "BTCUSDT",
+			"positionAmt": -0.002,
+			"entryPrice":  0.0,
+			"markPrice":   74618.69,
+		},
+	})
+	if err != nil {
+		t.Fatalf("reconcile live account positions failed: %v", err)
+	}
+
+	position, found, err := platform.store.FindPosition("live-main", "BTCUSDT")
+	if err != nil {
+		t.Fatalf("find position failed: %v", err)
+	}
+	if !found {
+		t.Fatal("expected reconciled BTCUSDT position")
+	}
+	if position.EntryPrice != 74123.45 {
+		t.Fatalf("expected existing entry price to be preserved, got %v", position.EntryPrice)
+	}
+}
+
+func TestRefreshLiveSessionPositionContextBuildsRiskStateFromRecoveredBreakEvenEntryPrice(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	account, err := platform.store.GetAccount("live-main")
+	if err != nil {
+		t.Fatalf("get account failed: %v", err)
+	}
+	account.Metadata = cloneMetadata(account.Metadata)
+	account.Metadata["liveSyncSnapshot"] = map[string]any{
+		"openOrders": []map[string]any{},
+	}
+	if _, err := platform.store.UpdateAccount(account); err != nil {
+		t.Fatalf("update account failed: %v", err)
+	}
+
+	if err := platform.reconcileLiveAccountPositions(account, []map[string]any{
+		{
+			"symbol":         "BTCUSDT",
+			"positionAmt":    -0.002,
+			"entryPrice":     0.0,
+			"breakEvenPrice": 74512.34,
+			"markPrice":      74520.0,
+		},
+	}); err != nil {
+		t.Fatalf("reconcile live account positions failed: %v", err)
+	}
+
+	session, err := platform.CreateLiveSession("live-main", "strategy-bk-1d", map[string]any{
+		"symbol":          "BTCUSDT",
+		"signalTimeframe": "1d",
+	})
+	if err != nil {
+		t.Fatalf("create live session failed: %v", err)
+	}
+	state := cloneMetadata(session.State)
+	state["lastStrategyEvaluationSignalBarStates"] = testLiveRecoverySignalBarStates("BTCUSDT", 74520.0)
+	session, err = platform.store.UpdateLiveSessionState(session.ID, state)
+	if err != nil {
+		t.Fatalf("update live session state failed: %v", err)
+	}
+
+	updated, err := platform.refreshLiveSessionPositionContext(session, time.Date(2026, 4, 20, 2, 0, 0, 0, time.UTC), "test-refresh")
+	if err != nil {
+		t.Fatalf("refresh live session position context failed: %v", err)
+	}
+	liveState := mapValue(updated.State["livePositionState"])
+	if len(liveState) == 0 {
+		t.Fatal("expected live position state to be rebuilt from recovered entry price")
+	}
+	if got := parseFloatValue(liveState["entryPrice"]); got != 74512.34 {
+		t.Fatalf("expected recovered break-even entry price in live position state, got %v", got)
+	}
+	if got := stringValue(liveState["side"]); got != "SHORT" {
+		t.Fatalf("expected SHORT live position side, got %s", got)
+	}
+	if got := stringValue(updated.State["positionRecoveryStatus"]); got != "unprotected-open-position" {
+		t.Fatalf("expected unprotected-open-position without recovered protection orders, got %s", got)
+	}
+}
+
 type testLiveAccountSyncAdapter struct {
 	key                 string
 	syncErr             error


### PR DESCRIPTION
## 目的
修复 live 持仓恢复链里 `entryPrice` 被同步成 `0` 的问题，避免真实持仓进入 `position-unavailable`、无法建立内部风控状态、也无法触发 watchdog fallback 的危险状态。

这次改动做了两层兜底：
- Binance 账户同步构造 `openPositions` 时，`entryPrice` 依次回退到 `positionRisk.entryPrice`、`breakEvenPrice`
- reconcile 本地 `positions` 时，如果交易所快照里的 `entryPrice` 仍然缺失，则回退到 `breakEvenPrice`，最后保留本地已有有效 `EntryPrice`

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [x] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
- [x] `dispatchMode` 默认值无变化
- [x] 不涉及 `mainnet` 凭证或路由硬编码
- [x] 不涉及 DB migration
- [x] 未混改策略默认参数、下单路径或退出触发条件

## 验证方式与测试证据
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

本地已验证：
- `go test ./internal/service -run 'TestResolveRecoveredLiveEntryPriceFallsBackThroughRiskAndExistingValues|TestReconcileLiveAccountPositionsFallsBackToBreakEvenPrice|TestReconcileLiveAccountPositionsPreservesExistingEntryPriceWhenSnapshotIsZero|TestRefreshLiveSessionPositionContextBuildsRiskStateFromRecoveredBreakEvenEntryPrice'`
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`

新增回归覆盖：
- `TestResolveRecoveredLiveEntryPriceFallsBackThroughRiskAndExistingValues`
- `TestReconcileLiveAccountPositionsFallsBackToBreakEvenPrice`
- `TestReconcileLiveAccountPositionsPreservesExistingEntryPriceWhenSnapshotIsZero`
- `TestRefreshLiveSessionPositionContextBuildsRiskStateFromRecoveredBreakEvenEntryPrice`

## 额外说明
这次 PR 只修复持仓同步/恢复的 `entryPrice` fallback，不改变 SL/PT 判定、trailing stop 语义、dispatch mode 默认值或 session 生命周期。