### PR TITLE
[codex] Fix live immediate fill settlement and stop defaults

### DIFF
--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -3345,7 +3345,40 @@ func (p *Platform) resolveLiveSessionParameters(session domain.LiveSession, vers
 			parameters[key] = value
 		}
 	}
+	parameters = applyLiveSafeStopDefaults(parameters)
 	return NormalizeBacktestParameters(parameters)
+}
+
+const (
+	liveDefaultTrailingStopATR           = 0.3
+	liveDefaultDelayedTrailingActivation = 0.5
+)
+
+func applyLiveSafeStopDefaults(parameters map[string]any) map[string]any {
+	normalized := cloneMetadata(parameters)
+	if normalized == nil {
+		normalized = map[string]any{}
+	}
+
+	trailingStopATR, trailingConfigured := normalized["trailing_stop_atr"]
+	resolvedTrailingStopATR := parseFloatValue(trailingStopATR)
+	if !trailingConfigured || resolvedTrailingStopATR <= 0 {
+		resolvedTrailingStopATR = liveDefaultTrailingStopATR
+		normalized["trailing_stop_atr"] = resolvedTrailingStopATR
+	}
+
+	delayedActivationATR, delayedConfigured := normalized["delayed_trailing_activation_atr"]
+	resolvedDelayedActivationATR := parseFloatValue(delayedActivationATR)
+	if !delayedConfigured || resolvedDelayedActivationATR <= 0 {
+		normalized["delayed_trailing_activation_atr"] = liveDefaultDelayedTrailingActivation
+	}
+
+	stopLossATR, stopConfigured := normalized["stop_loss_atr"]
+	if !stopConfigured || parseFloatValue(stopLossATR) <= 0 {
+		normalized["stop_loss_atr"] = resolvedTrailingStopATR
+	}
+
+	return normalized
 }
 
 func deriveLiveSignalIntent(decision StrategySignalDecision, symbol string) *SignalIntent {

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -428,6 +428,38 @@ func TestBuildLiveExecutionPlanFromMarketDataAcceptsTickExecutionSource(t *testi
 	}
 }
 
+func TestResolveLiveSessionParametersDefaultsMissingStopsToTrailingForLive(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+
+	if _, err := platform.store.UpdateStrategyParameters("strategy-bk-1d", map[string]any{}); err != nil {
+		t.Fatalf("update strategy parameters failed: %v", err)
+	}
+
+	session, err := platform.store.GetLiveSession("live-session-main")
+	if err != nil {
+		t.Fatalf("get live session failed: %v", err)
+	}
+	version, err := platform.resolveCurrentStrategyVersion(session.StrategyID)
+	if err != nil {
+		t.Fatalf("resolve strategy version failed: %v", err)
+	}
+
+	parameters, err := platform.resolveLiveSessionParameters(session, version)
+	if err != nil {
+		t.Fatalf("resolve live session parameters failed: %v", err)
+	}
+
+	if got := parseFloatValue(parameters["trailing_stop_atr"]); got != 0.3 {
+		t.Fatalf("expected trailing_stop_atr live default 0.3, got %v", got)
+	}
+	if got := parseFloatValue(parameters["delayed_trailing_activation_atr"]); got != 0.5 {
+		t.Fatalf("expected delayed_trailing_activation_atr live default 0.5, got %v", got)
+	}
+	if got := parseFloatValue(parameters["stop_loss_atr"]); got != 0.3 {
+		t.Fatalf("expected stop_loss_atr to inherit trailing live default 0.3, got %v", got)
+	}
+}
+
 func TestRefreshLiveMarketSnapshotFailsWithoutRESTWarmData(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
 	originalFetch := fetchLiveCandleRange

--- a/internal/service/order.go
+++ b/internal/service/order.go
@@ -522,6 +522,24 @@ func (p *Platform) applyLiveSubmissionResult(
 	if telemetryErr := p.recordLiveOrderExecutionEvent(updatedOrder, "submitted", time.Now().UTC(), false, nil); telemetryErr != nil {
 		logger.Warn("record live order submission event failed", "error", telemetryErr)
 	}
+	if strings.EqualFold(updatedOrder.Status, "FILLED") {
+		syncedOrder, syncErr := p.SyncLiveOrder(updatedOrder.ID)
+		if syncErr == nil {
+			return syncedOrder, nil
+		}
+		updatedOrder.Metadata = cloneMetadata(updatedOrder.Metadata)
+		updatedOrder.Metadata["immediateFillSyncError"] = syncErr.Error()
+		updatedOrder.Metadata["immediateFillSyncRequired"] = true
+		persistedOrder, updateErr := p.store.UpdateOrder(updatedOrder)
+		if updateErr != nil {
+			return domain.Order{}, updateErr
+		}
+		logger.Warn("live order immediate fill sync failed",
+			"exchange_order_id", submission.ExchangeOrderID,
+			"error", syncErr,
+		)
+		return persistedOrder, syncErr
+	}
 	return updatedOrder, nil
 }
 

--- a/internal/service/order_test.go
+++ b/internal/service/order_test.go
@@ -242,6 +242,125 @@ func TestClosePositionAllowsLiveManualCloseWithoutRuntimeSession(t *testing.T) {
 	}
 }
 
+func TestCreateLiveOrderImmediateFilledSubmissionSettlesReduceOnlyExit(t *testing.T) {
+	store := memory.NewStore()
+	platform := NewPlatform(store)
+	tradeTime := time.Date(2026, 4, 20, 12, 33, 23, 0, time.UTC)
+	syncCalls := 0
+	platform.registerLiveAdapter(testLiveAccountSyncAdapter{
+		key: "test-immediate-filled",
+		submitOrderFunc: func(domain.Account, domain.Order, map[string]any) (LiveOrderSubmission, error) {
+			return LiveOrderSubmission{
+				Status:          "FILLED",
+				ExchangeOrderID: "exchange-order-1",
+				AcceptedAt:      tradeTime.Format(time.RFC3339),
+				Metadata: map[string]any{
+					"adapterMode":   "test",
+					"executionMode": "rest",
+					"executedQty":   0.002,
+					"avgPrice":      75399.42,
+					"updateTime":    tradeTime.Format(time.RFC3339),
+				},
+			}, nil
+		},
+		syncOrderFunc: func(domain.Account, domain.Order, map[string]any) (LiveOrderSync, error) {
+			syncCalls++
+			return LiveOrderSync{
+				Status:   "FILLED",
+				SyncedAt: tradeTime.Format(time.RFC3339),
+				Fills: []LiveFillReport{{
+					Price:    75399.42,
+					Quantity: 0.002,
+					Fee:      0.06,
+					Metadata: map[string]any{
+						"source":          "exchange-sync",
+						"exchangeOrderId": "exchange-order-1",
+						"tradeId":         "trade-1",
+						"tradeTime":       tradeTime.Format(time.RFC3339),
+					},
+				}},
+				Terminal:   true,
+				FeeSource:  "exchange",
+				FundingSrc: "exchange",
+			}, nil
+		},
+	})
+
+	account, err := platform.BindLiveAccount("live-main", map[string]any{
+		"adapterKey": "test-immediate-filled",
+	})
+	if err != nil {
+		t.Fatalf("bind live account failed: %v", err)
+	}
+
+	if _, err := store.SavePosition(domain.Position{
+		AccountID:         account.ID,
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "LONG",
+		Quantity:          0.002,
+		EntryPrice:        75405,
+		MarkPrice:         75399.42,
+	}); err != nil {
+		t.Fatalf("save position failed: %v", err)
+	}
+
+	order, err := platform.CreateOrder(domain.Order{
+		AccountID:         account.ID,
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "SELL",
+		Type:              "MARKET",
+		Quantity:          0.002,
+		Price:             75399.42,
+		ReduceOnly:        true,
+		Metadata: map[string]any{
+			"skipRuntimeCheck": true,
+			"executionProposal": map[string]any{
+				"role":       "exit",
+				"signalKind": "risk-exit",
+				"reason":     "SL",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("create order failed: %v", err)
+	}
+
+	if syncCalls != 1 {
+		t.Fatalf("expected immediate FILLED submission to force one sync, got %d", syncCalls)
+	}
+	if got := order.Status; got != "FILLED" {
+		t.Fatalf("expected order to stay FILLED after settlement, got %s", got)
+	}
+	if got := parseFloatValue(order.Metadata["filledQuantity"]); got != 0.002 {
+		t.Fatalf("expected filledQuantity 0.002, got %v", got)
+	}
+	if _, found, err := store.FindPosition(account.ID, "BTCUSDT"); err != nil {
+		t.Fatalf("find position failed: %v", err)
+	} else if found {
+		t.Fatal("expected reduce-only FILLED exit to clear the local position")
+	}
+
+	fills, err := store.ListFills()
+	if err != nil {
+		t.Fatalf("list fills failed: %v", err)
+	}
+	orderFillCount := 0
+	for _, item := range fills {
+		if item.OrderID != order.ID {
+			continue
+		}
+		orderFillCount++
+		if item.Fee != 0.06 {
+			t.Fatalf("expected synced fee 0.06, got %v", item.Fee)
+		}
+	}
+	if orderFillCount != 1 {
+		t.Fatalf("expected one fill for settled immediate-FILLED order, got %d", orderFillCount)
+	}
+}
+
 func TestRecoveredPassiveCloseExecutionBoundaryAllowsValidHedgeClose(t *testing.T) {
 	store := memory.NewStore()
 	platform := NewPlatform(store)


### PR DESCRIPTION
## 目的
修复两个会直接影响 live session 安全性的缺口：
1. live 下单如果提交回包直接就是 `FILLED`，之前只把订单状态写成 `FILLED`，不会立刻跑 fill settlement，导致 canonical `Position` 可能残留，最终把 session 卡进 `db-position-exchange-missing` 的 stale reconcile gate。
2. 当 live session / strategy 没显式提供 stop 参数时，参数解析会回落到研究侧的 `stop_loss_atr=0.05`，这会在 auto-dispatch 场景里把初始止损收得过紧，容易出现刚开仓就被 `SL` 平掉的行为。

本次改动：
- 在 live order submit 回包直接为 `FILLED` 时，立即强制执行一次 `SyncLiveOrder`，让 fill settlement / canonical position 更新在 submit 链路内完成。
- 仅在 live 参数解析路径里注入更安全的 trailing-stop 默认：缺失时默认 `trailing_stop_atr=0.3`、`delayed_trailing_activation_atr=0.5`，并让缺失的 `stop_loss_atr` 继承 trailing stop 距离，而不是回落到 `0.05`。
- 补了两个回归测试，分别覆盖“immediate FILLED reduce-only exit 必须清仓”和“live 缺省 stop 参数必须走 trailing 默认”。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [x] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main)
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？
- [x] DB migration 是否具备向下兼容幂等性？
- [x] 配置字段有没有无意被混改？

说明：
- `dispatchMode` 默认值没有变化，仍是 `manual-review`。
- 没有新增 mainnet 路由、凭证或 migration。
- 默认值调整只发生在 live 参数解析路径，不改 research/backtest 的全局默认语义。

## Root Cause
- `internal/service/order.go` 的 `applyLiveSubmissionResult(...)` 在 submit response 为 `FILLED` 时只更新订单状态，不会触发 `SyncLiveOrder` / `finalizeExecutedOrder(...)`，所以 live 订单可能已经在交易所成交，但本地 `Position` 还停留在旧状态。
- `internal/service/live.go` 的 live 参数解析在缺失 stop 参数时，会通过 `NormalizeBacktestParameters(...)` 间接回落到研究侧默认 `stop_loss_atr=0.05`。这对 auto-dispatch 的 live 开仓过紧，容易在下一拍被 `risk-exit / SL` 直接平掉。

## 行为变化
- live submit response 如果直接返回 `FILLED`，现在会立刻执行一次 `SyncLiveOrder`，让 fill settlement 和 canonical 仓位更新在同一条 submit 链上完成；如果即时 sync 失败，会在订单 metadata 里留下 `immediateFillSyncError` / `immediateFillSyncRequired` 方便排查。
- live session 在缺失 stop 参数时，现在会默认注入 trailing-stop 配置，并让 `stop_loss_atr` 继承 trailing stop 距离，避免再次无提示回落到 `0.05 ATR` 的初始止损。

## 验证方式与测试证据
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

本地验证：
- `gofmt -w internal/service/order.go internal/service/live.go internal/service/order_test.go internal/service/live_test.go`
- `go test ./internal/service -run 'Test(CreateLiveOrderImmediateFilledSubmissionSettlesReduceOnlyExit|ResolveLiveSessionParametersDefaultsMissingStopsToTrailingForLive|ApplyLiveSubmissionResultPersistsOrderExecutionEvent|BuildLiveSyncSettlementKeepsExchangeTradeIDEmptyWithoutRealTradeID)'`
- `go test ./internal/service`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
- `go test ./...`
