### PR TITLE
[codex] align intraday live gate with SMA5 baseline

### DIFF
--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -111,6 +111,40 @@ func TestEvaluateSignalBarGateAllowsLongAfterBreakoutAlignmentWithResearch(t *te
 	}
 }
 
+func TestEvaluateSignalBarGateUsesSMA5ForIntradayReentry(t *testing.T) {
+	gate := evaluateSignalBarGate(map[string]any{
+		"timeframe": "30m",
+		"sma5":      76485.78,
+		"ma20":      76151.175,
+		"atr14":     520.0,
+		"current": map[string]any{
+			"close": 76312.10,
+			"high":  76455.40,
+			"low":   76200.00,
+		},
+		"prevBar1": map[string]any{
+			"high": 74253.80,
+			"low":  76180.00,
+		},
+		"prevBar2": map[string]any{
+			"high": 76520.00,
+			"low":  76250.00,
+		},
+	}, "SELL", "entry", "Zero-Initial-Reentry", 76236.80, "trade_tick.price")
+	if boolValue(gate["longStructureReady"]) {
+		t.Fatalf("expected intraday SMA5 hard filter to block long structure, got %#v", gate)
+	}
+	if !boolValue(gate["shortStructureReady"]) {
+		t.Fatalf("expected intraday SMA5 hard filter to allow short structure, got %#v", gate)
+	}
+	if !boolValue(gate["shortReady"]) || !boolValue(gate["ready"]) {
+		t.Fatalf("expected zero-initial reentry short gate to be ready, got %#v", gate)
+	}
+	if boolValue(gate["usedLegacyMA20Fallback"]) {
+		t.Fatalf("expected SMA5 to be used instead of MA20 fallback, got %#v", gate)
+	}
+}
+
 func TestEvaluateSignalBarGateTracksCurrentPriceBreakoutPattern(t *testing.T) {
 	gate := evaluateSignalBarGate(map[string]any{
 		"ma20":  68000.0,

--- a/internal/service/strategy_registry.go
+++ b/internal/service/strategy_registry.go
@@ -730,11 +730,17 @@ func evaluateSignalBarGate(signalBarState map[string]any, nextSide, nextRole, ne
 		longStructureReady = longStructureReady || longEarlyReversalReady
 		shortStructureReady = shortStructureReady || shortEarlyReversalReady
 	default:
+		if sma5 > 0 {
+			longStructureReady = closePrice > sma5
+			shortStructureReady = closePrice < sma5
+			break
+		}
 		if ma20 <= 0 {
 			result["ready"] = false
 			result["reason"] = "insufficient-signal-bars"
 			return result
 		}
+		result["usedLegacyMA20Fallback"] = true
 		longStructureReady = closePrice > ma20
 		shortStructureReady = closePrice < ma20
 	}


### PR DESCRIPTION
## 目的
修复 live signal gate 在非 `1d` 周期仍使用 MA20 structure filter 的问题，使 `15m` / `30m` / `4h` 等 intraday 周期优先使用当前 research baseline 约定的 SMA5 hard filter。根因是远端 `main` 中 `evaluateSignalBarGate` 的 `default` 分支仍直接按 MA20 判断，导致 `30m currentClose < SMA5` 但 `currentClose > MA20` 时，`SELL Zero-Initial-Reentry` 会错误停在 `signal-filter-not-ready`。

本 PR 只修改 signal gate 的 structure filter：非 `1d` 周期若存在 `sma5`，按 `close > sma5` / `close < sma5` 判定方向；仅在 `sma5` 缺失时回退 MA20，并写入 `usedLegacyMA20Fallback=true` 诊断字段。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [x] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) — 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？— 无
- [x] DB migration 是否具备向下兼容幂等性？— 不涉及 DB migration
- [x] 配置字段有没有无意被混改？— 无配置字段改动

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

测试已在独立 worktree `/Users/wuyaocheng/Downloads/bkTrader-pr-sma5` 通过：

```sh
go test ./internal/service -run TestEvaluateSignalBarGateUsesSMA5ForIntradayReentry -count=1
go test ./internal/service -run 'TestEvaluateSignalBarGate|TestEvaluateLiveSessionOnSignalUsesZeroInitialReentryWindowInsteadOfVirtualInitial|TestEvaluateLiveSessionOnSignalKeepsReentryDispatchableWithoutInitialBreakout' -count=1
go test ./...
go build ./cmd/platform-api
go build ./cmd/db-migrate
```

Codex assisted with diagnosis, implementation, tests, and PR creation.