### PR TITLE
[codex] align live signal trace and BTC baseline stop loss

### DIFF
--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -2227,6 +2227,16 @@ func (p *Platform) evaluateLiveSessionOnSignal(session domain.LiveSession, runti
 		"reason":   decision.Reason,
 		"metadata": cloneMetadata(decision.Metadata),
 	}
+	if signalBarDecision := cloneMetadata(mapValue(decision.Metadata["signalBarDecision"])); len(signalBarDecision) > 0 {
+		state["lastStrategyEvaluationSignalBarDecision"] = signalBarDecision
+	} else {
+		delete(state, "lastStrategyEvaluationSignalBarDecision")
+	}
+	if signalBarStateKey := stringValue(decision.Metadata["signalBarStateKey"]); signalBarStateKey != "" {
+		state["lastStrategyEvaluationSignalBarStateKey"] = signalBarStateKey
+	} else {
+		delete(state, "lastStrategyEvaluationSignalBarStateKey")
+	}
 	recordStrategyDecisionHealth(state, decision, eventTime)
 	if livePositionState := cloneMetadata(mapValue(decision.Metadata["livePositionState"])); len(livePositionState) > 0 {
 		state["lastLivePositionState"] = livePositionState

--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -2237,6 +2237,7 @@ func (p *Platform) evaluateLiveSessionOnSignal(session domain.LiveSession, runti
 	} else {
 		delete(state, "lastStrategyEvaluationSignalBarStateKey")
 	}
+	recordLatestBreakoutSignal(state, decision, eventTime)
 	recordStrategyDecisionHealth(state, decision, eventTime)
 	if livePositionState := cloneMetadata(mapValue(decision.Metadata["livePositionState"])); len(livePositionState) > 0 {
 		state["lastLivePositionState"] = livePositionState
@@ -3636,6 +3637,77 @@ func deriveLiveSignalIntent(decision StrategySignalDecision, symbol string) *Sig
 			"bookImbalance":     parseFloatValue(meta["bookImbalance"]),
 		},
 	}
+}
+
+func recordLatestBreakoutSignal(state map[string]any, decision StrategySignalDecision, eventTime time.Time) {
+	if state == nil {
+		return
+	}
+	breakout := deriveBreakoutSignalSnapshot(decision, eventTime)
+	if len(breakout) == 0 {
+		return
+	}
+	state["lastBreakoutSignal"] = breakout
+	history := metadataList(state["breakoutHistory"])
+	signature := stringValue(breakout["signature"])
+	if len(history) > 0 {
+		last := mapValue(history[len(history)-1])
+		if stringValue(last["signature"]) == signature {
+			state["breakoutHistory"] = history
+			return
+		}
+	}
+	history = append(history, breakout)
+	if len(history) > 24 {
+		history = history[len(history)-24:]
+	}
+	state["breakoutHistory"] = history
+}
+
+func deriveBreakoutSignalSnapshot(decision StrategySignalDecision, eventTime time.Time) map[string]any {
+	meta := cloneMetadata(decision.Metadata)
+	signalBarDecision := mapValue(meta["signalBarDecision"])
+	if len(signalBarDecision) == 0 {
+		return nil
+	}
+	current := mapValue(signalBarDecision["current"])
+	prevBar2 := mapValue(signalBarDecision["prevBar2"])
+	side := ""
+	level := 0.0
+	switch {
+	case boolValue(signalBarDecision["longBreakoutPatternReady"]):
+		side = "BUY"
+		level = parseFloatValue(prevBar2["high"])
+	case boolValue(signalBarDecision["shortBreakoutPatternReady"]):
+		side = "SELL"
+		level = parseFloatValue(prevBar2["low"])
+	default:
+		return nil
+	}
+	if level <= 0 {
+		return nil
+	}
+	barTime := resolveBreakoutSignalTime(current["barStart"], eventTime)
+	return map[string]any{
+		"signature":         fmt.Sprintf("%s|%s|%.8f", side, barTime.Format(time.RFC3339), level),
+		"side":              side,
+		"level":             level,
+		"barTime":           barTime.Format(time.RFC3339),
+		"close":             parseFloatValue(current["close"]),
+		"timeframe":         stringValue(signalBarDecision["timeframe"]),
+		"signalBarStateKey": stringValue(meta["signalBarStateKey"]),
+		"source":            "signal-breakout-pattern",
+	}
+}
+
+func resolveBreakoutSignalTime(raw any, fallback time.Time) time.Time {
+	if numeric, ok := toFloat64(raw); ok && numeric > 0 {
+		return time.UnixMilli(int64(numeric)).UTC()
+	}
+	if parsed := parseOptionalRFC3339(stringValue(raw)); !parsed.IsZero() {
+		return parsed.UTC()
+	}
+	return fallback.UTC()
 }
 
 func (p *Platform) buildLiveExecutionProposal(session domain.LiveSession, executionContext StrategyExecutionContext, summary map[string]any, sourceStates map[string]any, eventTime time.Time, intent SignalIntent) (ExecutionProposal, error) {

--- a/internal/service/live_launch_templates.go
+++ b/internal/service/live_launch_templates.go
@@ -120,7 +120,7 @@ func (p *Platform) LiveLaunchTemplates() ([]LiveLaunchTemplate, error) {
 			liveOverrides["dir2_zero_initial"] = true
 			liveOverrides["zero_initial_mode"] = "reentry_window"
 			liveOverrides["stop_mode"] = "atr"
-			liveOverrides["stop_loss_atr"] = 0.05
+			liveOverrides["stop_loss_atr"] = 0.3
 			liveOverrides["profit_protect_atr"] = 1.0
 			liveOverrides["trailing_stop_atr"] = 0.3
 			liveOverrides["delayed_trailing_activation_atr"] = 0.5
@@ -130,7 +130,7 @@ func (p *Platform) LiveLaunchTemplates() ([]LiveLaunchTemplate, error) {
 			liveOverrides["reentry_size_schedule"] = []float64{0.20, 0.10}
 			baselineNotes = append(baselineNotes,
 				"该模板已显式固化 intraday research baseline：dir2 zero initial + reentry_window + reentry_size_schedule=[0.20, 0.10] + max_trades_per_bar=2。",
-				"非 1d 周期默认使用 canonical SMA5 hard filter；移动止损与利润保护参数分别固定为 trailing_stop_atr=0.3、profit_protect_atr=1.0、delayed_trailing_activation_atr=0.5。",
+				"非 1d 周期默认使用 canonical SMA5 hard filter；止损与移动止损参数分别固定为 stop_loss_atr=0.3、trailing_stop_atr=0.3、profit_protect_atr=1.0、delayed_trailing_activation_atr=0.5。",
 				"当前 research baseline 只提升 BTCUSDT 15m/30m；BTCUSDT 5m 暂保留为通用模板，因为现阶段 5m 对执行摩擦更敏感，尚不作为默认 intraday baseline 候选。",
 			)
 		}

--- a/internal/service/live_launch_templates_test.go
+++ b/internal/service/live_launch_templates_test.go
@@ -108,8 +108,8 @@ func TestLiveLaunchTemplatesExposeEightBinanceTestnetVariants(t *testing.T) {
 			if got := stringValue(item.LaunchPayload.LiveSessionOverrides["stop_mode"]); got != "atr" {
 				t.Fatalf("expected stop_mode=atr for %s, got %s", item.Key, got)
 			}
-			if got := parseFloatValue(item.LaunchPayload.LiveSessionOverrides["stop_loss_atr"]); got != 0.05 {
-				t.Fatalf("expected stop_loss_atr=0.05 for %s, got %v", item.Key, got)
+			if got := parseFloatValue(item.LaunchPayload.LiveSessionOverrides["stop_loss_atr"]); got != 0.3 {
+				t.Fatalf("expected stop_loss_atr=0.3 for %s, got %v", item.Key, got)
 			}
 			if got := parseFloatValue(item.LaunchPayload.LiveSessionOverrides["profit_protect_atr"]); got != 1.0 {
 				t.Fatalf("expected profit_protect_atr=1.0 for %s, got %v", item.Key, got)

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -110,6 +110,32 @@ func TestEvaluateSignalBarGateAllowsLongAfterBreakoutAlignmentWithResearch(t *te
 	}
 }
 
+func TestEvaluateSignalBarGateTracksClosedBarBreakoutPattern(t *testing.T) {
+	gate := evaluateSignalBarGate(map[string]any{
+		"ma20":  68000.0,
+		"atr14": 900.0,
+		"current": map[string]any{
+			"close": 69010.0,
+			"high":  69030.0,
+			"low":   67800.0,
+		},
+		"prevBar1": map[string]any{
+			"high": 68850.0,
+			"low":  67750.0,
+		},
+		"prevBar2": map[string]any{
+			"high": 69000.0,
+			"low":  67600.0,
+		},
+	}, "BUY", "entry", "")
+	if !boolValue(gate["longBreakoutPatternReady"]) {
+		t.Fatalf("expected close-based long breakout pattern, got %#v", gate)
+	}
+	if boolValue(gate["shortBreakoutPatternReady"]) {
+		t.Fatalf("expected short breakout pattern to stay false, got %#v", gate)
+	}
+}
+
 func TestEvaluateSignalBarGateDoesNotRequireOppositeBreakoutForExit(t *testing.T) {
 	gate := evaluateSignalBarGate(map[string]any{
 		"ma20":  68000.0,

--- a/internal/service/strategy_registry.go
+++ b/internal/service/strategy_registry.go
@@ -682,6 +682,8 @@ func evaluateSignalBarGate(signalBarState map[string]any, nextSide, nextRole, ne
 	}
 	longBreakoutReady := highPrice >= prevHigh2 && prevHigh2 > 0
 	shortBreakoutReady := lowPrice <= prevLow2 && prevLow2 > 0
+	longBreakoutPatternReady := prevHigh2 > prevHigh1 && closePrice > prevHigh2 && prevHigh2 > 0
+	shortBreakoutPatternReady := prevLow2 < prevLow1 && closePrice < prevLow2 && prevLow2 > 0
 	longReady := longStructureReady && longBreakoutReady
 	shortReady := shortStructureReady && shortBreakoutReady
 	if role == "entry" && (reasonTag == "zero-initial-reentry" || reasonTag == "sl-reentry" || reasonTag == "pt-reentry") {
@@ -694,6 +696,8 @@ func evaluateSignalBarGate(signalBarState map[string]any, nextSide, nextRole, ne
 	result["shortEarlyReversalReady"] = shortEarlyReversalReady
 	result["longBreakoutReady"] = longBreakoutReady
 	result["shortBreakoutReady"] = shortBreakoutReady
+	result["longBreakoutPatternReady"] = longBreakoutPatternReady
+	result["shortBreakoutPatternReady"] = shortBreakoutPatternReady
 	result["longReady"] = longReady
 	result["shortReady"] = shortReady
 	if role == "exit" {

--- a/internal/service/telemetry_test.go
+++ b/internal/service/telemetry_test.go
@@ -45,9 +45,62 @@ func TestEvaluateLiveSessionOnSignalPersistsStrategyDecisionEvent(t *testing.T) 
 	if got := stringValue(updated.State["lastStrategyEvaluationSignalBarStateKey"]); got == "" {
 		t.Fatal("expected lastStrategyEvaluationSignalBarStateKey to be recorded")
 	}
+	if breakout := mapValue(updated.State["lastBreakoutSignal"]); len(breakout) != 0 {
+		t.Fatalf("expected no close-based breakout snapshot for default fixture, got %#v", breakout)
+	}
 	dispatchedIntent := mapValue(updated.State["lastDispatchedIntent"])
 	if got := stringValue(dispatchedIntent["decisionEventId"]); got != events[0].ID {
 		t.Fatalf("expected dispatched intent to carry decision event id %s, got %s", events[0].ID, got)
+	}
+}
+
+func TestEvaluateLiveSessionOnSignalPersistsBreakoutHistory(t *testing.T) {
+	platform, session, runtimeSessionID, summary, eventTime := prepareLiveDecisionTelemetryFixture(t)
+	signalKey := signalBindingMatchKey("binance-kline", "signal", "BTCUSDT")
+	err := platform.updateSignalRuntimeSessionState(runtimeSessionID, func(runtimeSession *domain.SignalRuntimeSession) {
+		state := cloneMetadata(runtimeSession.State)
+		signalStates := cloneMetadata(mapValue(state["signalBarStates"]))
+		entry := cloneMetadata(mapValue(signalStates[signalKey]))
+		current := cloneMetadata(mapValue(entry["current"]))
+		prevBar1 := cloneMetadata(mapValue(entry["prevBar1"]))
+		prevBar2 := cloneMetadata(mapValue(entry["prevBar2"]))
+		current["close"] = 69010.0
+		current["high"] = 69030.0
+		current["barStart"] = eventTime.Add(-24 * time.Hour).UnixMilli()
+		prevBar1["high"] = 68850.0
+		prevBar2["high"] = 69000.0
+		entry["current"] = current
+		entry["prevBar1"] = prevBar1
+		entry["prevBar2"] = prevBar2
+		signalStates[signalKey] = entry
+		state["signalBarStates"] = signalStates
+		runtimeSession.State = state
+	})
+	if err != nil {
+		t.Fatalf("update runtime breakout state failed: %v", err)
+	}
+
+	if err := platform.evaluateLiveSessionOnSignal(session, runtimeSessionID, summary, eventTime); err != nil {
+		t.Fatalf("evaluate live session failed: %v", err)
+	}
+
+	updated, err := platform.store.GetLiveSession(session.ID)
+	if err != nil {
+		t.Fatalf("get updated live session failed: %v", err)
+	}
+	breakout := mapValue(updated.State["lastBreakoutSignal"])
+	if len(breakout) == 0 {
+		t.Fatal("expected breakout snapshot to be recorded")
+	}
+	if got := stringValue(breakout["side"]); got != "BUY" {
+		t.Fatalf("expected breakout side BUY, got %s", got)
+	}
+	if got := parseFloatValue(breakout["level"]); got != 69000.0 {
+		t.Fatalf("expected breakout level 69000, got %v", got)
+	}
+	history := metadataList(updated.State["breakoutHistory"])
+	if len(history) != 1 {
+		t.Fatalf("expected breakout history length 1, got %#v", history)
 	}
 }
 

--- a/internal/service/telemetry_test.go
+++ b/internal/service/telemetry_test.go
@@ -35,6 +35,16 @@ func TestEvaluateLiveSessionOnSignalPersistsStrategyDecisionEvent(t *testing.T) 
 	if events[0].Action == "" || events[0].Reason == "" {
 		t.Fatalf("expected non-empty action/reason, got %+v", events[0])
 	}
+	signalBarDecision := mapValue(updated.State["lastStrategyEvaluationSignalBarDecision"])
+	if len(signalBarDecision) == 0 {
+		t.Fatal("expected lastStrategyEvaluationSignalBarDecision to be recorded")
+	}
+	if !boolValue(signalBarDecision["longBreakoutReady"]) {
+		t.Fatalf("expected longBreakoutReady=true, got %#v", signalBarDecision)
+	}
+	if got := stringValue(updated.State["lastStrategyEvaluationSignalBarStateKey"]); got == "" {
+		t.Fatal("expected lastStrategyEvaluationSignalBarStateKey to be recorded")
+	}
 	dispatchedIntent := mapValue(updated.State["lastDispatchedIntent"])
 	if got := stringValue(dispatchedIntent["decisionEventId"]); got != events[0].ID {
 		t.Fatalf("expected dispatched intent to carry decision event id %s, got %s", events[0].ID, got)

--- a/web/console/src/components/charts/SignalMonitorChart.tsx
+++ b/web/console/src/components/charts/SignalMonitorChart.tsx
@@ -1,14 +1,15 @@
 import { useEffect, useRef } from 'react';
-import { Time, CandlestickSeries, ColorType, CrosshairMode, LineStyle, createChart, createSeriesMarkers } from 'lightweight-charts';
-import { SignalBarCandle, SessionMarker } from '../../types/domain';
+import { Time, CandlestickSeries, LineSeries, ColorType, CrosshairMode, LineStyle, createChart, createSeriesMarkers } from 'lightweight-charts';
+import { SignalBarCandle, SessionMarker, SignalMonitorOverlay } from '../../types/domain';
 import { applyDefaultChartWindow } from '../../utils/derivation';
 import { normalizeChartData } from '../../utils/chart';
 
-export function SignalMonitorChart(props: { candles: SignalBarCandle[]; markers: SessionMarker[] }) {
+export function SignalMonitorChart(props: { candles: SignalBarCandle[]; markers: SessionMarker[]; overlays?: SignalMonitorOverlay[] }) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const chartRef = useRef<ReturnType<typeof createChart> | null>(null);
   const seriesRef = useRef<ReturnType<any> | null>(null);
   const markersRef = useRef<ReturnType<any> | null>(null);
+  const overlaySeriesRefs = useRef<Array<ReturnType<any>>>([]);
   const isInitialRender = useRef(true);
 
   useEffect(() => {
@@ -51,6 +52,7 @@ export function SignalMonitorChart(props: { candles: SignalBarCandle[]; markers:
     markersRef.current = createSeriesMarkers(series, []);
 
     return () => {
+      overlaySeriesRefs.current = [];
       chart.remove();
       chartRef.current = null;
       seriesRef.current = null;
@@ -76,11 +78,47 @@ export function SignalMonitorChart(props: { candles: SignalBarCandle[]; markers:
       }))
     );
 
+    overlaySeriesRefs.current.forEach((overlaySeries) => {
+      chart.removeSeries(overlaySeries);
+    });
+    overlaySeriesRefs.current = [];
+
+    for (const overlay of props.overlays ?? []) {
+      if (!overlay.startTime || !overlay.endTime || !Number.isFinite(overlay.price) || overlay.price <= 0) {
+        continue;
+      }
+      const lineSeries = chart.addSeries(LineSeries, {
+        color: overlay.color,
+        lineWidth: 2,
+        lineStyle:
+          overlay.lineStyle === "dotted"
+            ? LineStyle.Dotted
+            : overlay.lineStyle === "dashed"
+              ? LineStyle.Dashed
+              : LineStyle.Solid,
+        priceLineVisible: false,
+        lastValueVisible: false,
+        crosshairMarkerVisible: false,
+        pointMarkersVisible: false,
+      });
+      lineSeries.setData([
+        {
+          time: Math.floor(new Date(overlay.startTime).getTime() / 1000) as Time,
+          value: overlay.price,
+        },
+        {
+          time: Math.floor(new Date(overlay.endTime).getTime() / 1000) as Time,
+          value: overlay.price,
+        },
+      ]);
+      overlaySeriesRefs.current.push(lineSeries);
+    }
+
     if (isInitialRender.current) {
       applyDefaultChartWindow(chart, props.candles.length, 90);
       isInitialRender.current = false;
     }
-  }, [props.candles, props.markers]);
+  }, [props.candles, props.markers, props.overlays]);
 
   return <div ref={containerRef} className="tv-chart" />;
 }

--- a/web/console/src/pages/AccountStage.tsx
+++ b/web/console/src/pages/AccountStage.tsx
@@ -264,7 +264,20 @@ export function AccountStage({
   const selectedSignalBarStates = getRecord(selectedSignalRuntimeState.signalBarStates);
   const selectedSignalRuntimeTimeline = getList(selectedSignalRuntimeState.timeline);
   const selectedRuntimeSymbol = String(selectedSignalRuntimeState.symbol ?? "").trim().toUpperCase();
-  const selectedSignalRuntimeSignalBars = deriveSignalBarCandles(selectedSignalRuntimeSourceStates, selectedRuntimeSymbol);
+  const selectedRuntimeSession = selectedSignalRuntime
+    ? validLiveSessions.find((item) => String(item.state?.signalRuntimeSessionId ?? "") === selectedSignalRuntime.id) ??
+      validLiveSessions.find(
+        (item) => item.accountId === selectedSignalRuntime.accountId && item.strategyId === selectedSignalRuntime.strategyId
+      ) ??
+      null
+    : null;
+  const selectedRuntimeSignalTimeframe = String(selectedRuntimeSession?.state?.signalTimeframe ?? "").trim().toLowerCase();
+  const selectedRuntimeSignalBarStateKey = String(selectedRuntimeSession?.state?.lastStrategyEvaluationSignalBarStateKey ?? "").trim();
+  const selectedSignalRuntimeSignalBars = deriveSignalBarCandles(selectedSignalRuntimeSourceStates, {
+    targetSymbol: selectedRuntimeSymbol,
+    targetTimeframe: selectedRuntimeSignalTimeframe,
+    targetStateKey: selectedRuntimeSignalBarStateKey,
+  });
   const selectedSignalRuntimeSubscriptions = Array.isArray(selectedSignalRuntimeState.subscriptions)
     ? (selectedSignalRuntimeState.subscriptions as Array<Record<string, unknown>>)
     : [];
@@ -470,7 +483,13 @@ export function AccountStage({
                  const activeRuntimeMarket = deriveRuntimeMarketSnapshot(getRecord(activeRuntimeState.sourceStates), activeRuntimeSummary, accountSymbol);
                 const strategyBindings = (activeRuntime?.strategyId ? strategySignalBindingMap[activeRuntime.strategyId] : undefined) ?? strategySignalBindingMap[validLiveSessions.find((item) => item.accountId === account.id)?.strategyId ?? ""] ?? [];
                 const activeRuntimeSourceSummary = deriveRuntimeSourceSummary(getRecord(activeRuntimeState.sourceStates), runtimePolicy, accountSymbol);
-                const activeSignalBarState = derivePrimarySignalBarState(getRecord(activeRuntimeState.signalBarStates));
+                const activeSignalTimeframe = String(accountSession?.state?.signalTimeframe ?? "").trim().toLowerCase();
+                const activeSignalBarStateKey = String(accountSession?.state?.lastStrategyEvaluationSignalBarStateKey ?? "").trim();
+                const activeSignalBarState = derivePrimarySignalBarState(getRecord(activeRuntimeState.signalBarStates), {
+                  targetSymbol: accountSymbol,
+                  targetTimeframe: activeSignalTimeframe,
+                  targetStateKey: activeSignalBarStateKey,
+                });
                 const activeSignalAction = deriveSignalActionSummary(activeSignalBarState);
                 const activeRuntimeTimeline = getList(activeRuntimeState.timeline);
                 const activeRuntimeReadiness = deriveRuntimeReadiness(activeRuntimeState, activeRuntimeSourceSummary, {

--- a/web/console/src/pages/MonitorStage.tsx
+++ b/web/console/src/pages/MonitorStage.tsx
@@ -17,8 +17,11 @@ import {
   deriveRuntimeReadiness,
   deriveRuntimeSourceSummary,
   deriveLiveSessionExecutionSummary,
+  buildSignalBarDecisionNotes,
+  buildSignalBarStateNotes,
   deriveLiveSessionHealth,
   buildTimelineNotes,
+  boolLabel,
   liveSessionHealthTone,
   getNumber,
   runtimePolicyValueLabel,
@@ -124,14 +127,33 @@ export function MonitorStage({ syncLiveOrder, dockTab, onDockTabChange, dockCont
   const monitorRuntimeState = highlightedLiveSession?.session ? highlightedLiveRuntimeState : {};
   const monitorSessionState = getRecord(monitorSession?.state);
   const sessionSymbol = String(monitorSession?.state?.symbol ?? "").trim().toUpperCase();
+  const monitorSignalContext = getRecord(monitorSessionState.lastStrategyEvaluationContext);
+  const monitorDecisionMeta = getRecord(getRecord(monitorSession?.state?.lastStrategyDecision).metadata);
+  const monitorSignalTimeframe = String(
+    monitorSessionState.signalTimeframe ?? monitorSignalContext.signalTimeframe ?? monitorDecisionMeta.signalTimeframe ?? ""
+  )
+    .trim()
+    .toLowerCase();
+  const monitorSignalBarStateKey = String(
+    monitorSessionState.lastStrategyEvaluationSignalBarStateKey ?? monitorDecisionMeta.signalBarStateKey ?? ""
+  ).trim();
 
   const monitorBars = useMemo(() => {
-    return deriveSignalBarCandles(getRecord(highlightedLiveRuntimeState.sourceStates), sessionSymbol);
-  }, [highlightedLiveRuntimeState.sourceStates, sessionSymbol]);
+    return deriveSignalBarCandles(getRecord(highlightedLiveRuntimeState.sourceStates), {
+      targetSymbol: sessionSymbol,
+      targetTimeframe: monitorSignalTimeframe,
+      targetStateKey: monitorSignalBarStateKey,
+    });
+  }, [highlightedLiveRuntimeState.sourceStates, sessionSymbol, monitorSignalTimeframe, monitorSignalBarStateKey]);
 
   const monitorSignalState = derivePrimarySignalBarState(
     getRecord(highlightedLiveRuntimeState.signalBarStates),
-    getRecord(monitorSessionState.lastStrategyEvaluationSignalBarStates)
+    {
+      fallbackStates: getRecord(monitorSessionState.lastStrategyEvaluationSignalBarStates),
+      targetSymbol: sessionSymbol,
+      targetTimeframe: monitorSignalTimeframe,
+      targetStateKey: monitorSignalBarStateKey,
+    }
   );
   const monitorMarket = deriveRuntimeMarketSnapshot(
     getRecord(monitorRuntimeState.sourceStates),
@@ -158,7 +180,21 @@ export function MonitorStage({ syncLiveOrder, dockTab, onDockTabChange, dockCont
     { requireTick: true, requireOrderBook: false }
   );
   const monitorIntent = getRecord(monitorSession?.state?.lastStrategyIntent);
-  const monitorSignalBarDecision = getRecord(monitorSession?.state?.lastStrategyEvaluationSignalBarDecision);
+  const monitorSignalBarDecision = getRecord(
+    monitorSession?.state?.lastStrategyEvaluationSignalBarDecision ?? monitorDecisionMeta.signalBarDecision
+  );
+  const monitorSignalTraceNotes = monitorSession
+    ? [
+        `decision: ${String(monitorDecisionMeta.decisionState ?? "--")} · kind=${String(monitorDecisionMeta.signalKind ?? "--")} · planned=${String(monitorDecisionMeta.nextPlannedRole ?? "--")}/${String(monitorDecisionMeta.nextPlannedReason ?? "--")}`,
+        `gate: long struct=${boolLabel(monitorSignalBarDecision.longStructureReady)} breakout=${boolLabel(monitorSignalBarDecision.longBreakoutReady)} ready=${boolLabel(monitorSignalBarDecision.longReady)} · short struct=${boolLabel(monitorSignalBarDecision.shortStructureReady)} breakout=${boolLabel(monitorSignalBarDecision.shortBreakoutReady)} ready=${boolLabel(monitorSignalBarDecision.shortReady)}`,
+        `current-bar: closed=${boolLabel(getRecord(monitorSignalBarDecision.current).isClosed ?? monitorSignalState.currentClosed)} · key=${String(monitorSignalBarStateKey || "--")}`,
+        ...(
+          Object.keys(monitorSignalBarDecision).length > 0
+            ? buildSignalBarDecisionNotes(monitorSignalBarDecision, monitorSignalState)
+            : buildSignalBarStateNotes(monitorSignalState)
+        ),
+      ]
+    : [];
   const monitorTimeline = getList(monitorSession?.state?.timeline);
   const monitorDispatchPreview = deriveLiveDispatchPreview(
     monitorSession,
@@ -431,6 +467,21 @@ export function MonitorStage({ syncLiveOrder, dockTab, onDockTabChange, dockCont
               <p className="text-center text-[11px] font-bold leading-tight text-[var(--bk-text-muted)] italic opacity-70">
                 {String(monitorSignalBarDecision.reason ?? "当前无执行信号或正在等待波动...")}
               </p>
+
+              {monitorSignalTraceNotes.length > 0 && (
+                <div className="rounded-2xl border border-[var(--bk-border)] bg-[var(--bk-surface-primary-faint)] p-3 shadow-sm">
+                  <div className="mb-2 text-[9px] font-black uppercase tracking-widest text-[var(--bk-text-muted)]">
+                    Signal Trace
+                  </div>
+                  <div className="space-y-1.5">
+                    {monitorSignalTraceNotes.slice(0, 7).map((note, idx) => (
+                      <div key={`${idx}-${note}`} className="font-mono text-[10px] leading-relaxed text-[var(--bk-text-primary)]">
+                        {note}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
             </div>
           </CardContent>
         </Card>

--- a/web/console/src/pages/MonitorStage.tsx
+++ b/web/console/src/pages/MonitorStage.tsx
@@ -9,7 +9,8 @@ import {
   deriveSignalBarCandles,
   derivePrimarySignalBarState, 
   deriveRuntimeMarketSnapshot, 
-  deriveSessionMarkers, 
+  deriveSessionMarkers,
+  deriveSignalMonitorDecorations,
   derivePaperSessionExecutionSummary,
   deriveHighlightedLiveSession,
   deriveLiveDispatchPreview,
@@ -17,11 +18,8 @@ import {
   deriveRuntimeReadiness,
   deriveRuntimeSourceSummary,
   deriveLiveSessionExecutionSummary,
-  buildSignalBarDecisionNotes,
-  buildSignalBarStateNotes,
   deriveLiveSessionHealth,
   buildTimelineNotes,
-  boolLabel,
   liveSessionHealthTone,
   getNumber,
   runtimePolicyValueLabel,
@@ -163,6 +161,21 @@ export function MonitorStage({ syncLiveOrder, dockTab, onDockTabChange, dockCont
   const monitorSummary =
     monitorSession ? summaries.find((item) => item.accountId === monitorSession.accountId) ?? null : null;
   const monitorMarkers = deriveSessionMarkers(monitorSession, orders, fills);
+  const monitorDecorations = useMemo(
+    () =>
+      deriveSignalMonitorDecorations(
+        monitorSession,
+        monitorBars,
+        monitorExecutionSummary.position,
+        orders,
+        fills
+      ),
+    [monitorBars, monitorExecutionSummary.position, monitorSession, orders, fills]
+  );
+  const monitorChartMarkers = useMemo(
+    () => [...monitorMarkers, ...monitorDecorations.markers],
+    [monitorMarkers, monitorDecorations.markers]
+  );
   const monitorFlow = useMemo(
     () =>
       highlightedLiveSession
@@ -183,18 +196,6 @@ export function MonitorStage({ syncLiveOrder, dockTab, onDockTabChange, dockCont
   const monitorSignalBarDecision = getRecord(
     monitorSession?.state?.lastStrategyEvaluationSignalBarDecision ?? monitorDecisionMeta.signalBarDecision
   );
-  const monitorSignalTraceNotes = monitorSession
-    ? [
-        `decision: ${String(monitorDecisionMeta.decisionState ?? "--")} · kind=${String(monitorDecisionMeta.signalKind ?? "--")} · planned=${String(monitorDecisionMeta.nextPlannedRole ?? "--")}/${String(monitorDecisionMeta.nextPlannedReason ?? "--")}`,
-        `gate: long struct=${boolLabel(monitorSignalBarDecision.longStructureReady)} breakout=${boolLabel(monitorSignalBarDecision.longBreakoutReady)} ready=${boolLabel(monitorSignalBarDecision.longReady)} · short struct=${boolLabel(monitorSignalBarDecision.shortStructureReady)} breakout=${boolLabel(monitorSignalBarDecision.shortBreakoutReady)} ready=${boolLabel(monitorSignalBarDecision.shortReady)}`,
-        `current-bar: closed=${boolLabel(getRecord(monitorSignalBarDecision.current).isClosed ?? monitorSignalState.currentClosed)} · key=${String(monitorSignalBarStateKey || "--")}`,
-        ...(
-          Object.keys(monitorSignalBarDecision).length > 0
-            ? buildSignalBarDecisionNotes(monitorSignalBarDecision, monitorSignalState)
-            : buildSignalBarStateNotes(monitorSignalState)
-        ),
-      ]
-    : [];
   const monitorTimeline = getList(monitorSession?.state?.timeline);
   const monitorDispatchPreview = deriveLiveDispatchPreview(
     monitorSession,
@@ -273,7 +274,11 @@ export function MonitorStage({ syncLiveOrder, dockTab, onDockTabChange, dockCont
          <CardContent className="p-0">
             <div className="chart-shell relative h-[360px] overflow-hidden bg-[color-mix(in_srgb,var(--bk-surface-strong)_40%,transparent)]">
                 {monitorBars.length > 0 ? (
-                  <SignalMonitorChart candles={monitorBars} markers={monitorMarkers} />
+                  <SignalMonitorChart
+                    candles={monitorBars}
+                    markers={monitorChartMarkers}
+                    overlays={monitorDecorations.overlays}
+                  />
                 ) : (
                   <div className="absolute inset-0 flex flex-col items-center justify-center space-y-3 opacity-30">
                     <Activity className="size-16 animate-pulse" />
@@ -467,21 +472,6 @@ export function MonitorStage({ syncLiveOrder, dockTab, onDockTabChange, dockCont
               <p className="text-center text-[11px] font-bold leading-tight text-[var(--bk-text-muted)] italic opacity-70">
                 {String(monitorSignalBarDecision.reason ?? "当前无执行信号或正在等待波动...")}
               </p>
-
-              {monitorSignalTraceNotes.length > 0 && (
-                <div className="rounded-2xl border border-[var(--bk-border)] bg-[var(--bk-surface-primary-faint)] p-3 shadow-sm">
-                  <div className="mb-2 text-[9px] font-black uppercase tracking-widest text-[var(--bk-text-muted)]">
-                    Signal Trace
-                  </div>
-                  <div className="space-y-1.5">
-                    {monitorSignalTraceNotes.slice(0, 7).map((note, idx) => (
-                      <div key={`${idx}-${note}`} className="font-mono text-[10px] leading-relaxed text-[var(--bk-text-primary)]">
-                        {note}
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              )}
             </div>
           </CardContent>
         </Card>

--- a/web/console/src/types/domain.ts
+++ b/web/console/src/types/domain.ts
@@ -507,6 +507,14 @@ export type SessionMarker = {
   text: string;
 };
 
+export type SignalMonitorOverlay = {
+  startTime: string;
+  endTime: string;
+  price: number;
+  color: string;
+  lineStyle: "solid" | "dashed" | "dotted";
+};
+
 export type AuthSession = {
   token: string;
   username: string;
@@ -660,4 +668,3 @@ export type TimelineConfig = {
   quietSeconds: number;
   maxRepeats: number;
 };
-

--- a/web/console/src/utils/derivation.ts
+++ b/web/console/src/utils/derivation.ts
@@ -508,19 +508,90 @@ export function deriveRuntimeReadiness(
   return { ready: true, status: "ready", reason: "健康" };
 }
 
-export function deriveSignalBarCandles(sourceStates: Record<string, unknown>, targetSymbol?: string): SignalBarCandle[] {
-  const candles: SignalBarCandle[] = [];
-  const normalizedTarget = (targetSymbol ?? "").trim().toUpperCase();
+type SignalBarSelectionOptions = {
+  fallbackStates?: Record<string, unknown>;
+  targetSymbol?: string;
+  targetTimeframe?: string;
+  targetStateKey?: string;
+};
 
-  for (const value of Object.values(sourceStates)) {
+function normalizeSignalSymbol(value: unknown) {
+  return String(value ?? "").trim().toUpperCase();
+}
+
+function normalizeSignalTimeframe(value: unknown) {
+  return String(value ?? "").trim().toLowerCase();
+}
+
+function resolveSignalBarEntry(
+  signalBarStates: Record<string, unknown>,
+  options?: Omit<SignalBarSelectionOptions, "fallbackStates">
+) {
+  const targetStateKey = String(options?.targetStateKey ?? "").trim();
+  const targetSymbol = normalizeSignalSymbol(options?.targetSymbol);
+  const targetTimeframe = normalizeSignalTimeframe(options?.targetTimeframe);
+
+  if (targetStateKey) {
+    const exact = getRecord(signalBarStates[targetStateKey]);
+    if (Object.keys(exact).length > 0) {
+      return exact;
+    }
+  }
+
+  for (const value of Object.values(signalBarStates)) {
+    const entry = getRecord(value);
+    if (Object.keys(entry).length === 0) {
+      continue;
+    }
+    const entrySymbol = normalizeSignalSymbol(entry.symbol ?? getRecord(entry.current).symbol);
+    const entryTimeframe = normalizeSignalTimeframe(entry.timeframe ?? getRecord(entry.current).timeframe);
+    if (targetSymbol && entrySymbol && entrySymbol !== targetSymbol) {
+      continue;
+    }
+    if (targetTimeframe && entryTimeframe && entryTimeframe !== targetTimeframe) {
+      continue;
+    }
+    return entry;
+  }
+
+  return {};
+}
+
+export function deriveSignalBarCandles(
+  sourceStates: Record<string, unknown>,
+  options?: Omit<SignalBarSelectionOptions, "fallbackStates">
+): SignalBarCandle[] {
+  const candles: SignalBarCandle[] = [];
+  const targetStateKey = String(options?.targetStateKey ?? "").trim();
+  const targetSymbol = normalizeSignalSymbol(options?.targetSymbol);
+  const targetTimeframe = normalizeSignalTimeframe(options?.targetTimeframe);
+  const candidateEntries = targetStateKey
+    ? Object.entries(sourceStates).filter(([key]) => key === targetStateKey)
+    : Object.entries(sourceStates);
+
+  for (const [, value] of candidateEntries) {
     const state = getRecord(value);
     if (String(state.streamType ?? "") !== "signal_bar") {
       continue;
     }
+    if (!targetStateKey) {
+      const stateSymbol = normalizeSignalSymbol(state.symbol);
+      const stateTimeframe = normalizeSignalTimeframe(state.timeframe);
+      if (targetSymbol && stateSymbol && stateSymbol !== targetSymbol) {
+        continue;
+      }
+      if (targetTimeframe && stateTimeframe && stateTimeframe !== targetTimeframe) {
+        continue;
+      }
+    }
     const bars = Array.isArray(state.bars) ? (state.bars as Array<Record<string, unknown>>) : [];
     for (const bar of bars) {
-      const barSymbol = String(bar.symbol ?? "").trim().toUpperCase();
-      if (normalizedTarget && barSymbol && barSymbol !== normalizedTarget) {
+      const barSymbol = normalizeSignalSymbol(bar.symbol);
+      const barTimeframe = normalizeSignalTimeframe(bar.timeframe ?? state.timeframe);
+      if (targetSymbol && barSymbol && barSymbol !== targetSymbol) {
+        continue;
+      }
+      if (targetTimeframe && barTimeframe && barTimeframe !== targetTimeframe) {
         continue;
       }
       const barStart = String(bar.barStart ?? "");
@@ -539,10 +610,16 @@ export function deriveSignalBarCandles(sourceStates: Record<string, unknown>, ta
         high,
         low,
         close,
-        timeframe: String(bar.timeframe ?? "--"),
+        timeframe: String(bar.timeframe ?? state.timeframe ?? "--"),
         isClosed: Boolean(bar.isClosed),
       });
     }
+  }
+  if (candles.length === 0 && targetStateKey) {
+    return deriveSignalBarCandles(sourceStates, {
+      targetSymbol: options?.targetSymbol,
+      targetTimeframe: options?.targetTimeframe,
+    });
   }
   candles.sort((a, b) => Date.parse(a.time) - Date.parse(b.time));
   return candles.slice(-120);
@@ -571,13 +648,12 @@ export function applyDefaultChartWindow(chart: ReturnType<typeof createChart>, c
   chart.timeScale().setVisibleLogicalRange({ from, to });
 }
 
-export function derivePrimarySignalBarState(signalBarStates: Record<string, unknown>, fallbackStates?: Record<string, unknown>) {
-  const primary = Object.values(signalBarStates)[0];
-  if (primary != null) {
-    return getRecord(primary);
+export function derivePrimarySignalBarState(signalBarStates: Record<string, unknown>, options?: SignalBarSelectionOptions) {
+  const primary = resolveSignalBarEntry(signalBarStates, options);
+  if (Object.keys(primary).length > 0) {
+    return primary;
   }
-  const first = Object.values(fallbackStates ?? {})[0];
-  return getRecord(first);
+  return resolveSignalBarEntry(getRecord(options?.fallbackStates), options);
 }
 
 export function buildRuntimeEventNotes(summary: Record<string, unknown>) {
@@ -623,10 +699,13 @@ export function buildSignalBarDecisionNotes(signalBarDecision: Record<string, un
   const prevBar1 = getRecord(signalBarDecision.prevBar1);
   const prevBar2 = getRecord(signalBarDecision.prevBar2);
   const timeframe = String(signalBarDecision.timeframe ?? signalBarState.timeframe ?? "--");
+  const usesLegacyFallback = signalBarDecision.usedLegacyMA20Fallback === true;
   const filterLabel =
     timeframe === "1d"
       ? `sma5 ${formatMaybeNumber(signalBarDecision.sma5)} · early-long=${boolLabel(signalBarDecision.longEarlyReversalReady)} · early-short=${boolLabel(signalBarDecision.shortEarlyReversalReady)}`
-      : `ma20 ${formatMaybeNumber(signalBarDecision.ma20)}`;
+      : usesLegacyFallback
+        ? `ma20 ${formatMaybeNumber(signalBarDecision.ma20)} · legacy fallback`
+        : `sma5 ${formatMaybeNumber(signalBarDecision.sma5)}`;
   return [
     `signal-bar: ${String(signalBarDecision.reason ?? "--")} · longReady=${boolLabel(signalBarDecision.longReady)} · shortReady=${boolLabel(signalBarDecision.shortReady)}`,
     `filter: tf=${timeframe} · ${filterLabel}`,
@@ -683,11 +762,16 @@ export function deriveSignalActionSummary(signalBarState: Record<string, unknown
     shortReady = shortHard || shortEarly;
     longReason = longHard ? "收盘>sma5" : longEarly ? "早期反转触发" : "1d 做多过滤阻断";
     shortReason = shortHard ? "收盘<sma5" : shortEarly ? "早期反转触发" : "1d 做空过滤阻断";
+  } else if (sma5 != null) {
+    longReady = close > sma5 && longBreakoutShape;
+    shortReady = close < sma5 && shortBreakoutShape;
+    longReason = longReady ? "收盘>sma5且高点突破" : "趋势/形态未就绪";
+    shortReason = shortReady ? "收盘<sma5且低点突破" : "趋势/形态未就绪";
   } else if (ma20 != null) {
     longReady = close > ma20 && longBreakoutShape;
     shortReady = close < ma20 && shortBreakoutShape;
-    longReason = longReady ? "收盘>ma20且高点突破" : "趋势/形态未就绪";
-    shortReason = shortReady ? "收盘<ma20且低点突破" : "趋势/形态未就绪";
+    longReason = longReady ? "收盘>ma20且高点突破（legacy fallback）" : "趋势/形态未就绪";
+    shortReason = shortReady ? "收盘<ma20且低点突破（legacy fallback）" : "趋势/形态未就绪";
   } else {
     return { bias: "中性", state: "等待中", reason: "信号 K 线不足" };
   }
@@ -706,11 +790,17 @@ export function deriveSignalActionSummary(signalBarState: Record<string, unknown
     }
     return { bias: "中性", state: "观察中", reason: "收盘于 sma5 附近" };
   }
+  if (sma5 != null && close > sma5) {
+    return { bias: "看多", state: "观察中", reason: "位于 sma5 上方，形态未就绪" };
+  }
+  if (sma5 != null && close < sma5) {
+    return { bias: "看空", state: "观察中", reason: "位于 sma5 下方，形态未就绪" };
+  }
   if (ma20 != null && close > ma20) {
-    return { bias: "看多", state: "观察中", reason: "趋势看多，形态未就绪" };
+    return { bias: "看多", state: "观察中", reason: "位于 ma20 上方，形态未就绪（legacy fallback）" };
   }
   if (ma20 != null && close < ma20) {
-    return { bias: "看空", state: "观察中", reason: "趋势看空，形态未就绪" };
+    return { bias: "看空", state: "观察中", reason: "位于 ma20 下方，形态未就绪（legacy fallback）" };
   }
   return { bias: "中性", state: "观察中", reason: "收盘于均线附近" };
 }
@@ -1345,7 +1435,7 @@ export function derivePaperAlerts(
     alerts.push({ level: "warning", title: "缺失 K 线", detail: "运行时尚未采集到足够的周期 K 线" });
   }
   if (signalReason === "insufficient-signal-bars") {
-    alerts.push({ level: "warning", title: "信号过滤阻断", detail: "MA20 / t-1 / t-2 所需的已收盘 K 线不足" });
+    alerts.push({ level: "warning", title: "信号过滤阻断", detail: "SMA5 / t-1 / t-2 所需的已收盘 K 线不足" });
   }
   if (Number.isFinite(lastEventAt) && Date.now()-lastEventAt > runtimeQuietMs) {
     alerts.push({

--- a/web/console/src/utils/derivation.ts
+++ b/web/console/src/utils/derivation.ts
@@ -1,4 +1,4 @@
-import { AccountSummary, AccountRecord, StrategyVersion, StrategyRecord, AccountEquitySnapshot, Order, Fill, Position, PaperSession, LiveSession, ChartCandle, ChartAnnotation, MarkerLegendItem, BacktestRun, BacktestOptions, LiveAdapter, SignalSourceDefinition, SignalSourceCatalog, SignalSourceType, SignalBinding, SignalRuntimeAdapter, SignalRuntimeSession, ReplayReasonStats, ReplaySample, ExecutionTrade, SourceFilter, EventFilter, TimeWindow, MarkerDetail, ChartOverrideRange, SelectedSample, SelectableSample, RuntimeMarketSnapshot, RuntimeSourceSummary, RuntimeReadiness, SignalBarCandle, AlertItem, PlatformAlert, PlatformNotification, TelegramConfig, RuntimePolicy, LivePreflightSummary, LiveNextAction, LiveDispatchPreview, LiveSessionExecutionSummary, LiveSessionHealth, HighlightedLiveSession, LiveSessionFlowStep, SessionMarker, AuthSession, TimelineConfig } from '../types/domain';
+import { AccountSummary, AccountRecord, StrategyVersion, StrategyRecord, AccountEquitySnapshot, Order, Fill, Position, PaperSession, LiveSession, ChartCandle, ChartAnnotation, MarkerLegendItem, BacktestRun, BacktestOptions, LiveAdapter, SignalSourceDefinition, SignalSourceCatalog, SignalSourceType, SignalBinding, SignalRuntimeAdapter, SignalRuntimeSession, ReplayReasonStats, ReplaySample, ExecutionTrade, SourceFilter, EventFilter, TimeWindow, MarkerDetail, ChartOverrideRange, SelectedSample, SelectableSample, RuntimeMarketSnapshot, RuntimeSourceSummary, RuntimeReadiness, SignalBarCandle, AlertItem, PlatformAlert, PlatformNotification, TelegramConfig, RuntimePolicy, LivePreflightSummary, LiveNextAction, LiveDispatchPreview, LiveSessionExecutionSummary, LiveSessionHealth, HighlightedLiveSession, LiveSessionFlowStep, SessionMarker, SignalMonitorOverlay, AuthSession, TimelineConfig } from '../types/domain';
 
 
 import { formatMoney, formatSigned, formatPercent, formatNumber, formatMaybeNumber, formatTime, formatShortTime, shrink } from './format';
@@ -1056,6 +1056,138 @@ export function deriveSessionMarkers(session: LiveSession | PaperSession | null,
       text: `${isBuy ? "开" : "平"} ${formatMaybeNumber(order.price)}`,
     };
   });
+}
+
+function resolveSessionOrders(session: LiveSession | PaperSession | null, orders: Order[]) {
+  if (!session) {
+    return [];
+  }
+  const isLiveSession = "strategyId" in session && !("startEquity" in session);
+  return orders
+    .filter((order) =>
+      isLiveSession
+        ? String(order.metadata?.liveSessionId ?? "") === session.id
+        : String(order.metadata?.paperSession ?? "") === session.id
+    )
+    .sort((left, right) => Date.parse(left.createdAt) - Date.parse(right.createdAt));
+}
+
+function clampAnnotationTime(time: string, visibleStart: string, visibleEnd: string) {
+  const parsed = Date.parse(time);
+  const start = Date.parse(visibleStart);
+  const end = Date.parse(visibleEnd);
+  if (!Number.isFinite(parsed) || !Number.isFinite(start) || !Number.isFinite(end)) {
+    return "";
+  }
+  if (parsed <= start) {
+    return visibleStart;
+  }
+  if (parsed >= end) {
+    return visibleEnd;
+  }
+  return new Date(parsed).toISOString();
+}
+
+export function deriveSignalMonitorDecorations(
+  session: LiveSession | PaperSession | null,
+  candles: SignalBarCandle[],
+  position: Position | null,
+  orders: Order[],
+  fills: Fill[]
+): { markers: SessionMarker[]; overlays: SignalMonitorOverlay[] } {
+  if (!session || candles.length < 3) {
+    return { markers: [], overlays: [] };
+  }
+
+  const markers: SessionMarker[] = [];
+  const overlays: SignalMonitorOverlay[] = [];
+  const visibleStart = candles[0]?.time ?? "";
+  const visibleEnd = candles[candles.length - 1]?.time ?? "";
+  const state = getRecord(session.state);
+
+  const breakoutEntries = getList(state.breakoutHistory);
+  if (breakoutEntries.length === 0 && Object.keys(getRecord(state.lastBreakoutSignal)).length > 0) {
+    breakoutEntries.push(getRecord(state.lastBreakoutSignal));
+  }
+
+  for (const rawEntry of breakoutEntries.slice(-12)) {
+    const breakout = getRecord(rawEntry);
+    const breakoutTime = clampAnnotationTime(
+      String(breakout.barTime ?? breakout.eventAt ?? ""),
+      visibleStart,
+      visibleEnd
+    );
+    const breakoutLevel = getNumber(breakout.level);
+    const breakoutSide = String(breakout.side ?? "").trim().toUpperCase();
+    if (!breakoutTime || breakoutLevel == null || breakoutLevel <= 0) {
+      continue;
+    }
+    const breakoutColor = breakoutSide === "SELL" ? "#b04a37" : "#0e6d60";
+    const nextCandleTime =
+      candles.find((item) => Date.parse(item.time) > Date.parse(breakoutTime))?.time ?? visibleEnd;
+    overlays.push({
+      startTime: breakoutTime,
+      endTime: nextCandleTime,
+      price: breakoutLevel,
+      color: breakoutColor,
+      lineStyle: "dotted",
+    });
+    markers.push({
+      time: breakoutTime,
+      position: breakoutSide === "SELL" ? "aboveBar" : "belowBar",
+      color: breakoutColor,
+      shape: "circle",
+      text: "BO",
+    });
+  }
+
+  if (!position || Math.abs(Number(position.quantity ?? 0)) <= 0 || !visibleEnd) {
+    return { markers, overlays };
+  }
+
+  const livePositionState =
+    getRecord(state.lastLivePositionState).found === true
+      ? getRecord(state.lastLivePositionState)
+      : getRecord(state.livePositionState);
+  const stopLoss = getNumber(livePositionState.stopLoss);
+  if (stopLoss == null || stopLoss <= 0) {
+    return { markers, overlays };
+  }
+
+  const sessionOrders = resolveSessionOrders(session, orders);
+  const fillByOrderId = new Map(fills.map((fill) => [fill.orderId, fill] as const));
+  const normalizedSide = String(position.side ?? livePositionState.side ?? "").trim().toUpperCase();
+  const entrySide = normalizedSide === "SHORT" ? "SELL" : "BUY";
+  const entryOrder = [...sessionOrders]
+    .reverse()
+    .find((order) => String(order.side ?? "").trim().toUpperCase() === entrySide);
+  const entryTime = clampAnnotationTime(
+    fillByOrderId.get(entryOrder?.id ?? "")?.createdAt ?? entryOrder?.createdAt ?? visibleStart,
+    visibleStart,
+    visibleEnd
+  );
+  const trailingActive =
+    livePositionState.trailingStopActive === true ||
+    String(livePositionState.stopLossSource ?? "").trim().toLowerCase() === "trailing-stop";
+  const stopMarkerPosition = normalizedSide === "SHORT" ? "aboveBar" : "belowBar";
+  const stopMarkerColor = trailingActive ? "#2563eb" : "#b04a37";
+
+  overlays.push({
+    startTime: entryTime || visibleStart,
+    endTime: visibleEnd,
+    price: stopLoss,
+    color: stopMarkerColor,
+    lineStyle: "dashed",
+  });
+  markers.push({
+    time: visibleEnd,
+    position: stopMarkerPosition,
+    color: stopMarkerColor,
+    shape: "square",
+    text: trailingActive ? "TSL" : "SL",
+  });
+
+  return { markers, overlays };
 }
 
 export function deriveLiveSessionHealth(session: LiveSession, summary: LiveSessionExecutionSummary): LiveSessionHealth {


### PR DESCRIPTION
## 目的
- 修正 `BTCUSDT 15m/30m` 一键模板仍显式携带 `stop_loss_atr=0.05` 的问题，使其与最新 intraday research baseline 对齐到 `0.3`。
- 修正监控台/账户台读取 signal-bar 状态时只按 symbol 或直接取第一条 state 的问题，避免前端展示的 K 线与 live 策略实际评估的 `signalBarStateKey` 不一致。
- 把 live 策略评估时已经算出的 `signalBarDecision` 和 `signalBarStateKey` 落到 session state，便于后续追单、还原具体开仓原因。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [x] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
- [ ] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main)
- [ ] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？
- [ ] DB migration 是否具备向下兼容幂等性？
- [ ] 配置字段有没有无意被混改？

## 验证方式与测试证据
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

已执行：
- `go test ./internal/service -run 'TestEvaluateLiveSessionOnSignalPersistsStrategyDecisionEvent|TestLiveLaunchTemplatesExposeEightBinanceTestnetVariants|TestLiveLaunchTemplatesIncludeIdempotentFrontendWorkflow|TestLiveLaunchTemplatesExposeDispatchModeMetadata'`
- `/Users/wuyaocheng/Downloads/bkTrader/web/console/node_modules/.bin/tsc --noEmit src/pages/MonitorStage.tsx src/pages/AccountStage.tsx src/utils/derivation.ts --jsx react-jsx --esModuleInterop --skipLibCheck --target esnext --moduleResolution node --allowSyntheticDefaultImports`

## 行为变化
- `BTCUSDT 15m/30m` 模板默认 `stop_loss_atr` 由 `0.05` 调整为 `0.3`。
- live session state 会额外记录 `lastStrategyEvaluationSignalBarDecision` 与 `lastStrategyEvaluationSignalBarStateKey`。
- MonitorStage / AccountStage 会优先绑定策略刚评估过的同一组 signal bars，再回退到 `symbol + timeframe` 匹配；同时监控台增加 `Signal Trace` 区块，帮助追踪 breakout gate 与当前 bar 状态。
- 前端基于 signal bar 的解释文案优先使用 intraday `SMA5`，仅在 legacy fallback 时显示 `MA20`。
