### PR TITLE
feat: add BTC 15m/30m live launch templates

### DIFF
--- a/internal/service/live_launch_templates.go
+++ b/internal/service/live_launch_templates.go
@@ -131,6 +131,7 @@ func (p *Platform) LiveLaunchTemplates() ([]LiveLaunchTemplate, error) {
 			baselineNotes = append(baselineNotes,
 				"该模板已显式固化 intraday research baseline：dir2 zero initial + reentry_window + reentry_size_schedule=[0.20, 0.10] + max_trades_per_bar=2。",
 				"非 1d 周期默认使用 canonical SMA5 hard filter；移动止损与利润保护参数分别固定为 trailing_stop_atr=0.3、profit_protect_atr=1.0、delayed_trailing_activation_atr=0.5。",
+				"当前 research baseline 只提升 BTCUSDT 15m/30m；BTCUSDT 5m 暂保留为通用模板，因为现阶段 5m 对执行摩擦更敏感，尚不作为默认 intraday baseline 候选。",
 			)
 		}
 		key := fmt.Sprintf("binance-testnet-%s-%s", strings.ToLower(symbol[:3]), strings.ToLower(timeframe))

--- a/internal/service/live_launch_templates.go
+++ b/internal/service/live_launch_templates.go
@@ -71,7 +71,7 @@ func (p *Platform) LiveLaunchTemplates() ([]LiveLaunchTemplate, error) {
 		},
 	}
 
-	buildTemplate := func(symbol, timeframe string, quantity float64) LiveLaunchTemplate {
+	buildTemplate := func(symbol, timeframe string, quantity float64, applyResearchBaseline bool) LiveLaunchTemplate {
 		signalBindings := []map[string]any{
 			{
 				"sourceKey": "binance-kline",
@@ -114,8 +114,36 @@ func (p *Platform) LiveLaunchTemplates() ([]LiveLaunchTemplate, error) {
 			"executionSLExitTimeoutFallbackOrderType": "MARKET",
 			"dispatchCooldownSeconds":                 30,
 		}
+		baselineNotes := []string{}
+		if applyResearchBaseline {
+			liveOverrides["strategyEngine"] = firstNonEmpty(strategyEngine, "bk-default")
+			liveOverrides["dir2_zero_initial"] = true
+			liveOverrides["zero_initial_mode"] = "reentry_window"
+			liveOverrides["stop_mode"] = "atr"
+			liveOverrides["stop_loss_atr"] = 0.05
+			liveOverrides["profit_protect_atr"] = 1.0
+			liveOverrides["trailing_stop_atr"] = 0.3
+			liveOverrides["delayed_trailing_activation_atr"] = 0.5
+			liveOverrides["long_reentry_atr"] = 0.1
+			liveOverrides["short_reentry_atr"] = 0.0
+			liveOverrides["max_trades_per_bar"] = 2
+			liveOverrides["reentry_size_schedule"] = []float64{0.20, 0.10}
+			baselineNotes = append(baselineNotes,
+				"该模板已显式固化 intraday research baseline：dir2 zero initial + reentry_window + reentry_size_schedule=[0.20, 0.10] + max_trades_per_bar=2。",
+				"非 1d 周期默认使用 canonical SMA5 hard filter；移动止损与利润保护参数分别固定为 trailing_stop_atr=0.3、profit_protect_atr=1.0、delayed_trailing_activation_atr=0.5。",
+			)
+		}
 		key := fmt.Sprintf("binance-testnet-%s-%s", strings.ToLower(symbol[:3]), strings.ToLower(timeframe))
 		quantityNote := fmt.Sprintf("默认下单量 %.3f 用于尽量避免 Binance testnet 最小名义价值拦截。", quantity)
+		notes := []string{
+			fmt.Sprintf("当前主策略使用 %s（strategyEngine=%s）。", strategyName, firstNonEmpty(strategyEngine, "bk-default")),
+			"signal 绑定使用 Binance 原生 kline；trigger 绑定使用 Binance trade tick；feature 绑定使用 Binance order book。",
+			"点击模板会独占替换该策略当前模板绑定，不再在旧模板之上继续叠加 symbol / timeframe。",
+			quantityNote,
+			"模板里只有 dispatchMode 需要前端在提交前注入；其余 launch 参数保持固定。",
+			"launch 会在安全前提下刷新 account + strategy 级 runtime 订阅，live session 仍按 symbol + signalTimeframe 分开创建或复用。",
+		}
+		notes = append(notes, baselineNotes...)
 		return LiveLaunchTemplate{
 			Key:                 key,
 			Name:                fmt.Sprintf("Binance Testnet %s %s", symbol, timeframe),
@@ -148,24 +176,19 @@ func (p *Platform) LiveLaunchTemplates() ([]LiveLaunchTemplate, error) {
 				StartSession:           true,
 			},
 			Steps: cloneLiveLaunchTemplateSteps(steps),
-			Notes: []string{
-				fmt.Sprintf("当前主策略使用 %s（strategyEngine=%s）。", strategyName, firstNonEmpty(strategyEngine, "bk-default")),
-				"signal 绑定使用 Binance 原生 kline；trigger 绑定使用 Binance trade tick；feature 绑定使用 Binance order book。",
-				"点击模板会独占替换该策略当前模板绑定，不再在旧模板之上继续叠加 symbol / timeframe。",
-				quantityNote,
-				"模板里只有 dispatchMode 需要前端在提交前注入；其余 launch 参数保持固定。",
-				"launch 会在安全前提下刷新 account + strategy 级 runtime 订阅，live session 仍按 symbol + signalTimeframe 分开创建或复用。",
-			},
+			Notes: notes,
 		}
 	}
 
 	return []LiveLaunchTemplate{
-		buildTemplate("BTCUSDT", "5m", 0.002),
-		buildTemplate("BTCUSDT", "4h", 0.002),
-		buildTemplate("BTCUSDT", "1d", 0.002),
-		buildTemplate("ETHUSDT", "5m", 0.100),
-		buildTemplate("ETHUSDT", "4h", 0.100),
-		buildTemplate("ETHUSDT", "1d", 0.100),
+		buildTemplate("BTCUSDT", "5m", 0.002, false),
+		buildTemplate("BTCUSDT", "15m", 0.002, true),
+		buildTemplate("BTCUSDT", "30m", 0.002, true),
+		buildTemplate("BTCUSDT", "4h", 0.002, false),
+		buildTemplate("BTCUSDT", "1d", 0.002, false),
+		buildTemplate("ETHUSDT", "5m", 0.100, false),
+		buildTemplate("ETHUSDT", "4h", 0.100, false),
+		buildTemplate("ETHUSDT", "1d", 0.100, false),
 	}, nil
 }
 

--- a/internal/service/live_launch_templates_test.go
+++ b/internal/service/live_launch_templates_test.go
@@ -6,28 +6,31 @@ import (
 	"github.com/wuyaocheng/bktrader/internal/store/memory"
 )
 
-func TestLiveLaunchTemplatesExposeSixBinanceTestnetVariants(t *testing.T) {
+func TestLiveLaunchTemplatesExposeEightBinanceTestnetVariants(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
 
 	templates, err := platform.LiveLaunchTemplates()
 	if err != nil {
 		t.Fatalf("list live launch templates failed: %v", err)
 	}
-	if len(templates) != 6 {
-		t.Fatalf("expected 6 launch templates, got %d", len(templates))
+	if len(templates) != 8 {
+		t.Fatalf("expected 8 launch templates, got %d", len(templates))
 	}
 
 	expected := map[string]struct {
-		symbol    string
-		timeframe string
-		quantity  float64
+		symbol           string
+		timeframe        string
+		quantity         float64
+		researchBaseline bool
 	}{
-		"binance-testnet-btc-5m": {symbol: "BTCUSDT", timeframe: "5m", quantity: 0.002},
-		"binance-testnet-btc-4h": {symbol: "BTCUSDT", timeframe: "4h", quantity: 0.002},
-		"binance-testnet-btc-1d": {symbol: "BTCUSDT", timeframe: "1d", quantity: 0.002},
-		"binance-testnet-eth-5m": {symbol: "ETHUSDT", timeframe: "5m", quantity: 0.1},
-		"binance-testnet-eth-4h": {symbol: "ETHUSDT", timeframe: "4h", quantity: 0.1},
-		"binance-testnet-eth-1d": {symbol: "ETHUSDT", timeframe: "1d", quantity: 0.1},
+		"binance-testnet-btc-5m":  {symbol: "BTCUSDT", timeframe: "5m", quantity: 0.002},
+		"binance-testnet-btc-15m": {symbol: "BTCUSDT", timeframe: "15m", quantity: 0.002, researchBaseline: true},
+		"binance-testnet-btc-30m": {symbol: "BTCUSDT", timeframe: "30m", quantity: 0.002, researchBaseline: true},
+		"binance-testnet-btc-4h":  {symbol: "BTCUSDT", timeframe: "4h", quantity: 0.002},
+		"binance-testnet-btc-1d":  {symbol: "BTCUSDT", timeframe: "1d", quantity: 0.002},
+		"binance-testnet-eth-5m":  {symbol: "ETHUSDT", timeframe: "5m", quantity: 0.1},
+		"binance-testnet-eth-4h":  {symbol: "ETHUSDT", timeframe: "4h", quantity: 0.1},
+		"binance-testnet-eth-1d":  {symbol: "ETHUSDT", timeframe: "1d", quantity: 0.1},
 	}
 
 	for _, item := range templates {
@@ -91,6 +94,45 @@ func TestLiveLaunchTemplatesExposeSixBinanceTestnetVariants(t *testing.T) {
 		}
 		if got := parseFloatValue(item.LaunchPayload.LiveSessionOverrides["defaultOrderQuantity"]); got != want.quantity {
 			t.Fatalf("expected defaultOrderQuantity=%v, got %v", want.quantity, got)
+		}
+		if want.researchBaseline {
+			if got := stringValue(item.LaunchPayload.LiveSessionOverrides["strategyEngine"]); got == "" {
+				t.Fatalf("expected explicit strategyEngine for %s", item.Key)
+			}
+			if !boolValue(item.LaunchPayload.LiveSessionOverrides["dir2_zero_initial"]) {
+				t.Fatalf("expected dir2_zero_initial=true for %s", item.Key)
+			}
+			if got := stringValue(item.LaunchPayload.LiveSessionOverrides["zero_initial_mode"]); got != "reentry_window" {
+				t.Fatalf("expected zero_initial_mode=reentry_window for %s, got %s", item.Key, got)
+			}
+			if got := stringValue(item.LaunchPayload.LiveSessionOverrides["stop_mode"]); got != "atr" {
+				t.Fatalf("expected stop_mode=atr for %s, got %s", item.Key, got)
+			}
+			if got := parseFloatValue(item.LaunchPayload.LiveSessionOverrides["stop_loss_atr"]); got != 0.05 {
+				t.Fatalf("expected stop_loss_atr=0.05 for %s, got %v", item.Key, got)
+			}
+			if got := parseFloatValue(item.LaunchPayload.LiveSessionOverrides["profit_protect_atr"]); got != 1.0 {
+				t.Fatalf("expected profit_protect_atr=1.0 for %s, got %v", item.Key, got)
+			}
+			if got := parseFloatValue(item.LaunchPayload.LiveSessionOverrides["trailing_stop_atr"]); got != 0.3 {
+				t.Fatalf("expected trailing_stop_atr=0.3 for %s, got %v", item.Key, got)
+			}
+			if got := parseFloatValue(item.LaunchPayload.LiveSessionOverrides["delayed_trailing_activation_atr"]); got != 0.5 {
+				t.Fatalf("expected delayed_trailing_activation_atr=0.5 for %s, got %v", item.Key, got)
+			}
+			if got := parseFloatValue(item.LaunchPayload.LiveSessionOverrides["long_reentry_atr"]); got != 0.1 {
+				t.Fatalf("expected long_reentry_atr=0.1 for %s, got %v", item.Key, got)
+			}
+			if got := parseFloatValue(item.LaunchPayload.LiveSessionOverrides["short_reentry_atr"]); got != 0.0 {
+				t.Fatalf("expected short_reentry_atr=0.0 for %s, got %v", item.Key, got)
+			}
+			if got := maxIntValue(item.LaunchPayload.LiveSessionOverrides["max_trades_per_bar"], 0); got != 2 {
+				t.Fatalf("expected max_trades_per_bar=2 for %s, got %d", item.Key, got)
+			}
+			schedule := normalizeBacktestFloatSlice(item.LaunchPayload.LiveSessionOverrides["reentry_size_schedule"], nil)
+			if len(schedule) != 2 || schedule[0] != 0.20 || schedule[1] != 0.10 {
+				t.Fatalf("expected reentry_size_schedule [0.20, 0.10] for %s, got %#v", item.Key, item.LaunchPayload.LiveSessionOverrides["reentry_size_schedule"])
+			}
 		}
 		if item.LaunchPayload.LaunchTemplateKey != item.Key {
 			t.Fatalf("expected launch template key %s, got %s", item.Key, item.LaunchPayload.LaunchTemplateKey)

--- a/internal/service/live_market_data.go
+++ b/internal/service/live_market_data.go
@@ -112,6 +112,14 @@ func (p *Platform) refreshLiveMarketSnapshot(symbol string) error {
 	if err != nil {
 		return err
 	}
+	signal15M, err := p.syncStoredSignalBars(normalizedSymbol, "15m", fastSignalStart, end)
+	if err != nil {
+		return err
+	}
+	signal30M, err := p.syncStoredSignalBars(normalizedSymbol, "30m", fastSignalStart, end)
+	if err != nil {
+		return err
+	}
 	signal1D, err := p.syncStoredSignalBars(normalizedSymbol, "1d", signalStart, end)
 	if err != nil {
 		return err
@@ -125,9 +133,11 @@ func (p *Platform) refreshLiveMarketSnapshot(symbol string) error {
 		Symbol:     normalizedSymbol,
 		MinuteBars: minuteBars,
 		SignalBars: map[string][]strategySignalBar{
-			"5m": signal5M,
-			"1d": signal1D,
-			"4h": signal4H,
+			"5m":  signal5M,
+			"15m": signal15M,
+			"30m": signal30M,
+			"1d":  signal1D,
+			"4h":  signal4H,
 		},
 		UpdatedAt: time.Now().UTC(),
 	}
@@ -135,6 +145,8 @@ func (p *Platform) refreshLiveMarketSnapshot(symbol string) error {
 	logger.Debug("live market snapshot refreshed",
 		"minute_bar_count", len(minuteBars),
 		"signal_5m_bar_count", len(signal5M),
+		"signal_15m_bar_count", len(signal15M),
+		"signal_30m_bar_count", len(signal30M),
 		"signal_1d_bar_count", len(signal1D),
 		"signal_4h_bar_count", len(signal4H),
 	)
@@ -218,7 +230,7 @@ func (p *Platform) ingestLiveSignalBarSummary(summary map[string]any, eventTime 
 		return nil
 	}
 	timeframe := normalizeSignalBarInterval(stringValue(summary["timeframe"]))
-	if timeframe != "5m" && timeframe != "1d" && timeframe != "4h" {
+	if timeframe != "5m" && timeframe != "15m" && timeframe != "30m" && timeframe != "1d" && timeframe != "4h" {
 		return nil
 	}
 	symbol := NormalizeSymbol(stringValue(summary["symbol"]))
@@ -289,6 +301,10 @@ func liveSignalResolution(timeframe string) string {
 	switch normalizeSignalBarInterval(timeframe) {
 	case "5m":
 		return "5"
+	case "15m":
+		return "15"
+	case "30m":
+		return "30"
 	case "1d":
 		return "1D"
 	case "4h":

--- a/internal/service/live_signal_timeframe_test.go
+++ b/internal/service/live_signal_timeframe_test.go
@@ -1,0 +1,49 @@
+package service
+
+import "testing"
+
+func TestNormalizePaperSignalTimeframeAcceptsFifteenAndThirtyMinuteBars(t *testing.T) {
+	for _, item := range []struct {
+		input string
+		want  string
+	}{
+		{input: "15min", want: "15m"},
+		{input: "15m", want: "15m"},
+		{input: "30min", want: "30m"},
+		{input: "30m", want: "30m"},
+	} {
+		if got := normalizePaperSignalTimeframe(item.input); got != item.want {
+			t.Fatalf("expected normalizePaperSignalTimeframe(%q)=%q, got %q", item.input, item.want, got)
+		}
+	}
+}
+
+func TestLiveSignalResolutionSupportsIntradayBaselineTemplates(t *testing.T) {
+	for _, item := range []struct {
+		input string
+		want  string
+	}{
+		{input: "15m", want: "15"},
+		{input: "30m", want: "30"},
+	} {
+		if got := liveSignalResolution(item.input); got != item.want {
+			t.Fatalf("expected liveSignalResolution(%q)=%q, got %q", item.input, item.want, got)
+		}
+	}
+}
+
+func TestNormalizeBacktestParametersAcceptsIntradayBaselineTemplateTimeframes(t *testing.T) {
+	for _, timeframe := range []string{"15m", "30m"} {
+		normalized, err := NormalizeBacktestParameters(map[string]any{
+			"signalTimeframe":     timeframe,
+			"executionDataSource": "tick",
+			"symbol":              "BTCUSDT",
+		})
+		if err != nil {
+			t.Fatalf("expected %s to be accepted by NormalizeBacktestParameters: %v", timeframe, err)
+		}
+		if got := stringValue(normalized["signalTimeframe"]); got != timeframe {
+			t.Fatalf("expected normalized signalTimeframe %s, got %s", timeframe, got)
+		}
+	}
+}

--- a/internal/service/paper.go
+++ b/internal/service/paper.go
@@ -1196,7 +1196,7 @@ func (p *Platform) resolvePaperSessionParameters(session domain.PaperSession, ve
 func normalizePaperSignalTimeframe(value string) string {
 	normalized := normalizeSignalBarInterval(value)
 	switch normalized {
-	case "5m", "4h", "1d":
+	case "5m", "15m", "30m", "4h", "1d":
 		return normalized
 	default:
 		return "1d"

--- a/internal/service/signal_runtime_registry.go
+++ b/internal/service/signal_runtime_registry.go
@@ -159,6 +159,10 @@ func normalizeSignalBarInterval(value string) string {
 	switch value {
 	case "5m", "5", "5min", "5minute":
 		return "5m"
+	case "15m", "15", "15min", "15minute":
+		return "15m"
+	case "30m", "30", "30min", "30minute":
+		return "30m"
 	case "1d", "d", "1day":
 		return "1d"
 	case "4h", "240", "4hour":

--- a/internal/service/signal_source_registry.go
+++ b/internal/service/signal_source_registry.go
@@ -84,10 +84,10 @@ func (p *Platform) registerBuiltInSignalSources() {
 		Roles:        []string{"signal"},
 		Environments: []string{"paper", "live"},
 		SymbolScope:  "multi_symbol",
-		Description:  "交易所原生 5m/4h/1d K 线流，用于实时策略信号计算、MA20 和前两根 OHLC 状态。",
+		Description:  "交易所原生 5m/15m/30m/4h/1d K 线流，用于实时策略信号计算、SMA5/MA20 和前两根 OHLC 状态。",
 		Metadata: map[string]any{
 			"stream":               "kline",
-			"supportedTimeframes":  []string{"5m", "4h", "1d"},
+			"supportedTimeframes":  []string{"5m", "15m", "30m", "4h", "1d"},
 			"preferForSignalState": true,
 		},
 	}})
@@ -211,7 +211,7 @@ func (p *Platform) SignalSourceCatalog() map[string]any {
 		"sources": sources,
 		"notes": []string{
 			"账户级信号源绑定支持多源并行，可同时绑定交易触发源和盘口特征源。",
-			"5m / 4h / 1d 策略信号建议直接绑定交易所 kline 源，而不是从 tick 聚合 signal bar。",
+			"5m / 15m / 30m / 4h / 1d 策略信号建议直接绑定交易所 kline 源，而不是从 tick 聚合 signal bar。",
 			"paper/live 应优先绑定交易所 trade tick；order book 建议作为 feature 源单独接入。",
 			"跨市场套利可在单账户或多账户上并行绑定 Binance / OKX 等多个来源。",
 		},
@@ -224,7 +224,7 @@ func (p *Platform) SignalSourceTypes() []map[string]any {
 		{
 			"streamType":    "signal_bar",
 			"primaryRole":   "signal",
-			"description":   "交易所原生 K 线流，适合作为 5m / 4h / 1d 策略信号源。",
+			"description":   "交易所原生 K 线流，适合作为 5m / 15m / 30m / 4h / 1d 策略信号源。",
 			"typicalInputs": []string{"open", "high", "low", "close", "volume", "interval", "barStart", "barEnd", "isClosed"},
 		},
 		{

--- a/internal/service/signal_source_registry_test.go
+++ b/internal/service/signal_source_registry_test.go
@@ -97,6 +97,53 @@ func TestBindStrategySignalSourceCanonicalizesFiveMinuteKlineBinding(t *testing.
 	}
 }
 
+func TestBindStrategySignalSourceCanonicalizesFifteenAndThirtyMinuteKlineBindings(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+
+	for _, item := range []struct {
+		input    string
+		wantTF   string
+		wantChan string
+	}{
+		{input: "15min", wantTF: "15m", wantChan: "btcusdt@kline_15m"},
+		{input: "30min", wantTF: "30m", wantChan: "btcusdt@kline_30m"},
+	} {
+		if _, err := platform.BindStrategySignalSource("strategy-bk-1d", map[string]any{
+			"sourceKey": "binance-kline",
+			"role":      "signal",
+			"symbol":    "BTCUSDT",
+			"options":   map[string]any{"timeframe": item.input},
+		}); err != nil {
+			t.Fatalf("bind %s kline failed: %v", item.input, err)
+		}
+
+		bindings, err := platform.ListStrategySignalBindings("strategy-bk-1d")
+		if err != nil {
+			t.Fatalf("list strategy bindings failed: %v", err)
+		}
+		if len(bindings) != 1 {
+			t.Fatalf("expected one %s kline binding, got %#v", item.wantTF, bindings)
+		}
+		if got := stringValue(bindings[0].Options["timeframe"]); got != item.wantTF {
+			t.Fatalf("expected canonicalized timeframe %s, got %s", item.wantTF, got)
+		}
+
+		plan, err := platform.BuildSignalRuntimePlan("live-main", "strategy-bk-1d")
+		if err != nil {
+			t.Fatalf("build runtime plan failed: %v", err)
+		}
+		subscriptions := metadataList(plan["subscriptions"])
+		if len(subscriptions) != 1 {
+			t.Fatalf("expected one %s kline subscription, got %#v", item.wantTF, subscriptions)
+		}
+		if got := stringValue(subscriptions[0]["channel"]); got != item.wantChan {
+			t.Fatalf("expected %s kline subscription, got %s", item.wantTF, got)
+		}
+
+		platform = NewPlatform(memory.NewStore())
+	}
+}
+
 func TestLegacyStrategyBindingWithoutTimeframeCanonicalizesToSingle1dBinding(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
 

--- a/internal/service/strategy.go
+++ b/internal/service/strategy.go
@@ -534,7 +534,7 @@ func (p *Platform) BacktestOptions() map[string]any {
 	}
 
 	return map[string]any{
-		"signalTimeframes":           []string{"5m", "4h", "1d"},
+		"signalTimeframes":           []string{"5m", "15m", "30m", "4h", "1d"},
 		"executionDataSources":       []string{"tick", "1min"},
 		"defaultSignalTimeframe":     "1d",
 		"defaultExecutionDataSource": "tick",
@@ -567,7 +567,7 @@ func (p *Platform) BacktestOptions() map[string]any {
 			"1min": minuteDatasets,
 		},
 		"notes": []string{
-			"5m 用于调试快速出信号，4h 和 1d 用于常规策略信号周期。",
+			"5m 用于调试快速出信号，15m / 30m / 4h / 1d 用于常规策略信号周期。",
 			"执行层测试可选 tick 或 1min。",
 			"回测模块聚焦单一执行源回放，不做 tick 与 1min 的结果对比分析。",
 		},
@@ -605,7 +605,7 @@ func NormalizeBacktestParameters(parameters map[string]any) (map[string]any, err
 	if signalTimeframe == "" {
 		signalTimeframe = "1d"
 	}
-	if signalTimeframe != "5m" && signalTimeframe != "4h" && signalTimeframe != "1d" {
+	if signalTimeframe != "5m" && signalTimeframe != "15m" && signalTimeframe != "30m" && signalTimeframe != "4h" && signalTimeframe != "1d" {
 		return nil, fmt.Errorf("unsupported signalTimeframe: %s", signalTimeframe)
 	}
 

--- a/internal/service/strategy_registry.go
+++ b/internal/service/strategy_registry.go
@@ -168,7 +168,7 @@ func (e bkStrategyEngine) Describe() map[string]any {
 	return map[string]any{
 		"key":                  e.Key(),
 		"name":                 "BK Default Strategy",
-		"supportedSignalBars":  []string{"5m", "4h", "1d"},
+		"supportedSignalBars":  []string{"5m", "15m", "30m", "4h", "1d"},
 		"supportedExecutions":  []string{"tick", "1min"},
 		"runtimeConsistency":   "canonical-execution-shared",
 		"backtestSlippageOnly": true,


### PR DESCRIPTION
## 目的
为 `BTCUSDT` 新增 `15m` 和 `30m` 的一键启动模板，并把它们显式对齐到当前 intraday research baseline：SMA5 过滤、`dir2_zero_initial=true`、`zero_initial_mode=reentry_window`、`reentry_size_schedule=[0.20, 0.10]`、`max_trades_per_bar=2`、ATR 止损/利润保护/移动止损参数全部写实，不留空。

同时补通 `15m/30m` 在 live/paper/runtime 参数归一化和 signal kline 支持链路里的兼容性，避免模板可见但启动时被旧白名单拦住。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [x] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
- [x] `dispatchMode` 默认值无变化
- [x] 不存在直接调用 `mainnet` 凭证或路由地址的硬编码
- [x] 不涉及 DB migration
- [x] 配置字段没有无意被混改

## 验证方式与测试证据
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

本地执行：
```bash
go test ./internal/service -run 'TestLiveLaunchTemplatesExposeEightBinanceTestnetVariants|TestLiveLaunchTemplatesIncludeIdempotentFrontendWorkflow|TestLiveLaunchTemplatesExposeDispatchModeMetadata|TestBindStrategySignalSourceCanonicalizesFifteenAndThirtyMinuteKlineBindings|TestNormalizePaperSignalTimeframeAcceptsFifteenAndThirtyMinuteBars|TestLiveSignalResolutionSupportsIntradayBaselineTemplates|TestNormalizeBacktestParametersAcceptsIntradayBaselineTemplateTimeframes|TestLaunchLiveFlowTemplateSwitchReplacesBindingsAndRefreshesRuntimePlan'
```

通过结果：`ok github.com/wuyaocheng/bktrader/internal/service`

## 主要改动
- 新增 `BTCUSDT 15m` 与 `BTCUSDT 30m` live launch templates，并显式固定 research baseline 参数。
- 扩展 signal timeframe 归一化与 runtime/live market snapshot 支持，允许 `15m/30m` 使用 Binance kline 作为 signal source。
- 补充模板、signal source canonicalization、timeframe normalization 的针对性测试。

## Review Follow-up
- `BTCUSDT 5m` 这次没有一起切到 research baseline，是有意保留：当前研究结论里 `5m` 对执行摩擦更敏感，因此仍维持通用模板，不把它提升为默认 intraday baseline 候选；这个口径现在也补进模板 notes 里了。
- 模板里显式写入的 baseline 参数优先于 live 路径里的 fallback / 安全默认值。也就是说，这个 PR 的目标是把 `15m/30m` baseline 写实到模板 payload，避免维护者误以为 runtime 默认值会自动与研究 baseline 同步。