### PR TITLE
[codex] fix zero initial reentry audit and position settlement

### DIFF
--- a/internal/service/live_execution.go
+++ b/internal/service/live_execution.go
@@ -441,6 +441,11 @@ func (p *Platform) dispatchLiveSessionIntent(session domain.LiveSession) (domain
 	if err := validateLiveExecutionProposalMetadata(session, proposalMap); err != nil {
 		return domain.Order{}, err
 	}
+	dispatchStartedAt := time.Now().UTC()
+	proposalMap, err = p.ensureStrategyDecisionEventForExecutionProposal(session, version.ID, proposalMap, dispatchStartedAt, "dispatch-preflight")
+	if err != nil {
+		return domain.Order{}, err
+	}
 	proposal = executionProposalFromMap(proposalMap)
 	order := buildLiveOrderFromExecutionProposal(session, version.ID, proposal, proposalMap)
 	created, createErr := p.CreateOrder(order)
@@ -451,6 +456,12 @@ func (p *Platform) dispatchLiveSessionIntent(session domain.LiveSession) (domain
 	state := cloneMetadata(session.State)
 	intentSignature := buildLiveIntentSignature(proposalMap)
 	dispatchedAt := time.Now().UTC()
+	if dispatchedAt.Before(dispatchStartedAt) {
+		dispatchedAt = dispatchStartedAt
+	}
+	if decisionEventID := stringValue(proposalMap["decisionEventId"]); decisionEventID != "" {
+		state["lastStrategyDecisionEventId"] = decisionEventID
+	}
 	state["lastDispatchedOrderId"] = created.ID
 	state["lastDispatchedOrderStatus"] = created.Status
 	state["lastExecutionDispatch"] = executionDispatchSummary(proposalMap, created, false)

--- a/internal/service/live_recovery.go
+++ b/internal/service/live_recovery.go
@@ -129,6 +129,9 @@ func (p *Platform) refreshLiveSessionPositionContext(session domain.LiveSession,
 	state["hasRecoveredVirtualPosition"] = hasVirtualPosition
 	state["lastRecoveredPositionAt"] = eventTime.UTC().Format(time.RFC3339)
 	state["positionRecoverySource"] = firstNonEmpty(source, "live-position-refresh")
+	if hasRealPositionContext {
+		clearLivePendingZeroInitialWindow(state, eventTime, "real-position-confirmed")
+	}
 	if !hasRealPositionContext && !hasVirtualPosition {
 		clearLiveWatchdogExitState(state)
 		clearLivePositionWatermarks(state)

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -243,6 +243,18 @@ func TestPrepareLivePlanStepForSignalEvaluationUsesZeroInitialWindowAcrossTwoBar
 	if stringValue(pending["side"]) != "BUY" {
 		t.Fatalf("expected pending BUY window, got %+v", pending)
 	}
+	timeline := metadataList(state["timeline"])
+	if len(timeline) != 1 {
+		t.Fatalf("expected one zero initial window timeline event, got %+v", timeline)
+	}
+	if got := stringValue(timeline[0]["title"]); got != "zero-initial-window-armed" {
+		t.Fatalf("expected zero-initial-window-armed timeline event, got %s", got)
+	}
+	timelineMetadata := mapValue(timeline[0]["metadata"])
+	pendingFromTimeline := mapValue(timelineMetadata[livePendingZeroInitialWindowStateKey])
+	if stringValue(pendingFromTimeline["side"]) != "BUY" || stringValue(pendingFromTimeline["symbol"]) != "BTCUSDT" {
+		t.Fatalf("expected pending window snapshot in timeline metadata, got %+v", pendingFromTimeline)
+	}
 
 	nextBarStart := barStart.Add(24 * time.Hour)
 	nextBarStates := map[string]any{
@@ -286,6 +298,9 @@ func TestPrepareLivePlanStepForSignalEvaluationUsesZeroInitialWindowAcrossTwoBar
 	)
 	if gotRole != "entry" || gotReason != "Zero-Initial-Reentry" || gotSide != "BUY" {
 		t.Fatalf("expected pending zero initial window to remain active on next bar, got side=%s role=%s reason=%s", gotSide, gotRole, gotReason)
+	}
+	if timeline := metadataList(state["timeline"]); len(timeline) != 1 {
+		t.Fatalf("expected existing pending window to avoid duplicate timeline events, got %+v", timeline)
 	}
 
 	expiredState, _, _, _, _, _ := prepareLivePlanStepForSignalEvaluation(

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -1554,6 +1554,139 @@ func TestDispatchLiveSessionIntentRejectsNonDispatchableProposal(t *testing.T) {
 	}
 }
 
+func TestDispatchLiveSessionIntentBackfillsMissingDecisionEventReference(t *testing.T) {
+	platform, session, runtimeSessionID, _, _ := prepareLiveDecisionTelemetryFixture(t)
+	platform.registerLiveAdapter(testLiveAccountSyncAdapter{key: "test-decision-event-backfill"})
+
+	account, err := platform.store.GetAccount("live-main")
+	if err != nil {
+		t.Fatalf("get account failed: %v", err)
+	}
+	account.Status = "READY"
+	account.Metadata = cloneMetadata(account.Metadata)
+	account.Metadata["liveBinding"] = map[string]any{
+		"adapterKey":     "test-decision-event-backfill",
+		"connectionMode": "mock",
+		"executionMode":  "mock",
+	}
+	if _, err := platform.store.UpdateAccount(account); err != nil {
+		t.Fatalf("update account failed: %v", err)
+	}
+
+	freshRuntimeAt := time.Now().UTC()
+	if err := platform.updateSignalRuntimeSessionState(runtimeSessionID, func(runtimeSession *domain.SignalRuntimeSession) {
+		state := cloneMetadata(runtimeSession.State)
+		state["lastEventAt"] = freshRuntimeAt.Format(time.RFC3339)
+		state["lastHeartbeatAt"] = freshRuntimeAt.Format(time.RFC3339)
+		sourceStates := cloneMetadata(mapValue(state["sourceStates"]))
+		for key, item := range sourceStates {
+			sourceState := cloneMetadata(mapValue(item))
+			sourceState["lastEventAt"] = freshRuntimeAt.Format(time.RFC3339)
+			sourceStates[key] = sourceState
+		}
+		state["sourceStates"] = sourceStates
+		runtimeSession.State = state
+		runtimeSession.UpdatedAt = freshRuntimeAt
+	}); err != nil {
+		t.Fatalf("refresh runtime state failed: %v", err)
+	}
+
+	missingDecisionEventID := "strategy-decision-event-missing-live-dispatch"
+	proposal := executionProposalToMap(ExecutionProposal{
+		Action:            "entry",
+		Role:              "entry",
+		Reason:            "SL-Reentry",
+		Side:              "SELL",
+		Symbol:            "BTCUSDT",
+		Type:              "LIMIT",
+		Quantity:          0.002,
+		LimitPrice:        75600.0,
+		PriceHint:         75600.0,
+		PriceSource:       "test-book",
+		TimeInForce:       "GTC",
+		SignalKind:        "sl-reentry",
+		DecisionState:     "entry-ready",
+		SignalBarStateKey: "binance-kline|BTCUSDT|signal|1d",
+		ExecutionStrategy: "book-aware-v1",
+		Status:            "dispatchable",
+		Metadata: map[string]any{
+			"runtimeSessionId":  runtimeSessionID,
+			"executionDecision": "maker-resting",
+			"executionMode":     "live",
+		},
+	})
+	proposal = setExecutionProposalDecisionEventID(proposal, missingDecisionEventID)
+	state := cloneMetadata(session.State)
+	state["lastExecutionProposal"] = proposal
+	state["lastStrategyIntent"] = proposal
+	state["lastStrategyIntentSignature"] = buildLiveIntentSignature(proposal)
+	state["lastStrategyEvaluationContext"] = map[string]any{
+		"strategyVersionId":   "strategy-version-bk-1d-v010",
+		"signalTimeframe":     "1d",
+		"executionDataSource": "tick",
+		"symbol":              "BTCUSDT",
+	}
+	state["lastStrategyDecision"] = map[string]any{
+		"action": "advance-plan",
+		"reason": "SL-Reentry",
+		"metadata": map[string]any{
+			"signalKind":    "sl-reentry",
+			"decisionState": "entry-ready",
+		},
+	}
+	session, err = platform.store.UpdateLiveSessionState(session.ID, state)
+	if err != nil {
+		t.Fatalf("update live session state failed: %v", err)
+	}
+
+	order, err := platform.dispatchLiveSessionIntent(session)
+	if err != nil {
+		t.Fatalf("dispatch live session intent failed: %v", err)
+	}
+	if got := stringValue(order.Metadata["decisionEventId"]); got != missingDecisionEventID {
+		t.Fatalf("expected order decisionEventId %s, got %s", missingDecisionEventID, got)
+	}
+	updatedSession, err := platform.store.GetLiveSession(session.ID)
+	if err != nil {
+		t.Fatalf("get updated live session failed: %v", err)
+	}
+	if got := stringValue(updatedSession.State["lastStrategyDecisionEventId"]); got != missingDecisionEventID {
+		t.Fatalf("expected session lastStrategyDecisionEventId %s, got %s", missingDecisionEventID, got)
+	}
+
+	events, err := platform.store.ListStrategyDecisionEvents(session.ID)
+	if err != nil {
+		t.Fatalf("list strategy decision events failed: %v", err)
+	}
+	var backfilled domain.StrategyDecisionEvent
+	for _, event := range events {
+		if event.ID == missingDecisionEventID {
+			backfilled = event
+			break
+		}
+	}
+	if backfilled.ID == "" {
+		t.Fatalf("expected missing decision event %s to be backfilled", missingDecisionEventID)
+	}
+	if !boolValue(backfilled.DecisionMetadata["decisionEventBackfilled"]) {
+		t.Fatalf("expected backfilled decision metadata, got %+v", backfilled.DecisionMetadata)
+	}
+	if got := stringValue(backfilled.ExecutionProposal["decisionEventId"]); got != missingDecisionEventID {
+		t.Fatalf("expected backfilled execution proposal decisionEventId %s, got %s", missingDecisionEventID, got)
+	}
+
+	executionEvents, err := platform.store.ListOrderExecutionEvents(order.ID)
+	if err != nil {
+		t.Fatalf("list order execution events failed: %v", err)
+	}
+	if len(executionEvents) == 0 {
+		t.Fatal("expected order execution telemetry to be persisted")
+	}
+	if got := executionEvents[0].DecisionEventID; got != missingDecisionEventID {
+		t.Fatalf("expected order execution event decisionEventId %s, got %s", missingDecisionEventID, got)
+	}
+}
+
 func TestDispatchLiveSessionIntentRejectsRecoveredPassiveCloseWithIncompleteMetadata(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
 	session, err := platform.CreateLiveSession("", "live-main", "strategy-bk-1d", map[string]any{

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -326,6 +326,72 @@ func TestPrepareLivePlanStepForSignalEvaluationUsesZeroInitialWindowAcrossTwoBar
 	}
 }
 
+func TestPrepareLivePlanStepForSignalEvaluationPrioritizesExitReentryOverZeroInitialWindow(t *testing.T) {
+	eventTime := time.Date(2026, 4, 10, 2, 0, 0, 0, time.UTC)
+	state := map[string]any{
+		livePendingZeroInitialWindowStateKey: map[string]any{
+			"side":            "SELL",
+			"symbol":          "BTCUSDT",
+			"signalTimeframe": "1d",
+			"armedAt":         eventTime.Add(-time.Minute).Format(time.RFC3339),
+			"signalBarStart":  eventTime.Truncate(24 * time.Hour).Format(time.RFC3339),
+			"expiresAt":       eventTime.Truncate(24 * time.Hour).Add(48 * time.Hour).Format(time.RFC3339),
+		},
+	}
+	signalStates := map[string]any{
+		signalBindingMatchKey("binance-kline", "signal", "BTCUSDT"): map[string]any{
+			"symbol":    "BTCUSDT",
+			"timeframe": "1d",
+			"sma5":      75650.0,
+			"atr14":     100.0,
+			"current": map[string]any{
+				"barStart": eventTime.Truncate(24 * time.Hour).Format(time.RFC3339),
+				"close":    75600.0,
+				"high":     75700.0,
+				"low":      75500.0,
+			},
+			"prevBar1": map[string]any{
+				"high": 75600.0,
+				"low":  75400.0,
+			},
+		},
+	}
+
+	updated, gotEvent, gotPrice, gotSide, gotRole, gotReason := prepareLivePlanStepForSignalEvaluation(
+		state,
+		map[string]any{
+			"dir2_zero_initial": true,
+			"zero_initial_mode": "reentry_window",
+		},
+		signalStates,
+		"BTCUSDT",
+		"1d",
+		map[string]any{},
+		eventTime,
+		eventTime,
+		75600.0,
+		"SELL",
+		"entry",
+		"SL-Reentry",
+	)
+	if gotRole != "entry" || gotReason != "SL-Reentry" || gotSide != "SELL" {
+		t.Fatalf("expected SL-Reentry to outrank pending zero initial window, got side=%s role=%s reason=%s", gotSide, gotRole, gotReason)
+	}
+	if !gotEvent.Equal(eventTime) || gotPrice != 75600.0 {
+		t.Fatalf("expected original SL-Reentry plan step to be preserved, got event=%s price=%v", gotEvent, gotPrice)
+	}
+	if pending := mapValue(updated[livePendingZeroInitialWindowStateKey]); len(pending) != 0 {
+		t.Fatalf("expected pending zero initial window to be consumed by exit reentry priority, got %+v", pending)
+	}
+	timeline := metadataList(updated["timeline"])
+	if len(timeline) != 1 || stringValue(timeline[0]["title"]) != "zero-initial-window-consumed" {
+		t.Fatalf("expected zero initial window consumed timeline event, got %+v", timeline)
+	}
+	if got := stringValue(mapValue(timeline[0]["metadata"])["reason"]); got != "exit-reentry-priority" {
+		t.Fatalf("expected exit-reentry-priority consume reason, got %s", got)
+	}
+}
+
 func TestEvaluateSignalBarGateAllowsReentryWithoutInitialBreakout(t *testing.T) {
 	gate := evaluateSignalBarGate(map[string]any{
 		"timeframe": "1d",
@@ -4040,6 +4106,14 @@ func TestRefreshLiveSessionPositionContextRebuildsLivePositionState(t *testing.T
 			},
 		},
 	}
+	state[livePendingZeroInitialWindowStateKey] = map[string]any{
+		"side":            "BUY",
+		"symbol":          "BTCUSDT",
+		"signalTimeframe": "1d",
+		"armedAt":         time.Date(2026, 4, 17, 1, 0, 0, 0, time.UTC).Format(time.RFC3339),
+		"signalBarStart":  time.Date(2026, 4, 17, 0, 0, 0, 0, time.UTC).Format(time.RFC3339),
+		"expiresAt":       time.Date(2026, 4, 19, 0, 0, 0, 0, time.UTC).Format(time.RFC3339),
+	}
 	session, err = platform.store.UpdateLiveSessionState(session.ID, state)
 	if err != nil {
 		t.Fatalf("update live session state failed: %v", err)
@@ -4061,6 +4135,22 @@ func TestRefreshLiveSessionPositionContextRebuildsLivePositionState(t *testing.T
 	}
 	if got := stringValue(updated.State["positionRecoveryStatus"]); got != "protected-open-position" {
 		t.Fatalf("expected protected-open-position, got %s", got)
+	}
+	if pending := mapValue(updated.State[livePendingZeroInitialWindowStateKey]); len(pending) != 0 {
+		t.Fatalf("expected real position refresh to consume pending zero initial window, got %+v", pending)
+	}
+	var consumed map[string]any
+	for _, item := range metadataList(updated.State["timeline"]) {
+		if stringValue(item["title"]) == "zero-initial-window-consumed" {
+			consumed = item
+			break
+		}
+	}
+	if consumed == nil {
+		t.Fatalf("expected zero initial window consumed timeline event, got %+v", metadataList(updated.State["timeline"]))
+	}
+	if got := stringValue(mapValue(consumed["metadata"])["reason"]); got != "real-position-confirmed" {
+		t.Fatalf("expected real-position-confirmed consume reason, got %s", got)
 	}
 }
 

--- a/internal/service/live_zero_initial.go
+++ b/internal/service/live_zero_initial.go
@@ -36,6 +36,10 @@ func prepareLivePlanStepForSignalEvaluation(
 	}
 
 	updatedState = refreshLiveZeroInitialWindowState(updatedState, signalBarStates, symbol, signalTimeframe, currentPosition, eventTime)
+	if liveExitReentryPlanStep(nextPlannedRole, nextPlannedReason) {
+		clearLivePendingZeroInitialWindow(updatedState, eventTime, "exit-reentry-priority")
+		return updatedState, nextPlannedEvent, nextPlannedPrice, nextPlannedSide, nextPlannedRole, nextPlannedReason
+	}
 	if updatedState, alignedEvent, alignedPrice, alignedSide, alignedRole, alignedReason, ok := liveZeroInitialWindowPlanStep(
 		updatedState,
 		parameters,
@@ -107,7 +111,7 @@ func refreshLiveZeroInitialWindowState(
 		state = map[string]any{}
 	}
 	if hasActiveLivePositionSnapshot(currentPosition) {
-		delete(state, livePendingZeroInitialWindowStateKey)
+		clearLivePendingZeroInitialWindow(state, eventTime, "real-position-confirmed")
 		return state
 	}
 	pending := cloneMetadata(mapValue(state[livePendingZeroInitialWindowStateKey]))
@@ -140,6 +144,34 @@ func refreshLiveZeroInitialWindowState(
 	}
 	state[livePendingZeroInitialWindowStateKey] = pending
 	return state
+}
+
+func liveExitReentryPlanStep(nextRole, nextReason string) bool {
+	if !strings.EqualFold(strings.TrimSpace(nextRole), "entry") {
+		return false
+	}
+	switch normalizeStrategyReasonTag(nextReason) {
+	case "sl-reentry", "pt-reentry":
+		return true
+	default:
+		return false
+	}
+}
+
+func clearLivePendingZeroInitialWindow(state map[string]any, eventTime time.Time, reason string) {
+	if state == nil {
+		return
+	}
+	pending := cloneMetadata(mapValue(state[livePendingZeroInitialWindowStateKey]))
+	if len(pending) == 0 {
+		delete(state, livePendingZeroInitialWindowStateKey)
+		return
+	}
+	delete(state, livePendingZeroInitialWindowStateKey)
+	appendTimelineEvent(state, "strategy", eventTime, "zero-initial-window-consumed", map[string]any{
+		livePendingZeroInitialWindowStateKey: pending,
+		"reason":                             firstNonEmpty(strings.TrimSpace(reason), "consumed"),
+	})
 }
 
 func liveZeroInitialWindowPlanStep(

--- a/internal/service/live_zero_initial.go
+++ b/internal/service/live_zero_initial.go
@@ -74,7 +74,7 @@ func prepareLivePlanStepForSignalEvaluation(
 	if shortReady {
 		side = "SELL"
 	}
-	updatedState[livePendingZeroInitialWindowStateKey] = map[string]any{
+	pendingWindow := map[string]any{
 		"side":            side,
 		"symbol":          NormalizeSymbol(symbol),
 		"signalTimeframe": strings.ToLower(strings.TrimSpace(signalTimeframe)),
@@ -82,6 +82,14 @@ func prepareLivePlanStepForSignalEvaluation(
 		"signalBarStart":  currentBarStart.UTC().Format(time.RFC3339),
 		"expiresAt":       currentBarStart.UTC().Add(2 * step).Format(time.RFC3339),
 	}
+	updatedState[livePendingZeroInitialWindowStateKey] = pendingWindow
+	appendTimelineEvent(updatedState, "strategy", eventTime, "zero-initial-window-armed", map[string]any{
+		livePendingZeroInitialWindowStateKey: cloneMetadata(pendingWindow),
+		"reason":                             "Zero-Initial-Reentry",
+		"side":                               side,
+		"symbol":                             NormalizeSymbol(symbol),
+		"signalTimeframe":                    strings.ToLower(strings.TrimSpace(signalTimeframe)),
+	})
 	updatedState, alignedEvent, alignedPrice, alignedSide, alignedRole, alignedReason, _ := liveZeroInitialWindowPlanStep(updatedState, parameters, signalBarStates, symbol, signalTimeframe, eventTime)
 	return updatedState, alignedEvent, alignedPrice, alignedSide, alignedRole, alignedReason
 }

--- a/internal/service/order.go
+++ b/internal/service/order.go
@@ -778,8 +778,8 @@ func (p *Platform) applyLiveSyncResult(account domain.Account, order domain.Orde
 		markOrderLifecycle(order.Metadata, "filled", false)
 	}
 	markOrderLifecycle(order.Metadata, "synced", true)
-	if len(syncResult.Fills) > 0 {
-		fills, lastFundingPnL, lastPrice := buildLiveSyncSettlement(order, syncResult)
+	fills, lastFundingPnL, lastPrice := buildLiveSyncSettlement(order, syncResult)
+	if len(fills) > 0 {
 		order.Price = lastPrice
 		order.Metadata["fundingPnL"] = lastFundingPnL
 		order.Metadata["fillCount"] = len(fills)
@@ -808,10 +808,19 @@ func (p *Platform) applyLiveSyncResult(account domain.Account, order domain.Orde
 }
 
 func buildLiveSyncSettlement(order domain.Order, syncResult LiveOrderSync) ([]domain.Fill, float64, float64) {
-	fills := make([]domain.Fill, 0, len(syncResult.Fills))
+	reports := syncResult.Fills
+	if len(reports) == 0 {
+		if fallback, ok := buildTerminalFilledFallbackReport(order, syncResult); ok {
+			reports = []LiveFillReport{fallback}
+		}
+	}
+	fills := make([]domain.Fill, 0, len(reports))
 	lastFundingPnL := 0.0
 	lastPrice := order.Price
-	for _, report := range syncResult.Fills {
+	for _, report := range reports {
+		if report.Quantity <= 0 {
+			continue
+		}
 		price := report.Price
 		if price <= 0 {
 			price = resolveExecutionPrice(order)
@@ -822,12 +831,84 @@ func buildLiveSyncSettlement(order domain.Order, syncResult LiveOrderSync) ([]do
 			OrderID:           order.ID,
 			ExchangeTradeID:   resolveLiveFillTradeID(report),
 			ExchangeTradeTime: resolveLiveFillTradeTime(report),
+			DedupFingerprint:  strings.TrimSpace(stringValue(mapValue(report.Metadata)["dedupFingerprint"])),
 			Price:             price,
 			Quantity:          report.Quantity,
 			Fee:               report.Fee - report.FundingPnL,
 		})
 	}
 	return fills, lastFundingPnL, lastPrice
+}
+
+func buildTerminalFilledFallbackReport(order domain.Order, syncResult LiveOrderSync) (LiveFillReport, bool) {
+	if !strings.EqualFold(strings.TrimSpace(syncResult.Status), "FILLED") {
+		return LiveFillReport{}, false
+	}
+	metadata := cloneMetadata(syncResult.Metadata)
+	if metadata == nil {
+		metadata = map[string]any{}
+	}
+	totalFilledQty := firstPositive(
+		parseFloatValue(metadata["executedQty"]),
+		firstPositive(
+			parseFloatValue(metadata["cumQty"]),
+			firstPositive(
+				parseFloatValue(metadata["filledQuantity"]),
+				order.Quantity,
+			),
+		),
+	)
+	if totalFilledQty <= 0 {
+		return LiveFillReport{}, false
+	}
+	alreadyFilledQty := parseFloatValue(order.Metadata["filledQuantity"])
+	fallbackQty := totalFilledQty - alreadyFilledQty
+	if order.Quantity > 0 && fallbackQty > order.Quantity-alreadyFilledQty {
+		fallbackQty = order.Quantity - alreadyFilledQty
+	}
+	if fallbackQty <= 1e-9 {
+		return LiveFillReport{}, false
+	}
+	price := firstPositive(
+		parseFloatValue(metadata["avgPrice"]),
+		firstPositive(
+			parseFloatValue(metadata["price"]),
+			firstPositive(order.Price, resolveExecutionPrice(order)),
+		),
+	)
+	tradeTime := firstNonEmpty(
+		stringValue(metadata["updateTime"]),
+		syncResult.SyncedAt,
+		stringValue(order.Metadata["lastExchangeUpdateAt"]),
+		stringValue(order.Metadata["acceptedAt"]),
+		time.Now().UTC().Format(time.RFC3339),
+	)
+	exchangeOrderID := firstNonEmpty(
+		stringValue(metadata["exchangeOrderId"]),
+		stringValue(order.Metadata["exchangeOrderId"]),
+	)
+	metadata["source"] = firstNonEmpty(stringValue(metadata["source"]), "terminal-filled-order-fallback")
+	metadata["exchangeOrderId"] = exchangeOrderID
+	metadata["clientOrderId"] = firstNonEmpty(stringValue(metadata["clientOrderId"]), order.ID)
+	metadata["tradeTime"] = tradeTime
+	metadata["syntheticFill"] = true
+	metadata["dedupFingerprint"] = terminalFilledFallbackDedupFingerprint(order, syncResult, totalFilledQty)
+	return LiveFillReport{
+		Price:    price,
+		Quantity: fallbackQty,
+		Fee:      0,
+		Metadata: metadata,
+	}, true
+}
+
+func terminalFilledFallbackDedupFingerprint(order domain.Order, syncResult LiveOrderSync, totalFilledQty float64) string {
+	metadata := mapValue(syncResult.Metadata)
+	return strings.Join([]string{
+		"terminal-filled-order-fallback",
+		strings.TrimSpace(order.ID),
+		firstNonEmpty(stringValue(metadata["exchangeOrderId"]), stringValue(order.Metadata["exchangeOrderId"])),
+		fmt.Sprintf("%.12f", totalFilledQty),
+	}, "|")
 }
 
 func (p *Platform) finalizeExecutedOrder(account domain.Account, order domain.Order, fills []domain.Fill) (domain.Order, error) {
@@ -838,6 +919,11 @@ func (p *Platform) finalizeExecutedOrder(account domain.Account, order domain.Or
 	if err != nil {
 		return domain.Order{}, err
 	}
+	existingFilledQuantity, err := p.store.TotalFilledQuantityForOrder(order.ID)
+	if err != nil {
+		return domain.Order{}, err
+	}
+	newFills = limitExecutionFillsToRemainingQuantity(newFills, order.Quantity-existingFilledQuantity)
 	lastPrice := order.Price
 	for _, fill := range newFills {
 		createdFill, err := p.store.CreateFill(fill)
@@ -969,6 +1055,27 @@ func buildFillDedupKey(fill domain.Fill) string {
 		fingerprint = fill.FallbackFingerprint()
 	}
 	return orderID + "|fallback|" + fingerprint
+}
+
+func limitExecutionFillsToRemainingQuantity(fills []domain.Fill, remainingQuantity float64) []domain.Fill {
+	if len(fills) == 0 || remainingQuantity <= 1e-9 {
+		return nil
+	}
+	limited := make([]domain.Fill, 0, len(fills))
+	remaining := remainingQuantity
+	for _, fill := range fills {
+		if fill.Quantity <= 0 || remaining <= 1e-9 {
+			continue
+		}
+		if fill.Quantity > remaining {
+			ratio := remaining / fill.Quantity
+			fill.Quantity = remaining
+			fill.Fee *= ratio
+		}
+		limited = append(limited, fill)
+		remaining -= fill.Quantity
+	}
+	return limited
 }
 
 func resolveLiveFillTradeID(report LiveFillReport) string {

--- a/internal/service/order_test.go
+++ b/internal/service/order_test.go
@@ -170,6 +170,137 @@ func TestFinalizeExecutedOrderSkipsDuplicateFallbackFillsWithoutExchangeTradeID(
 	}
 }
 
+func TestFilledExitWithoutFillReportsDoesNotLeaveStaleShortPosition(t *testing.T) {
+	store := memory.NewStore()
+	platform := NewPlatform(store)
+
+	account, err := store.GetAccount("live-main")
+	if err != nil {
+		t.Fatalf("get account failed: %v", err)
+	}
+
+	entryOrder, err := store.CreateOrder(domain.Order{
+		AccountID:         account.ID,
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "SELL",
+		Type:              "LIMIT",
+		Quantity:          0.002,
+		Price:             75600.0,
+		Metadata: map[string]any{
+			"source":        "live-session-intent",
+			"executionMode": "live",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create entry order failed: %v", err)
+	}
+	if _, err := platform.finalizeExecutedOrder(account, entryOrder, []domain.Fill{{
+		OrderID:         entryOrder.ID,
+		ExchangeTradeID: "entry-trade-1",
+		Price:           75600.0,
+		Quantity:        0.002,
+	}}); err != nil {
+		t.Fatalf("finalize entry order failed: %v", err)
+	}
+
+	exitOrder, err := store.CreateOrder(domain.Order{
+		AccountID:         account.ID,
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "BUY",
+		Type:              "LIMIT",
+		Quantity:          0.002,
+		Price:             75600.1,
+		ReduceOnly:        true,
+		Status:            "ACCEPTED",
+		Metadata: map[string]any{
+			"source":          "live-session-intent",
+			"executionMode":   "live",
+			"exchangeOrderId": "exchange-exit-1",
+			"executionProposal": map[string]any{
+				"role":       "exit",
+				"reason":     "SL",
+				"signalKind": "risk-exit",
+				"reduceOnly": true,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("create exit order failed: %v", err)
+	}
+	syncedExit, err := platform.applyLiveSyncResult(account, exitOrder, LiveOrderSync{
+		Status:   "FILLED",
+		SyncedAt: "2026-04-21T06:03:12Z",
+		Metadata: map[string]any{
+			"exchangeOrderId": "exchange-exit-1",
+			"executedQty":     0.002,
+			"avgPrice":        75600.1,
+			"updateTime":      "2026-04-21T06:03:12Z",
+		},
+	})
+	if err != nil {
+		t.Fatalf("apply filled exit sync without fills failed: %v", err)
+	}
+	if got := parseFloatValue(syncedExit.Metadata["filledQuantity"]); got != 0.002 {
+		t.Fatalf("expected fallback settlement to mark filled quantity 0.002, got %v", got)
+	}
+	if position, found, err := store.FindPosition(account.ID, "BTCUSDT"); err != nil {
+		t.Fatalf("find position after exit failed: %v", err)
+	} else if found {
+		t.Fatalf("expected filled reduce-only exit to clear local short, got %+v", position)
+	}
+
+	if _, err := platform.finalizeExecutedOrder(account, syncedExit, []domain.Fill{{
+		OrderID:         syncedExit.ID,
+		ExchangeTradeID: "late-exit-trade-1",
+		Price:           75600.1,
+		Quantity:        0.002,
+	}}); err != nil {
+		t.Fatalf("late duplicate exit fill should be ignored: %v", err)
+	}
+	if position, found, err := store.FindPosition(account.ID, "BTCUSDT"); err != nil {
+		t.Fatalf("find position after duplicate exit failed: %v", err)
+	} else if found {
+		t.Fatalf("expected late duplicate exit fill not to reopen/invert position, got %+v", position)
+	}
+
+	reentryOrder, err := store.CreateOrder(domain.Order{
+		AccountID:         account.ID,
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "SELL",
+		Type:              "LIMIT",
+		Quantity:          0.002,
+		Price:             75600.0,
+		Metadata: map[string]any{
+			"source":        "live-session-intent",
+			"executionMode": "live",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create reentry order failed: %v", err)
+	}
+	if _, err := platform.finalizeExecutedOrder(account, reentryOrder, []domain.Fill{{
+		OrderID:         reentryOrder.ID,
+		ExchangeTradeID: "reentry-trade-1",
+		Price:           75600.0,
+		Quantity:        0.002,
+	}}); err != nil {
+		t.Fatalf("finalize reentry order failed: %v", err)
+	}
+	position, found, err := store.FindPosition(account.ID, "BTCUSDT")
+	if err != nil {
+		t.Fatalf("find final position failed: %v", err)
+	}
+	if !found {
+		t.Fatal("expected final reentry short position")
+	}
+	if position.Side != "SHORT" || position.Quantity != 0.002 {
+		t.Fatalf("expected final position SHORT 0.002, got %+v", position)
+	}
+}
+
 func TestFinalizeExecutedOrderUsesExchangeTradeTimeForLastFilledAt(t *testing.T) {
 	store := memory.NewStore()
 	platform := NewPlatform(store)

--- a/internal/service/telemetry.go
+++ b/internal/service/telemetry.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"fmt"
 	"strings"
 	"time"
 
@@ -78,6 +79,266 @@ func (p *Platform) recordStrategyDecisionEvent(
 	return recorded, err
 }
 
+func (p *Platform) ensureStrategyDecisionEventForExecutionProposal(session domain.LiveSession, strategyVersionID string, proposalMap map[string]any, eventTime time.Time, trigger string) (map[string]any, error) {
+	normalized := cloneMetadata(proposalMap)
+	if len(normalized) == 0 {
+		return normalized, nil
+	}
+	metadata := cloneMetadata(mapValue(normalized["metadata"]))
+	if metadata == nil {
+		metadata = map[string]any{}
+	}
+	decisionEventID := firstNonEmpty(stringValue(normalized["decisionEventId"]), stringValue(metadata["decisionEventId"]))
+	if decisionEventID != "" {
+		exists, err := p.strategyDecisionEventExists(session.ID, decisionEventID)
+		if err != nil {
+			return normalized, err
+		}
+		if exists {
+			return setExecutionProposalDecisionEventID(normalized, decisionEventID), nil
+		}
+	} else {
+		decisionEventID = newStrategyDecisionEventID()
+	}
+
+	normalized = setExecutionProposalDecisionEventID(normalized, decisionEventID)
+	event := strategyDecisionEventFromExecutionProposal(session, strategyVersionID, normalized, eventTime, trigger)
+	event.ID = decisionEventID
+	recorded, err := p.store.CreateStrategyDecisionEvent(event)
+	if err != nil {
+		return normalized, err
+	}
+	p.publishLogEvent(strategyDecisionToUnifiedLogEvent(recorded))
+	return setExecutionProposalDecisionEventID(normalized, recorded.ID), nil
+}
+
+func (p *Platform) ensureStrategyDecisionEventForOrderExecution(order domain.Order, proposalMap map[string]any, eventTime time.Time, eventType string) error {
+	metadata := mapValue(order.Metadata)
+	decisionEventID := firstNonEmpty(stringValue(metadata["decisionEventId"]), stringValue(proposalMap["decisionEventId"]))
+	if decisionEventID == "" {
+		return nil
+	}
+	liveSessionID := stringValue(metadata["liveSessionId"])
+	if liveSessionID == "" {
+		return nil
+	}
+	exists, err := p.strategyDecisionEventExists(liveSessionID, decisionEventID)
+	if err != nil || exists {
+		return err
+	}
+	session, err := p.store.GetLiveSession(liveSessionID)
+	if err != nil {
+		return err
+	}
+	proposal := cloneMetadata(proposalMap)
+	if len(proposal) == 0 {
+		proposal = cloneMetadata(mapValue(firstNonEmptyMapValue(metadata["executionProposal"], metadata["intent"])))
+	}
+	if len(proposal) == 0 {
+		proposal = map[string]any{
+			"action":            liveOrderActionFromOrder(order),
+			"role":              liveOrderRoleFromOrder(order),
+			"reason":            firstNonEmpty(stringValue(metadata["reason"]), "order-execution"),
+			"side":              order.Side,
+			"symbol":            order.Symbol,
+			"type":              order.Type,
+			"quantity":          order.Quantity,
+			"priceHint":         order.Price,
+			"executionStrategy": stringValue(metadata["executionStrategy"]),
+			"status":            "dispatchable",
+		}
+	}
+	proposal = setExecutionProposalDecisionEventID(proposal, decisionEventID)
+	_, err = p.ensureStrategyDecisionEventForExecutionProposal(
+		session,
+		order.StrategyVersionID,
+		proposal,
+		eventTime,
+		orderExecutionDecisionBackfillTrigger(eventType),
+	)
+	return err
+}
+
+func strategyDecisionEventFromExecutionProposal(session domain.LiveSession, strategyVersionID string, proposalMap map[string]any, eventTime time.Time, trigger string) domain.StrategyDecisionEvent {
+	if eventTime.IsZero() {
+		eventTime = time.Now().UTC()
+	}
+	state := cloneMetadata(session.State)
+	metadata := cloneMetadata(mapValue(proposalMap["metadata"]))
+	if metadata == nil {
+		metadata = map[string]any{}
+	}
+	lastDecision := mapValue(state["lastStrategyDecision"])
+	decisionMetadata := cloneMetadata(mapValue(lastDecision["metadata"]))
+	if decisionMetadata == nil {
+		decisionMetadata = map[string]any{}
+	}
+	decisionMetadata["decisionEventBackfilled"] = true
+	decisionMetadata["decisionEventBackfillTrigger"] = firstNonEmpty(trigger, "dispatch-preflight")
+
+	sourceGate := cloneMetadata(mapValue(state["lastStrategyEvaluationSourceGate"]))
+	if len(sourceGate) == 0 {
+		sourceGate = map[string]any{
+			"ready":      true,
+			"backfilled": true,
+			"trigger":    firstNonEmpty(trigger, "dispatch-preflight"),
+		}
+	}
+	triggerSummary := cloneMetadata(mapValue(state["lastStrategyEvaluationRuntimeSummary"]))
+	if len(triggerSummary) == 0 {
+		triggerSummary = map[string]any{}
+	}
+	triggerSummary["event"] = firstNonEmpty(stringValue(triggerSummary["event"]), trigger, "dispatch-preflight")
+	triggerSummary["decisionEventBackfilled"] = true
+
+	evaluationContext := cloneMetadata(mapValue(metadata["executionContext"]))
+	if len(evaluationContext) == 0 {
+		evaluationContext = cloneMetadata(mapValue(state["lastStrategyEvaluationContext"]))
+	}
+	if evaluationContext == nil {
+		evaluationContext = map[string]any{}
+	}
+	strategyVersionID = firstNonEmpty(strategyVersionID, stringValue(proposalMap["strategyVersionId"]), stringValue(metadata["strategyVersionId"]), stringValue(evaluationContext["strategyVersionId"]))
+	if strategyVersionID != "" {
+		evaluationContext["strategyVersionId"] = strategyVersionID
+	}
+	evaluationContext["signalTimeframe"] = firstNonEmpty(stringValue(evaluationContext["signalTimeframe"]), stringValue(state["signalTimeframe"]))
+	evaluationContext["executionDataSource"] = firstNonEmpty(stringValue(evaluationContext["executionDataSource"]), stringValue(state["executionDataSource"]))
+	evaluationContext["symbol"] = firstNonEmpty(NormalizeSymbol(stringValue(evaluationContext["symbol"])), NormalizeSymbol(stringValue(proposalMap["symbol"])), NormalizeSymbol(stringValue(state["symbol"])))
+	evaluationContext["executionMode"] = firstNonEmpty(stringValue(evaluationContext["executionMode"]), stringValue(metadata["executionMode"]), "live")
+
+	signalIntent := cloneMetadata(mapValue(state["lastSignalIntent"]))
+	if len(signalIntent) == 0 {
+		signalIntent = signalIntentFromExecutionProposalMap(proposalMap)
+	}
+	positionSnapshot := cloneMetadata(mapValue(state["recoveredPosition"]))
+	if len(positionSnapshot) == 0 {
+		positionSnapshot = cloneMetadata(mapValue(state["livePositionState"]))
+	}
+
+	return domain.StrategyDecisionEvent{
+		LiveSessionID:     session.ID,
+		RuntimeSessionID:  firstNonEmpty(stringValue(metadata["runtimeSessionId"]), stringValue(state["signalRuntimeSessionId"]), stringValue(state["lastSignalRuntimeSessionId"])),
+		AccountID:         session.AccountID,
+		StrategyID:        session.StrategyID,
+		StrategyVersionID: strategyVersionID,
+		Symbol: firstNonEmpty(
+			NormalizeSymbol(stringValue(proposalMap["symbol"])),
+			NormalizeSymbol(stringValue(evaluationContext["symbol"])),
+			NormalizeSymbol(stringValue(state["symbol"])),
+		),
+		TriggerType:       firstNonEmpty(stringValue(triggerSummary["event"]), trigger, "dispatch-preflight"),
+		Action:            firstNonEmpty(stringValue(proposalMap["action"]), stringValue(lastDecision["action"]), "dispatch"),
+		Reason:            firstNonEmpty(stringValue(proposalMap["reason"]), stringValue(lastDecision["reason"]), "dispatchable-intent"),
+		SignalKind:        firstNonEmpty(stringValue(proposalMap["signalKind"]), stringValue(metadata["signalKind"]), stringValue(decisionMetadata["signalKind"])),
+		DecisionState:     firstNonEmpty(stringValue(proposalMap["decisionState"]), stringValue(metadata["decisionState"]), stringValue(decisionMetadata["decisionState"])),
+		IntentSignature:   buildLiveIntentSignature(proposalMap),
+		SourceGateReady:   boolValue(sourceGate["ready"]),
+		MissingCount:      len(metadataList(sourceGate["missing"])),
+		StaleCount:        len(metadataList(sourceGate["stale"])),
+		EventTime:         eventTime.UTC(),
+		TriggerSummary:    triggerSummary,
+		SourceGate:        sourceGate,
+		SourceStates:      cloneMetadata(mapValue(state["lastStrategyEvaluationSourceStates"])),
+		SignalBarStates:   cloneMetadata(mapValue(state["lastStrategyEvaluationSignalBarStates"])),
+		PositionSnapshot:  positionSnapshot,
+		DecisionMetadata:  decisionMetadata,
+		SignalIntent:      signalIntent,
+		ExecutionProposal: cloneMetadata(proposalMap),
+		EvaluationContext: evaluationContext,
+	}
+}
+
+func (p *Platform) strategyDecisionEventExists(liveSessionID, decisionEventID string) (bool, error) {
+	decisionEventID = strings.TrimSpace(decisionEventID)
+	if decisionEventID == "" {
+		return false, nil
+	}
+	if reader, ok := p.store.(strategyDecisionEventQueryReader); ok {
+		items, err := reader.QueryStrategyDecisionEvents(domain.StrategyDecisionEventQuery{
+			LiveSessionID:   strings.TrimSpace(liveSessionID),
+			DecisionEventID: decisionEventID,
+			Limit:           1,
+		})
+		if err != nil {
+			return false, err
+		}
+		return len(items) > 0, nil
+	}
+	items, err := p.store.ListStrategyDecisionEvents(strings.TrimSpace(liveSessionID))
+	if err != nil {
+		return false, err
+	}
+	for _, item := range items {
+		if strings.TrimSpace(item.ID) != decisionEventID {
+			continue
+		}
+		if strings.TrimSpace(liveSessionID) == "" || strings.TrimSpace(item.LiveSessionID) == strings.TrimSpace(liveSessionID) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func setExecutionProposalDecisionEventID(proposalMap map[string]any, decisionEventID string) map[string]any {
+	normalized := cloneMetadata(proposalMap)
+	if len(normalized) == 0 || strings.TrimSpace(decisionEventID) == "" {
+		return normalized
+	}
+	metadata := cloneMetadata(mapValue(normalized["metadata"]))
+	if metadata == nil {
+		metadata = map[string]any{}
+	}
+	normalized["decisionEventId"] = decisionEventID
+	metadata["decisionEventId"] = decisionEventID
+	normalized["metadata"] = metadata
+	return normalized
+}
+
+func signalIntentFromExecutionProposalMap(proposalMap map[string]any) map[string]any {
+	return map[string]any{
+		"action":         stringValue(proposalMap["action"]),
+		"role":           stringValue(proposalMap["role"]),
+		"reason":         stringValue(proposalMap["reason"]),
+		"side":           stringValue(proposalMap["side"]),
+		"symbol":         NormalizeSymbol(stringValue(proposalMap["symbol"])),
+		"signalKind":     stringValue(proposalMap["signalKind"]),
+		"decisionState":  stringValue(proposalMap["decisionState"]),
+		"plannedEventAt": stringValue(proposalMap["plannedEventAt"]),
+		"plannedPrice":   parseFloatValue(proposalMap["plannedPrice"]),
+		"priceHint":      parseFloatValue(proposalMap["priceHint"]),
+		"priceSource":    stringValue(proposalMap["priceSource"]),
+		"quantity":       parseFloatValue(proposalMap["quantity"]),
+		"metadata":       cloneMetadata(mapValue(proposalMap["metadata"])),
+	}
+}
+
+func liveOrderActionFromOrder(order domain.Order) string {
+	if order.EffectiveReduceOnly() || order.EffectiveClosePosition() {
+		return "exit"
+	}
+	return "entry"
+}
+
+func liveOrderRoleFromOrder(order domain.Order) string {
+	if order.EffectiveReduceOnly() || order.EffectiveClosePosition() {
+		return "exit"
+	}
+	return "entry"
+}
+
+func orderExecutionDecisionBackfillTrigger(eventType string) string {
+	eventType = strings.TrimSpace(eventType)
+	if eventType == "" {
+		return "order-execution"
+	}
+	return "order-execution-" + eventType
+}
+
+func newStrategyDecisionEventID() string {
+	return fmt.Sprintf("strategy-decision-event-%d", time.Now().UTC().UnixNano())
+}
+
 func (p *Platform) recordLiveOrderExecutionEvent(order domain.Order, eventType string, eventTime time.Time, failed bool, eventErr error) error {
 	if !stringsEqualFoldSafe(stringValue(order.Metadata["executionMode"]), "live") && !stringsEqualFoldSafe(stringValue(order.Metadata["source"]), "live-session-intent") {
 		return nil
@@ -93,6 +354,10 @@ func (p *Platform) recordLiveOrderExecutionEvent(order domain.Order, eventType s
 			order.CreatedAt,
 			time.Now().UTC(),
 		)
+	}
+
+	if err := p.ensureStrategyDecisionEventForOrderExecution(order, proposalMap, eventTime, eventType); err != nil {
+		return err
 	}
 
 	event := domain.OrderExecutionEvent{


### PR DESCRIPTION
## 目的
补齐 `zero_initial_mode=reentry_window` 在 live 链路里的四个缺口：

- 可观测性：`pendingZeroInitialWindow` 第一次 armed 时写入明确 timeline，后续可以直接按 `zero-initial-window-armed` / `pendingZeroInitialWindow` 回溯。
- 执行语义：`pendingZeroInitialWindow` 在确认已有真实持仓后被消费，并且不能覆盖明确的 `SL-Reentry` / `PT-Reentry` entry 计划，避免 SL 平仓后下一笔重新开仓仍被标成 `Zero-Initial-Reentry`。
- 审计完整性：live order metadata / order execution event 里的 `decisionEventId` 必须能在 `strategy_decision_events.id` 反查到；若最终建单前发现引用缺失，会用同一个 ID 回填一条 backfilled strategy decision event。
- DB 持仓一致性：当交易所/适配器同步结果已经是 `FILLED`，但没有返回 trade-level fills 明细时，仍要在服务层生成可去重的 settlement fill，调用原有 `finalizeExecutedOrder` 冲减 `positions`，避免已平仓 exit 单不落账导致下一笔 entry 把 DB short 叠加成 0.004。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [x] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？无
- [x] DB migration 是否具备向下兼容幂等性？无 DB migration
- [x] 配置字段有没有无意被混改？无配置变更

## Root cause
`pendingZeroInitialWindow` 的原始设计是当前 signal bar + 下一根 signal bar 有效；research 与 Go replay 都是在该窗口真实 entry 后清掉窗口。

live 链路缺少对应消费点：如果第一笔 zero-initial reentry 已经真实成仓，之后又被 SL 平掉，旧的 `pendingZeroInitialWindow` 仍可能残留在 session state 里，并在下一次 plan evaluation 时覆盖明确的 `SL-Reentry` / `PT-Reentry` 计划，导致第三笔重新开仓仍被标记为 `Zero-Initial-Reentry`。

同时，最终建单边界过去只信任 cached proposal 中携带的 `decisionEventId`。如果该 proposal 是人工/延迟 dispatch、历史缓存、或先前 telemetry 写入没有形成可查记录，order metadata 仍可能引用一个不存在的 `strategy_decision_events.id`，导致订单 -> 决策审计链断裂。

这次用户反馈的 `positions` DB 数量错误根因不是 UI：`applyLiveSyncResult` 过去只有 `len(syncResult.Fills) > 0` 才进入 settlement。若第二笔 reduce-only BUY 已被同步为 `FILLED`，但同步结果没有 fills 明细，本地只会更新订单状态，不会创建 fill，也不会调用 `applyExecutionFill` 删除第一笔 short。第三笔 SELL 再落账时，DB 中 stale short 0.002 会被加到新 short 0.002 上，最终显示 0.004 short。

## 改动说明
- `pendingZeroInitialWindow` 第一次写入 session state 时追加 `strategy` timeline 事件 `zero-initial-window-armed`，metadata 含 `pendingZeroInitialWindow` 快照、side、symbol、signalTimeframe 和 `Zero-Initial-Reentry` reason。
- 新增统一消费 helper，消费时写 `zero-initial-window-consumed` timeline，metadata 含被消费的 pending window 快照与消费原因。
- 在 live position context 确认存在真实持仓时消费 pending window，原因标记为 `real-position-confirmed`。
- 当下一步计划已经是明确的 `SL-Reentry` / `PT-Reentry` entry 时，优先保留该计划并消费旧 pending window，原因标记为 `exit-reentry-priority`。
- 在 `dispatchLiveSessionIntent` 最终建单前校验 proposal 的 `decisionEventId` 是否已存在；不存在则用同一个 ID 回填 `strategy_decision_events`，并把 top-level / metadata / session `lastStrategyDecisionEventId` 对齐。
- 在 `recordLiveOrderExecutionEvent` 落执行事件前也做同样兜底，保证已有坏订单后续 sync/fill 时可以补齐审计行。
- `buildLiveSyncSettlement` 现在会为 `FILLED` 但无 fills 的 sync result 生成稳定去重的 fallback settlement fill，来源标记为 `terminal-filled-order-fallback` / `syntheticFill=true`。
- `finalizeExecutedOrder` 增加 remaining quantity 上限，防止 fallback settlement 后迟到的真实 trade 明细再次把同一笔订单累计进 DB position。
- 不改变窗口生命周期设计：仍然是当前 signal bar + 下一根 signal bar；只是补上“真实 entry 后必须消费”的 live 侧行为。

## 行为变化
- 第一笔真实 zero-initial reentry 成仓后，pending window 会在后续真实持仓确认路径被清理。
- SL/PT 平仓后的下一笔 reentry 不再被旧 zero-initial pending window 抢占；如果计划本身是 `SL-Reentry`，metadata 将保留 `SL-Reentry`。
- 如果 pending window 只是 armed 后等待下一根 signal bar，且还没有真实 entry，仍可按原设计延续到下一根 bar。
- 新建 live order 不再允许携带一个反查不到的 `decisionEventId`；缺失审计行会被标记为 `decisionEventBackfilled=true` 并补齐。
- 若 order execution telemetry 遇到历史缺失引用，会尝试按同一个 ID 补齐 strategy decision event 后再落执行事件。
- FILLED exit 单即使没有 fills 明细，也会在 DB 中形成 settlement fill 并冲减/删除本地 position；三笔 `SELL 0.002 -> BUY 0.002 -> SELL 0.002` 后，本地最终应只剩 `SHORT 0.002`。

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

已验证：
- `/usr/local/go/bin/go test ./internal/service -run 'TestFilledExitWithoutFillReportsDoesNotLeaveStaleShortPosition|TestFinalizeExecutedOrderSkipsDuplicateExchangeTradeIDFills|TestFinalizeExecutedOrderSkipsDuplicateFallbackFillsWithoutExchangeTradeID'`
- `/usr/local/go/bin/go test ./internal/service -run 'TestDispatchLiveSessionIntentBackfillsMissingDecisionEventReference|TestEvaluateLiveSessionOnSignalPersistsStrategyDecisionEvent|TestApplyLiveSubmissionResultPersistsOrderExecutionEvent'`
- `/usr/local/go/bin/go test ./internal/service -run 'TestPrepareLivePlanStepForSignalEvaluation|TestRefreshLiveSessionPositionContextRebuildsLivePositionState'`
- `/usr/local/go/bin/go test ./internal/service`
- `/usr/local/go/bin/go test ./...`
- `/usr/local/go/bin/go build ./cmd/platform-api`
- `/usr/local/go/bin/go build ./cmd/db-migrate`