### PR TITLE
[codex] guard stale live reentry window

### DIFF
--- a/internal/service/live_zero_initial.go
+++ b/internal/service/live_zero_initial.go
@@ -40,7 +40,10 @@ func prepareLivePlanStepForSignalEvaluation(
 	}
 
 	updatedState = refreshLiveZeroInitialWindowState(updatedState, signalBarStates, symbol, signalTimeframe, currentPosition, eventTime)
-	if liveExitReentryPlanStep(nextPlannedRole, nextPlannedReason) {
+	// Replay only keeps PT/SL reentry eligible through the next signal bar.
+	// Once the planned step is stale, live should fall back to current-market alignment.
+	if liveExitReentryPlanStep(nextPlannedRole, nextPlannedReason) &&
+		(hasActiveLivePositionSnapshot(currentPosition) || !isLivePlanStepStale(nextPlannedEvent, signalTimeframe, eventTime)) {
 		clearLivePendingZeroInitialWindow(updatedState, eventTime, "exit-reentry-priority")
 		return updatedState, nextPlannedEvent, nextPlannedPrice, nextPlannedSide, nextPlannedRole, nextPlannedReason
 	}

--- a/internal/service/live_zero_initial_test.go
+++ b/internal/service/live_zero_initial_test.go
@@ -1,0 +1,65 @@
+package service
+
+import (
+	"testing"
+	"time"
+)
+
+func TestPrepareLivePlanStepForSignalEvaluationExpiresStaleExitReentryWindow(t *testing.T) {
+	barStart := time.Date(2026, 4, 10, 0, 0, 0, 0, time.UTC)
+	signalStates := map[string]any{
+		signalBindingMatchKey("binance-kline", "signal", "BTCUSDT"): map[string]any{
+			"symbol":    "BTCUSDT",
+			"timeframe": "1d",
+			"sma5":      68050.0,
+			"atr14":     900.0,
+			"current": map[string]any{
+				"barStart": barStart.Format(time.RFC3339),
+				"close":    68100.0,
+				"high":     69010.0,
+				"low":      67800.0,
+			},
+			"prevBar1": map[string]any{
+				"high": 68850.0,
+				"low":  67750.0,
+			},
+			"prevBar2": map[string]any{
+				"high": 69000.0,
+				"low":  67600.0,
+			},
+		},
+	}
+
+	state, gotEvent, gotPrice, gotSide, gotRole, gotReason := prepareLivePlanStepForSignalEvaluation(
+		map[string]any{},
+		map[string]any{
+			"dir2_zero_initial": true,
+			"zero_initial_mode": "reentry_window",
+			"long_reentry_atr":  0.1,
+		},
+		signalStates,
+		"BTCUSDT",
+		"1d",
+		map[string]any{},
+		barStart.Add(49*time.Hour),
+		69010.0,
+		"trade_tick.price",
+		barStart.Add(-48*time.Hour),
+		75600.0,
+		"SELL",
+		"entry",
+		"SL-Reentry",
+	)
+	if gotRole != "entry" || gotReason != "Zero-Initial-Reentry" || gotSide != "BUY" {
+		t.Fatalf("expected stale SL-Reentry to fall back to current bar alignment, got side=%s role=%s reason=%s", gotSide, gotRole, gotReason)
+	}
+	if gotPrice != 67840.0 {
+		t.Fatalf("expected stale SL-Reentry fallback price 67840, got %.2f", gotPrice)
+	}
+	if gotEvent.IsZero() {
+		t.Fatal("expected stale SL-Reentry fallback planned event")
+	}
+	if pending := mapValue(state[livePendingZeroInitialWindowStateKey]); stringValue(pending["side"]) != "BUY" {
+		t.Fatalf("expected pending BUY window after stale SL-Reentry fallback, got %+v", pending)
+	}
+}


### PR DESCRIPTION
## 目的
修复 live `reentry_window` 模式下 stale `SL-Reentry` / `PT-Reentry` 计划步会长期压住当前 signal bar 对齐的问题，避免 decision 在旧 reentry 语境里持续停留在 `waiting-signal-filter`。

另外把这次回归测试拆到独立测试文件，减少 `internal/service/live_test.go` 的继续膨胀。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [x] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
- [x] `dispatchMode` 默认值有否变化？(无变化)
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？(无)
- [ ] DB migration 是否具备向下兼容幂等性？(N/A，本次无 migration)
- [x] 配置字段有没有无意被混改？(无)

## Root Cause
在 `zero_initial_mode=reentry_window` 下，live 评估会优先保留当前 replay 计划里的 `SL-Reentry` / `PT-Reentry` 步骤。

此前这条优先级没有 stale 边界判断，导致计划步即使已经跨过 replay 的 reentry 窗口，live 仍会继续沿用旧的 `SL-Reentry` 语义做 signal filter 判断，而不是回到当前 signal bar 的对齐逻辑。

## 修改点
- 仅在 exit reentry 计划步仍处于有效窗口内，或者当前仍有 active live/virtual position 时，才继续保留原来的 `SL/PT-Reentry` 优先级。
- 当该计划步已经 stale 时，live 回退到当前市场 / 当前 signal bar 的对齐路径。
- 新增独立回归测试，覆盖 stale `SL-Reentry` 不再无限保留，而是回到当前 bar 语义。

## 行为变化
- 之前：旧 `SL-Reentry` 可以在多个 signal bar 之后仍持续参与 live decision，容易长期停在 `waiting-signal-filter` / `sl-reentry-watch`。
- 现在：超出 replay reentry 窗口后，live 不再继续盯住旧的 `SL-Reentry` 计划步，而是回到当前 signal bar 对齐结果。

## 新增测试
- 新增 `TestPrepareLivePlanStepForSignalEvaluationExpiresStaleExitReentryWindow`
- 将该回归测试拆到独立文件 `internal/service/live_zero_initial_test.go`

## 验证方式与测试证据
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

已完成验证：
- `go test ./internal/service -run 'TestPrepareLivePlanStepForSignalEvaluation(UsesZeroInitialWindowAcrossTwoBars|PrioritizesExitReentryOverZeroInitialWindow|ExpiresStaleExitReentryWindow|RequiresCurrentBreakoutPrice)|TestEvaluateSignalBarGateAllowsReentryWithoutInitialBreakout'`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`

补充说明：
- 本地 `go test ./...` 在 `internal/service` 大测试集上长时间运行，提交 PR 时尚未拿到最终完成结果。