### PR TITLE
[codex] Fix live runtime fanout state loss

### DIFF
--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -3015,8 +3015,10 @@ func (p *Platform) completeRecoveredLiveSessionMetadata(session domain.LiveSessi
 		delete(state, "recoveryBlockedAt")
 		delete(state, "runtimeMode")
 		delete(state, "signalRuntimeMode")
-		delete(state, "signalRuntimeRequired")
-		delete(state, "signalRuntimeReady")
+		// Preserve the current runtime linkage gate for RUNNING sessions.
+		// Clearing these flags while flat can silently detach runtime fanout
+		// from an otherwise healthy live session until some later resync
+		// happens to rebuild the linkage state.
 		if strings.EqualFold(stringValue(state["lastStrategyEvaluationStatus"]), liveRecoveryModeCloseOnlyTakeover) {
 			delete(state, "lastStrategyEvaluationStatus")
 		}

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -6050,6 +6050,64 @@ func TestCompleteRecoveredLiveSessionMetadataClearsCloseOnlyTakeoverWhenPosition
 	}
 }
 
+func TestEnsureLiveExecutionPlanPreservesSignalRuntimeRequirementWhenFlat(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	for _, payload := range []map[string]any{
+		{
+			"sourceKey": "binance-kline",
+			"role":      "signal",
+			"symbol":    "BTCUSDT",
+			"options":   map[string]any{"timeframe": "1d"},
+		},
+		{
+			"sourceKey": "binance-trade-tick",
+			"role":      "trigger",
+			"symbol":    "BTCUSDT",
+		},
+	} {
+		if _, err := platform.BindStrategySignalSource("strategy-bk-1d", payload); err != nil {
+			t.Fatalf("bind strategy signal source failed: %v", err)
+		}
+	}
+
+	session, err := platform.CreateLiveSession("live-main", "strategy-bk-1d", map[string]any{
+		"symbol":              "BTCUSDT",
+		"signalTimeframe":     "1d",
+		"executionDataSource": "tick",
+	})
+	if err != nil {
+		t.Fatalf("create live session failed: %v", err)
+	}
+	if !boolValue(session.State["signalRuntimeRequired"]) {
+		t.Fatalf("expected linked live session to require runtime before plan evaluation, got %#v", session.State)
+	}
+
+	eventTime := time.Date(2026, 4, 20, 8, 36, 10, 0, time.UTC)
+	platform.mu.Lock()
+	platform.livePlans[session.ID] = []paperPlannedOrder{{
+		EventTime: eventTime,
+		Price:     70000.0,
+		Side:      "BUY",
+		Role:      "entry",
+		Reason:    "cached-plan",
+	}}
+	platform.mu.Unlock()
+
+	updated, plan, err := platform.ensureLiveExecutionPlan(session)
+	if err != nil {
+		t.Fatalf("ensure live execution plan failed: %v", err)
+	}
+	if len(plan) != 1 {
+		t.Fatalf("expected cached plan to be preserved, got %#v", plan)
+	}
+	if _, ok := updated.State["signalRuntimeRequired"]; !ok {
+		t.Fatalf("expected signalRuntimeRequired to remain present, got %#v", updated.State)
+	}
+	if !boolValue(updated.State["signalRuntimeRequired"]) {
+		t.Fatalf("expected flat RUNNING session to keep signalRuntimeRequired, got %#v", updated.State)
+	}
+}
+
 func TestStartLiveSessionRejectsActiveCloseOnlyTakeoverMode(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
 	platform.registerLiveAdapter(testLiveAccountSyncAdapter{key: "test-start-close-only"})

--- a/internal/service/signal_runtime_ws.go
+++ b/internal/service/signal_runtime_ws.go
@@ -479,7 +479,13 @@ func (p *Platform) runExchangeWebsocketLoop(
 				session.State = state
 				session.UpdatedAt = now
 			})
-			_ = p.handleSignalRuntimeMessage(session.ID, summary, now)
+			if err := p.handleSignalRuntimeMessage(session.ID, summary, now); err != nil {
+				p.logger("service.signal_runtime",
+					"session_id", session.ID,
+					"symbol", signalRuntimeSummarySymbol(summary),
+					"stream_type", inferSignalRuntimeStreamType(summary),
+				).Warn("signal runtime live fanout failed", "error", err)
+			}
 		}
 	}()
 
@@ -574,19 +580,80 @@ func (p *Platform) handleSignalRuntimeMessage(runtimeSessionID string, summary m
 		if session.Status != "RUNNING" {
 			continue
 		}
+		requiredValue, hasRequired := session.State["signalRuntimeRequired"]
+		if !boolValue(requiredValue) && (!hasRequired || requiredValue == nil) {
+			refreshed, refreshErr := p.syncLiveSessionRuntime(session)
+			if refreshErr != nil {
+				p.recordLiveRuntimeFanoutDrop(session, runtimeSessionID, summary, eventTime, "runtime-state-refresh-failed", map[string]any{
+					"error": refreshErr.Error(),
+				})
+				continue
+			} else {
+				session = refreshed
+				p.logger("service.live",
+					"session_id", session.ID,
+					"runtime_session_id", runtimeSessionID,
+					"symbol", targetSymbol,
+				).Info("restored missing signalRuntimeRequired before live runtime fanout")
+			}
+		}
 		if !boolValue(session.State["signalRuntimeRequired"]) {
+			p.recordLiveRuntimeFanoutDrop(session, runtimeSessionID, summary, eventTime, "runtime-not-required", map[string]any{
+				"signalRuntimeRequired": session.State["signalRuntimeRequired"],
+			})
 			continue
 		}
 		sessionSymbol := NormalizeSymbol(firstNonEmpty(stringValue(session.State["symbol"]), stringValue(session.State["lastSymbol"])))
 		if sessionSymbol == "" {
+			p.recordLiveRuntimeFanoutDrop(session, runtimeSessionID, summary, eventTime, "missing-session-symbol", nil)
 			continue // session has no symbol — skip
 		}
 		if sessionSymbol != targetSymbol {
 			continue
 		}
-		_ = p.triggerLiveSessionFromSignal(session.ID, runtimeSessionID, summary, eventTime)
+		if err := p.triggerLiveSessionFromSignal(session.ID, runtimeSessionID, summary, eventTime); err != nil {
+			p.logger("service.live",
+				"session_id", session.ID,
+				"runtime_session_id", runtimeSessionID,
+				"symbol", targetSymbol,
+			).Warn("trigger live session from signal failed", "error", err)
+		}
 	}
 	return nil
+}
+
+func (p *Platform) recordLiveRuntimeFanoutDrop(
+	session domain.LiveSession,
+	runtimeSessionID string,
+	summary map[string]any,
+	eventTime time.Time,
+	reason string,
+	details map[string]any,
+) {
+	state := cloneMetadata(session.State)
+	lastReason := stringValue(state["lastRuntimeFanoutDropReason"])
+	lastRecordedAt := parseOptionalRFC3339(stringValue(state["lastRuntimeFanoutDropAt"]))
+	if lastReason == reason && !lastRecordedAt.IsZero() && eventTime.Sub(lastRecordedAt) < 30*time.Second {
+		return
+	}
+	state["lastRuntimeFanoutDropReason"] = reason
+	state["lastRuntimeFanoutDropAt"] = eventTime.UTC().Format(time.RFC3339)
+	state["lastRuntimeFanoutDropRuntimeSessionId"] = runtimeSessionID
+	state["lastRuntimeFanoutDropSummary"] = cloneMetadata(summary)
+	if len(details) > 0 {
+		state["lastRuntimeFanoutDropDetails"] = cloneMetadata(details)
+	} else {
+		delete(state, "lastRuntimeFanoutDropDetails")
+	}
+	if updated, err := p.store.UpdateLiveSessionState(session.ID, state); err == nil {
+		session = updated
+	}
+	p.logger("service.live",
+		"session_id", session.ID,
+		"runtime_session_id", runtimeSessionID,
+		"reason", reason,
+		"symbol", signalRuntimeSummarySymbol(summary),
+	).Warn("runtime event skipped for live session fanout")
 }
 
 func signalRuntimeSummaryShouldTriggerLiveEvaluation(summary map[string]any) bool {

--- a/internal/service/signal_runtime_ws_test.go
+++ b/internal/service/signal_runtime_ws_test.go
@@ -506,6 +506,141 @@ func TestHandleSignalRuntimeMessageScopesTriggerByLiveSessionSymbol(t *testing.T
 	}
 }
 
+func TestHandleSignalRuntimeMessageRepairsMissingSignalRuntimeRequired(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	for _, payload := range []map[string]any{
+		{
+			"sourceKey": "binance-kline",
+			"role":      "signal",
+			"symbol":    "BTCUSDT",
+			"options":   map[string]any{"timeframe": "1d"},
+		},
+		{
+			"sourceKey": "binance-trade-tick",
+			"role":      "trigger",
+			"symbol":    "BTCUSDT",
+		},
+	} {
+		if _, err := platform.BindStrategySignalSource("strategy-bk-1d", payload); err != nil {
+			t.Fatalf("bind strategy source failed: %v", err)
+		}
+	}
+
+	session, err := platform.CreateLiveSession("live-main", "strategy-bk-1d", map[string]any{
+		"symbol":              "BTCUSDT",
+		"signalTimeframe":     "1d",
+		"executionDataSource": "tick",
+	})
+	if err != nil {
+		t.Fatalf("create live session failed: %v", err)
+	}
+	runtimeSessionID := stringValue(session.State["signalRuntimeSessionId"])
+	if runtimeSessionID == "" {
+		t.Fatal("expected linked runtime session id")
+	}
+	if _, err := platform.store.UpdateLiveSessionStatus(session.ID, "RUNNING"); err != nil {
+		t.Fatalf("mark live session running failed: %v", err)
+	}
+	state := cloneMetadata(session.State)
+	state["signalRuntimeRequired"] = nil
+	session, err = platform.store.UpdateLiveSessionState(session.ID, state)
+	if err != nil {
+		t.Fatalf("corrupt live session state failed: %v", err)
+	}
+
+	eventTime := time.Date(2026, 4, 20, 10, 23, 0, 0, time.UTC)
+	if err := platform.handleSignalRuntimeMessage(runtimeSessionID, map[string]any{
+		"role":               "trigger",
+		"streamType":         "trade_tick",
+		"symbol":             "BTCUSDT",
+		"subscriptionSymbol": "BTCUSDT",
+		"event":              "trade",
+		"price":              "75229.70",
+	}, eventTime); err != nil {
+		t.Fatalf("handle trigger after missing signalRuntimeRequired failed: %v", err)
+	}
+
+	updated, err := platform.store.GetLiveSession(session.ID)
+	if err != nil {
+		t.Fatalf("get updated live session failed: %v", err)
+	}
+	if !boolValue(updated.State["signalRuntimeRequired"]) {
+		t.Fatalf("expected fanout to restore signalRuntimeRequired, got %#v", updated.State)
+	}
+	if got := stringValue(updated.State["lastSignalRuntimeEventAt"]); got == "" {
+		t.Fatalf("expected repaired session to consume runtime trigger, got %#v", updated.State)
+	}
+}
+
+func TestHandleSignalRuntimeMessageRecordsRuntimeNotRequiredDrop(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	for _, payload := range []map[string]any{
+		{
+			"sourceKey": "binance-kline",
+			"role":      "signal",
+			"symbol":    "BTCUSDT",
+			"options":   map[string]any{"timeframe": "1d"},
+		},
+		{
+			"sourceKey": "binance-trade-tick",
+			"role":      "trigger",
+			"symbol":    "BTCUSDT",
+		},
+	} {
+		if _, err := platform.BindStrategySignalSource("strategy-bk-1d", payload); err != nil {
+			t.Fatalf("bind strategy source failed: %v", err)
+		}
+	}
+
+	session, err := platform.CreateLiveSession("live-main", "strategy-bk-1d", map[string]any{
+		"symbol":              "BTCUSDT",
+		"signalTimeframe":     "1d",
+		"executionDataSource": "tick",
+	})
+	if err != nil {
+		t.Fatalf("create live session failed: %v", err)
+	}
+	runtimeSessionID := stringValue(session.State["signalRuntimeSessionId"])
+	if runtimeSessionID == "" {
+		t.Fatal("expected linked runtime session id")
+	}
+	if _, err := platform.store.UpdateLiveSessionStatus(session.ID, "RUNNING"); err != nil {
+		t.Fatalf("mark live session running failed: %v", err)
+	}
+	state := cloneMetadata(session.State)
+	state["signalRuntimeRequired"] = false
+	session, err = platform.store.UpdateLiveSessionState(session.ID, state)
+	if err != nil {
+		t.Fatalf("update live session state failed: %v", err)
+	}
+
+	eventTime := time.Date(2026, 4, 20, 10, 23, 0, 0, time.UTC)
+	if err := platform.handleSignalRuntimeMessage(runtimeSessionID, map[string]any{
+		"role":               "trigger",
+		"streamType":         "trade_tick",
+		"symbol":             "BTCUSDT",
+		"subscriptionSymbol": "BTCUSDT",
+		"event":              "trade",
+		"price":              "75229.70",
+	}, eventTime); err != nil {
+		t.Fatalf("handle trigger with runtime disabled failed: %v", err)
+	}
+
+	updated, err := platform.store.GetLiveSession(session.ID)
+	if err != nil {
+		t.Fatalf("get updated live session failed: %v", err)
+	}
+	if got := stringValue(updated.State["lastSignalRuntimeEventAt"]); got != "" {
+		t.Fatalf("expected runtime-not-required session to skip fanout, got lastSignalRuntimeEventAt=%s", got)
+	}
+	if got := stringValue(updated.State["lastRuntimeFanoutDropReason"]); got != "runtime-not-required" {
+		t.Fatalf("expected runtime-not-required drop breadcrumb, got %s", got)
+	}
+	if got := stringValue(updated.State["lastRuntimeFanoutDropAt"]); got == "" {
+		t.Fatalf("expected runtime fanout drop timestamp, got %#v", updated.State)
+	}
+}
+
 func runTestSignalRuntimeReconnect(platform *Platform, runtimeSessionID string) {
 	outcomes := []struct {
 		connected bool


### PR DESCRIPTION
## 目的
修复 live session 在 runtime 仍然健康、trade tick 仍然推进时，因 `signalRuntimeRequired` 被错误清空而静默失去 runtime fanout 的问题。

Root cause:
- `completeRecoveredLiveSessionMetadata(...)` 在 flat recovery 清理路径里删除了 `signalRuntimeRequired` / `signalRuntimeReady`
- `handleSignalRuntimeMessage(...)` 在 runtime -> live fanout 前又依赖 `boolValue(session.State["signalRuntimeRequired"])`
- 当该字段变成 `null` 时，RUNNING live session 会被静默跳过，表现为 session 仍是 RUNNING，但 `lastSignalRuntimeEventAt` / `lastStrategyEvaluationAt` 卡死

本次修改:
- 保留 flat recovery 清理后的 runtime linkage gate，避免 RUNNING live session 因 state 清理丢失 `signalRuntimeRequired`
- 在 runtime fanout 前对缺失的 `signalRuntimeRequired` 做一次 `syncLiveSessionRuntime(...)` 自愈
- 为 runtime fanout skip 增加 breadcrumb 和 warn 日志，记录 drop reason / timestamp / runtime session / summary

行为变化:
- 已经进入坏状态但仍绑定正确 runtime 的 live session，在后续 tick 到来时可自动修复 fanout 条件并恢复推进
- 如果 session 确实不应消费 runtime 事件，会留下明确的 `lastRuntimeFanoutDrop*` 状态和 warn 日志，而不是静默跳过

新增测试:
- `TestEnsureLiveExecutionPlanPreservesSignalRuntimeRequirementWhenFlat`
- `TestHandleSignalRuntimeMessageRepairsMissingSignalRuntimeRequired`
- `TestHandleSignalRuntimeMessageRecordsRuntimeNotRequiredDrop`

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [x] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了
- 补充说明：本 PR 由 Codex 起草并提交，合并前仍需人工复核。

## 风险点 checklist
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main)
- [ ] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？
- [ ] DB migration 是否具备向下兼容幂等性？
- [ ] 配置字段有没有无意被混改？

说明：本 PR 未修改 `dispatchMode` 默认值；仅修复 live/runtime fanout 状态保持与诊断日志。

## 验证方式与测试证据
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

已执行:
- `go test ./internal/service`

重点覆盖:
- flat recovery 后保留 runtime gate
- 缺失 `signalRuntimeRequired` 时的 fanout 自愈
- 明确 `runtime-not-required` drop breadcrumb
