### PR TITLE
fix(web): add recovery category to timeline deduplication

### DIFF
--- a/web/console/src/utils/derivation.ts
+++ b/web/console/src/utils/derivation.ts
@@ -1228,7 +1228,7 @@ export function buildTimelineNotes(items: Array<Record<string, unknown>>, config
       const digest = `${activeSessionId}|${category}|${title}|${reason}|${action}|${metadata.symbol ?? ""}`;
 
       const currentTime = !Number.isNaN(eventTime) ? eventTime : 0;
-      const isDeduplicatable = category === "strategy" || category === "reconcile" || title === "waiting-source-states";
+      const isDeduplicatable = category === "strategy" || category === "reconcile" || category === "recovery" || title === "waiting-source-states";
 
       if (isDeduplicatable) {
         const record = lastSeenMap.get(digest);


### PR DESCRIPTION
## 目的
修复 UI 时间线日志噪音。在高频恢复场景下，'live-position-recovered' 等日志未被去重逻辑过滤，原因在于 'recovery' 类别未包含在 'isDeduplicatable' 白名单中。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [x] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)

## AI Agent 参与声明
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
- [x] 'dispatchMode' 默认值有否变化？(否)

## 验证方式与测试证据
- 已通过 'tsc' 静态类型校验。
- 逻辑上确认 'category === "recovery"' 已加入去重白名单。