### PR TITLE
[codex] Fix Issue #87 runtime recovery passive-close metadata completeness

### DIFF
--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -2862,7 +2862,9 @@ func (p *Platform) buildLiveExecutionProposal(session domain.LiveSession, execut
 	if err != nil {
 		return ExecutionProposal{}, err
 	}
-	return adjustLiveExecutionProposalForVirtualSemantics(session, executionContext.Parameters, proposal), nil
+	proposal = adjustLiveExecutionProposalForVirtualSemantics(session, executionContext.Parameters, proposal)
+	proposalMap := assembleLiveExecutionProposalMetadata(session, executionContext.StrategyVersionID, executionProposalToMap(proposal))
+	return executionProposalFromMap(proposalMap), nil
 }
 
 func adjustLiveExecutionProposalForVirtualSemantics(session domain.LiveSession, parameters map[string]any, proposal ExecutionProposal) ExecutionProposal {
@@ -2881,7 +2883,12 @@ func adjustLiveExecutionProposalForVirtualSemantics(session domain.LiveSession, 
 			return proposal
 		}
 	}
-	if strings.EqualFold(proposal.Role, "exit") && boolValue(mapValue(session.State["virtualPosition"])["virtual"]) {
+	hasRecoveredRealPosition := boolValue(session.State["hasRecoveredPosition"]) ||
+		boolValue(session.State["hasRecoveredRealPosition"]) ||
+		math.Abs(parseFloatValue(mapValue(session.State["recoveredPosition"])["quantity"])) > 0
+	if strings.EqualFold(proposal.Role, "exit") &&
+		boolValue(mapValue(session.State["virtualPosition"])["virtual"]) &&
+		!hasRecoveredRealPosition {
 		proposal.Status = "virtual-exit"
 		proposal.Metadata = cloneMetadata(proposal.Metadata)
 		proposal.Metadata["virtualExit"] = true
@@ -3055,6 +3062,9 @@ func shouldAutoDispatchLiveIntent(session domain.LiveSession, intent map[string]
 	}
 	signature := buildLiveIntentSignature(intent)
 	if signature == "" {
+		return false
+	}
+	if shouldBlockAutoDispatchForRecoveryIntent(session, intent) {
 		return false
 	}
 	lastSignature := stringValue(session.State["lastDispatchedIntentSignature"])

--- a/internal/service/live_execution.go
+++ b/internal/service/live_execution.go
@@ -218,6 +218,187 @@ func (p *Platform) DispatchLiveSessionIntent(sessionID string) (domain.Order, er
 	return p.dispatchLiveSessionIntent(session)
 }
 
+func isRecoveryTriggeredPassiveCloseProposal(proposalMap map[string]any) bool {
+	if len(proposalMap) == 0 {
+		return false
+	}
+	metadata := mapValue(proposalMap["metadata"])
+	if boolValue(metadata["recoveryTriggered"]) {
+		return true
+	}
+	if !strings.EqualFold(strings.TrimSpace(stringValue(proposalMap["role"])), "exit") {
+		return false
+	}
+	if !boolValue(proposalMap["reduceOnly"]) && !boolValue(metadata["reduceOnly"]) {
+		return false
+	}
+	if strings.EqualFold(strings.TrimSpace(stringValue(proposalMap["signalKind"])), "recovery-watchdog") {
+		return true
+	}
+	return strings.EqualFold(strings.TrimSpace(stringValue(proposalMap["reason"])), "sl-breached-fallback")
+}
+
+func buildLiveExecutionContextMetadata(session domain.LiveSession, strategyVersionID string, proposalMap map[string]any, metadata map[string]any) map[string]any {
+	context := cloneMetadata(mapValue(metadata["executionContext"]))
+	sessionContext := cloneMetadata(mapValue(session.State["lastStrategyEvaluationContext"]))
+	if context == nil {
+		context = map[string]any{}
+	}
+	for key, value := range sessionContext {
+		if stringValue(context[key]) == "" {
+			context[key] = value
+		}
+	}
+	if value := firstNonEmpty(
+		stringValue(context["strategyVersionId"]),
+		stringValue(sessionContext["strategyVersionId"]),
+		stringValue(metadata["strategyVersionId"]),
+		strategyVersionID,
+		stringValue(session.State["strategyVersionId"]),
+	); value != "" {
+		context["strategyVersionId"] = value
+	}
+	if value := NormalizeSymbol(firstNonEmpty(
+		stringValue(context["symbol"]),
+		stringValue(sessionContext["symbol"]),
+		stringValue(proposalMap["symbol"]),
+		stringValue(session.State["symbol"]),
+		stringValue(session.State["lastSymbol"]),
+	)); value != "" {
+		context["symbol"] = value
+	}
+	if value := firstNonEmpty(
+		stringValue(context["signalTimeframe"]),
+		stringValue(sessionContext["signalTimeframe"]),
+		stringValue(session.State["signalTimeframe"]),
+	); value != "" {
+		context["signalTimeframe"] = value
+	}
+	if value := firstNonEmpty(
+		stringValue(context["executionDataSource"]),
+		stringValue(sessionContext["executionDataSource"]),
+		stringValue(session.State["executionDataSource"]),
+	); value != "" {
+		context["executionDataSource"] = value
+	}
+	if value := firstNonEmpty(
+		stringValue(context["executionMode"]),
+		stringValue(sessionContext["executionMode"]),
+		stringValue(metadata["executionMode"]),
+		stringValue(session.State["executionMode"]),
+		"live",
+	); value != "" {
+		context["executionMode"] = value
+	}
+	if value := firstNonEmpty(
+		stringValue(context["strategyEngineKey"]),
+		stringValue(sessionContext["strategyEngineKey"]),
+		stringValue(session.State["strategyEngine"]),
+	); value != "" {
+		context["strategyEngineKey"] = value
+	}
+	return context
+}
+
+func assembleLiveExecutionProposalMetadata(session domain.LiveSession, strategyVersionID string, proposalMap map[string]any) map[string]any {
+	if len(proposalMap) == 0 {
+		return map[string]any{}
+	}
+	normalized := cloneMetadata(proposalMap)
+	metadata := cloneMetadata(mapValue(normalized["metadata"]))
+	if metadata == nil {
+		metadata = map[string]any{}
+	}
+	strategyVersionID = firstNonEmpty(
+		strategyVersionID,
+		stringValue(normalized["strategyVersionId"]),
+		stringValue(metadata["strategyVersionId"]),
+		stringValue(mapValue(session.State["lastStrategyEvaluationContext"])["strategyVersionId"]),
+		stringValue(session.State["strategyVersionId"]),
+	)
+	if strategyVersionID != "" {
+		normalized["strategyVersionId"] = strategyVersionID
+		metadata["strategyVersionId"] = strategyVersionID
+	}
+	if runtimeSessionID := firstNonEmpty(
+		stringValue(metadata["runtimeSessionId"]),
+		stringValue(session.State["signalRuntimeSessionId"]),
+		stringValue(session.State["lastSignalRuntimeSessionId"]),
+	); runtimeSessionID != "" {
+		metadata["runtimeSessionId"] = runtimeSessionID
+	}
+	if session.ID != "" {
+		metadata["liveSessionId"] = session.ID
+	}
+	metadata["executionMode"] = firstNonEmpty(stringValue(metadata["executionMode"]), "live")
+	metadata["executionContext"] = buildLiveExecutionContextMetadata(session, strategyVersionID, normalized, metadata)
+	if isRecoveryTriggeredPassiveCloseProposal(normalized) {
+		metadata["recoveryTriggered"] = true
+		if value := firstNonEmpty(stringValue(metadata["positionRecoveryStatus"]), stringValue(session.State["positionRecoveryStatus"])); value != "" {
+			metadata["positionRecoveryStatus"] = value
+		}
+		if value := firstNonEmpty(stringValue(metadata["positionRecoverySource"]), stringValue(session.State["positionRecoverySource"])); value != "" {
+			metadata["positionRecoverySource"] = value
+		}
+	}
+	normalized["metadata"] = metadata
+	return normalized
+}
+
+func validateLiveExecutionProposalMetadata(session domain.LiveSession, proposalMap map[string]any) error {
+	if len(proposalMap) == 0 {
+		return fmt.Errorf("live session %s has no execution proposal metadata", session.ID)
+	}
+	metadata := mapValue(proposalMap["metadata"])
+	strategyVersionID := firstNonEmpty(stringValue(proposalMap["strategyVersionId"]), stringValue(metadata["strategyVersionId"]))
+	if strings.TrimSpace(strategyVersionID) == "" {
+		return fmt.Errorf("live session %s execution proposal missing strategyVersionId", session.ID)
+	}
+	executionContext := mapValue(metadata["executionContext"])
+	if len(executionContext) == 0 {
+		return fmt.Errorf("live session %s execution proposal missing execution context", session.ID)
+	}
+	missing := make([]string, 0, 4)
+	if strings.TrimSpace(stringValue(executionContext["strategyVersionId"])) == "" {
+		missing = append(missing, "strategyVersionId")
+	}
+	if NormalizeSymbol(stringValue(executionContext["symbol"])) == "" {
+		missing = append(missing, "symbol")
+	}
+	if strings.TrimSpace(stringValue(executionContext["signalTimeframe"])) == "" {
+		missing = append(missing, "signalTimeframe")
+	}
+	if strings.TrimSpace(stringValue(executionContext["executionDataSource"])) == "" {
+		missing = append(missing, "executionDataSource")
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf(
+			"live session %s execution proposal missing execution context fields: %s",
+			session.ID,
+			strings.Join(missing, ", "),
+		)
+	}
+	if isRecoveryTriggeredPassiveCloseProposal(proposalMap) && strings.TrimSpace(stringValue(metadata["runtimeSessionId"])) == "" {
+		return fmt.Errorf("live session %s recovery close proposal missing runtimeSessionId", session.ID)
+	}
+	return nil
+}
+
+func shouldBlockAutoDispatchForRecoveryIntent(session domain.LiveSession, intent map[string]any) bool {
+	if !isRecoveryTriggeredPassiveCloseProposal(intent) {
+		return false
+	}
+	status := strings.TrimSpace(stringValue(session.State["positionRecoveryStatus"]))
+	if status == "" || status == "unprotected-open-position" {
+		return true
+	}
+	if !boolValue(session.State["hasRecoveredPosition"]) && !boolValue(session.State["hasRecoveredRealPosition"]) {
+		return true
+	}
+	proposalMap := assembleLiveExecutionProposalMetadata(session, "", intent)
+	return validateLiveExecutionProposalMetadata(session, proposalMap) != nil
+}
+
 func (p *Platform) dispatchLiveSessionIntent(session domain.LiveSession) (domain.Order, error) {
 	if !strings.EqualFold(session.Status, "RUNNING") && !strings.EqualFold(session.Status, "READY") {
 		return domain.Order{}, fmt.Errorf("live session %s is not dispatchable in status %s", session.ID, session.Status)
@@ -236,6 +417,11 @@ func (p *Platform) dispatchLiveSessionIntent(session domain.LiveSession) (domain
 	if err != nil {
 		return domain.Order{}, err
 	}
+	proposalMap = assembleLiveExecutionProposalMetadata(session, version.ID, proposalMap)
+	if err := validateLiveExecutionProposalMetadata(session, proposalMap); err != nil {
+		return domain.Order{}, err
+	}
+	proposal = executionProposalFromMap(proposalMap)
 	order := buildLiveOrderFromExecutionProposal(session, version.ID, proposal, proposalMap)
 	created, createErr := p.CreateOrder(order)
 	if createErr != nil && created.ID == "" {
@@ -328,6 +514,33 @@ func buildLiveOrderFromExecutionProposal(session domain.LiveSession, strategyVer
 	if orderType != "MARKET" {
 		price = firstPositive(proposal.LimitPrice, proposal.PriceHint)
 	}
+	proposalMeta := cloneMetadata(mapValue(proposalMap["metadata"]))
+	if proposalMeta == nil {
+		proposalMeta = map[string]any{}
+	}
+	orderMetadata := map[string]any{
+		"source":             "live-session-intent",
+		"liveSessionId":      session.ID,
+		"signalKind":         proposal.SignalKind,
+		"dispatchMode":       stringValue(session.State["dispatchMode"]),
+		"timeInForce":        proposal.TimeInForce,
+		"postOnly":           proposal.PostOnly,
+		"reduceOnly":         proposal.ReduceOnly,
+		"decisionEventId":    stringValue(proposalMap["decisionEventId"]),
+		"executionStrategy":  proposal.ExecutionStrategy,
+		"executionExpiresAt": stringValue(proposal.Metadata["executionExpiresAt"]),
+		"executionProposal":  cloneMetadata(proposalMap),
+		"intent":             cloneMetadata(proposalMap),
+	}
+	applyExecutionMetadata(orderMetadata, map[string]any{
+		"strategyVersionId":      firstNonEmpty(stringValue(proposalMeta["strategyVersionId"]), strategyVersionID),
+		"runtimeSessionId":       stringValue(proposalMeta["runtimeSessionId"]),
+		"executionContext":       cloneMetadata(mapValue(proposalMeta["executionContext"])),
+		"executionMode":          firstNonEmpty(stringValue(proposalMeta["executionMode"]), "live"),
+		"recoveryTriggered":      boolValue(proposalMeta["recoveryTriggered"]),
+		"positionRecoveryStatus": stringValue(proposalMeta["positionRecoveryStatus"]),
+		"positionRecoverySource": stringValue(proposalMeta["positionRecoverySource"]),
+	})
 	return domain.Order{
 		AccountID:         session.AccountID,
 		StrategyVersionID: strategyVersionID,
@@ -337,20 +550,7 @@ func buildLiveOrderFromExecutionProposal(session domain.LiveSession, strategyVer
 		Quantity:          quantity,
 		Price:             price,
 		ReduceOnly:        proposal.ReduceOnly,
-		Metadata: map[string]any{
-			"source":             "live-session-intent",
-			"liveSessionId":      session.ID,
-			"signalKind":         proposal.SignalKind,
-			"dispatchMode":       stringValue(session.State["dispatchMode"]),
-			"timeInForce":        proposal.TimeInForce,
-			"postOnly":           proposal.PostOnly,
-			"reduceOnly":         proposal.ReduceOnly,
-			"decisionEventId":    stringValue(proposalMap["decisionEventId"]),
-			"executionStrategy":  proposal.ExecutionStrategy,
-			"executionExpiresAt": stringValue(proposal.Metadata["executionExpiresAt"]),
-			"executionProposal":  cloneMetadata(proposalMap),
-			"intent":             cloneMetadata(proposalMap),
-		},
+		Metadata:          orderMetadata,
 	}
 }
 

--- a/internal/service/live_execution.go
+++ b/internal/service/live_execution.go
@@ -232,10 +232,7 @@ func isRecoveryTriggeredPassiveCloseProposal(proposalMap map[string]any) bool {
 	if !boolValue(proposalMap["reduceOnly"]) && !boolValue(metadata["reduceOnly"]) {
 		return false
 	}
-	if strings.EqualFold(strings.TrimSpace(stringValue(proposalMap["signalKind"])), "recovery-watchdog") {
-		return true
-	}
-	return strings.EqualFold(strings.TrimSpace(stringValue(proposalMap["reason"])), "sl-breached-fallback")
+	return strings.EqualFold(strings.TrimSpace(stringValue(proposalMap["signalKind"])), "recovery-watchdog")
 }
 
 func buildLiveExecutionContextMetadata(session domain.LiveSession, strategyVersionID string, proposalMap map[string]any, metadata map[string]any) map[string]any {
@@ -360,7 +357,7 @@ func validateLiveExecutionProposalMetadata(session domain.LiveSession, proposalM
 	if len(executionContext) == 0 {
 		return fmt.Errorf("live session %s execution proposal missing execution context", session.ID)
 	}
-	missing := make([]string, 0, 4)
+	missing := make([]string, 0, 5)
 	if strings.TrimSpace(stringValue(executionContext["strategyVersionId"])) == "" {
 		missing = append(missing, "strategyVersionId")
 	}
@@ -372,6 +369,9 @@ func validateLiveExecutionProposalMetadata(session domain.LiveSession, proposalM
 	}
 	if strings.TrimSpace(stringValue(executionContext["executionDataSource"])) == "" {
 		missing = append(missing, "executionDataSource")
+	}
+	if strings.TrimSpace(stringValue(executionContext["executionMode"])) == "" {
+		missing = append(missing, "executionMode")
 	}
 	if len(missing) > 0 {
 		return fmt.Errorf(

--- a/internal/service/live_execution.go
+++ b/internal/service/live_execution.go
@@ -330,6 +330,8 @@ func assembleLiveExecutionProposalMetadata(session domain.LiveSession, strategyV
 	if session.ID != "" {
 		metadata["liveSessionId"] = session.ID
 	}
+	// executionMode here describes the live-session execution pipeline semantics.
+	// It is intentionally separate from account binding modes such as mock/rest.
 	metadata["executionMode"] = firstNonEmpty(stringValue(metadata["executionMode"]), "live")
 	metadata["executionContext"] = buildLiveExecutionContextMetadata(session, strategyVersionID, normalized, metadata)
 	if isRecoveryTriggeredPassiveCloseProposal(normalized) {
@@ -378,6 +380,9 @@ func validateLiveExecutionProposalMetadata(session domain.LiveSession, proposalM
 			strings.Join(missing, ", "),
 		)
 	}
+	// Recovery-triggered passive closes stay fail-closed here: if the current session
+	// no longer has an explicit runtime linkage, we do not recover lineage indirectly
+	// from historical evaluation context and we block dispatch instead.
 	if isRecoveryTriggeredPassiveCloseProposal(proposalMap) && strings.TrimSpace(stringValue(metadata["runtimeSessionId"])) == "" {
 		return fmt.Errorf("live session %s recovery close proposal missing runtimeSessionId", session.ID)
 	}

--- a/internal/service/live_recovery.go
+++ b/internal/service/live_recovery.go
@@ -250,12 +250,15 @@ func (p *Platform) refreshLiveSessionPositionContext(session domain.LiveSession,
 							"livePositionState": cloneMetadata(livePositionState),
 						},
 					}
-					executionProposalMap := executionProposalToMap(proposal)
+					state["positionRecoveryStatus"] = livePositionRecoveryStatusClosingPending
+					executionProposalMap := assembleLiveExecutionProposalMetadata(domain.LiveSession{
+						ID:    refreshed.ID,
+						State: state,
+					}, version.ID, executionProposalToMap(proposal))
 					state["lastExecutionProposal"] = executionProposalMap
 					state["lastStrategyIntent"] = executionProposalMap
 					state["lastStrategyEvaluationStatus"] = "intent-ready"
 					markLiveWatchdogExitState(state, eventTime.UTC().Format(time.RFC3339), "sl-breached-fallback", "", "", "intent-ready")
-					state["positionRecoveryStatus"] = livePositionRecoveryStatusClosingPending
 				}
 			}
 		}

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -1487,6 +1487,60 @@ func TestDispatchLiveSessionIntentRejectsRecoveredPassiveCloseWithIncompleteMeta
 	}
 }
 
+func TestDispatchLiveSessionIntentRejectsRecoveredPassiveCloseWithoutCurrentRuntimeLink(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	session, err := platform.CreateLiveSession("live-main", "strategy-bk-1d", map[string]any{
+		"symbol":              "BTCUSDT",
+		"signalTimeframe":     "1d",
+		"executionDataSource": "tick",
+	})
+	if err != nil {
+		t.Fatalf("create live session failed: %v", err)
+	}
+	state := cloneMetadata(session.State)
+	delete(state, "signalRuntimeSessionId")
+	delete(state, "lastSignalRuntimeSessionId")
+	state["positionRecoveryStatus"] = livePositionRecoveryStatusClosingPending
+	state["hasRecoveredPosition"] = true
+	state["hasRecoveredRealPosition"] = true
+	state["lastStrategyEvaluationContext"] = map[string]any{
+		"strategyVersionId":   "strategy-version-bk-1d-v010",
+		"signalTimeframe":     "1d",
+		"executionDataSource": "tick",
+		"symbol":              "BTCUSDT",
+	}
+	state["lastExecutionProposal"] = executionProposalToMap(ExecutionProposal{
+		Action:            "risk-exit-fallback",
+		Role:              "exit",
+		Reason:            "sl-breached-fallback",
+		Side:              "SELL",
+		Symbol:            "BTCUSDT",
+		Type:              "MARKET",
+		Quantity:          0.002,
+		PriceHint:         68900.0,
+		PriceSource:       "fallback-watchdog",
+		TimeInForce:       "GTC",
+		ReduceOnly:        true,
+		SignalKind:        "recovery-watchdog",
+		DecisionState:     "unprotected",
+		ExecutionStrategy: "book-aware-v1",
+		Status:            "dispatchable",
+		Metadata: map[string]any{
+			"recoveryTriggered": true,
+		},
+	})
+	session, err = platform.store.UpdateLiveSessionState(session.ID, state)
+	if err != nil {
+		t.Fatalf("update live session state failed: %v", err)
+	}
+
+	if _, err := platform.dispatchLiveSessionIntent(session); err == nil {
+		t.Fatal("expected recovered passive close without current runtime link to be rejected")
+	} else if !strings.Contains(err.Error(), "runtimeSessionId") {
+		t.Fatalf("expected runtimeSessionId validation error, got %v", err)
+	}
+}
+
 func TestNormalizeLiveSessionOverridesIncludesExecutionControls(t *testing.T) {
 	overrides := normalizeLiveSessionOverrides(map[string]any{
 		"executionStrategy":                   "book-aware-v1",

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -1541,6 +1541,25 @@ func TestDispatchLiveSessionIntentRejectsRecoveredPassiveCloseWithoutCurrentRunt
 	}
 }
 
+func TestIsRecoveryTriggeredPassiveCloseProposalRequiresExplicitRecoverySignal(t *testing.T) {
+	if isRecoveryTriggeredPassiveCloseProposal(map[string]any{
+		"role":       "exit",
+		"reduceOnly": true,
+		"reason":     "sl-breached-fallback",
+		"signalKind": "protect-exit",
+	}) {
+		t.Fatal("expected reason-only passive close not to be treated as recovery-triggered")
+	}
+	if !isRecoveryTriggeredPassiveCloseProposal(map[string]any{
+		"role":       "exit",
+		"reduceOnly": true,
+		"reason":     "sl-breached-fallback",
+		"signalKind": "recovery-watchdog",
+	}) {
+		t.Fatal("expected recovery-watchdog passive close to be treated as recovery-triggered")
+	}
+}
+
 func TestNormalizeLiveSessionOverridesIncludesExecutionControls(t *testing.T) {
 	overrides := normalizeLiveSessionOverrides(map[string]any{
 		"executionStrategy":                   "book-aware-v1",

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -1441,6 +1441,52 @@ func TestDispatchLiveSessionIntentRejectsNonDispatchableProposal(t *testing.T) {
 	}
 }
 
+func TestDispatchLiveSessionIntentRejectsRecoveredPassiveCloseWithIncompleteMetadata(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	session, err := platform.CreateLiveSession("live-main", "strategy-bk-1d", map[string]any{
+		"symbol":          "BTCUSDT",
+		"signalTimeframe": "1d",
+	})
+	if err != nil {
+		t.Fatalf("create live session failed: %v", err)
+	}
+	state := cloneMetadata(session.State)
+	delete(state, "signalRuntimeSessionId")
+	delete(state, "lastSignalRuntimeSessionId")
+	delete(state, "executionDataSource")
+	state["positionRecoveryStatus"] = livePositionRecoveryStatusClosingPending
+	state["hasRecoveredPosition"] = true
+	state["hasRecoveredRealPosition"] = true
+	state["lastExecutionProposal"] = executionProposalToMap(ExecutionProposal{
+		Action:            "risk-exit-fallback",
+		Role:              "exit",
+		Reason:            "sl-breached-fallback",
+		Side:              "SELL",
+		Symbol:            "BTCUSDT",
+		Type:              "MARKET",
+		Quantity:          0.002,
+		PriceHint:         68900.0,
+		PriceSource:       "fallback-watchdog",
+		TimeInForce:       "GTC",
+		ReduceOnly:        true,
+		SignalKind:        "recovery-watchdog",
+		DecisionState:     "unprotected",
+		ExecutionStrategy: "book-aware-v1",
+		Status:            "dispatchable",
+		Metadata: map[string]any{
+			"recoveryTriggered": true,
+		},
+	})
+	session, err = platform.store.UpdateLiveSessionState(session.ID, state)
+	if err != nil {
+		t.Fatalf("update live session state failed: %v", err)
+	}
+
+	if _, err := platform.dispatchLiveSessionIntent(session); err == nil {
+		t.Fatal("expected incomplete recovered passive close metadata to be rejected")
+	}
+}
+
 func TestNormalizeLiveSessionOverridesIncludesExecutionControls(t *testing.T) {
 	overrides := normalizeLiveSessionOverrides(map[string]any{
 		"executionStrategy":                   "book-aware-v1",
@@ -1904,6 +1950,41 @@ func TestShouldAutoDispatchLiveIntentAllowsTerminalOrder(t *testing.T) {
 	}
 	if !shouldAutoDispatchLiveIntent(session, intent, now) {
 		t.Fatal("expected terminal order to allow auto dispatch for new intent")
+	}
+}
+
+func TestShouldAutoDispatchLiveIntentBlocksUnresolvedRecoveryWatchdogClose(t *testing.T) {
+	now := time.Now().UTC()
+	intent := map[string]any{
+		"action":     "risk-exit-fallback",
+		"role":       "exit",
+		"reason":     "sl-breached-fallback",
+		"side":       "SELL",
+		"symbol":     "BTCUSDT",
+		"signalKind": "recovery-watchdog",
+		"reduceOnly": true,
+		"status":     "dispatchable",
+		"metadata": map[string]any{
+			"strategyVersionId": "strategy-version-bk-1d-v010",
+			"runtimeSessionId":  "runtime-1",
+			"executionContext": map[string]any{
+				"strategyVersionId":   "strategy-version-bk-1d-v010",
+				"signalTimeframe":     "1d",
+				"executionDataSource": "tick",
+				"symbol":              "BTCUSDT",
+			},
+		},
+	}
+	session := domain.LiveSession{
+		State: map[string]any{
+			"dispatchMode":             "auto-dispatch",
+			"positionRecoveryStatus":   "unprotected-open-position",
+			"hasRecoveredPosition":     true,
+			"hasRecoveredRealPosition": true,
+		},
+	}
+	if shouldAutoDispatchLiveIntent(session, intent, now) {
+		t.Fatal("expected unresolved recovery watchdog close to stay manual")
 	}
 }
 
@@ -3686,6 +3767,60 @@ func TestRefreshLiveSessionPositionContextGeneratesShortWatchdogFallbackOnStopLo
 	}
 }
 
+func TestRefreshLiveSessionPositionContextBuildsCompleteMetadataForRecoveredWatchdogClose(t *testing.T) {
+	platform, session, runtimeSessionID, _, _ := prepareLiveDecisionTelemetryFixture(t)
+	if _, err := platform.store.SavePosition(domain.Position{
+		AccountID:         "live-main",
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "LONG",
+		Quantity:          0.002,
+		EntryPrice:        69000,
+		MarkPrice:         68900,
+	}); err != nil {
+		t.Fatalf("save position failed: %v", err)
+	}
+
+	state := cloneMetadata(session.State)
+	state["lastStrategyEvaluationSignalBarStates"] = testLiveRecoverySignalBarStates("BTCUSDT", 68900.0)
+	session, err := platform.store.UpdateLiveSessionState(session.ID, state)
+	if err != nil {
+		t.Fatalf("update live session state failed: %v", err)
+	}
+
+	updated, err := platform.refreshLiveSessionPositionContext(session, time.Date(2026, 4, 17, 2, 0, 0, 0, time.UTC), "test-refresh")
+	if err != nil {
+		t.Fatalf("refresh live session position context failed: %v", err)
+	}
+	proposal := mapValue(updated.State["lastExecutionProposal"])
+	metadata := mapValue(proposal["metadata"])
+	if got := stringValue(metadata["strategyVersionId"]); got == "" {
+		t.Fatal("expected recovered watchdog proposal to carry strategyVersionId")
+	}
+	if got := stringValue(metadata["runtimeSessionId"]); got != runtimeSessionID {
+		t.Fatalf("expected runtimeSessionId %s, got %s", runtimeSessionID, got)
+	}
+	if !boolValue(metadata["recoveryTriggered"]) {
+		t.Fatal("expected recovered watchdog proposal to be marked recoveryTriggered")
+	}
+	if got := stringValue(metadata["positionRecoveryStatus"]); got != livePositionRecoveryStatusClosingPending {
+		t.Fatalf("expected positionRecoveryStatus %s, got %s", livePositionRecoveryStatusClosingPending, got)
+	}
+	executionContext := mapValue(metadata["executionContext"])
+	if got := stringValue(executionContext["strategyVersionId"]); got == "" {
+		t.Fatal("expected recovered watchdog proposal execution context to include strategyVersionId")
+	}
+	if got := stringValue(executionContext["signalTimeframe"]); got != "1d" {
+		t.Fatalf("expected signalTimeframe 1d, got %s", got)
+	}
+	if got := stringValue(executionContext["executionDataSource"]); got != "tick" {
+		t.Fatalf("expected executionDataSource tick, got %s", got)
+	}
+	if got := stringValue(executionContext["symbol"]); got != "BTCUSDT" {
+		t.Fatalf("expected execution context symbol BTCUSDT, got %s", got)
+	}
+}
+
 func TestRefreshLiveSessionPositionContextDoesNotGenerateWatchdogFallbackWithoutBreach(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
 	if _, err := platform.store.SavePosition(domain.Position{
@@ -3848,6 +3983,83 @@ func TestRefreshLiveSessionPositionContextDoesNotCrossProtectedBoundary(t *testi
 	}
 	if got := stringValue(updated.State["positionRecoveryStatus"]); got != "protected-open-position" {
 		t.Fatalf("expected protected-open-position, got %s", got)
+	}
+}
+
+func TestDispatchLiveSessionIntentAllowsRecoveredPassiveCloseWithCompleteMetadata(t *testing.T) {
+	platform, session, runtimeSessionID, _, _ := prepareLiveDecisionTelemetryFixture(t)
+	platform.registerLiveAdapter(testLiveAccountSyncAdapter{key: "test-recovered-passive-close"})
+
+	account, err := platform.store.GetAccount("live-main")
+	if err != nil {
+		t.Fatalf("get account failed: %v", err)
+	}
+	account.Status = "READY"
+	account.Metadata = cloneMetadata(account.Metadata)
+	account.Metadata["liveBinding"] = map[string]any{
+		"adapterKey":     "test-recovered-passive-close",
+		"connectionMode": "mock",
+		"executionMode":  "mock",
+	}
+	if _, err := platform.store.UpdateAccount(account); err != nil {
+		t.Fatalf("update account failed: %v", err)
+	}
+	if _, err := platform.store.SavePosition(domain.Position{
+		AccountID:         "live-main",
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "LONG",
+		Quantity:          0.002,
+		EntryPrice:        69000,
+		MarkPrice:         68900,
+	}); err != nil {
+		t.Fatalf("save position failed: %v", err)
+	}
+
+	state := cloneMetadata(session.State)
+	state["lastStrategyEvaluationSignalBarStates"] = testLiveRecoverySignalBarStates("BTCUSDT", 68900.0)
+	session, err = platform.store.UpdateLiveSessionState(session.ID, state)
+	if err != nil {
+		t.Fatalf("update live session state failed: %v", err)
+	}
+	freshRuntimeAt := time.Now().UTC()
+	if err := platform.updateSignalRuntimeSessionState(runtimeSessionID, func(runtimeSession *domain.SignalRuntimeSession) {
+		state := cloneMetadata(runtimeSession.State)
+		state["lastEventAt"] = freshRuntimeAt.Format(time.RFC3339)
+		state["lastHeartbeatAt"] = freshRuntimeAt.Format(time.RFC3339)
+		sourceStates := cloneMetadata(mapValue(state["sourceStates"]))
+		for key, item := range sourceStates {
+			sourceState := cloneMetadata(mapValue(item))
+			sourceState["lastEventAt"] = freshRuntimeAt.Format(time.RFC3339)
+			sourceStates[key] = sourceState
+		}
+		runtimeSession.State = state
+		runtimeSession.State["sourceStates"] = sourceStates
+		runtimeSession.UpdatedAt = freshRuntimeAt
+	}); err != nil {
+		t.Fatalf("refresh runtime state failed: %v", err)
+	}
+
+	updated, err := platform.refreshLiveSessionPositionContext(session, time.Date(2026, 4, 17, 2, 0, 0, 0, time.UTC), "test-refresh")
+	if err != nil {
+		t.Fatalf("refresh live session position context failed: %v", err)
+	}
+	order, err := platform.dispatchLiveSessionIntent(updated)
+	if err != nil {
+		t.Fatalf("expected recovered passive close dispatch to succeed, got %v", err)
+	}
+	if got := order.StrategyVersionID; got == "" {
+		t.Fatal("expected dispatched recovery close order to keep strategyVersionId")
+	}
+	if got := stringValue(order.Metadata["runtimeSessionId"]); got != runtimeSessionID {
+		t.Fatalf("expected order runtimeSessionId %s, got %s", runtimeSessionID, got)
+	}
+	executionContext := mapValue(order.Metadata["executionContext"])
+	if got := stringValue(executionContext["executionDataSource"]); got != "tick" {
+		t.Fatalf("expected order executionDataSource tick, got %s", got)
+	}
+	if got := stringValue(order.Metadata["executionMode"]); got != "live" {
+		t.Fatalf("expected order executionMode live, got %s", got)
 	}
 }
 


### PR DESCRIPTION
## 目的
修复 Issue #87: `[runtime-recovery] Passive-close execution metadata completeness`。

恢复链路里由 historical/recovered position 触发的 passive-close，之前会直接从 recovery/watchdog 路径手工拼 proposal，再进入 dispatch；这条路径没有稳定复用正常 live execution 的 metadata 组装与校验，导致 close order 可能缺失 `strategyVersionId`、`runtimeSessionId` 或完整 `executionContext`，并在 auto-dispatch 下带着不完整上下文继续尝试执行。

Fixes #87

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [x] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main)
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？
- [x] DB migration 是否具备向下兼容幂等性？
- [x] 配置字段有没有无意被混改？

说明：
- 未修改默认 `dispatchMode`，只是为 recovery-triggered passive-close 增加 metadata completeness guard，并在 recovery unresolved / metadata incomplete 时阻止 auto-dispatch。
- 未触碰 mainnet 路由、部署、migration 或默认配置。

## 本次改动
- 给 live execution proposal 增加统一的 metadata 组装步骤，补齐 `strategyVersionId`、`runtimeSessionId`、`executionContext`、`executionMode`，并把 recovery passive-close 明确标记为 `recoveryTriggered`。
- 在 `dispatchLiveSessionIntent` 前增加最小完备性校验，缺少 strategy/runtime/execution context 时直接拒绝 dispatch，而不是进入下游执行路径后再报错。
- 在 `shouldAutoDispatchLiveIntent` 增加 recovery guard，未完成恢复或 metadata 不完整的 passive-close 不再自动派发。
- 修正 virtual semantics，避免 recovered real position 的 exit 被 stale `virtualPosition` 错误改写成 `virtual-exit`。
- 给 recovery watchdog fallback 增加回归测试，覆盖完整 metadata、缺失 metadata、成功 dispatch、auto-dispatch blocked 四类场景。

## Root Cause
recovery-triggered passive-close proposal 由 `refreshLiveSessionPositionContext` 手工构造，之前没有经过 normal live execution proposal 的完整 metadata assembly pipeline；因此它依赖 session/position 的偶然状态去补足 strategy/runtime link，缺字段时会在 dispatch / preflight / telemetry 等后续阶段出错。

## 验证方式与测试证据
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

已执行：
- `go test ./internal/service -run 'Test(DispatchLiveSessionIntent|ShouldAutoDispatchLiveIntent|RefreshLiveSessionPositionContext).*'`
- `go test ./internal/service -run 'Test(RefreshLiveSessionPositionContextBuildsCompleteMetadataForRecoveredWatchdogClose|DispatchLiveSessionIntentRejectsRecoveredPassiveCloseWithIncompleteMetadata|DispatchLiveSessionIntentAllowsRecoveredPassiveCloseWithCompleteMetadata|ShouldAutoDispatchLiveIntentBlocksUnresolvedRecoveryWatchdogClose)$'`
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`

## 影响
- recovery-triggered close order 现在和正常 execution 一样，必须带齐最小 metadata 保证。
- 不再允许 recovery passive-close 绕过 metadata 注入或 validation。
- recovery 状态未收敛时，系统保持 manual / blocked 行为，不会抢跑 auto-dispatch。
