### PR TITLE
[codex] debounce telegram stale-source alerts

### DIFF
--- a/internal/service/telegram.go
+++ b/internal/service/telegram.go
@@ -13,6 +13,12 @@ import (
 )
 
 var telegramBaseURL = "https://api.telegram.org"
+var telegramNow = func() time.Time { return time.Now().UTC() }
+
+const (
+	telegramFlapSendGrace    = 45 * time.Second
+	telegramFlapRecoverGrace = 60 * time.Second
+)
 
 func (p *Platform) SendNotificationToTelegram(notificationID string) error {
 	logger := p.logger("service.telegram", "notification_id", strings.TrimSpace(notificationID))
@@ -139,10 +145,11 @@ func (p *Platform) DispatchTelegramNotifications() error {
 		logger.Warn("list notification deliveries failed", "error", err)
 		return err
 	}
-	delivered := make(map[string]struct{}, len(deliveries))
+	now := telegramNow()
+	deliveryByID := make(map[string]domain.NotificationDelivery, len(deliveries))
 	for _, item := range deliveries {
-		if strings.EqualFold(item.Channel, "telegram") && strings.EqualFold(item.Status, "sent") {
-			delivered[item.NotificationID] = struct{}{}
+		if strings.EqualFold(item.Channel, "telegram") {
+			deliveryByID[item.NotificationID] = item
 		}
 	}
 	allowedLevels := make(map[string]struct{}, len(config.SendLevels))
@@ -158,7 +165,30 @@ func (p *Platform) DispatchTelegramNotifications() error {
 		if _, ok := allowedLevels[level]; !ok {
 			continue
 		}
-		if _, ok := delivered[item.ID]; ok {
+		delivery, hasDelivery := deliveryByID[item.ID]
+		if telegramAlertNeedsFlapSuppression(item.Alert) {
+			nextDelivery, shouldSend, sendErr := p.advanceTelegramFlapSuppressedActiveDelivery(item, delivery, hasDelivery, now)
+			if sendErr != nil {
+				_, _ = p.store.UpsertNotificationDelivery(item.ID, "telegram", "failed", sendErr.Error(), nil)
+				if firstErr == nil {
+					firstErr = sendErr
+				}
+				p.logger("service.telegram", "notification_id", item.ID).Warn("send telegram notification failed", "error", sendErr)
+				continue
+			}
+			if nextDelivery.NotificationID != "" {
+				deliveryByID[item.ID] = nextDelivery
+			}
+			if strings.EqualFold(nextDelivery.Status, "sent") {
+				p.telegramSentAlertCache.Store(item.ID, item.Alert.Title)
+			}
+			if !shouldSend {
+				continue
+			}
+			sentCount++
+			continue
+		}
+		if hasDelivery && strings.EqualFold(delivery.Status, "sent") {
 			// 如果已经发送过，确保缓存中有标题（用于后续恢复）
 			p.telegramSentAlertCache.Store(item.ID, item.Alert.Title)
 			continue
@@ -186,39 +216,168 @@ func (p *Platform) DispatchTelegramNotifications() error {
 	// 恢复检测：遍历已发送的 delivery
 	recoveredCount := 0
 	for _, delivery := range deliveries {
-		if !strings.EqualFold(delivery.Channel, "telegram") || !strings.EqualFold(delivery.Status, "sent") {
+		if !strings.EqualFold(delivery.Channel, "telegram") {
 			continue
 		}
-		// 如果该告警 ID 不再活跃，说明已恢复
-		if _, isActive := activeNotificationIDs[delivery.NotificationID]; !isActive {
-			titleRaw, ok := p.telegramSentAlertCache.Load(delivery.NotificationID)
-			title := "未知告警"
-			if ok {
-				title = titleRaw.(string)
-			} else if delivery.Metadata != nil {
-				// 如果内存缓存失效（如重启后），尝试从持久化的 Metadata 中恢复标题
-				if persistentTitle, exists := delivery.Metadata["title"]; exists {
-					title = fmt.Sprintf("%v", persistentTitle)
-				}
-			}
-
-			recoveryMsg := fmt.Sprintf("✅ *[已恢复]* %s\n告警已自动解除。ID: %s", title, delivery.NotificationID)
-			if err := p.sendTelegramMessage(recoveryMsg); err != nil {
-				p.logger("service.telegram", "notification_id", delivery.NotificationID).Warn("send telegram recovery notification failed", "error", err)
+		if _, isActive := activeNotificationIDs[delivery.NotificationID]; isActive {
+			continue
+		}
+		if telegramDeliveryNeedsFlapSuppression(delivery) {
+			nextDelivery, recovered, recoverErr := p.advanceTelegramFlapSuppressedRecoveredDelivery(delivery, now)
+			if recoverErr != nil {
+				p.logger("service.telegram", "notification_id", delivery.NotificationID).Warn("send telegram recovery notification failed", "error", recoverErr)
 				continue
 			}
-
-			// 标记为已恢复，防止重复发送
-			if _, err := p.store.UpsertNotificationDelivery(delivery.NotificationID, "telegram", "recovered", "", delivery.Metadata); err != nil {
-				p.logger("service.telegram", "notification_id", delivery.NotificationID).Warn("record telegram recovery delivery failed", "error", err)
+			if nextDelivery.NotificationID != "" {
+				deliveryByID[delivery.NotificationID] = nextDelivery
 			}
-			p.telegramSentAlertCache.Delete(delivery.NotificationID)
-			recoveredCount++
+			if recovered {
+				recoveredCount++
+			}
+			continue
 		}
+		if !strings.EqualFold(delivery.Status, "sent") {
+			continue
+		}
+		titleRaw, ok := p.telegramSentAlertCache.Load(delivery.NotificationID)
+		title := "未知告警"
+		if ok {
+			title = titleRaw.(string)
+		} else if delivery.Metadata != nil {
+			// 如果内存缓存失效（如重启后），尝试从持久化的 Metadata 中恢复标题
+			if persistentTitle, exists := delivery.Metadata["title"]; exists {
+				title = fmt.Sprintf("%v", persistentTitle)
+			}
+		}
+
+		recoveryMsg := fmt.Sprintf("✅ *[已恢复]* %s\n告警已自动解除。ID: %s", title, delivery.NotificationID)
+		if err := p.sendTelegramMessage(recoveryMsg); err != nil {
+			p.logger("service.telegram", "notification_id", delivery.NotificationID).Warn("send telegram recovery notification failed", "error", err)
+			continue
+		}
+
+		// 标记为已恢复，防止重复发送
+		if _, err := p.store.UpsertNotificationDelivery(delivery.NotificationID, "telegram", "recovered", "", delivery.Metadata); err != nil {
+			p.logger("service.telegram", "notification_id", delivery.NotificationID).Warn("record telegram recovery delivery failed", "error", err)
+		}
+		p.telegramSentAlertCache.Delete(delivery.NotificationID)
+		recoveredCount++
 	}
 
 	if sentCount > 0 || recoveredCount > 0 {
 		logger.Debug("telegram dispatch cycle completed", "sent", sentCount, "recovered", recoveredCount, "active", len(notifications))
 	}
 	return firstErr
+}
+
+func telegramAlertNeedsFlapSuppression(alert domain.PlatformAlert) bool {
+	if alert.Scope == "runtime" && alert.ID != "" && strings.HasPrefix(alert.ID, "runtime-stale-") {
+		return true
+	}
+	return alert.Scope == "live" && alert.Title == "实盘运行时告警" && alert.Detail == "stale-source-states"
+}
+
+func telegramDeliveryNeedsFlapSuppression(delivery domain.NotificationDelivery) bool {
+	if delivery.NotificationID == "" {
+		return false
+	}
+	if strings.HasPrefix(delivery.NotificationID, "runtime-stale-") {
+		return true
+	}
+	if delivery.Metadata == nil {
+		return false
+	}
+	return stringValue(delivery.Metadata["flapSuppressionKey"]) == "live-stale-source-states"
+}
+
+func (p *Platform) advanceTelegramFlapSuppressedActiveDelivery(
+	item domain.PlatformNotification,
+	delivery domain.NotificationDelivery,
+	hasDelivery bool,
+	now time.Time,
+) (domain.NotificationDelivery, bool, error) {
+	metadata := cloneMetadata(delivery.Metadata)
+	if metadata == nil {
+		metadata = map[string]any{}
+	}
+	metadata["title"] = item.Alert.Title
+	metadata["scope"] = item.Alert.Scope
+	metadata["detail"] = item.Alert.Detail
+	metadata["firstActiveAt"] = firstNonEmpty(stringValue(metadata["firstActiveAt"]), now.Format(time.RFC3339))
+	if item.Alert.Scope == "live" {
+		metadata["flapSuppressionKey"] = "live-stale-source-states"
+	}
+	delete(metadata, "resolveObservedAt")
+
+	if hasDelivery {
+		switch {
+		case strings.EqualFold(delivery.Status, "sent"):
+			return delivery, false, nil
+		case strings.EqualFold(delivery.Status, "resolve_pending"):
+			nextDelivery, err := p.store.UpsertNotificationDelivery(item.ID, "telegram", "sent", "", metadata)
+			return nextDelivery, false, err
+		case strings.EqualFold(delivery.Status, "pending"):
+			firstActiveAt := parseOptionalRFC3339(stringValue(metadata["firstActiveAt"]))
+			if firstActiveAt.IsZero() {
+				firstActiveAt = now
+				metadata["firstActiveAt"] = now.Format(time.RFC3339)
+			}
+			if now.Sub(firstActiveAt) < telegramFlapSendGrace {
+				nextDelivery, err := p.store.UpsertNotificationDelivery(item.ID, "telegram", "pending", "", metadata)
+				return nextDelivery, false, err
+			}
+		}
+	}
+
+	if !hasDelivery || !strings.EqualFold(delivery.Status, "pending") {
+		nextDelivery, err := p.store.UpsertNotificationDelivery(item.ID, "telegram", "pending", "", metadata)
+		return nextDelivery, false, err
+	}
+	if err := p.sendTelegramMessage(formatTelegramNotification(item)); err != nil {
+		return domain.NotificationDelivery{}, false, err
+	}
+	nextDelivery, err := p.store.UpsertNotificationDelivery(item.ID, "telegram", "sent", "", metadata)
+	return nextDelivery, true, err
+}
+
+func (p *Platform) advanceTelegramFlapSuppressedRecoveredDelivery(delivery domain.NotificationDelivery, now time.Time) (domain.NotificationDelivery, bool, error) {
+	metadata := cloneMetadata(delivery.Metadata)
+	if metadata == nil {
+		metadata = map[string]any{}
+	}
+	if strings.EqualFold(delivery.Status, "pending") {
+		nextDelivery, err := p.store.UpsertNotificationDelivery(delivery.NotificationID, "telegram", "recovered", "", metadata)
+		return nextDelivery, false, err
+	}
+	if !strings.EqualFold(delivery.Status, "sent") && !strings.EqualFold(delivery.Status, "resolve_pending") {
+		return delivery, false, nil
+	}
+	resolveObservedAt := parseOptionalRFC3339(stringValue(metadata["resolveObservedAt"]))
+	if strings.EqualFold(delivery.Status, "sent") || resolveObservedAt.IsZero() {
+		metadata["resolveObservedAt"] = now.Format(time.RFC3339)
+		nextDelivery, err := p.store.UpsertNotificationDelivery(delivery.NotificationID, "telegram", "resolve_pending", "", metadata)
+		return nextDelivery, false, err
+	}
+	if now.Sub(resolveObservedAt) < telegramFlapRecoverGrace {
+		nextDelivery, err := p.store.UpsertNotificationDelivery(delivery.NotificationID, "telegram", "resolve_pending", "", metadata)
+		return nextDelivery, false, err
+	}
+
+	titleRaw, ok := p.telegramSentAlertCache.Load(delivery.NotificationID)
+	title := "未知告警"
+	if ok {
+		title = titleRaw.(string)
+	} else if persistentTitle, exists := metadata["title"]; exists {
+		title = fmt.Sprintf("%v", persistentTitle)
+	}
+	recoveryMsg := fmt.Sprintf("✅ *[已恢复]* %s\n告警已自动解除。ID: %s", title, delivery.NotificationID)
+	if err := p.sendTelegramMessage(recoveryMsg); err != nil {
+		return domain.NotificationDelivery{}, false, err
+	}
+	nextDelivery, err := p.store.UpsertNotificationDelivery(delivery.NotificationID, "telegram", "recovered", "", metadata)
+	if err != nil {
+		return domain.NotificationDelivery{}, false, err
+	}
+	p.telegramSentAlertCache.Delete(delivery.NotificationID)
+	return nextDelivery, true, nil
 }

--- a/internal/service/telegram_test.go
+++ b/internal/service/telegram_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/wuyaocheng/bktrader/internal/domain"
 	"github.com/wuyaocheng/bktrader/internal/store/memory"
@@ -134,5 +135,121 @@ func TestTelegramNotificationRecoveryRestart(t *testing.T) {
 	}
 	if !strings.Contains(lastMsg, "✅ *[已恢复]*") {
 		t.Fatalf("expected recovery marker, got: %s", lastMsg)
+	}
+}
+
+func TestTelegramDispatchSuppressesFlappingRuntimeStaleAlerts(t *testing.T) {
+	var messages []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var p map[string]any
+		_ = json.Unmarshal(body, &p)
+		messages = append(messages, p["text"].(string))
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"ok":true}`))
+	}))
+	defer server.Close()
+
+	oldURL := telegramBaseURL
+	telegramBaseURL = server.URL
+	defer func() { telegramBaseURL = oldURL }()
+
+	oldNow := telegramNow
+	base := time.Date(2026, 4, 21, 13, 0, 0, 0, time.UTC)
+	now := base
+	telegramNow = func() time.Time { return now }
+	defer func() { telegramNow = oldNow }()
+
+	store := memory.NewStore()
+	p := &Platform{
+		store: store,
+		telegramConfig: domain.TelegramConfig{
+			Enabled:    true,
+			BotToken:   "test-token",
+			ChatID:     "123",
+			SendLevels: []string{"warning", "error"},
+		},
+	}
+
+	item := domain.PlatformNotification{
+		ID:     "runtime-stale-signal-runtime-1",
+		Status: "active",
+		Alert: domain.PlatformAlert{
+			ID:               "runtime-stale-signal-runtime-1",
+			Scope:            "runtime",
+			Level:            "warning",
+			Title:            "数据源过期",
+			Detail:           "1 个数据源状态已陈旧",
+			AccountName:      "Binance Testnet",
+			StrategyID:       "2",
+			RuntimeSessionID: "signal-runtime-1",
+			EventTime:        base,
+		},
+		UpdatedAt: base,
+	}
+
+	pending, shouldSend, err := p.advanceTelegramFlapSuppressedActiveDelivery(item, domain.NotificationDelivery{}, false, now)
+	if err != nil {
+		t.Fatalf("seed pending delivery failed: %v", err)
+	}
+	if shouldSend {
+		t.Fatal("expected first observation to stay pending")
+	}
+	if pending.Status != "pending" {
+		t.Fatalf("expected pending status, got %s", pending.Status)
+	}
+	if len(messages) != 0 {
+		t.Fatalf("expected no telegram message on first observation, got %#v", messages)
+	}
+
+	now = base.Add(30 * time.Second)
+	pending, shouldSend, err = p.advanceTelegramFlapSuppressedActiveDelivery(item, pending, true, now)
+	if err != nil {
+		t.Fatalf("refresh pending delivery failed: %v", err)
+	}
+	if shouldSend {
+		t.Fatal("expected flap-suppressed alert to stay pending before grace window")
+	}
+	if len(messages) != 0 {
+		t.Fatalf("expected no telegram message before grace window, got %#v", messages)
+	}
+
+	now = base.Add(50 * time.Second)
+	sent, shouldSend, err := p.advanceTelegramFlapSuppressedActiveDelivery(item, pending, true, now)
+	if err != nil {
+		t.Fatalf("send suppressed alert failed: %v", err)
+	}
+	if !shouldSend {
+		t.Fatal("expected alert to send after grace window")
+	}
+	if sent.Status != "sent" {
+		t.Fatalf("expected sent status, got %s", sent.Status)
+	}
+	if len(messages) != 1 || !strings.Contains(messages[0], "数据源过期") {
+		t.Fatalf("expected one alert message after grace window, got %#v", messages)
+	}
+
+	now = base.Add(70 * time.Second)
+	resolvePending, recovered, err := p.advanceTelegramFlapSuppressedRecoveredDelivery(sent, now)
+	if err != nil {
+		t.Fatalf("mark resolve pending failed: %v", err)
+	}
+	if recovered {
+		t.Fatal("expected recovery to wait for stabilization window")
+	}
+	if resolvePending.Status != "resolve_pending" {
+		t.Fatalf("expected resolve_pending status, got %s", resolvePending.Status)
+	}
+
+	now = base.Add(135 * time.Second)
+	_, recovered, err = p.advanceTelegramFlapSuppressedRecoveredDelivery(resolvePending, now)
+	if err != nil {
+		t.Fatalf("send stabilized recovery failed: %v", err)
+	}
+	if !recovered {
+		t.Fatal("expected stabilized recovery message after grace window")
+	}
+	if len(messages) != 2 || !strings.Contains(messages[1], "✅ *[已恢复]*") {
+		t.Fatalf("expected recovery message after stabilization window, got %#v", messages)
 	}
 }


### PR DESCRIPTION
## 目的
降低 `runtime-stale-*` 与 live `stale-source-states` Telegram 告警的抖动噪声，避免短暂 stale 后立刻恢复时反复推送“告警/已恢复”。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [x] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main)
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？
- [x] DB migration 是否具备向下兼容幂等性？
- [x] 配置字段有没有无意被混改？

## 验证方式与测试证据
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

### What Changed
- 在 Telegram dispatcher 中仅对两类 flap 告警增加延迟发送和延迟恢复：`runtime-stale-*` 与 live `stale-source-states`
- 告警首次命中先落为 `pending`，持续 45 秒后才真正发送
- 已发送告警恢复后先落为 `resolve_pending`，持续稳定 60 秒后才发送“已恢复”
- 若恢复窗口内再次活跃，则直接回到 `sent`，避免来回刷屏
- 补充对应单测，覆盖 pending、延迟发送、延迟恢复三段行为

### Root Cause
当前通知层没有滞回窗口。短暂 source stale 一旦命中就立刻发送，下一轮不活跃又立刻发送恢复通知，导致同一事实在 Telegram 上反复 flap。

### Impact
- 不改变 live/runtime 健康判定，也不影响页面和健康快照的实时状态
- 仅降低 Telegram 外发噪声，保留持续性 stale 的可见性

### Validation
- `go test ./internal/service -run 'TestTelegram'`
