### PR TITLE
Reduce monitor chart Binance polling

### DIFF
--- a/web/console/src/hooks/useDashboard.ts
+++ b/web/console/src/hooks/useDashboard.ts
@@ -1,18 +1,17 @@
 import { useEffect } from 'react';
 import { useUIStore } from '../store/useUIStore';
 import { useTradingStore } from '../store/useTradingStore';
-import { fetchJSON, API_BASE } from '../utils/api';
+import { fetchJSON } from '../utils/api';
 import { writeStoredAuthSession } from '../utils/auth';
 import { 
   AccountSummary, AccountRecord, Order, Fill, Position, PaperSession, LiveSession, 
   StrategyRecord, BacktestRun, BacktestOptions, LiveAdapter, SignalSourceCatalog, 
   SignalSourceType, SignalRuntimeAdapter, SignalRuntimeSession, RuntimePolicy, 
   PlatformAlert, PlatformNotification, TelegramConfig, AccountEquitySnapshot, PlatformHealthSnapshot,
-  ChartCandle, ChartAnnotation, SignalBinding 
+  ChartAnnotation, SignalBinding 
 } from '../types/domain';
 import { 
-  resolveChartAnchor, buildTimeRange, strategyLabel, getRecord, getList, 
-  deriveRuntimeMarketSnapshot, summarizeOrderPreflight 
+  resolveChartAnchor, buildTimeRange
 } from '../utils/derivation';
 
 export function useDashboard() {
@@ -26,8 +25,6 @@ export function useDashboard() {
   const authSession = useUIStore(s => s.authSession);
   const timeWindow = useUIStore(s => s.timeWindow);
   const chartOverrideRange = useUIStore(s => s.chartOverrideRange);
-  const monitorResolution = useUIStore(s => s.monitorResolution);
-  const liveOrderForm = useUIStore(s => s.liveOrderForm);
   const setSelectedBacktestId = useUIStore(s => s.setSelectedBacktestId);
   const setBacktestForm = useUIStore(s => s.setBacktestForm);
 
@@ -38,7 +35,6 @@ export function useDashboard() {
   const setFills = useTradingStore(s => s.setFills);
   const setPositions = useTradingStore(s => s.setPositions);
   const setSnapshots = useTradingStore(s => s.setSnapshots);
-  const setMonitorCandles = useTradingStore(s => s.setMonitorCandles);
   const setStrategies = useTradingStore(s => s.setStrategies);
   const setSelectedStrategyId = useTradingStore(s => s.setSelectedStrategyId);
   const setBacktests = useTradingStore(s => s.setBacktests);
@@ -151,15 +147,12 @@ export function useDashboard() {
     const range = chartOverrideRange ?? buildTimeRange(anchorDate, timeWindow);
     const { from, to } = range;
 
-    const [snapshotData, candleData, annotationData] = await Promise.all([
+    const [snapshotData, annotationData] = await Promise.all([
       summaryData[0]?.accountId
         ? fetchJSON<AccountEquitySnapshot[]>(
             `/api/v1/account-equity-snapshots?accountId=${encodeURIComponent(summaryData[0].accountId)}`
           )
         : Promise.resolve([]),
-      fetchJSON<{ candles: ChartCandle[] }>(
-        `/api/v1/chart/candles?symbol=BTCUSDT&resolution=1&from=${from}&to=${to}&limit=840`
-      ),
       fetchJSON<ChartAnnotation[]>(
         `/api/v1/chart/annotations?symbol=BTCUSDT&from=${from}&to=${to}&limit=300`
       ),
@@ -182,7 +175,6 @@ export function useDashboard() {
     const normalizedNotifications = Array.isArray(notificationData) ? notificationData : [];
     const normalizedSnapshots = Array.isArray(snapshotData) ? snapshotData : [];
     const normalizedAnnotations = Array.isArray(annotationData) ? annotationData : [];
-    const normalizedCandles = Array.isArray(candleData?.candles) ? candleData.candles : [];
     const normalizedSignalCatalog = signalCatalogData && typeof signalCatalogData === "object" ? signalCatalogData : { sources: [], notes: [] };
     const normalizedBacktestOptions =
       backtestOptionsData && typeof backtestOptionsData === "object" ? backtestOptionsData : ({} as BacktestOptions);
@@ -255,7 +247,7 @@ export function useDashboard() {
       }
       return normalizedSignalRuntimeSessions[0]?.id ?? normalizedLiveSessions[0]?.id ?? null;
     });
-    setCandles(normalizedCandles);
+    setCandles([]);
     setAnnotations(normalizedAnnotations);
     setBacktestForm((current: any) => ({
       strategyVersionId: current.strategyVersionId || normalizedStrategies[0]?.currentVersion?.id || "",
@@ -305,7 +297,7 @@ export function useDashboard() {
       active = false;
       window.clearInterval(timer);
     };
-  }, [authSession?.token, timeWindow, chartOverrideRange, monitorResolution]);
+  }, [authSession?.token, timeWindow, chartOverrideRange]);
 
   return { loadDashboard };
 }

--- a/web/console/src/pages/MonitorStage.tsx
+++ b/web/console/src/pages/MonitorStage.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef } from 'react';
 import { useUIStore } from '../store/useUIStore';
 import { useTradingStore } from '../store/useTradingStore';
 import { SignalMonitorChart } from '../components/charts/SignalMonitorChart';
@@ -6,7 +6,10 @@ import { formatMoney, formatSigned, formatMaybeNumber, formatTime, shrink } from
 import { 
   getRecord, 
   getList,
+  resolveChartAnchor,
+  buildTimeRange,
   deriveSignalBarCandles,
+  mapChartCandlesToSignalBarCandles,
   derivePrimarySignalBarState, 
   deriveRuntimeMarketSnapshot, 
   deriveSessionMarkers,
@@ -25,6 +28,7 @@ import {
   runtimePolicyValueLabel,
   technicalStatusLabel
 } from '../utils/derivation';
+import { fetchJSON } from '../utils/api';
 import { Card, CardHeader, CardTitle, CardContent } from '../components/ui/card';
 import { Badge } from '../components/ui/badge';
 import { Table, TableHeader, TableBody, TableHead, TableRow, TableCell } from '../components/ui/table';
@@ -38,6 +42,21 @@ import { Input } from '../components/ui/input';
 import { Label } from '../components/ui/label';
 
 import { cn } from '../lib/utils';
+import type { ChartCandle } from '../types/domain';
+
+function resolveMonitorFallbackResolution(timeframe: string) {
+  const normalized = String(timeframe ?? "").trim().toLowerCase();
+  const supported: Record<string, string> = {
+    "5m": "5",
+    "15m": "15",
+    "30m": "30",
+    "1h": "60",
+    "2h": "120",
+    "4h": "240",
+    "1d": "1D",
+  };
+  return supported[normalized] ?? "5";
+}
 
 type MonitorStageProps = {
   syncLiveOrder: (id: string) => void;
@@ -58,10 +77,15 @@ export function MonitorStage({ syncLiveOrder, dockTab, onDockTabChange, dockCont
   const accounts = useTradingStore(s => s.accounts);
   const strategySignalBindingMap = useTradingStore(s => s.strategySignalBindingMap);
   const liveSyncAction = useUIStore(s => s.liveSyncAction);
+  const timeWindow = useUIStore(s => s.timeWindow);
+  const chartOverrideRange = useUIStore(s => s.chartOverrideRange);
   const selectedSignalRuntimeId = useTradingStore(s => s.selectedSignalRuntimeId);
   const setSelectedSignalRuntimeId = useTradingStore(s => s.setSelectedSignalRuntimeId);
+  const monitorCandles = useTradingStore(s => s.monitorCandles);
+  const setMonitorCandles = useTradingStore(s => s.setMonitorCandles);
   const timelineConfig = useUIStore(s => s.timelineConfig);
   const setTimelineConfig = useUIStore(s => s.setTimelineConfig);
+  const fallbackRequestKeyRef = useRef<string>("");
 
 
   // 1. 高亮会话选择逻辑
@@ -144,6 +168,80 @@ export function MonitorStage({ syncLiveOrder, dockTab, onDockTabChange, dockCont
     });
   }, [highlightedLiveRuntimeState.sourceStates, sessionSymbol, monitorSignalTimeframe, monitorSignalBarStateKey]);
 
+  const fallbackResolution = useMemo(
+    () => resolveMonitorFallbackResolution(monitorSignalTimeframe),
+    [monitorSignalTimeframe]
+  );
+  const fallbackMonitorBars = useMemo(
+    () => mapChartCandlesToSignalBarCandles(monitorCandles, fallbackResolution),
+    [monitorCandles, fallbackResolution]
+  );
+  const displayMonitorBars = monitorBars.length > 0 ? monitorBars : fallbackMonitorBars;
+
+  useEffect(() => {
+    const monitorSessionId = monitorSession?.id ?? "";
+    if (!monitorSessionId || !sessionSymbol) {
+      fallbackRequestKeyRef.current = "";
+      setMonitorCandles([]);
+      return;
+    }
+    if (monitorBars.length > 0) {
+      fallbackRequestKeyRef.current = "";
+      setMonitorCandles([]);
+      return;
+    }
+
+    const requestKey = [
+      monitorSessionId,
+      sessionSymbol,
+      fallbackResolution,
+      timeWindow,
+      chartOverrideRange?.from ?? "",
+      chartOverrideRange?.to ?? "",
+    ].join(":");
+
+    if (fallbackRequestKeyRef.current === requestKey) {
+      return;
+    }
+    fallbackRequestKeyRef.current = requestKey;
+    setMonitorCandles([]);
+
+    const anchorDate = resolveChartAnchor(monitorSession, orders);
+    const range = chartOverrideRange ?? buildTimeRange(anchorDate, timeWindow);
+
+    let active = true;
+    fetchJSON<{ candles: ChartCandle[] }>(
+      `/api/v1/chart/candles?symbol=${encodeURIComponent(sessionSymbol)}&resolution=${fallbackResolution}&from=${range.from}&to=${range.to}&limit=240`
+    )
+      .then((payload) => {
+        if (!active) {
+          return;
+        }
+        const candles = Array.isArray(payload?.candles) ? payload.candles : [];
+        setMonitorCandles(candles);
+      })
+      .catch((error) => {
+        if (!active) {
+          return;
+        }
+        console.warn("Failed to load monitor fallback candles", error);
+        setMonitorCandles([]);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [
+    chartOverrideRange,
+    fallbackResolution,
+    monitorBars.length,
+    monitorSession,
+    orders,
+    sessionSymbol,
+    setMonitorCandles,
+    timeWindow,
+  ]);
+
   const monitorSignalState = derivePrimarySignalBarState(
     getRecord(highlightedLiveRuntimeState.signalBarStates),
     {
@@ -165,12 +263,12 @@ export function MonitorStage({ syncLiveOrder, dockTab, onDockTabChange, dockCont
     () =>
       deriveSignalMonitorDecorations(
         monitorSession,
-        monitorBars,
+        displayMonitorBars,
         monitorExecutionSummary.position,
         orders,
         fills
       ),
-    [monitorBars, monitorExecutionSummary.position, monitorSession, orders, fills]
+    [displayMonitorBars, monitorExecutionSummary.position, monitorSession, orders, fills]
   );
   const monitorChartMarkers = useMemo(
     () => [...monitorMarkers, ...monitorDecorations.markers],
@@ -273,9 +371,9 @@ export function MonitorStage({ syncLiveOrder, dockTab, onDockTabChange, dockCont
          </CardHeader>
          <CardContent className="p-0">
             <div className="chart-shell relative h-[360px] overflow-hidden bg-[color-mix(in_srgb,var(--bk-surface-strong)_40%,transparent)]">
-                {monitorBars.length > 0 ? (
+                {displayMonitorBars.length > 0 ? (
                   <SignalMonitorChart
-                    candles={monitorBars}
+                    candles={displayMonitorBars}
                     markers={monitorChartMarkers}
                     overlays={monitorDecorations.overlays}
                   />


### PR DESCRIPTION
## 目的
_降低监控页对 Binance K 线 REST 的前端请求压力，避免 dashboard 每 5 秒固定轮询 `/api/v1/chart/candles`。_

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [x] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main)
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？
- [x] DB migration 是否具备向下兼容幂等性？
- [x] 配置字段有没有无意被混改？

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

### 改动说明
- 移除 `useDashboard` 中固定 `BTCUSDT + 1m` 的 5 秒 `/api/v1/chart/candles` 轮询。
- 监控主图默认只使用 runtime `sourceStates.signal_bar` 渲染。
- 仅当当前高亮会话拿不到 runtime bars 时，`MonitorStage` 才按需拉取一次 `/api/v1/chart/candles` 作为兜底。
- 兜底请求的最小粒度提升到 `5m`，更大周期沿用当前 monitor timeframe 对应的原生周期。

### 验证
- `cd web/console && ./node_modules/.bin/tsc --noEmit`
- `cd web/console && npm run build`
