### PR TITLE
Add live sync and stale source observability

### DIFF
--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -180,20 +180,28 @@ func (p *Platform) requestLiveAccountSync(accountID, trigger string) (domain.Acc
 	if accountID == "" {
 		return domain.Account{}, fmt.Errorf("live account id is required")
 	}
+	normalizedTrigger := firstNonEmpty(strings.TrimSpace(trigger), "unspecified")
 	state := p.liveAccountSyncEntry(accountID)
-	logger := p.logger("service.live", "account_id", accountID, "trigger", firstNonEmpty(strings.TrimSpace(trigger), "unspecified"))
+	logger := p.logger("service.live", "account_id", accountID, "trigger", normalizedTrigger)
 
 	state.mu.Lock()
 	if state.running {
 		done := state.done
 		state.mu.Unlock()
-		logger.Debug("coalescing live account sync request while another sync is in progress")
+		waitStartedAt := time.Now()
 		if done != nil {
 			<-done
 		}
 		state.mu.Lock()
 		result, err := state.result, state.err
 		state.mu.Unlock()
+		logger.Info("live account sync request reused in-flight result",
+			"coalesced", true,
+			"waited_for_inflight", true,
+			"wait_ms", time.Since(waitStartedAt).Milliseconds(),
+			"reused_recent_result", false,
+			"result_error", err != nil,
+		)
 		return result, err
 	}
 	if p.liveAccountSyncAllowsRecentReuse(trigger) {
@@ -202,7 +210,14 @@ func (p *Platform) requestLiveAccountSync(accountID, trigger string) (domain.Acc
 			if age >= 0 && age < reuseWindow {
 				result, err := state.result, state.err
 				state.mu.Unlock()
-				logger.Debug("reusing recent live account sync result", "age_ms", age.Milliseconds(), "reuse_window_ms", reuseWindow.Milliseconds(), "has_error", err != nil)
+				logger.Info("live account sync request reused recent result",
+					"coalesced", false,
+					"waited_for_inflight", false,
+					"reused_recent_result", true,
+					"age_ms", age.Milliseconds(),
+					"reuse_window_ms", reuseWindow.Milliseconds(),
+					"result_error", err != nil,
+				)
 				return result, err
 			}
 		}
@@ -225,6 +240,11 @@ func (p *Platform) requestLiveAccountSync(accountID, trigger string) (domain.Acc
 		return domain.Account{}, err
 	}
 	defer release()
+	logger.Info("live account sync request executing",
+		"coalesced", false,
+		"waited_for_inflight", false,
+		"reused_recent_result", false,
+	)
 	result, err := p.syncLiveAccountWithoutGate(accountID)
 	state.mu.Lock()
 	state.result = result
@@ -234,6 +254,13 @@ func (p *Platform) requestLiveAccountSync(accountID, trigger string) (domain.Acc
 	state.done = nil
 	close(done)
 	state.mu.Unlock()
+	logger.Info("live account sync request completed",
+		"coalesced", false,
+		"waited_for_inflight", false,
+		"reused_recent_result", false,
+		"result_error", err != nil,
+		"completed_at", state.completedAt.Format(time.RFC3339),
+	)
 	return result, err
 }
 
@@ -278,6 +305,72 @@ func (p *Platform) liveAccountSyncAllowsRecentReuse(trigger string) bool {
 	default:
 		return true
 	}
+}
+
+func compactSourceGateEntries(entries []map[string]any) []map[string]any {
+	if len(entries) == 0 {
+		return []map[string]any{}
+	}
+	items := make([]map[string]any, 0, len(entries))
+	for _, entry := range entries {
+		items = append(items, map[string]any{
+			"sourceKey":   stringValue(entry["sourceKey"]),
+			"role":        stringValue(entry["role"]),
+			"streamType":  stringValue(entry["streamType"]),
+			"symbol":      stringValue(entry["symbol"]),
+			"lastEventAt": stringValue(entry["lastEventAt"]),
+			"maxAgeSec":   maxIntValue(entry["maxAgeSec"], 0),
+		})
+	}
+	return items
+}
+
+func runtimeSourceGateIssueSignature(sourceGate map[string]any) string {
+	payload, err := json.Marshal(map[string]any{
+		"missing": compactSourceGateEntries(metadataList(sourceGate["missing"])),
+		"stale":   compactSourceGateEntries(metadataList(sourceGate["stale"])),
+		"ready":   boolValue(sourceGate["ready"]),
+	})
+	if err != nil {
+		return ""
+	}
+	return string(payload)
+}
+
+func (p *Platform) logRuntimeSourceGateState(strategyID string, runtimeSession domain.SignalRuntimeSession, sourceGate map[string]any, eventTime time.Time) {
+	runtimeID := strings.TrimSpace(runtimeSession.ID)
+	if runtimeID == "" {
+		return
+	}
+	signature := runtimeSourceGateIssueSignature(sourceGate)
+	previous, hadPrevious := p.runtimeSourceGateState.Load(runtimeID)
+	previousSignature, _ := previous.(string)
+	if boolValue(sourceGate["ready"]) {
+		if hadPrevious && previousSignature != "" {
+			p.logger("service.runtime_source_gate",
+				"runtime_session_id", runtimeID,
+				"account_id", runtimeSession.AccountID,
+				"strategy_id", strategyID,
+			).Info("runtime source gate recovered", "event_time", eventTime.Format(time.RFC3339))
+			p.runtimeSourceGateState.Delete(runtimeID)
+		}
+		return
+	}
+	if signature != "" && hadPrevious && previousSignature == signature {
+		return
+	}
+	p.runtimeSourceGateState.Store(runtimeID, signature)
+	p.logger("service.runtime_source_gate",
+		"runtime_session_id", runtimeID,
+		"account_id", runtimeSession.AccountID,
+		"strategy_id", strategyID,
+	).Warn("runtime source gate blocked",
+		"event_time", eventTime.Format(time.RFC3339),
+		"missing_count", len(metadataList(sourceGate["missing"])),
+		"stale_count", len(metadataList(sourceGate["stale"])),
+		"missing_sources", compactSourceGateEntries(metadataList(sourceGate["missing"])),
+		"stale_sources", compactSourceGateEntries(metadataList(sourceGate["stale"])),
+	)
 }
 
 func (p *Platform) syncLiveAccountWithoutGate(accountID string) (domain.Account, error) {

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -5958,6 +5958,72 @@ func TestSyncLiveAccountAuthoritativeReconcileBypassesRecentReuseWindow(t *testi
 	}
 }
 
+func TestCompactSourceGateEntriesPreservesStaleDetailFields(t *testing.T) {
+	items := compactSourceGateEntries([]map[string]any{
+		map[string]any{
+			"sourceKey":   "binance-trade-tick",
+			"role":        "trigger",
+			"streamType":  "trade_tick",
+			"symbol":      "BTCUSDT",
+			"lastEventAt": "2026-04-22T02:20:00Z",
+			"maxAgeSec":   15,
+		},
+	})
+	if len(items) != 1 {
+		t.Fatalf("expected one compacted source gate entry, got %d", len(items))
+	}
+	item := items[0]
+	if item["sourceKey"] != "binance-trade-tick" || item["streamType"] != "trade_tick" {
+		t.Fatalf("unexpected compacted source gate item: %#v", item)
+	}
+	if item["lastEventAt"] != "2026-04-22T02:20:00Z" || item["maxAgeSec"] != 15 {
+		t.Fatalf("expected stale detail fields to be preserved, got %#v", item)
+	}
+}
+
+func TestLogRuntimeSourceGateStateTracksBlockedSignatureTransitions(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	runtimeSession := domain.SignalRuntimeSession{
+		ID:        "runtime-1",
+		AccountID: "live-main",
+	}
+	blocked := map[string]any{
+		"ready": false,
+		"stale": []any{
+			map[string]any{
+				"sourceKey":   "binance-trade-tick",
+				"role":        "trigger",
+				"streamType":  "trade_tick",
+				"symbol":      "BTCUSDT",
+				"lastEventAt": "2026-04-22T02:20:00Z",
+				"maxAgeSec":   15,
+			},
+		},
+		"missing": []any{},
+	}
+
+	platform.logRuntimeSourceGateState("strategy-bk-1d", runtimeSession, blocked, time.Date(2026, 4, 22, 2, 21, 0, 0, time.UTC))
+	firstSignature, ok := platform.runtimeSourceGateState.Load(runtimeSession.ID)
+	if !ok || strings.TrimSpace(stringValue(firstSignature)) == "" {
+		t.Fatal("expected blocked runtime source gate signature to be recorded")
+	}
+
+	platform.logRuntimeSourceGateState("strategy-bk-1d", runtimeSession, blocked, time.Date(2026, 4, 22, 2, 21, 5, 0, time.UTC))
+	secondSignature, ok := platform.runtimeSourceGateState.Load(runtimeSession.ID)
+	if !ok || secondSignature != firstSignature {
+		t.Fatalf("expected identical blocked source gate signature to remain stable, got first=%v second=%v", firstSignature, secondSignature)
+	}
+
+	platform.logRuntimeSourceGateState("strategy-bk-1d", runtimeSession, map[string]any{
+		"ready":   true,
+		"missing": []any{},
+		"stale":   []any{},
+	}, time.Date(2026, 4, 22, 2, 21, 10, 0, time.UTC))
+	if _, ok := platform.runtimeSourceGateState.Load(runtimeSession.ID); ok {
+		t.Fatal("expected ready runtime source gate to clear recorded blocked signature")
+	}
+}
+
 func TestSyncLiveAccountReusesRecentFailureWithinReuseWindow(t *testing.T) {
 	baseStore := memory.NewStore()
 	platform := NewPlatform(&testFailingListOrdersStore{

--- a/internal/service/paper.go
+++ b/internal/service/paper.go
@@ -473,6 +473,7 @@ func (p *Platform) evaluateRuntimeSignalSourceReadiness(strategyID string, runti
 	result["missing"] = missing
 	result["stale"] = stale
 	result["ready"] = len(missing) == 0 && len(stale) == 0
+	p.logRuntimeSourceGateState(strategyID, runtimeSession, result, eventTime)
 	return result
 }
 

--- a/internal/service/platform.go
+++ b/internal/service/platform.go
@@ -40,6 +40,7 @@ type Platform struct {
 	liveMarketData         map[string]liveMarketSnapshot
 	liveAccountOpMu        sync.Map // accountID -> *sync.Mutex
 	liveAccountSyncState   sync.Map // accountID -> *liveAccountSyncState
+	runtimeSourceGateState sync.Map // runtimeSessionID -> last blocked source gate signature
 	manifestMu             sync.Mutex
 	once                   sync.Once             // 确保 CSV ledger 只加载一次
 	ledger                 []strategyReplayEvent // 缓存的策略回放账本


### PR DESCRIPTION
## 目的
补齐 live sync 与 stale source 的可观测性：让 system log 能直接说明是谁触发了 SyncLiveAccount、是否命中 coalescing/recent reuse，以及 runtime source gate 具体是哪一路 stale/missing。此 PR 只加观测，不改执行语义。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [x] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main)
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？
- [x] DB migration 是否具备向下兼容幂等性？
- [x] 配置字段有没有无意被混改？

补充说明：本 PR 未改默认交易行为、未改 Binance requester、未改 recovery/reconcile gate。

## 验证方式与测试证据
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

已验证：
- `go test ./internal/service -run 'Test(SyncLiveAccount(ReusesRecentFailureWithinReuseWindow|CoalescesConcurrentAdapterSyncForSameAccount|ReusesRecentResultWithinReuseWindow|AuthoritativeReconcileBypassesRecentReuseWindow)|CompactSourceGateEntriesPreservesStaleDetailFields|LogRuntimeSourceGateStateTracksBlockedSignatureTransitions)'
- `go test ./internal/service/...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`

## 改动点
- `requestLiveAccountSync` 增加结构化日志：trigger、coalesced、waited_for_inflight、reused_recent_result、result_error。
- runtime source gate 增加 stale/missing 明细日志，直接输出 sourceKey/role/streamType/symbol/lastEventAt/maxAgeSec。
- source gate 日志带去重：只有 blocked 内容变化时记 warn，恢复时记一条 recovered info，避免日志风暴。
