### PR TITLE
[codex] add recovered close execution boundary guard

### DIFF
--- a/internal/service/live_registry.go
+++ b/internal/service/live_registry.go
@@ -421,7 +421,7 @@ func (a binanceFuturesLiveAdapter) submitRESTOrder(account domain.Account, order
 	if orderType != "MARKET" && timeInForce != "" {
 		params["timeInForce"] = timeInForce
 	}
-	if positionSide := strings.ToUpper(strings.TrimSpace(stringValue(normalizedOrder.Metadata["positionSide"]))); positionSide != "" {
+	if positionSide := resolveBinancePositionSideForSubmission(binding, normalizedOrder); positionSide != "" {
 		params["positionSide"] = positionSide
 	}
 	if shouldSendBinanceReduceOnlyFlag(binding, normalizedOrder) {
@@ -886,6 +886,20 @@ func shouldSendBinanceReduceOnlyFlag(binding map[string]any, order domain.Order)
 		return false
 	}
 	return !strings.EqualFold(strings.TrimSpace(stringValue(binding["positionMode"])), "HEDGE")
+}
+
+func resolveBinancePositionSideForSubmission(binding map[string]any, order domain.Order) string {
+	positionSide := strings.ToUpper(strings.TrimSpace(stringValue(order.Metadata["positionSide"])))
+	if positionSide == "" {
+		return ""
+	}
+	if strings.EqualFold(strings.TrimSpace(stringValue(binding["positionMode"])), "HEDGE") {
+		return positionSide
+	}
+	if positionSide == "BOTH" {
+		return ""
+	}
+	return positionSide
 }
 
 func fetchBinanceSymbolRules(creds binanceRESTCredentials, symbol string) (binanceSymbolRules, error) {

--- a/internal/service/live_registry.go
+++ b/internal/service/live_registry.go
@@ -322,6 +322,7 @@ func (a binanceFuturesLiveAdapter) submitMockOrder(account domain.Account, order
 			"accountMode":    stringValue(binding["accountMode"]),
 			"marginMode":     stringValue(binding["marginMode"]),
 			"positionMode":   stringValue(binding["positionMode"]),
+			"positionSide":   stringValue(order.Metadata["positionSide"]),
 			"sandbox":        boolValue(binding["sandbox"]),
 			"symbol":         order.Symbol,
 			"side":           order.Side,
@@ -420,7 +421,10 @@ func (a binanceFuturesLiveAdapter) submitRESTOrder(account domain.Account, order
 	if orderType != "MARKET" && timeInForce != "" {
 		params["timeInForce"] = timeInForce
 	}
-	if normalizedOrder.EffectiveReduceOnly() {
+	if positionSide := strings.ToUpper(strings.TrimSpace(stringValue(normalizedOrder.Metadata["positionSide"]))); positionSide != "" {
+		params["positionSide"] = positionSide
+	}
+	if shouldSendBinanceReduceOnlyFlag(binding, normalizedOrder) {
 		params["reduceOnly"] = "true"
 	}
 	if normalizedOrder.EffectiveClosePosition() {
@@ -875,6 +879,13 @@ func containsString(items []string, target string) bool {
 		}
 	}
 	return false
+}
+
+func shouldSendBinanceReduceOnlyFlag(binding map[string]any, order domain.Order) bool {
+	if !order.EffectiveReduceOnly() {
+		return false
+	}
+	return !strings.EqualFold(strings.TrimSpace(stringValue(binding["positionMode"])), "HEDGE")
 }
 
 func fetchBinanceSymbolRules(creds binanceRESTCredentials, symbol string) (binanceSymbolRules, error) {

--- a/internal/service/order.go
+++ b/internal/service/order.go
@@ -343,8 +343,109 @@ func (p *Platform) submitLiveOrder(account domain.Account, order domain.Order) (
 			return domain.Order{}, err
 		}
 	}
+	order, err = p.prepareLiveOrderForSubmission(account, order, binding)
+	if err != nil {
+		return p.applyLiveSubmissionResult(order, binding, runtimeSession, sourceGate, LiveOrderSubmission{}, err)
+	}
 	submission, submitErr := adapter.SubmitOrder(account, order, binding)
 	return p.applyLiveSubmissionResult(order, binding, runtimeSession, sourceGate, submission, submitErr)
+}
+
+const (
+	liveExecutionBoundaryClassNormalEntry           = "normal-entry"
+	liveExecutionBoundaryClassNormalExit            = "normal-exit"
+	liveExecutionBoundaryClassRecoveredPassiveClose = "recovered-passive-close"
+	liveExecutionBoundaryClassVirtualPath           = "virtual-path"
+)
+
+func (p *Platform) prepareLiveOrderForSubmission(account domain.Account, order domain.Order, binding map[string]any) (domain.Order, error) {
+	order.Metadata = cloneMetadata(order.Metadata)
+	if order.Metadata == nil {
+		order.Metadata = map[string]any{}
+	}
+	classification := classifyLiveExecutionBoundaryOrder(order)
+	order.Metadata["executionBoundaryClass"] = classification
+	if classification != liveExecutionBoundaryClassRecoveredPassiveClose {
+		return order, nil
+	}
+	if !order.EffectiveReduceOnly() {
+		return order, fmt.Errorf("recovered passive close requires reduceOnly semantics at execution boundary for %s", NormalizeSymbol(order.Symbol))
+	}
+	position, found, err := p.resolveReduceOnlyTargetPosition(account.ID, order)
+	if err != nil {
+		return order, err
+	}
+	if !found || position.Quantity <= 0 {
+		return order, fmt.Errorf("recovered passive close requires an open position for %s", NormalizeSymbol(order.Symbol))
+	}
+	expectedSide := "SELL"
+	expectedPositionSide := "LONG"
+	if strings.EqualFold(strings.TrimSpace(position.Side), "SHORT") {
+		expectedSide = "BUY"
+		expectedPositionSide = "SHORT"
+	}
+	if !strings.EqualFold(strings.TrimSpace(order.Side), expectedSide) {
+		return order, fmt.Errorf("recovered passive close side %s does not reduce %s position on %s", order.Side, position.Side, NormalizeSymbol(order.Symbol))
+	}
+	positionMode := strings.ToUpper(strings.TrimSpace(firstNonEmpty(stringValue(binding["positionMode"]), "ONE_WAY")))
+	providedPositionSide := strings.ToUpper(strings.TrimSpace(stringValue(order.Metadata["positionSide"])))
+	switch positionMode {
+	case "HEDGE":
+		if providedPositionSide != "" && providedPositionSide != expectedPositionSide {
+			return order, fmt.Errorf("recovered passive close positionSide %s does not match %s position on %s", providedPositionSide, expectedPositionSide, NormalizeSymbol(order.Symbol))
+		}
+		order.Metadata["positionSide"] = expectedPositionSide
+	case "ONE_WAY":
+		if providedPositionSide != "" && providedPositionSide != "BOTH" {
+			return order, fmt.Errorf("recovered passive close positionSide %s is invalid in ONE_WAY mode for %s", providedPositionSide, NormalizeSymbol(order.Symbol))
+		}
+		order.Metadata["positionSide"] = "BOTH"
+	default:
+		return order, fmt.Errorf("unsupported positionMode: %s", positionMode)
+	}
+	order.Metadata["executionBoundaryGuard"] = liveExecutionBoundaryClassRecoveredPassiveClose
+	order.Metadata["executionBoundaryTargetSide"] = strings.ToUpper(strings.TrimSpace(position.Side))
+	return order, nil
+}
+
+func classifyLiveExecutionBoundaryOrder(order domain.Order) string {
+	metadata := mapValue(order.Metadata)
+	if metadata == nil {
+		metadata = map[string]any{}
+	}
+	if isVirtualExecutionBoundaryOrder(order, metadata) {
+		return liveExecutionBoundaryClassVirtualPath
+	}
+	if isRecoveredPassiveCloseOrder(order, metadata) {
+		return liveExecutionBoundaryClassRecoveredPassiveClose
+	}
+	proposal := mapValue(firstNonEmptyMapValue(metadata["executionProposal"], metadata["intent"]))
+	if order.EffectiveReduceOnly() || order.EffectiveClosePosition() || strings.EqualFold(strings.TrimSpace(stringValue(proposal["role"])), "exit") {
+		return liveExecutionBoundaryClassNormalExit
+	}
+	return liveExecutionBoundaryClassNormalEntry
+}
+
+func isRecoveredPassiveCloseOrder(order domain.Order, metadata map[string]any) bool {
+	if boolValue(metadata["recoveryCloseOnlyTakeover"]) {
+		return true
+	}
+	proposal := mapValue(firstNonEmptyMapValue(metadata["executionProposal"], metadata["intent"]))
+	proposalMeta := mapValue(proposal["metadata"])
+	if boolValue(metadata["recoveryTriggered"]) || boolValue(proposalMeta["recoveryTriggered"]) {
+		return strings.EqualFold(strings.TrimSpace(firstNonEmpty(stringValue(proposal["role"]), stringValue(metadata["role"]), "exit")), "exit")
+	}
+	return strings.EqualFold(strings.TrimSpace(stringValue(proposal["signalKind"])), "recovery-watchdog") &&
+		strings.EqualFold(strings.TrimSpace(firstNonEmpty(stringValue(proposal["role"]), "exit")), "exit")
+}
+
+func isVirtualExecutionBoundaryOrder(order domain.Order, metadata map[string]any) bool {
+	status := strings.ToLower(strings.TrimSpace(order.Status))
+	if strings.HasPrefix(status, "virtual-") {
+		return true
+	}
+	source := strings.ToLower(strings.TrimSpace(stringValue(metadata["source"])))
+	return strings.HasPrefix(source, "virtual-")
 }
 
 func shouldSkipLiveRuntimeCheck(order domain.Order) bool {

--- a/internal/service/order_test.go
+++ b/internal/service/order_test.go
@@ -1,6 +1,11 @@
 package service
 
 import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	neturl "net/url"
 	"strings"
 	"testing"
 	"time"
@@ -484,6 +489,131 @@ func TestShouldSendBinanceReduceOnlyFlagRespectsPositionMode(t *testing.T) {
 	}
 	if shouldSendBinanceReduceOnlyFlag(map[string]any{"positionMode": "HEDGE"}, order) {
 		t.Fatal("expected reduceOnly flag to be omitted in HEDGE mode")
+	}
+}
+
+func TestResolveBinancePositionSideForSubmissionOmitsOneWayBoth(t *testing.T) {
+	order := domain.Order{Metadata: map[string]any{"positionSide": "BOTH"}}
+	if got := resolveBinancePositionSideForSubmission(map[string]any{"positionMode": "ONE_WAY"}, order); got != "" {
+		t.Fatalf("expected ONE_WAY BOTH to be omitted, got %s", got)
+	}
+	if got := resolveBinancePositionSideForSubmission(map[string]any{"positionMode": "HEDGE"}, domain.Order{
+		Metadata: map[string]any{"positionSide": "LONG"},
+	}); got != "LONG" {
+		t.Fatalf("expected hedge positionSide LONG to be preserved, got %s", got)
+	}
+}
+
+func TestSubmitRESTOrderRecoveredPassiveClosePayloadMatchesBinanceModes(t *testing.T) {
+	tests := []struct {
+		name                  string
+		positionMode          string
+		side                  string
+		positionSide          string
+		reduceOnly            bool
+		wantPositionSide      string
+		wantReduceOnlyPresent bool
+	}{
+		{
+			name:                  "hedge long close",
+			positionMode:          "HEDGE",
+			side:                  "SELL",
+			positionSide:          "LONG",
+			reduceOnly:            true,
+			wantPositionSide:      "LONG",
+			wantReduceOnlyPresent: false,
+		},
+		{
+			name:                  "one way close",
+			positionMode:          "ONE_WAY",
+			side:                  "SELL",
+			positionSide:          "BOTH",
+			reduceOnly:            true,
+			wantPositionSide:      "",
+			wantReduceOnlyPresent: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var capturedForm neturl.Values
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/fapi/v1/exchangeInfo":
+					_ = json.NewEncoder(w).Encode(map[string]any{
+						"symbols": []map[string]any{{
+							"symbol": "BTCUSDT",
+							"filters": []map[string]any{
+								{"filterType": "PRICE_FILTER", "tickSize": "0.1"},
+								{"filterType": "LOT_SIZE", "stepSize": "0.001", "minQty": "0.001", "maxQty": "1000"},
+								{"filterType": "MIN_NOTIONAL", "notional": "100"},
+							},
+						}},
+					})
+				case "/fapi/v1/order":
+					body, err := io.ReadAll(r.Body)
+					if err != nil {
+						t.Fatalf("read order body failed: %v", err)
+					}
+					capturedForm, err = neturl.ParseQuery(string(body))
+					if err != nil {
+						t.Fatalf("parse order form failed: %v", err)
+					}
+					_ = json.NewEncoder(w).Encode(map[string]any{
+						"status":        "NEW",
+						"orderId":       12345,
+						"clientOrderId": "order-test",
+						"updateTime":    time.Now().UTC().UnixMilli(),
+					})
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			defer server.Close()
+
+			t.Setenv("TEST_BINANCE_KEY", "key")
+			t.Setenv("TEST_BINANCE_SECRET", "secret")
+
+			binanceSymbolRulesCacheMu.Lock()
+			binanceSymbolRulesCache = map[string]binanceSymbolRules{}
+			binanceSymbolRulesCacheMu.Unlock()
+
+			adapter := binanceFuturesLiveAdapter{}
+			_, err := adapter.submitRESTOrder(domain.Account{Exchange: "binance-futures"}, domain.Order{
+				ID:         "order-test",
+				AccountID:  "live-main",
+				Symbol:     "BTCUSDT",
+				Side:       tt.side,
+				Type:       "MARKET",
+				Quantity:   0.25,
+				ReduceOnly: tt.reduceOnly,
+				Metadata: map[string]any{
+					"positionSide": tt.positionSide,
+				},
+			}, map[string]any{
+				"executionMode": "rest",
+				"positionMode":  tt.positionMode,
+				"restBaseUrl":   server.URL,
+				"recvWindowMs":  5000,
+				"credentialRefs": map[string]any{
+					"apiKeyRef":    "TEST_BINANCE_KEY",
+					"apiSecretRef": "TEST_BINANCE_SECRET",
+				},
+			})
+			if err != nil {
+				t.Fatalf("submit REST order failed: %v", err)
+			}
+			if got := capturedForm.Get("side"); got != tt.side {
+				t.Fatalf("expected side %s, got %s", tt.side, got)
+			}
+			if got := capturedForm.Get("positionSide"); got != tt.wantPositionSide {
+				t.Fatalf("expected positionSide %q, got %q", tt.wantPositionSide, got)
+			}
+			_, hasReduceOnly := capturedForm["reduceOnly"]
+			if hasReduceOnly != tt.wantReduceOnlyPresent {
+				t.Fatalf("expected reduceOnly present=%t, form=%v", tt.wantReduceOnlyPresent, capturedForm)
+			}
+		})
 	}
 }
 

--- a/internal/service/order_test.go
+++ b/internal/service/order_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -236,6 +237,256 @@ func TestClosePositionAllowsLiveManualCloseWithoutRuntimeSession(t *testing.T) {
 	}
 }
 
+func TestRecoveredPassiveCloseExecutionBoundaryAllowsValidHedgeClose(t *testing.T) {
+	store := memory.NewStore()
+	platform := NewPlatform(store)
+	adapter := &recordingLiveExecutionAdapter{key: "test-recovered-close-valid"}
+	platform.registerLiveAdapter(adapter)
+
+	account, err := platform.BindLiveAccount("live-main", map[string]any{
+		"adapterKey":    adapter.key,
+		"executionMode": "mock",
+		"positionMode":  "HEDGE",
+	})
+	if err != nil {
+		t.Fatalf("bind live account failed: %v", err)
+	}
+	if _, err := store.SavePosition(domain.Position{
+		AccountID:         account.ID,
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "LONG",
+		Quantity:          0.25,
+		MarkPrice:         68100,
+	}); err != nil {
+		t.Fatalf("save live position failed: %v", err)
+	}
+
+	order, err := platform.CreateOrder(domain.Order{
+		AccountID:         account.ID,
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "SELL",
+		Type:              "MARKET",
+		Quantity:          0.25,
+		ReduceOnly:        true,
+		Metadata: map[string]any{
+			"skipRuntimeCheck": true,
+			"executionProposal": map[string]any{
+				"role":       "exit",
+				"side":       "SELL",
+				"symbol":     "BTCUSDT",
+				"signalKind": "recovery-watchdog",
+				"metadata": map[string]any{
+					"recoveryTriggered": true,
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("create recovered close order failed: %v", err)
+	}
+	if adapter.submitCount != 1 {
+		t.Fatalf("expected adapter submit to be called once, got %d", adapter.submitCount)
+	}
+	if got := stringValue(adapter.lastOrder.Metadata["executionBoundaryClass"]); got != liveExecutionBoundaryClassRecoveredPassiveClose {
+		t.Fatalf("expected recovered-passive-close classification, got %s", got)
+	}
+	if got := stringValue(adapter.lastOrder.Metadata["positionSide"]); got != "LONG" {
+		t.Fatalf("expected hedge recovered close to submit positionSide LONG, got %s", got)
+	}
+	if got := order.Status; got != "ACCEPTED" {
+		t.Fatalf("expected recovered close order to be accepted, got %s", got)
+	}
+}
+
+func TestRecoveredPassiveCloseExecutionBoundaryBlocksMissingReduceOnly(t *testing.T) {
+	store := memory.NewStore()
+	platform := NewPlatform(store)
+	adapter := &recordingLiveExecutionAdapter{key: "test-recovered-close-missing-reduce-only"}
+	platform.registerLiveAdapter(adapter)
+
+	account, err := platform.BindLiveAccount("live-main", map[string]any{
+		"adapterKey":    adapter.key,
+		"executionMode": "mock",
+		"positionMode":  "ONE_WAY",
+	})
+	if err != nil {
+		t.Fatalf("bind live account failed: %v", err)
+	}
+	if _, err := store.SavePosition(domain.Position{
+		AccountID:         account.ID,
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "LONG",
+		Quantity:          0.25,
+		MarkPrice:         68100,
+	}); err != nil {
+		t.Fatalf("save live position failed: %v", err)
+	}
+
+	order, err := platform.CreateOrder(domain.Order{
+		AccountID:         account.ID,
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "SELL",
+		Type:              "MARKET",
+		Quantity:          0.25,
+		Metadata: map[string]any{
+			"skipRuntimeCheck": true,
+			"executionProposal": map[string]any{
+				"role":       "exit",
+				"side":       "SELL",
+				"symbol":     "BTCUSDT",
+				"signalKind": "recovery-watchdog",
+				"metadata": map[string]any{
+					"recoveryTriggered": true,
+				},
+			},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected recovered close without reduceOnly to be blocked")
+	}
+	if adapter.submitCount != 0 {
+		t.Fatalf("expected adapter submit not to be called, got %d", adapter.submitCount)
+	}
+	if got := order.Status; got != "REJECTED" {
+		t.Fatalf("expected blocked recovered close order to be marked REJECTED, got %s", got)
+	}
+}
+
+func TestRecoveredPassiveCloseExecutionBoundaryBlocksInvalidSideAndHedgePayload(t *testing.T) {
+	tests := []struct {
+		name         string
+		side         string
+		positionSide string
+		wantErr      string
+	}{
+		{
+			name:    "wrong side",
+			side:    "BUY",
+			wantErr: "does not reduce LONG position",
+		},
+		{
+			name:         "wrong hedge positionSide",
+			side:         "SELL",
+			positionSide: "SHORT",
+			wantErr:      "does not match LONG position",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := memory.NewStore()
+			platform := NewPlatform(store)
+			adapter := &recordingLiveExecutionAdapter{key: "test-recovered-close-" + strings.ReplaceAll(tt.name, " ", "-")}
+			platform.registerLiveAdapter(adapter)
+
+			account, err := platform.BindLiveAccount("live-main", map[string]any{
+				"adapterKey":    adapter.key,
+				"executionMode": "mock",
+				"positionMode":  "HEDGE",
+			})
+			if err != nil {
+				t.Fatalf("bind live account failed: %v", err)
+			}
+			if _, err := store.SavePosition(domain.Position{
+				AccountID:         account.ID,
+				StrategyVersionID: "strategy-version-bk-1d-v010",
+				Symbol:            "BTCUSDT",
+				Side:              "LONG",
+				Quantity:          0.25,
+				MarkPrice:         68100,
+			}); err != nil {
+				t.Fatalf("save live position failed: %v", err)
+			}
+			binding := resolveLiveBinding(account)
+			order, err := platform.prepareLiveOrderForSubmission(account, domain.Order{
+				AccountID:         account.ID,
+				StrategyVersionID: "strategy-version-bk-1d-v010",
+				Symbol:            "BTCUSDT",
+				Side:              tt.side,
+				Type:              "MARKET",
+				Quantity:          0.25,
+				ReduceOnly:        true,
+				Metadata: map[string]any{
+					"skipRuntimeCheck": true,
+					"positionSide":     tt.positionSide,
+					"executionProposal": map[string]any{
+						"role":       "exit",
+						"side":       tt.side,
+						"symbol":     "BTCUSDT",
+						"signalKind": "recovery-watchdog",
+						"metadata": map[string]any{
+							"recoveryTriggered": true,
+						},
+					},
+				},
+			}, binding)
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("expected error containing %q, got %v", tt.wantErr, err)
+			}
+			if got := stringValue(order.Metadata["executionBoundaryClass"]); got != liveExecutionBoundaryClassRecoveredPassiveClose {
+				t.Fatalf("expected recovered-passive-close classification, got %s", got)
+			}
+		})
+	}
+}
+
+func TestRecoveredPassiveCloseExecutionBoundaryLeavesNormalEntryFlowIntact(t *testing.T) {
+	store := memory.NewStore()
+	platform := NewPlatform(store)
+	adapter := &recordingLiveExecutionAdapter{key: "test-normal-entry"}
+	platform.registerLiveAdapter(adapter)
+
+	account, err := platform.BindLiveAccount("live-main", map[string]any{
+		"adapterKey":    adapter.key,
+		"executionMode": "mock",
+		"positionMode":  "ONE_WAY",
+	})
+	if err != nil {
+		t.Fatalf("bind live account failed: %v", err)
+	}
+
+	order, err := platform.CreateOrder(domain.Order{
+		AccountID:         account.ID,
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "BUY",
+		Type:              "MARKET",
+		Quantity:          0.25,
+		Metadata: map[string]any{
+			"skipRuntimeCheck": true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("create normal entry order failed: %v", err)
+	}
+	if adapter.submitCount != 1 {
+		t.Fatalf("expected adapter submit to be called once, got %d", adapter.submitCount)
+	}
+	if got := stringValue(adapter.lastOrder.Metadata["executionBoundaryClass"]); got != liveExecutionBoundaryClassNormalEntry {
+		t.Fatalf("expected normal-entry classification, got %s", got)
+	}
+	if got := stringValue(adapter.lastOrder.Metadata["positionSide"]); got != "" {
+		t.Fatalf("expected normal entry not to inject positionSide, got %s", got)
+	}
+	if got := order.Status; got != "ACCEPTED" {
+		t.Fatalf("expected normal entry order to be accepted, got %s", got)
+	}
+}
+
+func TestShouldSendBinanceReduceOnlyFlagRespectsPositionMode(t *testing.T) {
+	order := domain.Order{ReduceOnly: true}
+	if !shouldSendBinanceReduceOnlyFlag(map[string]any{"positionMode": "ONE_WAY"}, order) {
+		t.Fatal("expected reduceOnly flag to be sent in ONE_WAY mode")
+	}
+	if shouldSendBinanceReduceOnlyFlag(map[string]any{"positionMode": "HEDGE"}, order) {
+		t.Fatal("expected reduceOnly flag to be omitted in HEDGE mode")
+	}
+}
+
 func TestFinalizeExecutedOrderFallsBackToNowWhenExchangeTradeTimeMissing(t *testing.T) {
 	store := memory.NewStore()
 	platform := NewPlatform(store)
@@ -311,4 +562,46 @@ func TestFinalizeExecutedOrderKeepsLastFilledAtOnDuplicateSync(t *testing.T) {
 	if got := stringValue(filledOrder.Metadata["lastFilledAt"]); got != firstTradeTime.Format(time.RFC3339) {
 		t.Fatalf("expected duplicate sync to keep original lastFilledAt, got %q", got)
 	}
+}
+
+type recordingLiveExecutionAdapter struct {
+	key         string
+	submitCount int
+	lastOrder   domain.Order
+}
+
+func (a *recordingLiveExecutionAdapter) Key() string {
+	return a.key
+}
+
+func (a *recordingLiveExecutionAdapter) Describe() map[string]any {
+	return map[string]any{"key": a.key}
+}
+
+func (a *recordingLiveExecutionAdapter) ValidateAccountConfig(map[string]any) error {
+	return nil
+}
+
+func (a *recordingLiveExecutionAdapter) SubmitOrder(_ domain.Account, order domain.Order, binding map[string]any) (LiveOrderSubmission, error) {
+	a.submitCount++
+	a.lastOrder = order
+	return LiveOrderSubmission{
+		Status:          "ACCEPTED",
+		ExchangeOrderID: "exchange-order-1",
+		AcceptedAt:      time.Now().UTC().Format(time.RFC3339),
+		Metadata: map[string]any{
+			"adapterMode":   "recording",
+			"executionMode": stringValue(binding["executionMode"]),
+			"positionMode":  stringValue(binding["positionMode"]),
+			"positionSide":  stringValue(order.Metadata["positionSide"]),
+		},
+	}, nil
+}
+
+func (a *recordingLiveExecutionAdapter) SyncOrder(domain.Account, domain.Order, map[string]any) (LiveOrderSync, error) {
+	return LiveOrderSync{}, nil
+}
+
+func (a *recordingLiveExecutionAdapter) CancelOrder(domain.Account, domain.Order, map[string]any) (LiveOrderSync, error) {
+	return LiveOrderSync{}, nil
 }


### PR DESCRIPTION
## 目的
修复 Issue #88，在最终执行提交边界为 recovered historical position 的被动平仓单增加 reduce-only 安全护栏，避免恢复态平仓因为 payload 语义不完整而反手开仓或错误命中仓位。

Closes #88

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [x] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
- [ ] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main)
- [ ] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？
- [ ] DB migration 是否具备向下兼容幂等性？
- [ ] 配置字段有没有无意被混改？

## 验证方式与测试证据
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

### 变更摘要
- 在 `submitLiveOrder()` 里增加最终提交边界校验，分类 `normal-entry` / `normal-exit` / `recovered-passive-close` / `virtual-path`
- recovered passive close 现在在 adapter 提交前强制校验 `side`、`reduceOnly`、`positionSide`、`positionMode`
- Binance REST payload 组装补充 `positionSide`，并在 `HEDGE` 模式避免发送 Binance 不接受的 `reduceOnly` 参数

### Root Cause
现有恢复态校验主要停留在 proposal / intent metadata 阶段，但最后提交到交易所前没有再次校验 recovered-close 的 reduce-only 语义，也没有把 `positionSide` 带到最终 Binance payload。这样会留下恢复态平仓单在最终边界语义不一致的窗口。

### 验证
- `go test ./internal/service -run 'TestRecoveredPassiveCloseExecutionBoundary|TestClosePositionAllowsLiveManualCloseWithoutRuntimeSession|TestShouldSendBinanceReduceOnlyFlagRespectsPositionMode'`
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
