### PR TITLE
[codex] fix #85 live recovery close-only fallback

### DIFF
--- a/docs/research-runtime-recovery-review-plan.md
+++ b/docs/research-runtime-recovery-review-plan.md
@@ -1,0 +1,317 @@
+# Research Runtime Recovery and Passive-Close Code Review & Remediation Plan
+
+## Background
+
+The research strategy logic was originally validated in offline backtesting and paper-like flows. Those environments do not fully exercise runtime-specific failure modes such as service restart, recovery of persisted positions, exchange state drift, or passive close execution for positions that were opened in a previous process.
+
+In production-like live execution, the main bugs are not in the entry logic itself, but in the runtime handover path:
+
+- service restarts and runtime recovery
+- takeover of persisted historical positions
+- passive close of previously opened positions
+- exchange synchronization and reconciliation drift
+- missing execution metadata during recovery-triggered exits
+
+A representative failure pattern is an exit path that can decide to close a recovered position, but cannot actually route the order because required runtime metadata is missing or inconsistent.
+
+This plan defines how to review, judge, and remediate those paths.
+
+---
+
+## Review Objectives
+
+The goal is not to re-validate signal generation formulas. The goal is to prove that runtime state remains correct and actionable across restart, recovery, and takeover scenarios.
+
+The review covers three high-risk scenarios:
+
+1. **Restart & Recovery**  
+   After backend restart, the system must correctly rediscover and manage previously open positions.
+
+2. **Passive Close of Historical Positions**  
+   The system must be able to close positions loaded from DB or synced from the exchange even when the current process did not create the original entry.
+
+3. **Exchange Synchronization & Reconciliation**  
+   The system must prevent DB, in-memory state, session state, and Binance reality from drifting into contradictory truths.
+
+---
+
+## Core Review Principles
+
+The review must follow the runtime fact chain, not just file-by-file code reading.
+
+For every path, answer these four questions in order:
+
+1. **Fact source**: what is the authoritative truth for the current position and order state?
+2. **Internal state**: how is that truth represented in DB, session state, and runtime state?
+3. **Behavior**: what trading action can the system take from that state?
+4. **Recovery**: after restart, can the system reconstruct the same truth and the same allowed behavior?
+
+Anything that relies on cached or inferred state without reconciling against an authoritative fact source must be treated as high risk.
+
+---
+
+## Review Workstreams
+
+### A. Position Fact Source Review
+
+#### Goal
+Identify every place where the system decides whether a position exists, what side it is on, what quantity it has, and what entry price it uses.
+
+#### Scope
+- `internal/service/live*.go`
+- position store/repository accessors
+- order/fill derived position reconstruction
+- session state readers such as `livePositionState`, `recoveredPosition`, `virtualPosition`
+- exchange snapshot and sync functions
+
+#### Review Questions
+For each function that reads or reconstructs position state:
+
+1. What is the primary source of truth?
+   - DB position
+   - exchange position snapshot
+   - session state cache
+   - order/fill inference
+
+2. Is the source a fact source, a cache, or a derived approximation?
+
+3. If multiple sources are mixed, is there an explicit priority order?
+
+4. Can a stale cached value overwrite a newer factual value?
+
+5. Can `0`, empty, or missing fields be written back as if they were real values?
+
+#### Required Output
+A source-of-truth matrix for:
+- normal running state
+- startup recovery
+- takeover of historical positions
+- exchange reconcile path
+
+---
+
+### B. Restart Recovery Review
+
+#### Goal
+Verify that restart recovery is deterministic, idempotent, and safe.
+
+#### Scope
+- startup recovery flow
+- live session recovery
+- runtime session recovery
+- position recovery and plan recovery
+- session status rehydration
+
+#### Review Questions
+1. Is there a single recovery entrypoint, or multiple competing recovery paths?
+2. Is recovery idempotent if triggered twice?
+3. Can restart recovery accidentally trigger a new entry or duplicate exit?
+4. Are recovered session fields sufficient to rebuild the same runtime semantics as before restart?
+5. Is there any implicit auto-advance of plan state before position truth is re-established?
+
+#### Required Judgment Rules
+Recovery is acceptable only if:
+- running recovery multiple times yields the same state
+- missing session cache does not erase a real position
+- recovery does not silently fabricate tradeable context from incomplete metadata
+- recovery cannot auto-dispatch until position truth is confirmed
+
+---
+
+### C. Historical Position Takeover Review
+
+#### Goal
+Review the path where the system inherits an already-open position and is only expected to manage or close it.
+
+#### Key Scenarios
+1. DB position exists and exchange position exists and they match
+2. DB position exists but exchange position does not
+3. DB position does not exist but exchange position exists
+4. DB and exchange positions both exist but side, quantity, or entry price differ
+
+#### Review Questions
+1. Does the system distinguish takeover mode from normal fresh-entry mode?
+2. Does takeover mode allow only a restricted action set?
+3. If position truth cannot be proven, does the system enter a restricted error/stale/conflict state?
+4. Can the system accidentally treat a recovered historical position as a fresh strategy cycle?
+
+#### Required Action Matrix
+Define explicit allowed behavior per recovery state, for example:
+- `close-only-takeover`
+- `recovery-monitoring`
+- `unprotected-open-position`
+- `recovery-conflict`
+- `stale-sync`
+
+For each state, define whether the system may:
+- open a new position
+- close an existing position
+- place protection orders
+- auto-dispatch
+- require manual review
+
+---
+
+### D. Execution Path and Passive-Close Routing Review
+
+#### Goal
+Ensure that recovery-triggered exit orders go through a complete and safe execution path.
+
+#### Scope
+- `internal/service/execution_strategy.go`
+- order routing and order creation path
+- exchange-specific submit path
+- metadata assembly and order context generation
+
+#### Review Questions
+1. When a close decision is triggered for a recovered position, does the system still provide all required execution metadata?
+2. Can the passive-close path skip metadata injection steps that are present for fresh orders?
+3. Can the path fail because `strategyVersionId`, runtime link, or execution context is missing?
+4. Are exchange-facing fields such as `reduceOnly`, `closePosition`, `positionSide`, and direction always validated for close-only behavior?
+5. In hedge mode, is close routing precise enough to avoid cross-side mistakes?
+
+#### Mandatory Remediation Item
+Recovered historical positions must not rely on an incomplete execution shortcut. Recovery-triggered close orders must pass through the same metadata completeness checks as normal execution.
+
+---
+
+### E. Exchange Sync and Hard Reconciliation Review
+
+#### Goal
+Prevent divergence between DB state, in-memory state, session state, and Binance reality.
+
+#### Scope
+- exchange REST sync
+- websocket runtime updates
+- reconcile functions
+- position and open-order snapshot ingestion
+- reconciliation docs and requirements
+
+#### Review Questions
+1. Is there a combined WS + REST consistency model, or is the system over-trusting one side?
+2. Before takeover becomes actionable, does the system force a hard REST reconciliation?
+3. After WS reconnect or restart, can the system prove that local state still matches the exchange?
+4. If Binance shows no position but DB still has one, does the system stop instead of issuing a blind exit?
+5. Can stale local data be re-promoted into authoritative state during fallback?
+
+#### Mandatory Remediation Item
+Before a recovered historical position becomes eligible for monitoring, protection, or exit execution, the system must perform a synchronous Binance REST position check. If local and remote facts do not match, the system must enter `stale`, `conflict`, or `error` state and block automated actions.
+
+---
+
+### F. Plan Index and Runtime State Machine Review
+
+#### Goal
+Ensure that plan recovery and runtime progression never move ahead of proven position truth.
+
+#### Review Questions
+1. Can `planIndexRecoveredFromPosition` or similar logic advance plan state before the recovered position is validated?
+2. Does the runtime state machine explicitly distinguish normal running state from recovery state?
+3. Is there any “seamless transition” assumption that hides unresolved inconsistency?
+4. If runtime/session linkage cannot be re-established, does the system downgrade into a restricted close-only mode rather than fabricating a normal linked state?
+
+#### Required Rule
+Plan progression must never auto-advance solely because a position-like shape was reconstructed. Position truth must be validated first.
+
+---
+
+## Required Additions to the Existing Plan
+
+The following items are mandatory additions and must be explicitly included in implementation and review:
+
+### 1. Recovery Context Completion Check
+When taking over a historical position, the system must validate whether `StrategyVersionId`, execution context, and usable runtime/session linkage can be reconstructed. If not, it must not continue into a normal execution path.
+
+### 2. Hard Reconcile Before Takeover Becomes Actionable
+Recovered positions must not become tradable based only on DB state. A hard Binance REST position check is required before allowing automatic monitoring or close execution.
+
+### 3. Full Metadata Assembly for Recovery-Triggered Close Orders
+Recovery-triggered exits must not bypass metadata injection. They must carry the same minimum context guarantees as standard order execution.
+
+### 4. Reduce-Only Safety Guard
+All historical-position close orders must pass a reduce-only safety check before exchange submission. This is a final guardrail, not a substitute for correct state recovery.
+
+### 5. WS + REST Dual-Channel Consistency Model
+WS provides timeliness; REST provides authoritative catch-up. Restart, WS reconnect, and historical takeover must each force explicit REST verification.
+
+### 6. No Automatic Plan Progression from Unproven Recovery
+Recovered runtime state may enter monitoring, but cannot auto-progress into normal strategy action unless position truth is verified.
+
+### 7. Explicit Action Matrix for Takeover States
+Recovery-specific states must define allowed actions for open, close, protection, auto-dispatch, and manual review.
+
+### 8. Targeted Runtime Verification Scenarios
+The test plan must explicitly cover DB-backed historical takeover, exchange-only takeover, mismatch scenarios, and duplicate-exit prevention.
+
+---
+
+## Remediation Plan
+
+### Phase 1: Deep Code Review
+Deliverables:
+- source-of-truth matrix
+- restart recovery sequence diagram
+- takeover action matrix
+- list of P0/P1/P2 defects
+- minimum regression test inventory
+
+### Phase 2: Runtime Safety Fixes
+Priority order:
+1. Recovery metadata completion and close-only fallback mode
+2. Hard reconciliation gate before takeover activation
+3. Execution-path metadata completeness for passive-close orders
+4. Reduce-only safety guard at exchange submit boundary
+5. Plan/runtime state machine restrictions during recovery
+6. WS reconnect and restart consistency checks
+
+### Phase 3: Verification and Smoke Testing
+Use mock/testnet or equivalent safe environment.
+
+Required scenarios:
+1. DB position exists, no active process, startup takeover succeeds
+2. DB position exists, exchange matches, close signal executes without missing-context errors
+3. DB position exists, exchange missing, system blocks automated close and marks stale/conflict
+4. Exchange position exists, DB missing, system enters takeover mode without treating it as a fresh entry cycle
+5. Existing open exit order is recognized so recovery does not create a duplicate exit order
+6. Partial fill followed by restart preserves quantity truth and close behavior
+
+---
+
+## Severity Classification
+
+### P0
+May cause:
+- duplicate order submission
+- wrong-side closing
+- unintended reverse opening
+- failure to close a real position
+- closing based on false local state
+
+### P1
+May cause:
+- recovery state drift
+- missing risk state
+- blocked passive-close path
+- incorrect plan index progression
+- watchdog/protection not rebuilding correctly
+
+### P2
+May cause:
+- weak observability
+- incomplete logging
+- missing or shallow regression tests
+
+---
+
+## Final Review Standard
+
+The review is complete only when the team can prove the following:
+
+1. A recovered historical position is never treated as tradable solely because it exists in DB.
+2. A recovery-triggered close order never reaches the exchange without complete execution metadata.
+3. Restart recovery is idempotent and cannot silently drift plan/runtime state.
+4. Exchange truth can override stale local assumptions in a controlled way.
+5. Recovery-specific runtime states have an explicit action matrix.
+6. The regression suite contains startup takeover, mismatch, and duplicate-exit scenarios.
+
+If those conditions are not met, the runtime recovery and passive-close flow must still be considered unsafe for live use.

--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"reflect"
 	"sort"
 	"strings"
 	"time"
@@ -767,7 +768,11 @@ func (p *Platform) RecoverLiveTradingOnStartup(ctx context.Context) {
 		state := cloneMetadata(recovered.State)
 		delete(state, "lastRecoveryError")
 		state["lastRecoveryAttemptAt"] = time.Now().UTC().Format(time.RFC3339)
-		state["lastRecoveryStatus"] = "recovered"
+		if isLiveSessionRecoveryCloseOnlyMode(state) {
+			state["lastRecoveryStatus"] = liveRecoveryModeCloseOnlyTakeover
+		} else {
+			state["lastRecoveryStatus"] = "recovered"
+		}
 		_, _ = p.store.UpdateLiveSessionState(recovered.ID, state)
 	}
 	logger.Info("live trading recovery completed",
@@ -1525,18 +1530,39 @@ func (p *Platform) recoverRunningLiveSession(session domain.LiveSession) (domain
 	if _, syncErr := p.SyncLiveAccount(account.ID); syncErr != nil {
 		// Keep recovery moving so runtime monitoring can still come back.
 	}
+	session, recoveredPosition, incompleteRecoveryMetadata, err := p.completeRecoveredLiveSessionMetadata(session)
+	if err != nil {
+		return domain.LiveSession{}, err
+	}
+	if incompleteRecoveryMetadata {
+		session, err = p.enterRecoveredLiveSessionCloseOnlyMode(session, recoveredPosition, "missing-strategy-version", "recovered position is missing strategyVersionId")
+		if err != nil {
+			return domain.LiveSession{}, err
+		}
+		session, _ = p.refreshLiveSessionPositionContext(session, time.Now().UTC(), "live-startup-recovery-close-only")
+		return session, nil
+	}
 	session, err = p.syncLiveSessionRuntime(session)
 	if err != nil {
+		if recoveredPosition.Quantity > 0 {
+			return p.enterRecoveredLiveSessionCloseOnlyMode(session, recoveredPosition, "runtime-linkage-unavailable", err.Error())
+		}
 		return domain.LiveSession{}, err
 	}
 	session, err = p.ensureLiveSessionSignalRuntimeStarted(session)
 	if err != nil {
+		if recoveredPosition.Quantity > 0 {
+			return p.enterRecoveredLiveSessionCloseOnlyMode(session, recoveredPosition, "runtime-linkage-unavailable", err.Error())
+		}
 		return domain.LiveSession{}, err
 	}
 	if strings.TrimSpace(stringValue(session.State["lastDispatchedOrderId"])) != "" {
 		session, _ = p.syncLatestLiveSessionOrder(session, time.Now().UTC())
 	}
 	session, _ = p.refreshLiveSessionPositionContext(session, time.Now().UTC(), "live-startup-recovery")
+	if isLiveSessionRecoveryCloseOnlyMode(session.State) {
+		return session, nil
+	}
 	return p.store.UpdateLiveSessionStatus(session.ID, "RUNNING")
 }
 
@@ -1605,23 +1631,7 @@ func resolveRecoveredLiveEntryPrice(primary, secondary, fallback float64) float6
 }
 
 func (p *Platform) resolveLivePositionStrategyVersionID(accountID, symbol string) string {
-	sessions, err := p.ListLiveSessions()
-	if err == nil {
-		for _, session := range sessions {
-			if session.AccountID != accountID {
-				continue
-			}
-			sessionSymbol := NormalizeSymbol(firstNonEmpty(stringValue(session.State["symbol"]), stringValue(session.State["lastSymbol"])))
-			if sessionSymbol != "" && sessionSymbol != symbol {
-				continue
-			}
-			version, versionErr := p.resolveCurrentStrategyVersion(session.StrategyID)
-			if versionErr == nil {
-				return version.ID
-			}
-		}
-	}
-	return ""
+	return p.inferReconcileStrategyVersionID(accountID, symbol)
 }
 
 func (p *Platform) StopLiveSession(sessionID string) (domain.LiveSession, error) {
@@ -2172,6 +2182,15 @@ func isLivePlanStepStale(nextPlannedEvent time.Time, signalTimeframe string, now
 
 func (p *Platform) syncLiveSessionRuntime(session domain.LiveSession) (domain.LiveSession, error) {
 	state := cloneMetadata(session.State)
+	if isLiveSessionRecoveryCloseOnlyMode(state) {
+		state["runtimeMode"] = liveRecoveryModeCloseOnlyTakeover
+		state["signalRuntimeMode"] = liveRecoveryModeCloseOnlyTakeover
+		state["signalRuntimeRequired"] = false
+		state["signalRuntimeReady"] = false
+		delete(state, "signalRuntimeSessionId")
+		delete(state, "signalRuntimeStatus")
+		return p.store.UpdateLiveSessionState(session.ID, state)
+	}
 	plan, err := p.BuildSignalRuntimePlan(session.AccountID, session.StrategyID)
 	if err != nil {
 		state["signalRuntimeMode"] = "detached"
@@ -2305,6 +2324,21 @@ func (p *Platform) stopLinkedLiveSignalRuntime(session domain.LiveSession) (doma
 }
 
 func (p *Platform) ensureLiveExecutionPlan(session domain.LiveSession) (domain.LiveSession, []paperPlannedOrder, error) {
+	session, recoveredPosition, incompleteRecoveryMetadata, err := p.completeRecoveredLiveSessionMetadata(session)
+	if err != nil {
+		return domain.LiveSession{}, nil, err
+	}
+	if incompleteRecoveryMetadata {
+		session, err = p.enterRecoveredLiveSessionCloseOnlyMode(session, recoveredPosition, "missing-strategy-version", "recovered position is missing strategyVersionId")
+		if err != nil {
+			return domain.LiveSession{}, nil, err
+		}
+		return session, nil, fmt.Errorf("live session %s is in close-only takeover mode", session.ID)
+	}
+	if isLiveSessionRecoveryCloseOnlyMode(session.State) {
+		return session, nil, fmt.Errorf("live session %s is in close-only takeover mode", session.ID)
+	}
+
 	p.mu.Lock()
 	if plan, ok := p.livePlans[session.ID]; ok {
 		p.mu.Unlock()
@@ -2316,7 +2350,7 @@ func (p *Platform) ensureLiveExecutionPlan(session domain.LiveSession) (domain.L
 	}
 	p.mu.Unlock()
 
-	session, err := p.syncLiveSessionRuntime(session)
+	session, err = p.syncLiveSessionRuntime(session)
 	if err != nil {
 		return domain.LiveSession{}, nil, err
 	}
@@ -2400,6 +2434,129 @@ func (p *Platform) ensureLiveExecutionPlan(session domain.LiveSession) (domain.L
 		return domain.LiveSession{}, nil, err
 	}
 	return updatedSession, plan, nil
+}
+
+const (
+	liveRecoveryModeCloseOnlyTakeover    = "close-only-takeover"
+	liveRecoveryMetadataStatusComplete   = "complete"
+	liveRecoveryMetadataStatusIncomplete = "incomplete"
+)
+
+func isLiveSessionRecoveryCloseOnlyMode(state map[string]any) bool {
+	return strings.EqualFold(strings.TrimSpace(stringValue(state["recoveryMode"])), liveRecoveryModeCloseOnlyTakeover)
+}
+
+func buildRecoveredLivePositionStateSnapshot(position domain.Position) map[string]any {
+	if position.Quantity <= 0 {
+		return map[string]any{}
+	}
+	return map[string]any{
+		"id":                position.ID,
+		"symbol":            NormalizeSymbol(position.Symbol),
+		"side":              position.Side,
+		"quantity":          position.Quantity,
+		"entryPrice":        position.EntryPrice,
+		"markPrice":         position.MarkPrice,
+		"strategyVersionId": position.StrategyVersionID,
+		"updatedAt":         position.UpdatedAt.UTC().Format(time.RFC3339),
+		"found":             true,
+	}
+}
+
+func (p *Platform) completeRecoveredLiveSessionMetadata(session domain.LiveSession) (domain.LiveSession, domain.Position, bool, error) {
+	symbol := NormalizeSymbol(firstNonEmpty(stringValue(session.State["symbol"]), stringValue(session.State["lastSymbol"])))
+	if symbol == "" {
+		return session, domain.Position{}, false, nil
+	}
+	position, found, err := p.store.FindPosition(session.AccountID, symbol)
+	if err != nil {
+		return domain.LiveSession{}, domain.Position{}, false, err
+	}
+	if !found || position.Quantity <= 0 {
+		state := cloneMetadata(session.State)
+		delete(state, "recoveryMetadataStatus")
+		delete(state, "recoveryMetadataMissing")
+		delete(state, "recoveryMetadataCompletedAt")
+		if !metadataEqual(state, session.State) {
+			session, err = p.store.UpdateLiveSessionState(session.ID, state)
+			if err != nil {
+				return domain.LiveSession{}, domain.Position{}, false, err
+			}
+		}
+		return session, domain.Position{}, false, nil
+	}
+
+	state := cloneMetadata(session.State)
+	if strings.TrimSpace(position.StrategyVersionID) == "" {
+		position.StrategyVersionID = p.resolveLivePositionStrategyVersionID(session.AccountID, symbol)
+		if strings.TrimSpace(position.StrategyVersionID) != "" {
+			position, err = p.store.SavePosition(position)
+			if err != nil {
+				return domain.LiveSession{}, domain.Position{}, false, err
+			}
+		}
+	}
+	if strings.TrimSpace(position.StrategyVersionID) == "" {
+		state["recoveryMetadataStatus"] = liveRecoveryMetadataStatusIncomplete
+		state["recoveryMetadataMissing"] = []any{"strategyVersionId"}
+		if !metadataEqual(state, session.State) {
+			session, err = p.store.UpdateLiveSessionState(session.ID, state)
+			if err != nil {
+				return domain.LiveSession{}, domain.Position{}, false, err
+			}
+		}
+		return session, position, true, nil
+	}
+
+	state["strategyVersionId"] = position.StrategyVersionID
+	state["recoveryMetadataStatus"] = liveRecoveryMetadataStatusComplete
+	state["recoveryMetadataCompletedAt"] = time.Now().UTC().Format(time.RFC3339)
+	delete(state, "recoveryMetadataMissing")
+	delete(state, "recoveryMode")
+	delete(state, "recoveryCloseOnlyReason")
+	delete(state, "recoveryCloseOnlyDetail")
+	delete(state, "recoveryCloseOnlyAt")
+	if !metadataEqual(state, session.State) {
+		session, err = p.store.UpdateLiveSessionState(session.ID, state)
+		if err != nil {
+			return domain.LiveSession{}, domain.Position{}, false, err
+		}
+	}
+	return session, position, false, nil
+}
+
+func (p *Platform) enterRecoveredLiveSessionCloseOnlyMode(session domain.LiveSession, position domain.Position, reason, detail string) (domain.LiveSession, error) {
+	state := cloneMetadata(session.State)
+	state["recoveryMode"] = liveRecoveryModeCloseOnlyTakeover
+	state["runtimeMode"] = liveRecoveryModeCloseOnlyTakeover
+	state["signalRuntimeMode"] = liveRecoveryModeCloseOnlyTakeover
+	state["signalRuntimeRequired"] = false
+	state["signalRuntimeReady"] = false
+	state["recoveryMetadataStatus"] = liveRecoveryMetadataStatusIncomplete
+	state["recoveryCloseOnlyReason"] = reason
+	state["recoveryCloseOnlyDetail"] = detail
+	state["recoveryCloseOnlyAt"] = time.Now().UTC().Format(time.RFC3339)
+	state["lastStrategyEvaluationStatus"] = liveRecoveryModeCloseOnlyTakeover
+	state["positionRecoveryStatus"] = liveRecoveryModeCloseOnlyTakeover
+	state["recoveredPosition"] = buildRecoveredLivePositionStateSnapshot(position)
+	state["hasRecoveredPosition"] = position.Quantity > 0
+	state["hasRecoveredRealPosition"] = position.Quantity > 0
+	state["hasRecoveredVirtualPosition"] = false
+	delete(state, "signalRuntimeSessionId")
+	delete(state, "signalRuntimeStatus")
+	delete(state, "lastExecutionProposal")
+	delete(state, "lastStrategyIntent")
+	delete(state, "lastSignalIntent")
+	delete(state, "lastStrategyIntentSignature")
+	session, err := p.store.UpdateLiveSessionState(session.ID, state)
+	if err != nil {
+		return domain.LiveSession{}, err
+	}
+	return p.store.UpdateLiveSessionStatus(session.ID, "BLOCKED")
+}
+
+func metadataEqual(left, right map[string]any) bool {
+	return reflect.DeepEqual(left, right)
 }
 
 func (p *Platform) reconcileLiveSessionPlanIndex(session domain.LiveSession, plan []paperPlannedOrder, recoveredAt time.Time, source string) (domain.LiveSession, error) {

--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -1427,10 +1427,18 @@ func (p *Platform) StartLiveSession(sessionID string) (domain.LiveSession, error
 		logger.Warn("resolve live adapter failed", "error", err)
 		return domain.LiveSession{}, err
 	}
-	session, _, _, err = p.completeRecoveredLiveSessionMetadata(session)
+	session, recoveredPosition, incompleteRecoveryMetadata, err := p.completeRecoveredLiveSessionMetadata(session)
 	if err != nil {
 		logger.Warn("complete recovered live session metadata failed", "error", err)
 		return domain.LiveSession{}, err
+	}
+	if incompleteRecoveryMetadata {
+		session, err = p.enterRecoveredLiveSessionCloseOnlyMode(session, recoveredPosition, "missing-strategy-version", "recovered position is missing strategyVersionId")
+		if err != nil {
+			logger.Warn("enter close-only takeover mode failed", "error", err)
+			return domain.LiveSession{}, err
+		}
+		return domain.LiveSession{}, fmt.Errorf("live session %s is blocked in %s mode", session.ID, liveRecoveryModeCloseOnlyTakeover)
 	}
 	if isLiveSessionRecoveryCloseOnlyMode(session.State) {
 		return domain.LiveSession{}, fmt.Errorf("live session %s is blocked in %s mode", session.ID, liveRecoveryModeCloseOnlyTakeover)

--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -1427,6 +1427,14 @@ func (p *Platform) StartLiveSession(sessionID string) (domain.LiveSession, error
 		logger.Warn("resolve live adapter failed", "error", err)
 		return domain.LiveSession{}, err
 	}
+	session, _, _, err = p.completeRecoveredLiveSessionMetadata(session)
+	if err != nil {
+		logger.Warn("complete recovered live session metadata failed", "error", err)
+		return domain.LiveSession{}, err
+	}
+	if isLiveSessionRecoveryCloseOnlyMode(session.State) {
+		return domain.LiveSession{}, fmt.Errorf("live session %s is blocked in %s mode", session.ID, liveRecoveryModeCloseOnlyTakeover)
+	}
 
 	session, err = p.syncLiveSessionRuntime(session)
 	if err != nil {
@@ -2477,6 +2485,20 @@ func (p *Platform) completeRecoveredLiveSessionMetadata(session domain.LiveSessi
 		delete(state, "recoveryMetadataStatus")
 		delete(state, "recoveryMetadataMissing")
 		delete(state, "recoveryMetadataCompletedAt")
+		delete(state, "recoveryMode")
+		delete(state, "recoveryCloseOnlyReason")
+		delete(state, "recoveryCloseOnlyDetail")
+		delete(state, "recoveryCloseOnlyAt")
+		delete(state, "runtimeMode")
+		delete(state, "signalRuntimeMode")
+		delete(state, "signalRuntimeRequired")
+		delete(state, "signalRuntimeReady")
+		if strings.EqualFold(stringValue(state["lastStrategyEvaluationStatus"]), liveRecoveryModeCloseOnlyTakeover) {
+			delete(state, "lastStrategyEvaluationStatus")
+		}
+		if strings.EqualFold(stringValue(state["positionRecoveryStatus"]), liveRecoveryModeCloseOnlyTakeover) {
+			state["positionRecoveryStatus"] = "flat"
+		}
 		if !metadataEqual(state, session.State) {
 			session, err = p.store.UpdateLiveSessionState(session.ID, state)
 			if err != nil {

--- a/internal/service/live_recovery.go
+++ b/internal/service/live_recovery.go
@@ -78,6 +78,13 @@ func (p *Platform) refreshLiveSessionProtectionState(session domain.LiveSession)
 }
 
 func (p *Platform) refreshLiveSessionPositionContext(session domain.LiveSession, eventTime time.Time, source string) (domain.LiveSession, error) {
+	applyRecoveryMode := func(state map[string]any) {
+		if !isLiveSessionRecoveryCloseOnlyMode(state) {
+			return
+		}
+		state["positionRecoveryStatus"] = liveRecoveryModeCloseOnlyTakeover
+		state["lastStrategyEvaluationStatus"] = liveRecoveryModeCloseOnlyTakeover
+	}
 	persistSnapshot := func(updated domain.LiveSession) (domain.LiveSession, error) {
 		if updated.ID == "" {
 			return updated, nil
@@ -115,6 +122,7 @@ func (p *Platform) refreshLiveSessionPositionContext(session domain.LiveSession,
 		delete(state, "livePositionState")
 		state["lastLivePositionState"] = map[string]any{}
 		state["positionRecoveryStatus"] = "flat"
+		applyRecoveryMode(state)
 		updated, updateErr := p.store.UpdateLiveSessionState(refreshed.ID, state)
 		if updateErr != nil {
 			return domain.LiveSession{}, updateErr
@@ -154,6 +162,7 @@ func (p *Platform) refreshLiveSessionPositionContext(session domain.LiveSession,
 				applyLivePositionWatermarks(state, watermarks)
 			}
 		}
+		applyRecoveryMode(state)
 		updated, updateErr := p.store.UpdateLiveSessionState(refreshed.ID, state)
 		if updateErr != nil {
 			return domain.LiveSession{}, updateErr
@@ -163,6 +172,7 @@ func (p *Platform) refreshLiveSessionPositionContext(session domain.LiveSession,
 	marketPrice := firstPositive(parseFloatValue(positionSnapshot["markPrice"]), parseFloatValue(mapValue(signalBarState["current"])["close"]))
 	livePositionState := evaluateLivePositionState(parameters, positionSnapshot, signalBarState, marketPrice, state)
 	if len(livePositionState) == 0 {
+		applyRecoveryMode(state)
 		updated, updateErr := p.store.UpdateLiveSessionState(refreshed.ID, state)
 		if updateErr != nil {
 			return domain.LiveSession{}, updateErr
@@ -245,6 +255,7 @@ func (p *Platform) refreshLiveSessionPositionContext(session domain.LiveSession,
 		}
 	}
 
+	applyRecoveryMode(state)
 	updated, updateErr := p.store.UpdateLiveSessionState(refreshed.ID, state)
 	if updateErr != nil {
 		return domain.LiveSession{}, updateErr

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -4797,6 +4797,113 @@ func TestClosePositionAllowsRecoveredCloseOnlyTakeoverWithoutRuntimeLinkage(t *t
 	}
 }
 
+func TestCompleteRecoveredLiveSessionMetadataClearsCloseOnlyTakeoverWhenPositionFlat(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	session, err := platform.CreateLiveSession("live-main", "strategy-bk-1d", map[string]any{
+		"symbol":          "BTCUSDT",
+		"signalTimeframe": "1d",
+	})
+	if err != nil {
+		t.Fatalf("create live session failed: %v", err)
+	}
+	state := cloneMetadata(session.State)
+	state["recoveryMode"] = liveRecoveryModeCloseOnlyTakeover
+	state["recoveryCloseOnlyReason"] = "missing-strategy-version"
+	state["recoveryCloseOnlyDetail"] = "test"
+	state["recoveryCloseOnlyAt"] = time.Now().UTC().Format(time.RFC3339)
+	state["runtimeMode"] = liveRecoveryModeCloseOnlyTakeover
+	state["signalRuntimeMode"] = liveRecoveryModeCloseOnlyTakeover
+	state["signalRuntimeRequired"] = false
+	state["signalRuntimeReady"] = false
+	state["lastStrategyEvaluationStatus"] = liveRecoveryModeCloseOnlyTakeover
+	state["positionRecoveryStatus"] = liveRecoveryModeCloseOnlyTakeover
+	session, err = platform.store.UpdateLiveSessionState(session.ID, state)
+	if err != nil {
+		t.Fatalf("update live session state failed: %v", err)
+	}
+
+	updated, _, incomplete, err := platform.completeRecoveredLiveSessionMetadata(session)
+	if err != nil {
+		t.Fatalf("complete recovered live session metadata failed: %v", err)
+	}
+	if incomplete {
+		t.Fatal("expected flat session not to remain incomplete")
+	}
+	if got := stringValue(updated.State["recoveryMode"]); got != "" {
+		t.Fatalf("expected recoveryMode to be cleared, got %s", got)
+	}
+	if got := stringValue(updated.State["recoveryCloseOnlyReason"]); got != "" {
+		t.Fatalf("expected recoveryCloseOnlyReason to be cleared, got %s", got)
+	}
+	if got := stringValue(updated.State["lastStrategyEvaluationStatus"]); got != "" {
+		t.Fatalf("expected lastStrategyEvaluationStatus takeover marker to be cleared, got %s", got)
+	}
+	if got := stringValue(updated.State["positionRecoveryStatus"]); got != "flat" {
+		t.Fatalf("expected positionRecoveryStatus to reset to flat, got %s", got)
+	}
+}
+
+func TestStartLiveSessionRejectsActiveCloseOnlyTakeoverMode(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	platform.registerLiveAdapter(testLiveAccountSyncAdapter{key: "test-start-close-only"})
+
+	account, err := platform.store.GetAccount("live-main")
+	if err != nil {
+		t.Fatalf("get live account failed: %v", err)
+	}
+	account.Status = "READY"
+	account.Metadata = cloneMetadata(account.Metadata)
+	account.Metadata["liveBinding"] = map[string]any{
+		"adapterKey":     "test-start-close-only",
+		"connectionMode": "mock",
+		"executionMode":  "mock",
+	}
+	if _, err := platform.store.UpdateAccount(account); err != nil {
+		t.Fatalf("update live account failed: %v", err)
+	}
+
+	session, err := platform.CreateLiveSession("live-main", "strategy-bk-1d", map[string]any{
+		"symbol":          "BTCUSDT",
+		"signalTimeframe": "1d",
+	})
+	if err != nil {
+		t.Fatalf("create live session failed: %v", err)
+	}
+	if _, err := platform.store.SavePosition(domain.Position{
+		AccountID:  session.AccountID,
+		Symbol:     "BTCUSDT",
+		Side:       "LONG",
+		Quantity:   0.01,
+		EntryPrice: 68000,
+		MarkPrice:  68100,
+	}); err != nil {
+		t.Fatalf("save position failed: %v", err)
+	}
+	secondary, err := platform.store.CreateLiveSession("live-main", "strategy-ambiguous")
+	if err != nil {
+		t.Fatalf("create secondary live session failed: %v", err)
+	}
+	secondaryState := cloneMetadata(secondary.State)
+	secondaryState["symbol"] = "BTCUSDT"
+	if _, err := platform.store.UpdateLiveSessionState(secondary.ID, secondaryState); err != nil {
+		t.Fatalf("update secondary live session state failed: %v", err)
+	}
+
+	recovered, err := platform.recoverRunningLiveSession(session)
+	if err != nil {
+		t.Fatalf("recover running live session failed: %v", err)
+	}
+	if recovered.Status != "BLOCKED" {
+		t.Fatalf("expected blocked close-only recovery session, got %s", recovered.Status)
+	}
+
+	if _, err := platform.StartLiveSession(session.ID); err == nil {
+		t.Fatal("expected StartLiveSession to reject active close-only takeover mode")
+	} else if !strings.Contains(err.Error(), liveRecoveryModeCloseOnlyTakeover) {
+		t.Fatalf("expected close-only takeover error, got %v", err)
+	}
+}
+
 type testLiveAccountSyncAdapter struct {
 	key                 string
 	syncErr             error

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -4904,6 +4904,73 @@ func TestStartLiveSessionRejectsActiveCloseOnlyTakeoverMode(t *testing.T) {
 	}
 }
 
+func TestStartLiveSessionDowngradesIncompleteRecoveredMetadataToCloseOnly(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	platform.registerLiveAdapter(testLiveAccountSyncAdapter{key: "test-start-incomplete"})
+
+	account, err := platform.store.GetAccount("live-main")
+	if err != nil {
+		t.Fatalf("get live account failed: %v", err)
+	}
+	account.Status = "READY"
+	account.Metadata = cloneMetadata(account.Metadata)
+	account.Metadata["liveBinding"] = map[string]any{
+		"adapterKey":     "test-start-incomplete",
+		"connectionMode": "mock",
+		"executionMode":  "mock",
+	}
+	if _, err := platform.store.UpdateAccount(account); err != nil {
+		t.Fatalf("update live account failed: %v", err)
+	}
+
+	session, err := platform.CreateLiveSession("live-main", "strategy-bk-1d", map[string]any{
+		"symbol":          "BTCUSDT",
+		"signalTimeframe": "1d",
+	})
+	if err != nil {
+		t.Fatalf("create live session failed: %v", err)
+	}
+	secondary, err := platform.store.CreateLiveSession("live-main", "strategy-ambiguous")
+	if err != nil {
+		t.Fatalf("create secondary live session failed: %v", err)
+	}
+	secondaryState := cloneMetadata(secondary.State)
+	secondaryState["symbol"] = "BTCUSDT"
+	if _, err := platform.store.UpdateLiveSessionState(secondary.ID, secondaryState); err != nil {
+		t.Fatalf("update secondary live session state failed: %v", err)
+	}
+	if _, err := platform.store.SavePosition(domain.Position{
+		AccountID:  session.AccountID,
+		Symbol:     "BTCUSDT",
+		Side:       "LONG",
+		Quantity:   0.01,
+		EntryPrice: 68000,
+		MarkPrice:  68100,
+	}); err != nil {
+		t.Fatalf("save position failed: %v", err)
+	}
+
+	if _, err := platform.StartLiveSession(session.ID); err == nil {
+		t.Fatal("expected StartLiveSession to block incomplete recovered metadata")
+	} else if !strings.Contains(err.Error(), liveRecoveryModeCloseOnlyTakeover) {
+		t.Fatalf("expected close-only takeover error, got %v", err)
+	}
+
+	updated, err := platform.store.GetLiveSession(session.ID)
+	if err != nil {
+		t.Fatalf("get updated live session failed: %v", err)
+	}
+	if updated.Status != "BLOCKED" {
+		t.Fatalf("expected session to downgrade to BLOCKED, got %s", updated.Status)
+	}
+	if got := stringValue(updated.State["recoveryMode"]); got != liveRecoveryModeCloseOnlyTakeover {
+		t.Fatalf("expected recoveryMode %s, got %s", liveRecoveryModeCloseOnlyTakeover, got)
+	}
+	if got := stringValue(updated.State["recoveryMetadataStatus"]); got != liveRecoveryMetadataStatusIncomplete {
+		t.Fatalf("expected incomplete recovery metadata status, got %s", got)
+	}
+}
+
 type testLiveAccountSyncAdapter struct {
 	key                 string
 	syncErr             error

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -4618,6 +4618,185 @@ func TestRefreshLiveSessionPositionContextBuildsRiskStateFromRecoveredBreakEvenE
 	}
 }
 
+func TestRecoverRunningLiveSessionCompletesRecoveredPositionMetadata(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	session, err := platform.CreateLiveSession("live-main", "strategy-bk-1d", map[string]any{
+		"symbol":          "BTCUSDT",
+		"signalTimeframe": "1d",
+	})
+	if err != nil {
+		t.Fatalf("create live session failed: %v", err)
+	}
+	if _, err := platform.store.SavePosition(domain.Position{
+		AccountID:  session.AccountID,
+		Symbol:     "BTCUSDT",
+		Side:       "LONG",
+		Quantity:   0.01,
+		EntryPrice: 68000,
+		MarkPrice:  68100,
+	}); err != nil {
+		t.Fatalf("save position failed: %v", err)
+	}
+
+	recovered, err := platform.recoverRunningLiveSession(session)
+	if err != nil {
+		t.Fatalf("recover running live session failed: %v", err)
+	}
+	if recovered.Status != "RUNNING" {
+		t.Fatalf("expected recovered session to stay RUNNING, got %s", recovered.Status)
+	}
+	if got := stringValue(recovered.State["recoveryMetadataStatus"]); got != liveRecoveryMetadataStatusComplete {
+		t.Fatalf("expected recovery metadata status complete, got %s", got)
+	}
+	if got := stringValue(recovered.State["recoveryMode"]); got != "" {
+		t.Fatalf("expected no restricted recovery mode, got %s", got)
+	}
+	position, found, err := platform.store.FindPosition(session.AccountID, "BTCUSDT")
+	if err != nil {
+		t.Fatalf("find position failed: %v", err)
+	}
+	if !found {
+		t.Fatal("expected recovered position to remain present")
+	}
+	if got := position.StrategyVersionID; got != "strategy-version-bk-1d-v010" {
+		t.Fatalf("expected recovered strategy version to be completed, got %s", got)
+	}
+}
+
+func TestRecoverRunningLiveSessionFallsBackToCloseOnlyWhenMetadataIsAmbiguous(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	session, err := platform.CreateLiveSession("live-main", "strategy-bk-1d", map[string]any{
+		"symbol":          "BTCUSDT",
+		"signalTimeframe": "1d",
+	})
+	if err != nil {
+		t.Fatalf("create primary live session failed: %v", err)
+	}
+	secondary, err := platform.store.CreateLiveSession("live-main", "strategy-ambiguous")
+	if err != nil {
+		t.Fatalf("create secondary live session failed: %v", err)
+	}
+	secondaryState := cloneMetadata(secondary.State)
+	secondaryState["symbol"] = "BTCUSDT"
+	if _, err := platform.store.UpdateLiveSessionState(secondary.ID, secondaryState); err != nil {
+		t.Fatalf("update secondary live session state failed: %v", err)
+	}
+	if _, err := platform.store.SavePosition(domain.Position{
+		AccountID:  session.AccountID,
+		Symbol:     "BTCUSDT",
+		Side:       "LONG",
+		Quantity:   0.01,
+		EntryPrice: 68000,
+		MarkPrice:  68100,
+	}); err != nil {
+		t.Fatalf("save position failed: %v", err)
+	}
+
+	recovered, err := platform.recoverRunningLiveSession(session)
+	if err != nil {
+		t.Fatalf("recover running live session failed: %v", err)
+	}
+	if recovered.Status != "BLOCKED" {
+		t.Fatalf("expected recovered session to downgrade into BLOCKED close-only mode, got %s", recovered.Status)
+	}
+	if got := stringValue(recovered.State["recoveryMode"]); got != liveRecoveryModeCloseOnlyTakeover {
+		t.Fatalf("expected recovery mode %s, got %s", liveRecoveryModeCloseOnlyTakeover, got)
+	}
+	if got := stringValue(recovered.State["recoveryMetadataStatus"]); got != liveRecoveryMetadataStatusIncomplete {
+		t.Fatalf("expected incomplete recovery metadata status, got %s", got)
+	}
+	if got := stringValue(recovered.State["lastStrategyEvaluationStatus"]); got != liveRecoveryModeCloseOnlyTakeover {
+		t.Fatalf("expected strategy evaluation status %s, got %s", liveRecoveryModeCloseOnlyTakeover, got)
+	}
+	if got := stringValue(recovered.State["positionRecoveryStatus"]); got != liveRecoveryModeCloseOnlyTakeover {
+		t.Fatalf("expected position recovery status %s, got %s", liveRecoveryModeCloseOnlyTakeover, got)
+	}
+	position, found, err := platform.store.FindPosition(session.AccountID, "BTCUSDT")
+	if err != nil {
+		t.Fatalf("find position failed: %v", err)
+	}
+	if !found {
+		t.Fatal("expected recovered position to remain present")
+	}
+	if got := position.StrategyVersionID; got != "" {
+		t.Fatalf("expected ambiguous recovered position to remain unlinked, got %s", got)
+	}
+}
+
+func TestClosePositionAllowsRecoveredCloseOnlyTakeoverWithoutRuntimeLinkage(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	platform.registerLiveAdapter(testLiveAccountSyncAdapter{key: "test-close-only"})
+
+	account, err := platform.store.GetAccount("live-main")
+	if err != nil {
+		t.Fatalf("get live account failed: %v", err)
+	}
+	account.Status = "READY"
+	account.Metadata = cloneMetadata(account.Metadata)
+	account.Metadata["liveBinding"] = map[string]any{
+		"adapterKey":     "test-close-only",
+		"connectionMode": "mock",
+		"executionMode":  "mock",
+	}
+	if _, err := platform.store.UpdateAccount(account); err != nil {
+		t.Fatalf("update live account failed: %v", err)
+	}
+
+	session, err := platform.CreateLiveSession("live-main", "strategy-bk-1d", map[string]any{
+		"symbol":          "BTCUSDT",
+		"signalTimeframe": "1d",
+	})
+	if err != nil {
+		t.Fatalf("create primary live session failed: %v", err)
+	}
+	secondary, err := platform.store.CreateLiveSession("live-main", "strategy-ambiguous")
+	if err != nil {
+		t.Fatalf("create secondary live session failed: %v", err)
+	}
+	secondaryState := cloneMetadata(secondary.State)
+	secondaryState["symbol"] = "BTCUSDT"
+	if _, err := platform.store.UpdateLiveSessionState(secondary.ID, secondaryState); err != nil {
+		t.Fatalf("update secondary live session state failed: %v", err)
+	}
+	position, err := platform.store.SavePosition(domain.Position{
+		AccountID:  session.AccountID,
+		Symbol:     "BTCUSDT",
+		Side:       "LONG",
+		Quantity:   0.01,
+		EntryPrice: 68000,
+		MarkPrice:  68100,
+	})
+	if err != nil {
+		t.Fatalf("save position failed: %v", err)
+	}
+
+	recovered, err := platform.recoverRunningLiveSession(session)
+	if err != nil {
+		t.Fatalf("recover running live session failed: %v", err)
+	}
+	if got := stringValue(recovered.State["recoveryMode"]); got != liveRecoveryModeCloseOnlyTakeover {
+		t.Fatalf("expected close-only recovery mode, got %s", got)
+	}
+
+	platform.mu.Lock()
+	platform.signalSessions = map[string]domain.SignalRuntimeSession{}
+	platform.mu.Unlock()
+
+	order, err := platform.ClosePosition(position.ID)
+	if err != nil {
+		t.Fatalf("expected close-only takeover close to bypass missing runtime linkage, got %v", err)
+	}
+	if !boolValue(order.Metadata["skipRuntimeCheck"]) {
+		t.Fatal("expected close-only takeover close order to skip runtime preflight")
+	}
+	if !boolValue(order.Metadata["recoveryCloseOnlyTakeover"]) {
+		t.Fatal("expected close-only takeover marker on close order metadata")
+	}
+	if got := stringValue(order.Status); got == "" {
+		t.Fatal("expected live close order to be persisted with a status")
+	}
+}
+
 type testLiveAccountSyncAdapter struct {
 	key                 string
 	syncErr             error

--- a/internal/service/order.go
+++ b/internal/service/order.go
@@ -33,7 +33,16 @@ func (p *Platform) ClosePosition(positionID string) (domain.Order, error) {
 	if err != nil {
 		return domain.Order{}, err
 	}
-	return p.CreateOrder(buildClosePositionOrder(position))
+	order := buildClosePositionOrder(position)
+	if session, ok := p.findLiveRecoveryCloseOnlySession(position.AccountID, position.Symbol); ok {
+		order.Metadata = cloneMetadata(order.Metadata)
+		order.Metadata["skipRuntimeCheck"] = true
+		order.Metadata["recoveryMode"] = liveRecoveryModeCloseOnlyTakeover
+		order.Metadata["recoveryCloseOnlyTakeover"] = true
+		order.Metadata["recoveryTakeoverSessionId"] = session.ID
+		order.StrategyVersionID = firstNonEmpty(order.StrategyVersionID, stringValue(session.State["strategyVersionId"]))
+	}
+	return p.CreateOrder(order)
 }
 
 func buildClosePositionOrder(position domain.Position) domain.Order {
@@ -57,6 +66,28 @@ func buildClosePositionOrder(position domain.Position) domain.Order {
 			"manualAction": "close-position",
 		},
 	}
+}
+
+func (p *Platform) findLiveRecoveryCloseOnlySession(accountID, symbol string) (domain.LiveSession, bool) {
+	sessions, err := p.ListLiveSessions()
+	if err != nil {
+		return domain.LiveSession{}, false
+	}
+	normalizedSymbol := NormalizeSymbol(symbol)
+	for _, session := range sessions {
+		if session.AccountID != accountID {
+			continue
+		}
+		if !isLiveSessionRecoveryCloseOnlyMode(session.State) {
+			continue
+		}
+		sessionSymbol := NormalizeSymbol(firstNonEmpty(stringValue(session.State["symbol"]), stringValue(session.State["lastSymbol"])))
+		if normalizedSymbol != "" && sessionSymbol != "" && sessionSymbol != normalizedSymbol {
+			continue
+		}
+		return session, true
+	}
+	return domain.LiveSession{}, false
 }
 
 // CreateOrder 创建订单。对于 PAPER 模式账户，订单会被立即执行（模拟成交），


### PR DESCRIPTION
## 目的
解决 #85：`[runtime-recovery] Recovery metadata completion & close-only fallback mode`。

本 PR 修复 live runtime recovery 中 recovered / historical position 的执行上下文缺失问题，确保：
- 能安全补全 `strategyVersionId` / runtime linkage 的 recovered position 先补全再恢复
- 不能安全补全的 recovered position 显式降级到 `close-only-takeover` 模式
- metadata 不完整时阻断正常 strategy progression
- 不再把缺失 metadata 拖到执行层才报 `live order requires strategyVersionId or a linked runtime session`

Closes #85.

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [x] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main)
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？
- [x] DB migration 是否具备向下兼容幂等性？
- [x] 配置字段有没有无意被混改？

说明：以上检查项均未引入变化；本 PR 只调整 recovery metadata gate、restricted close-only state 和对应测试。

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

已执行：
- `go test ./internal/service`
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`

新增/覆盖测试：
- `TestRecoverRunningLiveSessionCompletesRecoveredPositionMetadata`
- `TestRecoverRunningLiveSessionFallsBackToCloseOnlyWhenMetadataIsAmbiguous`
- `TestClosePositionAllowsRecoveredCloseOnlyTakeoverWithoutRuntimeLinkage`

## 本次行为变化
- recovered position 会在 recovery / plan build 前先尝试补全 `strategyVersionId`
- 若 metadata 无法安全唯一重建，session 显式降级为 `close-only-takeover`
- normal strategy progression 在 metadata 不完整时被阻断
- close-only takeover 下允许 reduce-only `ClosePosition()`，不再把缺失 metadata 拖到执行层报错

## Root cause
- `reconcileLiveAccountPositions()` 允许 `StrategyVersionID` 为空的 recovered position 落库
- `recoverRunningLiveSession()` / `ensureLiveExecutionPlan()` 会继续把这类仓位当作正常 RUNNING session 推进
- 直到下游 order execution 才在 `resolveLiveStrategyIDForOrder()` 抛出 `live order requires strategyVersionId or a linked runtime session`
