### PR TITLE
[codex] issue-86 hard reconcile gate before takeover

### DIFF
--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -1671,7 +1671,7 @@ func (p *Platform) reconcileLiveAccountPositions(account domain.Account, exchang
 				return nil, err
 			}
 			recordGate(symbol, map[string]any{
-				"status":           livePositionReconcileGateStatusVerified,
+				"status":           livePositionReconcileGateStatusAdopted,
 				"scenario":         "exchange-position-db-missing",
 				"blocking":         false,
 				"dbPosition":       map[string]any{},
@@ -2576,6 +2576,7 @@ const (
 	liveRecoveryModeReconcileGateBlocked    = "reconcile-gate-blocked"
 	liveRecoveryMetadataStatusComplete      = "complete"
 	liveRecoveryMetadataStatusIncomplete    = "incomplete"
+	livePositionReconcileGateStatusAdopted  = "adopted"
 	livePositionReconcileGateStatusVerified = "verified"
 	livePositionReconcileGateStatusStale    = "stale"
 	livePositionReconcileGateStatusConflict = "conflict"

--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -997,7 +997,8 @@ func (p *Platform) syncLiveAccountFromBinance(account domain.Account, binding ma
 	if err != nil {
 		return domain.Account{}, err
 	}
-	if reconcileErr := p.reconcileLiveAccountPositions(account, openPositions); reconcileErr != nil {
+	reconcileGate, reconcileErr := p.reconcileLiveAccountPositions(account, openPositions)
+	if reconcileErr != nil {
 		account.Metadata = cloneMetadata(account.Metadata)
 		account.Metadata["lastLivePositionSyncError"] = reconcileErr.Error()
 		account, _ = p.store.UpdateAccount(account)
@@ -1006,6 +1007,7 @@ func (p *Platform) syncLiveAccountFromBinance(account domain.Account, binding ma
 	account.Metadata = cloneMetadata(account.Metadata)
 	delete(account.Metadata, "lastLivePositionSyncError")
 	account.Metadata["lastLivePositionSyncAt"] = time.Now().UTC().Format(time.RFC3339)
+	account.Metadata["livePositionReconcileGate"] = reconcileGate
 	return p.store.UpdateAccount(account)
 }
 
@@ -1443,6 +1445,17 @@ func (p *Platform) StartLiveSession(sessionID string) (domain.LiveSession, error
 	if isLiveSessionRecoveryCloseOnlyMode(session.State) {
 		return domain.LiveSession{}, fmt.Errorf("live session %s is blocked in %s mode", session.ID, liveRecoveryModeCloseOnlyTakeover)
 	}
+	if gate := resolveLivePositionReconcileGate(account, recoveredPosition.Symbol, recoveredPosition.Quantity > 0); boolValue(gate["blocking"]) {
+		session, err = p.enterRecoveredLiveSessionReconcileGateBlocked(session, recoveredPosition, gate)
+		if err != nil {
+			logger.Warn("enter reconcile gate blocked mode failed", "error", err)
+			return domain.LiveSession{}, err
+		}
+		return domain.LiveSession{}, fmt.Errorf("live session %s is blocked in %s mode", session.ID, liveRecoveryModeReconcileGateBlocked)
+	}
+	if isLiveSessionRecoveryReconcileGateBlocked(session.State) {
+		return domain.LiveSession{}, fmt.Errorf("live session %s is blocked in %s mode", session.ID, liveRecoveryModeReconcileGateBlocked)
+	}
 
 	session, err = p.syncLiveSessionRuntime(session)
 	if err != nil {
@@ -1543,8 +1556,10 @@ func (p *Platform) recoverRunningLiveSession(session domain.LiveSession) (domain
 	if err != nil {
 		return domain.LiveSession{}, err
 	}
-	if _, syncErr := p.SyncLiveAccount(account.ID); syncErr != nil {
+	if syncedAccount, syncErr := p.SyncLiveAccount(account.ID); syncErr != nil {
 		// Keep recovery moving so runtime monitoring can still come back.
+	} else {
+		account = syncedAccount
 	}
 	session, recoveredPosition, incompleteRecoveryMetadata, err := p.completeRecoveredLiveSessionMetadata(session)
 	if err != nil {
@@ -1557,6 +1572,9 @@ func (p *Platform) recoverRunningLiveSession(session domain.LiveSession) (domain
 		}
 		session, _ = p.refreshLiveSessionPositionContext(session, time.Now().UTC(), "live-startup-recovery-close-only")
 		return session, nil
+	}
+	if gate := resolveLivePositionReconcileGate(account, recoveredPosition.Symbol, recoveredPosition.Quantity > 0); boolValue(gate["blocking"]) {
+		return p.enterRecoveredLiveSessionReconcileGateBlocked(session, recoveredPosition, gate)
 	}
 	session, err = p.syncLiveSessionRuntime(session)
 	if err != nil {
@@ -1582,10 +1600,10 @@ func (p *Platform) recoverRunningLiveSession(session domain.LiveSession) (domain
 	return p.store.UpdateLiveSessionStatus(session.ID, "RUNNING")
 }
 
-func (p *Platform) reconcileLiveAccountPositions(account domain.Account, exchangePositions []map[string]any) error {
+func (p *Platform) reconcileLiveAccountPositions(account domain.Account, exchangePositions []map[string]any) (map[string]any, error) {
 	existing, err := p.store.ListPositions()
 	if err != nil {
-		return err
+		return nil, err
 	}
 	existingBySymbol := make(map[string]domain.Position)
 	for _, position := range existing {
@@ -1595,6 +1613,21 @@ func (p *Platform) reconcileLiveAccountPositions(account domain.Account, exchang
 		existingBySymbol[NormalizeSymbol(position.Symbol)] = position
 	}
 
+	syncedAt := time.Now().UTC()
+	symbols := make(map[string]any)
+	blockingCount := 0
+	recordGate := func(symbol string, gate map[string]any) {
+		if symbol == "" || gate == nil {
+			return
+		}
+		gate = cloneMetadata(gate)
+		gate["symbol"] = symbol
+		gate["comparedAt"] = firstNonEmpty(stringValue(gate["comparedAt"]), syncedAt.Format(time.RFC3339))
+		if boolValue(gate["blocking"]) {
+			blockingCount++
+		}
+		symbols[symbol] = gate
+	}
 	seenSymbols := make(map[string]struct{}, len(exchangePositions))
 	for _, item := range exchangePositions {
 		symbol := NormalizeSymbol(stringValue(item["symbol"]))
@@ -1619,6 +1652,55 @@ func (p *Platform) reconcileLiveAccountPositions(account domain.Account, exchang
 			position.EntryPrice,
 		)
 		markPrice := firstPositive(parseFloatValue(item["markPrice"]), entryPrice)
+		exchangeSnapshot := map[string]any{
+			"symbol":     symbol,
+			"side":       side,
+			"quantity":   quantity,
+			"entryPrice": entryPrice,
+			"markPrice":  markPrice,
+		}
+		if position.ID == "" || position.Quantity <= 0 {
+			position.AccountID = account.ID
+			position.StrategyVersionID = firstNonEmpty(strategyVersionID, position.StrategyVersionID)
+			position.Symbol = symbol
+			position.Side = side
+			position.Quantity = quantity
+			position.EntryPrice = entryPrice
+			position.MarkPrice = markPrice
+			if _, err := p.store.SavePosition(position); err != nil {
+				return nil, err
+			}
+			recordGate(symbol, map[string]any{
+				"status":           livePositionReconcileGateStatusVerified,
+				"scenario":         "exchange-position-db-missing",
+				"blocking":         false,
+				"dbPosition":       map[string]any{},
+				"exchangePosition": exchangeSnapshot,
+			})
+			continue
+		}
+		dbSnapshot := buildRecoveredLivePositionStateSnapshot(position)
+		mismatchFields := make([]any, 0, 3)
+		if !strings.EqualFold(strings.TrimSpace(position.Side), side) {
+			mismatchFields = append(mismatchFields, "side")
+		}
+		if math.Abs(position.Quantity-quantity) > 1e-9 {
+			mismatchFields = append(mismatchFields, "quantity")
+		}
+		if math.Abs(position.EntryPrice-entryPrice) > 1e-6 {
+			mismatchFields = append(mismatchFields, "entryPrice")
+		}
+		if len(mismatchFields) > 0 {
+			recordGate(symbol, map[string]any{
+				"status":           livePositionReconcileGateStatusConflict,
+				"scenario":         classifyLivePositionReconcileScenario(mismatchFields),
+				"blocking":         true,
+				"mismatchFields":   mismatchFields,
+				"dbPosition":       dbSnapshot,
+				"exchangePosition": exchangeSnapshot,
+			})
+			continue
+		}
 		position.AccountID = account.ID
 		position.StrategyVersionID = firstNonEmpty(strategyVersionID, position.StrategyVersionID)
 		position.Symbol = symbol
@@ -1627,23 +1709,57 @@ func (p *Platform) reconcileLiveAccountPositions(account domain.Account, exchang
 		position.EntryPrice = entryPrice
 		position.MarkPrice = markPrice
 		if _, err := p.store.SavePosition(position); err != nil {
-			return err
+			return nil, err
 		}
+		recordGate(symbol, map[string]any{
+			"status":           livePositionReconcileGateStatusVerified,
+			"scenario":         "db-position-matches-exchange",
+			"blocking":         false,
+			"dbPosition":       dbSnapshot,
+			"exchangePosition": exchangeSnapshot,
+		})
 	}
 
 	for symbol, position := range existingBySymbol {
 		if _, ok := seenSymbols[symbol]; ok {
 			continue
 		}
-		if err := p.store.DeletePosition(position.ID); err != nil {
-			return err
+		if position.Quantity <= 0 {
+			continue
 		}
+		recordGate(symbol, map[string]any{
+			"status":           livePositionReconcileGateStatusStale,
+			"scenario":         "db-position-exchange-missing",
+			"blocking":         true,
+			"dbPosition":       buildRecoveredLivePositionStateSnapshot(position),
+			"exchangePosition": map[string]any{},
+		})
 	}
-	return nil
+	return map[string]any{
+		"source":              "binance-position-reconcile",
+		"syncedAt":            syncedAt.Format(time.RFC3339),
+		"authoritative":       true,
+		"blockingSymbolCount": blockingCount,
+		"symbols":             symbols,
+	}, nil
 }
 
 func resolveRecoveredLiveEntryPrice(primary, secondary, fallback float64) float64 {
 	return firstPositive(primary, firstPositive(secondary, fallback))
+}
+
+func classifyLivePositionReconcileScenario(mismatchFields []any) string {
+	if len(mismatchFields) == 1 {
+		switch stringValue(mismatchFields[0]) {
+		case "side":
+			return "side-mismatch"
+		case "quantity":
+			return "quantity-mismatch"
+		case "entryPrice":
+			return "entry-price-mismatch"
+		}
+	}
+	return "multi-field-mismatch"
 }
 
 func (p *Platform) resolveLivePositionStrategyVersionID(accountID, symbol string) string {
@@ -2354,6 +2470,9 @@ func (p *Platform) ensureLiveExecutionPlan(session domain.LiveSession) (domain.L
 	if isLiveSessionRecoveryCloseOnlyMode(session.State) {
 		return session, nil, fmt.Errorf("live session %s is in close-only takeover mode", session.ID)
 	}
+	if isLiveSessionRecoveryReconcileGateBlocked(session.State) {
+		return session, nil, fmt.Errorf("live session %s is blocked by reconcile gate", session.ID)
+	}
 
 	p.mu.Lock()
 	if plan, ok := p.livePlans[session.ID]; ok {
@@ -2453,13 +2572,96 @@ func (p *Platform) ensureLiveExecutionPlan(session domain.LiveSession) (domain.L
 }
 
 const (
-	liveRecoveryModeCloseOnlyTakeover    = "close-only-takeover"
-	liveRecoveryMetadataStatusComplete   = "complete"
-	liveRecoveryMetadataStatusIncomplete = "incomplete"
+	liveRecoveryModeCloseOnlyTakeover       = "close-only-takeover"
+	liveRecoveryModeReconcileGateBlocked    = "reconcile-gate-blocked"
+	liveRecoveryMetadataStatusComplete      = "complete"
+	liveRecoveryMetadataStatusIncomplete    = "incomplete"
+	livePositionReconcileGateStatusVerified = "verified"
+	livePositionReconcileGateStatusStale    = "stale"
+	livePositionReconcileGateStatusConflict = "conflict"
+	livePositionReconcileGateStatusError    = "error"
 )
 
 func isLiveSessionRecoveryCloseOnlyMode(state map[string]any) bool {
 	return strings.EqualFold(strings.TrimSpace(stringValue(state["recoveryMode"])), liveRecoveryModeCloseOnlyTakeover)
+}
+
+func isLiveSessionRecoveryReconcileGateBlocked(state map[string]any) bool {
+	return strings.EqualFold(strings.TrimSpace(stringValue(state["recoveryMode"])), liveRecoveryModeReconcileGateBlocked)
+}
+
+func isLiveSessionBlockedByPositionReconcileGate(state map[string]any) bool {
+	if boolValue(state["positionReconcileGateBlocking"]) {
+		return true
+	}
+	switch strings.TrimSpace(stringValue(state["positionReconcileGateStatus"])) {
+	case livePositionReconcileGateStatusStale, livePositionReconcileGateStatusConflict, livePositionReconcileGateStatusError:
+		return true
+	}
+	return isLiveSessionRecoveryReconcileGateBlocked(state)
+}
+
+func livePositionReconcileGateRequired(snapshot map[string]any) bool {
+	return strings.EqualFold(strings.TrimSpace(stringValue(snapshot["executionMode"])), "rest")
+}
+
+func resolveLivePositionReconcileGate(account domain.Account, symbol string, requiresVerification bool) map[string]any {
+	symbol = NormalizeSymbol(symbol)
+	snapshot := cloneMetadata(mapValue(account.Metadata["liveSyncSnapshot"]))
+	gate := map[string]any{
+		"symbol":        symbol,
+		"status":        livePositionReconcileGateStatusVerified,
+		"blocking":      false,
+		"source":        stringValue(snapshot["source"]),
+		"authoritative": liveProtectionSnapshotIsAuthoritative(snapshot),
+		"required":      livePositionReconcileGateRequired(snapshot),
+	}
+	if !requiresVerification || symbol == "" || !boolValue(gate["required"]) {
+		return gate
+	}
+	if !boolValue(gate["authoritative"]) {
+		gate["status"] = livePositionReconcileGateStatusError
+		gate["blocking"] = true
+		gate["scenario"] = "exchange-truth-unavailable"
+		return gate
+	}
+	symbolGate := cloneMetadata(mapValue(mapValue(mapValue(account.Metadata["livePositionReconcileGate"])["symbols"])[symbol]))
+	if len(symbolGate) == 0 {
+		gate["status"] = livePositionReconcileGateStatusError
+		gate["blocking"] = true
+		gate["scenario"] = "missing-reconcile-verdict"
+		return gate
+	}
+	for key, value := range symbolGate {
+		gate[key] = value
+	}
+	gate["symbol"] = symbol
+	gate["blocking"] = boolValue(gate["blocking"])
+	gate["status"] = firstNonEmpty(stringValue(gate["status"]), livePositionReconcileGateStatusVerified)
+	return gate
+}
+
+func applyLivePositionReconcileGateState(state map[string]any, gate map[string]any) {
+	if state == nil {
+		return
+	}
+	gate = cloneMetadata(gate)
+	state["positionReconcileGateStatus"] = firstNonEmpty(stringValue(gate["status"]), livePositionReconcileGateStatusVerified)
+	state["positionReconcileGateBlocking"] = boolValue(gate["blocking"])
+	state["positionReconcileGateScenario"] = stringValue(gate["scenario"])
+	state["positionReconcileGateComparedAt"] = stringValue(gate["comparedAt"])
+	state["positionReconcileGateSource"] = stringValue(gate["source"])
+	state["positionReconcileGateDBPosition"] = cloneMetadata(mapValue(gate["dbPosition"]))
+	state["positionReconcileGateExchangePosition"] = cloneMetadata(mapValue(gate["exchangePosition"]))
+	if mismatchFields := metadataList(gate["mismatchFields"]); len(mismatchFields) > 0 {
+		state["positionReconcileGateMismatchFields"] = mismatchFields
+	} else {
+		delete(state, "positionReconcileGateMismatchFields")
+	}
+	if boolValue(gate["blocking"]) {
+		state["positionRecoveryStatus"] = firstNonEmpty(stringValue(gate["status"]), livePositionReconcileGateStatusError)
+		state["lastStrategyEvaluationStatus"] = liveRecoveryModeReconcileGateBlocked
+	}
 }
 
 func buildRecoveredLivePositionStateSnapshot(position domain.Position) map[string]any {
@@ -2497,6 +2699,9 @@ func (p *Platform) completeRecoveredLiveSessionMetadata(session domain.LiveSessi
 		delete(state, "recoveryCloseOnlyReason")
 		delete(state, "recoveryCloseOnlyDetail")
 		delete(state, "recoveryCloseOnlyAt")
+		delete(state, "recoveryBlockedReason")
+		delete(state, "recoveryBlockedDetail")
+		delete(state, "recoveryBlockedAt")
 		delete(state, "runtimeMode")
 		delete(state, "signalRuntimeMode")
 		delete(state, "signalRuntimeRequired")
@@ -2504,9 +2709,26 @@ func (p *Platform) completeRecoveredLiveSessionMetadata(session domain.LiveSessi
 		if strings.EqualFold(stringValue(state["lastStrategyEvaluationStatus"]), liveRecoveryModeCloseOnlyTakeover) {
 			delete(state, "lastStrategyEvaluationStatus")
 		}
+		if strings.EqualFold(stringValue(state["lastStrategyEvaluationStatus"]), liveRecoveryModeReconcileGateBlocked) {
+			delete(state, "lastStrategyEvaluationStatus")
+		}
 		if strings.EqualFold(stringValue(state["positionRecoveryStatus"]), liveRecoveryModeCloseOnlyTakeover) {
 			state["positionRecoveryStatus"] = "flat"
 		}
+		if isLiveSessionRecoveryReconcileGateBlocked(state) || strings.EqualFold(stringValue(state["positionRecoveryStatus"]), livePositionReconcileGateStatusStale) ||
+			strings.EqualFold(stringValue(state["positionRecoveryStatus"]), livePositionReconcileGateStatusConflict) ||
+			strings.EqualFold(stringValue(state["positionRecoveryStatus"]), livePositionReconcileGateStatusError) {
+			state["positionRecoveryStatus"] = "flat"
+		}
+		delete(state, "recoveryMode")
+		delete(state, "positionReconcileGateStatus")
+		delete(state, "positionReconcileGateBlocking")
+		delete(state, "positionReconcileGateScenario")
+		delete(state, "positionReconcileGateComparedAt")
+		delete(state, "positionReconcileGateSource")
+		delete(state, "positionReconcileGateMismatchFields")
+		delete(state, "positionReconcileGateDBPosition")
+		delete(state, "positionReconcileGateExchangePosition")
 		if !metadataEqual(state, session.State) {
 			session, err = p.store.UpdateLiveSessionState(session.ID, state)
 			if err != nil {
@@ -2546,6 +2768,9 @@ func (p *Platform) completeRecoveredLiveSessionMetadata(session domain.LiveSessi
 	delete(state, "recoveryCloseOnlyReason")
 	delete(state, "recoveryCloseOnlyDetail")
 	delete(state, "recoveryCloseOnlyAt")
+	delete(state, "recoveryBlockedReason")
+	delete(state, "recoveryBlockedDetail")
+	delete(state, "recoveryBlockedAt")
 	if !metadataEqual(state, session.State) {
 		session, err = p.store.UpdateLiveSessionState(session.ID, state)
 		if err != nil {
@@ -2578,6 +2803,34 @@ func (p *Platform) enterRecoveredLiveSessionCloseOnlyMode(session domain.LiveSes
 	delete(state, "lastStrategyIntent")
 	delete(state, "lastSignalIntent")
 	delete(state, "lastStrategyIntentSignature")
+	session, err := p.store.UpdateLiveSessionState(session.ID, state)
+	if err != nil {
+		return domain.LiveSession{}, err
+	}
+	return p.store.UpdateLiveSessionStatus(session.ID, "BLOCKED")
+}
+
+func (p *Platform) enterRecoveredLiveSessionReconcileGateBlocked(session domain.LiveSession, position domain.Position, gate map[string]any) (domain.LiveSession, error) {
+	state := cloneMetadata(session.State)
+	state["recoveryMode"] = liveRecoveryModeReconcileGateBlocked
+	state["runtimeMode"] = liveRecoveryModeReconcileGateBlocked
+	state["signalRuntimeMode"] = liveRecoveryModeReconcileGateBlocked
+	state["signalRuntimeRequired"] = false
+	state["signalRuntimeReady"] = false
+	state["recoveryBlockedReason"] = firstNonEmpty(stringValue(gate["status"]), livePositionReconcileGateStatusError)
+	state["recoveryBlockedDetail"] = firstNonEmpty(stringValue(gate["scenario"]), "position-reconcile-gate-blocked")
+	state["recoveryBlockedAt"] = time.Now().UTC().Format(time.RFC3339)
+	state["recoveredPosition"] = buildRecoveredLivePositionStateSnapshot(position)
+	state["hasRecoveredPosition"] = position.Quantity > 0
+	state["hasRecoveredRealPosition"] = position.Quantity > 0
+	state["hasRecoveredVirtualPosition"] = false
+	delete(state, "signalRuntimeSessionId")
+	delete(state, "signalRuntimeStatus")
+	delete(state, "lastExecutionProposal")
+	delete(state, "lastStrategyIntent")
+	delete(state, "lastSignalIntent")
+	delete(state, "lastStrategyIntentSignature")
+	applyLivePositionReconcileGateState(state, gate)
 	session, err := p.store.UpdateLiveSessionState(session.ID, state)
 	if err != nil {
 		return domain.LiveSession{}, err

--- a/internal/service/live_execution.go
+++ b/internal/service/live_execution.go
@@ -390,6 +390,9 @@ func validateLiveExecutionProposalMetadata(session domain.LiveSession, proposalM
 }
 
 func shouldBlockAutoDispatchForRecoveryIntent(session domain.LiveSession, intent map[string]any) bool {
+	if isLiveSessionBlockedByPositionReconcileGate(session.State) {
+		return true
+	}
 	if !isRecoveryTriggeredPassiveCloseProposal(intent) {
 		return false
 	}
@@ -407,6 +410,14 @@ func shouldBlockAutoDispatchForRecoveryIntent(session domain.LiveSession, intent
 func (p *Platform) dispatchLiveSessionIntent(session domain.LiveSession) (domain.Order, error) {
 	if !strings.EqualFold(session.Status, "RUNNING") && !strings.EqualFold(session.Status, "READY") {
 		return domain.Order{}, fmt.Errorf("live session %s is not dispatchable in status %s", session.ID, session.Status)
+	}
+	if isLiveSessionBlockedByPositionReconcileGate(session.State) {
+		return domain.Order{}, fmt.Errorf(
+			"live session %s is blocked by reconcile gate: %s (%s)",
+			session.ID,
+			firstNonEmpty(stringValue(session.State["positionReconcileGateStatus"]), livePositionReconcileGateStatusError),
+			firstNonEmpty(stringValue(session.State["positionReconcileGateScenario"]), "unknown"),
+		)
 	}
 
 	proposalMap := cloneMetadata(mapValue(firstNonEmptyMapValue(session.State["lastExecutionProposal"], session.State["lastStrategyIntent"])))

--- a/internal/service/live_recovery.go
+++ b/internal/service/live_recovery.go
@@ -112,6 +112,11 @@ func (p *Platform) refreshLiveSessionPositionContext(session domain.LiveSession,
 		return domain.LiveSession{}, err
 	}
 	hasRealPositionContext := foundPosition || math.Abs(parseFloatValue(positionSnapshot["quantity"])) > 0
+	account, err := p.store.GetAccount(refreshed.AccountID)
+	if err != nil {
+		return domain.LiveSession{}, err
+	}
+	reconcileGate := resolveLivePositionReconcileGate(account, symbol, hasRealPositionContext)
 	state["recoveredPosition"] = positionSnapshot
 	state["hasRecoveredPosition"] = foundPosition
 	state["hasRecoveredRealPosition"] = foundPosition
@@ -126,6 +131,7 @@ func (p *Platform) refreshLiveSessionPositionContext(session domain.LiveSession,
 		delete(state, "livePositionState")
 		state["lastLivePositionState"] = map[string]any{}
 		state["positionRecoveryStatus"] = "flat"
+		applyLivePositionReconcileGateState(state, reconcileGate)
 		applyRecoveryMode(state)
 		updated, updateErr := p.store.UpdateLiveSessionState(refreshed.ID, state)
 		if updateErr != nil {
@@ -137,6 +143,7 @@ func (p *Platform) refreshLiveSessionPositionContext(session domain.LiveSession,
 		clearLiveWatchdogExitState(state)
 		state["positionRecoveryStatus"] = "monitoring-virtual-position"
 	}
+	applyLivePositionReconcileGateState(state, reconcileGate)
 
 	version, err := p.resolveCurrentStrategyVersion(refreshed.StrategyID)
 	if err != nil {
@@ -166,6 +173,7 @@ func (p *Platform) refreshLiveSessionPositionContext(session domain.LiveSession,
 				applyLivePositionWatermarks(state, watermarks)
 			}
 		}
+		applyLivePositionReconcileGateState(state, reconcileGate)
 		applyRecoveryMode(state)
 		updated, updateErr := p.store.UpdateLiveSessionState(refreshed.ID, state)
 		if updateErr != nil {
@@ -176,6 +184,7 @@ func (p *Platform) refreshLiveSessionPositionContext(session domain.LiveSession,
 	marketPrice := firstPositive(parseFloatValue(positionSnapshot["markPrice"]), parseFloatValue(mapValue(signalBarState["current"])["close"]))
 	livePositionState := evaluateLivePositionState(parameters, positionSnapshot, signalBarState, marketPrice, state)
 	if len(livePositionState) == 0 {
+		applyLivePositionReconcileGateState(state, reconcileGate)
 		applyRecoveryMode(state)
 		updated, updateErr := p.store.UpdateLiveSessionState(refreshed.ID, state)
 		if updateErr != nil {
@@ -196,7 +205,8 @@ func (p *Platform) refreshLiveSessionPositionContext(session domain.LiveSession,
 		watchdogExitPending = syncLiveWatchdogExitState(state, eventTime)
 	}
 
-	if !watchdogExitPending &&
+	if !boolValue(reconcileGate["blocking"]) &&
+		!watchdogExitPending &&
 		boolValue(state["protectionRecoveryAuthoritative"]) &&
 		stringValue(state["positionRecoveryStatus"]) == "unprotected-open-position" {
 		stopLoss := parseFloatValue(livePositionState["stopLoss"])
@@ -264,6 +274,7 @@ func (p *Platform) refreshLiveSessionPositionContext(session domain.LiveSession,
 		}
 	}
 
+	applyLivePositionReconcileGateState(state, reconcileGate)
 	applyRecoveryMode(state)
 	updated, updateErr := p.store.UpdateLiveSessionState(refreshed.ID, state)
 	if updateErr != nil {

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -5194,6 +5194,9 @@ func TestRecoverRunningLiveSessionAllowsControlledExchangeOnlyTakeover(t *testin
 	if recovered.Status != "RUNNING" {
 		t.Fatalf("expected controlled exchange takeover to proceed, got %s", recovered.Status)
 	}
+	if got := stringValue(recovered.State["positionReconcileGateStatus"]); got != livePositionReconcileGateStatusAdopted {
+		t.Fatalf("expected adopted reconcile gate status, got %s", got)
+	}
 	if got := stringValue(recovered.State["positionReconcileGateScenario"]); got != "exchange-position-db-missing" {
 		t.Fatalf("expected exchange-position-db-missing scenario, got %s", got)
 	}

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -4900,7 +4900,7 @@ func TestReconcileLiveAccountPositionsFallsBackToBreakEvenPrice(t *testing.T) {
 		t.Fatalf("get account failed: %v", err)
 	}
 
-	err = platform.reconcileLiveAccountPositions(account, []map[string]any{
+	_, err = platform.reconcileLiveAccountPositions(account, []map[string]any{
 		{
 			"symbol":         "BTCUSDT",
 			"positionAmt":    -0.002,
@@ -4946,7 +4946,7 @@ func TestReconcileLiveAccountPositionsPreservesExistingEntryPriceWhenSnapshotIsZ
 		t.Fatalf("get account failed: %v", err)
 	}
 
-	err = platform.reconcileLiveAccountPositions(account, []map[string]any{
+	_, err = platform.reconcileLiveAccountPositions(account, []map[string]any{
 		{
 			"symbol":      "BTCUSDT",
 			"positionAmt": -0.002,
@@ -4984,7 +4984,7 @@ func TestRefreshLiveSessionPositionContextBuildsRiskStateFromRecoveredBreakEvenE
 		t.Fatalf("update account failed: %v", err)
 	}
 
-	if err := platform.reconcileLiveAccountPositions(account, []map[string]any{
+	if _, err := platform.reconcileLiveAccountPositions(account, []map[string]any{
 		{
 			"symbol":         "BTCUSDT",
 			"positionAmt":    -0.002,
@@ -5071,6 +5071,248 @@ func TestRecoverRunningLiveSessionCompletesRecoveredPositionMetadata(t *testing.
 	}
 	if got := position.StrategyVersionID; got != "strategy-version-bk-1d-v010" {
 		t.Fatalf("expected recovered strategy version to be completed, got %s", got)
+	}
+}
+
+func TestRecoverRunningLiveSessionAllowsTakeoverAfterVerifiedReconcileMatch(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	configureTestLiveRESTReconcileAdapter(t, platform, "test-reconcile-match", []map[string]any{
+		{
+			"symbol":      "BTCUSDT",
+			"positionAmt": 0.01,
+			"entryPrice":  68000.0,
+			"markPrice":   68100.0,
+		},
+	})
+	session, err := platform.CreateLiveSession("live-main", "strategy-bk-1d", map[string]any{
+		"symbol":          "BTCUSDT",
+		"signalTimeframe": "1d",
+	})
+	if err != nil {
+		t.Fatalf("create live session failed: %v", err)
+	}
+	if _, err := platform.store.SavePosition(domain.Position{
+		AccountID:  session.AccountID,
+		Symbol:     "BTCUSDT",
+		Side:       "LONG",
+		Quantity:   0.01,
+		EntryPrice: 68000,
+		MarkPrice:  68100,
+	}); err != nil {
+		t.Fatalf("save position failed: %v", err)
+	}
+
+	recovered, err := platform.recoverRunningLiveSession(session)
+	if err != nil {
+		t.Fatalf("recover running live session failed: %v", err)
+	}
+	if recovered.Status != "RUNNING" {
+		t.Fatalf("expected recovered session to stay RUNNING, got %s", recovered.Status)
+	}
+	if got := stringValue(recovered.State["positionReconcileGateStatus"]); got != livePositionReconcileGateStatusVerified {
+		t.Fatalf("expected verified reconcile gate status, got %s", got)
+	}
+	if got := stringValue(recovered.State["positionReconcileGateScenario"]); got != "db-position-matches-exchange" {
+		t.Fatalf("expected db-position-matches-exchange scenario, got %s", got)
+	}
+	if boolValue(recovered.State["positionReconcileGateBlocking"]) {
+		t.Fatal("expected verified reconcile gate not to block execution")
+	}
+}
+
+func TestRecoverRunningLiveSessionBlocksWhenDBPositionMissingOnExchange(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	configureTestLiveRESTReconcileAdapter(t, platform, "test-reconcile-stale", []map[string]any{})
+	session, err := platform.CreateLiveSession("live-main", "strategy-bk-1d", map[string]any{
+		"symbol":          "BTCUSDT",
+		"signalTimeframe": "1d",
+	})
+	if err != nil {
+		t.Fatalf("create live session failed: %v", err)
+	}
+	position, err := platform.store.SavePosition(domain.Position{
+		AccountID:  session.AccountID,
+		Symbol:     "BTCUSDT",
+		Side:       "LONG",
+		Quantity:   0.01,
+		EntryPrice: 68000,
+		MarkPrice:  68100,
+	})
+	if err != nil {
+		t.Fatalf("save position failed: %v", err)
+	}
+
+	recovered, err := platform.recoverRunningLiveSession(session)
+	if err != nil {
+		t.Fatalf("recover running live session failed: %v", err)
+	}
+	if recovered.Status != "BLOCKED" {
+		t.Fatalf("expected stale recovery to stay BLOCKED, got %s", recovered.Status)
+	}
+	if got := stringValue(recovered.State["recoveryMode"]); got != liveRecoveryModeReconcileGateBlocked {
+		t.Fatalf("expected reconcile gate blocked mode, got %s", got)
+	}
+	if got := stringValue(recovered.State["positionReconcileGateStatus"]); got != livePositionReconcileGateStatusStale {
+		t.Fatalf("expected stale reconcile gate status, got %s", got)
+	}
+	if got := stringValue(recovered.State["positionRecoveryStatus"]); got != livePositionReconcileGateStatusStale {
+		t.Fatalf("expected stale position recovery status, got %s", got)
+	}
+	if got := stringValue(recovered.State["positionReconcileGateScenario"]); got != "db-position-exchange-missing" {
+		t.Fatalf("expected db-position-exchange-missing scenario, got %s", got)
+	}
+	if !boolValue(recovered.State["positionReconcileGateBlocking"]) {
+		t.Fatal("expected stale reconcile gate to block execution")
+	}
+	if _, err := platform.ClosePosition(position.ID); err == nil {
+		t.Fatal("expected ClosePosition to be blocked by reconcile gate")
+	}
+}
+
+func TestRecoverRunningLiveSessionAllowsControlledExchangeOnlyTakeover(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	configureTestLiveRESTReconcileAdapter(t, platform, "test-reconcile-exchange-only", []map[string]any{
+		{
+			"symbol":      "BTCUSDT",
+			"positionAmt": -0.02,
+			"entryPrice":  70250.0,
+			"markPrice":   70100.0,
+		},
+	})
+	session, err := platform.CreateLiveSession("live-main", "strategy-bk-1d", map[string]any{
+		"symbol":          "BTCUSDT",
+		"signalTimeframe": "1d",
+	})
+	if err != nil {
+		t.Fatalf("create live session failed: %v", err)
+	}
+
+	recovered, err := platform.recoverRunningLiveSession(session)
+	if err != nil {
+		t.Fatalf("recover running live session failed: %v", err)
+	}
+	if recovered.Status != "RUNNING" {
+		t.Fatalf("expected controlled exchange takeover to proceed, got %s", recovered.Status)
+	}
+	if got := stringValue(recovered.State["positionReconcileGateScenario"]); got != "exchange-position-db-missing" {
+		t.Fatalf("expected exchange-position-db-missing scenario, got %s", got)
+	}
+	position, found, err := platform.store.FindPosition(session.AccountID, "BTCUSDT")
+	if err != nil {
+		t.Fatalf("find position failed: %v", err)
+	}
+	if !found {
+		t.Fatal("expected exchange-backed position to be created in store")
+	}
+	if position.Side != "SHORT" || position.Quantity != 0.02 {
+		t.Fatalf("expected short exchange-backed takeover position, got side=%s qty=%v", position.Side, position.Quantity)
+	}
+}
+
+func TestRecoverRunningLiveSessionBlocksSideMismatchAndPreventsCloseExecution(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	configureTestLiveRESTReconcileAdapter(t, platform, "test-reconcile-conflict", []map[string]any{
+		{
+			"symbol":      "BTCUSDT",
+			"positionAmt": -0.01,
+			"entryPrice":  68000.0,
+			"markPrice":   67950.0,
+		},
+	})
+	session, err := platform.CreateLiveSession("live-main", "strategy-bk-1d", map[string]any{
+		"symbol":          "BTCUSDT",
+		"signalTimeframe": "1d",
+	})
+	if err != nil {
+		t.Fatalf("create live session failed: %v", err)
+	}
+	position, err := platform.store.SavePosition(domain.Position{
+		AccountID:  session.AccountID,
+		Symbol:     "BTCUSDT",
+		Side:       "LONG",
+		Quantity:   0.01,
+		EntryPrice: 68000,
+		MarkPrice:  68100,
+	})
+	if err != nil {
+		t.Fatalf("save position failed: %v", err)
+	}
+
+	recovered, err := platform.recoverRunningLiveSession(session)
+	if err != nil {
+		t.Fatalf("recover running live session failed: %v", err)
+	}
+	if recovered.Status != "BLOCKED" {
+		t.Fatalf("expected mismatched recovery to stay BLOCKED, got %s", recovered.Status)
+	}
+	if got := stringValue(recovered.State["positionReconcileGateStatus"]); got != livePositionReconcileGateStatusConflict {
+		t.Fatalf("expected conflict reconcile gate status, got %s", got)
+	}
+	if got := stringValue(recovered.State["positionReconcileGateScenario"]); got != "side-mismatch" {
+		t.Fatalf("expected side-mismatch scenario, got %s", got)
+	}
+	stored, found, err := platform.store.FindPosition(session.AccountID, "BTCUSDT")
+	if err != nil {
+		t.Fatalf("find position failed: %v", err)
+	}
+	if !found {
+		t.Fatal("expected local conflict position to be preserved")
+	}
+	if stored.Side != "LONG" || stored.Quantity != 0.01 {
+		t.Fatalf("expected conflicting local position to stay unchanged, got side=%s qty=%v", stored.Side, stored.Quantity)
+	}
+	if _, err := platform.ClosePosition(position.ID); err == nil {
+		t.Fatal("expected ClosePosition to be blocked during unresolved conflict")
+	}
+}
+
+func TestUnresolvedReconcileMismatchPreventsAutoDispatch(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	configureTestLiveRESTReconcileAdapter(t, platform, "test-reconcile-auto-dispatch", []map[string]any{
+		{
+			"symbol":      "BTCUSDT",
+			"positionAmt": 0.02,
+			"entryPrice":  68000.0,
+			"markPrice":   67950.0,
+		},
+	})
+	session, err := platform.CreateLiveSession("live-main", "strategy-bk-1d", map[string]any{
+		"symbol":                  "BTCUSDT",
+		"signalTimeframe":         "1d",
+		"dispatchMode":            "auto-dispatch",
+		"dispatchCooldownSeconds": 0,
+	})
+	if err != nil {
+		t.Fatalf("create live session failed: %v", err)
+	}
+	if _, err := platform.store.SavePosition(domain.Position{
+		AccountID:  session.AccountID,
+		Symbol:     "BTCUSDT",
+		Side:       "LONG",
+		Quantity:   0.01,
+		EntryPrice: 68000,
+		MarkPrice:  68100,
+	}); err != nil {
+		t.Fatalf("save position failed: %v", err)
+	}
+
+	recovered, err := platform.recoverRunningLiveSession(session)
+	if err != nil {
+		t.Fatalf("recover running live session failed: %v", err)
+	}
+	if got := stringValue(recovered.State["positionReconcileGateScenario"]); got != "quantity-mismatch" {
+		t.Fatalf("expected quantity-mismatch scenario, got %s", got)
+	}
+	intent := map[string]any{
+		"action":   "exit",
+		"side":     "SELL",
+		"symbol":   "BTCUSDT",
+		"status":   "dispatchable",
+		"quantity": 0.01,
+		"metadata": map[string]any{},
+	}
+	if shouldAutoDispatchLiveIntent(recovered, intent, time.Now().UTC()) {
+		t.Fatal("expected unresolved reconcile mismatch to suppress auto-dispatch")
 	}
 }
 
@@ -5425,6 +5667,56 @@ func (a testLiveAccountSyncAdapter) SyncAccountSnapshot(platform *Platform, acco
 		return a.syncSnapshotFunc(platform, account, binding)
 	}
 	return account, nil
+}
+
+func configureTestLiveRESTReconcileAdapter(t *testing.T, platform *Platform, adapterKey string, exchangePositions []map[string]any) {
+	t.Helper()
+	platform.registerLiveAdapter(testLiveAccountSyncAdapter{
+		key: adapterKey,
+		syncSnapshotFunc: func(p *Platform, account domain.Account, binding map[string]any) (domain.Account, error) {
+			previousSuccessAt := parseOptionalRFC3339(stringValue(account.Metadata["lastLiveSyncAt"]))
+			account.Metadata = cloneMetadata(account.Metadata)
+			account.Metadata["liveSyncSnapshot"] = map[string]any{
+				"source":          "binance-rest-account-v3",
+				"adapterKey":      normalizeLiveAdapterKey(stringValue(binding["adapterKey"])),
+				"syncedAt":        time.Now().UTC().Format(time.RFC3339),
+				"bindingMode":     stringValue(binding["connectionMode"]),
+				"executionMode":   "rest",
+				"syncStatus":      "SYNCED",
+				"accountExchange": account.Exchange,
+				"positions":       exchangePositions,
+				"openOrders":      []map[string]any{},
+			}
+			var err error
+			account, err = p.persistLiveAccountSyncSuccess(account, binding, previousSuccessAt)
+			if err != nil {
+				return domain.Account{}, err
+			}
+			reconcileGate, err := p.reconcileLiveAccountPositions(account, exchangePositions)
+			if err != nil {
+				return domain.Account{}, err
+			}
+			account.Metadata = cloneMetadata(account.Metadata)
+			account.Metadata["livePositionReconcileGate"] = reconcileGate
+			account.Metadata["lastLivePositionSyncAt"] = time.Now().UTC().Format(time.RFC3339)
+			return p.store.UpdateAccount(account)
+		},
+	})
+
+	account, err := platform.store.GetAccount("live-main")
+	if err != nil {
+		t.Fatalf("get live account failed: %v", err)
+	}
+	account.Status = "READY"
+	account.Metadata = cloneMetadata(account.Metadata)
+	account.Metadata["liveBinding"] = map[string]any{
+		"adapterKey":     adapterKey,
+		"connectionMode": "mock",
+		"executionMode":  "rest",
+	}
+	if _, err := platform.store.UpdateAccount(account); err != nil {
+		t.Fatalf("update live account failed: %v", err)
+	}
 }
 
 type testFailingListOrdersStore struct {

--- a/internal/service/order.go
+++ b/internal/service/order.go
@@ -33,6 +33,10 @@ func (p *Platform) ClosePosition(positionID string) (domain.Order, error) {
 	if err != nil {
 		return domain.Order{}, err
 	}
+	// Reconcile-gated recoveries are intentionally fail-closed: once local state
+	// diverges from exchange truth, the platform must not place any additional
+	// execution claim, including manual close orders, until an operator resolves
+	// the position directly against the exchange.
 	if err := p.ensureLivePositionReconcileGateAllowsExecution(position.AccountID, position.Symbol, position.Quantity > 0); err != nil {
 		return domain.Order{}, err
 	}

--- a/internal/service/order.go
+++ b/internal/service/order.go
@@ -33,6 +33,9 @@ func (p *Platform) ClosePosition(positionID string) (domain.Order, error) {
 	if err != nil {
 		return domain.Order{}, err
 	}
+	if err := p.ensureLivePositionReconcileGateAllowsExecution(position.AccountID, position.Symbol, position.Quantity > 0); err != nil {
+		return domain.Order{}, err
+	}
 	order := buildClosePositionOrder(position)
 	if session, ok := p.findLiveRecoveryCloseOnlySession(position.AccountID, position.Symbol); ok {
 		order.Metadata = cloneMetadata(order.Metadata)
@@ -43,6 +46,23 @@ func (p *Platform) ClosePosition(positionID string) (domain.Order, error) {
 		order.StrategyVersionID = firstNonEmpty(order.StrategyVersionID, stringValue(session.State["strategyVersionId"]))
 	}
 	return p.CreateOrder(order)
+}
+
+func (p *Platform) ensureLivePositionReconcileGateAllowsExecution(accountID, symbol string, requiresVerification bool) error {
+	account, err := p.store.GetAccount(accountID)
+	if err != nil {
+		return err
+	}
+	gate := resolveLivePositionReconcileGate(account, symbol, requiresVerification)
+	if !boolValue(gate["blocking"]) {
+		return nil
+	}
+	return fmt.Errorf(
+		"live position %s execution blocked by reconcile gate: %s (%s)",
+		NormalizeSymbol(symbol),
+		firstNonEmpty(stringValue(gate["status"]), livePositionReconcileGateStatusError),
+		firstNonEmpty(stringValue(gate["scenario"]), "unknown"),
+	)
 }
 
 func buildClosePositionOrder(position domain.Position) domain.Order {


### PR DESCRIPTION
## 目的
为 runtime recovery 增加 hard reconcile gate，确保 recovered/taken-over 持仓在和交易所 truth 完成校验前，不会变成可交易或可自动平仓/派发状态。

Closes #86

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [x] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main)
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？
- [x] DB migration 是否具备向下兼容幂等性？
- [x] 配置字段有没有无意被混改？

说明：本次未改 `dispatchMode` 默认值，未引入 migration，也未触碰部署/凭证路径；变更集中在 live recovery/reconcile/dispatch gate。

## 验证方式与测试证据
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

已验证：
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
- 定向 recovery/reconcile 测试覆盖 match、exchange-missing、db-missing、side mismatch、quantity mismatch、auto-dispatch block

## 变更摘要
- 在 `syncLiveAccountFromBinance` / `reconcileLiveAccountPositions` 持久化 per-symbol reconcile verdict，而不是把 mismatch 静默归一化为健康状态。
- 在 `recoverRunningLiveSession` 和 `StartLiveSession` 加入 hard gate；若 recovered real position 仍存在 unresolved mismatch，则进入显式 `reconcile-gate-blocked` / `stale|conflict|error` 安全态。
- 在 `refreshLiveSessionPositionContext`、`dispatchLiveSessionIntent`、`shouldAutoDispatchLiveIntent`、`ClosePosition` 上消费 gate，阻断自动派单、被动 close/watchdog 和手动 close 执行。
- 保留 entryPrice fallback 语义，但不再允许用本地假设覆盖未解决的交易所冲突。
