### PR TITLE
Coalesce live account sync requests

### DIFF
--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -95,6 +95,15 @@ const (
 	liveAccountOperationReconcile liveAccountOperationKind = "reconcile"
 )
 
+type liveAccountSyncState struct {
+	mu          sync.Mutex
+	running     bool
+	done        chan struct{}
+	result      domain.Account
+	err         error
+	completedAt time.Time
+}
+
 func (p *Platform) ListLiveSessions() ([]domain.LiveSession, error) {
 	return p.store.ListLiveSessions()
 }
@@ -163,12 +172,112 @@ func (p *Platform) UpdateLiveSession(sessionID, alias, accountID, strategyID str
 }
 
 func (p *Platform) SyncLiveAccount(accountID string) (domain.Account, error) {
+	return p.requestLiveAccountSync(accountID, "direct")
+}
+
+func (p *Platform) requestLiveAccountSync(accountID, trigger string) (domain.Account, error) {
+	accountID = strings.TrimSpace(accountID)
+	if accountID == "" {
+		return domain.Account{}, fmt.Errorf("live account id is required")
+	}
+	state := p.liveAccountSyncEntry(accountID)
+	logger := p.logger("service.live", "account_id", accountID, "trigger", firstNonEmpty(strings.TrimSpace(trigger), "unspecified"))
+
+	state.mu.Lock()
+	if state.running {
+		done := state.done
+		state.mu.Unlock()
+		logger.Debug("coalescing live account sync request while another sync is in progress")
+		if done != nil {
+			<-done
+		}
+		state.mu.Lock()
+		result, err := state.result, state.err
+		state.mu.Unlock()
+		return result, err
+	}
+	if p.liveAccountSyncAllowsRecentReuse(trigger) {
+		if reuseWindow := p.liveAccountSyncReuseWindow(); reuseWindow > 0 && !state.completedAt.IsZero() {
+			age := time.Since(state.completedAt)
+			if age >= 0 && age < reuseWindow {
+				result, err := state.result, state.err
+				state.mu.Unlock()
+				logger.Debug("reusing recent live account sync result", "age_ms", age.Milliseconds(), "reuse_window_ms", reuseWindow.Milliseconds(), "has_error", err != nil)
+				return result, err
+			}
+		}
+	}
+	done := make(chan struct{})
+	state.running = true
+	state.done = done
+	state.mu.Unlock()
+
 	release, acquired := p.tryStartLiveAccountOperation(accountID, liveAccountOperationSync)
 	if !acquired {
-		return domain.Account{}, fmt.Errorf("%w: sync account=%s", ErrLiveAccountOperationInProgress, accountID)
+		err := fmt.Errorf("%w: sync account=%s", ErrLiveAccountOperationInProgress, accountID)
+		state.mu.Lock()
+		state.result = domain.Account{}
+		state.err = err
+		state.running = false
+		state.done = nil
+		close(done)
+		state.mu.Unlock()
+		return domain.Account{}, err
 	}
 	defer release()
-	return p.syncLiveAccountWithoutGate(accountID)
+	result, err := p.syncLiveAccountWithoutGate(accountID)
+	state.mu.Lock()
+	state.result = result
+	state.err = err
+	state.completedAt = time.Now().UTC()
+	state.running = false
+	state.done = nil
+	close(done)
+	state.mu.Unlock()
+	return result, err
+}
+
+func (p *Platform) liveAccountSyncEntry(accountID string) *liveAccountSyncState {
+	actual, _ := p.liveAccountSyncState.LoadOrStore(strings.TrimSpace(accountID), &liveAccountSyncState{})
+	entry, _ := actual.(*liveAccountSyncState)
+	if entry == nil {
+		entry = &liveAccountSyncState{}
+		p.liveAccountSyncState.Store(strings.TrimSpace(accountID), entry)
+	}
+	return entry
+}
+
+func (p *Platform) liveAccountSyncReuseWindow() time.Duration {
+	threshold := time.Duration(p.runtimePolicy.LiveAccountSyncFreshnessSecs) * time.Second
+	switch {
+	case threshold <= 0:
+		return 5 * time.Second
+	case threshold < 4*time.Second:
+		return threshold
+	default:
+		window := threshold / 4
+		if window > 5*time.Second {
+			window = 5 * time.Second
+		}
+		if window < time.Second {
+			window = time.Second
+		}
+		return window
+	}
+}
+
+func (p *Platform) liveAccountSyncAllowsRecentReuse(trigger string) bool {
+	switch strings.TrimSpace(trigger) {
+	case "authoritative-reconcile",
+		"recover-live-session",
+		"live-immediate-fill-settlement",
+		"live-intent-dispatched-filled",
+		"live-terminal-order-sync",
+		"live-filled-order-sync":
+		return false
+	default:
+		return true
+	}
 }
 
 func (p *Platform) syncLiveAccountWithoutGate(accountID string) (domain.Account, error) {
@@ -277,7 +386,7 @@ func (p *Platform) triggerAuthoritativeLiveAccountReconcile(accountID, trigger s
 	}
 	p.syncLiveSessionsForAccountSnapshot(account)
 
-	synced, syncErr := p.SyncLiveAccount(accountID)
+	synced, syncErr := p.requestLiveAccountSync(accountID, "authoritative-reconcile")
 	if syncErr != nil {
 		latest, latestErr := p.store.GetAccount(accountID)
 		if latestErr == nil {
@@ -951,7 +1060,7 @@ func (p *Platform) RecoverLiveTradingOnStartup(ctx context.Context) {
 		if !strings.EqualFold(account.Mode, "LIVE") {
 			continue
 		}
-		syncedAccount, syncErr := p.SyncLiveAccount(account.ID)
+		syncedAccount, syncErr := p.requestLiveAccountSync(account.ID, "recover-live-session")
 		if syncErr == nil {
 			account = syncedAccount
 			syncedAccounts++
@@ -1804,7 +1913,7 @@ func (p *Platform) syncActiveLiveAccounts(eventTime time.Time) error {
 		if !p.shouldRefreshLiveAccountSync(account, eventTime) {
 			continue
 		}
-		if _, syncErr := p.SyncLiveAccount(account.ID); syncErr != nil {
+		if _, syncErr := p.requestLiveAccountSync(account.ID, "sync-active-live-accounts"); syncErr != nil {
 			syncErrs = append(syncErrs, fmt.Errorf("live account %s sync failed: %w", account.ID, syncErr))
 		}
 	}

--- a/internal/service/live_execution.go
+++ b/internal/service/live_execution.go
@@ -554,7 +554,7 @@ func (p *Platform) dispatchLiveSessionIntent(session domain.LiveSession) (domain
 	appendTimelineEvent(state, "order", dispatchedAt, "live-intent-dispatched", executionDispatchTimelineMetadata(proposalMap, created, createErr != nil))
 	settlementPending := liveOrderSettlementSyncPending(created)
 	if strings.EqualFold(created.Status, "FILLED") && !settlementPending {
-		if _, syncErr := p.SyncLiveAccount(session.AccountID); syncErr != nil {
+		if _, syncErr := p.requestLiveAccountSync(session.AccountID, "live-intent-dispatched-filled"); syncErr != nil {
 			if !errors.Is(syncErr, ErrLiveAccountOperationInProgress) {
 				state["lastSyncError"] = syncErr.Error()
 			}
@@ -849,7 +849,7 @@ func (p *Platform) syncLatestLiveSessionOrder(session domain.LiveSession, eventT
 		state["lastExecutionDispatch"] = executionDispatchSummary(mapValue(order.Metadata["executionProposal"]), order, false)
 		updateExecutionEventStats(state, mapValue(order.Metadata["executionProposal"]), mapValue(state["lastExecutionDispatch"]))
 		if strings.EqualFold(order.Status, "FILLED") {
-			if _, syncErr := p.SyncLiveAccount(session.AccountID); syncErr != nil && !errors.Is(syncErr, ErrLiveAccountOperationInProgress) {
+			if _, syncErr := p.requestLiveAccountSync(session.AccountID, "live-terminal-order-sync"); syncErr != nil && !errors.Is(syncErr, ErrLiveAccountOperationInProgress) {
 				p.logger("service.live_execution", "session_id", session.ID, "account_id", session.AccountID).Warn("live account sync failed after terminal order sync", "error", syncErr)
 			}
 		}
@@ -928,7 +928,7 @@ func (p *Platform) syncLatestLiveSessionOrder(session domain.LiveSession, eventT
 	state["lastExecutionDispatch"] = executionDispatchSummary(mapValue(order.Metadata["executionProposal"]), syncedOrder, false)
 	updateExecutionEventStats(state, mapValue(order.Metadata["executionProposal"]), mapValue(state["lastExecutionDispatch"]))
 	if strings.EqualFold(syncedOrder.Status, "FILLED") {
-		if _, syncErr := p.SyncLiveAccount(session.AccountID); syncErr != nil && !errors.Is(syncErr, ErrLiveAccountOperationInProgress) {
+		if _, syncErr := p.requestLiveAccountSync(session.AccountID, "live-filled-order-sync"); syncErr != nil && !errors.Is(syncErr, ErrLiveAccountOperationInProgress) {
 			p.logger("service.live_execution", "session_id", session.ID, "account_id", session.AccountID).Warn("live account sync failed after filled order sync", "error", syncErr)
 		}
 	}

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -5958,6 +5958,50 @@ func TestSyncLiveAccountAuthoritativeReconcileBypassesRecentReuseWindow(t *testi
 	}
 }
 
+func TestSyncLiveAccountReusesRecentFailureWithinReuseWindow(t *testing.T) {
+	baseStore := memory.NewStore()
+	platform := NewPlatform(&testFailingListOrdersStore{
+		Store:     baseStore,
+		listError: errors.New("orders unavailable"),
+	})
+	platform.runtimePolicy.LiveAccountSyncFreshnessSecs = 60
+	var syncCalls atomic.Int32
+
+	platform.registerLiveAdapter(testLiveAccountSyncAdapter{
+		key: "test-sync-failure-reuse-window",
+		syncSnapshotFunc: func(p *Platform, account domain.Account, binding map[string]any) (domain.Account, error) {
+			syncCalls.Add(1)
+			return domain.Account{}, errors.New("adapter sync failed")
+		},
+	})
+
+	account, err := platform.store.GetAccount("live-main")
+	if err != nil {
+		t.Fatalf("get account failed: %v", err)
+	}
+	account.Metadata = cloneMetadata(account.Metadata)
+	account.Metadata["liveBinding"] = map[string]any{
+		"adapterKey":     "test-sync-failure-reuse-window",
+		"connectionMode": "mock",
+		"executionMode":  "rest",
+	}
+	if _, err := platform.store.UpdateAccount(account); err != nil {
+		t.Fatalf("update account failed: %v", err)
+	}
+
+	if _, err := platform.requestLiveAccountSync("live-main", "direct"); err == nil {
+		t.Fatal("expected first sync to fail")
+	}
+	if _, err := platform.requestLiveAccountSync("live-main", "follow-up"); err == nil {
+		t.Fatal("expected follow-up sync to reuse recent failure")
+	} else if !strings.Contains(err.Error(), "orders unavailable") {
+		t.Fatalf("expected follow-up sync to reuse failure result, got %v", err)
+	}
+	if got := syncCalls.Load(); got != 1 {
+		t.Fatalf("expected recent follow-up sync to reuse prior failure, got %d adapter calls", got)
+	}
+}
+
 func TestSyncLiveAccountNormalizesAdapterSuccessHealthState(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
 	platform.runtimePolicy.LiveAccountSyncFreshnessSecs = 60

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -5803,7 +5803,7 @@ func TestSyncActiveLiveAccountsThrottlesFailedRetriesUntilFreshnessWindow(t *tes
 	}
 }
 
-func TestSyncLiveAccountSkipsConcurrentAdapterSyncForSameAccount(t *testing.T) {
+func TestSyncLiveAccountCoalescesConcurrentAdapterSyncForSameAccount(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
 	blockSync := make(chan struct{})
 	enteredSync := make(chan struct{}, 1)
@@ -5856,15 +5856,12 @@ func TestSyncLiveAccountSkipsConcurrentAdapterSyncForSameAccount(t *testing.T) {
 	}()
 
 	select {
-	case err := <-secondDone:
-		if !errors.Is(err, ErrLiveAccountOperationInProgress) {
-			t.Fatalf("expected concurrent sync to return in-progress error, got %v", err)
-		}
+	case <-secondDone:
+		t.Fatal("expected concurrent sync to wait for the in-flight sync result")
 	case <-time.After(200 * time.Millisecond):
-		t.Fatal("expected concurrent sync to return immediately while first sync is in progress")
 	}
-	if elapsed := time.Since(start); elapsed > time.Second {
-		t.Fatalf("expected concurrent sync to skip adapter call quickly, took %s", elapsed)
+	if elapsed := time.Since(start); elapsed < 150*time.Millisecond {
+		t.Fatalf("expected concurrent sync to wait instead of returning immediately, took %s", elapsed)
 	}
 	if got := syncCalls.Load(); got != 1 {
 		t.Fatalf("expected only one adapter sync call, got %d", got)
@@ -5873,6 +5870,91 @@ func TestSyncLiveAccountSkipsConcurrentAdapterSyncForSameAccount(t *testing.T) {
 	close(blockSync)
 	if err := <-firstDone; err != nil {
 		t.Fatalf("first sync failed: %v", err)
+	}
+	if err := <-secondDone; err != nil {
+		t.Fatalf("expected coalesced sync to reuse first result, got %v", err)
+	}
+}
+
+func TestSyncLiveAccountReusesRecentResultWithinReuseWindow(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	platform.runtimePolicy.LiveAccountSyncFreshnessSecs = 60
+	var syncCalls atomic.Int32
+
+	platform.registerLiveAdapter(testLiveAccountSyncAdapter{
+		key: "test-sync-reuse-window",
+		syncSnapshotFunc: func(p *Platform, account domain.Account, binding map[string]any) (domain.Account, error) {
+			syncCalls.Add(1)
+			account.Metadata = cloneMetadata(account.Metadata)
+			account.Metadata["lastLiveSyncAt"] = time.Now().UTC().Format(time.RFC3339)
+			return p.store.UpdateAccount(account)
+		},
+	})
+
+	account, err := platform.store.GetAccount("live-main")
+	if err != nil {
+		t.Fatalf("get account failed: %v", err)
+	}
+	account.Metadata = cloneMetadata(account.Metadata)
+	account.Metadata["liveBinding"] = map[string]any{
+		"adapterKey":     "test-sync-reuse-window",
+		"connectionMode": "mock",
+		"executionMode":  "rest",
+	}
+	if _, err := platform.store.UpdateAccount(account); err != nil {
+		t.Fatalf("update account failed: %v", err)
+	}
+
+	if _, err := platform.SyncLiveAccount("live-main"); err != nil {
+		t.Fatalf("first sync failed: %v", err)
+	}
+	if _, err := platform.requestLiveAccountSync("live-main", "follow-up"); err != nil {
+		t.Fatalf("expected immediate follow-up sync to reuse recent result, got %v", err)
+	}
+	if got := syncCalls.Load(); got != 1 {
+		t.Fatalf("expected recent follow-up sync to reuse prior result, got %d adapter calls", got)
+	}
+}
+
+func TestSyncLiveAccountAuthoritativeReconcileBypassesRecentReuseWindow(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	platform.runtimePolicy.LiveAccountSyncFreshnessSecs = 60
+	var syncCalls atomic.Int32
+
+	platform.registerLiveAdapter(testLiveAccountSyncAdapter{
+		key: "test-sync-authoritative-bypass",
+		syncSnapshotFunc: func(p *Platform, account domain.Account, binding map[string]any) (domain.Account, error) {
+			syncCalls.Add(1)
+			account.Metadata = cloneMetadata(account.Metadata)
+			now := time.Now().UTC().Format(time.RFC3339)
+			account.Metadata["lastLiveSyncAt"] = now
+			account.Metadata["lastLivePositionSyncAt"] = now
+			return p.store.UpdateAccount(account)
+		},
+	})
+
+	account, err := platform.store.GetAccount("live-main")
+	if err != nil {
+		t.Fatalf("get account failed: %v", err)
+	}
+	account.Metadata = cloneMetadata(account.Metadata)
+	account.Metadata["liveBinding"] = map[string]any{
+		"adapterKey":     "test-sync-authoritative-bypass",
+		"connectionMode": "mock",
+		"executionMode":  "rest",
+	}
+	if _, err := platform.store.UpdateAccount(account); err != nil {
+		t.Fatalf("update account failed: %v", err)
+	}
+
+	if _, err := platform.requestLiveAccountSync("live-main", "direct"); err != nil {
+		t.Fatalf("first sync failed: %v", err)
+	}
+	if _, err := platform.requestLiveAccountSync("live-main", "authoritative-reconcile"); err != nil {
+		t.Fatalf("authoritative reconcile sync failed: %v", err)
+	}
+	if got := syncCalls.Load(); got != 2 {
+		t.Fatalf("expected authoritative reconcile to bypass recent reuse, got %d adapter calls", got)
 	}
 }
 

--- a/internal/service/order.go
+++ b/internal/service/order.go
@@ -212,7 +212,7 @@ func (p *Platform) resolveClosePositionTarget(positionID string) (domain.Positio
 		return domain.Position{}, domain.Account{}, err
 	}
 	if strings.EqualFold(strings.TrimSpace(account.Mode), "LIVE") {
-		syncedAccount, err := p.SyncLiveAccount(account.ID)
+		syncedAccount, err := p.requestLiveAccountSync(account.ID, "resolve-close-position-target")
 		if err != nil {
 			return domain.Position{}, domain.Account{}, err
 		}
@@ -605,7 +605,7 @@ func (p *Platform) settleImmediatelyFilledLiveOrder(order domain.Order) (domain.
 	if err != nil {
 		return order, fmt.Errorf("live order %s submitted as FILLED but settlement sync failed: %w", order.ID, err)
 	}
-	if _, syncErr := p.SyncLiveAccount(order.AccountID); syncErr != nil {
+	if _, syncErr := p.requestLiveAccountSync(order.AccountID, "live-immediate-fill-settlement"); syncErr != nil {
 		if errors.Is(syncErr, ErrLiveAccountOperationInProgress) {
 			return settledOrder, nil
 		}

--- a/internal/service/platform.go
+++ b/internal/service/platform.go
@@ -39,6 +39,7 @@ type Platform struct {
 	liveMarketMu           sync.RWMutex
 	liveMarketData         map[string]liveMarketSnapshot
 	liveAccountOpMu        sync.Map // accountID -> *sync.Mutex
+	liveAccountSyncState   sync.Map // accountID -> *liveAccountSyncState
 	manifestMu             sync.Mutex
 	once                   sync.Once             // 确保 CSV ledger 只加载一次
 	ledger                 []strategyReplayEvent // 缓存的策略回放账本


### PR DESCRIPTION
## 目的
治理 SyncLiveAccount 风暴：把同一账户的并发 sync 合并为一次执行，并在短窗口内复用最近结果，减少多个 live 路径在短时间内重复打账户同步。此 PR 不改 Binance requester，不改 reconcile/execute 事实源语义。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [x] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main)
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？
- [x] DB migration 是否具备向下兼容幂等性？
- [x] 配置字段有没有无意被混改？

补充说明：本 PR 未改默认交易行为、未改 DB schema、未放宽 recovery/reconcile gate。

## 验证方式与测试证据
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

已验证：
- `go test ./internal/service -run 'TestSyncLiveAccount(CoalescesConcurrentAdapterSyncForSameAccount|ReusesRecentResultWithinReuseWindow|AuthoritativeReconcileBypassesRecentReuseWindow)|TestSyncActiveLiveAccountsThrottlesFailedRetriesUntilFreshnessWindow'
- `go test ./internal/service -run TestClosePositionFilledLiveManualCloseClearsRecoverySessionState -v`
- `go test ./internal/service/...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`

## 改动点
- 新增 per-account sync state，把并发 `SyncLiveAccount` 请求合并为一次底层执行，其余请求等待并复用结果。
- 新增短窗口 recent-result reuse，压制短时间串行重复 sync。
- `authoritative-reconcile`、startup recovery、filled/settlement 这几类必须刷新的触发显式绕过 recent reuse，避免吞掉权威刷新。
- 内部调用点改走带 trigger 的 sync helper，便于后续继续做触发源观测。
