### PR TITLE
[codex] Heal stale filled exits before reconcile gate

### DIFF
--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -1507,6 +1507,11 @@ func (p *Platform) StartLiveSession(sessionID string) (domain.LiveSession, error
 			}
 		}
 	}
+	if strings.TrimSpace(stringValue(session.State["lastDispatchedOrderId"])) != "" {
+		if syncedSession, syncErr := p.syncLatestLiveSessionOrder(session, time.Now().UTC()); syncErr == nil {
+			session = syncedSession
+		}
+	}
 	session, recoveredPosition, incompleteRecoveryMetadata, err := p.completeRecoveredLiveSessionMetadata(session)
 	if err != nil {
 		logger.Warn("complete recovered live session metadata failed", "error", err)
@@ -1644,6 +1649,11 @@ func (p *Platform) recoverRunningLiveSession(session domain.LiveSession) (domain
 		}
 	} else {
 		account = syncedAccount
+	}
+	if strings.TrimSpace(stringValue(session.State["lastDispatchedOrderId"])) != "" {
+		if syncedSession, syncErr := p.syncLatestLiveSessionOrder(session, time.Now().UTC()); syncErr == nil {
+			session = syncedSession
+		}
 	}
 	session, recoveredPosition, incompleteRecoveryMetadata, err := p.completeRecoveredLiveSessionMetadata(session)
 	if err != nil {

--- a/internal/service/live_execution.go
+++ b/internal/service/live_execution.go
@@ -755,6 +755,28 @@ func (p *Platform) syncLatestLiveSessionOrder(session domain.LiveSession, eventT
 	}
 	state := cloneMetadata(session.State)
 	if isTerminalOrderStatus(order.Status) {
+		if shouldBackfillTerminalFilledLiveOrder(order, state) {
+			state["lastSyncAttemptAt"] = eventTime.UTC().Format(time.RFC3339)
+			recordExecutionSyncAttemptHealth(state, eventTime)
+			syncedOrder, syncErr := p.SyncLiveOrder(order.ID)
+			if syncErr != nil {
+				state["lastSyncError"] = syncErr.Error()
+				recordExecutionSyncResultHealth(state, eventTime, order.Status, syncErr)
+				appendTimelineEvent(state, "order", eventTime, "live-order-sync-error", map[string]any{
+					"orderId": order.ID,
+					"error":   syncErr.Error(),
+				})
+				updated, updateErr := p.store.UpdateLiveSessionState(session.ID, state)
+				if updateErr != nil {
+					return domain.LiveSession{}, updateErr
+				}
+				return updated, syncErr
+			}
+			order = syncedOrder
+			delete(state, "lastSyncError")
+			state["lastSyncedAt"] = eventTime.UTC().Format(time.RFC3339)
+			recordExecutionSyncResultHealth(state, eventTime, order.Status, nil)
+		}
 		maybeIncrementLiveSessionReentryCount(state, mapValue(order.Metadata["executionProposal"]), order.ID, order.Status)
 		state["lastSyncedOrderId"] = order.ID
 		state["lastSyncedOrderStatus"] = order.Status
@@ -852,6 +874,19 @@ func (p *Platform) syncLatestLiveSessionOrder(session domain.LiveSession, eventT
 		}
 	}
 	return updated, nil
+}
+
+func shouldBackfillTerminalFilledLiveOrder(order domain.Order, state map[string]any) bool {
+	if !strings.EqualFold(order.Status, "FILLED") {
+		return false
+	}
+	if parseFloatValue(order.Metadata["filledQuantity"]) < order.Quantity-1e-9 {
+		return true
+	}
+	if strings.TrimSpace(stringValue(order.Metadata["lastFilledAt"])) == "" {
+		return true
+	}
+	return isLiveSessionBlockedByPositionReconcileGate(state)
 }
 
 func isTerminalOrderStatus(status string) bool {

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -6281,6 +6281,157 @@ func TestStartLiveSessionRequiresRESTVerificationForHistoricalTakeoverActivation
 	}
 }
 
+func TestStartLiveSessionBackfillsFilledExitBeforeReconcileGateBlock(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	tradeTime := time.Date(2026, 4, 20, 12, 33, 23, 0, time.UTC)
+	syncCalls := 0
+	platform.registerLiveAdapter(testLiveAccountSyncAdapter{
+		key: "test-start-filled-backfill",
+		syncSnapshotFunc: func(p *Platform, account domain.Account, binding map[string]any) (domain.Account, error) {
+			previousSuccessAt := parseOptionalRFC3339(stringValue(account.Metadata["lastLiveSyncAt"]))
+			account.Metadata = cloneMetadata(account.Metadata)
+			account.Metadata["liveSyncSnapshot"] = map[string]any{
+				"source":          "binance-rest-account-v3",
+				"adapterKey":      normalizeLiveAdapterKey(stringValue(binding["adapterKey"])),
+				"syncedAt":        time.Now().UTC().Format(time.RFC3339),
+				"bindingMode":     stringValue(binding["connectionMode"]),
+				"executionMode":   "rest",
+				"syncStatus":      "SYNCED",
+				"accountExchange": account.Exchange,
+				"positions":       []map[string]any{},
+				"openOrders":      []map[string]any{},
+			}
+			var err error
+			account, err = p.persistLiveAccountSyncSuccess(account, binding, previousSuccessAt)
+			if err != nil {
+				return domain.Account{}, err
+			}
+			reconcileGate, err := p.reconcileLiveAccountPositions(account, []map[string]any{})
+			if err != nil {
+				return domain.Account{}, err
+			}
+			account.Metadata = cloneMetadata(account.Metadata)
+			account.Metadata["livePositionReconcileGate"] = reconcileGate
+			account.Metadata["lastLivePositionSyncAt"] = time.Now().UTC().Format(time.RFC3339)
+			clearLiveAccountPositionReconcileRequirement(account.Metadata)
+			return p.store.UpdateAccount(account)
+		},
+		syncOrderFunc: func(_ domain.Account, order domain.Order, _ map[string]any) (LiveOrderSync, error) {
+			syncCalls++
+			return LiveOrderSync{
+				Status:   "FILLED",
+				SyncedAt: tradeTime.Format(time.RFC3339),
+				Fills: []LiveFillReport{{
+					Price:    67950.0,
+					Quantity: order.Quantity,
+					Fee:      0.01,
+					Metadata: map[string]any{
+						"exchangeOrderId": stringValue(order.Metadata["exchangeOrderId"]),
+						"tradeId":         "trade-terminal-fill-1",
+						"tradeTime":       tradeTime.Format(time.RFC3339),
+					},
+				}},
+				Terminal:   true,
+				FeeSource:  "exchange",
+				FundingSrc: "exchange",
+			}, nil
+		},
+	})
+
+	account, err := platform.store.GetAccount("live-main")
+	if err != nil {
+		t.Fatalf("get live account failed: %v", err)
+	}
+	account.Status = "READY"
+	account.Metadata = cloneMetadata(account.Metadata)
+	account.Metadata["liveBinding"] = map[string]any{
+		"adapterKey":     "test-start-filled-backfill",
+		"connectionMode": "mock",
+		"executionMode":  "rest",
+	}
+	if _, err := platform.store.UpdateAccount(account); err != nil {
+		t.Fatalf("update live account failed: %v", err)
+	}
+
+	session, err := platform.CreateLiveSession("live-main", "strategy-bk-1d", map[string]any{
+		"symbol":          "BTCUSDT",
+		"signalTimeframe": "1d",
+	})
+	if err != nil {
+		t.Fatalf("create live session failed: %v", err)
+	}
+	if _, err := platform.store.SavePosition(domain.Position{
+		AccountID:         session.AccountID,
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "LONG",
+		Quantity:          0.01,
+		EntryPrice:        68000,
+		MarkPrice:         67950,
+	}); err != nil {
+		t.Fatalf("save stale position failed: %v", err)
+	}
+	order, err := platform.store.CreateOrder(domain.Order{
+		AccountID:         session.AccountID,
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "SELL",
+		Type:              "MARKET",
+		Status:            "FILLED",
+		Quantity:          0.01,
+		Price:             67950,
+		ReduceOnly:        true,
+		Metadata: map[string]any{
+			"source":          "live-session-intent",
+			"liveSessionId":   session.ID,
+			"exchangeOrderId": "exchange-order-terminal-fill-1",
+			"executionProposal": map[string]any{
+				"role":       "exit",
+				"reason":     "SL",
+				"side":       "SELL",
+				"symbol":     "BTCUSDT",
+				"quantity":   0.01,
+				"reduceOnly": true,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("create filled order failed: %v", err)
+	}
+	state := cloneMetadata(session.State)
+	state["lastDispatchedOrderId"] = order.ID
+	state["lastDispatchedOrderStatus"] = "FILLED"
+	if _, err := platform.store.UpdateLiveSessionState(session.ID, state); err != nil {
+		t.Fatalf("update live session state failed: %v", err)
+	}
+
+	started, err := platform.StartLiveSession(session.ID)
+	if err != nil {
+		t.Fatalf("expected StartLiveSession to self-heal stale filled exit, got %v", err)
+	}
+	if started.Status != "RUNNING" {
+		t.Fatalf("expected session to start RUNNING after backfill, got %s", started.Status)
+	}
+	if syncCalls == 0 {
+		t.Fatal("expected start-time recovery to sync the terminal filled order before gate evaluation")
+	}
+	if _, found, err := platform.store.FindPosition(session.AccountID, "BTCUSDT"); err != nil {
+		t.Fatalf("find position failed: %v", err)
+	} else if found {
+		t.Fatal("expected backfilled filled exit to clear stale local position before start completes")
+	}
+	syncedOrder, err := platform.GetOrder(order.ID)
+	if err != nil {
+		t.Fatalf("get synced order failed: %v", err)
+	}
+	if got := parseFloatValue(syncedOrder.Metadata["filledQuantity"]); got != 0.01 {
+		t.Fatalf("expected synced filledQuantity 0.01, got %v", got)
+	}
+	if got := stringValue(started.State["recoveryMode"]); got == liveRecoveryModeReconcileGateBlocked {
+		t.Fatalf("expected reconcile gate block to clear after backfill, got %s", got)
+	}
+}
+
 func TestStartLiveSessionDowngradesIncompleteRecoveredMetadataToCloseOnly(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
 	platform.registerLiveAdapter(testLiveAccountSyncAdapter{key: "test-start-incomplete"})


### PR DESCRIPTION
## 目的
修复一个启动阶段的 live session 恢复缺口：当上一笔 exit order 实际已经 `FILLED`，但历史上没有完成 fill settlement，本地会残留一条 stale `Position`。随后 `StartLiveSession()` 会先看到这条残留仓位，再被 `db-position-exchange-missing` 的 reconcile gate 挡成 `reconcile-gate-blocked`，导致 session 无法重新启动。

本次改动只处理这一个问题域：
- 在启动 / recovery 流程进入 reconcile gate 判断前，先同步 `lastDispatchedOrderId` 对应的订单。
- 对已经 terminal `FILLED` 但明显还没 settle 的 live order，允许 `syncLatestLiveSessionOrder(...)` 主动 backfill 一次 `SyncLiveOrder`，把 fill settlement 和 canonical position 补齐。
- 新增回归测试覆盖“启动前自愈 stale filled exit，避免被 reconcile gate 误挡”。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [x] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main)
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？
- [x] DB migration 是否具备向下兼容幂等性？
- [x] 配置字段有没有无意被混改？

说明：
- `dispatchMode` 默认值没有变化。
- 没有新增 mainnet 路由、凭证或 migration。
- 这次只改启动/恢复阶段对历史 terminal `FILLED` order 的 backfill 行为，不放宽 reconcile gate 的 fail-closed 原则。

## Root Cause
- 历史上存在一类 live order：submit / exchange 侧已经 `FILLED`，但没有跑到 `finalizeExecutedOrder(...)`，导致本地 canonical `Position` 没清掉。
- `StartLiveSession()` / `recoverRunningLiveSession()` 在进入 reconcile gate 判断前，没有先尝试同步这条 terminal `FILLED` order，于是 stale 本地仓位会先触发 `db-position-exchange-missing`，把 session 卡进 `reconcile-gate-blocked`。

## 行为变化
- 启动和 startup-recovery 现在会在 gate 判断前，优先同步 `lastDispatchedOrderId` 对应的订单。
- `syncLatestLiveSessionOrder(...)` 对 terminal `FILLED` order 会在以下条件下主动 backfill `SyncLiveOrder`：
  - `filledQuantity` 还没完整落账；或
  - `lastFilledAt` 缺失；或
  - 当前 session 已经被 reconcile gate 挡住。
- 如果 backfill 成功，stale 本地仓位会被 settle 掉，session 就不会再被这类历史残留误挡。

## 验证方式与测试证据
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

本地验证：
- `go test ./internal/service -run 'Test(StartLiveSessionBackfillsFilledExitBeforeReconcileGateBlock|StartLiveSessionRequiresRESTVerificationForHistoricalTakeoverActivation|CreateLiveOrderImmediateFilledSubmissionSettlesReduceOnlyExit)'`

新增测试：
- `TestStartLiveSessionBackfillsFilledExitBeforeReconcileGateBlock`
  - 复现“交易所已 flat、本地仍残留 LONG、上一笔 exit order 为 terminal FILLED 但未 settle”的场景。
  - 断言启动前会先 backfill order settlement，并成功把 session 启到 `RUNNING`。
