### PR TITLE
[codex] Heal stale live reconcile gate from REST history

### DIFF
--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -80,8 +80,9 @@ type liveAccountSyncSuccessOwner interface {
 }
 
 const (
-	liveOrderStatusVirtualInitial = "VIRTUAL_INITIAL"
-	liveOrderStatusVirtualExit    = "VIRTUAL_EXIT"
+	liveOrderStatusVirtualInitial             = "VIRTUAL_INITIAL"
+	liveOrderStatusVirtualExit                = "VIRTUAL_EXIT"
+	liveAccountReconcileSelfHealLookbackHours = 24
 )
 
 func (p *Platform) ListLiveSessions() ([]domain.LiveSession, error) {
@@ -347,6 +348,62 @@ func (p *Platform) ReconcileLiveAccount(accountID string, options LiveAccountRec
 	}
 	result.Account = account
 	return result, nil
+}
+
+func livePositionReconcileGateCanSelfHeal(gate map[string]any) bool {
+	return strings.EqualFold(strings.TrimSpace(stringValue(gate["status"])), livePositionReconcileGateStatusStale) &&
+		strings.EqualFold(strings.TrimSpace(stringValue(gate["scenario"])), "db-position-exchange-missing")
+}
+
+func (p *Platform) supportsLiveAccountReconcile(account domain.Account) bool {
+	if !strings.EqualFold(strings.TrimSpace(account.Mode), "LIVE") {
+		return false
+	}
+	binding := cloneMetadata(mapValue(account.Metadata["liveBinding"]))
+	if normalizeLiveExecutionMode(binding["executionMode"], boolValue(binding["sandbox"])) != "rest" {
+		return false
+	}
+	adapter, _, err := p.resolveLiveAdapterForAccount(account)
+	if err != nil {
+		return false
+	}
+	_, ok := adapter.(LiveAccountReconcileAdapter)
+	return ok
+}
+
+func (p *Platform) attemptLiveAccountReconcileSelfHeal(account domain.Account, symbol string) (domain.Account, bool, error) {
+	symbol = NormalizeSymbol(symbol)
+	if symbol == "" {
+		return account, false, nil
+	}
+	gate := resolveLivePositionReconcileGate(account, symbol, true)
+	if !livePositionReconcileGateCanSelfHeal(gate) || !p.supportsLiveAccountReconcile(account) {
+		return account, false, nil
+	}
+	result, err := p.ReconcileLiveAccount(account.ID, LiveAccountReconcileOptions{
+		LookbackHours: liveAccountReconcileSelfHealLookbackHours,
+	})
+	if err != nil {
+		return account, true, err
+	}
+	return result.Account, true, nil
+}
+
+func (p *Platform) attemptLiveExposureReconcileSelfHeal(accountID string) (bool, error) {
+	account, err := p.store.GetAccount(accountID)
+	if err != nil {
+		return false, err
+	}
+	if !p.supportsLiveAccountReconcile(account) {
+		return false, nil
+	}
+	_, err = p.ReconcileLiveAccount(accountID, LiveAccountReconcileOptions{
+		LookbackHours: liveAccountReconcileSelfHealLookbackHours,
+	})
+	if err != nil {
+		return true, err
+	}
+	return true, nil
 }
 
 func (p *Platform) persistLiveAccountSyncFailure(account domain.Account, attemptedAt time.Time, err error) domain.Account {
@@ -1528,7 +1585,34 @@ func (p *Platform) StartLiveSession(sessionID string) (domain.LiveSession, error
 	if isLiveSessionRecoveryCloseOnlyMode(session.State) {
 		return domain.LiveSession{}, fmt.Errorf("live session %s is blocked in %s mode", session.ID, liveRecoveryModeCloseOnlyTakeover)
 	}
-	if gate := resolveLivePositionReconcileGate(account, recoveredPosition.Symbol, recoveredPosition.Quantity > 0); boolValue(gate["blocking"]) {
+	gate := resolveLivePositionReconcileGate(account, recoveredPosition.Symbol, recoveredPosition.Quantity > 0)
+	if boolValue(gate["blocking"]) {
+		if healedAccount, attempted, healErr := p.attemptLiveAccountReconcileSelfHeal(account, recoveredPosition.Symbol); attempted {
+			if healErr != nil {
+				logger.Warn("reconcile self-heal failed before start gate evaluation", "error", healErr)
+			} else {
+				account = healedAccount
+				session, recoveredPosition, incompleteRecoveryMetadata, err = p.completeRecoveredLiveSessionMetadata(session)
+				if err != nil {
+					logger.Warn("complete recovered live session metadata failed after self-heal", "error", err)
+					return domain.LiveSession{}, err
+				}
+				if incompleteRecoveryMetadata {
+					session, err = p.enterRecoveredLiveSessionCloseOnlyMode(session, recoveredPosition, "missing-strategy-version", "recovered position is missing strategyVersionId")
+					if err != nil {
+						logger.Warn("enter close-only takeover mode failed after self-heal", "error", err)
+						return domain.LiveSession{}, err
+					}
+					return domain.LiveSession{}, fmt.Errorf("live session %s is blocked in %s mode", session.ID, liveRecoveryModeCloseOnlyTakeover)
+				}
+				if isLiveSessionRecoveryCloseOnlyMode(session.State) {
+					return domain.LiveSession{}, fmt.Errorf("live session %s is blocked in %s mode", session.ID, liveRecoveryModeCloseOnlyTakeover)
+				}
+				gate = resolveLivePositionReconcileGate(account, recoveredPosition.Symbol, recoveredPosition.Quantity > 0)
+			}
+		}
+	}
+	if boolValue(gate["blocking"]) {
 		session, err = p.enterRecoveredLiveSessionReconcileGateBlocked(session, recoveredPosition, gate)
 		if err != nil {
 			logger.Warn("enter reconcile gate blocked mode failed", "error", err)
@@ -1667,7 +1751,28 @@ func (p *Platform) recoverRunningLiveSession(session domain.LiveSession) (domain
 		session, _ = p.refreshLiveSessionPositionContext(session, time.Now().UTC(), "live-startup-recovery-close-only")
 		return session, nil
 	}
-	if gate := resolveLivePositionReconcileGate(account, recoveredPosition.Symbol, recoveredPosition.Quantity > 0); boolValue(gate["blocking"]) {
+	gate := resolveLivePositionReconcileGate(account, recoveredPosition.Symbol, recoveredPosition.Quantity > 0)
+	if boolValue(gate["blocking"]) {
+		if healedAccount, attempted, healErr := p.attemptLiveAccountReconcileSelfHeal(account, recoveredPosition.Symbol); attempted {
+			if healErr == nil {
+				account = healedAccount
+				session, recoveredPosition, incompleteRecoveryMetadata, err = p.completeRecoveredLiveSessionMetadata(session)
+				if err != nil {
+					return domain.LiveSession{}, err
+				}
+				if incompleteRecoveryMetadata {
+					session, err = p.enterRecoveredLiveSessionCloseOnlyMode(session, recoveredPosition, "missing-strategy-version", "recovered position is missing strategyVersionId")
+					if err != nil {
+						return domain.LiveSession{}, err
+					}
+					session, _ = p.refreshLiveSessionPositionContext(session, time.Now().UTC(), "live-startup-recovery-close-only")
+					return session, nil
+				}
+				gate = resolveLivePositionReconcileGate(account, recoveredPosition.Symbol, recoveredPosition.Quantity > 0)
+			}
+		}
+	}
+	if boolValue(gate["blocking"]) {
 		return p.enterRecoveredLiveSessionReconcileGateBlocked(session, recoveredPosition, gate)
 	}
 	session, err = p.syncLiveSessionRuntime(session)

--- a/internal/service/live_reconcile_test.go
+++ b/internal/service/live_reconcile_test.go
@@ -144,6 +144,66 @@ func TestReconcileLiveAccountRecoversMissingFilledOrder(t *testing.T) {
 	}
 }
 
+func configureTestLiveRESTReconcileHistoryAdapter(
+	t *testing.T,
+	platform *Platform,
+	adapterKey string,
+	exchangePositions []map[string]any,
+	ordersBySymbol map[string][]map[string]any,
+	tradesBySymbol map[string][]LiveFillReport,
+) {
+	t.Helper()
+	platform.registerLiveAdapter(testLiveAccountReconcileAdapter{
+		key: adapterKey,
+		syncSnapshotFunc: func(p *Platform, account domain.Account, binding map[string]any) (domain.Account, error) {
+			previousSuccessAt := parseOptionalRFC3339(stringValue(account.Metadata["lastLiveSyncAt"]))
+			account.Metadata = cloneMetadata(account.Metadata)
+			account.Metadata["liveSyncSnapshot"] = map[string]any{
+				"source":          "binance-rest-account-v3",
+				"adapterKey":      normalizeLiveAdapterKey(stringValue(binding["adapterKey"])),
+				"syncedAt":        time.Now().UTC().Format(time.RFC3339),
+				"bindingMode":     stringValue(binding["connectionMode"]),
+				"executionMode":   "rest",
+				"syncStatus":      "SYNCED",
+				"accountExchange": account.Exchange,
+				"positions":       exchangePositions,
+				"openOrders":      []map[string]any{},
+			}
+			var err error
+			account, err = p.persistLiveAccountSyncSuccess(account, binding, previousSuccessAt)
+			if err != nil {
+				return domain.Account{}, err
+			}
+			reconcileGate, err := p.reconcileLiveAccountPositions(account, exchangePositions)
+			if err != nil {
+				return domain.Account{}, err
+			}
+			account.Metadata = cloneMetadata(account.Metadata)
+			account.Metadata["livePositionReconcileGate"] = reconcileGate
+			account.Metadata["lastLivePositionSyncAt"] = time.Now().UTC().Format(time.RFC3339)
+			clearLiveAccountPositionReconcileRequirement(account.Metadata)
+			return p.store.UpdateAccount(account)
+		},
+		ordersBySymbol: ordersBySymbol,
+		tradesBySymbol: tradesBySymbol,
+	})
+
+	account, err := platform.store.GetAccount("live-main")
+	if err != nil {
+		t.Fatalf("get live account failed: %v", err)
+	}
+	account.Status = "READY"
+	account.Metadata = cloneMetadata(account.Metadata)
+	account.Metadata["liveBinding"] = map[string]any{
+		"adapterKey":     adapterKey,
+		"connectionMode": "mock",
+		"executionMode":  "rest",
+	}
+	if _, err := platform.store.UpdateAccount(account); err != nil {
+		t.Fatalf("update live account failed: %v", err)
+	}
+}
+
 type testLiveAccountReconcileAdapter struct {
 	key              string
 	syncSnapshotFunc func(*Platform, domain.Account, map[string]any) (domain.Account, error)

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -6432,6 +6432,86 @@ func TestStartLiveSessionBackfillsFilledExitBeforeReconcileGateBlock(t *testing.
 	}
 }
 
+func TestStartLiveSessionSelfHealsStaleDBPositionViaReconcileHistory(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	syncedAt := time.Date(2026, 4, 20, 12, 33, 23, 0, time.UTC)
+	configureTestLiveRESTReconcileHistoryAdapter(
+		t,
+		platform,
+		"test-start-reconcile-history-heal",
+		[]map[string]any{},
+		map[string][]map[string]any{
+			"BTCUSDT": {{
+				"symbol":        "BTCUSDT",
+				"orderId":       "9201",
+				"clientOrderId": "client-9201",
+				"status":        "FILLED",
+				"side":          "SELL",
+				"type":          "MARKET",
+				"origType":      "MARKET",
+				"origQty":       0.01,
+				"executedQty":   0.01,
+				"price":         67950.0,
+				"avgPrice":      67950.0,
+				"reduceOnly":    true,
+				"closePosition": false,
+				"time":          float64(syncedAt.Add(-2 * time.Minute).UnixMilli()),
+				"updateTime":    float64(syncedAt.UnixMilli()),
+			}},
+		},
+		map[string][]LiveFillReport{
+			"BTCUSDT": {{
+				Price:    67950.0,
+				Quantity: 0.01,
+				Fee:      0.01,
+				Metadata: map[string]any{
+					"exchangeOrderId": "9201",
+					"tradeId":         "trade-9201",
+					"tradeTime":       syncedAt.Format(time.RFC3339),
+				},
+			}},
+		},
+	)
+
+	session, err := platform.CreateLiveSession("live-main", "strategy-bk-1d", map[string]any{
+		"symbol":          "BTCUSDT",
+		"signalTimeframe": "1d",
+	})
+	if err != nil {
+		t.Fatalf("create live session failed: %v", err)
+	}
+	if _, err := platform.store.SavePosition(domain.Position{
+		AccountID:         session.AccountID,
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "LONG",
+		Quantity:          0.01,
+		EntryPrice:        68000,
+		MarkPrice:         67950,
+	}); err != nil {
+		t.Fatalf("save stale position failed: %v", err)
+	}
+
+	started, err := platform.StartLiveSession(session.ID)
+	if err != nil {
+		t.Fatalf("expected StartLiveSession to self-heal stale db-position-exchange-missing state, got %v", err)
+	}
+	if started.Status != "RUNNING" {
+		t.Fatalf("expected session to start RUNNING after reconcile history heal, got %s", started.Status)
+	}
+	if _, found, err := platform.store.FindPosition(session.AccountID, "BTCUSDT"); err != nil {
+		t.Fatalf("find position failed: %v", err)
+	} else if found {
+		t.Fatal("expected reconcile history self-heal to clear stale BTCUSDT position before start completes")
+	}
+	if got := stringValue(started.State["recoveryMode"]); got == liveRecoveryModeReconcileGateBlocked {
+		t.Fatalf("expected reconcile gate block to clear after reconcile history self-heal, got %s", got)
+	}
+	if got := stringValue(started.State["positionReconcileGateScenario"]); got == "db-position-exchange-missing" {
+		t.Fatalf("expected stale db-position-exchange-missing scenario to clear after self-heal, got %s", got)
+	}
+}
+
 func TestStartLiveSessionDowngradesIncompleteRecoveredMetadataToCloseOnly(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
 	platform.registerLiveAdapter(testLiveAccountSyncAdapter{key: "test-start-incomplete"})

--- a/internal/service/order.go
+++ b/internal/service/order.go
@@ -184,8 +184,16 @@ func (p *Platform) resolveClosePositionTarget(positionID string) (domain.Positio
 		return domain.Position{}, domain.Account{}, err
 	}
 	if strings.EqualFold(strings.TrimSpace(account.Mode), "LIVE") {
-		if _, err := p.SyncLiveAccount(account.ID); err != nil {
+		syncedAccount, err := p.SyncLiveAccount(account.ID)
+		if err != nil {
 			return domain.Position{}, domain.Account{}, err
+		}
+		account = syncedAccount
+		if healedAccount, attempted, healErr := p.attemptLiveAccountReconcileSelfHeal(account, position.Symbol); attempted {
+			if healErr != nil {
+				return domain.Position{}, domain.Account{}, healErr
+			}
+			account = healedAccount
 		}
 		position, found, err = p.findPositionByID(positionID)
 		if err != nil {

--- a/internal/service/safety_checks.go
+++ b/internal/service/safety_checks.go
@@ -65,6 +65,18 @@ func (p *Platform) ensureNoActivePositionsOrOrders(accountID, strategyID string)
 		return err
 	}
 	if active {
+		healed, healErr := p.attemptLiveExposureReconcileSelfHeal(accountID)
+		if healErr != nil {
+			return healErr
+		}
+		if healed {
+			active, err = p.HasActivePositionsOrOrders(accountID, strategyID)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	if active {
 		return activePositionsOrOrdersError{}
 	}
 	return nil

--- a/internal/service/safety_checks_test.go
+++ b/internal/service/safety_checks_test.go
@@ -333,6 +333,138 @@ func TestResolveClosePositionTargetFailsWhenPositionDisappearsAfterRefresh(t *te
 	}
 }
 
+func TestEnsureNoActivePositionsOrOrdersSelfHealsStaleLiveExposureViaReconcile(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	syncedAt := time.Date(2026, 4, 20, 12, 33, 23, 0, time.UTC)
+	configureTestLiveRESTReconcileHistoryAdapter(
+		t,
+		platform,
+		"test-active-exposure-self-heal",
+		[]map[string]any{},
+		map[string][]map[string]any{
+			"BTCUSDT": {{
+				"symbol":        "BTCUSDT",
+				"orderId":       "9101",
+				"clientOrderId": "client-9101",
+				"status":        "FILLED",
+				"side":          "SELL",
+				"type":          "MARKET",
+				"origType":      "MARKET",
+				"origQty":       0.01,
+				"executedQty":   0.01,
+				"price":         67950.0,
+				"avgPrice":      67950.0,
+				"reduceOnly":    true,
+				"closePosition": false,
+				"time":          float64(syncedAt.Add(-2 * time.Minute).UnixMilli()),
+				"updateTime":    float64(syncedAt.UnixMilli()),
+			}},
+		},
+		map[string][]LiveFillReport{
+			"BTCUSDT": {{
+				Price:    67950.0,
+				Quantity: 0.01,
+				Fee:      0.01,
+				Metadata: map[string]any{
+					"exchangeOrderId": "9101",
+					"tradeId":         "trade-9101",
+					"tradeTime":       syncedAt.Format(time.RFC3339),
+				},
+			}},
+		},
+	)
+	if _, err := platform.store.SavePosition(domain.Position{
+		AccountID:         "live-main",
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "LONG",
+		Quantity:          0.01,
+		EntryPrice:        68000,
+		MarkPrice:         67950,
+	}); err != nil {
+		t.Fatalf("save position failed: %v", err)
+	}
+
+	if err := platform.ensureNoActivePositionsOrOrders("live-main", "strategy-bk-1d"); err != nil {
+		t.Fatalf("expected stale live exposure to self-heal before blocking, got %v", err)
+	}
+	if _, found, err := platform.store.FindPosition("live-main", "BTCUSDT"); err != nil {
+		t.Fatalf("find position failed: %v", err)
+	} else if found {
+		t.Fatal("expected reconcile self-heal to clear stale BTCUSDT position")
+	}
+	active, err := platform.HasActivePositionsOrOrders("live-main", "strategy-bk-1d")
+	if err != nil {
+		t.Fatalf("HasActivePositionsOrOrders after self-heal returned error: %v", err)
+	}
+	if active {
+		t.Fatal("expected no remaining active exposure after reconcile self-heal")
+	}
+}
+
+func TestClosePositionSelfHealsStaleLivePositionViaReconcile(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	syncedAt := time.Date(2026, 4, 20, 12, 33, 23, 0, time.UTC)
+	configureTestLiveRESTReconcileHistoryAdapter(
+		t,
+		platform,
+		"test-close-self-heal",
+		[]map[string]any{},
+		map[string][]map[string]any{
+			"BTCUSDT": {{
+				"symbol":        "BTCUSDT",
+				"orderId":       "9102",
+				"clientOrderId": "client-9102",
+				"status":        "FILLED",
+				"side":          "SELL",
+				"type":          "MARKET",
+				"origType":      "MARKET",
+				"origQty":       0.01,
+				"executedQty":   0.01,
+				"price":         67950.0,
+				"avgPrice":      67950.0,
+				"reduceOnly":    true,
+				"closePosition": false,
+				"time":          float64(syncedAt.Add(-2 * time.Minute).UnixMilli()),
+				"updateTime":    float64(syncedAt.UnixMilli()),
+			}},
+		},
+		map[string][]LiveFillReport{
+			"BTCUSDT": {{
+				Price:    67950.0,
+				Quantity: 0.01,
+				Fee:      0.01,
+				Metadata: map[string]any{
+					"exchangeOrderId": "9102",
+					"tradeId":         "trade-9102",
+					"tradeTime":       syncedAt.Format(time.RFC3339),
+				},
+			}},
+		},
+	)
+	position, err := platform.store.SavePosition(domain.Position{
+		AccountID:         "live-main",
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "LONG",
+		Quantity:          0.01,
+		EntryPrice:        68000,
+		MarkPrice:         67950,
+	})
+	if err != nil {
+		t.Fatalf("save position failed: %v", err)
+	}
+
+	if _, err := platform.ClosePosition(position.ID); err == nil || !strings.Contains(err.Error(), "position not found") {
+		t.Fatalf("expected ClosePosition to self-heal stale local position before manual close, got %v", err)
+	}
+	if _, found, err := platform.store.FindPosition("live-main", "BTCUSDT"); err != nil {
+		t.Fatalf("find position failed: %v", err)
+	} else if found {
+		t.Fatal("expected stale BTCUSDT position to be removed after reconcile self-heal")
+	}
+}
+
 func TestCreateOrderReduceOnlyFormalFieldPreventsReverseOpen(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
 	account, err := platform.CreateAccount("Paper ReduceOnly", "PAPER", "binance-futures")


### PR DESCRIPTION
## 目的
解决 LIVE/REST 账户在交易所实际上已经 flat，但本地仍残留 `db-position-exchange-missing` stale 仓位时的连锁阻断问题：
- 手动平仓会被 `reconcile gate: stale (db-position-exchange-missing)` 拦住
- launch template switch / stop live session 会被“存在活动中的订单或未平仓头寸”拦住
- StartLiveSession 会直接落入 `reconcile-gate-blocked`，即使交易所已经没有真实仓位

本次改动只在这一类 stale gate 上增加 fail-closed 的 REST reconcile 自愈：先用交易所最近订单/成交回补本地事实，再重新判断 gate；没有放宽其他 stale/conflict/error 场景。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [x] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main)
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？
- [x] DB migration 是否具备向下兼容幂等性？
- [x] 配置字段有没有无意被混改？

说明：以上 checklist 均为“已检查，本 PR 未引入对应风险”。

## Root Cause
`SyncLiveAccount` / startup reconcile 只能把本地仓位标成 `stale (db-position-exchange-missing)`，但不会继续用交易所最近订单/成交把这笔 stale 本地仓位真正结算掉。
因此当 terminal `FILLED` exit 没被当前 session 的 `lastDispatchedOrderId` 关联到时，系统会卡在：
- 本地 position 仍存在
- 交易所权威快照已经 flat
- manual close / stop / restart 都只看到本地 stale 状态并 fail-closed

## 修改点
- `internal/service/live.go`
  - 新增只针对 `status=stale && scenario=db-position-exchange-missing` 的 REST reconcile self-heal 判定
  - `StartLiveSession` / `recoverRunningLiveSession` 在进入 `reconcile-gate-blocked` 前，若账户支持 REST reconcile，会先跑一次 `ReconcileLiveAccount` 再重新计算 gate
- `internal/service/order.go`
  - `resolveClosePositionTarget` 在 LIVE 账户 refresh 后，会先尝试同样的 stale self-heal；若交易所历史已证明该仓位早已被平掉，则返回 `position not found`，不再卡在 reconcile gate
- `internal/service/safety_checks.go`
  - `ensureNoActivePositionsOrOrders` 在本地仍显示 active exposure 时，会先尝试 REST reconcile self-heal，再重新检查活动仓位/订单，避免 launch template switch / stop session 被 stale 本地状态误挡
- `internal/service/live_reconcile_test.go`
  - 新增 REST reconcile history test helper，复用到 startup / safety / manual close 回归

## 行为变化
- 只有 `db-position-exchange-missing` 这类“本地有仓、交易所无仓”的 stale gate 才会尝试自愈
- `conflict` / `exchange-truth-unavailable` / `missing-reconcile-verdict` 等其他 gate 仍保持原来的 fail-closed 语义
- launch template switch / stop / manual close / session start 在这类 stale local position 场景下，会优先用交易所 recent orders/trades 自愈，而不是一直卡在本地残留状态

## 新增测试
- `TestEnsureNoActivePositionsOrOrdersSelfHealsStaleLiveExposureViaReconcile`
- `TestClosePositionSelfHealsStaleLivePositionViaReconcile`
- `TestStartLiveSessionSelfHealsStaleDBPositionViaReconcileHistory`
- 同时回归确认已有 stale/conflict/startup tests 仍通过

## 验证方式与测试证据
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

本地验证：
- `go test ./internal/service -run 'Test(EnsureNoActivePositionsOrOrdersSelfHealsStaleLiveExposureViaReconcile|ClosePositionSelfHealsStaleLivePositionViaReconcile|StartLiveSessionSelfHealsStaleDBPositionViaReconcileHistory|StartLiveSessionBackfillsFilledExitBeforeReconcileGateBlock|RecoverRunningLiveSessionBlocksWhenDBPositionMissingOnExchange|StartLiveSessionRequiresRESTVerificationForHistoricalTakeoverActivation)'`
- `go test ./internal/service`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
- `go test ./...`
