### PR TITLE
[codex] Fix live manual close and watchdog recovery gating

### DIFF
--- a/internal/service/alerts.go
+++ b/internal/service/alerts.go
@@ -311,6 +311,8 @@ func (p *Platform) ListAlerts() ([]domain.PlatformAlert, error) {
 		}
 		recoveryStatus := strings.TrimSpace(stringValue(state["protectionRecoveryStatus"]))
 		recoveryError := strings.TrimSpace(stringValue(state["lastRecoveryError"]))
+		recoveryAuthoritative := boolValue(state["protectionRecoveryAuthoritative"])
+		recoverySource := firstNonEmpty(strings.TrimSpace(stringValue(state["protectionRecoverySource"])), "local-fallback")
 		eventTime := parseOptionalRFC3339(firstNonEmpty(stringValue(state["lastProtectionRecoveryAt"]), stringValue(state["lastRecoveryAttemptAt"])))
 		if recoveryError != "" {
 			appendAlert(domain.PlatformAlert{
@@ -327,6 +329,26 @@ func (p *Platform) ListAlerts() ([]domain.PlatformAlert, error) {
 			})
 		}
 		if recoveryStatus == "unprotected-open-position" {
+			if !recoveryAuthoritative {
+				appendAlert(domain.PlatformAlert{
+					ID:           fmt.Sprintf("live-recovery-awaiting-authoritative-sync-%s", session.ID),
+					Scope:        "live",
+					Level:        "warning",
+					Title:        "Recovery awaiting authoritative sync",
+					Detail:       fmt.Sprintf("watchdog auto-exit is paused because recovery state came from %s; run a successful live account sync or reconcile to confirm exchange positions and open orders", recoverySource),
+					AccountID:    session.AccountID,
+					StrategyID:   session.StrategyID,
+					StrategyName: strategyNameByID[session.StrategyID],
+					Anchor:       "live",
+					EventTime:    eventTime,
+					Metadata: map[string]any{
+						"protectionRecoverySource":        recoverySource,
+						"protectionRecoveryAuthoritative": false,
+						"watchdogAutoExitPaused":          true,
+					},
+				})
+				continue
+			}
 			appendAlert(domain.PlatformAlert{
 				ID:           fmt.Sprintf("live-unprotected-position-%s", session.ID),
 				Scope:        "live",

--- a/internal/service/health_state_test.go
+++ b/internal/service/health_state_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -219,6 +220,49 @@ func TestUpdateRuntimePolicyAllowsDisablingHealthThresholds(t *testing.T) {
 	}
 	if updated.LiveAccountSyncFreshnessSecs != 0 {
 		t.Fatalf("expected live account sync freshness threshold to allow zero, got %d", updated.LiveAccountSyncFreshnessSecs)
+	}
+}
+
+func TestListAlertsShowsAuthoritativeSyncWarningForLocalRecoveryFallback(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	session, err := platform.store.GetLiveSession("live-session-main")
+	if err != nil {
+		t.Fatalf("get live session failed: %v", err)
+	}
+
+	state := cloneMetadata(session.State)
+	state["protectionRecoveryStatus"] = "unprotected-open-position"
+	state["positionRecoveryStatus"] = "unprotected-open-position"
+	state["protectionRecoveryAuthoritative"] = false
+	state["protectionRecoverySource"] = "platform-live-reconciliation"
+	state["lastProtectionRecoveryAt"] = time.Date(2026, 4, 20, 3, 0, 0, 0, time.UTC).Format(time.RFC3339)
+	session.State = state
+	if _, err := platform.store.UpdateLiveSession(session); err != nil {
+		t.Fatalf("update live session failed: %v", err)
+	}
+
+	alerts, err := platform.ListAlerts()
+	if err != nil {
+		t.Fatalf("list alerts failed: %v", err)
+	}
+
+	foundSyncWarning := false
+	for _, alert := range alerts {
+		if alert.ID == "live-recovery-awaiting-authoritative-sync-"+session.ID {
+			foundSyncWarning = true
+			if alert.Level != "warning" {
+				t.Fatalf("expected warning level, got %s", alert.Level)
+			}
+			if !strings.Contains(alert.Detail, "watchdog auto-exit is paused") {
+				t.Fatalf("expected pause detail in alert, got %s", alert.Detail)
+			}
+		}
+		if alert.ID == "live-unprotected-position-"+session.ID {
+			t.Fatal("expected local fallback recovery to suppress authoritative unprotected-position alert")
+		}
+	}
+	if !foundSyncWarning {
+		t.Fatal("expected authoritative sync warning alert to be present")
 	}
 }
 

--- a/internal/service/live_recovery.go
+++ b/internal/service/live_recovery.go
@@ -17,6 +17,8 @@ func (p *Platform) refreshLiveSessionProtectionState(session domain.LiveSession)
 	}
 	snapshot := cloneMetadata(mapValue(account.Metadata["liveSyncSnapshot"]))
 	openOrders := metadataList(snapshot["openOrders"])
+	protectionRecoverySource := strings.TrimSpace(stringValue(snapshot["source"]))
+	protectionRecoveryAuthoritative := liveProtectionSnapshotIsAuthoritative(snapshot)
 	sessionSymbol := NormalizeSymbol(firstNonEmpty(stringValue(session.State["symbol"]), stringValue(session.State["lastSymbol"])))
 	position, found, err := p.resolvePaperSessionPositionSnapshot(session.AccountID, sessionSymbol)
 	if err != nil {
@@ -53,6 +55,8 @@ func (p *Platform) refreshLiveSessionProtectionState(session domain.LiveSession)
 	state["recoveredTakeProfitOrderCount"] = len(takeProfitOrders)
 	state["lastProtectionRecoveryAt"] = time.Now().UTC().Format(time.RFC3339)
 	state["lastProtectionRecoverySymbol"] = sessionSymbol
+	state["protectionRecoverySource"] = protectionRecoverySource
+	state["protectionRecoveryAuthoritative"] = protectionRecoveryAuthoritative
 	state["recoveredStopOrder"] = firstMetadataOrEmpty(stopOrders)
 	state["recoveredTakeProfitOrder"] = firstMetadataOrEmpty(takeProfitOrders)
 
@@ -182,7 +186,9 @@ func (p *Platform) refreshLiveSessionPositionContext(session domain.LiveSession,
 		watchdogExitPending = syncLiveWatchdogExitState(state, eventTime)
 	}
 
-	if !watchdogExitPending && stringValue(state["positionRecoveryStatus"]) == "unprotected-open-position" {
+	if !watchdogExitPending &&
+		boolValue(state["protectionRecoveryAuthoritative"]) &&
+		stringValue(state["positionRecoveryStatus"]) == "unprotected-open-position" {
 		stopLoss := parseFloatValue(livePositionState["stopLoss"])
 		entryPrice := parseFloatValue(livePositionState["entryPrice"])
 		quantity := math.Abs(parseFloatValue(positionSnapshot["quantity"]))
@@ -275,6 +281,11 @@ func firstMetadataOrEmpty(items []map[string]any) map[string]any {
 		return map[string]any{}
 	}
 	return cloneMetadata(items[0])
+}
+
+func liveProtectionSnapshotIsAuthoritative(snapshot map[string]any) bool {
+	source := strings.TrimSpace(stringValue(snapshot["source"]))
+	return !strings.EqualFold(source, "platform-live-reconciliation")
 }
 
 func syncLiveWatchdogExitState(state map[string]any, eventTime time.Time) bool {

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -4053,6 +4053,73 @@ func TestRefreshLiveSessionPositionContextDoesNotGenerateWatchdogFallbackFromLoc
 	}
 }
 
+func TestRefreshLiveSessionPositionContextGeneratesWatchdogFallbackFromAuthoritativeSyncSnapshot(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	account, err := platform.store.GetAccount("live-main")
+	if err != nil {
+		t.Fatalf("get account failed: %v", err)
+	}
+	account.Metadata = cloneMetadata(account.Metadata)
+	account.Metadata["liveSyncSnapshot"] = map[string]any{
+		"source":         "binance-rest-account-v3",
+		"syncStatus":     "SYNCED",
+		"openOrderCount": 0,
+		"openOrders":     []map[string]any{},
+	}
+	if _, err := platform.store.UpdateAccount(account); err != nil {
+		t.Fatalf("update account failed: %v", err)
+	}
+	if _, err := platform.store.SavePosition(domain.Position{
+		AccountID:         "live-main",
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "LONG",
+		Quantity:          0.002,
+		EntryPrice:        69000,
+		MarkPrice:         68900,
+	}); err != nil {
+		t.Fatalf("save position failed: %v", err)
+	}
+
+	session, err := platform.CreateLiveSession("live-main", "strategy-bk-1d", map[string]any{
+		"symbol":          "BTCUSDT",
+		"signalTimeframe": "1d",
+	})
+	if err != nil {
+		t.Fatalf("create live session failed: %v", err)
+	}
+	state := cloneMetadata(session.State)
+	state["lastStrategyEvaluationSignalBarStates"] = testLiveRecoverySignalBarStates("BTCUSDT", 68900.0)
+	session, err = platform.store.UpdateLiveSessionState(session.ID, state)
+	if err != nil {
+		t.Fatalf("update live session state failed: %v", err)
+	}
+
+	updated, err := platform.refreshLiveSessionPositionContext(session, time.Date(2026, 4, 17, 4, 10, 0, 0, time.UTC), "test-refresh")
+	if err != nil {
+		t.Fatalf("refresh live session position context failed: %v", err)
+	}
+	proposal := executionProposalFromMap(mapValue(updated.State["lastExecutionProposal"]))
+	if proposal.Reason != "sl-breached-fallback" {
+		t.Fatalf("expected sl-breached-fallback reason, got %s", proposal.Reason)
+	}
+	if proposal.Side != "SELL" {
+		t.Fatalf("expected SELL exit side, got %s", proposal.Side)
+	}
+	if proposal.Type != "MARKET" || !proposal.ReduceOnly {
+		t.Fatalf("expected reduce-only MARKET fallback proposal, got type=%s reduceOnly=%t", proposal.Type, proposal.ReduceOnly)
+	}
+	if got := stringValue(updated.State["positionRecoveryStatus"]); got != livePositionRecoveryStatusClosingPending {
+		t.Fatalf("expected %s recovery status, got %s", livePositionRecoveryStatusClosingPending, got)
+	}
+	if !boolValue(updated.State["protectionRecoveryAuthoritative"]) {
+		t.Fatal("expected exchange sync snapshot to remain authoritative")
+	}
+	if got := stringValue(updated.State["protectionRecoverySource"]); got != "binance-rest-account-v3" {
+		t.Fatalf("expected authoritative recovery source to be recorded, got %s", got)
+	}
+}
+
 func TestRefreshLiveSessionPositionContextRebuildsVirtualWatermarksFromVirtualPosition(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
 	session, err := platform.CreateLiveSession("live-main", "strategy-bk-1d", map[string]any{

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -3994,6 +3994,65 @@ func TestRefreshLiveSessionPositionContextTracksActiveReduceOnlyExitOrder(t *tes
 	}
 }
 
+func TestRefreshLiveSessionPositionContextDoesNotGenerateWatchdogFallbackFromLocalSyncSnapshot(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	account, err := platform.store.GetAccount("live-main")
+	if err != nil {
+		t.Fatalf("get account failed: %v", err)
+	}
+	account.Metadata = cloneMetadata(account.Metadata)
+	account.Metadata["liveSyncSnapshot"] = map[string]any{
+		"source":         "platform-live-reconciliation",
+		"syncStatus":     "SYNCED",
+		"openOrderCount": 0,
+	}
+	if _, err := platform.store.UpdateAccount(account); err != nil {
+		t.Fatalf("update account failed: %v", err)
+	}
+	if _, err := platform.store.SavePosition(domain.Position{
+		AccountID:         "live-main",
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "LONG",
+		Quantity:          0.002,
+		EntryPrice:        69000,
+		MarkPrice:         68900,
+	}); err != nil {
+		t.Fatalf("save position failed: %v", err)
+	}
+
+	session, err := platform.CreateLiveSession("live-main", "strategy-bk-1d", map[string]any{
+		"symbol":          "BTCUSDT",
+		"signalTimeframe": "1d",
+	})
+	if err != nil {
+		t.Fatalf("create live session failed: %v", err)
+	}
+	state := cloneMetadata(session.State)
+	state["lastStrategyEvaluationSignalBarStates"] = testLiveRecoverySignalBarStates("BTCUSDT", 68900.0)
+	session, err = platform.store.UpdateLiveSessionState(session.ID, state)
+	if err != nil {
+		t.Fatalf("update live session state failed: %v", err)
+	}
+
+	updated, err := platform.refreshLiveSessionPositionContext(session, time.Date(2026, 4, 17, 4, 5, 0, 0, time.UTC), "test-refresh")
+	if err != nil {
+		t.Fatalf("refresh live session position context failed: %v", err)
+	}
+	if proposal := mapValue(updated.State["lastExecutionProposal"]); len(proposal) != 0 {
+		t.Fatalf("expected local fallback snapshot to suppress watchdog proposal, got %+v", proposal)
+	}
+	if got := stringValue(updated.State["positionRecoveryStatus"]); got != "unprotected-open-position" {
+		t.Fatalf("expected unprotected-open-position to remain while awaiting authoritative sync, got %s", got)
+	}
+	if boolValue(updated.State["protectionRecoveryAuthoritative"]) {
+		t.Fatal("expected local fallback snapshot to be marked non-authoritative")
+	}
+	if got := stringValue(updated.State["protectionRecoverySource"]); got != "platform-live-reconciliation" {
+		t.Fatalf("expected local fallback recovery source to be recorded, got %s", got)
+	}
+}
+
 func TestRefreshLiveSessionPositionContextRebuildsVirtualWatermarksFromVirtualPosition(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
 	session, err := platform.CreateLiveSession("live-main", "strategy-bk-1d", map[string]any{

--- a/internal/service/order.go
+++ b/internal/service/order.go
@@ -50,11 +50,12 @@ func buildClosePositionOrder(position domain.Position) domain.Order {
 		Quantity:          position.Quantity,
 		ReduceOnly:        true,
 		Metadata: map[string]any{
-			"source":       "manual-position-close",
-			"positionId":   position.ID,
-			"markPrice":    position.MarkPrice,
-			"priceHint":    position.MarkPrice,
-			"manualAction": "close-position",
+			"source":           "manual-position-close",
+			"positionId":       position.ID,
+			"markPrice":        position.MarkPrice,
+			"priceHint":        position.MarkPrice,
+			"manualAction":     "close-position",
+			"skipRuntimeCheck": true,
 		},
 	}
 }

--- a/internal/service/order_test.go
+++ b/internal/service/order_test.go
@@ -198,6 +198,44 @@ func TestFinalizeExecutedOrderUsesExchangeTradeTimeForLastFilledAt(t *testing.T)
 	}
 }
 
+func TestClosePositionAllowsLiveManualCloseWithoutRuntimeSession(t *testing.T) {
+	store := memory.NewStore()
+	platform := NewPlatform(store)
+	platform.registerLiveAdapter(testLiveAccountSyncAdapter{key: "test-manual-close"})
+
+	account, err := platform.BindLiveAccount("live-main", map[string]any{
+		"adapterKey": "test-manual-close",
+	})
+	if err != nil {
+		t.Fatalf("bind live account failed: %v", err)
+	}
+
+	position, err := store.SavePosition(domain.Position{
+		AccountID: account.ID,
+		Symbol:    "BTCUSDT",
+		Side:      "LONG",
+		Quantity:  0.25,
+		MarkPrice: 68100,
+	})
+	if err != nil {
+		t.Fatalf("save live position failed: %v", err)
+	}
+
+	order, err := platform.ClosePosition(position.ID)
+	if err != nil {
+		t.Fatalf("expected live manual close to bypass runtime session checks, got %v", err)
+	}
+	if got := boolValue(order.Metadata["skipRuntimeCheck"]); !got {
+		t.Fatal("expected live manual close order to set skipRuntimeCheck")
+	}
+	if got := order.Status; got != "ACCEPTED" {
+		t.Fatalf("expected live manual close order to be accepted, got %s", got)
+	}
+	if got := stringValue(order.Metadata["runtimeSessionId"]); got != "" {
+		t.Fatalf("expected bypassed live manual close to avoid linking a runtime session, got %s", got)
+	}
+}
+
 func TestFinalizeExecutedOrderFallsBackToNowWhenExchangeTradeTimeMissing(t *testing.T) {
 	store := memory.NewStore()
 	platform := NewPlatform(store)


### PR DESCRIPTION
## 目的
修复两个实盘干预/恢复链路问题：

1. 手动强平在 LIVE 模式下，如果没有可用的 runtime session 或无法解析 strategyVersionId，会被 runtime readiness 校验拦截，导致紧急人工平仓失败。
2. live recovery / watchdog 在只拿到本地 fallback 恢复状态时，可能基于非权威的本地持仓视图再次生成平仓 proposal，存在重复发退出信号的风险。

另外补了一条明确告警：当恢复状态来自本地 fallback 时，提示当前正在等待权威交易所同步，watchdog 自动平仓已暂停。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [x] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
- [x] `dispatchMode` 默认值有否变化？无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？无
- [x] DB migration 是否具备向下兼容幂等性？未涉及
- [x] 配置字段有没有无意被混改？已检查，无额外混改

## 验证方式与测试证据
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

已执行：
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`

本次改动摘要：
- `internal/service/order.go`: 手动平仓订单注入 `skipRuntimeCheck=true`，让紧急人工强平复用现有 bypass 机制。
- `internal/service/order_test.go`: 覆盖 LIVE 无 runtime session 的手动强平下单路径。
- `internal/service/live_recovery.go`: 记录恢复快照来源/权威性，只允许权威交易所快照触发新的 watchdog fallback proposal。
- `internal/service/alerts.go`: 对本地 fallback 恢复增加“等待权威同步、watchdog 自动平仓已暂停”的明确告警。
- `internal/service/live_test.go` / `internal/service/health_state_test.go`: 补充防重复平仓与告警提示的回归测试。

## AI 参与说明
本 PR 由 Codex 协助完成实现、测试与 PR 草稿整理。