### PR TITLE
[codex] fix live session config modal state display

### DIFF
--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -1838,6 +1838,24 @@ func TestEnsureLaunchLiveSessionCreatesDistinctSessionPerSymbolAndTimeframe(t *t
 	}
 }
 
+func TestCreateLiveSessionPersistsLaunchScopeIntoState(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+
+	session, err := platform.CreateLiveSession("live-main", "strategy-bk-1d", map[string]any{
+		"symbol":          "BTCUSDT",
+		"signalTimeframe": "5m",
+	})
+	if err != nil {
+		t.Fatalf("create live session failed: %v", err)
+	}
+	if got := stringValue(session.State["symbol"]); got != "BTCUSDT" {
+		t.Fatalf("expected session state symbol BTCUSDT, got %q", got)
+	}
+	if got := stringValue(session.State["signalTimeframe"]); got != "5m" {
+		t.Fatalf("expected session state signalTimeframe 5m, got %q", got)
+	}
+}
+
 func TestIsLivePlanStepStaleUsesFiveMinuteTimeframe(t *testing.T) {
 	nextPlannedEvent := time.Date(2026, 4, 16, 12, 0, 0, 0, time.UTC)
 	if isLivePlanStepStale(nextPlannedEvent, "5m", nextPlannedEvent.Add(4*time.Minute+59*time.Second)) {

--- a/web/console/src/hooks/useTradingActions.ts
+++ b/web/console/src/hooks/useTradingActions.ts
@@ -1033,6 +1033,7 @@ export function useTradingActions(loadDashboard: () => Promise<void>) {
     const nextAccountId = session?.accountId || quickLiveAccountId || accounts[0]?.id || "";
     const nextStrategyId = normalizeStrategyId(session?.strategyId ?? "", strategies[0]?.id || "");
     const sessionState = getRecord(session?.state);
+    const isEditingExistingSession = Boolean(session);
     if (nextAccountId) {
       selectQuickLiveAccount(nextAccountId);
     }
@@ -1040,26 +1041,48 @@ export function useTradingActions(loadDashboard: () => Promise<void>) {
       ...current,
       accountId: nextAccountId || current.accountId,
       strategyId: nextStrategyId,
-      signalTimeframe: String(sessionState.signalTimeframe ?? current.signalTimeframe ?? "1d"),
-      executionDataSource: String(sessionState.executionDataSource ?? current.executionDataSource ?? "tick"),
-      symbol: String(sessionState.symbol ?? current.symbol ?? "BTCUSDT"),
-      defaultOrderQuantity: String(sessionState.defaultOrderQuantity ?? current.defaultOrderQuantity ?? "0.001"),
-      executionEntryOrderType: String(sessionState.executionEntryOrderType ?? current.executionEntryOrderType ?? "MARKET"),
-      executionEntryMaxSpreadBps: String(sessionState.executionEntryMaxSpreadBps ?? current.executionEntryMaxSpreadBps ?? "8"),
-      executionEntryWideSpreadMode: String(sessionState.executionEntryWideSpreadMode ?? current.executionEntryWideSpreadMode ?? "limit-maker"),
+      signalTimeframe: String(sessionState.signalTimeframe ?? (isEditingExistingSession ? "" : current.signalTimeframe ?? "1d")),
+      executionDataSource: String(sessionState.executionDataSource ?? (isEditingExistingSession ? "" : current.executionDataSource ?? "tick")),
+      symbol: String(sessionState.symbol ?? (isEditingExistingSession ? "" : current.symbol ?? "BTCUSDT")),
+      defaultOrderQuantity: String(
+        sessionState.defaultOrderQuantity ?? (isEditingExistingSession ? "" : current.defaultOrderQuantity ?? "0.001")
+      ),
+      executionEntryOrderType: String(
+        sessionState.executionEntryOrderType ?? (isEditingExistingSession ? "" : current.executionEntryOrderType ?? "MARKET")
+      ),
+      executionEntryMaxSpreadBps: String(
+        sessionState.executionEntryMaxSpreadBps ?? (isEditingExistingSession ? "" : current.executionEntryMaxSpreadBps ?? "8")
+      ),
+      executionEntryWideSpreadMode: String(
+        sessionState.executionEntryWideSpreadMode ?? (isEditingExistingSession ? "" : current.executionEntryWideSpreadMode ?? "limit-maker")
+      ),
       executionEntryTimeoutFallbackOrderType: String(
-        sessionState.executionEntryTimeoutFallbackOrderType ?? current.executionEntryTimeoutFallbackOrderType ?? "MARKET"
+        sessionState.executionEntryTimeoutFallbackOrderType ??
+          (isEditingExistingSession ? "" : current.executionEntryTimeoutFallbackOrderType ?? "MARKET")
       ),
-      executionPTExitOrderType: String(sessionState.executionPTExitOrderType ?? current.executionPTExitOrderType ?? "LIMIT"),
-      executionPTExitTimeInForce: String(sessionState.executionPTExitTimeInForce ?? current.executionPTExitTimeInForce ?? "GTX"),
-      executionPTExitPostOnly: Boolean(sessionState.executionPTExitPostOnly ?? current.executionPTExitPostOnly),
+      executionPTExitOrderType: String(
+        sessionState.executionPTExitOrderType ?? (isEditingExistingSession ? "" : current.executionPTExitOrderType ?? "LIMIT")
+      ),
+      executionPTExitTimeInForce: String(
+        sessionState.executionPTExitTimeInForce ?? (isEditingExistingSession ? "" : current.executionPTExitTimeInForce ?? "GTX")
+      ),
+      executionPTExitPostOnly: isEditingExistingSession
+        ? Boolean(sessionState.executionPTExitPostOnly)
+        : Boolean(sessionState.executionPTExitPostOnly ?? current.executionPTExitPostOnly),
       executionPTExitTimeoutFallbackOrderType: String(
-        sessionState.executionPTExitTimeoutFallbackOrderType ?? current.executionPTExitTimeoutFallbackOrderType ?? "MARKET"
+        sessionState.executionPTExitTimeoutFallbackOrderType ??
+          (isEditingExistingSession ? "" : current.executionPTExitTimeoutFallbackOrderType ?? "MARKET")
       ),
-      executionSLExitOrderType: String(sessionState.executionSLExitOrderType ?? current.executionSLExitOrderType ?? "MARKET"),
-      executionSLExitMaxSpreadBps: String(sessionState.executionSLExitMaxSpreadBps ?? current.executionSLExitMaxSpreadBps ?? "999"),
-      dispatchMode: String(sessionState.dispatchMode ?? current.dispatchMode ?? "manual-review"),
-      dispatchCooldownSeconds: String(sessionState.dispatchCooldownSeconds ?? current.dispatchCooldownSeconds ?? "30"),
+      executionSLExitOrderType: String(
+        sessionState.executionSLExitOrderType ?? (isEditingExistingSession ? "" : current.executionSLExitOrderType ?? "MARKET")
+      ),
+      executionSLExitMaxSpreadBps: String(
+        sessionState.executionSLExitMaxSpreadBps ?? (isEditingExistingSession ? "" : current.executionSLExitMaxSpreadBps ?? "999")
+      ),
+      dispatchMode: String(sessionState.dispatchMode ?? (isEditingExistingSession ? "" : current.dispatchMode ?? "manual-review")),
+      dispatchCooldownSeconds: String(
+        sessionState.dispatchCooldownSeconds ?? (isEditingExistingSession ? "" : current.dispatchCooldownSeconds ?? "30")
+      ),
     }));
     setEditingLiveSessionId(session?.id ?? null);
     setError(null);

--- a/web/console/src/pages/MonitorStage.tsx
+++ b/web/console/src/pages/MonitorStage.tsx
@@ -305,14 +305,12 @@ export function MonitorStage({ syncLiveOrder, dockTab, onDockTabChange, dockCont
 
                   <div className="flex items-center gap-2 overflow-hidden">
                     <Popover>
-                      <PopoverTrigger>
-                        <button 
-                          className={`flex shrink-0 items-center gap-1.5 rounded-lg border border-[var(--bk-border)] bg-[var(--bk-surface)] px-2.5 py-1 font-mono text-[10px] font-bold shadow-sm transition-all active:scale-95 ${allSessionItems.length > 1 ? 'cursor-pointer hover:bg-[var(--bk-surface-muted)]' : 'cursor-default'}`}
-                          disabled={allSessionItems.length <= 1}
-                        >
-                          <span className="truncate max-w-[120px]">{highlightedLiveSession.session.id}</span>
-                          {allSessionItems.length > 1 && <ChevronDown className="size-2.5 shrink-0 text-[var(--bk-text-muted)] opacity-60" />}
-                        </button>
+                      <PopoverTrigger
+                        className={`flex shrink-0 items-center gap-1.5 rounded-lg border border-[var(--bk-border)] bg-[var(--bk-surface)] px-2.5 py-1 font-mono text-[10px] font-bold shadow-sm transition-all active:scale-95 ${allSessionItems.length > 1 ? 'cursor-pointer hover:bg-[var(--bk-surface-muted)]' : 'cursor-default'}`}
+                        disabled={allSessionItems.length <= 1}
+                      >
+                        <span className="truncate max-w-[120px]">{highlightedLiveSession.session.id}</span>
+                        {allSessionItems.length > 1 && <ChevronDown className="size-2.5 shrink-0 text-[var(--bk-text-muted)] opacity-60" />}
                       </PopoverTrigger>
                       <PopoverContent align="start" className="isolate z-[60] w-[320px] rounded-[20px] border-2 border-[var(--bk-border)] bg-[var(--bk-surface-overlay-strong)] p-2 shadow-xl">
                          <div className="space-y-1.5">
@@ -475,11 +473,9 @@ export function MonitorStage({ syncLiveOrder, dockTab, onDockTabChange, dockCont
                 </div>
                 <div className="flex items-center gap-3">
                   <Popover>
-                    <PopoverTrigger asChild>
-                      <button className="flex items-center gap-1.5 rounded-lg border border-[var(--bk-border)] bg-[var(--bk-surface)] px-2 py-1 font-mono text-[9px] font-black uppercase shadow-sm text-[var(--bk-text-muted)] hover:bg-[var(--bk-surface-muted)] transition-colors">
-                        <Settings className="size-3" />
-                        终端配置
-                      </button>
+                    <PopoverTrigger className="flex items-center gap-1.5 rounded-lg border border-[var(--bk-border)] bg-[var(--bk-surface)] px-2 py-1 font-mono text-[9px] font-black uppercase shadow-sm text-[var(--bk-text-muted)] transition-colors hover:bg-[var(--bk-surface-muted)]">
+                      <Settings className="size-3" />
+                      终端配置
                     </PopoverTrigger>
                     <PopoverContent align="end" className="w-[280px] p-5 rounded-3xl border-2 border-[var(--bk-border)] bg-[var(--bk-surface-overlay-strong)] shadow-2xl isolate z-[70]">
                       <div className="space-y-5">


### PR DESCRIPTION
## 目的
修复两个前端误导/阻断问题：
1. 编辑实盘会话时，配置对话框会用旧表单残值兜底，导致 UI 可能显示并非来自后端 session state 的 symbol / signalTimeframe / dispatchMode。
2. MonitorStage 的 PopoverTrigger 使用了当前封装不支持的 `asChild`/嵌套 button 形式，导致前端全量 TypeScript 校验失败。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [x] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
- [ ] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main)
- [ ] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？
- [ ] DB migration 是否具备向下兼容幂等性？
- [ ] 配置字段有没有无意被混改？

## 验证方式与测试证据
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

### 变更说明
- 编辑已有 live session 时，配置弹窗现在只信任 `session.state`，字段缺失时不再用旧表单值冒充当前配置。
- 补充后端回归测试，确认 `CreateLiveSession` 会把 `symbol` 和 `signalTimeframe` 持久化进 `session.state`。
- 调整 MonitorStage 的 popover trigger 用法，去掉不受支持的 `asChild` 和嵌套 button，恢复前端全量 `tsc` 通过。

### Root Cause
- 前端 `openLiveSessionModal` 在编辑模式下混用了当前表单残值和后端 state，导致 UI 可能展示与真实 session state 不一致的配置。
- `PopoverTrigger` 的封装基于当前 `@base-ui/react/popover` 接口，不支持 `asChild`，但调用侧仍按 Radix 风格使用，触发类型错误。

### 验证命令
```bash
go test ./internal/service -run 'TestCreateLiveSessionPersistsLaunchScopeIntoState|TestEnsureLiveExecutionPlanPreservesSignalRuntimeRequirementWhenFlat' -count=1
cd web/console
./node_modules/.bin/tsc --noEmit -p tsconfig.json
```
