### PR TITLE
Unify Binance REST request gating

### DIFF
--- a/internal/service/chart.go
+++ b/internal/service/chart.go
@@ -4,8 +4,6 @@ import (
 	"encoding/csv"
 	"encoding/json"
 	"fmt"
-	"net/http"
-	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -149,32 +147,28 @@ func fetchBinanceFuturesCandles(symbol string, resolution string, from int64, to
 	if strings.TrimSpace(endpoint) == "" {
 		endpoint = "https://fapi.binance.com"
 	}
-	baseURL := strings.TrimRight(endpoint, "/") + "/fapi/v1/klines"
-	params := url.Values{}
-	params.Set("symbol", NormalizeSymbol(symbol))
-	params.Set("interval", interval)
+	params := map[string]string{
+		"symbol":   NormalizeSymbol(symbol),
+		"interval": interval,
+	}
 	if limit > 0 {
 		if limit > 1500 {
 			limit = 1500
 		}
-		params.Set("limit", strconv.Itoa(limit))
+		params["limit"] = strconv.Itoa(limit)
 	}
 	if from > 0 {
-		params.Set("startTime", strconv.FormatInt(from*1000, 10))
+		params["startTime"] = strconv.FormatInt(from*1000, 10)
 	}
 	if to > 0 {
-		params.Set("endTime", strconv.FormatInt(to*1000, 10))
+		params["endTime"] = strconv.FormatInt(to*1000, 10)
 	}
-	resp, err := http.Get(baseURL + "?" + params.Encode())
+	responseBody, _, err := doBinancePublicGET(endpoint, "/fapi/v1/klines", params, binanceRESTCategoryMarketData)
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("binance klines request failed: %s", resp.Status)
-	}
 	var payload [][]any
-	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+	if err := json.Unmarshal(responseBody, &payload); err != nil {
 		return nil, err
 	}
 	bars := make([]candleBar, 0, len(payload))

--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -1081,24 +1081,24 @@ func (p *Platform) syncLiveAccountFromBinance(account domain.Account, binding ma
 	if err != nil {
 		return domain.Account{}, err
 	}
-	accountPayload, err := binanceSignedGET(resolved, "/fapi/v3/account", map[string]string{
+	accountPayload, err := binanceSignedGETWithCategory(resolved, "/fapi/v3/account", map[string]string{
 		"timestamp":  fmt.Sprintf("%d", time.Now().UTC().UnixMilli()),
 		"recvWindow": fmt.Sprintf("%d", maxIntValue(binding["recvWindowMs"], 5000)),
-	})
+	}, binanceRESTCategoryAccountSync)
 	if err != nil {
 		return domain.Account{}, fmt.Errorf("binance account sync failed: %w", err)
 	}
-	positionRiskPayload, err := binanceSignedGET(resolved, "/fapi/v2/positionRisk", map[string]string{
+	positionRiskPayload, err := binanceSignedGETWithCategory(resolved, "/fapi/v2/positionRisk", map[string]string{
 		"timestamp":  fmt.Sprintf("%d", time.Now().UTC().UnixMilli()),
 		"recvWindow": fmt.Sprintf("%d", maxIntValue(binding["recvWindowMs"], 5000)),
-	})
+	}, binanceRESTCategoryAccountSync)
 	if err != nil {
 		return domain.Account{}, fmt.Errorf("binance position risk sync failed: %w", err)
 	}
-	openOrdersPayload, err := binanceSignedGET(resolved, "/fapi/v1/openOrders", map[string]string{
+	openOrdersPayload, err := binanceSignedGETWithCategory(resolved, "/fapi/v1/openOrders", map[string]string{
 		"timestamp":  fmt.Sprintf("%d", time.Now().UTC().UnixMilli()),
 		"recvWindow": fmt.Sprintf("%d", maxIntValue(binding["recvWindowMs"], 5000)),
-	})
+	}, binanceRESTCategoryAccountSync)
 	if err != nil {
 		return domain.Account{}, fmt.Errorf("binance open orders sync failed: %w", err)
 	}

--- a/internal/service/live_registry.go
+++ b/internal/service/live_registry.go
@@ -271,7 +271,7 @@ func (a binanceFuturesLiveAdapter) FetchRecentOrders(account domain.Account, bin
 		"limit":      "1000",
 	}
 	params["signature"] = signBinanceQuery(params, resolved.APISecret)
-	payload, err := doBinanceSignedRequest(http.MethodGet, resolved, "/fapi/v1/allOrders", params)
+	payload, err := doBinanceSignedRequest(http.MethodGet, resolved, "/fapi/v1/allOrders", params, binanceRESTCategoryHistoryRead)
 	if err != nil {
 		return nil, err
 	}
@@ -431,7 +431,7 @@ func (a binanceFuturesLiveAdapter) submitRESTOrder(account domain.Account, order
 		params["closePosition"] = "true"
 	}
 	params["signature"] = signBinanceQuery(params, resolved.APISecret)
-	responseBody, err := doBinanceSignedRequest(http.MethodPost, resolved, "/fapi/v1/order", params)
+	responseBody, err := doBinanceSignedRequest(http.MethodPost, resolved, "/fapi/v1/order", params, binanceRESTCategoryTradeCritical)
 	if err != nil {
 		return LiveOrderSubmission{}, err
 	}
@@ -502,7 +502,7 @@ func (a binanceFuturesLiveAdapter) syncRESTOrder(account domain.Account, order d
 		params["origClientOrderId"] = order.ID
 	}
 	params["signature"] = signBinanceQuery(params, resolved.APISecret)
-	responseBody, err := doBinanceSignedRequest(http.MethodGet, resolved, "/fapi/v1/order", params)
+	responseBody, err := doBinanceSignedRequest(http.MethodGet, resolved, "/fapi/v1/order", params, binanceRESTCategoryTradeCritical)
 	if err != nil {
 		return LiveOrderSync{}, err
 	}
@@ -593,7 +593,7 @@ func (a binanceFuturesLiveAdapter) cancelRESTOrder(account domain.Account, order
 		params["origClientOrderId"] = order.ID
 	}
 	params["signature"] = signBinanceQuery(params, resolved.APISecret)
-	responseBody, err := doBinanceSignedRequest(http.MethodDelete, resolved, "/fapi/v1/order", params)
+	responseBody, err := doBinanceSignedRequest(http.MethodDelete, resolved, "/fapi/v1/order", params, binanceRESTCategoryTradeCritical)
 	if err != nil {
 		return LiveOrderSync{}, err
 	}
@@ -639,7 +639,7 @@ func (a binanceFuturesLiveAdapter) fetchRESTTradeReports(account domain.Account,
 	if exchangeOrderID := normalizeBinanceOrderID(order.Metadata["exchangeOrderId"], nil); exchangeOrderID != "" {
 		params["orderId"] = exchangeOrderID
 	}
-	payload, err := binanceSignedGET(resolved, "/fapi/v1/userTrades", params)
+	payload, err := binanceSignedGETWithCategory(resolved, "/fapi/v1/userTrades", params, binanceRESTCategoryHistoryRead)
 	if err != nil {
 		return nil, err
 	}
@@ -661,7 +661,7 @@ func (a binanceFuturesLiveAdapter) fetchRESTTradeReportsForSymbol(account domain
 		"endTime":    fmt.Sprintf("%d", endTime.UnixMilli()),
 		"limit":      "1000",
 	}
-	payload, err := binanceSignedGET(resolved, "/fapi/v1/userTrades", params)
+	payload, err := binanceSignedGETWithCategory(resolved, "/fapi/v1/userTrades", params, binanceRESTCategoryHistoryRead)
 	if err != nil {
 		return nil, err
 	}
@@ -770,6 +770,17 @@ var (
 	binanceRESTBackoffDuration   = 60 * time.Second
 )
 
+type binanceRESTRequestCategory string
+
+const (
+	binanceRESTCategoryTradeCritical binanceRESTRequestCategory = "trade-critical"
+	binanceRESTCategoryAccountSync   binanceRESTRequestCategory = "account-sync"
+	binanceRESTCategoryReconcile     binanceRESTRequestCategory = "reconcile"
+	binanceRESTCategoryHistoryRead   binanceRESTRequestCategory = "history-read"
+	binanceRESTCategoryMetadataRead  binanceRESTRequestCategory = "metadata-read"
+	binanceRESTCategoryMarketData    binanceRESTRequestCategory = "market-data"
+)
+
 type binanceRESTLimiter struct {
 	mu    sync.Mutex
 	gates map[string]*binanceRESTGate
@@ -847,8 +858,12 @@ func (g *binanceRESTGate) markBackoff(duration time.Duration) {
 	g.mu.Unlock()
 }
 
-func binanceRESTLimiterKey(creds binanceRESTCredentials) string {
-	return creds.BaseURL + "|" + creds.APIKeyRef
+func binanceRESTLimiterKey(baseURL string) string {
+	return strings.TrimRight(strings.TrimSpace(baseURL), "/")
+}
+
+func binanceRESTLimiterKeyForCreds(creds binanceRESTCredentials) string {
+	return binanceRESTLimiterKey(creds.BaseURL)
 }
 
 func parseBinanceRetryAfter(headers http.Header) time.Duration {
@@ -1014,29 +1029,20 @@ func fetchBinanceSymbolRules(creds binanceRESTCredentials, symbol string) (binan
 	if ok && time.Since(cached.UpdatedAt) < 30*time.Minute {
 		return cached, nil
 	}
-	requestURL := creds.BaseURL + "/fapi/v1/exchangeInfo?symbol=" + url.QueryEscape(normalizedSymbol)
-	gate := binanceRESTLimiterState.gate(binanceRESTLimiterKey(creds))
-	if err := gate.acquire(); err != nil {
-		return binanceSymbolRules{}, err
-	}
-	request, err := http.NewRequest(http.MethodGet, requestURL, nil)
+	responseBody, _, err := doBinancePublicGET(
+		creds.BaseURL,
+		"/fapi/v1/exchangeInfo",
+		map[string]string{"symbol": normalizedSymbol},
+		binanceRESTCategoryMetadataRead,
+	)
 	if err != nil {
+		if strings.Contains(err.Error(), "rate-limited") {
+			return binanceSymbolRules{}, err
+		}
+		if strings.HasPrefix(err.Error(), "binance request failed:") {
+			return binanceSymbolRules{}, fmt.Errorf("binance exchangeInfo failed: %s", strings.TrimPrefix(err.Error(), "binance request failed: "))
+		}
 		return binanceSymbolRules{}, err
-	}
-	response, err := http.DefaultClient.Do(request)
-	if err != nil {
-		return binanceSymbolRules{}, err
-	}
-	defer response.Body.Close()
-	responseBody, readErr := io.ReadAll(response.Body)
-	if readErr != nil {
-		return binanceSymbolRules{}, readErr
-	}
-	if response.StatusCode == http.StatusTooManyRequests {
-		gate.markBackoff(firstPositiveDuration(parseBinanceRetryAfter(response.Header), binanceRESTBackoffDuration))
-	}
-	if response.StatusCode < 200 || response.StatusCode >= 300 {
-		return binanceSymbolRules{}, fmt.Errorf("binance exchangeInfo failed: %s %s", response.Status, strings.TrimSpace(string(responseBody)))
 	}
 	var payload map[string]any
 	if err := json.Unmarshal(responseBody, &payload); err != nil {
@@ -1204,9 +1210,13 @@ func decimalPlacesForStep(step float64) int {
 }
 
 func binanceSignedGET(creds binanceRESTCredentials, path string, params map[string]string) ([]byte, error) {
+	return binanceSignedGETWithCategory(creds, path, params, binanceRESTCategoryTradeCritical)
+}
+
+func binanceSignedGETWithCategory(creds binanceRESTCredentials, path string, params map[string]string, category binanceRESTRequestCategory) ([]byte, error) {
 	params = cloneStringMap(params)
 	params["signature"] = signBinanceQuery(params, creds.APISecret)
-	return doBinanceSignedRequest(http.MethodGet, creds, path, params)
+	return doBinanceSignedRequest(http.MethodGet, creds, path, params, category)
 }
 
 func cloneStringMap(input map[string]string) map[string]string {
@@ -1220,44 +1230,61 @@ func cloneStringMap(input map[string]string) map[string]string {
 	return out
 }
 
-func doBinanceSignedRequest(method string, creds binanceRESTCredentials, path string, params map[string]string) ([]byte, error) {
-	gate := binanceRESTLimiterState.gate(binanceRESTLimiterKey(creds))
-	if err := gate.acquire(); err != nil {
-		return nil, err
-	}
+func doBinancePublicGET(baseURL, path string, params map[string]string, category binanceRESTRequestCategory) ([]byte, http.Header, error) {
 	query := encodeBinanceQuery(params, false)
-	requestURL := creds.BaseURL + path
+	return doBinanceRESTRequest(http.MethodGet, baseURL, path, query, nil, nil, category)
+}
+
+func doBinanceSignedRequest(method string, creds binanceRESTCredentials, path string, params map[string]string, category binanceRESTRequestCategory) ([]byte, error) {
+	query := encodeBinanceQuery(params, false)
+	headers := map[string]string{
+		"X-MBX-APIKEY": creds.APIKey,
+		"Content-Type": "application/x-www-form-urlencoded",
+	}
 	var body io.Reader
-	if method == http.MethodGet || method == http.MethodDelete {
-		requestURL += "?" + query
-	} else {
+	if method != http.MethodGet && method != http.MethodDelete {
 		body = strings.NewReader(query)
+		headers["Accept"] = "application/json"
+	}
+	responseBody, _, err := doBinanceRESTRequest(method, creds.BaseURL, path, query, headers, body, category)
+	return responseBody, err
+}
+
+func doBinanceRESTRequest(method, baseURL, path, query string, headers map[string]string, body io.Reader, category binanceRESTRequestCategory) ([]byte, http.Header, error) {
+	// Categories are tracked now so later PRs can add per-class scheduling without
+	// changing call sites again; this pass only unifies enforcement under one gate.
+	_ = category
+	gate := binanceRESTLimiterState.gate(binanceRESTLimiterKey(baseURL))
+	if err := gate.acquire(); err != nil {
+		return nil, nil, err
+	}
+	requestURL := strings.TrimRight(baseURL, "/") + path
+	if (method == http.MethodGet || method == http.MethodDelete) && query != "" {
+		requestURL += "?" + query
 	}
 	request, err := http.NewRequest(method, requestURL, body)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	request.Header.Set("X-MBX-APIKEY", creds.APIKey)
-	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	if method != http.MethodGet && method != http.MethodDelete {
-		request.Header.Set("Accept", "application/json")
+	for key, value := range headers {
+		request.Header.Set(key, value)
 	}
 	response, err := http.DefaultClient.Do(request)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	defer response.Body.Close()
 	responseBody, readErr := io.ReadAll(response.Body)
 	if readErr != nil {
-		return nil, readErr
+		return nil, response.Header, readErr
 	}
 	if response.StatusCode == http.StatusTooManyRequests {
 		gate.markBackoff(firstPositiveDuration(parseBinanceRetryAfter(response.Header), binanceRESTBackoffDuration))
 	}
 	if response.StatusCode < 200 || response.StatusCode >= 300 {
-		return nil, fmt.Errorf("binance request failed: %s %s", response.Status, strings.TrimSpace(string(responseBody)))
+		return nil, response.Header, fmt.Errorf("binance request failed: %s %s", response.Status, strings.TrimSpace(string(responseBody)))
 	}
-	return responseBody, nil
+	return responseBody, response.Header, nil
 }
 
 func firstPositiveDuration(values ...time.Duration) time.Duration {

--- a/internal/service/live_registry_test.go
+++ b/internal/service/live_registry_test.go
@@ -45,15 +45,67 @@ func TestDoBinanceSignedRequestBacksOffAfter429(t *testing.T) {
 		"recvWindow": "5000",
 	}
 
-	if _, err := doBinanceSignedRequest(http.MethodGet, creds, "/fapi/v1/order", params); err == nil {
+	if _, err := doBinanceSignedRequest(http.MethodGet, creds, "/fapi/v1/order", params, binanceRESTCategoryTradeCritical); err == nil {
 		t.Fatal("expected first request to fail with 429")
 	}
-	if _, err := doBinanceSignedRequest(http.MethodGet, creds, "/fapi/v1/order", params); err == nil {
+	if _, err := doBinanceSignedRequest(http.MethodGet, creds, "/fapi/v1/order", params, binanceRESTCategoryTradeCritical); err == nil {
 		t.Fatal("expected second request during backoff to be rejected")
 	} else if !strings.Contains(err.Error(), "rate-limited") {
 		t.Fatalf("expected second request to be rejected by local backoff, got %v", err)
 	}
 	if got := requestCount.Load(); got != 1 {
 		t.Fatalf("expected only the first request to reach the server during backoff, got %d", got)
+	}
+}
+
+func TestBinancePublicRequestsShareBackoffGateWithSignedRequests(t *testing.T) {
+	var requestCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount.Add(1)
+		http.Error(w, "too many requests", http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	previousLimiter := binanceRESTLimiterState
+	previousRate := binanceRESTRequestsPerSecond
+	previousBurst := binanceRESTBurst
+	previousBackoff := binanceRESTBackoffDuration
+	binanceRESTLimiterState = newBinanceRESTLimiter()
+	binanceRESTRequestsPerSecond = 1000
+	binanceRESTBurst = 10
+	binanceRESTBackoffDuration = 50 * time.Millisecond
+	defer func() {
+		binanceRESTLimiterState = previousLimiter
+		binanceRESTRequestsPerSecond = previousRate
+		binanceRESTBurst = previousBurst
+		binanceRESTBackoffDuration = previousBackoff
+	}()
+
+	creds := binanceRESTCredentials{
+		APIKeyRef: "test-key-ref",
+		APIKey:    "test-key",
+		APISecret: "test-secret",
+		BaseURL:   server.URL,
+	}
+	params := map[string]string{
+		"symbol":     "BTCUSDT",
+		"timestamp":  "1",
+		"signature":  "test-signature",
+		"recvWindow": "5000",
+	}
+
+	if _, err := doBinanceSignedRequest(http.MethodGet, creds, "/fapi/v1/order", params, binanceRESTCategoryTradeCritical); err == nil {
+		t.Fatal("expected signed request to fail with 429")
+	}
+	if _, _, err := doBinancePublicGET(server.URL, "/fapi/v1/klines", map[string]string{
+		"symbol":   "BTCUSDT",
+		"interval": "1m",
+	}, binanceRESTCategoryMarketData); err == nil {
+		t.Fatal("expected public request during backoff to be rejected")
+	} else if !strings.Contains(err.Error(), "rate-limited") {
+		t.Fatalf("expected public request to be rejected by shared local backoff, got %v", err)
+	}
+	if got := requestCount.Load(); got != 1 {
+		t.Fatalf("expected only the signed request to reach the server during shared backoff, got %d", got)
 	}
 }


### PR DESCRIPTION
## 目的
统一 Binance REST 请求治理入口，让 signed 请求、exchangeInfo 和 klines 都走同一个 limiter/backoff gate，避免部分请求绕开治理。此 PR 只收口 requester / limiter，不改 SyncLiveAccount 调度逻辑。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [x] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main)
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？
- [x] DB migration 是否具备向下兼容幂等性？
- [x] 配置字段有没有无意被混改？

补充说明：本 PR 未改默认交易行为、未改 mainnet/testnet 切换语义、未改 DB schema。

## 验证方式与测试证据
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

已验证：
- `go test ./internal/service -run 'TestDoBinanceSignedRequestBacksOffAfter429|TestBinancePublicRequestsShareBackoffGateWithSignedRequests'
- `go test ./internal/service/...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`

## 改动点
- 新增统一 Binance REST request gate，signed/public 请求共享同一 baseURL 级 limiter。
- `exchangeInfo` 改走统一 public requester，不再单独裸调 HTTP。
- `klines` 改走统一 public requester，纳入同一 limiter/backoff。
- 为 Binance 请求埋入 request category，给后续按类别调度留稳定接口。
