### PR TITLE
fix manual close reconcile gate self-heal

### DIFF
--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -346,6 +346,10 @@ func (p *Platform) ReconcileLiveAccount(accountID string, options LiveAccountRec
 	if err != nil {
 		return result, err
 	}
+	account, err = p.refreshLiveAccountPositionReconcileGate(account)
+	if err != nil {
+		return result, err
+	}
 	p.syncLiveSessionsForAccountSnapshot(account)
 	result.Account = account
 	return result, nil
@@ -450,6 +454,24 @@ func (p *Platform) persistLiveAccountSyncSuccess(account domain.Account, binding
 	account.Metadata["liveSyncSnapshot"] = snapshot
 	account.Metadata["lastLiveSyncAt"] = syncedAt.Format(time.RFC3339)
 	updateAccountSyncSuccessHealth(&account, syncedAt, previousSuccessAt)
+	return p.store.UpdateAccount(account)
+}
+
+func (p *Platform) refreshLiveAccountPositionReconcileGate(account domain.Account) (domain.Account, error) {
+	snapshot := cloneMetadata(mapValue(account.Metadata["liveSyncSnapshot"]))
+	exchangePositions := metadataList(snapshot["positions"])
+	reconcileGate, reconcileErr := p.reconcileLiveAccountPositions(account, exchangePositions)
+	if reconcileErr != nil {
+		account.Metadata = cloneMetadata(account.Metadata)
+		account.Metadata["lastLivePositionSyncError"] = reconcileErr.Error()
+		account, _ = p.store.UpdateAccount(account)
+		return account, reconcileErr
+	}
+	account.Metadata = cloneMetadata(account.Metadata)
+	delete(account.Metadata, "lastLivePositionSyncError")
+	account.Metadata["lastLivePositionSyncAt"] = time.Now().UTC().Format(time.RFC3339)
+	account.Metadata["livePositionReconcileGate"] = reconcileGate
+	clearLiveAccountPositionReconcileRequirement(account.Metadata)
 	return p.store.UpdateAccount(account)
 }
 
@@ -1124,19 +1146,7 @@ func (p *Platform) syncLiveAccountFromBinance(account domain.Account, binding ma
 	if err != nil {
 		return domain.Account{}, err
 	}
-	reconcileGate, reconcileErr := p.reconcileLiveAccountPositions(account, openPositions)
-	if reconcileErr != nil {
-		account.Metadata = cloneMetadata(account.Metadata)
-		account.Metadata["lastLivePositionSyncError"] = reconcileErr.Error()
-		account, _ = p.store.UpdateAccount(account)
-		return account, reconcileErr
-	}
-	account.Metadata = cloneMetadata(account.Metadata)
-	delete(account.Metadata, "lastLivePositionSyncError")
-	account.Metadata["lastLivePositionSyncAt"] = time.Now().UTC().Format(time.RFC3339)
-	account.Metadata["livePositionReconcileGate"] = reconcileGate
-	clearLiveAccountPositionReconcileRequirement(account.Metadata)
-	return p.store.UpdateAccount(account)
+	return p.refreshLiveAccountPositionReconcileGate(account)
 }
 
 func (p *Platform) CreateLiveSession(accountID, strategyID string, overrides map[string]any) (domain.LiveSession, error) {
@@ -1829,6 +1839,14 @@ func (p *Platform) reconcileLiveAccountPositions(account domain.Account, exchang
 	syncedAt := time.Now().UTC()
 	symbols := make(map[string]any)
 	blockingCount := 0
+	previousSymbols := make(map[string]struct{})
+	for symbol := range mapValue(mapValue(account.Metadata["livePositionReconcileGate"])["symbols"]) {
+		normalized := NormalizeSymbol(symbol)
+		if normalized == "" {
+			continue
+		}
+		previousSymbols[normalized] = struct{}{}
+	}
 	recordGate := func(symbol string, gate map[string]any) {
 		if symbol == "" || gate == nil {
 			return
@@ -1945,6 +1963,24 @@ func (p *Platform) reconcileLiveAccountPositions(account domain.Account, exchang
 			"scenario":         "db-position-exchange-missing",
 			"blocking":         true,
 			"dbPosition":       buildRecoveredLivePositionStateSnapshot(position),
+			"exchangePosition": map[string]any{},
+		})
+	}
+	for symbol := range previousSymbols {
+		if _, ok := symbols[symbol]; ok {
+			continue
+		}
+		if _, ok := seenSymbols[symbol]; ok {
+			continue
+		}
+		if position, ok := existingBySymbol[symbol]; ok && position.Quantity > 0 {
+			continue
+		}
+		recordGate(symbol, map[string]any{
+			"status":           livePositionReconcileGateStatusVerified,
+			"scenario":         "exchange-flat",
+			"blocking":         false,
+			"dbPosition":       map[string]any{},
 			"exchangePosition": map[string]any{},
 		})
 	}

--- a/internal/service/live_reconcile_test.go
+++ b/internal/service/live_reconcile_test.go
@@ -307,6 +307,8 @@ type testLiveAccountReconcileAdapter struct {
 	syncSnapshotFunc func(*Platform, domain.Account, map[string]any) (domain.Account, error)
 	ordersBySymbol   map[string][]map[string]any
 	tradesBySymbol   map[string][]LiveFillReport
+	ordersErr        error
+	tradesErr        error
 }
 
 func (a testLiveAccountReconcileAdapter) Key() string {
@@ -341,10 +343,16 @@ func (a testLiveAccountReconcileAdapter) SyncAccountSnapshot(platform *Platform,
 }
 
 func (a testLiveAccountReconcileAdapter) FetchRecentOrders(_ domain.Account, _ map[string]any, symbol string, _ int) ([]map[string]any, error) {
+	if a.ordersErr != nil {
+		return nil, a.ordersErr
+	}
 	return cloneReconcileOrders(a.ordersBySymbol[symbol]), nil
 }
 
 func (a testLiveAccountReconcileAdapter) FetchRecentTrades(_ domain.Account, _ map[string]any, symbol string, _ int) ([]LiveFillReport, error) {
+	if a.tradesErr != nil {
+		return nil, a.tradesErr
+	}
 	return cloneReconcileTrades(a.tradesBySymbol[symbol]), nil
 }
 

--- a/internal/service/order.go
+++ b/internal/service/order.go
@@ -38,11 +38,14 @@ func (p *Platform) ClosePosition(positionID string) (domain.Order, error) {
 	if err != nil {
 		return domain.Order{}, err
 	}
-	// Reconcile-gated recoveries are intentionally fail-closed: once local state
-	// diverges from exchange truth, the platform must not place any additional
-	// execution claim, including manual close orders, until an operator resolves
-	// the position directly against the exchange.
+	// Manual close stays fail-closed for unresolved reconcile conflicts, but a
+	// stale local-only position is allowed one authoritative reconcile self-heal
+	// attempt before we block the close path.
 	if err := p.ensureLivePositionReconcileGateAllowsExecution(position.AccountID, position.Symbol, position.Quantity > 0); err != nil {
+		return domain.Order{}, err
+	}
+	position, _, err = p.resolveClosePositionTarget(positionID)
+	if err != nil {
 		return domain.Order{}, err
 	}
 	order := buildClosePositionOrder(position)
@@ -63,6 +66,25 @@ func (p *Platform) ensureLivePositionReconcileGateAllowsExecution(accountID, sym
 		return err
 	}
 	gate := resolveLivePositionReconcileGate(account, symbol, requiresVerification)
+	if boolValue(gate["blocking"]) {
+		if healedAccount, attempted, healErr := p.attemptLiveAccountReconcileSelfHeal(account, symbol); attempted {
+			if healErr != nil {
+				return healErr
+			}
+			account = healedAccount
+			gate = resolveLivePositionReconcileGate(account, symbol, requiresVerification)
+			if boolValue(gate["blocking"]) &&
+				strings.EqualFold(strings.TrimSpace(stringValue(gate["scenario"])), "missing-reconcile-verdict") {
+				position, found, findErr := p.store.FindPosition(accountID, symbol)
+				if findErr != nil {
+					return findErr
+				}
+				if !found || position.Quantity <= 0 {
+					return nil
+				}
+			}
+		}
+	}
 	if !boolValue(gate["blocking"]) {
 		return nil
 	}

--- a/internal/service/order_test.go
+++ b/internal/service/order_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -322,6 +323,170 @@ func TestEnsureLivePositionReconcileGateAllowsExecutionSelfHealsStaleDBOnlyPosit
 	healedGate := resolveLivePositionReconcileGate(account, "BTCUSDT", true)
 	if boolValue(healedGate["blocking"]) {
 		t.Fatalf("expected reconcile gate to clear after self-heal, got %#v", healedGate)
+	}
+}
+
+func TestClosePositionKeepsFailClosedWhenReconcileSelfHealFails(t *testing.T) {
+	store := memory.NewStore()
+	platform := NewPlatform(store)
+	platform.registerLiveAdapter(testLiveAccountReconcileAdapter{
+		key: "test-manual-close-self-heal-fails",
+		syncSnapshotFunc: func(p *Platform, account domain.Account, binding map[string]any) (domain.Account, error) {
+			previousSuccessAt := parseOptionalRFC3339(stringValue(account.Metadata["lastLiveSyncAt"]))
+			account.Metadata = cloneMetadata(account.Metadata)
+			account.Metadata["liveSyncSnapshot"] = map[string]any{
+				"source":          "binance-rest-account-v3",
+				"adapterKey":      normalizeLiveAdapterKey(stringValue(binding["adapterKey"])),
+				"syncedAt":        time.Now().UTC().Format(time.RFC3339),
+				"bindingMode":     stringValue(binding["connectionMode"]),
+				"executionMode":   "rest",
+				"syncStatus":      "SYNCED",
+				"accountExchange": account.Exchange,
+				"positions":       []map[string]any{},
+				"openOrders":      []map[string]any{},
+			}
+			var err error
+			account, err = p.persistLiveAccountSyncSuccess(account, binding, previousSuccessAt)
+			if err != nil {
+				return domain.Account{}, err
+			}
+			return p.refreshLiveAccountPositionReconcileGate(account)
+		},
+		ordersErr: errors.New("reconcile fetch recent orders failed"),
+	})
+
+	account, err := platform.BindLiveAccount("live-main", map[string]any{
+		"adapterKey":     "test-manual-close-self-heal-fails",
+		"connectionMode": "mock",
+		"executionMode":  "rest",
+	})
+	if err != nil {
+		t.Fatalf("bind live account failed: %v", err)
+	}
+	account.Status = "READY"
+	account.Metadata = cloneMetadata(account.Metadata)
+	account.Metadata["liveBinding"] = map[string]any{
+		"adapterKey":     "test-manual-close-self-heal-fails",
+		"connectionMode": "mock",
+		"executionMode":  "rest",
+	}
+	if _, err := store.UpdateAccount(account); err != nil {
+		t.Fatalf("update live account failed: %v", err)
+	}
+
+	position, err := store.SavePosition(domain.Position{
+		AccountID:         account.ID,
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "LONG",
+		Quantity:          0.01,
+		EntryPrice:        68000,
+		MarkPrice:         67940,
+	})
+	if err != nil {
+		t.Fatalf("save stale position failed: %v", err)
+	}
+
+	if _, err := platform.ClosePosition(position.ID); err == nil || !strings.Contains(err.Error(), "reconcile fetch recent orders failed") {
+		t.Fatalf("expected manual close to stay fail-closed when reconcile self-heal fails, got %v", err)
+	}
+}
+
+func TestClosePositionKeepsFailClosedWhenSelfHealStillLeavesBlockingGate(t *testing.T) {
+	store := memory.NewStore()
+	platform := NewPlatform(store)
+	syncedAt := time.Date(2026, 4, 21, 2, 0, 0, 0, time.UTC)
+
+	platform.registerLiveAdapter(testLiveAccountReconcileAdapter{
+		key: "test-manual-close-self-heal-still-blocked",
+		syncSnapshotFunc: func(p *Platform, account domain.Account, binding map[string]any) (domain.Account, error) {
+			previousSuccessAt := parseOptionalRFC3339(stringValue(account.Metadata["lastLiveSyncAt"]))
+			account.Metadata = cloneMetadata(account.Metadata)
+			account.Metadata["liveSyncSnapshot"] = map[string]any{
+				"source":          "binance-rest-account-v3",
+				"adapterKey":      normalizeLiveAdapterKey(stringValue(binding["adapterKey"])),
+				"syncedAt":        syncedAt.Format(time.RFC3339),
+				"bindingMode":     stringValue(binding["connectionMode"]),
+				"executionMode":   "rest",
+				"syncStatus":      "SYNCED",
+				"accountExchange": account.Exchange,
+				"positions":       []map[string]any{},
+				"openOrders":      []map[string]any{},
+			}
+			var err error
+			account, err = p.persistLiveAccountSyncSuccess(account, binding, previousSuccessAt)
+			if err != nil {
+				return domain.Account{}, err
+			}
+			return p.refreshLiveAccountPositionReconcileGate(account)
+		},
+		ordersBySymbol: map[string][]map[string]any{
+			"BTCUSDT": {{
+				"symbol":        "BTCUSDT",
+				"orderId":       "9201",
+				"clientOrderId": "client-9201",
+				"status":        "FILLED",
+				"side":          "BUY",
+				"type":          "MARKET",
+				"origType":      "MARKET",
+				"origQty":       0.02,
+				"executedQty":   0.02,
+				"price":         68020.0,
+				"avgPrice":      68020.0,
+				"reduceOnly":    false,
+				"closePosition": false,
+				"time":          float64(syncedAt.Add(-2 * time.Minute).UnixMilli()),
+				"updateTime":    float64(syncedAt.UnixMilli()),
+			}},
+		},
+		tradesBySymbol: map[string][]LiveFillReport{
+			"BTCUSDT": {{
+				Price:    68020.0,
+				Quantity: 0.02,
+				Fee:      0.01,
+				Metadata: map[string]any{
+					"exchangeOrderId": "9201",
+					"tradeId":         "trade-9201",
+					"tradeTime":       syncedAt.Format(time.RFC3339),
+				},
+			}},
+		},
+	})
+
+	account, err := platform.BindLiveAccount("live-main", map[string]any{
+		"adapterKey":     "test-manual-close-self-heal-still-blocked",
+		"connectionMode": "mock",
+		"executionMode":  "rest",
+	})
+	if err != nil {
+		t.Fatalf("bind live account failed: %v", err)
+	}
+	account.Status = "READY"
+	account.Metadata = cloneMetadata(account.Metadata)
+	account.Metadata["liveBinding"] = map[string]any{
+		"adapterKey":     "test-manual-close-self-heal-still-blocked",
+		"connectionMode": "mock",
+		"executionMode":  "rest",
+	}
+	if _, err := store.UpdateAccount(account); err != nil {
+		t.Fatalf("update live account failed: %v", err)
+	}
+
+	position, err := store.SavePosition(domain.Position{
+		AccountID:         account.ID,
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "LONG",
+		Quantity:          0.01,
+		EntryPrice:        68000,
+		MarkPrice:         67940,
+	})
+	if err != nil {
+		t.Fatalf("save stale position failed: %v", err)
+	}
+
+	if _, err := platform.ClosePosition(position.ID); err == nil || !strings.Contains(err.Error(), "execution blocked by reconcile gate") {
+		t.Fatalf("expected manual close to stay fail-closed when self-heal still leaves a blocking gate, got %v", err)
 	}
 }
 

--- a/internal/service/order_test.go
+++ b/internal/service/order_test.go
@@ -242,6 +242,89 @@ func TestClosePositionAllowsLiveManualCloseWithoutRuntimeSession(t *testing.T) {
 	}
 }
 
+func TestEnsureLivePositionReconcileGateAllowsExecutionSelfHealsStaleDBOnlyPosition(t *testing.T) {
+	store := memory.NewStore()
+	platform := NewPlatform(store)
+	syncedAt := time.Date(2026, 4, 21, 1, 23, 45, 0, time.UTC)
+
+	configureTestLiveRESTReconcileHistoryAdapter(
+		t,
+		platform,
+		"test-manual-close-gate-self-heal",
+		[]map[string]any{},
+		map[string][]map[string]any{
+			"BTCUSDT": {{
+				"symbol":        "BTCUSDT",
+				"orderId":       "9103",
+				"clientOrderId": "client-9103",
+				"status":        "FILLED",
+				"side":          "SELL",
+				"type":          "MARKET",
+				"origType":      "MARKET",
+				"origQty":       0.01,
+				"executedQty":   0.01,
+				"price":         67940.0,
+				"avgPrice":      67940.0,
+				"reduceOnly":    true,
+				"closePosition": false,
+				"time":          float64(syncedAt.Add(-2 * time.Minute).UnixMilli()),
+				"updateTime":    float64(syncedAt.UnixMilli()),
+			}},
+		},
+		map[string][]LiveFillReport{
+			"BTCUSDT": {{
+				Price:    67940.0,
+				Quantity: 0.01,
+				Fee:      0.01,
+				Metadata: map[string]any{
+					"exchangeOrderId": "9103",
+					"tradeId":         "trade-9103",
+					"tradeTime":       syncedAt.Format(time.RFC3339),
+				},
+			}},
+		},
+	)
+
+	if _, err := store.SavePosition(domain.Position{
+		AccountID:         "live-main",
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "LONG",
+		Quantity:          0.01,
+		EntryPrice:        68000,
+		MarkPrice:         67940,
+	}); err != nil {
+		t.Fatalf("save stale position failed: %v", err)
+	}
+
+	account, err := platform.SyncLiveAccount("live-main")
+	if err != nil {
+		t.Fatalf("sync live account failed: %v", err)
+	}
+	initialGate := resolveLivePositionReconcileGate(account, "BTCUSDT", true)
+	if !boolValue(initialGate["blocking"]) || stringValue(initialGate["scenario"]) != "db-position-exchange-missing" {
+		t.Fatalf("expected initial stale db-position-exchange-missing gate, got %#v", initialGate)
+	}
+
+	if err := platform.ensureLivePositionReconcileGateAllowsExecution("live-main", "BTCUSDT", true); err != nil {
+		t.Fatalf("expected reconcile gate check to self-heal stale db-only position, got %v", err)
+	}
+	if _, found, err := store.FindPosition("live-main", "BTCUSDT"); err != nil {
+		t.Fatalf("find position failed: %v", err)
+	} else if found {
+		t.Fatal("expected stale BTCUSDT position to be removed after reconcile gate self-heal")
+	}
+
+	account, err = store.GetAccount("live-main")
+	if err != nil {
+		t.Fatalf("get healed account failed: %v", err)
+	}
+	healedGate := resolveLivePositionReconcileGate(account, "BTCUSDT", true)
+	if boolValue(healedGate["blocking"]) {
+		t.Fatalf("expected reconcile gate to clear after self-heal, got %#v", healedGate)
+	}
+}
+
 func TestCreateLiveOrderImmediateFilledSubmissionSettlesReduceOnlyExit(t *testing.T) {
 	store := memory.NewStore()
 	platform := NewPlatform(store)


### PR DESCRIPTION
## 目的
修复 live manual close 在交易所已 flat、DB 残留 position 时仍被 reconcile gate 阻断的问题。当前补丁让 `manual close` 在命中 `stale (db-position-exchange-missing)` 时先尝试一次 authoritative REST reconcile self-heal，并在 reconcile 后同步重算 account-level gate / session cache，避免事实已收敛但 gate 仍残留在 stale/error。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [x] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main)
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？
- [x] DB migration 是否具备向下兼容幂等性？
- [x] 配置字段有没有无意被混改？

说明：以上风险项均未引入变化；本 PR 仅修改 `internal/service/live.go`、`internal/service/order.go` 与对应测试，未改默认 dispatch 行为、部署、配置或 migration。

## 验证方式与测试证据
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

本地验证：
- `go test ./internal/service -run 'TestEnsureLivePositionReconcileGateAllowsExecutionSelfHealsStaleDBOnlyPosition|TestClosePositionSelfHealsStaleLivePositionViaReconcile|TestClosePositionAllowsLiveManualCloseWithoutRuntimeSession|TestReconcileLiveAccountRefreshClearsStaleRecoveryCache|TestClosePositionFilledLiveManualCloseClearsRecoverySessionState'`
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
