### PR TITLE
[runtime-recovery] define takeover state machine and action matrix

### DIFF
--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -1854,6 +1854,7 @@ func (p *Platform) evaluateLiveSessionOnSignal(session domain.LiveSession, runti
 	if err != nil {
 		return err
 	}
+	recoveryActions := currentLiveRecoveryActionMatrix(session.State)
 
 	state := cloneMetadata(session.State)
 	state["strategyEvaluationMode"] = "signal-runtime-heartbeat"
@@ -2032,6 +2033,24 @@ func (p *Platform) evaluateLiveSessionOnSignal(session domain.LiveSession, runti
 		delete(state, "lastStrategyIntent")
 		delete(state, "lastStrategyIntentSignature")
 	}
+	if len(executionProposal) > 0 {
+		action := resolveLiveRecoveryIntentAction(executionProposal)
+		if !liveRecoveryIntentActionAllowed(recoveryActions, action) {
+			delete(state, "lastExecutionProposal")
+			delete(state, "lastExecutionProfile")
+			delete(state, "lastStrategyIntent")
+			delete(state, "lastStrategyIntentSignature")
+			state["lastStrategyEvaluationStatus"] = "recovery-manual-review"
+			state["lastRecoveryBlockedAction"] = action
+			state["lastRecoveryBlockedAt"] = eventTime.UTC().Format(time.RFC3339)
+			appendTimelineEvent(state, "recovery", eventTime, "recovery-action-blocked", map[string]any{
+				"takeoverState": stringValue(state["recoveryTakeoverState"]),
+				"action":        action,
+			})
+			intent = nil
+			executionProposal = nil
+		}
+	}
 	decisionEvent, decisionEventErr := p.recordStrategyDecisionEvent(
 		session,
 		firstNonEmpty(runtimeSessionID, stringValue(state["signalRuntimeSessionId"])),
@@ -2079,6 +2098,8 @@ func (p *Platform) evaluateLiveSessionOnSignal(session domain.LiveSession, runti
 		state["lastStrategyEvaluationStatus"] = "intent-ready"
 	} else if executionProposal != nil {
 		state["lastStrategyEvaluationStatus"] = "waiting-execution"
+	} else if strings.EqualFold(stringValue(state["lastStrategyEvaluationStatus"]), "recovery-manual-review") {
+		// Keep the takeover/manual-review verdict instead of downgrading back to a normal monitoring state.
 	} else if decision.Action == "advance-plan" {
 		state["lastStrategyEvaluationStatus"] = "monitoring"
 	} else {
@@ -2551,13 +2572,13 @@ func (p *Platform) ensureLiveExecutionPlan(session domain.LiveSession) (domain.L
 	state["hasRecoveredVirtualPosition"] = boolValue(positionSnapshot["virtual"])
 	state["lastRecoveredPositionAt"] = time.Now().UTC().Format(time.RFC3339)
 	state["positionRecoverySource"] = "platform-position-store"
-	state["positionRecoveryStatus"] = "flat"
-	if foundPosition {
-		state["positionRecoveryStatus"] = "monitoring-open-position"
-	} else if boolValue(positionSnapshot["virtual"]) {
-		state["positionRecoveryStatus"] = "monitoring-virtual-position"
-	}
-	if nextIndex, adjusted := reconcileLivePlanIndexWithPosition(plan, resolveLivePlanIndex(state), positionSnapshot, foundPosition); adjusted {
+	state["positionRecoveryStatus"] = normalizedRecoveredPositionStatus(
+		stringValue(state["positionRecoveryStatus"]),
+		foundPosition,
+		boolValue(positionSnapshot["virtual"]),
+	)
+	takeoverMatrix := applyLiveRecoveryTakeoverState(state, boolValue(state["recoveryTakeoverActive"]))
+	if nextIndex, adjusted := reconcileLivePlanIndexWithPosition(plan, resolveLivePlanIndex(state), positionSnapshot, foundPosition); adjusted && takeoverMatrix.AllowPlanProgression {
 		state["planIndex"] = nextIndex
 		state["planIndexRecoveredFromPosition"] = true
 		state["recoveredPlanIndex"] = nextIndex
@@ -2576,12 +2597,194 @@ const (
 	liveRecoveryModeReconcileGateBlocked    = "reconcile-gate-blocked"
 	liveRecoveryMetadataStatusComplete      = "complete"
 	liveRecoveryMetadataStatusIncomplete    = "incomplete"
+	liveRecoveryTakeoverStateMonitoring     = "recovery-monitoring"
+	liveRecoveryTakeoverStateUnprotected    = "unprotected-open-position"
+	liveRecoveryTakeoverStateStaleSync      = "stale-sync"
+	liveRecoveryTakeoverStateConflict       = "recovery-conflict"
+	liveRecoveryTakeoverStateError          = "error"
 	livePositionReconcileGateStatusAdopted  = "adopted"
 	livePositionReconcileGateStatusVerified = "verified"
 	livePositionReconcileGateStatusStale    = "stale"
 	livePositionReconcileGateStatusConflict = "conflict"
 	livePositionReconcileGateStatusError    = "error"
 )
+
+type liveRecoveryActionMatrix struct {
+	OpenNewPosition       bool
+	CloseExistingPosition bool
+	PlaceProtectionOrders bool
+	AutoDispatch          bool
+	ManualReviewRequired  bool
+	AllowPlanProgression  bool
+}
+
+// Recovery/takeover action matrix.
+// State                     open close protect auto-dispatch manual-review plan-progress
+// close-only-takeover       no   yes   no      no            yes           no
+// recovery-monitoring       no   yes   yes     no            yes           yes
+// unprotected-open-position no   yes   yes     no            yes           no
+// stale-sync                no   no    no      no            yes           no
+// recovery-conflict         no   no    no      no            yes           no
+// error                     no   no    no      no            yes           no
+func liveRecoveryActionMatrixForState(state string) liveRecoveryActionMatrix {
+	switch strings.TrimSpace(state) {
+	case liveRecoveryModeCloseOnlyTakeover:
+		return liveRecoveryActionMatrix{
+			CloseExistingPosition: true,
+			ManualReviewRequired:  true,
+		}
+	case liveRecoveryTakeoverStateMonitoring:
+		return liveRecoveryActionMatrix{
+			CloseExistingPosition: true,
+			PlaceProtectionOrders: true,
+			ManualReviewRequired:  true,
+			AllowPlanProgression:  true,
+		}
+	case liveRecoveryTakeoverStateUnprotected:
+		return liveRecoveryActionMatrix{
+			CloseExistingPosition: true,
+			PlaceProtectionOrders: true,
+			ManualReviewRequired:  true,
+		}
+	case liveRecoveryTakeoverStateStaleSync, liveRecoveryTakeoverStateConflict, liveRecoveryTakeoverStateError:
+		return liveRecoveryActionMatrix{ManualReviewRequired: true}
+	default:
+		return liveRecoveryActionMatrix{
+			OpenNewPosition:       true,
+			CloseExistingPosition: true,
+			PlaceProtectionOrders: true,
+			AutoDispatch:          true,
+			AllowPlanProgression:  true,
+		}
+	}
+}
+
+func hasRecoveredLiveRealPosition(state map[string]any) bool {
+	return boolValue(state["hasRecoveredPosition"]) ||
+		boolValue(state["hasRecoveredRealPosition"]) ||
+		math.Abs(parseFloatValue(mapValue(state["recoveredPosition"])["quantity"])) > 0
+}
+
+func shouldActivateLiveRecoveryTakeover(source string, state map[string]any) bool {
+	if boolValue(state["recoveryTakeoverActive"]) {
+		return true
+	}
+	return strings.HasPrefix(strings.TrimSpace(source), "live-startup-recovery")
+}
+
+func resolveLiveRecoveryTakeoverState(state map[string]any, active bool) string {
+	if !active {
+		return ""
+	}
+	if isLiveSessionRecoveryCloseOnlyMode(state) ||
+		strings.EqualFold(stringValue(state["positionRecoveryStatus"]), liveRecoveryModeCloseOnlyTakeover) {
+		return liveRecoveryModeCloseOnlyTakeover
+	}
+	switch strings.TrimSpace(stringValue(state["positionReconcileGateStatus"])) {
+	case livePositionReconcileGateStatusStale:
+		return liveRecoveryTakeoverStateStaleSync
+	case livePositionReconcileGateStatusConflict:
+		return liveRecoveryTakeoverStateConflict
+	case livePositionReconcileGateStatusError:
+		return liveRecoveryTakeoverStateError
+	}
+	switch strings.TrimSpace(stringValue(state["positionRecoveryStatus"])) {
+	case liveRecoveryTakeoverStateUnprotected:
+		return liveRecoveryTakeoverStateUnprotected
+	case "protected-open-position", "monitoring-open-position", "monitoring-virtual-position", livePositionRecoveryStatusClosingPending:
+		return liveRecoveryTakeoverStateMonitoring
+	case livePositionReconcileGateStatusStale:
+		return liveRecoveryTakeoverStateStaleSync
+	case livePositionReconcileGateStatusConflict:
+		return liveRecoveryTakeoverStateConflict
+	case livePositionReconcileGateStatusError:
+		return liveRecoveryTakeoverStateError
+	}
+	if hasRecoveredLiveRealPosition(state) {
+		return liveRecoveryTakeoverStateMonitoring
+	}
+	if strings.TrimSpace(stringValue(state["positionRecoveryStatus"])) == "" ||
+		strings.EqualFold(stringValue(state["positionRecoveryStatus"]), "flat") {
+		return ""
+	}
+	return liveRecoveryTakeoverStateError
+}
+
+func applyLiveRecoveryTakeoverState(state map[string]any, active bool) liveRecoveryActionMatrix {
+	if state == nil {
+		return liveRecoveryActionMatrixForState("")
+	}
+	takeoverState := resolveLiveRecoveryTakeoverState(state, active)
+	if takeoverState == "" {
+		delete(state, "recoveryTakeoverActive")
+		delete(state, "recoveryTakeoverState")
+		delete(state, "recoveryActionMatrix")
+		delete(state, "recoveryManualReviewRequired")
+		return liveRecoveryActionMatrixForState("")
+	}
+	matrix := liveRecoveryActionMatrixForState(takeoverState)
+	state["recoveryTakeoverActive"] = true
+	state["recoveryTakeoverState"] = takeoverState
+	state["recoveryManualReviewRequired"] = matrix.ManualReviewRequired
+	state["recoveryActionMatrix"] = map[string]any{
+		"openNewPosition":       matrix.OpenNewPosition,
+		"closeExistingPosition": matrix.CloseExistingPosition,
+		"placeProtectionOrders": matrix.PlaceProtectionOrders,
+		"autoDispatch":          matrix.AutoDispatch,
+		"manualReviewRequired":  matrix.ManualReviewRequired,
+		"allowPlanProgression":  matrix.AllowPlanProgression,
+	}
+	return matrix
+}
+
+func currentLiveRecoveryActionMatrix(state map[string]any) liveRecoveryActionMatrix {
+	return liveRecoveryActionMatrixForState(resolveLiveRecoveryTakeoverState(state, boolValue(state["recoveryTakeoverActive"])))
+}
+
+func normalizedRecoveredPositionStatus(currentStatus string, foundPosition, virtualPosition bool) string {
+	switch strings.TrimSpace(currentStatus) {
+	case "protected-open-position", "unprotected-open-position", livePositionRecoveryStatusClosingPending:
+		if foundPosition {
+			return currentStatus
+		}
+	}
+	switch {
+	case foundPosition:
+		return "monitoring-open-position"
+	case virtualPosition:
+		return "monitoring-virtual-position"
+	default:
+		return "flat"
+	}
+}
+
+func resolveLiveRecoveryIntentAction(intent map[string]any) string {
+	if len(intent) == 0 {
+		return ""
+	}
+	orderType := strings.ToUpper(strings.TrimSpace(firstNonEmpty(stringValue(intent["type"]), stringValue(mapValue(intent["metadata"])["orderType"]))))
+	role := strings.ToLower(strings.TrimSpace(stringValue(intent["role"])))
+	if strings.Contains(orderType, "STOP") || strings.Contains(orderType, "TAKE_PROFIT") {
+		return "place-protection-orders"
+	}
+	if role == "exit" || boolValue(intent["reduceOnly"]) || boolValue(intent["closePosition"]) {
+		return "close-existing-position"
+	}
+	return "open-new-position"
+}
+
+func liveRecoveryIntentActionAllowed(matrix liveRecoveryActionMatrix, action string) bool {
+	switch action {
+	case "open-new-position":
+		return matrix.OpenNewPosition
+	case "close-existing-position":
+		return matrix.CloseExistingPosition
+	case "place-protection-orders":
+		return matrix.PlaceProtectionOrders
+	default:
+		return true
+	}
+}
 
 func isLiveSessionRecoveryCloseOnlyMode(state map[string]any) bool {
 	return strings.EqualFold(strings.TrimSpace(stringValue(state["recoveryMode"])), liveRecoveryModeCloseOnlyTakeover)
@@ -2624,6 +2827,7 @@ func resolveLivePositionReconcileGate(account domain.Account, symbol string, req
 		gate["status"] = livePositionReconcileGateStatusError
 		gate["blocking"] = true
 		gate["scenario"] = "exchange-truth-unavailable"
+		gate["takeoverState"] = liveRecoveryTakeoverStateError
 		return gate
 	}
 	symbolGate := cloneMetadata(mapValue(mapValue(mapValue(account.Metadata["livePositionReconcileGate"])["symbols"])[symbol]))
@@ -2631,6 +2835,7 @@ func resolveLivePositionReconcileGate(account domain.Account, symbol string, req
 		gate["status"] = livePositionReconcileGateStatusError
 		gate["blocking"] = true
 		gate["scenario"] = "missing-reconcile-verdict"
+		gate["takeoverState"] = liveRecoveryTakeoverStateError
 		return gate
 	}
 	for key, value := range symbolGate {
@@ -2639,6 +2844,16 @@ func resolveLivePositionReconcileGate(account domain.Account, symbol string, req
 	gate["symbol"] = symbol
 	gate["blocking"] = boolValue(gate["blocking"])
 	gate["status"] = firstNonEmpty(stringValue(gate["status"]), livePositionReconcileGateStatusVerified)
+	switch strings.TrimSpace(stringValue(gate["status"])) {
+	case livePositionReconcileGateStatusStale:
+		gate["takeoverState"] = liveRecoveryTakeoverStateStaleSync
+	case livePositionReconcileGateStatusConflict:
+		gate["takeoverState"] = liveRecoveryTakeoverStateConflict
+	case livePositionReconcileGateStatusError:
+		gate["takeoverState"] = liveRecoveryTakeoverStateError
+	default:
+		gate["takeoverState"] = ""
+	}
 	return gate
 }
 
@@ -2660,7 +2875,7 @@ func applyLivePositionReconcileGateState(state map[string]any, gate map[string]a
 		delete(state, "positionReconcileGateMismatchFields")
 	}
 	if boolValue(gate["blocking"]) {
-		state["positionRecoveryStatus"] = firstNonEmpty(stringValue(gate["status"]), livePositionReconcileGateStatusError)
+		state["positionRecoveryStatus"] = firstNonEmpty(stringValue(gate["takeoverState"]), firstNonEmpty(stringValue(gate["status"]), livePositionReconcileGateStatusError))
 		state["lastStrategyEvaluationStatus"] = liveRecoveryModeReconcileGateBlocked
 	}
 }
@@ -2730,6 +2945,7 @@ func (p *Platform) completeRecoveredLiveSessionMetadata(session domain.LiveSessi
 		delete(state, "positionReconcileGateMismatchFields")
 		delete(state, "positionReconcileGateDBPosition")
 		delete(state, "positionReconcileGateExchangePosition")
+		applyLiveRecoveryTakeoverState(state, false)
 		if !metadataEqual(state, session.State) {
 			session, err = p.store.UpdateLiveSessionState(session.ID, state)
 			if err != nil {
@@ -2772,6 +2988,7 @@ func (p *Platform) completeRecoveredLiveSessionMetadata(session domain.LiveSessi
 	delete(state, "recoveryBlockedReason")
 	delete(state, "recoveryBlockedDetail")
 	delete(state, "recoveryBlockedAt")
+	applyLiveRecoveryTakeoverState(state, boolValue(state["recoveryTakeoverActive"]))
 	if !metadataEqual(state, session.State) {
 		session, err = p.store.UpdateLiveSessionState(session.ID, state)
 		if err != nil {
@@ -2804,6 +3021,7 @@ func (p *Platform) enterRecoveredLiveSessionCloseOnlyMode(session domain.LiveSes
 	delete(state, "lastStrategyIntent")
 	delete(state, "lastSignalIntent")
 	delete(state, "lastStrategyIntentSignature")
+	applyLiveRecoveryTakeoverState(state, true)
 	session, err := p.store.UpdateLiveSessionState(session.ID, state)
 	if err != nil {
 		return domain.LiveSession{}, err
@@ -2832,6 +3050,7 @@ func (p *Platform) enterRecoveredLiveSessionReconcileGateBlocked(session domain.
 	delete(state, "lastSignalIntent")
 	delete(state, "lastStrategyIntentSignature")
 	applyLivePositionReconcileGateState(state, gate)
+	applyLiveRecoveryTakeoverState(state, true)
 	session, err := p.store.UpdateLiveSessionState(session.ID, state)
 	if err != nil {
 		return domain.LiveSession{}, err
@@ -2863,24 +3082,28 @@ func (p *Platform) reconcileLiveSessionPlanIndex(session domain.LiveSession, pla
 	if err != nil {
 		return domain.LiveSession{}, err
 	}
+	state["recoveredPosition"] = positionSnapshot
+	state["hasRecoveredPosition"] = foundPosition
+	state["hasRecoveredRealPosition"] = foundPosition
+	state["hasRecoveredVirtualPosition"] = boolValue(positionSnapshot["virtual"])
+	takeoverMatrix := applyLiveRecoveryTakeoverState(state, boolValue(state["recoveryTakeoverActive"]))
 
 	nextIndex, adjusted := reconcileLivePlanIndexWithPosition(plan, currentIndex, positionSnapshot, foundPosition)
 	planLengthAdjusted := maxIntValue(state["planLength"], -1) != len(plan)
 	if !adjusted && !planLengthAdjusted {
-		return session, nil
+		if metadataEqual(state, session.State) {
+			return session, nil
+		}
+		return p.store.UpdateLiveSessionState(session.ID, state)
 	}
 
 	state["planLength"] = len(plan)
 	if nextIndex < len(plan) {
 		delete(state, "completedAt")
 	}
-	if !adjusted {
+	if !adjusted || !takeoverMatrix.AllowPlanProgression {
 		return p.store.UpdateLiveSessionState(session.ID, state)
 	}
-	state["recoveredPosition"] = positionSnapshot
-	state["hasRecoveredPosition"] = foundPosition
-	state["hasRecoveredRealPosition"] = foundPosition
-	state["hasRecoveredVirtualPosition"] = boolValue(positionSnapshot["virtual"])
 	state["lastRecoveredPositionAt"] = recoveredAt.UTC().Format(time.RFC3339)
 	state["positionRecoverySource"] = firstNonEmpty(source, "live-plan-cache-reconcile")
 	state["planIndex"] = nextIndex

--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -2875,7 +2875,7 @@ func applyLivePositionReconcileGateState(state map[string]any, gate map[string]a
 		delete(state, "positionReconcileGateMismatchFields")
 	}
 	if boolValue(gate["blocking"]) {
-		state["positionRecoveryStatus"] = firstNonEmpty(stringValue(gate["takeoverState"]), firstNonEmpty(stringValue(gate["status"]), livePositionReconcileGateStatusError))
+		state["positionRecoveryStatus"] = firstNonEmpty(stringValue(gate["status"]), livePositionReconcileGateStatusError)
 		state["lastStrategyEvaluationStatus"] = liveRecoveryModeReconcileGateBlocked
 	}
 }

--- a/internal/service/live_execution.go
+++ b/internal/service/live_execution.go
@@ -393,6 +393,13 @@ func shouldBlockAutoDispatchForRecoveryIntent(session domain.LiveSession, intent
 	if isLiveSessionBlockedByPositionReconcileGate(session.State) {
 		return true
 	}
+	recoveryActions := currentLiveRecoveryActionMatrix(session.State)
+	if !recoveryActions.AutoDispatch {
+		action := resolveLiveRecoveryIntentAction(intent)
+		if liveRecoveryIntentActionAllowed(recoveryActions, action) || boolValue(session.State["recoveryTakeoverActive"]) {
+			return true
+		}
+	}
 	if !isRecoveryTriggeredPassiveCloseProposal(intent) {
 		return false
 	}

--- a/internal/service/live_execution.go
+++ b/internal/service/live_execution.go
@@ -394,11 +394,8 @@ func shouldBlockAutoDispatchForRecoveryIntent(session domain.LiveSession, intent
 		return true
 	}
 	recoveryActions := currentLiveRecoveryActionMatrix(session.State)
-	if !recoveryActions.AutoDispatch {
-		action := resolveLiveRecoveryIntentAction(intent)
-		if liveRecoveryIntentActionAllowed(recoveryActions, action) || boolValue(session.State["recoveryTakeoverActive"]) {
-			return true
-		}
+	if boolValue(session.State["recoveryTakeoverActive"]) && !recoveryActions.AutoDispatch {
+		return true
 	}
 	if !isRecoveryTriggeredPassiveCloseProposal(intent) {
 		return false

--- a/internal/service/live_recovery.go
+++ b/internal/service/live_recovery.go
@@ -82,6 +82,7 @@ func (p *Platform) refreshLiveSessionProtectionState(session domain.LiveSession)
 }
 
 func (p *Platform) refreshLiveSessionPositionContext(session domain.LiveSession, eventTime time.Time, source string) (domain.LiveSession, error) {
+	takeoverActive := shouldActivateLiveRecoveryTakeover(source, session.State)
 	applyRecoveryMode := func(state map[string]any) {
 		if !isLiveSessionRecoveryCloseOnlyMode(state) {
 			return
@@ -132,6 +133,7 @@ func (p *Platform) refreshLiveSessionPositionContext(session domain.LiveSession,
 		state["lastLivePositionState"] = map[string]any{}
 		state["positionRecoveryStatus"] = "flat"
 		applyLivePositionReconcileGateState(state, reconcileGate)
+		applyLiveRecoveryTakeoverState(state, takeoverActive)
 		applyRecoveryMode(state)
 		updated, updateErr := p.store.UpdateLiveSessionState(refreshed.ID, state)
 		if updateErr != nil {
@@ -174,6 +176,7 @@ func (p *Platform) refreshLiveSessionPositionContext(session domain.LiveSession,
 			}
 		}
 		applyLivePositionReconcileGateState(state, reconcileGate)
+		applyLiveRecoveryTakeoverState(state, takeoverActive)
 		applyRecoveryMode(state)
 		updated, updateErr := p.store.UpdateLiveSessionState(refreshed.ID, state)
 		if updateErr != nil {
@@ -185,6 +188,7 @@ func (p *Platform) refreshLiveSessionPositionContext(session domain.LiveSession,
 	livePositionState := evaluateLivePositionState(parameters, positionSnapshot, signalBarState, marketPrice, state)
 	if len(livePositionState) == 0 {
 		applyLivePositionReconcileGateState(state, reconcileGate)
+		applyLiveRecoveryTakeoverState(state, takeoverActive)
 		applyRecoveryMode(state)
 		updated, updateErr := p.store.UpdateLiveSessionState(refreshed.ID, state)
 		if updateErr != nil {
@@ -275,6 +279,7 @@ func (p *Platform) refreshLiveSessionPositionContext(session domain.LiveSession,
 	}
 
 	applyLivePositionReconcileGateState(state, reconcileGate)
+	applyLiveRecoveryTakeoverState(state, takeoverActive)
 	applyRecoveryMode(state)
 	updated, updateErr := p.store.UpdateLiveSessionState(refreshed.ID, state)
 	if updateErr != nil {

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -2079,6 +2079,233 @@ func TestShouldAdvanceLivePlanForOrderStatus(t *testing.T) {
 	}
 }
 
+func TestLiveRecoveryActionMatrixUsesExplicitTakeoverStates(t *testing.T) {
+	cases := []struct {
+		state                string
+		openNewPosition      bool
+		closeExisting        bool
+		placeProtection      bool
+		autoDispatch         bool
+		manualReviewRequired bool
+		allowPlanProgression bool
+	}{
+		{state: liveRecoveryModeCloseOnlyTakeover, closeExisting: true, manualReviewRequired: true},
+		{state: liveRecoveryTakeoverStateMonitoring, closeExisting: true, placeProtection: true, manualReviewRequired: true, allowPlanProgression: true},
+		{state: liveRecoveryTakeoverStateUnprotected, closeExisting: true, placeProtection: true, manualReviewRequired: true},
+		{state: liveRecoveryTakeoverStateStaleSync, manualReviewRequired: true},
+		{state: liveRecoveryTakeoverStateConflict, manualReviewRequired: true},
+		{state: liveRecoveryTakeoverStateError, manualReviewRequired: true},
+	}
+	for _, tc := range cases {
+		matrix := liveRecoveryActionMatrixForState(tc.state)
+		if matrix.OpenNewPosition != tc.openNewPosition ||
+			matrix.CloseExistingPosition != tc.closeExisting ||
+			matrix.PlaceProtectionOrders != tc.placeProtection ||
+			matrix.AutoDispatch != tc.autoDispatch ||
+			matrix.ManualReviewRequired != tc.manualReviewRequired ||
+			matrix.AllowPlanProgression != tc.allowPlanProgression {
+			t.Fatalf("unexpected matrix for %s: %+v", tc.state, matrix)
+		}
+	}
+}
+
+func TestEnsureLiveExecutionPlanBlocksCloseOnlyTakeoverFreshEntry(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	session, err := platform.CreateLiveSession("live-main", "strategy-bk-1d", map[string]any{
+		"symbol":          "BTCUSDT",
+		"signalTimeframe": "1d",
+	})
+	if err != nil {
+		t.Fatalf("create live session failed: %v", err)
+	}
+	secondary, err := platform.store.CreateLiveSession("live-main", "strategy-ambiguous")
+	if err != nil {
+		t.Fatalf("create secondary live session failed: %v", err)
+	}
+	secondaryState := cloneMetadata(secondary.State)
+	secondaryState["symbol"] = "BTCUSDT"
+	if _, err := platform.store.UpdateLiveSessionState(secondary.ID, secondaryState); err != nil {
+		t.Fatalf("update secondary live session state failed: %v", err)
+	}
+	position, err := platform.store.SavePosition(domain.Position{
+		AccountID:  session.AccountID,
+		Symbol:     "BTCUSDT",
+		Side:       "LONG",
+		Quantity:   0.01,
+		EntryPrice: 68000,
+		MarkPrice:  68100,
+	})
+	if err != nil {
+		t.Fatalf("save position failed: %v", err)
+	}
+	session, err = platform.enterRecoveredLiveSessionCloseOnlyMode(session, position, "missing-strategy-version", "test")
+	if err != nil {
+		t.Fatalf("enter close-only mode failed: %v", err)
+	}
+
+	updated, plan, err := platform.ensureLiveExecutionPlan(session)
+	if err == nil {
+		t.Fatal("expected close-only takeover to block fresh entry plan construction")
+	}
+	if len(plan) != 0 {
+		t.Fatalf("expected no live plan to be returned, got %d steps", len(plan))
+	}
+	if got := stringValue(updated.State["recoveryTakeoverState"]); got != liveRecoveryModeCloseOnlyTakeover {
+		t.Fatalf("expected takeover state %s, got %s", liveRecoveryModeCloseOnlyTakeover, got)
+	}
+}
+
+func TestRecoveryMonitoringDisablesAutoDispatch(t *testing.T) {
+	now := time.Now().UTC()
+	session := domain.LiveSession{
+		State: map[string]any{
+			"dispatchMode":             "auto-dispatch",
+			"recoveryTakeoverActive":   true,
+			"positionRecoveryStatus":   "protected-open-position",
+			"hasRecoveredPosition":     true,
+			"hasRecoveredRealPosition": true,
+		},
+	}
+	intent := map[string]any{
+		"action": "open",
+		"role":   "entry",
+		"side":   "BUY",
+		"symbol": "BTCUSDT",
+		"status": "dispatchable",
+	}
+	if shouldAutoDispatchLiveIntent(session, intent, now) {
+		t.Fatal("expected recovery-monitoring takeover to stay manual")
+	}
+}
+
+func TestReconcileLiveSessionPlanIndexBlocksRecoveryConflictProgression(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	session, err := platform.CreateLiveSession("live-main", "strategy-bk-1d", map[string]any{
+		"symbol":          "BTCUSDT",
+		"signalTimeframe": "1d",
+	})
+	if err != nil {
+		t.Fatalf("create live session failed: %v", err)
+	}
+	if _, err := platform.store.SavePosition(domain.Position{
+		AccountID:         session.AccountID,
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "LONG",
+		Quantity:          0.01,
+		EntryPrice:        68000,
+		MarkPrice:         68100,
+	}); err != nil {
+		t.Fatalf("save position failed: %v", err)
+	}
+	state := cloneMetadata(session.State)
+	state["planIndex"] = 0
+	state["recoveryTakeoverActive"] = true
+	state["positionRecoveryStatus"] = liveRecoveryTakeoverStateConflict
+	state["positionReconcileGateStatus"] = livePositionReconcileGateStatusConflict
+	session, err = platform.store.UpdateLiveSessionState(session.ID, state)
+	if err != nil {
+		t.Fatalf("update live session state failed: %v", err)
+	}
+
+	reconciled, err := platform.reconcileLiveSessionPlanIndex(session, []paperPlannedOrder{
+		{Role: "entry", Side: "BUY", Symbol: "BTCUSDT"},
+		{Role: "exit", Side: "SELL", Symbol: "BTCUSDT"},
+	}, time.Now().UTC(), "test-recovery-conflict")
+	if err != nil {
+		t.Fatalf("reconcile live session plan index failed: %v", err)
+	}
+	gotIndex, ok := toFloat64(reconciled.State["planIndex"])
+	if !ok || int(gotIndex) != 0 {
+		t.Fatalf("expected recovery conflict to keep planIndex at entry, got %v", reconciled.State["planIndex"])
+	}
+	if got := stringValue(reconciled.State["recoveryTakeoverState"]); got != liveRecoveryTakeoverStateConflict {
+		t.Fatalf("expected takeover state %s, got %s", liveRecoveryTakeoverStateConflict, got)
+	}
+}
+
+func TestReconcileLiveSessionPlanIndexAllowsRecoveryMonitoringClosePath(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	session, err := platform.CreateLiveSession("live-main", "strategy-bk-1d", map[string]any{
+		"symbol":          "BTCUSDT",
+		"signalTimeframe": "1d",
+	})
+	if err != nil {
+		t.Fatalf("create live session failed: %v", err)
+	}
+	if _, err := platform.store.SavePosition(domain.Position{
+		AccountID:         session.AccountID,
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "LONG",
+		Quantity:          0.01,
+		EntryPrice:        68000,
+		MarkPrice:         68100,
+	}); err != nil {
+		t.Fatalf("save position failed: %v", err)
+	}
+	state := cloneMetadata(session.State)
+	state["planIndex"] = 0
+	state["recoveryTakeoverActive"] = true
+	state["positionRecoveryStatus"] = "protected-open-position"
+	session, err = platform.store.UpdateLiveSessionState(session.ID, state)
+	if err != nil {
+		t.Fatalf("update live session state failed: %v", err)
+	}
+
+	reconciled, err := platform.reconcileLiveSessionPlanIndex(session, []paperPlannedOrder{
+		{Role: "entry", Side: "BUY", Symbol: "BTCUSDT"},
+		{Role: "exit", Side: "SELL", Symbol: "BTCUSDT"},
+	}, time.Now().UTC(), "test-recovery-monitoring")
+	if err != nil {
+		t.Fatalf("reconcile live session plan index failed: %v", err)
+	}
+	gotIndex, ok := toFloat64(reconciled.State["planIndex"])
+	if !ok || int(gotIndex) != 1 {
+		t.Fatalf("expected recovery-monitoring takeover to advance into close path, got %v", reconciled.State["planIndex"])
+	}
+	if got := stringValue(reconciled.State["recoveryTakeoverState"]); got != liveRecoveryTakeoverStateMonitoring {
+		t.Fatalf("expected takeover state %s, got %s", liveRecoveryTakeoverStateMonitoring, got)
+	}
+}
+
+func TestReconcileLiveSessionPlanIndexLeavesHealthySessionUnchanged(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	session, err := platform.CreateLiveSession("live-main", "strategy-bk-1d", map[string]any{
+		"symbol":          "BTCUSDT",
+		"signalTimeframe": "1d",
+	})
+	if err != nil {
+		t.Fatalf("create live session failed: %v", err)
+	}
+	if _, err := platform.store.SavePosition(domain.Position{
+		AccountID:         session.AccountID,
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "LONG",
+		Quantity:          0.01,
+		EntryPrice:        68000,
+		MarkPrice:         68100,
+	}); err != nil {
+		t.Fatalf("save position failed: %v", err)
+	}
+
+	reconciled, err := platform.reconcileLiveSessionPlanIndex(session, []paperPlannedOrder{
+		{Role: "entry", Side: "BUY", Symbol: "BTCUSDT"},
+		{Role: "exit", Side: "SELL", Symbol: "BTCUSDT"},
+	}, time.Now().UTC(), "test-healthy")
+	if err != nil {
+		t.Fatalf("reconcile live session plan index failed: %v", err)
+	}
+	gotIndex, ok := toFloat64(reconciled.State["planIndex"])
+	if !ok || int(gotIndex) != 1 {
+		t.Fatalf("expected healthy session to keep advancing to exit, got %v", reconciled.State["planIndex"])
+	}
+	if got := stringValue(reconciled.State["recoveryTakeoverState"]); got != "" {
+		t.Fatalf("expected healthy session to avoid takeover state, got %s", got)
+	}
+}
+
 func TestEnsureLiveExecutionPlanReconcilesCachedPlanIndexBackToEntryWhenPositionFlat(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
 	session, err := platform.CreateLiveSession("live-main", "strategy-bk-1d", map[string]any{
@@ -5155,8 +5382,8 @@ func TestRecoverRunningLiveSessionBlocksWhenDBPositionMissingOnExchange(t *testi
 	if got := stringValue(recovered.State["positionReconcileGateStatus"]); got != livePositionReconcileGateStatusStale {
 		t.Fatalf("expected stale reconcile gate status, got %s", got)
 	}
-	if got := stringValue(recovered.State["positionRecoveryStatus"]); got != livePositionReconcileGateStatusStale {
-		t.Fatalf("expected stale position recovery status, got %s", got)
+	if got := stringValue(recovered.State["positionRecoveryStatus"]); got != liveRecoveryTakeoverStateStaleSync {
+		t.Fatalf("expected stale position recovery status %s, got %s", liveRecoveryTakeoverStateStaleSync, got)
 	}
 	if got := stringValue(recovered.State["positionReconcileGateScenario"]); got != "db-position-exchange-missing" {
 		t.Fatalf("expected db-position-exchange-missing scenario, got %s", got)

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -5382,8 +5382,11 @@ func TestRecoverRunningLiveSessionBlocksWhenDBPositionMissingOnExchange(t *testi
 	if got := stringValue(recovered.State["positionReconcileGateStatus"]); got != livePositionReconcileGateStatusStale {
 		t.Fatalf("expected stale reconcile gate status, got %s", got)
 	}
-	if got := stringValue(recovered.State["positionRecoveryStatus"]); got != liveRecoveryTakeoverStateStaleSync {
-		t.Fatalf("expected stale position recovery status %s, got %s", liveRecoveryTakeoverStateStaleSync, got)
+	if got := stringValue(recovered.State["positionRecoveryStatus"]); got != livePositionReconcileGateStatusStale {
+		t.Fatalf("expected stale position recovery status %s, got %s", livePositionReconcileGateStatusStale, got)
+	}
+	if got := stringValue(recovered.State["recoveryTakeoverState"]); got != liveRecoveryTakeoverStateStaleSync {
+		t.Fatalf("expected takeover state %s, got %s", liveRecoveryTakeoverStateStaleSync, got)
 	}
 	if got := stringValue(recovered.State["positionReconcileGateScenario"]); got != "db-position-exchange-missing" {
 		t.Fatalf("expected db-position-exchange-missing scenario, got %s", got)


### PR DESCRIPTION
## 目的
Closes #89

为 runtime recovery/takeover 引入显式状态机和动作矩阵，收敛恢复态下的 plan progression、signal evaluation 与 auto-dispatch 行为，避免未验证恢复态被当成正常策略会话继续推进。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [x] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main)
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？
- [x] DB migration 是否具备向下兼容幂等性？
- [x] 配置字段有没有无意被混改？

说明：本 PR 未修改默认 `dispatchMode`、未触碰 mainnet 凭证/路由、未涉及 migration、未混改部署或配置。

## 验证方式与测试证据
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

已执行：
- `gofmt -w internal/service/live.go internal/service/live_recovery.go internal/service/live_execution.go internal/service/live_test.go`
- `go test ./internal/service -run 'Test(LiveRecoveryActionMatrixUsesExplicitTakeoverStates|EnsureLiveExecutionPlanBlocksCloseOnlyTakeoverFreshEntry|RecoveryMonitoringDisablesAutoDispatch|ReconcileLiveSessionPlanIndexBlocksRecoveryConflictProgression|ReconcileLiveSessionPlanIndexAllowsRecoveryMonitoringClosePath|ReconcileLiveSessionPlanIndexLeavesHealthySessionUnchanged)$'`
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`

## 变更摘要
- 新增显式 recovery/takeover states 与代码内 action matrix 注释，并把状态同步到 session state。
- `ensureLiveExecutionPlan` / `reconcileLiveSessionPlanIndex` 现在按 takeover state 决定是否允许 plan progression。
- `evaluateLiveSessionOnSignal` / auto-dispatch gate 现在按 takeover state 阻断不允许的 entry 与自动派单。
- 新增回归测试覆盖 close-only、recovery-monitoring、recovery-conflict、valid recovered close-path、healthy session unchanged。