### PR TITLE
Align live breakout gating with current breakout price

### DIFF
--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -2620,6 +2620,7 @@ func (p *Platform) evaluateLiveSignalDecision(session domain.LiveSession, summar
 	if err != nil {
 		return executionContext, StrategySignalDecision{}, cloneMetadata(session.State), err
 	}
+	breakoutPrice, breakoutPriceSource := pickSignalBreakoutPrice(summary, sourceStates)
 	updatedState, nextPlannedEvent, nextPlannedPrice, nextPlannedSide, nextPlannedRole, nextPlannedReason := prepareLivePlanStepForSignalEvaluation(
 		session.State,
 		executionContext.Parameters,
@@ -2628,6 +2629,8 @@ func (p *Platform) evaluateLiveSignalDecision(session domain.LiveSession, summar
 		executionContext.SignalTimeframe,
 		currentPosition,
 		eventTime,
+		breakoutPrice,
+		breakoutPriceSource,
 		nextPlannedEvent,
 		nextPlannedPrice,
 		nextPlannedSide,
@@ -2665,6 +2668,8 @@ func alignLivePlanStepToCurrentMarket(
 	signalTimeframe string,
 	currentPosition map[string]any,
 	eventTime time.Time,
+	breakoutPrice float64,
+	breakoutPriceSource string,
 	nextPlannedEvent time.Time,
 	nextPlannedPrice float64,
 	nextPlannedSide, nextPlannedRole, nextPlannedReason string,
@@ -2679,7 +2684,7 @@ func alignLivePlanStepToCurrentMarket(
 	if signalBarState == nil {
 		return nextPlannedEvent, nextPlannedPrice, nextPlannedSide, nextPlannedRole, nextPlannedReason
 	}
-	gate := evaluateSignalBarGate(signalBarState, "", "entry", "")
+	gate := evaluateSignalBarGate(signalBarState, "", "entry", "", breakoutPrice, breakoutPriceSource)
 	longReady := boolValue(gate["longReady"])
 	shortReady := boolValue(gate["shortReady"])
 	if longReady == shortReady {
@@ -3799,10 +3804,13 @@ func deriveBreakoutSignalSnapshot(decision StrategySignalDecision, eventTime tim
 		"side":              side,
 		"level":             level,
 		"barTime":           barTime.Format(time.RFC3339),
+		"eventAt":           eventTime.UTC().Format(time.RFC3339),
+		"price":             parseFloatValue(signalBarDecision["breakoutPrice"]),
+		"priceSource":       stringValue(signalBarDecision["breakoutPriceSource"]),
 		"close":             parseFloatValue(current["close"]),
 		"timeframe":         stringValue(signalBarDecision["timeframe"]),
 		"signalBarStateKey": stringValue(meta["signalBarStateKey"]),
-		"source":            "signal-breakout-pattern",
+		"source":            "signal-breakout-price",
 	}
 }
 

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -56,7 +56,7 @@ func TestEvaluateSignalBarGateRequiresLongBreakoutAlignmentWithResearch(t *testi
 		"atr14": 900.0,
 		"current": map[string]any{
 			"close": 68100.0,
-			"high":  68900.0,
+			"high":  69010.0,
 			"low":   67800.0,
 		},
 		"prevBar1": map[string]any{
@@ -67,12 +67,12 @@ func TestEvaluateSignalBarGateRequiresLongBreakoutAlignmentWithResearch(t *testi
 			"high": 69000.0,
 			"low":  67600.0,
 		},
-	}, "BUY", "entry", "")
+	}, "BUY", "entry", "", 68990.0, "trade_tick.price")
 	if boolValue(gate["longStructureReady"]) != true {
 		t.Fatal("expected long structure to be ready")
 	}
 	if boolValue(gate["longBreakoutReady"]) {
-		t.Fatal("expected breakout to remain not ready before current high breaks prevHigh2")
+		t.Fatal("expected breakout to remain blocked until current breakout price crosses prevHigh2")
 	}
 	if boolValue(gate["longReady"]) {
 		t.Fatal("expected long signal to stay blocked without breakout confirmation")
@@ -99,25 +99,25 @@ func TestEvaluateSignalBarGateAllowsLongAfterBreakoutAlignmentWithResearch(t *te
 			"high": 69000.0,
 			"low":  67600.0,
 		},
-	}, "BUY", "entry", "")
+	}, "BUY", "entry", "", 69010.0, "trade_tick.price")
 	if !boolValue(gate["longStructureReady"]) {
 		t.Fatal("expected long structure to be ready")
 	}
 	if !boolValue(gate["longBreakoutReady"]) {
-		t.Fatal("expected breakout to be ready after current high breaks prevHigh2")
+		t.Fatal("expected breakout to be ready after current breakout price crosses prevHigh2")
 	}
 	if !boolValue(gate["longReady"]) {
 		t.Fatal("expected long signal to be ready after breakout confirmation")
 	}
 }
 
-func TestEvaluateSignalBarGateTracksClosedBarBreakoutPattern(t *testing.T) {
+func TestEvaluateSignalBarGateTracksCurrentPriceBreakoutPattern(t *testing.T) {
 	gate := evaluateSignalBarGate(map[string]any{
 		"ma20":  68000.0,
 		"atr14": 900.0,
 		"current": map[string]any{
-			"close": 69010.0,
-			"high":  69030.0,
+			"close": 68100.0,
+			"high":  68950.0,
 			"low":   67800.0,
 		},
 		"prevBar1": map[string]any{
@@ -128,12 +128,15 @@ func TestEvaluateSignalBarGateTracksClosedBarBreakoutPattern(t *testing.T) {
 			"high": 69000.0,
 			"low":  67600.0,
 		},
-	}, "BUY", "entry", "")
+	}, "BUY", "entry", "", 69010.0, "trade_tick.price")
 	if !boolValue(gate["longBreakoutPatternReady"]) {
-		t.Fatalf("expected close-based long breakout pattern, got %#v", gate)
+		t.Fatalf("expected current-price long breakout pattern, got %#v", gate)
 	}
 	if boolValue(gate["shortBreakoutPatternReady"]) {
 		t.Fatalf("expected short breakout pattern to stay false, got %#v", gate)
+	}
+	if got := parseFloatValue(gate["breakoutPrice"]); got != 69010.0 {
+		t.Fatalf("expected breakout price 69010, got %v", got)
 	}
 }
 
@@ -154,7 +157,7 @@ func TestEvaluateSignalBarGateDoesNotRequireOppositeBreakoutForExit(t *testing.T
 			"high": 69000.0,
 			"low":  67600.0,
 		},
-	}, "SELL", "exit", "")
+	}, "SELL", "exit", "", 68990.0, "trade_tick.price")
 	if !boolValue(gate["ready"]) {
 		t.Fatalf("expected exit gate to stay ready, got reason=%s", stringValue(gate["reason"]))
 	}
@@ -198,6 +201,8 @@ func TestAlignLivePlanStepToCurrentMarketKeepsExitForVirtualPosition(t *testing.
 		"1d",
 		currentPosition,
 		eventTime,
+		0,
+		"",
 		nextPlannedEvent,
 		68950.0,
 		"SELL",
@@ -251,6 +256,8 @@ func TestPrepareLivePlanStepForSignalEvaluationUsesZeroInitialWindowAcrossTwoBar
 		"1d",
 		map[string]any{},
 		barStart.Add(2*time.Hour),
+		69010.0,
+		"trade_tick.price",
 		barStart.Add(-48*time.Hour),
 		68950.0,
 		"BUY",
@@ -317,6 +324,8 @@ func TestPrepareLivePlanStepForSignalEvaluationUsesZeroInitialWindowAcrossTwoBar
 		"1d",
 		map[string]any{},
 		nextBarStart.Add(2*time.Hour),
+		0,
+		"",
 		barStart.Add(-24*time.Hour),
 		68950.0,
 		"BUY",
@@ -342,6 +351,8 @@ func TestPrepareLivePlanStepForSignalEvaluationUsesZeroInitialWindowAcrossTwoBar
 		"1d",
 		map[string]any{},
 		barStart.Add(49*time.Hour),
+		0,
+		"",
 		barStart.Add(-72*time.Hour),
 		68950.0,
 		"BUY",
@@ -395,6 +406,8 @@ func TestPrepareLivePlanStepForSignalEvaluationPrioritizesExitReentryOverZeroIni
 		"1d",
 		map[string]any{},
 		eventTime,
+		0,
+		"",
 		eventTime,
 		75600.0,
 		"SELL",
@@ -419,6 +432,58 @@ func TestPrepareLivePlanStepForSignalEvaluationPrioritizesExitReentryOverZeroIni
 	}
 }
 
+func TestPrepareLivePlanStepForSignalEvaluationRequiresCurrentBreakoutPrice(t *testing.T) {
+	barStart := time.Date(2026, 4, 10, 0, 0, 0, 0, time.UTC)
+	signalStates := map[string]any{
+		signalBindingMatchKey("binance-kline", "signal", "BTCUSDT"): map[string]any{
+			"symbol":    "BTCUSDT",
+			"timeframe": "1d",
+			"ma20":      68000.0,
+			"atr14":     900.0,
+			"current": map[string]any{
+				"barStart": barStart.Format(time.RFC3339),
+				"close":    68100.0,
+				"high":     69010.0,
+				"low":      67800.0,
+			},
+			"prevBar1": map[string]any{
+				"high": 68850.0,
+				"low":  67750.0,
+			},
+			"prevBar2": map[string]any{
+				"high": 69000.0,
+				"low":  67600.0,
+			},
+		},
+	}
+	state, _, _, gotSide, gotRole, gotReason := prepareLivePlanStepForSignalEvaluation(
+		map[string]any{},
+		map[string]any{
+			"dir2_zero_initial": true,
+			"zero_initial_mode": "reentry_window",
+			"long_reentry_atr":  0.1,
+		},
+		signalStates,
+		"BTCUSDT",
+		"1d",
+		map[string]any{},
+		barStart.Add(2*time.Hour),
+		68990.0,
+		"trade_tick.price",
+		barStart.Add(-48*time.Hour),
+		68950.0,
+		"BUY",
+		"entry",
+		"Initial",
+	)
+	if gotRole != "entry" || gotReason != "Initial" || gotSide != "BUY" {
+		t.Fatalf("expected zero initial window to stay unarmed without breakout price confirmation, got side=%s role=%s reason=%s", gotSide, gotRole, gotReason)
+	}
+	if pending := mapValue(state[livePendingZeroInitialWindowStateKey]); len(pending) != 0 {
+		t.Fatalf("expected no pending zero initial window before breakout price confirmation, got %+v", pending)
+	}
+}
+
 func TestEvaluateSignalBarGateAllowsReentryWithoutInitialBreakout(t *testing.T) {
 	gate := evaluateSignalBarGate(map[string]any{
 		"timeframe": "1d",
@@ -437,7 +502,7 @@ func TestEvaluateSignalBarGateAllowsReentryWithoutInitialBreakout(t *testing.T) 
 			"high": 69000.0,
 			"low":  67600.0,
 		},
-	}, "BUY", "entry", "SL-Reentry")
+	}, "BUY", "entry", "SL-Reentry", 68990.0, "trade_tick.price")
 	if !boolValue(gate["longStructureReady"]) {
 		t.Fatal("expected long structure to be ready for reentry")
 	}
@@ -3399,7 +3464,7 @@ func TestEvaluateLiveSessionOnSignalRecordsVirtualInitialForZeroInitialStrategy(
 		"role":               "trigger",
 		"symbol":             "BTCUSDT",
 		"subscriptionSymbol": "BTCUSDT",
-		"price":              68110.0,
+		"price":              69010.0,
 		"event":              "trade_tick",
 	}
 	err = platform.updateSignalRuntimeSessionState(runtimeSessionID, func(runtimeSession *domain.SignalRuntimeSession) {
@@ -3417,7 +3482,7 @@ func TestEvaluateLiveSessionOnSignalRecordsVirtualInitialForZeroInitialStrategy(
 				"streamType":  "trade_tick",
 				"lastEventAt": eventTime.UTC().Format(time.RFC3339),
 				"summary": map[string]any{
-					"price": 68110.0,
+					"price": 69010.0,
 				},
 			},
 			signalKey: map[string]any{
@@ -3546,7 +3611,7 @@ func TestEvaluateLiveSessionOnSignalUsesZeroInitialReentryWindowInsteadOfVirtual
 		"role":               "trigger",
 		"symbol":             "BTCUSDT",
 		"subscriptionSymbol": "BTCUSDT",
-		"price":              67845.0,
+		"price":              69010.0,
 		"event":              "trade_tick",
 	}
 	err = platform.updateSignalRuntimeSessionState(runtimeSessionID, func(runtimeSession *domain.SignalRuntimeSession) {
@@ -3564,7 +3629,7 @@ func TestEvaluateLiveSessionOnSignalUsesZeroInitialReentryWindowInsteadOfVirtual
 				"streamType":  "trade_tick",
 				"lastEventAt": eventTime.UTC().Format(time.RFC3339),
 				"summary": map[string]any{
-					"price": 67845.0,
+					"price": 69010.0,
 				},
 			},
 			signalKey: map[string]any{
@@ -3618,15 +3683,51 @@ func TestEvaluateLiveSessionOnSignalUsesZeroInitialReentryWindowInsteadOfVirtual
 	if virtualPosition := mapValue(updated.State["virtualPosition"]); len(virtualPosition) != 0 {
 		t.Fatalf("expected zero initial window mode to avoid virtual positions, got %+v", virtualPosition)
 	}
+	if pending := mapValue(updated.State[livePendingZeroInitialWindowStateKey]); stringValue(pending["side"]) != "BUY" {
+		t.Fatalf("expected pending BUY zero initial window in session state, got %+v", pending)
+	}
+
+	reentryTime := eventTime.Add(5 * time.Second)
+	reentrySummary := cloneMetadata(summary)
+	reentrySummary["price"] = 67845.0
+	err = platform.updateSignalRuntimeSessionState(runtimeSessionID, func(runtimeSession *domain.SignalRuntimeSession) {
+		state := cloneMetadata(runtimeSession.State)
+		state["lastEventAt"] = reentryTime.UTC().Format(time.RFC3339)
+		state["lastHeartbeatAt"] = reentryTime.UTC().Format(time.RFC3339)
+		state["lastEventSummary"] = cloneMetadata(reentrySummary)
+		sourceStates := cloneMetadata(mapValue(state["sourceStates"]))
+		triggerState := cloneMetadata(mapValue(sourceStates[triggerKey]))
+		triggerState["lastEventAt"] = reentryTime.UTC().Format(time.RFC3339)
+		triggerSummary := cloneMetadata(mapValue(triggerState["summary"]))
+		triggerSummary["price"] = 67845.0
+		triggerState["summary"] = triggerSummary
+		sourceStates[triggerKey] = triggerState
+		state["sourceStates"] = sourceStates
+		runtimeSession.State = state
+		runtimeSession.UpdatedAt = reentryTime
+	})
+	if err != nil {
+		t.Fatalf("update runtime state for reentry failed: %v", err)
+	}
+
+	updatedSession, err := platform.store.GetLiveSession(session.ID)
+	if err != nil {
+		t.Fatalf("reload live session before reentry failed: %v", err)
+	}
+	if err := platform.evaluateLiveSessionOnSignal(updatedSession, runtimeSessionID, reentrySummary, reentryTime); err != nil {
+		t.Fatalf("evaluate live session on reentry failed: %v", err)
+	}
+
+	updated, err = platform.store.GetLiveSession(session.ID)
+	if err != nil {
+		t.Fatalf("reload live session after reentry failed: %v", err)
+	}
 	proposal := mapValue(updated.State["lastExecutionProposal"])
 	if got := stringValue(proposal["status"]); got != "dispatchable" {
 		t.Fatalf("expected dispatchable reentry proposal, got %s", got)
 	}
 	if got := stringValue(proposal["reason"]); got != "Zero-Initial-Reentry" {
 		t.Fatalf("expected Zero-Initial-Reentry proposal reason, got %s", got)
-	}
-	if pending := mapValue(updated.State[livePendingZeroInitialWindowStateKey]); stringValue(pending["side"]) != "BUY" {
-		t.Fatalf("expected pending BUY zero initial window in session state, got %+v", pending)
 	}
 }
 

--- a/internal/service/live_zero_initial.go
+++ b/internal/service/live_zero_initial.go
@@ -15,6 +15,8 @@ func prepareLivePlanStepForSignalEvaluation(
 	signalTimeframe string,
 	currentPosition map[string]any,
 	eventTime time.Time,
+	breakoutPrice float64,
+	breakoutPriceSource string,
 	nextPlannedEvent time.Time,
 	nextPlannedPrice float64,
 	nextPlannedSide, nextPlannedRole, nextPlannedReason string,
@@ -26,6 +28,8 @@ func prepareLivePlanStepForSignalEvaluation(
 			signalTimeframe,
 			currentPosition,
 			eventTime,
+			breakoutPrice,
+			breakoutPriceSource,
 			nextPlannedEvent,
 			nextPlannedPrice,
 			nextPlannedSide,
@@ -58,7 +62,7 @@ func prepareLivePlanStepForSignalEvaluation(
 	if signalBarState == nil {
 		return updatedState, nextPlannedEvent, nextPlannedPrice, nextPlannedSide, nextPlannedRole, nextPlannedReason
 	}
-	gate := evaluateSignalBarGate(signalBarState, "", "entry", "")
+	gate := evaluateSignalBarGate(signalBarState, "", "entry", "", breakoutPrice, breakoutPriceSource)
 	longReady := boolValue(gate["longReady"])
 	shortReady := boolValue(gate["shortReady"])
 	if longReady == shortReady {

--- a/internal/service/signal_runtime_ws_test.go
+++ b/internal/service/signal_runtime_ws_test.go
@@ -350,9 +350,12 @@ func TestDeriveSignalBarStatesUsesOpenCurrentBarWithClosedHistory(t *testing.T) 
 	if stringValue(prevBar2["barStart"]) != base.Add(18*5*time.Minute).Format(time.RFC3339) {
 		t.Fatalf("expected prevBar2 to be second latest closed bar, got %#v", prevBar2)
 	}
-	gate := evaluateSignalBarGate(state, "BUY", "entry", "")
-	if !boolValue(gate["ready"]) || !boolValue(gate["longReady"]) {
-		t.Fatalf("expected open current bar breakout to be actionable, got %#v", gate)
+	gate := evaluateSignalBarGate(state, "BUY", "entry", "", parseFloatValue(current["high"]), "signal-bar.high")
+	if boolValue(gate["ready"]) || boolValue(gate["longReady"]) {
+		t.Fatalf("expected open current bar to stay blocked without prev t-2 > prev t-1 breakout shape, got %#v", gate)
+	}
+	if boolValue(gate["longBreakoutShapeReady"]) {
+		t.Fatalf("expected breakout shape to remain false for this monotonic sample, got %#v", gate)
 	}
 }
 

--- a/internal/service/strategy_registry.go
+++ b/internal/service/strategy_registry.go
@@ -209,10 +209,19 @@ func (e bkStrategyEngine) EvaluateSignal(context StrategySignalEvaluationContext
 		action = "wait"
 		reason = "planned-event-not-reached"
 	}
+	marketPrice, marketSource := pickDecisionMarketPrice(trigger, sourceStates, context.NextPlannedSide)
+	breakoutPrice, breakoutPriceSource := pickSignalBreakoutPrice(trigger, sourceStates)
 	signalBarDecision := map[string]any{}
 	signalFilterReady := true
 	if signalBarState != nil {
-		signalBarDecision = evaluateSignalBarGate(signalBarState, context.NextPlannedSide, context.NextPlannedRole, context.NextPlannedReason)
+		signalBarDecision = evaluateSignalBarGate(
+			signalBarState,
+			context.NextPlannedSide,
+			context.NextPlannedRole,
+			context.NextPlannedReason,
+			breakoutPrice,
+			breakoutPriceSource,
+		)
 		if value, ok := signalBarDecision["ready"].(bool); ok {
 			signalFilterReady = value
 		}
@@ -221,7 +230,6 @@ func (e bkStrategyEngine) EvaluateSignal(context StrategySignalEvaluationContext
 		action = "wait"
 		reason = "signal-filter-not-ready"
 	}
-	marketPrice, marketSource := pickDecisionMarketPrice(trigger, sourceStates, context.NextPlannedSide)
 	orderBookStats := extractOrderBookStats(trigger, sourceStates)
 	maxDeviationBps := firstPositive(parseFloatValue(context.ExecutionContext.Parameters["signalDecisionMaxDeviationBps"]), 50)
 	maxSpreadBps := firstPositive(parseFloatValue(context.ExecutionContext.Parameters["signalDecisionMaxSpreadBps"]), 8)
@@ -293,6 +301,8 @@ func (e bkStrategyEngine) EvaluateSignal(context StrategySignalEvaluationContext
 			"nextPlannedSide":     context.NextPlannedSide,
 			"nextPlannedRole":     context.NextPlannedRole,
 			"nextPlannedReason":   context.NextPlannedReason,
+			"breakoutPrice":       breakoutPrice,
+			"breakoutPriceSource": breakoutPriceSource,
 			"marketPrice":         marketPrice,
 			"marketSource":        marketSource,
 			"bestBid":             orderBookStats.bestBid,
@@ -312,6 +322,56 @@ func (e bkStrategyEngine) EvaluateSignal(context StrategySignalEvaluationContext
 			"priceActionable":     strings.EqualFold(strings.TrimSpace(context.NextPlannedRole), "exit") || isPlannedPriceActionable(context.NextPlannedSide, effectivePlannedPrice, marketPrice, maxDeviationBps),
 		},
 	}, nil
+}
+
+func pickSignalBreakoutPrice(trigger map[string]any, sourceStates map[string]any) (float64, string) {
+	symbol := NormalizeSymbol(firstNonEmpty(stringValue(trigger["subscriptionSymbol"]), stringValue(trigger["symbol"])))
+	tradePrice := parseFloatValue(trigger["price"])
+	tradeSource := ""
+	if tradePrice > 0 {
+		tradeSource = "trigger.price"
+	}
+	bestBid, bestAsk := 0.0, 0.0
+
+	for _, raw := range sourceStates {
+		entry := mapValue(raw)
+		if entry == nil {
+			continue
+		}
+		if symbol != "" && NormalizeSymbol(stringValue(entry["symbol"])) != symbol {
+			continue
+		}
+		summary := mapValue(entry["summary"])
+		switch strings.ToLower(strings.TrimSpace(stringValue(entry["streamType"]))) {
+		case "trade_tick":
+			if tradePrice <= 0 {
+				tradePrice = parseFloatValue(summary["price"])
+				if tradePrice > 0 {
+					tradeSource = "trade_tick.price"
+				}
+			}
+		case "order_book":
+			if bestBid <= 0 {
+				bestBid = parseFloatValue(summary["bestBid"])
+			}
+			if bestAsk <= 0 {
+				bestAsk = parseFloatValue(summary["bestAsk"])
+			}
+		}
+	}
+	if tradePrice > 0 {
+		return tradePrice, tradeSource
+	}
+	if bestBid > 0 && bestAsk > 0 {
+		return (bestBid + bestAsk) / 2, "order_book.mid"
+	}
+	if bestBid > 0 {
+		return bestBid, "order_book.bestBid"
+	}
+	if bestAsk > 0 {
+		return bestAsk, "order_book.bestAsk"
+	}
+	return 0, ""
 }
 
 func formatOptionalRFC3339(value time.Time) string {
@@ -604,7 +664,7 @@ func pickSignalBarState(signalBarStates map[string]any, symbol, timeframe string
 	return nil, ""
 }
 
-func evaluateSignalBarGate(signalBarState map[string]any, nextSide, nextRole, nextReason string) map[string]any {
+func evaluateSignalBarGate(signalBarState map[string]any, nextSide, nextRole, nextReason string, breakoutPrice float64, breakoutPriceSource string) map[string]any {
 	role := strings.ToLower(strings.TrimSpace(nextRole))
 	reasonTag := normalizeStrategyReasonTag(nextReason)
 	timeframe := strings.ToLower(strings.TrimSpace(stringValue(signalBarState["timeframe"])))
@@ -636,8 +696,6 @@ func evaluateSignalBarGate(signalBarState map[string]any, nextSide, nextRole, ne
 		return result
 	}
 	closePrice := parseFloatValue(current["close"])
-	highPrice := parseFloatValue(current["high"])
-	lowPrice := parseFloatValue(current["low"])
 	prevHigh1 := parseFloatValue(prevBar1["high"])
 	prevHigh2 := parseFloatValue(prevBar2["high"])
 	prevLow1 := parseFloatValue(prevBar1["low"])
@@ -680,10 +738,12 @@ func evaluateSignalBarGate(signalBarState map[string]any, nextSide, nextRole, ne
 		longStructureReady = closePrice > ma20
 		shortStructureReady = closePrice < ma20
 	}
-	longBreakoutReady := highPrice >= prevHigh2 && prevHigh2 > 0
-	shortBreakoutReady := lowPrice <= prevLow2 && prevLow2 > 0
-	longBreakoutPatternReady := prevHigh2 > prevHigh1 && closePrice > prevHigh2 && prevHigh2 > 0
-	shortBreakoutPatternReady := prevLow2 < prevLow1 && closePrice < prevLow2 && prevLow2 > 0
+	longBreakoutShapeReady := prevHigh2 > prevHigh1 && prevHigh2 > 0
+	shortBreakoutShapeReady := prevLow2 < prevLow1 && prevLow2 > 0
+	longBreakoutPriceReady := breakoutPrice > prevHigh2 && prevHigh2 > 0
+	shortBreakoutPriceReady := breakoutPrice < prevLow2 && prevLow2 > 0
+	longBreakoutReady := longBreakoutShapeReady && longBreakoutPriceReady
+	shortBreakoutReady := shortBreakoutShapeReady && shortBreakoutPriceReady
 	longReady := longStructureReady && longBreakoutReady
 	shortReady := shortStructureReady && shortBreakoutReady
 	if role == "entry" && (reasonTag == "zero-initial-reentry" || reasonTag == "sl-reentry" || reasonTag == "pt-reentry") {
@@ -694,10 +754,16 @@ func evaluateSignalBarGate(signalBarState map[string]any, nextSide, nextRole, ne
 	result["shortStructureReady"] = shortStructureReady
 	result["longEarlyReversalReady"] = longEarlyReversalReady
 	result["shortEarlyReversalReady"] = shortEarlyReversalReady
+	result["breakoutPrice"] = breakoutPrice
+	result["breakoutPriceSource"] = breakoutPriceSource
+	result["longBreakoutShapeReady"] = longBreakoutShapeReady
+	result["shortBreakoutShapeReady"] = shortBreakoutShapeReady
+	result["longBreakoutPriceReady"] = longBreakoutPriceReady
+	result["shortBreakoutPriceReady"] = shortBreakoutPriceReady
 	result["longBreakoutReady"] = longBreakoutReady
 	result["shortBreakoutReady"] = shortBreakoutReady
-	result["longBreakoutPatternReady"] = longBreakoutPatternReady
-	result["shortBreakoutPatternReady"] = shortBreakoutPatternReady
+	result["longBreakoutPatternReady"] = longBreakoutReady
+	result["shortBreakoutPatternReady"] = shortBreakoutReady
 	result["longReady"] = longReady
 	result["shortReady"] = shortReady
 	if role == "exit" {

--- a/internal/service/telemetry_test.go
+++ b/internal/service/telemetry_test.go
@@ -39,33 +39,42 @@ func TestEvaluateLiveSessionOnSignalPersistsStrategyDecisionEvent(t *testing.T) 
 	if len(signalBarDecision) == 0 {
 		t.Fatal("expected lastStrategyEvaluationSignalBarDecision to be recorded")
 	}
-	if !boolValue(signalBarDecision["longBreakoutReady"]) {
-		t.Fatalf("expected longBreakoutReady=true, got %#v", signalBarDecision)
+	if boolValue(signalBarDecision["longBreakoutReady"]) {
+		t.Fatalf("expected longBreakoutReady=false until breakout price crosses prevHigh2, got %#v", signalBarDecision)
 	}
 	if got := stringValue(updated.State["lastStrategyEvaluationSignalBarStateKey"]); got == "" {
 		t.Fatal("expected lastStrategyEvaluationSignalBarStateKey to be recorded")
 	}
 	if breakout := mapValue(updated.State["lastBreakoutSignal"]); len(breakout) != 0 {
-		t.Fatalf("expected no close-based breakout snapshot for default fixture, got %#v", breakout)
+		t.Fatalf("expected no breakout snapshot before breakout price crosses prevHigh2, got %#v", breakout)
 	}
-	dispatchedIntent := mapValue(updated.State["lastDispatchedIntent"])
-	if got := stringValue(dispatchedIntent["decisionEventId"]); got != events[0].ID {
-		t.Fatalf("expected dispatched intent to carry decision event id %s, got %s", events[0].ID, got)
+	if dispatchedIntent := mapValue(updated.State["lastDispatchedIntent"]); len(dispatchedIntent) != 0 {
+		t.Fatalf("expected no dispatched intent before breakout price crosses prevHigh2, got %#v", dispatchedIntent)
 	}
 }
 
 func TestEvaluateLiveSessionOnSignalPersistsBreakoutHistory(t *testing.T) {
 	platform, session, runtimeSessionID, summary, eventTime := prepareLiveDecisionTelemetryFixture(t)
 	signalKey := signalBindingMatchKey("binance-kline", "signal", "BTCUSDT")
+	triggerKey := signalBindingMatchKey("binance-trade-tick", "trigger", "BTCUSDT")
+	summary["price"] = 69010.0
 	err := platform.updateSignalRuntimeSessionState(runtimeSessionID, func(runtimeSession *domain.SignalRuntimeSession) {
 		state := cloneMetadata(runtimeSession.State)
+		state["lastEventSummary"] = cloneMetadata(summary)
+		sourceStates := cloneMetadata(mapValue(state["sourceStates"]))
+		triggerState := cloneMetadata(mapValue(sourceStates[triggerKey]))
+		triggerSummary := cloneMetadata(mapValue(triggerState["summary"]))
+		triggerSummary["price"] = 69010.0
+		triggerState["summary"] = triggerSummary
+		sourceStates[triggerKey] = triggerState
+		state["sourceStates"] = sourceStates
 		signalStates := cloneMetadata(mapValue(state["signalBarStates"]))
 		entry := cloneMetadata(mapValue(signalStates[signalKey]))
 		current := cloneMetadata(mapValue(entry["current"]))
 		prevBar1 := cloneMetadata(mapValue(entry["prevBar1"]))
 		prevBar2 := cloneMetadata(mapValue(entry["prevBar2"]))
-		current["close"] = 69010.0
-		current["high"] = 69030.0
+		current["close"] = 68100.0
+		current["high"] = 68950.0
 		current["barStart"] = eventTime.Add(-24 * time.Hour).UnixMilli()
 		prevBar1["high"] = 68850.0
 		prevBar2["high"] = 69000.0
@@ -97,6 +106,9 @@ func TestEvaluateLiveSessionOnSignalPersistsBreakoutHistory(t *testing.T) {
 	}
 	if got := parseFloatValue(breakout["level"]); got != 69000.0 {
 		t.Fatalf("expected breakout level 69000, got %v", got)
+	}
+	if got := parseFloatValue(breakout["price"]); got != 69010.0 {
+		t.Fatalf("expected breakout price 69010, got %v", got)
 	}
 	history := metadataList(updated.State["breakoutHistory"])
 	if len(history) != 1 {
@@ -346,7 +358,7 @@ func prepareLiveDecisionTelemetryFixture(t *testing.T) (*Platform, domain.LiveSe
 		"role":               "trigger",
 		"symbol":             "BTCUSDT",
 		"subscriptionSymbol": "BTCUSDT",
-		"price":              69010.0,
+		"price":              68990.0,
 		"event":              "trade_tick",
 	}
 	err = platform.updateSignalRuntimeSessionState(runtimeSessionID, func(runtimeSession *domain.SignalRuntimeSession) {
@@ -364,7 +376,7 @@ func prepareLiveDecisionTelemetryFixture(t *testing.T) (*Platform, domain.LiveSe
 				"streamType":  "trade_tick",
 				"lastEventAt": eventTime.UTC().Format(time.RFC3339),
 				"summary": map[string]any{
-					"price": 69010.0,
+					"price": 68990.0,
 				},
 			},
 			signalKey: map[string]any{


### PR DESCRIPTION
## 目的
对齐 live `reentry_window` / breakout 语义到当前价格触发：
- 多头改为 `prevHigh2 > prevHigh1 && breakoutPrice > prevHigh2`
- 空头改为 `prevLow2 < prevLow1 && breakoutPrice < prevLow2`
- `zero_initial` 挂窗与策略判定统一使用同一份 breakout price，不再只靠 `current.high/current.low`
- breakout trace 同步记录 `breakoutPrice` 与来源，便于后续监控与追单

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [x] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main)
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？
- [x] DB migration 是否具备向下兼容幂等性？
- [x] 配置字段有没有无意被混改？

说明：以上检查项均未引入风险变更；本次只调整 live breakout 判定与对应测试/trace。

## 验证方式与测试证据
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

已验证：
- `go test ./internal/service -run 'TestEvaluateSignalBarGateRequiresLongBreakoutAlignmentWithResearch|TestEvaluateSignalBarGateAllowsLongAfterBreakoutAlignmentWithResearch|TestEvaluateSignalBarGateTracksCurrentPriceBreakoutPattern|TestPrepareLivePlanStepForSignalEvaluationUsesZeroInitialWindowAcrossTwoBars|TestPrepareLivePlanStepForSignalEvaluationRequiresCurrentBreakoutPrice|TestEvaluateSignalBarGateAllowsReentryWithoutInitialBreakout|TestEvaluateLiveSessionOnSignalPersistsStrategyDecisionEvent|TestEvaluateLiveSessionOnSignalPersistsBreakoutHistory|TestEnrichSignalRuntimeSummaryKeepsKlineEventsScopedByTimeframe'`
- `go test ./internal/service`
