### PR TITLE
[codex] fix immediate filled settlement idempotency

### DIFF
--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -1845,6 +1845,10 @@ func (p *Platform) reconcileLiveAccountPositions(account domain.Account, exchang
 		}
 		existingBySymbol[NormalizeSymbol(position.Symbol)] = position
 	}
+	pendingSettlementSymbols, err := p.liveSettlementPendingOrderSymbols(account.ID)
+	if err != nil {
+		return nil, err
+	}
 
 	syncedAt := time.Now().UTC()
 	symbols := make(map[string]any)
@@ -1899,6 +1903,16 @@ func (p *Platform) reconcileLiveAccountPositions(account domain.Account, exchang
 			"quantity":   quantity,
 			"entryPrice": entryPrice,
 			"markPrice":  markPrice,
+		}
+		if _, pending := pendingSettlementSymbols[symbol]; pending {
+			recordGate(symbol, map[string]any{
+				"status":           livePositionReconcileGateStatusStale,
+				"scenario":         "order-settlement-pending",
+				"blocking":         true,
+				"dbPosition":       buildRecoveredLivePositionStateSnapshot(position),
+				"exchangePosition": exchangeSnapshot,
+			})
+			continue
 		}
 		if position.ID == "" || position.Quantity <= 0 {
 			position.AccountID = account.ID
@@ -2001,6 +2015,23 @@ func (p *Platform) reconcileLiveAccountPositions(account domain.Account, exchang
 		"blockingSymbolCount": blockingCount,
 		"symbols":             symbols,
 	}, nil
+}
+
+func (p *Platform) liveSettlementPendingOrderSymbols(accountID string) (map[string]struct{}, error) {
+	orders, err := p.store.ListOrders()
+	if err != nil {
+		return nil, err
+	}
+	symbols := make(map[string]struct{})
+	for _, order := range orders {
+		if order.AccountID != accountID || !liveOrderSettlementSyncPending(order) {
+			continue
+		}
+		if symbol := NormalizeSymbol(order.Symbol); symbol != "" {
+			symbols[symbol] = struct{}{}
+		}
+	}
+	return symbols, nil
 }
 
 func resolveRecoveredLiveEntryPrice(primary, secondary, fallback float64) float64 {

--- a/internal/service/live_execution.go
+++ b/internal/service/live_execution.go
@@ -501,13 +501,14 @@ func (p *Platform) dispatchLiveSessionIntent(session domain.LiveSession) (domain
 		delete(state, "lastAutoDispatchError")
 	}
 	appendTimelineEvent(state, "order", dispatchedAt, "live-intent-dispatched", executionDispatchTimelineMetadata(proposalMap, created, createErr != nil))
-	if strings.EqualFold(created.Status, "FILLED") {
+	settlementPending := liveOrderSettlementSyncPending(created)
+	if strings.EqualFold(created.Status, "FILLED") && !settlementPending {
 		if _, syncErr := p.SyncLiveAccount(session.AccountID); syncErr != nil {
 			state["lastSyncError"] = syncErr.Error()
 		}
 	}
 	updatedSession, _ := p.store.UpdateLiveSessionState(session.ID, state)
-	if strings.EqualFold(created.Status, "FILLED") && updatedSession.ID != "" {
+	if strings.EqualFold(created.Status, "FILLED") && !settlementPending && updatedSession.ID != "" {
 		if refreshed, refreshErr := p.refreshLiveSessionPositionContext(updatedSession, dispatchedAt, "live-order-fill-sync"); refreshErr == nil {
 			updatedSession = refreshed
 		}

--- a/internal/service/live_reconcile_test.go
+++ b/internal/service/live_reconcile_test.go
@@ -144,6 +144,149 @@ func TestReconcileLiveAccountRecoversMissingFilledOrder(t *testing.T) {
 	}
 }
 
+func TestReconcileLiveAccountDefersPositionAdoptForPendingImmediateFilledSettlement(t *testing.T) {
+	store := memory.NewStore()
+	platform := NewPlatform(store)
+	syncedAt := time.Date(2026, 4, 21, 6, 30, 0, 0, time.UTC)
+	platform.registerLiveAdapter(testLiveAccountReconcileAdapter{
+		key: "test-pending-immediate-filled",
+		syncSnapshotFunc: func(p *Platform, account domain.Account, binding map[string]any) (domain.Account, error) {
+			account.Metadata = cloneMetadata(account.Metadata)
+			account.Metadata["liveSyncSnapshot"] = map[string]any{
+				"source":   "test-pending-immediate-filled",
+				"syncedAt": syncedAt.Format(time.RFC3339),
+				"positions": []map[string]any{{
+					"symbol":         "BTCUSDT",
+					"positionAmt":    0.002,
+					"entryPrice":     75600.0,
+					"breakEvenPrice": 75600.0,
+					"markPrice":      75620.0,
+				}},
+				"openOrders":    []map[string]any{},
+				"bindingMode":   stringValue(binding["connectionMode"]),
+				"executionMode": stringValue(binding["executionMode"]),
+			}
+			account.Metadata["lastLiveSyncAt"] = syncedAt.Format(time.RFC3339)
+			updated, err := p.store.UpdateAccount(account)
+			if err != nil {
+				return domain.Account{}, err
+			}
+			return p.refreshLiveAccountPositionReconcileGate(updated)
+		},
+	})
+
+	account, err := platform.BindLiveAccount("live-main", map[string]any{
+		"adapterKey":     "test-pending-immediate-filled",
+		"connectionMode": "rest",
+		"executionMode":  "rest",
+	})
+	if err != nil {
+		t.Fatalf("bind live account failed: %v", err)
+	}
+	order, err := store.CreateOrder(domain.Order{
+		AccountID:         account.ID,
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "BUY",
+		Type:              "MARKET",
+		Quantity:          0.002,
+		Price:             75600.0,
+		Status:            "FILLED",
+		Metadata: map[string]any{
+			"exchangeOrderId":             "13056935018",
+			liveSettlementSyncErrorKey:    "live order order-1 submitted as FILLED but settlement sync failed: Order does not exist",
+			liveSettlementSyncRequiredKey: true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("create pending immediate filled order failed: %v", err)
+	}
+	order.Status = "FILLED"
+	if order, err = store.UpdateOrder(order); err != nil {
+		t.Fatalf("mark pending immediate filled order failed: %v", err)
+	}
+
+	syncedAccount, err := platform.SyncLiveAccount(account.ID)
+	if err != nil {
+		t.Fatalf("sync live account failed: %v", err)
+	}
+	if position, found, err := store.FindPosition(account.ID, "BTCUSDT"); err != nil {
+		t.Fatalf("find position failed: %v", err)
+	} else if found {
+		t.Fatalf("expected pending order settlement to block reconcile position adopt, got %+v", position)
+	}
+	gate := resolveLivePositionReconcileGate(syncedAccount, "BTCUSDT", true)
+	if got := stringValue(gate["status"]); got != livePositionReconcileGateStatusStale {
+		t.Fatalf("expected stale gate while settlement pending, got %s", got)
+	}
+	if got := stringValue(gate["scenario"]); got != "order-settlement-pending" {
+		t.Fatalf("expected order-settlement-pending scenario, got %s", got)
+	}
+	if !boolValue(gate["blocking"]) {
+		t.Fatal("expected pending settlement gate to block")
+	}
+
+	settledOrder, err := platform.applyLiveSyncResult(account, order, LiveOrderSync{
+		Status:   "FILLED",
+		SyncedAt: syncedAt.Add(time.Second).Format(time.RFC3339),
+		Fills: []LiveFillReport{{
+			Price:    75600.0,
+			Quantity: 0.002,
+			Fee:      0.04,
+			Metadata: map[string]any{
+				"exchangeOrderId": "13056935018",
+				"tradeId":         "trade-13056935018",
+				"tradeTime":       syncedAt.Add(time.Second).Format(time.RFC3339),
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("settle pending immediate filled order failed: %v", err)
+	}
+	if boolValue(settledOrder.Metadata[liveSettlementSyncRequiredKey]) {
+		t.Fatal("expected settlement marker to clear after order fill settlement")
+	}
+	position, found, err := store.FindPosition(account.ID, "BTCUSDT")
+	if err != nil {
+		t.Fatalf("find position after settlement failed: %v", err)
+	}
+	if !found {
+		t.Fatal("expected order settlement to create position")
+	}
+	if position.Quantity != 0.002 {
+		t.Fatalf("expected order settlement position quantity 0.002, got %v", position.Quantity)
+	}
+
+	account, err = store.GetAccount(account.ID)
+	if err != nil {
+		t.Fatalf("reload account failed: %v", err)
+	}
+	account, err = platform.refreshLiveAccountPositionReconcileGate(account)
+	if err != nil {
+		t.Fatalf("refresh position reconcile gate after settlement failed: %v", err)
+	}
+	gate = resolveLivePositionReconcileGate(account, "BTCUSDT", true)
+	if got := stringValue(gate["status"]); got != livePositionReconcileGateStatusVerified {
+		t.Fatalf("expected reconcile gate to verify after settlement, got %s", got)
+	}
+	if got := stringValue(gate["scenario"]); got != "db-position-matches-exchange" {
+		t.Fatalf("expected reconcile gate to clear pending scenario after settlement, got %s", got)
+	}
+	if boolValue(gate["blocking"]) {
+		t.Fatal("expected reconcile gate to unblock after settlement")
+	}
+	position, found, err = store.FindPosition(account.ID, "BTCUSDT")
+	if err != nil {
+		t.Fatalf("find position after reconcile verify failed: %v", err)
+	}
+	if !found {
+		t.Fatal("expected reconciled position to remain")
+	}
+	if position.Quantity != 0.002 {
+		t.Fatalf("expected reconcile verify not to double position quantity, got %v", position.Quantity)
+	}
+}
+
 func TestReconcileLiveAccountRefreshClearsStaleRecoveryCache(t *testing.T) {
 	store := memory.NewStore()
 	platform := NewPlatform(store)

--- a/internal/service/order.go
+++ b/internal/service/order.go
@@ -579,8 +579,24 @@ func (p *Platform) applyLiveSubmissionResult(
 func markLiveSettlementSyncRetry(order domain.Order, err error) domain.Order {
 	order.Metadata = cloneMetadata(order.Metadata)
 	order.Metadata[liveSettlementSyncErrorKey] = err.Error()
-	order.Metadata[liveSettlementSyncRequiredKey] = true
+	if liveOrderFillSettlementComplete(order) {
+		delete(order.Metadata, liveSettlementSyncRequiredKey)
+	} else {
+		order.Metadata[liveSettlementSyncRequiredKey] = true
+	}
 	return order
+}
+
+func liveOrderSettlementSyncPending(order domain.Order) bool {
+	return boolValue(order.Metadata[liveSettlementSyncRequiredKey]) &&
+		!liveOrderFillSettlementComplete(order)
+}
+
+func liveOrderFillSettlementComplete(order domain.Order) bool {
+	if order.Quantity <= 0 {
+		return false
+	}
+	return parseFloatValue(order.Metadata["filledQuantity"]) >= order.Quantity-1e-9
 }
 
 func (p *Platform) settleImmediatelyFilledLiveOrder(order domain.Order) (domain.Order, error) {
@@ -959,6 +975,8 @@ func (p *Platform) finalizeExecutedOrder(account domain.Account, order domain.Or
 	orderCompletelyFilled := filledQuantity >= order.Quantity-1e-9
 	if orderCompletelyFilled {
 		order.Status = "FILLED"
+		delete(order.Metadata, liveSettlementSyncRequiredKey)
+		delete(order.Metadata, liveSettlementSyncErrorKey)
 	} else if filledQuantity > 0 {
 		order.Status = "PARTIALLY_FILLED"
 	}

--- a/internal/service/order_test.go
+++ b/internal/service/order_test.go
@@ -1070,11 +1070,75 @@ func TestImmediateFilledLiveOrderRepeatedSyncKeepsRetryMarkerAndFillDedupeStable
 	if fillCount != 1 {
 		t.Fatalf("expected repeated sync to keep one fill, got %d", fillCount)
 	}
-	if got := stringValue(syncedOrder.Metadata[liveSettlementSyncErrorKey]); got != "previous refresh failure" {
-		t.Fatalf("expected retry marker error to remain stable, got %q", got)
+	if got := stringValue(syncedOrder.Metadata[liveSettlementSyncErrorKey]); got != "" {
+		t.Fatalf("expected retry marker error to clear after settlement, got %q", got)
 	}
-	if !boolValue(syncedOrder.Metadata[liveSettlementSyncRequiredKey]) {
-		t.Fatal("expected retry marker to remain stable across repeated sync")
+	if boolValue(syncedOrder.Metadata[liveSettlementSyncRequiredKey]) {
+		t.Fatal("expected retry marker to clear after settlement")
+	}
+}
+
+func TestImmediateFilledLiveOrderPartialSettlementKeepsRetryMarker(t *testing.T) {
+	store := memory.NewStore()
+	platform := NewPlatform(store)
+	platform.registerLiveAdapter(&recordingLiveExecutionAdapter{key: "test-partial-settlement"})
+	account, err := platform.BindLiveAccount("live-main", map[string]any{
+		"adapterKey": "test-partial-settlement",
+	})
+	if err != nil {
+		t.Fatalf("bind live account failed: %v", err)
+	}
+	order, err := store.CreateOrder(domain.Order{
+		AccountID:         account.ID,
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "BUY",
+		Type:              "MARKET",
+		Quantity:          0.004,
+		Price:             75600,
+		Status:            "FILLED",
+		Metadata: map[string]any{
+			"exchangeOrderId":             "exchange-order-partial",
+			liveSettlementSyncErrorKey:    "previous immediate settlement failure",
+			liveSettlementSyncRequiredKey: true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("create order failed: %v", err)
+	}
+	order.Status = "FILLED"
+	if order, err = store.UpdateOrder(order); err != nil {
+		t.Fatalf("mark order filled failed: %v", err)
+	}
+
+	settled, err := platform.applyLiveSyncResult(account, order, LiveOrderSync{
+		Status:   "FILLED",
+		SyncedAt: "2026-04-21T06:35:00Z",
+		Fills: []LiveFillReport{{
+			Price:    75600,
+			Quantity: 0.002,
+			Fee:      0.04,
+			Metadata: map[string]any{
+				"exchangeOrderId": "exchange-order-partial",
+				"tradeId":         "trade-partial-1",
+				"tradeTime":       "2026-04-21T06:35:00Z",
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("partial settlement failed: %v", err)
+	}
+	if got := settled.Status; got != "PARTIALLY_FILLED" {
+		t.Fatalf("expected partial settlement status PARTIALLY_FILLED, got %s", got)
+	}
+	if !boolValue(settled.Metadata[liveSettlementSyncRequiredKey]) {
+		t.Fatal("expected partial settlement to keep retry marker")
+	}
+	if got := stringValue(settled.Metadata[liveSettlementSyncErrorKey]); got == "" {
+		t.Fatal("expected partial settlement to keep retry error")
+	}
+	if !liveOrderSettlementSyncPending(settled) {
+		t.Fatal("expected partial settlement to remain pending")
 	}
 }
 


### PR DESCRIPTION
## 目的
修复 live 订单在提交即 `FILLED`、但 immediate settlement sync 首次失败时，账户级 position reconcile 和后续订单级 fill settlement 可能对同一笔成交重复产生仓位副作用的问题。

Root cause: `CreateOrder` 收到交易所 `FILLED` 后会立即 `SyncLiveOrder`；如果该 immediate sync 失败，订单会带 `immediateFillSyncRequired` 返回。但 live session 仍按普通 `FILLED` 路径继续 `SyncLiveAccount` / position refresh，账户级 reconcile 可能先 adopt 交易所仓位。之后正常 `SyncLiveOrder -> finalizeExecutedOrder -> applyExecutionFill` 又会按同一笔 fill 修改本地 position，造成 1 笔订单/1 笔 fill 下本地仓位翻倍。

本次改动：
- 将 `immediateFillSyncRequired` 收敛为“订单 fill settlement 尚未完成”的显式 pending 状态。
- `finalizeExecutedOrder` 在订单成交数量完整落账后清理 immediate settlement retry marker。
- live session dispatch 遇到 pending immediate-FILLED 订单时，不再提前触发账户级 `SyncLiveAccount` 和 position refresh。
- 账户级 position reconcile 遇到同账户同 symbol 的 pending settlement 订单时，记录 `order-settlement-pending` stale/blocking gate，不直接 adopt exchange position。
- 增加回归测试覆盖 pending immediate-FILLED settlement 下账户 reconcile 不先写 position，后续订单级 settlement 只写一次仓位。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [x] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) - 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？- 无
- [x] DB migration 是否具备向下兼容幂等性？- 无 DB migration
- [x] 配置字段有没有无意被混改？- 无配置字段改动

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

本地验证：
- `go test ./internal/service -run 'TestImmediateFilledLiveOrderRepeatedSyncKeepsRetryMarkerAndFillDedupeStable|TestReconcileLiveAccountDefersPositionAdoptForPendingImmediateFilledSettlement|TestCreateLiveOrderImmediateFilledSubmissionSettlesReduceOnlyExit|TestClosePositionImmediatelySettlesFilledLiveManualClose'`
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
- pre-push hook rebuilt graphify successfully
