### PR TITLE
[runtime-recovery] Build restart/takeover/passive-close regression suite

### DIFF
--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -4363,6 +4363,139 @@ func TestDispatchLiveSessionIntentAllowsRecoveredPassiveCloseWithCompleteMetadat
 	}
 }
 
+func TestRecoverRunningLiveSessionAllowsVerifiedTakeoverPassiveCloseDispatch(t *testing.T) {
+	platform, session, runtimeSessionID, _, _ := prepareLiveDecisionTelemetryFixture(t)
+	platform.registerLiveAdapter(testLiveAccountSyncAdapter{
+		key: "test-recovery-passive-close-rest",
+		syncSnapshotFunc: func(p *Platform, account domain.Account, binding map[string]any) (domain.Account, error) {
+			previousSuccessAt := parseOptionalRFC3339(stringValue(account.Metadata["lastLiveSyncAt"]))
+			exchangePositions := []map[string]any{{
+				"symbol":      "BTCUSDT",
+				"positionAmt": 0.002,
+				"entryPrice":  69000.0,
+				"markPrice":   68900.0,
+			}}
+			account.Metadata = cloneMetadata(account.Metadata)
+			account.Metadata["liveSyncSnapshot"] = map[string]any{
+				"source":          "binance-rest-account-v3",
+				"adapterKey":      normalizeLiveAdapterKey(stringValue(binding["adapterKey"])),
+				"syncedAt":        time.Now().UTC().Format(time.RFC3339),
+				"bindingMode":     stringValue(binding["connectionMode"]),
+				"executionMode":   "rest",
+				"syncStatus":      "SYNCED",
+				"accountExchange": account.Exchange,
+				"positions":       exchangePositions,
+				"openOrders":      []map[string]any{},
+			}
+			var err error
+			account, err = p.persistLiveAccountSyncSuccess(account, binding, previousSuccessAt)
+			if err != nil {
+				return domain.Account{}, err
+			}
+			reconcileGate, err := p.reconcileLiveAccountPositions(account, exchangePositions)
+			if err != nil {
+				return domain.Account{}, err
+			}
+			account.Metadata = cloneMetadata(account.Metadata)
+			account.Metadata["livePositionReconcileGate"] = reconcileGate
+			account.Metadata["lastLivePositionSyncAt"] = time.Now().UTC().Format(time.RFC3339)
+			clearLiveAccountPositionReconcileRequirement(account.Metadata)
+			return p.store.UpdateAccount(account)
+		},
+		submitOrderFunc: func(_ domain.Account, order domain.Order, binding map[string]any) (LiveOrderSubmission, error) {
+			return LiveOrderSubmission{
+				Status:          "ACCEPTED",
+				ExchangeOrderID: "recovery-exit-order-1",
+				AcceptedAt:      time.Now().UTC().Format(time.RFC3339),
+				Metadata: map[string]any{
+					"adapterMode":   "test-recovery-passive-close",
+					"executionMode": stringValue(binding["executionMode"]),
+					"positionSide":  stringValue(order.Metadata["positionSide"]),
+				},
+			}, nil
+		},
+	})
+
+	account, err := platform.store.GetAccount("live-main")
+	if err != nil {
+		t.Fatalf("get account failed: %v", err)
+	}
+	account.Status = "READY"
+	account.Metadata = cloneMetadata(account.Metadata)
+	account.Metadata["liveBinding"] = map[string]any{
+		"adapterKey":     "test-recovery-passive-close-rest",
+		"connectionMode": "mock",
+		"executionMode":  "rest",
+	}
+	if _, err := platform.store.UpdateAccount(account); err != nil {
+		t.Fatalf("update account failed: %v", err)
+	}
+	if _, err := platform.store.SavePosition(domain.Position{
+		AccountID:         session.AccountID,
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "LONG",
+		Quantity:          0.002,
+		EntryPrice:        69000,
+		MarkPrice:         68900,
+	}); err != nil {
+		t.Fatalf("save position failed: %v", err)
+	}
+
+	state := cloneMetadata(session.State)
+	state["lastStrategyEvaluationSignalBarStates"] = testLiveRecoverySignalBarStates("BTCUSDT", 68900.0)
+	session, err = platform.store.UpdateLiveSessionState(session.ID, state)
+	if err != nil {
+		t.Fatalf("update live session state failed: %v", err)
+	}
+	freshRuntimeAt := time.Now().UTC()
+	if err := platform.updateSignalRuntimeSessionState(runtimeSessionID, func(runtimeSession *domain.SignalRuntimeSession) {
+		state := cloneMetadata(runtimeSession.State)
+		state["lastEventAt"] = freshRuntimeAt.Format(time.RFC3339)
+		state["lastHeartbeatAt"] = freshRuntimeAt.Format(time.RFC3339)
+		sourceStates := cloneMetadata(mapValue(state["sourceStates"]))
+		for key, item := range sourceStates {
+			sourceState := cloneMetadata(mapValue(item))
+			sourceState["lastEventAt"] = freshRuntimeAt.Format(time.RFC3339)
+			sourceStates[key] = sourceState
+		}
+		runtimeSession.State = state
+		runtimeSession.State["sourceStates"] = sourceStates
+		runtimeSession.UpdatedAt = freshRuntimeAt
+	}); err != nil {
+		t.Fatalf("refresh runtime state failed: %v", err)
+	}
+
+	recovered, err := platform.recoverRunningLiveSession(session)
+	if err != nil {
+		t.Fatalf("recover running live session failed: %v", err)
+	}
+	if recovered.Status != "RUNNING" {
+		t.Fatalf("expected verified takeover session to stay RUNNING, got %s", recovered.Status)
+	}
+	if got := stringValue(recovered.State["positionReconcileGateStatus"]); got != livePositionReconcileGateStatusVerified {
+		t.Fatalf("expected verified reconcile gate status, got %s", got)
+	}
+	proposal := mapValue(recovered.State["lastExecutionProposal"])
+	if !isLiveWatchdogFallbackProposal(proposal) {
+		t.Fatalf("expected recovered watchdog passive-close proposal, got %+v", proposal)
+	}
+
+	order, err := platform.dispatchLiveSessionIntent(recovered)
+	if err != nil {
+		t.Fatalf("dispatch recovered passive close failed: %v", err)
+	}
+	if got := order.Status; got != "ACCEPTED" {
+		t.Fatalf("expected accepted recovery close order, got %s", got)
+	}
+	if got := stringValue(order.Metadata["runtimeSessionId"]); got != runtimeSessionID {
+		t.Fatalf("expected order runtimeSessionId %s, got %s", runtimeSessionID, got)
+	}
+	if got := stringValue(order.Metadata["exchangeOrderId"]); got != "recovery-exit-order-1" {
+		t.Fatalf("expected exchange order id recovery-exit-order-1, got %s", got)
+	}
+}
+
 func TestRefreshLiveSessionPositionContextDoesNotRetriggerWatchdogWhileExitOrderWorking(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
 	if _, err := platform.store.SavePosition(domain.Position{
@@ -5751,6 +5884,126 @@ func TestClosePositionAllowsRecoveredCloseOnlyTakeoverWithoutRuntimeLinkage(t *t
 	}
 }
 
+func TestRecoverRunningLiveSessionPreservesRemainingQuantityAfterPartialFillRestart(t *testing.T) {
+	platform, session, _, _, _ := prepareLiveDecisionTelemetryFixture(t)
+	platform.registerLiveAdapter(testLiveAccountSyncAdapter{
+		key: "test-partial-fill-restart",
+		syncOrderFunc: func(_ domain.Account, order domain.Order, _ map[string]any) (LiveOrderSync, error) {
+			return LiveOrderSync{
+				Status:   "PARTIALLY_FILLED",
+				SyncedAt: time.Now().UTC().Format(time.RFC3339),
+				Fills: []LiveFillReport{{
+					Quantity: 0.004,
+					Price:    68950.0,
+				}},
+			}, nil
+		},
+	})
+
+	account, err := platform.store.GetAccount("live-main")
+	if err != nil {
+		t.Fatalf("get account failed: %v", err)
+	}
+	account.Status = "READY"
+	account.Metadata = cloneMetadata(account.Metadata)
+	account.Metadata["liveBinding"] = map[string]any{
+		"adapterKey":     "test-partial-fill-restart",
+		"connectionMode": "mock",
+		"executionMode":  "mock",
+	}
+	if _, err := platform.store.UpdateAccount(account); err != nil {
+		t.Fatalf("update account failed: %v", err)
+	}
+	if _, err := platform.store.SavePosition(domain.Position{
+		AccountID:         session.AccountID,
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "LONG",
+		Quantity:          0.01,
+		EntryPrice:        69000,
+		MarkPrice:         68980,
+	}); err != nil {
+		t.Fatalf("save position failed: %v", err)
+	}
+
+	order, err := platform.store.CreateOrder(domain.Order{
+		AccountID:         session.AccountID,
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "SELL",
+		Type:              "MARKET",
+		Status:            "ACCEPTED",
+		Quantity:          0.01,
+		ReduceOnly:        true,
+		Metadata: map[string]any{
+			"source":        "live-session-intent",
+			"liveSessionId": session.ID,
+			"executionProposal": map[string]any{
+				"role":       "exit",
+				"reason":     "SL",
+				"side":       "SELL",
+				"symbol":     "BTCUSDT",
+				"quantity":   0.01,
+				"reduceOnly": true,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("create order failed: %v", err)
+	}
+
+	state := cloneMetadata(session.State)
+	state["lastDispatchedOrderId"] = order.ID
+	state["lastDispatchedOrderStatus"] = "ACCEPTED"
+	state["lastDispatchedIntent"] = map[string]any{
+		"role":       "exit",
+		"reason":     "SL",
+		"side":       "SELL",
+		"symbol":     "BTCUSDT",
+		"quantity":   0.01,
+		"reduceOnly": true,
+	}
+	session, err = platform.store.UpdateLiveSessionState(session.ID, state)
+	if err != nil {
+		t.Fatalf("update live session state failed: %v", err)
+	}
+
+	recovered, err := platform.recoverRunningLiveSession(session)
+	if err != nil {
+		t.Fatalf("recover running live session failed: %v", err)
+	}
+	if recovered.Status != "RUNNING" {
+		t.Fatalf("expected recovered session to stay RUNNING, got %s", recovered.Status)
+	}
+
+	syncedOrder, err := platform.GetOrder(order.ID)
+	if err != nil {
+		t.Fatalf("get synced order failed: %v", err)
+	}
+	if got := syncedOrder.Status; got != "PARTIALLY_FILLED" {
+		t.Fatalf("expected partial fill order status, got %s", got)
+	}
+	if got := parseFloatValue(syncedOrder.Metadata["filledQuantity"]); got != 0.004 {
+		t.Fatalf("expected filled quantity 0.004, got %v", got)
+	}
+	if got := parseFloatValue(syncedOrder.Metadata["remainingQuantity"]); got != 0.006 {
+		t.Fatalf("expected remaining quantity 0.006, got %v", got)
+	}
+	position, found, err := platform.store.FindPosition(session.AccountID, "BTCUSDT")
+	if err != nil {
+		t.Fatalf("find position failed: %v", err)
+	}
+	if !found {
+		t.Fatal("expected remaining position after partial fill restart")
+	}
+	if got := position.Quantity; got != 0.006 {
+		t.Fatalf("expected remaining position quantity 0.006, got %v", got)
+	}
+	if got := stringValue(recovered.State["lastSyncedOrderStatus"]); got != "PARTIALLY_FILLED" {
+		t.Fatalf("expected last synced order status PARTIALLY_FILLED, got %s", got)
+	}
+}
+
 func TestCompleteRecoveredLiveSessionMetadataClearsCloseOnlyTakeoverWhenPositionFlat(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
 	session, err := platform.CreateLiveSession("live-main", "strategy-bk-1d", map[string]any{
@@ -5992,6 +6245,9 @@ type testLiveAccountSyncAdapter struct {
 	syncErr             error
 	persistsSyncSuccess bool
 	syncSnapshotFunc    func(*Platform, domain.Account, map[string]any) (domain.Account, error)
+	submitOrderFunc     func(domain.Account, domain.Order, map[string]any) (LiveOrderSubmission, error)
+	syncOrderFunc       func(domain.Account, domain.Order, map[string]any) (LiveOrderSync, error)
+	cancelOrderFunc     func(domain.Account, domain.Order, map[string]any) (LiveOrderSync, error)
 }
 
 func (a testLiveAccountSyncAdapter) Key() string {
@@ -6010,15 +6266,24 @@ func (a testLiveAccountSyncAdapter) ValidateAccountConfig(map[string]any) error 
 	return nil
 }
 
-func (a testLiveAccountSyncAdapter) SubmitOrder(domain.Account, domain.Order, map[string]any) (LiveOrderSubmission, error) {
+func (a testLiveAccountSyncAdapter) SubmitOrder(account domain.Account, order domain.Order, binding map[string]any) (LiveOrderSubmission, error) {
+	if a.submitOrderFunc != nil {
+		return a.submitOrderFunc(account, order, binding)
+	}
 	return LiveOrderSubmission{}, nil
 }
 
-func (a testLiveAccountSyncAdapter) SyncOrder(domain.Account, domain.Order, map[string]any) (LiveOrderSync, error) {
+func (a testLiveAccountSyncAdapter) SyncOrder(account domain.Account, order domain.Order, binding map[string]any) (LiveOrderSync, error) {
+	if a.syncOrderFunc != nil {
+		return a.syncOrderFunc(account, order, binding)
+	}
 	return LiveOrderSync{}, nil
 }
 
-func (a testLiveAccountSyncAdapter) CancelOrder(domain.Account, domain.Order, map[string]any) (LiveOrderSync, error) {
+func (a testLiveAccountSyncAdapter) CancelOrder(account domain.Account, order domain.Order, binding map[string]any) (LiveOrderSync, error) {
+	if a.cancelOrderFunc != nil {
+		return a.cancelOrderFunc(account, order, binding)
+	}
 	return LiveOrderSync{}, nil
 }
 

--- a/internal/service/order.go
+++ b/internal/service/order.go
@@ -781,18 +781,38 @@ func (p *Platform) finalizeExecutedOrder(account domain.Account, order domain.Or
 		}
 		lastPrice = executionPrice
 		execOrder := order
+		execOrder.Quantity = createdFill.Quantity
 		execOrder.Price = executionPrice
 		if err := p.applyExecutionFill(account, execOrder, executionPrice); err != nil {
 			return domain.Order{}, err
 		}
 	}
-	order.Status = "FILLED"
+	filledQuantity, err := p.totalFilledQuantityForOrder(order.ID)
+	if err != nil {
+		return domain.Order{}, err
+	}
+	order.Metadata["filledQuantity"] = filledQuantity
+	remainingQuantity := order.Quantity - filledQuantity
+	if remainingQuantity < 0 && remainingQuantity > -1e-9 {
+		remainingQuantity = 0
+	}
+	if remainingQuantity < 0 {
+		remainingQuantity = 0
+	}
+	order.Metadata["remainingQuantity"] = remainingQuantity
+
+	orderCompletelyFilled := filledQuantity >= order.Quantity-1e-9
+	if orderCompletelyFilled {
+		order.Status = "FILLED"
+	} else if filledQuantity > 0 {
+		order.Status = "PARTIALLY_FILLED"
+	}
 	order.Price = lastPrice
-	markOrderLifecycle(order.Metadata, "filled", true)
+	markOrderLifecycle(order.Metadata, "filled", orderCompletelyFilled)
 	if order.Metadata["acceptedAt"] == nil {
 		order.Metadata["acceptedAt"] = time.Now().UTC().Format(time.RFC3339)
 	}
-	if len(newFills) > 0 || strings.TrimSpace(stringValue(order.Metadata["lastFilledAt"])) == "" {
+	if (len(newFills) > 0 || strings.TrimSpace(stringValue(order.Metadata["lastFilledAt"])) == "") && filledQuantity > 0 {
 		filledAt := time.Now().UTC()
 		if latestTradeTime := latestFillExchangeTradeTime(newFills); !latestTradeTime.IsZero() {
 			filledAt = latestTradeTime
@@ -817,11 +837,30 @@ func (p *Platform) finalizeExecutedOrder(account domain.Account, order domain.Or
 		"symbol", NormalizeSymbol(updatedOrder.Symbol),
 	)
 	if strings.EqualFold(account.Mode, "LIVE") {
-		levelLogger.Info("order filled", "fill_count", len(newFills), "price", updatedOrder.Price)
+		if strings.EqualFold(updatedOrder.Status, "FILLED") {
+			levelLogger.Info("order filled", "fill_count", len(newFills), "price", updatedOrder.Price)
+		} else {
+			levelLogger.Info("order partially filled", "fill_count", len(newFills), "price", updatedOrder.Price)
+		}
 	} else {
 		levelLogger.Debug("paper order filled", "fill_count", len(newFills), "price", updatedOrder.Price)
 	}
 	return updatedOrder, nil
+}
+
+func (p *Platform) totalFilledQuantityForOrder(orderID string) (float64, error) {
+	fills, err := p.store.ListFills()
+	if err != nil {
+		return 0, err
+	}
+	total := 0.0
+	for _, fill := range fills {
+		if fill.OrderID != orderID {
+			continue
+		}
+		total += fill.Quantity
+	}
+	return total, nil
 }
 
 func (p *Platform) filterExistingExecutionFills(orderID string, fills []domain.Fill) ([]domain.Fill, error) {

--- a/internal/service/order.go
+++ b/internal/service/order.go
@@ -787,7 +787,7 @@ func (p *Platform) finalizeExecutedOrder(account domain.Account, order domain.Or
 			return domain.Order{}, err
 		}
 	}
-	filledQuantity, err := p.totalFilledQuantityForOrder(order.ID)
+	filledQuantity, err := p.store.TotalFilledQuantityForOrder(order.ID)
 	if err != nil {
 		return domain.Order{}, err
 	}
@@ -846,21 +846,6 @@ func (p *Platform) finalizeExecutedOrder(account domain.Account, order domain.Or
 		levelLogger.Debug("paper order filled", "fill_count", len(newFills), "price", updatedOrder.Price)
 	}
 	return updatedOrder, nil
-}
-
-func (p *Platform) totalFilledQuantityForOrder(orderID string) (float64, error) {
-	fills, err := p.store.ListFills()
-	if err != nil {
-		return 0, err
-	}
-	total := 0.0
-	for _, fill := range fills {
-		if fill.OrderID != orderID {
-			continue
-		}
-		total += fill.Quantity
-	}
-	return total, nil
 }
 
 func (p *Platform) filterExistingExecutionFills(orderID string, fills []domain.Fill) ([]domain.Fill, error) {

--- a/internal/store/memory/store.go
+++ b/internal/store/memory/store.go
@@ -482,6 +482,19 @@ func (s *Store) ListFills() ([]domain.Fill, error) {
 	return items, nil
 }
 
+func (s *Store) TotalFilledQuantityForOrder(orderID string) (float64, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	total := 0.0
+	for _, item := range s.fills {
+		if item.OrderID != orderID {
+			continue
+		}
+		total += item.Quantity
+	}
+	return total, nil
+}
+
 func (s *Store) CreateFill(fill domain.Fill) (domain.Fill, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/store/postgres/store.go
+++ b/internal/store/postgres/store.go
@@ -585,6 +585,21 @@ func (s *Store) ListFills() ([]domain.Fill, error) {
 	return items, rows.Err()
 }
 
+func (s *Store) TotalFilledQuantityForOrder(orderID string) (float64, error) {
+	var total sql.NullFloat64
+	if err := s.db.QueryRow(`
+		select coalesce(sum(quantity), 0)
+		from fills
+		where order_id = $1
+	`, orderID).Scan(&total); err != nil {
+		return 0, err
+	}
+	if !total.Valid {
+		return 0, nil
+	}
+	return total.Float64, nil
+}
+
 func (s *Store) CreateFill(fill domain.Fill) (domain.Fill, error) {
 	now := time.Now().UTC()
 	fill.ID = fmt.Sprintf("fill-%d", now.UnixNano())

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -40,6 +40,8 @@ type Repository interface {
 
 	// ListFills 获取所有成交记录。
 	ListFills() ([]domain.Fill, error)
+	// TotalFilledQuantityForOrder 返回指定订单已落账成交数量总和。
+	TotalFilledQuantityForOrder(orderID string) (float64, error)
 	// CreateFill 创建新成交记录。
 	CreateFill(fill domain.Fill) (domain.Fill, error)
 


### PR DESCRIPTION
## 目的
Closes #91

为 runtime recovery / takeover / passive-close 增补回归测试，并修正部分成交在重启恢复时会被错误收敛为整单成交的问题。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [x] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main)
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？
- [x] DB migration 是否具备向下兼容幂等性？
- [x] 配置字段有没有无意被混改？

说明：本次未改默认 `dispatchMode`、未触碰 mainnet/部署/迁移，仅在 recovery/order 服务逻辑与测试中做最小修正。

## 验证方式与测试证据
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

已执行：
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`

新增/强化覆盖：
- verified DB-backed takeover 后 recovered passive-close 可继续 dispatch
- partial fill + restart 会保留剩余仓位与 `PARTIALLY_FILLED` 真相
- 既有 recovery/reconcile mismatch / exchange-only takeover / duplicate-exit / close-only safeguards 回归继续通过
