### PR TITLE
Guard live reconcile against historical external orders

### DIFF
--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/wuyaocheng/bktrader/internal/domain"
@@ -82,7 +83,16 @@ type liveAccountSyncSuccessOwner interface {
 const (
 	liveOrderStatusVirtualInitial             = "VIRTUAL_INITIAL"
 	liveOrderStatusVirtualExit                = "VIRTUAL_EXIT"
-	liveAccountReconcileSelfHealLookbackHours = 24
+	liveAccountReconcileSelfHealLookbackHours = 8
+)
+
+var ErrLiveAccountOperationInProgress = errors.New("live account operation already in progress")
+
+type liveAccountOperationKind string
+
+const (
+	liveAccountOperationSync      liveAccountOperationKind = "sync"
+	liveAccountOperationReconcile liveAccountOperationKind = "reconcile"
 )
 
 func (p *Platform) ListLiveSessions() ([]domain.LiveSession, error) {
@@ -153,6 +163,15 @@ func (p *Platform) UpdateLiveSession(sessionID, alias, accountID, strategyID str
 }
 
 func (p *Platform) SyncLiveAccount(accountID string) (domain.Account, error) {
+	release, acquired := p.tryStartLiveAccountOperation(accountID, liveAccountOperationSync)
+	if !acquired {
+		return domain.Account{}, fmt.Errorf("%w: sync account=%s", ErrLiveAccountOperationInProgress, accountID)
+	}
+	defer release()
+	return p.syncLiveAccountWithoutGate(accountID)
+}
+
+func (p *Platform) syncLiveAccountWithoutGate(accountID string) (domain.Account, error) {
 	logger := p.logger("service.live", "account_id", accountID)
 	logger.Debug("syncing live account")
 	attemptedAt := time.Now().UTC()
@@ -201,6 +220,19 @@ func (p *Platform) SyncLiveAccount(accountID string) (domain.Account, error) {
 	}
 	account = p.persistLiveAccountSyncFailure(account, attemptedAt, fallbackErr)
 	return account, fallbackErr
+}
+
+func (p *Platform) tryStartLiveAccountOperation(accountID string, kind liveAccountOperationKind) (func(), bool) {
+	if strings.TrimSpace(accountID) == "" {
+		return func() {}, false
+	}
+	actual, _ := p.liveAccountOpMu.LoadOrStore(accountID, &sync.Mutex{})
+	mu, _ := actual.(*sync.Mutex)
+	if mu == nil || !mu.TryLock() {
+		p.logger("service.live", "account_id", accountID, "operation", string(kind)).Debug("skip live account operation while another operation is in progress")
+		return func() {}, false
+	}
+	return mu.Unlock, true
 }
 
 func liveAccountPositionReconcilePending(account domain.Account) bool {
@@ -265,7 +297,13 @@ func (p *Platform) ReconcileLiveAccount(accountID string, options LiveAccountRec
 		LookbackHours: options.LookbackHours,
 	}
 
-	account, err := p.SyncLiveAccount(accountID)
+	release, acquired := p.tryStartLiveAccountOperation(accountID, liveAccountOperationReconcile)
+	if !acquired {
+		return result, fmt.Errorf("live account %s sync/reconcile already in progress", accountID)
+	}
+	defer release()
+
+	account, err := p.syncLiveAccountWithoutGate(accountID)
 	if err != nil {
 		return result, err
 	}
@@ -305,6 +343,7 @@ func (p *Platform) ReconcileLiveAccount(accountID string, options LiveAccountRec
 		return result, err
 	}
 	index := buildLiveOrderReconcileIndex(orders, account.ID)
+	snapshotPositions := liveSyncSnapshotPositionAmounts(account)
 
 	for _, symbol := range symbols {
 		exchangeOrders, err := reconcileAdapter.FetchRecentOrders(account, binding, symbol, options.LookbackHours)
@@ -324,7 +363,7 @@ func (p *Platform) ReconcileLiveAccount(accountID string, options LiveAccountRec
 			if exchangeOrderID == "" {
 				continue
 			}
-			reconciledOrder, created, err := p.reconcileLiveAccountExchangeOrder(account, binding, payload, tradesByExchangeOrderID[exchangeOrderID], &index)
+			reconciledOrder, created, err := p.reconcileLiveAccountExchangeOrder(account, binding, payload, tradesByExchangeOrderID[exchangeOrderID], snapshotPositions, &index)
 			if err != nil {
 				return result, err
 			}
@@ -479,31 +518,16 @@ func (p *Platform) refreshLiveAccountPositionReconcileGate(account domain.Accoun
 
 func normalizeLiveAccountReconcileOptions(options LiveAccountReconcileOptions) LiveAccountReconcileOptions {
 	if options.LookbackHours <= 0 {
-		options.LookbackHours = 24
+		options.LookbackHours = 4
 	}
-	if options.LookbackHours > 24*7 {
-		options.LookbackHours = 24 * 7
+	if options.LookbackHours > 48 {
+		options.LookbackHours = 48
 	}
 	return options
 }
 
 func (p *Platform) collectLiveAccountReconcileSymbols(account domain.Account, lookbackHours int) ([]string, error) {
 	symbolSet := make(map[string]struct{})
-	cutoff := time.Now().UTC().Add(-time.Duration(maxInt(lookbackHours, 1)) * time.Hour)
-
-	orders, err := p.store.ListOrders()
-	if err != nil {
-		return nil, err
-	}
-	for _, order := range orders {
-		if order.AccountID != account.ID {
-			continue
-		}
-		status := strings.ToUpper(strings.TrimSpace(order.Status))
-		if order.CreatedAt.After(cutoff) || !isTerminalOrderStatus(status) {
-			addLiveAccountReconcileSymbol(symbolSet, order.Symbol)
-		}
-	}
 
 	positions, err := p.store.ListPositions()
 	if err != nil {
@@ -529,7 +553,7 @@ func (p *Platform) collectLiveAccountReconcileSymbols(account domain.Account, lo
 		return nil, err
 	}
 	for _, session := range sessions {
-		if session.AccountID != account.ID {
+		if session.AccountID != account.ID || !strings.EqualFold(strings.TrimSpace(session.Status), "RUNNING") {
 			continue
 		}
 		addLiveAccountReconcileSymbol(symbolSet, stringValue(session.State["symbol"]))
@@ -549,6 +573,23 @@ func addLiveAccountReconcileSymbol(symbols map[string]struct{}, raw string) {
 		return
 	}
 	symbols[symbol] = struct{}{}
+}
+
+func liveSyncSnapshotPositionAmounts(account domain.Account) map[string]float64 {
+	snapshot := cloneMetadata(mapValue(account.Metadata["liveSyncSnapshot"]))
+	amounts := make(map[string]float64)
+	for _, item := range metadataList(snapshot["positions"]) {
+		symbol := NormalizeSymbol(stringValue(item["symbol"]))
+		if symbol == "" {
+			continue
+		}
+		amount := parseFloatValue(item["positionAmt"])
+		if amount == 0 {
+			amount = parseFloatValue(item["quantity"])
+		}
+		amounts[symbol] = math.Abs(amount)
+	}
+	return amounts
 }
 
 func buildLiveOrderReconcileIndex(orders []domain.Order, accountID string) liveOrderReconcileIndex {
@@ -612,7 +653,7 @@ func groupTradeReportsByExchangeOrderID(reports []LiveFillReport) map[string][]L
 	return grouped
 }
 
-func (p *Platform) reconcileLiveAccountExchangeOrder(account domain.Account, binding map[string]any, payload map[string]any, tradeReports []LiveFillReport, index *liveOrderReconcileIndex) (domain.Order, bool, error) {
+func (p *Platform) reconcileLiveAccountExchangeOrder(account domain.Account, binding map[string]any, payload map[string]any, tradeReports []LiveFillReport, snapshotPositions map[string]float64, index *liveOrderReconcileIndex) (domain.Order, bool, error) {
 	exchangeOrderID := normalizeBinanceOrderID(payload["orderId"], payload["clientOrderId"])
 	clientOrderID := strings.TrimSpace(stringValue(payload["clientOrderId"]))
 	if exchangeOrderID == "" {
@@ -622,6 +663,16 @@ func (p *Platform) reconcileLiveAccountExchangeOrder(account domain.Account, bin
 	created := false
 	var err error
 	if !found {
+		if skipReason := classifyLiveReconcileOrderSkip(payload, clientOrderID, snapshotPositions, index); skipReason != "" {
+			p.logger("service.live",
+				"account_id", account.ID,
+				"symbol", NormalizeSymbol(stringValue(payload["symbol"])),
+				"exchange_order_id", exchangeOrderID,
+				"client_order_id", clientOrderID,
+				"skip_reason", skipReason,
+			).Warn("skip reconcile exchange order")
+			return domain.Order{}, false, nil
+		}
 		order, err = p.createRecoveredLiveOrderFromExchange(account, binding, payload)
 		if err != nil {
 			return domain.Order{}, false, err
@@ -642,6 +693,30 @@ func (p *Platform) reconcileLiveAccountExchangeOrder(account domain.Account, bin
 	}
 	index.put(updated)
 	return updated, created, nil
+}
+
+func classifyLiveReconcileOrderSkip(payload map[string]any, clientOrderID string, snapshotPositions map[string]float64, index *liveOrderReconcileIndex) string {
+	status := strings.ToUpper(strings.TrimSpace(stringValue(payload["status"])))
+	terminal := isTerminalOrderStatus(mapBinanceOrderStatus(status)) || isTerminalOrderStatus(status)
+	executedQty := parseFloatValue(payload["executedQty"])
+	isSystemOrder := strings.HasPrefix(clientOrderID, "order-")
+	if !isSystemOrder && clientOrderID != "" && index != nil {
+		_, isSystemOrder = index.byClientOrderID[clientOrderID]
+	}
+	if !isSystemOrder {
+		return "non-system-order"
+	}
+	symbol := NormalizeSymbol(stringValue(payload["symbol"]))
+	if terminal && snapshotPositions[symbol] <= 1e-9 {
+		return "closed-position-historical-order"
+	}
+	if (strings.EqualFold(status, "CANCELED") || strings.EqualFold(status, "CANCELLED") || strings.EqualFold(status, "REJECTED")) && executedQty <= 1e-9 {
+		return "no-fill-cancelled"
+	}
+	if !terminal && snapshotPositions[symbol] <= 1e-9 {
+		return "no-live-position"
+	}
+	return ""
 }
 
 func (p *Platform) createRecoveredLiveOrderFromExchange(account domain.Account, binding map[string]any, payload map[string]any) (domain.Order, error) {

--- a/internal/service/live_execution.go
+++ b/internal/service/live_execution.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"strings"
@@ -504,7 +505,9 @@ func (p *Platform) dispatchLiveSessionIntent(session domain.LiveSession) (domain
 	settlementPending := liveOrderSettlementSyncPending(created)
 	if strings.EqualFold(created.Status, "FILLED") && !settlementPending {
 		if _, syncErr := p.SyncLiveAccount(session.AccountID); syncErr != nil {
-			state["lastSyncError"] = syncErr.Error()
+			if !errors.Is(syncErr, ErrLiveAccountOperationInProgress) {
+				state["lastSyncError"] = syncErr.Error()
+			}
 		}
 	}
 	updatedSession, _ := p.store.UpdateLiveSessionState(session.ID, state)
@@ -796,7 +799,9 @@ func (p *Platform) syncLatestLiveSessionOrder(session domain.LiveSession, eventT
 		state["lastExecutionDispatch"] = executionDispatchSummary(mapValue(order.Metadata["executionProposal"]), order, false)
 		updateExecutionEventStats(state, mapValue(order.Metadata["executionProposal"]), mapValue(state["lastExecutionDispatch"]))
 		if strings.EqualFold(order.Status, "FILLED") {
-			_, _ = p.SyncLiveAccount(session.AccountID)
+			if _, syncErr := p.SyncLiveAccount(session.AccountID); syncErr != nil && !errors.Is(syncErr, ErrLiveAccountOperationInProgress) {
+				p.logger("service.live_execution", "session_id", session.ID, "account_id", session.AccountID).Warn("live account sync failed after terminal order sync", "error", syncErr)
+			}
 		}
 		updated, err := p.store.UpdateLiveSessionState(session.ID, state)
 		if err != nil {
@@ -873,7 +878,9 @@ func (p *Platform) syncLatestLiveSessionOrder(session domain.LiveSession, eventT
 	state["lastExecutionDispatch"] = executionDispatchSummary(mapValue(order.Metadata["executionProposal"]), syncedOrder, false)
 	updateExecutionEventStats(state, mapValue(order.Metadata["executionProposal"]), mapValue(state["lastExecutionDispatch"]))
 	if strings.EqualFold(syncedOrder.Status, "FILLED") {
-		_, _ = p.SyncLiveAccount(session.AccountID)
+		if _, syncErr := p.SyncLiveAccount(session.AccountID); syncErr != nil && !errors.Is(syncErr, ErrLiveAccountOperationInProgress) {
+			p.logger("service.live_execution", "session_id", session.ID, "account_id", session.AccountID).Warn("live account sync failed after filled order sync", "error", syncErr)
+		}
 	}
 	appendTimelineEvent(state, "order", eventTime, "live-order-synced", executionDispatchTimelineMetadata(mapValue(order.Metadata["executionProposal"]), syncedOrder, false))
 	updated, err := p.store.UpdateLiveSessionState(session.ID, state)

--- a/internal/service/live_reconcile_test.go
+++ b/internal/service/live_reconcile_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -20,8 +21,8 @@ func TestReconcileLiveAccountRecoversMissingFilledOrder(t *testing.T) {
 			account.Metadata["liveSyncSnapshot"] = map[string]any{
 				"source":      "test-reconcile",
 				"syncedAt":    syncedAt.Format(time.RFC3339),
-				"openOrders":  []map[string]any{{"symbol": "BTCUSDT"}},
-				"positions":   []map[string]any{},
+				"openOrders":  []map[string]any{},
+				"positions":   []map[string]any{{"symbol": "BTCUSDT", "positionAmt": 0.2, "entryPrice": 68010.0}},
 				"bindingMode": stringValue(binding["connectionMode"]),
 			}
 			account.Metadata["lastLiveSyncAt"] = syncedAt.Format(time.RFC3339)
@@ -31,7 +32,7 @@ func TestReconcileLiveAccountRecoversMissingFilledOrder(t *testing.T) {
 			"BTCUSDT": {{
 				"symbol":        "BTCUSDT",
 				"orderId":       "9001",
-				"clientOrderId": "client-9001",
+				"clientOrderId": "order-9001",
 				"status":        "FILLED",
 				"side":          "BUY",
 				"type":          "MARKET",
@@ -141,6 +142,215 @@ func TestReconcileLiveAccountRecoversMissingFilledOrder(t *testing.T) {
 	lastReconcile := mapValue(updatedAccount.Metadata["lastLiveReconcile"])
 	if got := int(parseFloatValue(lastReconcile["createdOrderCount"])); got != 1 {
 		t.Fatalf("expected reconcile summary createdOrderCount=1, got %d", got)
+	}
+}
+
+func TestReconcileLiveAccountSkipsHistoricalTerminalOrderWithoutLocalMatchAndWithoutLivePosition(t *testing.T) {
+	store := memory.NewStore()
+	platform := NewPlatform(store)
+
+	configureTestLiveRESTReconcileHistoryAdapter(t, platform, "test-skip-historical-terminal", []map[string]any{}, map[string][]map[string]any{
+		"BTCUSDT": {{
+			"symbol":        "BTCUSDT",
+			"orderId":       "9002",
+			"clientOrderId": "external-9002",
+			"status":        "FILLED",
+			"side":          "BUY",
+			"type":          "MARKET",
+			"origType":      "MARKET",
+			"origQty":       0.2,
+			"executedQty":   0.2,
+			"price":         68000.0,
+			"avgPrice":      68010.0,
+			"time":          float64(time.Now().UTC().Add(-2 * time.Minute).UnixMilli()),
+			"updateTime":    float64(time.Now().UTC().UnixMilli()),
+		}},
+	}, map[string][]LiveFillReport{
+		"BTCUSDT": {{
+			Price:    68010,
+			Quantity: 0.2,
+			Fee:      1.2,
+			Metadata: map[string]any{
+				"exchangeOrderId": "9002",
+				"tradeId":         "trade-9002",
+				"executionMode":   "rest",
+			},
+		}},
+	})
+
+	result, err := platform.ReconcileLiveAccount("live-main", LiveAccountReconcileOptions{LookbackHours: 4})
+	if err != nil {
+		t.Fatalf("reconcile live account failed: %v", err)
+	}
+	if result.CreatedOrderCount != 0 || result.OrderCount != 0 {
+		t.Fatalf("expected historical terminal order to be skipped, got created=%d total=%d", result.CreatedOrderCount, result.OrderCount)
+	}
+
+	orders, err := store.ListOrders()
+	if err != nil {
+		t.Fatalf("list orders failed: %v", err)
+	}
+	for _, item := range orders {
+		if item.AccountID == "live-main" && stringValue(item.Metadata["exchangeOrderId"]) == "9002" {
+			t.Fatal("expected skipped historical order to not be persisted locally")
+		}
+	}
+	fills, err := store.ListFills()
+	if err != nil {
+		t.Fatalf("list fills failed: %v", err)
+	}
+	for _, item := range fills {
+		if item.ExchangeTradeID == "trade-9002" {
+			t.Fatal("expected skipped historical order to not create fills")
+		}
+	}
+	if _, found, err := store.FindPosition("live-main", "BTCUSDT"); err != nil {
+		t.Fatalf("find position failed: %v", err)
+	} else if found {
+		t.Fatal("expected skipped historical order to not rebuild a position")
+	}
+}
+
+func TestReconcileLiveAccountReusesExistingOrderByExchangeOrderIDInsteadOfCreatingRecoveredDuplicate(t *testing.T) {
+	store := memory.NewStore()
+	platform := NewPlatform(store)
+
+	configureTestLiveRESTReconcileHistoryAdapter(t, platform, "test-reuse-existing-order", []map[string]any{{
+		"symbol":      "BTCUSDT",
+		"positionAmt": 0.2,
+		"entryPrice":  68010.0,
+	}}, map[string][]map[string]any{
+		"BTCUSDT": {{
+			"symbol":        "BTCUSDT",
+			"orderId":       "9003",
+			"clientOrderId": "order-9003",
+			"status":        "FILLED",
+			"side":          "BUY",
+			"type":          "MARKET",
+			"origType":      "MARKET",
+			"origQty":       0.2,
+			"executedQty":   0.2,
+			"price":         68000.0,
+			"avgPrice":      68010.0,
+			"time":          float64(time.Now().UTC().Add(-2 * time.Minute).UnixMilli()),
+			"updateTime":    float64(time.Now().UTC().UnixMilli()),
+		}},
+	}, map[string][]LiveFillReport{
+		"BTCUSDT": {{
+			Price:    68010,
+			Quantity: 0.2,
+			Fee:      1.2,
+			Metadata: map[string]any{
+				"exchangeOrderId": "9003",
+				"tradeId":         "trade-9003",
+				"executionMode":   "rest",
+			},
+		}},
+	})
+
+	existing, err := store.CreateOrder(domain.Order{
+		ID:                "order-9003-local",
+		AccountID:         "live-main",
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "BUY",
+		Type:              "MARKET",
+		Status:            "ACCEPTED",
+		Quantity:          0.2,
+		Price:             68000,
+		Metadata: map[string]any{
+			"exchangeOrderId":       "9003",
+			"exchangeClientOrderId": "order-9003",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create existing order failed: %v", err)
+	}
+
+	result, err := platform.ReconcileLiveAccount("live-main", LiveAccountReconcileOptions{LookbackHours: 4})
+	if err != nil {
+		t.Fatalf("reconcile live account failed: %v", err)
+	}
+	if result.CreatedOrderCount != 0 {
+		t.Fatalf("expected reconcile to reuse existing order, got created=%d", result.CreatedOrderCount)
+	}
+	if result.UpdatedOrderCount != 1 || result.OrderCount != 1 {
+		t.Fatalf("expected one updated reconciled order, got updated=%d total=%d", result.UpdatedOrderCount, result.OrderCount)
+	}
+
+	orders, err := store.ListOrders()
+	if err != nil {
+		t.Fatalf("list orders failed: %v", err)
+	}
+	matchCount := 0
+	for _, item := range orders {
+		if item.AccountID == "live-main" && stringValue(item.Metadata["exchangeOrderId"]) == "9003" {
+			matchCount++
+			if item.ID != existing.ID {
+				t.Fatalf("expected reconcile to reuse order %s, got %s", existing.ID, item.ID)
+			}
+		}
+	}
+	if matchCount != 1 {
+		t.Fatalf("expected one local order for exchangeOrderId 9003, got %d", matchCount)
+	}
+}
+
+func TestCollectLiveAccountReconcileSymbolsExcludesHistoricalTerminalOrdersWithoutLiveReferences(t *testing.T) {
+	store := memory.NewStore()
+	platform := NewPlatform(store)
+
+	account, err := store.GetAccount("live-main")
+	if err != nil {
+		t.Fatalf("get account failed: %v", err)
+	}
+	account.Metadata = cloneMetadata(account.Metadata)
+	account.Metadata["liveSyncSnapshot"] = map[string]any{
+		"positions":  []map[string]any{{"symbol": "BTCUSDT", "positionAmt": 0.2}},
+		"openOrders": []map[string]any{{"symbol": "SOLUSDT"}},
+	}
+	account, err = store.UpdateAccount(account)
+	if err != nil {
+		t.Fatalf("update account failed: %v", err)
+	}
+
+	if _, err := store.CreateOrder(domain.Order{
+		AccountID: "live-main",
+		Symbol:    "ETHUSDT",
+		Status:    "FILLED",
+		Quantity:  0.1,
+		Price:     3000,
+		Metadata:  map[string]any{},
+	}); err != nil {
+		t.Fatalf("create historical terminal order failed: %v", err)
+	}
+	if _, err := store.SavePosition(domain.Position{
+		AccountID:  "live-main",
+		Symbol:     "BNBUSDT",
+		Side:       "LONG",
+		Quantity:   1,
+		EntryPrice: 600,
+		MarkPrice:  610,
+	}); err != nil {
+		t.Fatalf("save local position failed: %v", err)
+	}
+	session, err := platform.CreateLiveSession("", "live-main", "strategy-bk-1d", map[string]any{
+		"symbol": "XRPUSDT",
+	})
+	if err != nil {
+		t.Fatalf("create live session failed: %v", err)
+	}
+	if _, err := store.UpdateLiveSessionStatus(session.ID, "RUNNING"); err != nil {
+		t.Fatalf("mark session running failed: %v", err)
+	}
+
+	symbols, err := platform.collectLiveAccountReconcileSymbols(account, 4)
+	if err != nil {
+		t.Fatalf("collect reconcile symbols failed: %v", err)
+	}
+	got := strings.Join(symbols, ",")
+	if got != "BNBUSDT,BTCUSDT,SOLUSDT,XRPUSDT" {
+		t.Fatalf("unexpected reconcile symbols: %s", got)
 	}
 }
 

--- a/internal/service/live_registry.go
+++ b/internal/service/live_registry.go
@@ -761,7 +761,107 @@ type binanceSymbolRules struct {
 var (
 	binanceSymbolRulesCache   = map[string]binanceSymbolRules{}
 	binanceSymbolRulesCacheMu sync.Mutex
+	binanceRESTLimiterState   = newBinanceRESTLimiter()
 )
+
+var (
+	binanceRESTRequestsPerSecond = 30
+	binanceRESTBurst             = 50
+	binanceRESTBackoffDuration   = 60 * time.Second
+)
+
+type binanceRESTLimiter struct {
+	mu    sync.Mutex
+	gates map[string]*binanceRESTGate
+}
+
+type binanceRESTGate struct {
+	tokens chan struct{}
+	mu     sync.Mutex
+	block  time.Time
+}
+
+func newBinanceRESTLimiter() *binanceRESTLimiter {
+	return &binanceRESTLimiter{gates: make(map[string]*binanceRESTGate)}
+}
+
+func (l *binanceRESTLimiter) gate(key string) *binanceRESTGate {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if gate, ok := l.gates[key]; ok {
+		return gate
+	}
+	gate := newBinanceRESTGate(maxInt(binanceRESTRequestsPerSecond, 1), maxInt(binanceRESTBurst, 1))
+	l.gates[key] = gate
+	return gate
+}
+
+func newBinanceRESTGate(requestsPerSecond, burst int) *binanceRESTGate {
+	gate := &binanceRESTGate{tokens: make(chan struct{}, burst)}
+	for i := 0; i < burst; i++ {
+		gate.tokens <- struct{}{}
+	}
+	interval := time.Second
+	if requestsPerSecond > 0 {
+		interval = time.Second / time.Duration(requestsPerSecond)
+	}
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for range ticker.C {
+			select {
+			case gate.tokens <- struct{}{}:
+			default:
+			}
+		}
+	}()
+	return gate
+}
+
+func (g *binanceRESTGate) acquire() error {
+	g.mu.Lock()
+	blockedUntil := g.block
+	g.mu.Unlock()
+	if time.Now().UTC().Before(blockedUntil) {
+		return fmt.Errorf("binance rest temporarily rate-limited until %s", blockedUntil.Format(time.RFC3339))
+	}
+	<-g.tokens
+	g.mu.Lock()
+	blockedUntil = g.block
+	g.mu.Unlock()
+	if time.Now().UTC().Before(blockedUntil) {
+		return fmt.Errorf("binance rest temporarily rate-limited until %s", blockedUntil.Format(time.RFC3339))
+	}
+	return nil
+}
+
+func (g *binanceRESTGate) markBackoff(duration time.Duration) {
+	if duration <= 0 {
+		duration = binanceRESTBackoffDuration
+	}
+	until := time.Now().UTC().Add(duration)
+	g.mu.Lock()
+	if until.After(g.block) {
+		g.block = until
+	}
+	g.mu.Unlock()
+}
+
+func binanceRESTLimiterKey(creds binanceRESTCredentials) string {
+	return creds.BaseURL + "|" + creds.APIKeyRef
+}
+
+func parseBinanceRetryAfter(headers http.Header) time.Duration {
+	raw := strings.TrimSpace(headers.Get("Retry-After"))
+	if raw == "" {
+		return 0
+	}
+	seconds, err := strconv.Atoi(raw)
+	if err != nil || seconds <= 0 {
+		return 0
+	}
+	return time.Duration(seconds) * time.Second
+}
 
 func resolveBinanceRESTCredentials(binding map[string]any) (binanceRESTCredentials, error) {
 	credentialRefs := normalizeCredentialRefs(binding["credentialRefs"])
@@ -915,6 +1015,10 @@ func fetchBinanceSymbolRules(creds binanceRESTCredentials, symbol string) (binan
 		return cached, nil
 	}
 	requestURL := creds.BaseURL + "/fapi/v1/exchangeInfo?symbol=" + url.QueryEscape(normalizedSymbol)
+	gate := binanceRESTLimiterState.gate(binanceRESTLimiterKey(creds))
+	if err := gate.acquire(); err != nil {
+		return binanceSymbolRules{}, err
+	}
 	request, err := http.NewRequest(http.MethodGet, requestURL, nil)
 	if err != nil {
 		return binanceSymbolRules{}, err
@@ -927,6 +1031,9 @@ func fetchBinanceSymbolRules(creds binanceRESTCredentials, symbol string) (binan
 	responseBody, readErr := io.ReadAll(response.Body)
 	if readErr != nil {
 		return binanceSymbolRules{}, readErr
+	}
+	if response.StatusCode == http.StatusTooManyRequests {
+		gate.markBackoff(firstPositiveDuration(parseBinanceRetryAfter(response.Header), binanceRESTBackoffDuration))
 	}
 	if response.StatusCode < 200 || response.StatusCode >= 300 {
 		return binanceSymbolRules{}, fmt.Errorf("binance exchangeInfo failed: %s %s", response.Status, strings.TrimSpace(string(responseBody)))
@@ -1114,6 +1221,10 @@ func cloneStringMap(input map[string]string) map[string]string {
 }
 
 func doBinanceSignedRequest(method string, creds binanceRESTCredentials, path string, params map[string]string) ([]byte, error) {
+	gate := binanceRESTLimiterState.gate(binanceRESTLimiterKey(creds))
+	if err := gate.acquire(); err != nil {
+		return nil, err
+	}
 	query := encodeBinanceQuery(params, false)
 	requestURL := creds.BaseURL + path
 	var body io.Reader
@@ -1140,10 +1251,22 @@ func doBinanceSignedRequest(method string, creds binanceRESTCredentials, path st
 	if readErr != nil {
 		return nil, readErr
 	}
+	if response.StatusCode == http.StatusTooManyRequests {
+		gate.markBackoff(firstPositiveDuration(parseBinanceRetryAfter(response.Header), binanceRESTBackoffDuration))
+	}
 	if response.StatusCode < 200 || response.StatusCode >= 300 {
 		return nil, fmt.Errorf("binance request failed: %s %s", response.Status, strings.TrimSpace(string(responseBody)))
 	}
 	return responseBody, nil
+}
+
+func firstPositiveDuration(values ...time.Duration) time.Duration {
+	for _, value := range values {
+		if value > 0 {
+			return value
+		}
+	}
+	return 0
 }
 
 func mapBinanceOrderStatus(status string) string {

--- a/internal/service/live_registry_test.go
+++ b/internal/service/live_registry_test.go
@@ -1,0 +1,59 @@
+package service
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestDoBinanceSignedRequestBacksOffAfter429(t *testing.T) {
+	var requestCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount.Add(1)
+		http.Error(w, "too many requests", http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	previousLimiter := binanceRESTLimiterState
+	previousRate := binanceRESTRequestsPerSecond
+	previousBurst := binanceRESTBurst
+	previousBackoff := binanceRESTBackoffDuration
+	binanceRESTLimiterState = newBinanceRESTLimiter()
+	binanceRESTRequestsPerSecond = 1000
+	binanceRESTBurst = 10
+	binanceRESTBackoffDuration = 50 * time.Millisecond
+	defer func() {
+		binanceRESTLimiterState = previousLimiter
+		binanceRESTRequestsPerSecond = previousRate
+		binanceRESTBurst = previousBurst
+		binanceRESTBackoffDuration = previousBackoff
+	}()
+
+	creds := binanceRESTCredentials{
+		APIKeyRef: "test-key-ref",
+		APIKey:    "test-key",
+		APISecret: "test-secret",
+		BaseURL:   server.URL,
+	}
+	params := map[string]string{
+		"symbol":     "BTCUSDT",
+		"timestamp":  "1",
+		"signature":  "test-signature",
+		"recvWindow": "5000",
+	}
+
+	if _, err := doBinanceSignedRequest(http.MethodGet, creds, "/fapi/v1/order", params); err == nil {
+		t.Fatal("expected first request to fail with 429")
+	}
+	if _, err := doBinanceSignedRequest(http.MethodGet, creds, "/fapi/v1/order", params); err == nil {
+		t.Fatal("expected second request during backoff to be rejected")
+	} else if !strings.Contains(err.Error(), "rate-limited") {
+		t.Fatalf("expected second request to be rejected by local backoff, got %v", err)
+	}
+	if got := requestCount.Load(); got != 1 {
+		t.Fatalf("expected only the first request to reach the server during backoff, got %d", got)
+	}
+}

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -5442,6 +5443,79 @@ func TestSyncActiveLiveAccountsThrottlesFailedRetriesUntilFreshnessWindow(t *tes
 	}
 }
 
+func TestSyncLiveAccountSkipsConcurrentAdapterSyncForSameAccount(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	blockSync := make(chan struct{})
+	enteredSync := make(chan struct{}, 1)
+	var syncCalls atomic.Int32
+
+	platform.registerLiveAdapter(testLiveAccountSyncAdapter{
+		key: "test-sync-gate",
+		syncSnapshotFunc: func(p *Platform, account domain.Account, binding map[string]any) (domain.Account, error) {
+			if syncCalls.Add(1) == 1 {
+				enteredSync <- struct{}{}
+			}
+			<-blockSync
+			account.Metadata = cloneMetadata(account.Metadata)
+			account.Metadata["lastLiveSyncAt"] = time.Now().UTC().Format(time.RFC3339)
+			return p.store.UpdateAccount(account)
+		},
+	})
+
+	account, err := platform.store.GetAccount("live-main")
+	if err != nil {
+		t.Fatalf("get account failed: %v", err)
+	}
+	account.Metadata = cloneMetadata(account.Metadata)
+	account.Metadata["liveBinding"] = map[string]any{
+		"adapterKey":     "test-sync-gate",
+		"connectionMode": "mock",
+		"executionMode":  "rest",
+	}
+	if _, err := platform.store.UpdateAccount(account); err != nil {
+		t.Fatalf("update account failed: %v", err)
+	}
+
+	firstDone := make(chan error, 1)
+	go func() {
+		_, err := platform.SyncLiveAccount("live-main")
+		firstDone <- err
+	}()
+
+	select {
+	case <-enteredSync:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for first sync to enter adapter")
+	}
+
+	secondDone := make(chan error, 1)
+	start := time.Now()
+	go func() {
+		_, err := platform.SyncLiveAccount("live-main")
+		secondDone <- err
+	}()
+
+	select {
+	case err := <-secondDone:
+		if !errors.Is(err, ErrLiveAccountOperationInProgress) {
+			t.Fatalf("expected concurrent sync to return in-progress error, got %v", err)
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("expected concurrent sync to return immediately while first sync is in progress")
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("expected concurrent sync to skip adapter call quickly, took %s", elapsed)
+	}
+	if got := syncCalls.Load(); got != 1 {
+		t.Fatalf("expected only one adapter sync call, got %d", got)
+	}
+
+	close(blockSync)
+	if err := <-firstDone; err != nil {
+		t.Fatalf("first sync failed: %v", err)
+	}
+}
+
 func TestSyncLiveAccountNormalizesAdapterSuccessHealthState(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
 	platform.runtimePolicy.LiveAccountSyncFreshnessSecs = 60
@@ -6730,7 +6804,7 @@ func TestStartLiveSessionBackfillsFilledExitBeforeReconcileGateBlock(t *testing.
 	}
 }
 
-func TestStartLiveSessionSelfHealsStaleDBPositionViaReconcileHistory(t *testing.T) {
+func TestStartLiveSessionKeepsStaleDBPositionBlockedWhenReconcileOnlyFindsHistoricalExternalOrders(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
 	syncedAt := time.Date(2026, 4, 20, 12, 33, 23, 0, time.UTC)
 	configureTestLiveRESTReconcileHistoryAdapter(
@@ -6791,22 +6865,26 @@ func TestStartLiveSessionSelfHealsStaleDBPositionViaReconcileHistory(t *testing.
 	}
 
 	started, err := platform.StartLiveSession(session.ID)
-	if err != nil {
-		t.Fatalf("expected StartLiveSession to self-heal stale db-position-exchange-missing state, got %v", err)
+	if err == nil || !strings.Contains(err.Error(), liveRecoveryModeReconcileGateBlocked) {
+		t.Fatalf("expected StartLiveSession to remain blocked by reconcile gate, got %v", err)
 	}
-	if started.Status != "RUNNING" {
-		t.Fatalf("expected session to start RUNNING after reconcile history heal, got %s", started.Status)
+	started, err = platform.store.GetLiveSession(session.ID)
+	if err != nil {
+		t.Fatalf("get blocked live session failed: %v", err)
+	}
+	if started.Status != "BLOCKED" {
+		t.Fatalf("expected session to stay BLOCKED when reconcile only finds historical external orders, got %s", started.Status)
 	}
 	if _, found, err := platform.store.FindPosition(session.AccountID, "BTCUSDT"); err != nil {
 		t.Fatalf("find position failed: %v", err)
-	} else if found {
-		t.Fatal("expected reconcile history self-heal to clear stale BTCUSDT position before start completes")
+	} else if !found {
+		t.Fatal("expected stale BTCUSDT position to remain until manual review")
 	}
-	if got := stringValue(started.State["recoveryMode"]); got == liveRecoveryModeReconcileGateBlocked {
-		t.Fatalf("expected reconcile gate block to clear after reconcile history self-heal, got %s", got)
+	if got := stringValue(started.State["recoveryMode"]); got != liveRecoveryModeReconcileGateBlocked {
+		t.Fatalf("expected reconcile gate block to remain, got %s", got)
 	}
-	if got := stringValue(started.State["positionReconcileGateScenario"]); got == "db-position-exchange-missing" {
-		t.Fatalf("expected stale db-position-exchange-missing scenario to clear after self-heal, got %s", got)
+	if got := stringValue(started.State["positionReconcileGateScenario"]); got != "db-position-exchange-missing" {
+		t.Fatalf("expected stale db-position-exchange-missing scenario to remain, got %s", got)
 	}
 }
 

--- a/internal/service/order.go
+++ b/internal/service/order.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -605,6 +606,9 @@ func (p *Platform) settleImmediatelyFilledLiveOrder(order domain.Order) (domain.
 		return order, fmt.Errorf("live order %s submitted as FILLED but settlement sync failed: %w", order.ID, err)
 	}
 	if _, syncErr := p.SyncLiveAccount(order.AccountID); syncErr != nil {
+		if errors.Is(syncErr, ErrLiveAccountOperationInProgress) {
+			return settledOrder, nil
+		}
 		return settledOrder, fmt.Errorf("live order %s settled but account/session refresh failed: %w", order.ID, syncErr)
 	}
 	return settledOrder, nil
@@ -1030,7 +1034,11 @@ func (p *Platform) filterExistingExecutionFills(orderID string, fills []domain.F
 		return nil, err
 	}
 	seen := make(map[string]struct{}, len(existing)+len(fills))
+	globalTradeSeen := make(map[string]struct{}, len(existing)+len(fills))
 	for _, item := range existing {
+		if item.ExchangeTradeID != "" {
+			globalTradeSeen[strings.TrimSpace(item.ExchangeTradeID)] = struct{}{}
+		}
 		if item.OrderID != orderID {
 			continue
 		}
@@ -1045,6 +1053,12 @@ func (p *Platform) filterExistingExecutionFills(orderID string, fills []domain.F
 		fill.OrderID = orderID
 		if strings.TrimSpace(fill.ExchangeTradeID) == "" && strings.TrimSpace(fill.DedupFingerprint) == "" {
 			fill.DedupFingerprint = fill.FallbackFingerprint()
+		}
+		if tradeID := strings.TrimSpace(fill.ExchangeTradeID); tradeID != "" {
+			if _, exists := globalTradeSeen[tradeID]; exists {
+				continue
+			}
+			globalTradeSeen[tradeID] = struct{}{}
 		}
 		key := buildFillDedupKey(fill)
 		if key == "" {
@@ -1188,6 +1202,17 @@ func (p *Platform) ListFills() ([]domain.Fill, error) {
 // applyExecutionFill 根据已确认成交更新仓位。
 // 它是 paper/live 共用的持仓落账逻辑，只处理 canonical fill 之后的仓位变更。
 func (p *Platform) applyExecutionFill(account domain.Account, order domain.Order, executionPrice float64) error {
+	if boolValue(order.Metadata["reconcileRecovered"]) {
+		snapshotQty := liveSyncSnapshotPositionAmounts(account)[NormalizeSymbol(order.Symbol)]
+		if snapshotQty <= 1e-9 {
+			p.logger("service.order",
+				"account_id", account.ID,
+				"order_id", order.ID,
+				"symbol", NormalizeSymbol(order.Symbol),
+			).Warn("skip reconcile fill position apply without authoritative live position")
+			return nil
+		}
+	}
 	position, exists, err := p.store.FindPosition(account.ID, order.Symbol)
 	if err != nil {
 		return err

--- a/internal/service/order_test.go
+++ b/internal/service/order_test.go
@@ -374,7 +374,7 @@ func TestClosePositionAllowsLiveManualCloseWithoutRuntimeSession(t *testing.T) {
 	}
 }
 
-func TestEnsureLivePositionReconcileGateAllowsExecutionSelfHealsStaleDBOnlyPosition(t *testing.T) {
+func TestEnsureLivePositionReconcileGateKeepsHistoricalExternalOrdersFromSelfHealingStaleDBOnlyPosition(t *testing.T) {
 	store := memory.NewStore()
 	platform := NewPlatform(store)
 	syncedAt := time.Date(2026, 4, 21, 1, 23, 45, 0, time.UTC)
@@ -438,13 +438,13 @@ func TestEnsureLivePositionReconcileGateAllowsExecutionSelfHealsStaleDBOnlyPosit
 		t.Fatalf("expected initial stale db-position-exchange-missing gate, got %#v", initialGate)
 	}
 
-	if err := platform.ensureLivePositionReconcileGateAllowsExecution("live-main", "BTCUSDT", true); err != nil {
-		t.Fatalf("expected reconcile gate check to self-heal stale db-only position, got %v", err)
+	if err := platform.ensureLivePositionReconcileGateAllowsExecution("live-main", "BTCUSDT", true); err == nil || !strings.Contains(err.Error(), "reconcile gate") {
+		t.Fatalf("expected reconcile gate check to stay blocked, got %v", err)
 	}
 	if _, found, err := store.FindPosition("live-main", "BTCUSDT"); err != nil {
 		t.Fatalf("find position failed: %v", err)
-	} else if found {
-		t.Fatal("expected stale BTCUSDT position to be removed after reconcile gate self-heal")
+	} else if !found {
+		t.Fatal("expected stale BTCUSDT position to remain until manual review")
 	}
 
 	account, err = store.GetAccount("live-main")
@@ -452,8 +452,8 @@ func TestEnsureLivePositionReconcileGateAllowsExecutionSelfHealsStaleDBOnlyPosit
 		t.Fatalf("get healed account failed: %v", err)
 	}
 	healedGate := resolveLivePositionReconcileGate(account, "BTCUSDT", true)
-	if boolValue(healedGate["blocking"]) {
-		t.Fatalf("expected reconcile gate to clear after self-heal, got %#v", healedGate)
+	if !boolValue(healedGate["blocking"]) {
+		t.Fatalf("expected reconcile gate to remain blocking, got %#v", healedGate)
 	}
 }
 

--- a/internal/service/platform.go
+++ b/internal/service/platform.go
@@ -38,6 +38,7 @@ type Platform struct {
 	signalSessions         map[string]domain.SignalRuntimeSession
 	liveMarketMu           sync.RWMutex
 	liveMarketData         map[string]liveMarketSnapshot
+	liveAccountOpMu        sync.Map // accountID -> *sync.Mutex
 	manifestMu             sync.Mutex
 	once                   sync.Once             // 确保 CSV ledger 只加载一次
 	ledger                 []strategyReplayEvent // 缓存的策略回放账本

--- a/internal/service/safety_checks_test.go
+++ b/internal/service/safety_checks_test.go
@@ -333,7 +333,7 @@ func TestResolveClosePositionTargetFailsWhenPositionDisappearsAfterRefresh(t *te
 	}
 }
 
-func TestEnsureNoActivePositionsOrOrdersSelfHealsStaleLiveExposureViaReconcile(t *testing.T) {
+func TestEnsureNoActivePositionsOrOrdersKeepsStaleLiveExposureBlockedWhenReconcileOnlyFindsHistoricalExternalOrders(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
 	syncedAt := time.Date(2026, 4, 20, 12, 33, 23, 0, time.UTC)
 	configureTestLiveRESTReconcileHistoryAdapter(
@@ -385,24 +385,24 @@ func TestEnsureNoActivePositionsOrOrdersSelfHealsStaleLiveExposureViaReconcile(t
 		t.Fatalf("save position failed: %v", err)
 	}
 
-	if err := platform.ensureNoActivePositionsOrOrders("live-main", "strategy-bk-1d"); err != nil {
-		t.Fatalf("expected stale live exposure to self-heal before blocking, got %v", err)
+	if err := platform.ensureNoActivePositionsOrOrders("live-main", "strategy-bk-1d"); err == nil || !strings.Contains(err.Error(), "活动中的订单或未平仓头寸") {
+		t.Fatalf("expected stale live exposure to remain and block session cleanup, got %v", err)
 	}
 	if _, found, err := platform.store.FindPosition("live-main", "BTCUSDT"); err != nil {
 		t.Fatalf("find position failed: %v", err)
-	} else if found {
-		t.Fatal("expected reconcile self-heal to clear stale BTCUSDT position")
+	} else if !found {
+		t.Fatal("expected stale BTCUSDT position to remain until manual review")
 	}
 	active, err := platform.HasActivePositionsOrOrders("live-main", "strategy-bk-1d")
 	if err != nil {
-		t.Fatalf("HasActivePositionsOrOrders after self-heal returned error: %v", err)
+		t.Fatalf("HasActivePositionsOrOrders after blocked reconcile returned error: %v", err)
 	}
-	if active {
-		t.Fatal("expected no remaining active exposure after reconcile self-heal")
+	if !active {
+		t.Fatal("expected active exposure to remain until manual review")
 	}
 }
 
-func TestClosePositionSelfHealsStaleLivePositionViaReconcile(t *testing.T) {
+func TestClosePositionKeepsStaleLivePositionBlockedWhenReconcileOnlyFindsHistoricalExternalOrders(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
 	syncedAt := time.Date(2026, 4, 20, 12, 33, 23, 0, time.UTC)
 	configureTestLiveRESTReconcileHistoryAdapter(
@@ -455,13 +455,13 @@ func TestClosePositionSelfHealsStaleLivePositionViaReconcile(t *testing.T) {
 		t.Fatalf("save position failed: %v", err)
 	}
 
-	if _, err := platform.ClosePosition(position.ID); err == nil || !strings.Contains(err.Error(), "position not found") {
-		t.Fatalf("expected ClosePosition to self-heal stale local position before manual close, got %v", err)
+	if _, err := platform.ClosePosition(position.ID); err == nil || !strings.Contains(err.Error(), "reconcile gate") {
+		t.Fatalf("expected ClosePosition to stay blocked by reconcile gate, got %v", err)
 	}
 	if _, found, err := platform.store.FindPosition("live-main", "BTCUSDT"); err != nil {
 		t.Fatalf("find position failed: %v", err)
-	} else if found {
-		t.Fatal("expected stale BTCUSDT position to be removed after reconcile self-heal")
+	} else if !found {
+		t.Fatal("expected stale BTCUSDT position to remain until manual review")
 	}
 }
 


### PR DESCRIPTION
## 目的
修复 `ReconcileLiveAccount` / `SyncLiveAccount` 把交易所历史终态外部订单重新导入当前 live runtime 的问题，补上同账户 sync/reconcile 并发闸门与 Binance REST 429 backoff，避免历史订单污染本地 order/fill/position。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [x] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main)
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？
- [x] DB migration 是否具备向下兼容幂等性？
- [x] 配置字段有没有无意被混改？

补充说明：
- `dispatchMode` 默认值未改。
- 没有新增 mainnet 硬编码。
- 没有 DB migration。
- 修改集中在 live reconcile/sync 与对应测试，没有顺手改部署或执行策略默认行为。

## 验证方式与测试证据
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

已执行：
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`

关键新增/调整测试：
- `TestReconcileLiveAccountSkipsHistoricalTerminalOrderWithoutLocalMatchAndWithoutLivePosition`
- `TestReconcileLiveAccountReusesExistingOrderByExchangeOrderIDInsteadOfCreatingRecoveredDuplicate`
- `TestCollectLiveAccountReconcileSymbolsExcludesHistoricalTerminalOrdersWithoutLiveReferences`
- `TestSyncLiveAccountSkipsConcurrentAdapterSyncForSameAccount`
- `TestDoBinanceSignedRequestBacksOffAfter429`
- 将原先依赖“历史外部终态单可自愈 stale position”的测试，调整为新的安全预期：保持 reconcile gate 阻断并等待人工处理。
