### PR TITLE
[codex] guard live reentry stops and bar limits

### DIFF
--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -3570,12 +3570,8 @@ func (p *Platform) resolveLiveSessionPositionSnapshot(session domain.LiveSession
 	livePositionState := cloneMetadata(mapValue(session.State["livePositionState"]))
 	if len(livePositionState) > 0 && hasRealPosition {
 		liveSymbol := NormalizeSymbol(firstNonEmpty(stringValue(livePositionState["symbol"]), symbol))
-		if liveSymbol == NormalizeSymbol(symbol) {
-			mergedPosition := cloneMetadata(positionSnapshot)
-			for key, value := range livePositionState {
-				mergedPosition[key] = value
-			}
-			positionSnapshot = mergedPosition
+		if liveSymbol == NormalizeSymbol(symbol) && livePositionStateMatchesPositionSnapshot(positionSnapshot, livePositionState) {
+			positionSnapshot = mergeLivePositionRiskState(positionSnapshot, livePositionState)
 		}
 	}
 	if hasRealPosition {
@@ -3595,6 +3591,70 @@ func (p *Platform) resolveLiveSessionPositionSnapshot(session domain.LiveSession
 	virtualPosition["virtual"] = true
 	virtualPosition["symbol"] = virtualSymbol
 	return virtualPosition, false, nil
+}
+
+func livePositionStateMatchesPositionSnapshot(positionSnapshot map[string]any, livePositionState map[string]any) bool {
+	if len(positionSnapshot) == 0 || len(livePositionState) == 0 {
+		return false
+	}
+	positionSymbol := NormalizeSymbol(stringValue(positionSnapshot["symbol"]))
+	liveSymbol := NormalizeSymbol(stringValue(livePositionState["symbol"]))
+	if liveSymbol != "" && positionSymbol != "" && liveSymbol != positionSymbol {
+		return false
+	}
+	positionSide := strings.ToUpper(strings.TrimSpace(stringValue(positionSnapshot["side"])))
+	liveSide := strings.ToUpper(strings.TrimSpace(stringValue(livePositionState["side"])))
+	if liveSide != "" && positionSide != "" && liveSide != positionSide {
+		return false
+	}
+	positionEntry := parseFloatValue(positionSnapshot["entryPrice"])
+	liveEntry := parseFloatValue(livePositionState["entryPrice"])
+	if liveEntry > 0 && positionEntry > 0 && math.Abs(liveEntry-positionEntry) > 1e-6 {
+		return false
+	}
+	positionKey := buildLivePositionWatermarkKey(positionSnapshot)
+	if positionKey == "" {
+		return false
+	}
+	liveKey := strings.TrimSpace(stringValue(livePositionState["watermarkPositionKey"]))
+	if liveKey == "" {
+		return false
+	}
+	if liveKey == positionKey {
+		return true
+	}
+	if strings.TrimSpace(stringValue(positionSnapshot["id"])) != "" {
+		return liveKey == buildLegacyPrefixedLivePositionWatermarkKey(positionSnapshot)
+	}
+	return liveKey == buildLivePositionWatermarkBaseKey(positionSnapshot) ||
+		liveKey == buildLegacyLivePositionWatermarkKey(positionSnapshot)
+}
+
+func mergeLivePositionRiskState(positionSnapshot map[string]any, livePositionState map[string]any) map[string]any {
+	mergedPosition := cloneMetadata(positionSnapshot)
+	for _, key := range []string{
+		"baseStopLoss",
+		"stopLoss",
+		"stopLossSource",
+		"trailingStopConfigured",
+		"trailingStopActive",
+		"trailingActivationArmed",
+		"trailingStopCandidate",
+		"protected",
+		"protectionTrigger",
+		"prevHigh1",
+		"prevLow1",
+		"atr14",
+		"profitProtectATR",
+		"hwm",
+		"lwm",
+		"watermarkPositionKey",
+	} {
+		if value, ok := livePositionState[key]; ok {
+			mergedPosition[key] = value
+		}
+	}
+	return mergedPosition
 }
 
 func (p *Platform) resolveLiveSessionParameters(session domain.LiveSession, version domain.StrategyVersion) (map[string]any, error) {
@@ -4045,6 +4105,9 @@ func shouldAutoDispatchLiveIntent(session domain.LiveSession, intent map[string]
 		return false
 	}
 	if shouldBlockAutoDispatchForRecoveryIntent(session, intent) {
+		return false
+	}
+	if shouldBlockAutoDispatchForLiveEntryTradeLimit(session, intent) {
 		return false
 	}
 	lastSignature := stringValue(session.State["lastDispatchedIntentSignature"])

--- a/internal/service/live_execution.go
+++ b/internal/service/live_execution.go
@@ -412,6 +412,53 @@ func shouldBlockAutoDispatchForRecoveryIntent(session domain.LiveSession, intent
 	return validateLiveExecutionProposalMetadata(session, proposalMap) != nil
 }
 
+func shouldBlockAutoDispatchForLiveEntryTradeLimit(session domain.LiveSession, intent map[string]any) bool {
+	return validateLiveSignalBarEntryTradeLimit(session, intent) != nil
+}
+
+func validateLiveSignalBarEntryTradeLimit(session domain.LiveSession, proposalMap map[string]any) error {
+	if !liveEntryCountsTowardSignalBarLimit(proposalMap) {
+		return nil
+	}
+	maxTradesPerBar := maxIntValue(session.State["max_trades_per_bar"], 0)
+	if maxTradesPerBar <= 0 {
+		return nil
+	}
+	currentBarKey := liveProposalSignalBarStateKey(proposalMap)
+	if currentBarKey == "" || currentBarKey != stringValue(session.State["lastSignalBarStateKey"]) {
+		return nil
+	}
+	currentCount := maxIntValue(session.State["sessionReentryCount"], 0)
+	if currentCount < maxTradesPerBar {
+		return nil
+	}
+	return fmt.Errorf(
+		"live session %s reached max_trades_per_bar=%d for signal bar %s",
+		session.ID,
+		maxTradesPerBar,
+		currentBarKey,
+	)
+}
+
+func liveEntryCountsTowardSignalBarLimit(proposalMap map[string]any) bool {
+	if !strings.EqualFold(strings.TrimSpace(stringValue(proposalMap["role"])), "entry") {
+		return false
+	}
+	switch normalizeStrategyReasonTag(stringValue(proposalMap["reason"])) {
+	case "zero-initial-reentry", "sl-reentry", "pt-reentry":
+		return true
+	default:
+		return false
+	}
+}
+
+func liveProposalSignalBarStateKey(proposalMap map[string]any) string {
+	if key := strings.TrimSpace(stringValue(proposalMap["signalBarStateKey"])); key != "" {
+		return key
+	}
+	return strings.TrimSpace(stringValue(mapValue(proposalMap["metadata"])["signalBarStateKey"]))
+}
+
 func (p *Platform) dispatchLiveSessionIntent(session domain.LiveSession) (domain.Order, error) {
 	if !strings.EqualFold(session.Status, "RUNNING") && !strings.EqualFold(session.Status, "READY") {
 		return domain.Order{}, fmt.Errorf("live session %s is not dispatchable in status %s", session.ID, session.Status)
@@ -440,6 +487,9 @@ func (p *Platform) dispatchLiveSessionIntent(session domain.LiveSession) (domain
 	}
 	proposalMap = assembleLiveExecutionProposalMetadata(session, version.ID, proposalMap)
 	if err := validateLiveExecutionProposalMetadata(session, proposalMap); err != nil {
+		return domain.Order{}, err
+	}
+	if err := validateLiveSignalBarEntryTradeLimit(session, proposalMap); err != nil {
 		return domain.Order{}, err
 	}
 	dispatchStartedAt := time.Now().UTC()
@@ -942,7 +992,7 @@ func maybeIncrementLiveSessionReentryCount(state map[string]any, proposalMap map
 		return
 	}
 	reasonTag := normalizeStrategyReasonTag(stringValue(proposalMap["reason"]))
-	if reasonTag != "sl-reentry" && reasonTag != "pt-reentry" {
+	if reasonTag != "zero-initial-reentry" && reasonTag != "sl-reentry" && reasonTag != "pt-reentry" {
 		return
 	}
 	if orderID != "" && stringValue(state["lastCountedReentryOrderId"]) == orderID {

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -2296,6 +2296,205 @@ func TestMaybeIncrementLiveSessionReentryCountOnlyCountsFilledReentries(t *testi
 	}
 }
 
+func TestMaybeIncrementLiveSessionReentryCountCountsZeroInitialWindowEntry(t *testing.T) {
+	state := map[string]any{}
+	proposal := map[string]any{
+		"reason":            "Zero-Initial-Reentry",
+		"signalBarStateKey": "bar-1",
+	}
+	maybeIncrementLiveSessionReentryCount(state, proposal, "order-1", "FILLED")
+	if got := parseFloatValue(state["sessionReentryCount"]); got != 1 {
+		t.Fatalf("expected zero-initial window entry to count as first bar trade, got %v", got)
+	}
+	if got := stringValue(state["lastSignalBarStateKey"]); got != "bar-1" {
+		t.Fatalf("expected signal bar key to be recorded, got %s", got)
+	}
+}
+
+func TestShouldAutoDispatchLiveIntentBlocksEntryAfterMaxTradesPerSignalBar(t *testing.T) {
+	intent := map[string]any{
+		"action":            "entry",
+		"role":              "entry",
+		"reason":            "SL-Reentry",
+		"side":              "SELL",
+		"symbol":            "BTCUSDT",
+		"signalKind":        "sl-reentry",
+		"signalBarStateKey": "bar-1",
+		"status":            "dispatchable",
+	}
+	session := domain.LiveSession{
+		ID: "live-session-1",
+		State: map[string]any{
+			"dispatchMode":          "auto-dispatch",
+			"max_trades_per_bar":    2,
+			"lastSignalBarStateKey": "bar-1",
+			"sessionReentryCount":   2.0,
+		},
+	}
+	if shouldAutoDispatchLiveIntent(session, intent, time.Now().UTC()) {
+		t.Fatal("expected auto-dispatch to stop after max_trades_per_bar entries in one signal bar")
+	}
+}
+
+func TestValidateLiveSignalBarEntryTradeLimitAllowsNewBar(t *testing.T) {
+	session := domain.LiveSession{
+		ID: "live-session-1",
+		State: map[string]any{
+			"max_trades_per_bar":    2,
+			"lastSignalBarStateKey": "bar-1",
+			"sessionReentryCount":   2.0,
+		},
+	}
+	proposal := map[string]any{
+		"role":              "entry",
+		"reason":            "SL-Reentry",
+		"signalBarStateKey": "bar-2",
+	}
+	if err := validateLiveSignalBarEntryTradeLimit(session, proposal); err != nil {
+		t.Fatalf("expected a new signal bar to reset the entry limit, got %v", err)
+	}
+}
+
+func TestDispatchLiveSessionIntentRejectsEntryAfterMaxTradesPerSignalBar(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	session, err := platform.CreateLiveSession("", "live-main", "strategy-bk-1d", map[string]any{
+		"symbol":              "BTCUSDT",
+		"signalTimeframe":     "30m",
+		"executionDataSource": "tick",
+	})
+	if err != nil {
+		t.Fatalf("create live session failed: %v", err)
+	}
+	state := cloneMetadata(session.State)
+	state["max_trades_per_bar"] = 2
+	state["lastSignalBarStateKey"] = "bar-1"
+	state["sessionReentryCount"] = 2.0
+	state["signalRuntimeSessionId"] = "runtime-1"
+	state["lastExecutionProposal"] = map[string]any{
+		"action":            "entry",
+		"role":              "entry",
+		"reason":            "SL-Reentry",
+		"side":              "SELL",
+		"symbol":            "BTCUSDT",
+		"type":              "MARKET",
+		"quantity":          0.001,
+		"priceHint":         76129.0,
+		"reduceOnly":        false,
+		"signalKind":        "sl-reentry",
+		"signalBarStateKey": "bar-1",
+		"status":            "dispatchable",
+		"metadata": map[string]any{
+			"executionMode": "live",
+			"executionContext": map[string]any{
+				"symbol":              "BTCUSDT",
+				"signalTimeframe":     "30m",
+				"executionDataSource": "tick",
+				"executionMode":       "live",
+			},
+		},
+	}
+	session, err = platform.store.UpdateLiveSessionState(session.ID, state)
+	if err != nil {
+		t.Fatalf("update live session state failed: %v", err)
+	}
+	_, err = platform.dispatchLiveSessionIntent(session)
+	if err == nil || !strings.Contains(err.Error(), "max_trades_per_bar=2") {
+		t.Fatalf("expected dispatch to reject after max_trades_per_bar, got %v", err)
+	}
+}
+
+func TestResolveLiveSessionPositionSnapshotDoesNotMergeStaleLivePositionState(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	if _, err := platform.store.SavePosition(domain.Position{
+		ID:                "position-new",
+		AccountID:         "live-main",
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "SHORT",
+		Quantity:          0.001,
+		EntryPrice:        76129.0,
+		MarkPrice:         76130.6,
+	}); err != nil {
+		t.Fatalf("save position failed: %v", err)
+	}
+	session := domain.LiveSession{
+		AccountID: "live-main",
+		State: map[string]any{
+			"livePositionState": map[string]any{
+				"symbol":               "BTCUSDT",
+				"side":                 "SHORT",
+				"entryPrice":           76129.0,
+				"stopLoss":             75861.2,
+				"stopLossSource":       "trailing-stop",
+				"watermarkPositionKey": encodeLivePositionWatermarkIdentityComponent("position-old") + "|BTCUSDT|SHORT|76129.00000000",
+			},
+		},
+	}
+	snapshot, found, err := platform.resolveLiveSessionPositionSnapshot(session, "BTCUSDT")
+	if err != nil {
+		t.Fatalf("resolve position snapshot failed: %v", err)
+	}
+	if !found {
+		t.Fatal("expected real position to be found")
+	}
+	if got := parseFloatValue(snapshot["stopLoss"]); got != 0 {
+		t.Fatalf("expected stale cached stopLoss to stay out of factual snapshot, got %v", got)
+	}
+	if got := stringValue(snapshot["watermarkPositionKey"]); got != "" {
+		t.Fatalf("expected stale watermark key to stay out of factual snapshot, got %s", got)
+	}
+	if got := parseFloatValue(snapshot["entryPrice"]); got != 76129.0 {
+		t.Fatalf("expected factual entry price to be preserved, got %v", got)
+	}
+}
+
+func TestResolveLiveSessionPositionSnapshotMergesMatchingRiskStateOnly(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	if _, err := platform.store.SavePosition(domain.Position{
+		ID:                "position-1",
+		AccountID:         "live-main",
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "SHORT",
+		Quantity:          0.001,
+		EntryPrice:        76129.0,
+		MarkPrice:         76130.6,
+	}); err != nil {
+		t.Fatalf("save position failed: %v", err)
+	}
+	key := encodeLivePositionWatermarkIdentityComponent("position-1") + "|BTCUSDT|SHORT|76129.00000000"
+	session := domain.LiveSession{
+		AccountID: "live-main",
+		State: map[string]any{
+			"livePositionState": map[string]any{
+				"symbol":               "BTCUSDT",
+				"side":                 "SHORT",
+				"entryPrice":           76129.0,
+				"stopLoss":             76241.6,
+				"stopLossSource":       "initial-stop",
+				"protected":            true,
+				"watermarkPositionKey": key,
+			},
+		},
+	}
+	snapshot, found, err := platform.resolveLiveSessionPositionSnapshot(session, "BTCUSDT")
+	if err != nil {
+		t.Fatalf("resolve position snapshot failed: %v", err)
+	}
+	if !found {
+		t.Fatal("expected real position to be found")
+	}
+	if got := parseFloatValue(snapshot["stopLoss"]); got != 76241.6 {
+		t.Fatalf("expected matching risk stopLoss to be merged, got %v", got)
+	}
+	if got := stringValue(snapshot["watermarkPositionKey"]); got != key {
+		t.Fatalf("expected matching watermark key to be merged, got %s", got)
+	}
+	if got := parseFloatValue(snapshot["quantity"]); got != 0.001 {
+		t.Fatalf("expected factual quantity to remain authoritative, got %v", got)
+	}
+}
+
 func TestEvaluateExecutionQualityDoesNotTreatCancelsAsRejections(t *testing.T) {
 	state := map[string]any{
 		"executionEventStats": map[string]any{

--- a/internal/service/strategy_optimization_test.go
+++ b/internal/service/strategy_optimization_test.go
@@ -366,6 +366,29 @@ func TestResolveLivePositionWatermarksResetsLegacyRealPositionKey(t *testing.T) 
 	}
 }
 
+func TestResolveLivePositionWatermarksResetsSymbolBaseKeyForRealPositionWithID(t *testing.T) {
+	sessionState := map[string]any{
+		"hwm":                  52000.0,
+		"lwm":                  49000.0,
+		"watermarkPositionKey": "BTCUSDT|LONG|50000.00000000",
+	}
+	currentPosition := map[string]any{
+		"id":         "position-1",
+		"symbol":     "BTCUSDT",
+		"side":       "LONG",
+		"entryPrice": 50000.0,
+		"quantity":   1.0,
+		"found":      true,
+	}
+	watermarks := resolveLivePositionWatermarks(currentPosition, sessionState)
+	if got := watermarks.PositionKey; got != encodeLivePositionWatermarkIdentityComponent("position-1")+"|BTCUSDT|LONG|50000.00000000" {
+		t.Fatalf("expected canonical real-position watermark key, got %s", got)
+	}
+	if watermarks.HWM != 50000.0 || watermarks.LWM != 50000.0 {
+		t.Fatalf("expected symbol base key to reset for identified real position, got %+v", watermarks)
+	}
+}
+
 func TestResolveLivePositionWatermarksResetsForPositionIDOnlyLegacyKey(t *testing.T) {
 	sessionState := map[string]any{
 		"hwm":                  52000.0,

--- a/internal/service/strategy_registry.go
+++ b/internal/service/strategy_registry.go
@@ -929,9 +929,6 @@ func isCompatibleLivePositionWatermarkMigration(lastKey string, currentPosition 
 		if boolValue(currentPosition["virtual"]) && lastKey == positionID {
 			return true
 		}
-		if lastKey == baseKey {
-			return true
-		}
 		return lastKey == buildLegacyPrefixedLivePositionWatermarkKey(currentPosition)
 	}
 	return lastKey == baseKey


### PR DESCRIPTION
## 目的
修复 live session 在同一根 signal bar 内快速 `entry -> SL exit -> reentry -> SL exit` 循环的问题。

Root cause:
- `livePositionState` 是 session 缓存态，但 `resolveLiveSessionPositionSnapshot` 之前只按 symbol 把它整包合并到真实持仓快照里，可能让旧仓位的 trailing `stopLoss` 覆盖新仓位事实源。
- 对于 short 仓，如果旧 trailing stop 被带到新仓并低于 entry，`marketPrice >= stopLoss` 会立即成立，导致下一轮马上 `risk-exit`。
- live 侧的 `max_trades_per_bar` 之前没有作为最终 dispatch 硬闸门，且 `zero-initial-reentry` 没被计入同 bar entry 计数，异常退出后可以继续自动 reentry。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [x] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) - 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？- 无
- [x] DB migration 是否具备向下兼容幂等性？- 未涉及 DB migration
- [x] 配置字段有没有无意被混改？- 仅消费既有 `max_trades_per_bar` / `sessionReentryCount`

## 修改点
- 真实持仓快照不再被 `livePositionState` 整包覆盖；只有 watermark identity 匹配时，才继承 `stopLoss` / `protected` / trailing 水位等风险缓存字段。
- 对带真实 position id 的仓位，symbol base watermark key 不再被视为兼容，避免旧仓同 symbol / side / entry 复用水位线。
- `zero-initial-reentry` 现在计入同 signal bar entry 计数。
- auto-dispatch 和最终 `dispatchLiveSessionIntent` submit 前都会校验 `max_trades_per_bar`，达到上限后拒绝继续同 bar reentry。

## 行为变化
- 新仓不会继承旧仓的 trailing stop，从而避免 short 仓 stopLoss 被错误放到 entry 下方后立即触发 SL。
- 同一根 signal bar 内，`zero-initial-reentry` + `sl-reentry` / `pt-reentry` 合计达到 `max_trades_per_bar` 后，live entry 自动派单和最终派单边界都会被挡住。
- 未改变 `dispatchMode` 默认值，未改变 mainnet/testnet 路由，未新增 migration。

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

已运行：
- `go test ./internal/service -run 'TestResolveLiveSessionPositionSnapshot|TestMaybeIncrementLiveSessionReentryCount|TestShouldAutoDispatchLiveIntentBlocksEntryAfterMaxTradesPerSignalBar|TestValidateLiveSignalBarEntryTradeLimit|TestDispatchLiveSessionIntentRejectsEntryAfterMaxTradesPerSignalBar|TestResolveLivePositionWatermarks' -count=1`
- `go test ./internal/service -count=1`
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
- `git diff --check`