### PR TITLE
[codex] enforce runtime recovery reconcile gates

### DIFF
--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -200,6 +200,62 @@ func (p *Platform) SyncLiveAccount(accountID string) (domain.Account, error) {
 	return account, fallbackErr
 }
 
+func liveAccountPositionReconcilePending(account domain.Account) bool {
+	requiredAt := parseOptionalRFC3339(stringValue(account.Metadata["livePositionReconcileRequiredAt"]))
+	if requiredAt.IsZero() {
+		return false
+	}
+	lastSyncAt := parseOptionalRFC3339(stringValue(account.Metadata["lastLivePositionSyncAt"]))
+	return lastSyncAt.IsZero() || requiredAt.After(lastSyncAt)
+}
+
+func clearLiveAccountPositionReconcileRequirement(metadata map[string]any) {
+	if metadata == nil {
+		return
+	}
+	delete(metadata, "livePositionReconcileRequiredAt")
+	delete(metadata, "livePositionReconcileTrigger")
+}
+
+func (p *Platform) markLiveAccountPositionReconcileRequired(account domain.Account, trigger string, eventTime time.Time) (domain.Account, error) {
+	account.Metadata = cloneMetadata(account.Metadata)
+	account.Metadata["livePositionReconcileRequiredAt"] = eventTime.UTC().Format(time.RFC3339)
+	account.Metadata["livePositionReconcileTrigger"] = firstNonEmpty(strings.TrimSpace(trigger), "reconcile-required")
+	return p.store.UpdateAccount(account)
+}
+
+func (p *Platform) triggerAuthoritativeLiveAccountReconcile(accountID, trigger string, eventTime time.Time) (domain.Account, error) {
+	account, err := p.store.GetAccount(accountID)
+	if err != nil {
+		return domain.Account{}, err
+	}
+	if !strings.EqualFold(account.Mode, "LIVE") {
+		return domain.Account{}, fmt.Errorf("account %s is not a LIVE account", accountID)
+	}
+	binding := cloneMetadata(mapValue(account.Metadata["liveBinding"]))
+	if normalizeLiveExecutionMode(binding["executionMode"], boolValue(binding["sandbox"])) != "rest" {
+		return account, nil
+	}
+	account, err = p.markLiveAccountPositionReconcileRequired(account, trigger, eventTime)
+	if err != nil {
+		return domain.Account{}, err
+	}
+	p.syncLiveSessionsForAccountSnapshot(account)
+
+	synced, syncErr := p.SyncLiveAccount(accountID)
+	if syncErr != nil {
+		latest, latestErr := p.store.GetAccount(accountID)
+		if latestErr == nil {
+			return latest, syncErr
+		}
+		return account, syncErr
+	}
+	if liveAccountPositionReconcilePending(synced) {
+		return synced, fmt.Errorf("live account %s reconcile is still pending after %s", accountID, firstNonEmpty(strings.TrimSpace(trigger), "reconcile"))
+	}
+	return synced, nil
+}
+
 func (p *Platform) ReconcileLiveAccount(accountID string, options LiveAccountReconcileOptions) (LiveAccountReconcileResult, error) {
 	options = normalizeLiveAccountReconcileOptions(options)
 	result := LiveAccountReconcileResult{
@@ -1008,6 +1064,7 @@ func (p *Platform) syncLiveAccountFromBinance(account domain.Account, binding ma
 	delete(account.Metadata, "lastLivePositionSyncError")
 	account.Metadata["lastLivePositionSyncAt"] = time.Now().UTC().Format(time.RFC3339)
 	account.Metadata["livePositionReconcileGate"] = reconcileGate
+	clearLiveAccountPositionReconcileRequirement(account.Metadata)
 	return p.store.UpdateAccount(account)
 }
 
@@ -1429,6 +1486,16 @@ func (p *Platform) StartLiveSession(sessionID string) (domain.LiveSession, error
 		logger.Warn("resolve live adapter failed", "error", err)
 		return domain.LiveSession{}, err
 	}
+	if syncedAccount, reconcileErr := p.triggerAuthoritativeLiveAccountReconcile(account.ID, "historical-takeover-activation", time.Now().UTC()); reconcileErr == nil {
+		account = syncedAccount
+	} else {
+		if latestAccount, latestErr := p.store.GetAccount(account.ID); latestErr == nil {
+			account = latestAccount
+		}
+		if liveAccountPositionReconcilePending(account) {
+			logger.Warn("authoritative live account reconcile pending on start", "error", reconcileErr)
+		}
+	}
 	session, recoveredPosition, incompleteRecoveryMetadata, err := p.completeRecoveredLiveSessionMetadata(session)
 	if err != nil {
 		logger.Warn("complete recovered live session metadata failed", "error", err)
@@ -1536,6 +1603,9 @@ func (p *Platform) syncActiveLiveAccounts(eventTime time.Time) error {
 }
 
 func (p *Platform) shouldRefreshLiveAccountSync(account domain.Account, eventTime time.Time) bool {
+	if liveAccountPositionReconcilePending(account) {
+		return true
+	}
 	threshold := time.Duration(p.runtimePolicy.LiveAccountSyncFreshnessSecs) * time.Second
 	if threshold <= 0 {
 		return false
@@ -1556,8 +1626,11 @@ func (p *Platform) recoverRunningLiveSession(session domain.LiveSession) (domain
 	if err != nil {
 		return domain.LiveSession{}, err
 	}
-	if syncedAccount, syncErr := p.SyncLiveAccount(account.ID); syncErr != nil {
-		// Keep recovery moving so runtime monitoring can still come back.
+	if syncedAccount, syncErr := p.triggerAuthoritativeLiveAccountReconcile(account.ID, "startup-recovery", time.Now().UTC()); syncErr != nil {
+		latestAccount, latestErr := p.store.GetAccount(account.ID)
+		if latestErr == nil {
+			account = latestAccount
+		}
 	} else {
 		account = syncedAccount
 	}
@@ -2821,6 +2894,17 @@ func resolveLivePositionReconcileGate(account domain.Account, symbol string, req
 		"required":      livePositionReconcileGateRequired(snapshot),
 	}
 	if !requiresVerification || symbol == "" || !boolValue(gate["required"]) {
+		return gate
+	}
+	if liveAccountPositionReconcilePending(account) {
+		gate["status"] = livePositionReconcileGateStatusStale
+		gate["blocking"] = true
+		gate["scenario"] = firstNonEmpty(
+			strings.TrimSpace(stringValue(account.Metadata["livePositionReconcileTrigger"])),
+			"reconcile-required",
+		)
+		gate["requiredAt"] = stringValue(account.Metadata["livePositionReconcileRequiredAt"])
+		gate["takeoverState"] = liveRecoveryTakeoverStateStaleSync
 		return gate
 	}
 	if !boolValue(gate["authoritative"]) {

--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -1494,6 +1494,17 @@ func (p *Platform) StartLiveSession(sessionID string) (domain.LiveSession, error
 		}
 		if liveAccountPositionReconcilePending(account) {
 			logger.Warn("authoritative live account reconcile pending on start", "error", reconcileErr)
+			symbol := NormalizeSymbol(firstNonEmpty(stringValue(session.State["symbol"]), stringValue(session.State["lastSymbol"])))
+			if symbol != "" {
+				if position, found, findErr := p.store.FindPosition(session.AccountID, symbol); findErr == nil && found && position.Quantity > 0 {
+					gate := resolveLivePositionReconcileGate(account, symbol, true)
+					blocked, blockErr := p.enterRecoveredLiveSessionReconcileGateBlocked(session, position, gate)
+					if blockErr == nil {
+						return blocked, fmt.Errorf("live session %s requires authoritative reconcile before historical takeover activation", session.ID)
+					}
+					return domain.LiveSession{}, blockErr
+				}
+			}
 		}
 	}
 	session, recoveredPosition, incompleteRecoveryMetadata, err := p.completeRecoveredLiveSessionMetadata(session)

--- a/internal/service/live_recovery.go
+++ b/internal/service/live_recovery.go
@@ -118,6 +118,9 @@ func (p *Platform) refreshLiveSessionPositionContext(session domain.LiveSession,
 		return domain.LiveSession{}, err
 	}
 	reconcileGate := resolveLivePositionReconcileGate(account, symbol, hasRealPositionContext)
+	if boolValue(reconcileGate["blocking"]) {
+		takeoverActive = true
+	}
 	state["recoveredPosition"] = positionSnapshot
 	state["hasRecoveredPosition"] = foundPosition
 	state["hasRecoveredRealPosition"] = foundPosition

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -5902,6 +5902,9 @@ func TestStartLiveSessionRequiresRESTVerificationForHistoricalTakeoverActivation
 	if err == nil {
 		t.Fatal("expected historical takeover activation to require REST verification before start")
 	}
+	if !strings.Contains(err.Error(), "requires authoritative reconcile before historical takeover activation") {
+		t.Fatalf("expected fail-fast authoritative reconcile error, got %v", err)
+	}
 	updated, err := platform.store.GetLiveSession(session.ID)
 	if err != nil {
 		t.Fatalf("reload live session failed: %v", err)

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -5301,6 +5301,74 @@ func TestRecoverRunningLiveSessionCompletesRecoveredPositionMetadata(t *testing.
 	}
 }
 
+func TestRecoverRunningLiveSessionRequiresRESTVerificationBeforeRestartTakeover(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	platform.registerLiveAdapter(testLiveAccountSyncAdapter{
+		key:     "test-restart-rest-required",
+		syncErr: errors.New("rest adapter unavailable"),
+	})
+	account, err := platform.store.GetAccount("live-main")
+	if err != nil {
+		t.Fatalf("get account failed: %v", err)
+	}
+	account.Status = "READY"
+	account.Metadata = cloneMetadata(account.Metadata)
+	account.Metadata["liveBinding"] = map[string]any{
+		"adapterKey":     "test-restart-rest-required",
+		"connectionMode": "mock",
+		"executionMode":  "rest",
+	}
+	if _, err := platform.store.UpdateAccount(account); err != nil {
+		t.Fatalf("update account failed: %v", err)
+	}
+
+	session, err := platform.CreateLiveSession("live-main", "strategy-bk-1d", map[string]any{
+		"symbol":          "BTCUSDT",
+		"signalTimeframe": "1d",
+	})
+	if err != nil {
+		t.Fatalf("create live session failed: %v", err)
+	}
+	position, err := platform.store.SavePosition(domain.Position{
+		AccountID:  session.AccountID,
+		Symbol:     "BTCUSDT",
+		Side:       "LONG",
+		Quantity:   0.01,
+		EntryPrice: 68000,
+		MarkPrice:  68100,
+	})
+	if err != nil {
+		t.Fatalf("save position failed: %v", err)
+	}
+
+	recovered, err := platform.recoverRunningLiveSession(session)
+	if err != nil {
+		t.Fatalf("recover running live session failed: %v", err)
+	}
+	if recovered.Status != "BLOCKED" {
+		t.Fatalf("expected restart takeover to stay BLOCKED until REST verify succeeds, got %s", recovered.Status)
+	}
+	if got := stringValue(recovered.State["positionReconcileGateStatus"]); got != livePositionReconcileGateStatusStale {
+		t.Fatalf("expected stale reconcile gate while REST verify is pending, got %s", got)
+	}
+	if got := stringValue(recovered.State["positionReconcileGateScenario"]); got != "startup-recovery" {
+		t.Fatalf("expected startup-recovery gate scenario, got %s", got)
+	}
+	if got := stringValue(recovered.State["recoveryTakeoverState"]); got != liveRecoveryTakeoverStateStaleSync {
+		t.Fatalf("expected stale-sync takeover state while restart verify is pending, got %s", got)
+	}
+	account, err = platform.store.GetAccount(session.AccountID)
+	if err != nil {
+		t.Fatalf("reload account failed: %v", err)
+	}
+	if !liveAccountPositionReconcilePending(account) {
+		t.Fatal("expected account reconcile requirement to remain pending after fallback-only sync")
+	}
+	if _, err := platform.ClosePosition(position.ID); err == nil {
+		t.Fatal("expected restart takeover close to stay blocked until REST verify completes")
+	}
+}
+
 func TestRecoverRunningLiveSessionAllowsTakeoverAfterVerifiedReconcileMatch(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
 	configureTestLiveRESTReconcileAdapter(t, platform, "test-reconcile-match", []map[string]any{
@@ -5790,6 +5858,65 @@ func TestStartLiveSessionRejectsActiveCloseOnlyTakeoverMode(t *testing.T) {
 	}
 }
 
+func TestStartLiveSessionRequiresRESTVerificationForHistoricalTakeoverActivation(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	platform.registerLiveAdapter(testLiveAccountSyncAdapter{
+		key:     "test-start-rest-required",
+		syncErr: errors.New("rest adapter unavailable"),
+	})
+
+	account, err := platform.store.GetAccount("live-main")
+	if err != nil {
+		t.Fatalf("get live account failed: %v", err)
+	}
+	account.Status = "READY"
+	account.Metadata = cloneMetadata(account.Metadata)
+	account.Metadata["liveBinding"] = map[string]any{
+		"adapterKey":     "test-start-rest-required",
+		"connectionMode": "mock",
+		"executionMode":  "rest",
+	}
+	if _, err := platform.store.UpdateAccount(account); err != nil {
+		t.Fatalf("update live account failed: %v", err)
+	}
+
+	session, err := platform.CreateLiveSession("live-main", "strategy-bk-1d", map[string]any{
+		"symbol":          "BTCUSDT",
+		"signalTimeframe": "1d",
+	})
+	if err != nil {
+		t.Fatalf("create live session failed: %v", err)
+	}
+	if _, err := platform.store.SavePosition(domain.Position{
+		AccountID:  session.AccountID,
+		Symbol:     "BTCUSDT",
+		Side:       "LONG",
+		Quantity:   0.01,
+		EntryPrice: 68000,
+		MarkPrice:  68100,
+	}); err != nil {
+		t.Fatalf("save position failed: %v", err)
+	}
+
+	_, err = platform.StartLiveSession(session.ID)
+	if err == nil {
+		t.Fatal("expected historical takeover activation to require REST verification before start")
+	}
+	updated, err := platform.store.GetLiveSession(session.ID)
+	if err != nil {
+		t.Fatalf("reload live session failed: %v", err)
+	}
+	if updated.Status != "BLOCKED" {
+		t.Fatalf("expected start-time takeover to stay BLOCKED, got %s", updated.Status)
+	}
+	if got := stringValue(updated.State["positionReconcileGateStatus"]); got != livePositionReconcileGateStatusStale {
+		t.Fatalf("expected stale reconcile gate on start-time takeover, got %s", got)
+	}
+	if got := stringValue(updated.State["positionReconcileGateScenario"]); got != "historical-takeover-activation" {
+		t.Fatalf("expected historical takeover trigger scenario, got %s", got)
+	}
+}
+
 func TestStartLiveSessionDowngradesIncompleteRecoveredMetadataToCloseOnly(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
 	platform.registerLiveAdapter(testLiveAccountSyncAdapter{key: "test-start-incomplete"})
@@ -5932,6 +6059,7 @@ func configureTestLiveRESTReconcileAdapter(t *testing.T, platform *Platform, ada
 			account.Metadata = cloneMetadata(account.Metadata)
 			account.Metadata["livePositionReconcileGate"] = reconcileGate
 			account.Metadata["lastLivePositionSyncAt"] = time.Now().UTC().Format(time.RFC3339)
+			clearLiveAccountPositionReconcileRequirement(account.Metadata)
 			return p.store.UpdateAccount(account)
 		},
 	})

--- a/internal/service/signal_runtime_ws.go
+++ b/internal/service/signal_runtime_ws.go
@@ -172,6 +172,7 @@ func (p *Platform) runSignalRuntimeWithRecoveryUsing(
 			if connected {
 				// The reconnect succeeded and the runtime ran again before dropping later.
 				// Start a fresh recovery cycle so the next disconnect gets a full retry budget.
+				p.handleSignalRuntimeReconnect(sessionID, time.Now().UTC())
 				disconnectErr = retryErr
 				recovered = true
 				break
@@ -190,6 +191,17 @@ func (p *Platform) runSignalRuntimeWithRecoveryUsing(
 			"reconnect exhausted after %d attempts (severity=%s): %w",
 			policy.maxAttempts, severity.String(), disconnectErr))
 		return
+	}
+}
+
+func (p *Platform) handleSignalRuntimeReconnect(sessionID string, eventTime time.Time) {
+	runtimeSession, err := p.GetSignalRuntimeSession(sessionID)
+	if err != nil {
+		return
+	}
+	if _, reconcileErr := p.triggerAuthoritativeLiveAccountReconcile(runtimeSession.AccountID, "ws-reconnect-rest-verify-required", eventTime); reconcileErr != nil {
+		p.logger("service.signal_runtime", "session_id", sessionID, "account_id", runtimeSession.AccountID).
+			Warn("live account reconcile after websocket reconnect failed", "error", reconcileErr)
 	}
 }
 

--- a/internal/service/signal_runtime_ws_test.go
+++ b/internal/service/signal_runtime_ws_test.go
@@ -505,3 +505,134 @@ func TestHandleSignalRuntimeMessageScopesTriggerByLiveSessionSymbol(t *testing.T
 		t.Fatalf("expected BTC trigger to reach BTC session, got empty last event state")
 	}
 }
+
+func runTestSignalRuntimeReconnect(platform *Platform, runtimeSessionID string) {
+	outcomes := []struct {
+		connected bool
+		err       error
+	}{
+		{connected: true, err: errors.New("read tcp: EOF")},
+		{connected: true, err: errors.New("read tcp: EOF")},
+		{connected: false, err: errors.New("dial failed: 403 forbidden")},
+	}
+	callCount := 0
+	platform.runSignalRuntimeWithRecoveryUsing(
+		context.Background(),
+		runtimeSessionID,
+		func(context.Context, string) (bool, error) {
+			if callCount >= len(outcomes) {
+				return false, errors.New("unexpected extra reconnect loop")
+			}
+			outcome := outcomes[callCount]
+			callCount++
+			return outcome.connected, outcome.err
+		},
+		func(_ context.Context, _ time.Duration) bool {
+			return true
+		},
+	)
+}
+
+func TestRunSignalRuntimeWithRecoveryReconnectTriggersAuthoritativeRESTSync(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	configureTestLiveRESTReconcileAdapter(t, platform, "test-ws-reconnect-reconcile", []map[string]any{
+		{
+			"symbol":      "BTCUSDT",
+			"positionAmt": 0.01,
+			"entryPrice":  68000.0,
+			"markPrice":   68100.0,
+		},
+	})
+
+	session, err := platform.CreateLiveSession("live-main", "strategy-bk-1d", map[string]any{
+		"symbol":          "BTCUSDT",
+		"signalTimeframe": "1d",
+	})
+	if err != nil {
+		t.Fatalf("create live session failed: %v", err)
+	}
+	if _, err := platform.store.SavePosition(domain.Position{
+		AccountID:  session.AccountID,
+		Symbol:     "BTCUSDT",
+		Side:       "LONG",
+		Quantity:   0.01,
+		EntryPrice: 68000,
+		MarkPrice:  68100,
+	}); err != nil {
+		t.Fatalf("save position failed: %v", err)
+	}
+
+	runtimeSession, err := platform.CreateSignalRuntimeSession(session.AccountID, session.StrategyID)
+	if err != nil {
+		t.Fatalf("create runtime session failed: %v", err)
+	}
+	runTestSignalRuntimeReconnect(platform, runtimeSession.ID)
+
+	account, err := platform.store.GetAccount(session.AccountID)
+	if err != nil {
+		t.Fatalf("get account failed: %v", err)
+	}
+	if got := stringValue(account.Metadata["lastLivePositionSyncAt"]); got == "" {
+		t.Fatal("expected websocket reconnect to trigger a REST position sync")
+	}
+	if liveAccountPositionReconcilePending(account) {
+		t.Fatalf("expected reconnect-triggered reconcile to clear pending gate, account=%#v", account.Metadata)
+	}
+	updated, err := platform.store.GetLiveSession(session.ID)
+	if err != nil {
+		t.Fatalf("get live session failed: %v", err)
+	}
+	if got := stringValue(updated.State["positionReconcileGateStatus"]); got != livePositionReconcileGateStatusVerified {
+		t.Fatalf("expected verified gate after healthy reconnect reconcile, got %s", got)
+	}
+	if boolValue(updated.State["positionReconcileGateBlocking"]) {
+		t.Fatal("expected healthy reconnect reconcile not to block live session actions")
+	}
+}
+
+func TestRunSignalRuntimeWithRecoveryReconnectMarksStaleSyncOnRESTMismatch(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	configureTestLiveRESTReconcileAdapter(t, platform, "test-ws-reconnect-stale", []map[string]any{})
+
+	session, err := platform.CreateLiveSession("live-main", "strategy-bk-1d", map[string]any{
+		"symbol":          "BTCUSDT",
+		"signalTimeframe": "1d",
+	})
+	if err != nil {
+		t.Fatalf("create live session failed: %v", err)
+	}
+	position, err := platform.store.SavePosition(domain.Position{
+		AccountID:  session.AccountID,
+		Symbol:     "BTCUSDT",
+		Side:       "LONG",
+		Quantity:   0.01,
+		EntryPrice: 68000,
+		MarkPrice:  68100,
+	})
+	if err != nil {
+		t.Fatalf("save position failed: %v", err)
+	}
+
+	runtimeSession, err := platform.CreateSignalRuntimeSession(session.AccountID, session.StrategyID)
+	if err != nil {
+		t.Fatalf("create runtime session failed: %v", err)
+	}
+	runTestSignalRuntimeReconnect(platform, runtimeSession.ID)
+
+	updated, err := platform.store.GetLiveSession(session.ID)
+	if err != nil {
+		t.Fatalf("get live session failed: %v", err)
+	}
+	if got := stringValue(updated.State["positionReconcileGateStatus"]); got != livePositionReconcileGateStatusStale {
+		t.Fatalf("expected stale reconcile gate after reconnect mismatch, got %s", got)
+	}
+	if got := stringValue(updated.State["recoveryTakeoverState"]); got != liveRecoveryTakeoverStateStaleSync {
+		t.Fatalf("expected stale-sync takeover state after reconnect mismatch, got %s", got)
+	}
+	if !boolValue(updated.State["positionReconcileGateBlocking"]) {
+		t.Fatal("expected reconnect mismatch to block live session actions")
+	}
+	if _, err := platform.ClosePosition(position.ID); err == nil {
+		t.Fatal("expected stale reconnect mismatch to block close execution")
+	}
+}


### PR DESCRIPTION
## 目的
实现 Issue #90 的 runtime-recovery WS + REST dual-channel reconciliation model，明确把 REST 对账作为 restart / reconnect / takeover 边界上的 authoritative verification，避免仅凭缓存或 WS 派生状态恢复可执行交易。

Closes #90

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [x] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main)
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？
- [x] DB migration 是否具备向下兼容幂等性？
- [x] 配置字段有没有无意被混改？

## 验证方式与测试证据
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

### Root cause
- startup recovery 只把 `SyncLiveAccount` 当成 freshness/prefetch，用失败后 local fallback 继续恢复的方式推进，缺少 “REST truth 已验证” 的显式门。
- WS reconnect 只恢复 runtime 并检查 signal bar continuity，没有触发账户级 REST reconcile，也没有把 live session gate 压到 pending/stale。
- `shouldRefreshLiveAccountSync` 只看 freshness 时间窗，无法表达 “必须重新做 authoritative reconcile” 这种语义。

### What changed
- 新增账户级 `livePositionReconcileRequiredAt` / `livePositionReconcileTrigger`，把 authoritative reconcile requirement 从隐式 timing side-effect 收敛成显式状态。
- 新增 `triggerAuthoritativeLiveAccountReconcile(...)`，在 `startup-recovery`、`historical-takeover-activation`、`ws-reconnect-rest-verify-required` 三个入口显式标记 pending，并通过 `SyncLiveAccount` 执行 REST truth sync。
- `shouldRefreshLiveAccountSync` 现在优先消费 pending reconcile trigger，而不是只看 freshness 时间窗。
- `resolveLivePositionReconcileGate` 在 pending reconcile 时直接返回 `stale` gate，阻断 recovery/takeover 动作，直到新的 REST position sync 成功清掉 pending 标记。
- WS reconnect 成功后会调用账户级 reconcile，reconcile mismatch 会把 live session 推到 `stale-sync` controlled state，而健康无漂移路径会恢复到 verified gate。

### User / operator impact
- restart / takeover 有真实仓位时，不再接受 fallback/local-only truth 直接继续交易。
- WS reconnect 后不会静默按旧 gate 继续运行，而是先触发 REST verify；失败或 mismatch 会进入受控阻断态。
- healthy flow 仍保持可用，reconnect 后若 REST snapshot 与 DB 一致，会恢复 verified / non-blocking 状态。

### Checks
- `gofmt -w internal/service/live.go internal/service/live_recovery.go internal/service/live_test.go internal/service/signal_runtime_ws.go internal/service/signal_runtime_ws_test.go`
- `go test ./internal/service -run 'TestRecoverRunningLiveSessionRequiresRESTVerificationBeforeRestartTakeover|TestRecoverRunningLiveSessionAllowsTakeoverAfterVerifiedReconcileMatch|TestRecoverRunningLiveSessionBlocksWhenDBPositionMissingOnExchange|TestStartLiveSessionRequiresRESTVerificationForHistoricalTakeoverActivation|TestRunSignalRuntimeWithRecoveryReconnectTriggersAuthoritativeRESTSync|TestRunSignalRuntimeWithRecoveryReconnectMarksStaleSyncOnRESTMismatch'`
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
