### PR TITLE
fix(console): 增加数值显示精度 (最多8位)

### DIFF
--- a/web/console/src/utils/format.ts
+++ b/web/console/src/utils/format.ts
@@ -34,12 +34,16 @@ export function formatNumber(value?: number, digits = 2) {
   return value.toFixed(digits);
 }
 
-export function formatMaybeNumber(value: unknown) {
+export function formatMaybeNumber(value: unknown, maxDigits = 8) {
   const number = getNumber(value);
   if (number == null) {
     return "--";
   }
-  return number.toFixed(2);
+  return new Intl.NumberFormat("en-US", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: maxDigits,
+    useGrouping: false,
+  }).format(number);
 }
 
 export function formatTime(value: string) {


### PR DESCRIPTION
## 目的
解决前端数值显示精度不足的问题。之前 `formatMaybeNumber` 硬编码为两位小数，导致交易数量（如 0.002）被错误显示为 0.00。
本次改动将最大精度提升至 8 位，同时保留至少两位小数以维持视觉一致性。

## 本次改动风险定级
- [x] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)

## AI Agent 参与声明
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
- [x] `dispatchMode` 默认值有否变化？ (无变化)
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？ (无)

## 验证方式与测试证据
- 已运行 TypeScript 类型检查确保调用方兼容。
- 此格式化函数的改动在全站通用（MonitorStage, DockContent, AccountStage 等），能够统一提升用户体验。