### PR TITLE
[codex] fix runtime signal bar NaN state

### DIFF
--- a/internal/service/signal_runtime_ws.go
+++ b/internal/service/signal_runtime_ws.go
@@ -910,10 +910,16 @@ func deriveSignalBarStates(sourceStates map[string]any) map[string]any {
 			"barCount":       len(indicatorBars),
 			"closedBarCount": len(closed),
 			"currentClosed":  currentClosed,
-			"sma5":           rollingMean(closes, len(indicatorBars)-1, 5),
-			"ma20":           rollingMean(closes, len(indicatorBars)-1, 20),
-			"atr14":          rollingMean(trueRanges, len(indicatorBars)-1, 14),
 			"current":        cloneMetadata(current),
+		}
+		if sma5 := finiteSignalBarIndicator(rollingMean(closes, len(indicatorBars)-1, 5)); sma5 != nil {
+			entry["sma5"] = *sma5
+		}
+		if ma20 := finiteSignalBarIndicator(rollingMean(closes, len(indicatorBars)-1, 20)); ma20 != nil {
+			entry["ma20"] = *ma20
+		}
+		if atr14 := finiteSignalBarIndicator(rollingMean(trueRanges, len(indicatorBars)-1, 14)); atr14 != nil {
+			entry["atr14"] = *atr14
 		}
 		if len(previousClosed) >= 1 {
 			entry["prevBar1"] = cloneMetadata(previousClosed[len(previousClosed)-1])
@@ -924,6 +930,13 @@ func deriveSignalBarStates(sourceStates map[string]any) map[string]any {
 		out[key] = entry
 	}
 	return out
+}
+
+func finiteSignalBarIndicator(value float64) *float64 {
+	if math.IsNaN(value) || math.IsInf(value, 0) {
+		return nil
+	}
+	return &value
 }
 
 func normalizeSignalBarEntries(value any) []map[string]any {

--- a/internal/service/signal_runtime_ws_test.go
+++ b/internal/service/signal_runtime_ws_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 	"time"
@@ -407,6 +408,14 @@ func TestBootstrapSignalRuntimeSourceStatesUsesWarmMarketCache(t *testing.T) {
 	}
 	if mapValue(signalState["prevBar2"]) == nil {
 		t.Fatalf("expected bootstrap state to include previous bars, got %#v", signalState)
+	}
+	for _, indicatorKey := range []string{"sma5", "ma20", "atr14"} {
+		if _, exists := signalState[indicatorKey]; exists {
+			t.Fatalf("expected insufficient warm bars to omit %s, got %#v", indicatorKey, signalState[indicatorKey])
+		}
+	}
+	if _, err := json.Marshal(signalBarStates); err != nil {
+		t.Fatalf("expected derived signal bar states to remain JSON encodable, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## 目的
修复 signal runtime 在信号条数量不足时把 `NaN` 写入 runtime/live session state 的问题，避免创建/触发 live session 时后端返回空响应，导致前端报 `Unexpected end of JSON input`。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [x] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main)
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？
- [x] DB migration 是否具备向下兼容幂等性？
- [x] 配置字段有没有无意被混改？

说明：本 PR 不修改默认 `dispatchMode`、不涉及 migration、不触碰 mainnet 路由，也没有混入前端本地未提交改动。

## 验证方式与测试证据
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

执行：
- `go test ./internal/service -run 'TestBootstrapSignalRuntimeSourceStatesUsesWarmMarketCache|TestHandleSignalRuntimeMessageScopesTriggerByLiveSessionSymbol'`

## Root Cause
`deriveSignalBarStates()` 会在 warm bars 不足 5/14/20 根时调用 `rollingMean()`，而 `rollingMean()` 会返回 `math.NaN()`。这些值随后被写入 `signalBarStates`，并沿着 runtime/live session state 持久化或 JSON 响应路径触发 `json.Marshal` / `json.Encoder` 失败。

## 修改点
- 仅在指标值是有限数值时写入 `sma5` / `ma20` / `atr14`
- bars 不足时省略对应字段，不再把 `NaN` 落进 state
- 补充回归测试，覆盖 warm cache bars 不足时的 JSON 编码安全性

## 行为变化
- signal runtime / live session state 不再因指标 warmup 不足写入 `NaN`
- `/api/v1/signal-runtime/sessions` 和 live session 触发路径不再因空响应体导致前端 `response.json()` 报错
