### PR TITLE
fix: 成交记录时间缺失修复与 UI 优化

### DIFF
--- a/internal/service/chart.go
+++ b/internal/service/chart.go
@@ -363,6 +363,9 @@ func toInt64(value any) (int64, bool) {
 		return v, true
 	case int:
 		return int64(v), true
+	case json.Number:
+		i, err := v.Int64()
+		return i, err == nil
 	case string:
 		parsed, err := strconv.ParseInt(strings.TrimSpace(v), 10, 64)
 		return parsed, err == nil

--- a/web/console/src/components/layout/DockContent.tsx
+++ b/web/console/src/components/layout/DockContent.tsx
@@ -287,10 +287,12 @@ export function DockContent({ dockTab, actions }: DockContentProps) {
               formatTime(fill.exchangeTradeTime ?? ""),
               formatTime(fill.createdAt),
               suspiciousDuplicate ? (
-                <DockBadge key={`${fill.id}-dup`} tone="watch">疑似重复同步</DockBadge>
+                <DockBadge key={`${fill.id}-dup`} tone="watch">疑似重复</DockBadge>
+              ) : fill.exchangeTradeId ? (
+                <DockBadge key={`${fill.id}-ok`} tone="ready">已同步</DockBadge>
               ) : (
-                <span key={`${fill.id}-ok`} className="text-[11px] text-[var(--bk-text-muted)]">
-                  --
+                <span key={`${fill.id}-pending`} className="text-[11px] text-[var(--bk-text-muted)]">
+                  等待同步
                 </span>
               ),
             ];


### PR DESCRIPTION
## 目的
修复成交记录中交易所时间缺失的问题（支持 json.Number 解析），并优化同步状态的 UI 展示。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [x] **L1** - 中风险 (辅助工具修复与 UI 优化)

## AI Agent 参与声明
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了。由 Antigravity 协助完成。

## 风险点 checklist
- [x] dispatchMode 默认值无变化
- [x] 不涉及直接调用 mainnet 凭证
- [x] 无 DB migration

## 验证方式与测试证据
- [x] 提供单元测试证明 (TestToInt64, TestJsonNumberIntegration)
- [x] 后端测试通过：ok github.com/wuyaocheng/bktrader/internal/service 1.817s