### PR TITLE
[codex] add ETH Q1 baseline replay research and memory updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,12 +12,13 @@
 
 - **图谱** == **graphify** (本项目的知识图谱工具)
 - **UI 规范** == **shadcn** (本项目的基础 UI 组件库与规范指南，见 [.skills/shadcn/SKILL.md](.skills/shadcn/SKILL.md))
+- **Research Baseline**: 研究/回测语境下，当前长期 baseline 视为 `dir2_zero_initial=true` + `zero_initial_mode=reentry_window`，并固定使用 `reentry_size_schedule=[0.20, 0.10]`、`max_trades_per_bar=2`。也就是同一根 signal bar 内，第 1 次真实下单为 `20%`，第 2 次真实下单为 `10%`。除非人类明确要求复现历史对照组，否则不要再默认把 `position` 或旧的 `10%/5%/2.5%` 方案当作 baseline 反复判断。
 
 ### 环境路径规约 (Environment Paths)
 
 由于部分 Shell 会话环境受限，请在涉及以下工具的操作中优先使用绝对路径，或参考 [docs/AGENT_PATHS.md](docs/AGENT_PATHS.md)：
-- **GitHub CLI (gh)**: `/opt/homebrew/bin/gh`
-- **Git**: `/usr/bin/git`
+- **GitHub CLI (gh)**: `/usr/local/bin/gh`
+- **Git**: `/usr/local/bin/git`
 
 ### graphify 规则
 

--- a/docs/AGENT_PATHS.md
+++ b/docs/AGENT_PATHS.md
@@ -13,8 +13,8 @@
 
 ## 2. 协作与版本控制 (CLI Tools)
 
-- **GitHub CLI (gh)**: `/opt/homebrew/bin/gh`
-- **Git**: `/usr/bin/git`
+- **GitHub CLI (gh)**: `/usr/local/bin/gh`
+- **Git**: `/usr/local/bin/git`
 
 ## 3. 环境变量加载
 

--- a/research/20260420_eth_q1_intraday_reentry_window_tick_replay.md
+++ b/research/20260420_eth_q1_intraday_reentry_window_tick_replay.md
@@ -1,0 +1,107 @@
+# 2026-04-20 ETH Q1 Intraday `reentry_window` Baseline, Tick Replay
+
+Scope: research-only backtest work. No `internal/service` live or execution path was changed.
+
+## Question
+
+Run the latest research baseline on ETH `2026 Q1` for intraday signal timeframes:
+
+- `1h`
+- `30min`
+- `5min`
+
+Method constraint for this run:
+
+- large-period signal bars must come from tick-derived `1min` data, not from exchange-provided higher-timeframe klines
+- minute-level price occurrence order must be considered during replay, so the execution path should not rely on plain `1min OHLC` alone
+
+## Latest Baseline
+
+Per project memory in `AGENTS.md`, the latest research baseline is:
+
+- `dir2_zero_initial=true`
+- `zero_initial_mode='reentry_window'`
+
+Shared enhanced parameters:
+
+- Initial balance: `100000.0`
+- Slippage: `0.0005`
+- `stop_mode='atr'`
+- `stop_loss_atr=0.05`
+- `profit_protect_atr=1.0`
+- `max_trades_per_bar=4`
+- `reentry_size_schedule=[0.10, 0.05, 0.025]`
+- `trailing_stop_atr=0.3`
+- `delayed_trailing_activation=0.5`
+- `long_reentry_atr=0.1`
+- `short_reentry_atr=0.0`
+- `reentry_anchor_levels='wick'`
+- `reentry_trigger_mode='reclaim'`
+
+## Data And Replay Path
+
+Signal-bar source:
+
+- `ETH_1min_Q1.csv`
+- This file was previously generated directly from raw ETH Q1 tick data. See [20260416_breakout_reentry_experiments.md](./20260416_breakout_reentry_experiments.md).
+
+Raw tick replay source:
+
+- `dataset/archive/ETHUSDT-trades-2026-01/ETHUSDT-trades-2026-01.csv`
+- `dataset/archive/ETHUSDT-trades-2026-02/ETHUSDT-trades-2026-02.zip`
+- `dataset/archive/ETHUSDT-trades-2026-03/ETHUSDT-trades-2026-03.zip`
+
+Replay window:
+
+- `2026-01-01 00:00:00+00:00` to `2026-03-31 23:59:00+00:00`
+
+Important execution detail:
+
+- signal bars were aggregated from the raw-tick-derived `1min` file
+- replay used raw tick event streams built with intra-minute ordering preserved via `high_ts` / `low_ts`
+- combined Q1 tick event stream count: `488,115`
+- combined event range: `2026-01-01 00:00:01.703+00:00` to `2026-03-31 23:58:59.356+00:00`
+
+This means the run is materially stricter than a plain `1min OHLC` backtest, because the engine sees the minute-internal path ordering instead of only the final `open/high/low/close`.
+
+## ETH Q1 2026 Results
+
+| Timeframe | Final Balance | Return | Max DD | Trades | Win Rate | Sharpe | First Entry | Last Exit |
+|---|---:|---:|---:|---:|---:|---:|---|---|
+| `1h` | 193,219.18 | 93.22% | -0.51% | 1497 | 76.15% | 13.71 | `2026-01-01 22:55:37.017+00:00` | `2026-03-31 16:50:26.695+00:00` |
+| `30min` | 223,607.35 | 123.61% | -0.77% | 3384 | 70.86% | 11.96 | `2026-01-01 11:04:53.005+00:00` | `2026-03-31 23:29:59.720+00:00` |
+| `5min` | 39,458.59 | -60.54% | -60.54% | 22,755 | 37.57% | 6.45 | `2026-01-01 01:41:57.986+00:00` | `2026-03-31 23:54:59.689+00:00` |
+
+Signal-frame stats:
+
+| Timeframe | Signal Rows | Signal Range | Valid MA20 Rows | Valid ATR Rows |
+|---|---:|---|---:|---:|
+| `1h` | 2160 | `2026-01-01 00:00:00+00:00` to `2026-03-31 23:00:00+00:00` | 2141 | 2147 |
+| `30min` | 4320 | `2026-01-01 00:00:00+00:00` to `2026-03-31 23:30:00+00:00` | 4301 | 4307 |
+| `5min` | 25920 | `2026-01-01 00:00:00+00:00` to `2026-03-31 23:55:00+00:00` | 25901 | 25907 |
+
+Entry / exit mix:
+
+| Timeframe | Entry Reasons | Exit Reasons |
+|---|---|---|
+| `1h` | `SL-Reentry:1546`, `Zero-Initial-Reentry:279` | `SL:1497` |
+| `30min` | `SL-Reentry:3706`, `Zero-Initial-Reentry:575`, `PT-Reentry:3` | `SL:3380`, `PT:3`, `FinalMarkToMarket:1` |
+| `5min` | `SL-Reentry:31311`, `Zero-Initial-Reentry:2624`, `PT-Reentry:16` | `SL:22740`, `PT:14`, `FinalMarkToMarket:1` |
+
+## Read
+
+Under the stricter tick-replay path:
+
+- `30min` is the strongest intraday result in this Q1 batch
+- `1h` remains strong, but is weaker than `30min`
+- `5min` breaks badly once minute-internal price order is respected
+
+The `5min` failure is the most important outcome here. On a coarse `1min OHLC` path, very small signal bars can still look attractive because the engine does not know whether the minute hit favorable or unfavorable prices first. Once the replay sees the tick-ordered path, that optimism disappears and the strategy overtrades into a deep drawdown.
+
+## Current Takeaway
+
+For ETH `Q1 2026`, with the current enhanced `reentry_window` baseline and order-aware tick replay:
+
+- keep `30min` and `1h` as viable intraday research candidates
+- treat `5min` as a rejected baseline candidate for now
+- prefer any future low-timeframe comparison to use this tick-replay path, not a plain `1min OHLC` shortcut

--- a/research/20260420_eth_q1_reentry_window_second_bar_replay.md
+++ b/research/20260420_eth_q1_reentry_window_second_bar_replay.md
@@ -1,0 +1,111 @@
+# 2026-04-20 ETH Q1 `reentry_window` Baseline, 1s Bar Replay
+
+Scope: research-only backtest work. No `internal/service` live or execution path was changed.
+
+## Question
+
+Run ETH `Q1 2026` backtests with the latest research baseline, but use a finer execution approximation than the previous minute-order-aware replay:
+
+- raw tick -> continuous `1s` bars
+- `1s` bars -> `1min` bars
+- `1min` bars -> signal timeframe bars
+- execution replay on `1s` bars
+
+Requested signal timeframes:
+
+- `4h`
+- `1h`
+- `30min`
+
+## Latest Baseline
+
+Per project memory in `AGENTS.md`, the latest research baseline is:
+
+- `dir2_zero_initial=true`
+- `zero_initial_mode='reentry_window'`
+
+Shared enhanced parameters:
+
+- Initial balance: `100000.0`
+- Slippage: `0.0005`
+- `stop_mode='atr'`
+- `stop_loss_atr=0.05`
+- `profit_protect_atr=1.0`
+- `max_trades_per_bar=4`
+- `reentry_size_schedule=[0.10, 0.05, 0.025]`
+- `trailing_stop_atr=0.3`
+- `delayed_trailing_activation=0.5`
+- `long_reentry_atr=0.1`
+- `short_reentry_atr=0.0`
+- `reentry_anchor_levels='wick'`
+- `reentry_trigger_mode='reclaim'`
+
+## Data And Construction Path
+
+Raw tick source:
+
+- `dataset/archive/ETHUSDT-trades-2026-01/ETHUSDT-trades-2026-01.csv`
+- `dataset/archive/ETHUSDT-trades-2026-02/ETHUSDT-trades-2026-02.zip`
+- `dataset/archive/ETHUSDT-trades-2026-03/ETHUSDT-trades-2026-03.zip`
+
+Window:
+
+- `2026-01-01 00:00:00+00:00` to `2026-03-31 23:59:59+00:00`
+
+Construction summary:
+
+- raw tick rows processed: `748,747,244`
+- continuous `1s` rows built: `7,776,000`
+- derived `1min` rows built: `129,600`
+
+Important note:
+
+- this path is stricter than plain `1min OHLC` replay because execution sees second-level price movement
+- it is still an approximation, not a full raw-tick execution simulator, because multiple ticks inside the same second are compressed into one `1s OHLC` bar
+
+## ETH Q1 2026 Results
+
+| Timeframe | Final Balance | Return | Max DD | Trades | Win Rate | Sharpe | First Entry | Last Exit |
+|---|---:|---:|---:|---:|---:|---:|---|---|
+| `4h` | 147,342.50 | 47.34% | -0.13% | 374 | 85.56% | 18.73 | `2026-01-04 21:11:02+00:00` | `2026-03-31 14:49:09+00:00` |
+| `1h` | 186,386.65 | 86.39% | -0.42% | 1447 | 76.30% | 14.12 | `2026-01-01 22:55:36+00:00` | `2026-03-31 16:46:07+00:00` |
+| `30min` | 215,080.61 | 115.08% | -0.73% | 3194 | 72.67% | 13.02 | `2026-01-01 11:04:30+00:00` | `2026-03-31 23:59:59+00:00` |
+
+Signal-frame stats:
+
+| Timeframe | Signal Rows | Signal Range | Valid MA20 Rows | Valid ATR Rows |
+|---|---:|---|---:|---:|
+| `4h` | 540 | `2026-01-01 00:00:00+00:00` to `2026-03-31 20:00:00+00:00` | 521 | 527 |
+| `1h` | 2160 | `2026-01-01 00:00:00+00:00` to `2026-03-31 23:00:00+00:00` | 2141 | 2147 |
+| `30min` | 4320 | `2026-01-01 00:00:00+00:00` to `2026-03-31 23:30:00+00:00` | 4301 | 4307 |
+
+Entry / exit mix:
+
+| Timeframe | Entry Reasons | Exit Reasons |
+|---|---|---|
+| `4h` | `SL-Reentry:385`, `Zero-Initial-Reentry:65`, `PT-Reentry:2` | `SL:373`, `PT:1` |
+| `1h` | `SL-Reentry:1430`, `Zero-Initial-Reentry:285`, `PT-Reentry:1` | `SL:1446`, `PT:1` |
+| `30min` | `SL-Reentry:3248`, `Zero-Initial-Reentry:602`, `PT-Reentry:2` | `SL:3191`, `PT:2`, `FinalMarkToMarket:1` |
+
+## Read
+
+Under this `1s` execution approximation:
+
+- `30min` remains the highest-return intraday candidate in this batch
+- `1h` stays strong and materially profitable
+- `4h` gives the cleanest risk profile, with the shallowest drawdown and highest win rate
+
+Compared with the earlier minute-order-aware replay, the broad ranking does not flip:
+
+- `30min` still leads on return
+- `1h` remains a valid candidate
+- the strategy is still not showing evidence that coarser execution modeling was flattering only one side of the comparison
+
+## Current Takeaway
+
+For ETH `Q1 2026`, with the current enhanced `reentry_window` baseline:
+
+- keep `30min`, `1h`, and `4h` as valid candidates
+- if prioritizing raw return, `30min` is still best in this batch
+- if prioritizing risk cleanliness, `4h` looks strongest
+- this `1s` path is more trustworthy than a plain `1min OHLC` replay, but it still does not fully replace a true raw-tick execution simulator

--- a/research/20260420_eth_q1_reentry_window_second_bar_replay_20_10_max2.md
+++ b/research/20260420_eth_q1_reentry_window_second_bar_replay_20_10_max2.md
@@ -1,0 +1,132 @@
+# 2026-04-20 ETH Q1 `reentry_window` Baseline, 1s Replay, `20%/10%`, `max_trades_per_bar=2`
+
+Scope: research-only backtest work. No `internal/service` live or execution path was changed.
+
+## Question
+
+Rerun the ETH `Q1 2026` `1s`-bar replay after correcting the `reentry_window` real-order sizing logic.
+
+Requested sizing semantics:
+
+- first real order in a signal bar: `20%`
+- second real order in the same signal bar: `10%`
+- `max_trades_per_bar=2`
+
+Requested signal timeframes:
+
+- `4h`
+- `1h`
+- `30min`
+
+## Research Logic Adjustment
+
+The previous `reentry_window` implementation could still map the second real order in a bar back onto the first schedule bucket.
+
+For this run, research logic was adjusted so that under:
+
+- `dir2_zero_initial=true`
+- `zero_initial_mode='reentry_window'`
+
+the real-order count inside the bar is interpreted as:
+
+- first real order -> `reentry_size_schedule[0]`
+- second real order -> `reentry_size_schedule[1]`
+
+This keeps the sizing aligned with the intended semantics instead of reusing the first bucket for both real orders.
+
+## Shared Parameters
+
+- Initial balance: `100000.0`
+- Slippage: `0.0005`
+- `dir2_zero_initial=true`
+- `zero_initial_mode='reentry_window'`
+- `stop_mode='atr'`
+- `stop_loss_atr=0.05`
+- `profit_protect_atr=1.0`
+- `max_trades_per_bar=2`
+- `reentry_size_schedule=[0.20, 0.10]`
+- `trailing_stop_atr=0.3`
+- `delayed_trailing_activation=0.5`
+- `long_reentry_atr=0.1`
+- `short_reentry_atr=0.0`
+- `reentry_anchor_levels='wick'`
+- `reentry_trigger_mode='reclaim'`
+
+## Data And Construction Path
+
+Raw tick source:
+
+- `dataset/archive/ETHUSDT-trades-2026-01/ETHUSDT-trades-2026-01.csv`
+- `dataset/archive/ETHUSDT-trades-2026-02/ETHUSDT-trades-2026-02.zip`
+- `dataset/archive/ETHUSDT-trades-2026-03/ETHUSDT-trades-2026-03.zip`
+
+Window:
+
+- `2026-01-01 00:00:00+00:00` to `2026-03-31 23:59:59+00:00`
+
+Construction summary:
+
+- raw tick rows processed: `748,747,244`
+- continuous `1s` rows built: `7,776,000`
+- derived `1min` rows built: `129,600`
+
+Replay path:
+
+- raw tick -> continuous `1s` bars
+- `1s` bars -> `1min` bars
+- `1min` bars -> signal bars
+- execution replay on `1s` bars
+
+## ETH Q1 2026 Results
+
+| Timeframe | Final Balance | Return | Max DD | Trades | Win Rate | Sharpe | First Entry | Last Exit |
+|---|---:|---:|---:|---:|---:|---:|---|---|
+| `4h` | 151,400.17 | 51.40% | -0.13% | 180 | 94.44% | 21.61 | `2026-01-04 21:11:02+00:00` | `2026-03-31 14:34:50+00:00` |
+| `1h` | 221,038.10 | 121.04% | -0.45% | 802 | 86.78% | 16.06 | `2026-01-01 22:55:36+00:00` | `2026-03-31 16:42:11+00:00` |
+| `30min` | 263,418.74 | 163.42% | -0.90% | 1721 | 81.93% | 15.46 | `2026-01-01 11:04:30+00:00` | `2026-03-31 23:59:59+00:00` |
+
+Signal-frame stats:
+
+| Timeframe | Signal Rows | Signal Range | Valid MA20 Rows | Valid ATR Rows |
+|---|---:|---|---:|---:|
+| `4h` | 540 | `2026-01-01 00:00:00+00:00` to `2026-03-31 20:00:00+00:00` | 521 | 527 |
+| `1h` | 2160 | `2026-01-01 00:00:00+00:00` to `2026-03-31 23:00:00+00:00` | 2141 | 2147 |
+| `30min` | 4320 | `2026-01-01 00:00:00+00:00` to `2026-03-31 23:30:00+00:00` | 4301 | 4307 |
+
+Entry / exit mix:
+
+| Timeframe | Entry Reasons | Exit Reasons |
+|---|---|---|
+| `4h` | `SL-Reentry:106`, `Zero-Initial-Reentry:74` | `SL:180` |
+| `1h` | `SL-Reentry:503`, `Zero-Initial-Reentry:299` | `SL:802` |
+| `30min` | `SL-Reentry:1082`, `Zero-Initial-Reentry:638`, `PT-Reentry:1` | `SL:1719`, `PT:1`, `FinalMarkToMarket:1` |
+
+## Read
+
+This sizing change materially reduced trade count while improving trade quality:
+
+- `4h` trades fell from `374` to `180`
+- `1h` trades fell from `1447` to `802`
+- `30min` trades fell from `3194` to `1721`
+
+At the same time:
+
+- `4h` return improved from `47.34%` to `51.40%`
+- `1h` return improved from `86.39%` to `121.04%`
+- `30min` return improved from `115.08%` to `163.42%`
+
+The main interpretation is:
+
+- limiting same-bar churn helped more than the larger first real order hurt
+- forcing the second real order down to `10%` appears to reduce destructive same-bar overtrading
+- the strategy benefits from taking fewer, more decisive same-bar entries
+
+## Current Takeaway
+
+On ETH `Q1 2026`, under the stricter `1s` replay path:
+
+- `30min` remains the strongest return candidate
+- `1h` also improves materially and remains attractive
+- `4h` stays the cleanest risk profile and now also improves in return
+
+This `20% / 10% / max=2` configuration is a stronger candidate than the previous `20%`-agnostic `10% / 5% / 2.5%` with `max_trades_per_bar=4` setting for the tested Q1 window.

--- a/research/backTest.py
+++ b/research/backTest.py
@@ -2,6 +2,7 @@ import pandas as pd
 import numpy as np
 import glob
 import os
+import zipfile
 from tqdm import tqdm
 import matplotlib.pyplot as plt
 
@@ -153,25 +154,34 @@ def _build_tick_event_stream(tick_file, start_ts=None, end_ts=None, chunksize=2_
 
     summaries = []
     pending = None
-    with open(tick_file, 'r', encoding='utf-8') as fh:
-        first_line = fh.readline().strip().lower()
+    tick_file_str = str(tick_file)
+    if tick_file_str.lower().endswith('.zip'):
+        with zipfile.ZipFile(tick_file_str) as zf:
+            inner_name = zf.namelist()[0]
+            with zf.open(inner_name) as fh:
+                first_line = fh.readline().decode('utf-8').strip().lower()
+    else:
+        with open(tick_file_str, 'r', encoding='utf-8') as fh:
+            first_line = fh.readline().strip().lower()
 
     if first_line.startswith('id,price,qty,quote_qty,time'):
         reader = pd.read_csv(
-            tick_file,
+            tick_file_str,
             header=0,
             usecols=['price', 'time'],
             dtype={'price': 'float32', 'time': 'int64'},
             chunksize=chunksize,
+            compression='infer',
         )
     else:
         reader = pd.read_csv(
-            tick_file,
+            tick_file_str,
             header=None,
             usecols=[1, 4],
             names=['price', 'timestamp'],
             dtype={'price': 'float32', 'timestamp': 'int64'},
             chunksize=chunksize,
+            compression='infer',
         )
 
     for chunk in reader:
@@ -267,20 +277,25 @@ def run_tick_full_scan_dual(df_4h, tick_file, current_bal,
                             cooldown_bars=6,
                             reentry_mode='default',
                             reentry_anchor_levels='wick',
-                            reentry_trigger_mode='reclaim'):
+                            reentry_trigger_mode='reclaim',
+                            zero_initial_mode='position'):
     # Keep both signal windows and tick windows on the same UTC-aware contract.
     df_4h = apply_reentry_anchor_levels(df_4h, reentry_anchor_levels)
     df_4h = _normalize_utc_index(df_4h)
 
     replay_start = df_4h.index[0]
     replay_end = df_4h.index[-1]
-    print(f"正在构建 Tick 事件流: {tick_file} ({replay_start} ~ {replay_end}) ...")
-    df_tick = _build_tick_event_stream(
-        tick_file,
-        start_ts=replay_start,
-        end_ts=replay_end,
-    )
-    df_tick = _normalize_utc_index(df_tick)
+    if isinstance(tick_file, pd.DataFrame):
+        df_tick = _normalize_utc_index(tick_file).loc[replay_start:replay_end]
+        print(f"正在复用预构建 Tick 事件流 ({replay_start} ~ {replay_end}) ...")
+    else:
+        print(f"正在构建 Tick 事件流: {tick_file} ({replay_start} ~ {replay_end}) ...")
+        df_tick = _build_tick_event_stream(
+            tick_file,
+            start_ts=replay_start,
+            end_ts=replay_end,
+        )
+        df_tick = _normalize_utc_index(df_tick)
 
     balance = current_bal
     peak_balance = current_bal
@@ -294,6 +309,7 @@ def run_tick_full_scan_dual(df_4h, tick_file, current_bal,
     REENTRY_SIZE_SCHEDULE = _normalize_reentry_sizes(reentry_size_schedule)
     PROFIT_PROTECT = profit_protect_atr
     stop_mode = 'structural' if dir3_structural_sl and stop_mode is None else (stop_mode or 'atr')
+    zero_initial_mode = _normalize_zero_initial_mode(zero_initial_mode)
 
     if reentry_mode == 'fixed':
         base = REENTRY_SIZE_SCHEDULE[0] if REENTRY_SIZE_SCHEDULE else 0.10
@@ -306,6 +322,8 @@ def run_tick_full_scan_dual(df_4h, tick_file, current_bal,
     REENTRY_TIMEOUT = 1
     last_exit_reason = None
     last_exit_side = None
+    pending_zero_initial_side = None
+    pending_zero_initial_bar_index = -999
     circuit_breaker_until = -999
 
     label_parts = []
@@ -321,6 +339,8 @@ def run_tick_full_scan_dual(df_4h, tick_file, current_bal,
         label_parts.append(f"ReAnchor:{reentry_anchor_levels}")
     if reentry_trigger_mode != 'reclaim':
         label_parts.append(f"ReTrigger:{reentry_trigger_mode}")
+    if dir2_zero_initial and zero_initial_mode != 'position':
+        label_parts.append(f"ZeroInit:{zero_initial_mode}")
     label_parts.append(f"ReATR:{long_reentry_atr}/{short_reentry_atr}")
     label = " | ".join(label_parts) if label_parts else "TickEnhanced"
 
@@ -348,6 +368,8 @@ def run_tick_full_scan_dual(df_4h, tick_file, current_bal,
 
         if i - last_exit_bar_index > REENTRY_TIMEOUT:
             last_exit_side = None
+        if i - pending_zero_initial_bar_index > REENTRY_TIMEOUT:
+            pending_zero_initial_side = None
 
         while idx < total_ticks:
             current_tick = window_ticks.iloc[idx]
@@ -366,30 +388,37 @@ def run_tick_full_scan_dual(df_4h, tick_file, current_bal,
                     re_p = _resolve_reentry_price(sig, 'long', reentry_anchor_levels, long_reentry_atr)
                     if trades_in_bar == 0 and sig['prev_high_2'] > sig['prev_high_1']:
                         if current_p >= sig['prev_high_2']:
-                            entry_raw = max(current_p, sig['prev_high_2'])
-                            entry_p = entry_raw * (1 + SLIPPAGE)
-                            notional_value = balance * CASH_USAGE_INITIAL
-                            initial_sl = _resolve_stop_price('long', entry_p, sig, stop_mode, stop_loss_atr)
-                            position = {
-                                'side': 'long',
-                                'entry_p': entry_p,
-                                'sl': initial_sl,
-                                'protected': False,
-                                'notional': notional_value,
-                                'hwm': entry_p,
-                            }
-                            balance -= notional_value * COMMISSION
-                            trade_logs.append({
-                                'time': current_time,
-                                'type': 'BUY',
-                                'price': entry_p,
-                                'reason': 'Initial',
-                                'notional': notional_value,
-                                'bal': balance,
-                            })
-                            trades_in_bar += 1
-                            executed = True
-                    elif last_exit_side == 'long' and (i - last_exit_bar_index <= REENTRY_TIMEOUT):
+                            if dir2_zero_initial and zero_initial_mode == 'reentry_window':
+                                pending_zero_initial_side = 'long'
+                                pending_zero_initial_bar_index = i
+                            else:
+                                entry_raw = max(current_p, sig['prev_high_2'])
+                                entry_p = entry_raw * (1 + SLIPPAGE)
+                                notional_value = balance * CASH_USAGE_INITIAL
+                                initial_sl = _resolve_stop_price('long', entry_p, sig, stop_mode, stop_loss_atr)
+                                position = {
+                                    'side': 'long',
+                                    'entry_p': entry_p,
+                                    'sl': initial_sl,
+                                    'protected': False,
+                                    'notional': notional_value,
+                                    'hwm': entry_p,
+                                }
+                                balance -= notional_value * COMMISSION
+                                trade_logs.append({
+                                    'time': current_time,
+                                    'type': 'BUY',
+                                    'price': entry_p,
+                                    'reason': 'Initial',
+                                    'notional': notional_value,
+                                    'bal': balance,
+                                })
+                                trades_in_bar += 1
+                                executed = True
+
+                    has_exit_reentry_window = last_exit_side == 'long' and (i - last_exit_bar_index <= REENTRY_TIMEOUT)
+                    has_zero_initial_window = pending_zero_initial_side == 'long' and (i - pending_zero_initial_bar_index <= REENTRY_TIMEOUT)
+                    if has_exit_reentry_window or has_zero_initial_window:
                         is_triggered, entry_p_raw = _reentry_triggered(
                             'long',
                             reentry_trigger_mode,
@@ -401,9 +430,16 @@ def run_tick_full_scan_dual(df_4h, tick_file, current_bal,
                             dir1_reentry_confirm,
                         )
                         if is_triggered:
-                            reason = 'SL-Reentry' if last_exit_reason == 'SL' else 'PT-Reentry'
+                            reason = 'Zero-Initial-Reentry'
+                            if has_exit_reentry_window:
+                                reason = 'SL-Reentry' if last_exit_reason == 'SL' else 'PT-Reentry'
                             if trades_in_bar < MAX_TRADES_PER_BAR:
-                                current_reentry_size = _get_reentry_size(trades_in_bar, REENTRY_SIZE_SCHEDULE)
+                                if has_zero_initial_window and not has_exit_reentry_window:
+                                    current_reentry_size = REENTRY_SIZE_SCHEDULE[0]
+                                elif dir2_zero_initial and zero_initial_mode == 'reentry_window':
+                                    current_reentry_size = _get_reentry_window_real_order_size(trades_in_bar, REENTRY_SIZE_SCHEDULE)
+                                else:
+                                    current_reentry_size = _get_reentry_size(trades_in_bar, REENTRY_SIZE_SCHEDULE)
                                 notional_value = balance * current_reentry_size
                                 entry_price = entry_p_raw * (1 + SLIPPAGE)
                                 reentry_sl = _resolve_stop_price('long', entry_price, sig, stop_mode, stop_loss_atr)
@@ -426,36 +462,46 @@ def run_tick_full_scan_dual(df_4h, tick_file, current_bal,
                                 })
                                 trades_in_bar += 1
                                 executed = True
-                            last_exit_side = None
+                            if has_exit_reentry_window:
+                                last_exit_side = None
+                            if has_zero_initial_window:
+                                pending_zero_initial_side = None
 
                 elif short_regime_ready:
                     re_p = _resolve_reentry_price(sig, 'short', reentry_anchor_levels, short_reentry_atr)
                     if trades_in_bar == 0 and sig['prev_low_2'] < sig['prev_low_1']:
                         if current_p <= sig['prev_low_2']:
-                            entry_raw = min(current_p, sig['prev_low_2'])
-                            entry_p = entry_raw * (1 - SLIPPAGE)
-                            notional_value = balance * CASH_USAGE_INITIAL
-                            initial_sl = _resolve_stop_price('short', entry_p, sig, stop_mode, stop_loss_atr)
-                            position = {
-                                'side': 'short',
-                                'entry_p': entry_p,
-                                'sl': initial_sl,
-                                'protected': False,
-                                'notional': notional_value,
-                                'lwm': entry_p,
-                            }
-                            balance -= notional_value * COMMISSION
-                            trade_logs.append({
-                                'time': current_time,
-                                'type': 'SHORT',
-                                'price': entry_p,
-                                'reason': 'Initial',
-                                'notional': notional_value,
-                                'bal': balance,
-                            })
-                            trades_in_bar += 1
-                            executed = True
-                    elif last_exit_side == 'short' and (i - last_exit_bar_index <= REENTRY_TIMEOUT):
+                            if dir2_zero_initial and zero_initial_mode == 'reentry_window':
+                                pending_zero_initial_side = 'short'
+                                pending_zero_initial_bar_index = i
+                            else:
+                                entry_raw = min(current_p, sig['prev_low_2'])
+                                entry_p = entry_raw * (1 - SLIPPAGE)
+                                notional_value = balance * CASH_USAGE_INITIAL
+                                initial_sl = _resolve_stop_price('short', entry_p, sig, stop_mode, stop_loss_atr)
+                                position = {
+                                    'side': 'short',
+                                    'entry_p': entry_p,
+                                    'sl': initial_sl,
+                                    'protected': False,
+                                    'notional': notional_value,
+                                    'lwm': entry_p,
+                                }
+                                balance -= notional_value * COMMISSION
+                                trade_logs.append({
+                                    'time': current_time,
+                                    'type': 'SHORT',
+                                    'price': entry_p,
+                                    'reason': 'Initial',
+                                    'notional': notional_value,
+                                    'bal': balance,
+                                })
+                                trades_in_bar += 1
+                                executed = True
+
+                    has_exit_reentry_window = last_exit_side == 'short' and (i - last_exit_bar_index <= REENTRY_TIMEOUT)
+                    has_zero_initial_window = pending_zero_initial_side == 'short' and (i - pending_zero_initial_bar_index <= REENTRY_TIMEOUT)
+                    if has_exit_reentry_window or has_zero_initial_window:
                         is_triggered, entry_p_raw = _reentry_triggered(
                             'short',
                             reentry_trigger_mode,
@@ -467,9 +513,16 @@ def run_tick_full_scan_dual(df_4h, tick_file, current_bal,
                             dir1_reentry_confirm,
                         )
                         if is_triggered:
-                            reason = 'SL-Reentry' if last_exit_reason == 'SL' else 'PT-Reentry'
+                            reason = 'Zero-Initial-Reentry'
+                            if has_exit_reentry_window:
+                                reason = 'SL-Reentry' if last_exit_reason == 'SL' else 'PT-Reentry'
                             if trades_in_bar < MAX_TRADES_PER_BAR:
-                                current_reentry_size = _get_reentry_size(trades_in_bar, REENTRY_SIZE_SCHEDULE)
+                                if has_zero_initial_window and not has_exit_reentry_window:
+                                    current_reentry_size = REENTRY_SIZE_SCHEDULE[0]
+                                elif dir2_zero_initial and zero_initial_mode == 'reentry_window':
+                                    current_reentry_size = _get_reentry_window_real_order_size(trades_in_bar, REENTRY_SIZE_SCHEDULE)
+                                else:
+                                    current_reentry_size = _get_reentry_size(trades_in_bar, REENTRY_SIZE_SCHEDULE)
                                 notional_value = balance * current_reentry_size
                                 entry_price = entry_p_raw * (1 - SLIPPAGE)
                                 reentry_sl = _resolve_stop_price('short', entry_price, sig, stop_mode, stop_loss_atr)
@@ -492,7 +545,10 @@ def run_tick_full_scan_dual(df_4h, tick_file, current_bal,
                                 })
                                 trades_in_bar += 1
                                 executed = True
-                            last_exit_side = None
+                            if has_exit_reentry_window:
+                                last_exit_side = None
+                            if has_zero_initial_window:
+                                pending_zero_initial_side = None
 
                 if executed:
                     idx = window_ticks.index.searchsorted(current_time, side='right')
@@ -842,6 +898,12 @@ def _get_reentry_size(trades_in_bar, reentry_size_schedule):
         return 0.0
     schedule = _normalize_reentry_sizes(reentry_size_schedule)
     idx = max(0, trades_in_bar - 1)
+    return schedule[min(idx, len(schedule) - 1)]
+
+
+def _get_reentry_window_real_order_size(trades_in_bar, reentry_size_schedule):
+    schedule = _normalize_reentry_sizes(reentry_size_schedule)
+    idx = max(0, trades_in_bar)
     return schedule[min(idx, len(schedule) - 1)]
 
 def _resolve_stop_price(side, entry_p, sig, stop_mode, stop_loss_atr):
@@ -1545,7 +1607,12 @@ def run_backtest_enhanced(df_1min, df_4h, initial_balance=100000.0,
                             if has_exit_reentry_window:
                                 reason = 'SL-Reentry' if last_exit_reason == 'SL' else 'PT-Reentry'
                             if trades_in_bar < MAX_TRADES_PER_BAR:
-                                current_reentry_size = REENTRY_SIZE_SCHEDULE[0] if (has_zero_initial_window and not has_exit_reentry_window) else _get_reentry_size(trades_in_bar, REENTRY_SIZE_SCHEDULE)
+                                if has_zero_initial_window and not has_exit_reentry_window:
+                                    current_reentry_size = REENTRY_SIZE_SCHEDULE[0]
+                                elif dir2_zero_initial and zero_initial_mode == 'reentry_window':
+                                    current_reentry_size = _get_reentry_window_real_order_size(trades_in_bar, REENTRY_SIZE_SCHEDULE)
+                                else:
+                                    current_reentry_size = _get_reentry_size(trades_in_bar, REENTRY_SIZE_SCHEDULE)
                                 notional_value = balance * current_reentry_size
                                 entry_price = entry_p_raw * (1 + SLIPPAGE)
                                 reentry_sl = _resolve_stop_price('long', entry_price, sig, stop_mode, stop_loss_atr)
@@ -1608,7 +1675,12 @@ def run_backtest_enhanced(df_1min, df_4h, initial_balance=100000.0,
                             if has_exit_reentry_window:
                                 reason = 'SL-Reentry' if last_exit_reason == 'SL' else 'PT-Reentry'
                             if trades_in_bar < MAX_TRADES_PER_BAR:
-                                current_reentry_size = REENTRY_SIZE_SCHEDULE[0] if (has_zero_initial_window and not has_exit_reentry_window) else _get_reentry_size(trades_in_bar, REENTRY_SIZE_SCHEDULE)
+                                if has_zero_initial_window and not has_exit_reentry_window:
+                                    current_reentry_size = REENTRY_SIZE_SCHEDULE[0]
+                                elif dir2_zero_initial and zero_initial_mode == 'reentry_window':
+                                    current_reentry_size = _get_reentry_window_real_order_size(trades_in_bar, REENTRY_SIZE_SCHEDULE)
+                                else:
+                                    current_reentry_size = _get_reentry_size(trades_in_bar, REENTRY_SIZE_SCHEDULE)
                                 notional_value = balance * current_reentry_size
                                 entry_price = entry_p_raw * (1 - SLIPPAGE)
                                 reentry_sl = _resolve_stop_price('short', entry_price, sig, stop_mode, stop_loss_atr)


### PR DESCRIPTION
## 目的
固化当前 ETH Q1 research baseline，并补齐更可信的回放研究记录与 research-only 回测能力，避免后续 Agent 反复在旧 baseline、旧路径和本机 CLI 路径上来回判断。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [x] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main)
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？
- [x] DB migration 是否具备向下兼容幂等性？
- [x] 配置字段有没有无意被混改？

说明：本 PR 不涉及 `dispatchMode`、mainnet 地址、DB migration、部署流程或 live 执行路径，仅调整 research-only Python 回测逻辑与文档记忆。

## 验证方式与测试证据
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

本地验证：
- `python3 -m py_compile research/backTest.py`
- 使用 ETH Q1 raw tick 数据完成以下 research replay：
  - minute-order-aware tick replay (`1h / 30min / 5min`)
  - `1s` bar replay (`4h / 1h / 30min`)
  - `1s` bar replay with `reentry_size_schedule=[0.20, 0.10]` and `max_trades_per_bar=2`
- `git push` 过程中由 pre-push hook 自动重建 graphify，日志显示 graph 已刷新到 `graphify-out/`

## 变更内容
- 在 `AGENTS.md` 中固化当前长期 research baseline：`reentry_window` + `reentry_size_schedule=[0.20, 0.10]` + `max_trades_per_bar=2`
- 在 `docs/AGENT_PATHS.md` 和 `AGENTS.md` 中固化本机实际 CLI 路径：`/usr/local/bin/gh`、`/usr/local/bin/git`
- 扩展 `research/backTest.py` 的 research-only 回放能力：
  - 支持 zip tick 包读取
  - 支持复用预构建 tick 事件流
  - 将 `reentry_window` 语义接入 tick replay
  - 修正 `reentry_window` 下第二次真实单错误复用第一档仓位的问题
- 新增三篇 ETH Q1 research note，记录不同执行近似下的结果与结论：
  - `research/20260420_eth_q1_intraday_reentry_window_tick_replay.md`
  - `research/20260420_eth_q1_reentry_window_second_bar_replay.md`
  - `research/20260420_eth_q1_reentry_window_second_bar_replay_20_10_max2.md`

## 用户 / 开发者影响
- 后续 Agent 在研究语境下会默认把 `reentry_window + 20%/10% + max=2` 作为 baseline，不再把旧的 `position` 或 `10%/5%/2.5% max=4` 当默认候选。
- ETH Q1 intraday 回测结果现在有更完整的研究记录，便于后续继续做 timeframe 和 sizing 对比。
- 这批改动不影响 live、paper、Go 后端、部署或 CI 默认行为。