### PR TITLE
[codex] Keep feature source gate advisory-only

### DIFF
--- a/internal/service/paper.go
+++ b/internal/service/paper.go
@@ -411,12 +411,14 @@ func (p *Platform) evaluateSignalSourceReadiness(session domain.PaperSession, ru
 
 func (p *Platform) evaluateRuntimeSignalSourceReadiness(strategyID string, runtimeSession domain.SignalRuntimeSession, eventTime time.Time) map[string]any {
 	result := map[string]any{
-		"ready":          true,
-		"requiredCount":  0,
-		"availableCount": 0,
-		"freshCount":     0,
-		"missing":        []any{},
-		"stale":          []any{},
+		"ready":           true,
+		"requiredCount":   0,
+		"availableCount":  0,
+		"freshCount":      0,
+		"missing":         []any{},
+		"stale":           []any{},
+		"advisoryMissing": []any{},
+		"advisoryStale":   []any{},
 	}
 
 	requiredBindings, err := p.ListStrategySignalBindings(strategyID)
@@ -432,6 +434,8 @@ func (p *Platform) evaluateRuntimeSignalSourceReadiness(strategyID string, runti
 
 	missing := make([]any, 0)
 	stale := make([]any, 0)
+	advisoryMissing := make([]any, 0)
+	advisoryStale := make([]any, 0)
 	requiredCount := 0
 	available := 0
 	fresh := 0
@@ -439,32 +443,44 @@ func (p *Platform) evaluateRuntimeSignalSourceReadiness(strategyID string, runti
 		if strings.ToUpper(strings.TrimSpace(binding.Status)) == "DISABLED" {
 			continue
 		}
-		requiredCount++
+		blocking := signalBindingBlocksRuntimeReady(binding)
+		if blocking {
+			requiredCount++
+		}
+		readinessItem := map[string]any{
+			"sourceKey":  binding.SourceKey,
+			"role":       binding.Role,
+			"streamType": binding.StreamType,
+			"symbol":     binding.Symbol,
+		}
 		entry := resolveRuntimeSourceStateEntry(sourceStates, binding)
 		if entry == nil {
-			missing = append(missing, map[string]any{
-				"sourceKey":  binding.SourceKey,
-				"role":       binding.Role,
-				"streamType": binding.StreamType,
-				"symbol":     binding.Symbol,
-			})
+			if blocking {
+				missing = append(missing, readinessItem)
+			} else {
+				advisoryMissing = append(advisoryMissing, readinessItem)
+			}
 			continue
 		}
-		available++
+		if blocking {
+			available++
+		}
 		lastEventAt := parseOptionalRFC3339(stringValue(entry["lastEventAt"]))
 		maxAge := p.signalSourceFreshnessWindowWithOverride(binding, runtimeSession.State)
 		if lastEventAt.IsZero() || eventTime.Sub(lastEventAt) > maxAge {
-			stale = append(stale, map[string]any{
-				"sourceKey":   binding.SourceKey,
-				"role":        binding.Role,
-				"streamType":  binding.StreamType,
-				"symbol":      binding.Symbol,
-				"lastEventAt": stringValue(entry["lastEventAt"]),
-				"maxAgeSec":   int(maxAge.Seconds()),
-			})
+			staleItem := cloneMetadata(readinessItem)
+			staleItem["lastEventAt"] = stringValue(entry["lastEventAt"])
+			staleItem["maxAgeSec"] = int(maxAge.Seconds())
+			if blocking {
+				stale = append(stale, staleItem)
+			} else {
+				advisoryStale = append(advisoryStale, staleItem)
+			}
 			continue
 		}
-		fresh++
+		if blocking {
+			fresh++
+		}
 	}
 
 	result["requiredCount"] = requiredCount
@@ -472,6 +488,8 @@ func (p *Platform) evaluateRuntimeSignalSourceReadiness(strategyID string, runti
 	result["freshCount"] = fresh
 	result["missing"] = missing
 	result["stale"] = stale
+	result["advisoryMissing"] = advisoryMissing
+	result["advisoryStale"] = advisoryStale
 	result["ready"] = len(missing) == 0 && len(stale) == 0
 	p.logRuntimeSourceGateState(strategyID, runtimeSession, result, eventTime)
 	return result

--- a/internal/service/paper_test.go
+++ b/internal/service/paper_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/wuyaocheng/bktrader/internal/domain"
+	"github.com/wuyaocheng/bktrader/internal/store/memory"
 )
 
 func TestPlatformFreshnessOverridePriority(t *testing.T) {
@@ -74,4 +75,177 @@ func TestPlatformRuntimeQuietIsolation(t *testing.T) {
 	if got := p.signalSourceFreshnessWindowWithOverride(binding, sessionState); got != 60*time.Second {
 		t.Fatalf("runtimeQuietSeconds override must NOT affect signal bar freshness. expected 60s, got %v", got)
 	}
+}
+
+func TestEvaluateRuntimeSignalSourceReadinessAllowsMissingFeatureBinding(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	bindRuntimeReadinessSources(t, platform)
+
+	eventTime := time.Date(2026, 4, 22, 2, 35, 31, 0, time.UTC)
+	runtimeSession := domain.SignalRuntimeSession{
+		StrategyID: "strategy-bk-1d",
+		State: map[string]any{
+			"sourceStates": runtimeSourceStatesForReadiness(t, platform, eventTime, map[string]time.Duration{
+				"signal":  -5 * time.Second,
+				"trigger": -5 * time.Second,
+			}),
+		},
+	}
+
+	sourceGate := platform.evaluateRuntimeSignalSourceReadiness("strategy-bk-1d", runtimeSession, eventTime)
+	if !boolValue(sourceGate["ready"]) {
+		t.Fatalf("expected missing feature binding to stay advisory, got %#v", sourceGate)
+	}
+	if got := len(metadataList(sourceGate["missing"])); got != 0 {
+		t.Fatalf("expected no blocking missing bindings, got %d", got)
+	}
+	if got := len(metadataList(sourceGate["stale"])); got != 0 {
+		t.Fatalf("expected no blocking stale bindings, got %d", got)
+	}
+	if advisory := metadataList(sourceGate["advisoryMissing"]); len(advisory) != 1 || normalizeSignalSourceRole(stringValue(advisory[0]["role"])) != "feature" {
+		t.Fatalf("expected one advisory missing feature binding, got %#v", advisory)
+	}
+	if got := maxIntValue(sourceGate["requiredCount"], -1); got != 2 {
+		t.Fatalf("expected 2 blocking bindings, got %d", got)
+	}
+	if got := maxIntValue(sourceGate["availableCount"], -1); got != 2 {
+		t.Fatalf("expected 2 blocking available bindings, got %d", got)
+	}
+	if got := maxIntValue(sourceGate["freshCount"], -1); got != 2 {
+		t.Fatalf("expected 2 blocking fresh bindings, got %d", got)
+	}
+}
+
+func TestEvaluateRuntimeSignalSourceReadinessAllowsStaleFeatureBinding(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	bindRuntimeReadinessSources(t, platform)
+
+	eventTime := time.Date(2026, 4, 22, 2, 35, 31, 0, time.UTC)
+	runtimeSession := domain.SignalRuntimeSession{
+		StrategyID: "strategy-bk-1d",
+		State: map[string]any{
+			"sourceStates": runtimeSourceStatesForReadiness(t, platform, eventTime, map[string]time.Duration{
+				"signal":  -5 * time.Second,
+				"trigger": -5 * time.Second,
+				"feature": -11 * time.Second,
+			}),
+		},
+	}
+
+	sourceGate := platform.evaluateRuntimeSignalSourceReadiness("strategy-bk-1d", runtimeSession, eventTime)
+	if !boolValue(sourceGate["ready"]) {
+		t.Fatalf("expected stale feature binding to stay advisory, got %#v", sourceGate)
+	}
+	if got := len(metadataList(sourceGate["missing"])); got != 0 {
+		t.Fatalf("expected no blocking missing bindings, got %d", got)
+	}
+	if got := len(metadataList(sourceGate["stale"])); got != 0 {
+		t.Fatalf("expected no blocking stale bindings, got %d", got)
+	}
+	if advisory := metadataList(sourceGate["advisoryStale"]); len(advisory) != 1 || normalizeSignalSourceRole(stringValue(advisory[0]["role"])) != "feature" {
+		t.Fatalf("expected one advisory stale feature binding, got %#v", advisory)
+	}
+	if got := maxIntValue(sourceGate["requiredCount"], -1); got != 2 {
+		t.Fatalf("expected 2 blocking bindings, got %d", got)
+	}
+	if got := maxIntValue(sourceGate["availableCount"], -1); got != 2 {
+		t.Fatalf("expected 2 blocking available bindings, got %d", got)
+	}
+	if got := maxIntValue(sourceGate["freshCount"], -1); got != 2 {
+		t.Fatalf("expected 2 blocking fresh bindings, got %d", got)
+	}
+}
+
+func TestEvaluateRuntimeSignalSourceReadinessBlocksStaleTriggerBinding(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	bindRuntimeReadinessSources(t, platform)
+
+	eventTime := time.Date(2026, 4, 22, 2, 35, 31, 0, time.UTC)
+	runtimeSession := domain.SignalRuntimeSession{
+		StrategyID: "strategy-bk-1d",
+		State: map[string]any{
+			"sourceStates": runtimeSourceStatesForReadiness(t, platform, eventTime, map[string]time.Duration{
+				"signal":  -5 * time.Second,
+				"trigger": -16 * time.Second,
+				"feature": -5 * time.Second,
+			}),
+		},
+	}
+
+	sourceGate := platform.evaluateRuntimeSignalSourceReadiness("strategy-bk-1d", runtimeSession, eventTime)
+	if boolValue(sourceGate["ready"]) {
+		t.Fatalf("expected stale trigger binding to block readiness, got %#v", sourceGate)
+	}
+	if stale := metadataList(sourceGate["stale"]); len(stale) != 1 || normalizeSignalSourceRole(stringValue(stale[0]["role"])) != "trigger" {
+		t.Fatalf("expected one blocking stale trigger binding, got %#v", stale)
+	}
+	if advisory := metadataList(sourceGate["advisoryStale"]); len(advisory) != 0 {
+		t.Fatalf("expected no advisory stale bindings, got %#v", advisory)
+	}
+	if got := maxIntValue(sourceGate["requiredCount"], -1); got != 2 {
+		t.Fatalf("expected 2 blocking bindings, got %d", got)
+	}
+	if got := maxIntValue(sourceGate["availableCount"], -1); got != 2 {
+		t.Fatalf("expected 2 blocking available bindings, got %d", got)
+	}
+	if got := maxIntValue(sourceGate["freshCount"], -1); got != 1 {
+		t.Fatalf("expected only 1 blocking fresh binding, got %d", got)
+	}
+}
+
+func bindRuntimeReadinessSources(t *testing.T, platform *Platform) {
+	t.Helper()
+
+	for _, binding := range []map[string]any{
+		{
+			"sourceKey": "binance-kline",
+			"role":      "signal",
+			"symbol":    "BTCUSDT",
+			"options":   map[string]any{"timeframe": "30m"},
+		},
+		{
+			"sourceKey": "binance-trade-tick",
+			"role":      "trigger",
+			"symbol":    "BTCUSDT",
+		},
+		{
+			"sourceKey": "binance-order-book",
+			"role":      "feature",
+			"symbol":    "BTCUSDT",
+		},
+	} {
+		if _, err := platform.BindStrategySignalSource("strategy-bk-1d", binding); err != nil {
+			t.Fatalf("bind strategy source failed: %v", err)
+		}
+	}
+}
+
+func runtimeSourceStatesForReadiness(t *testing.T, platform *Platform, eventTime time.Time, offsets map[string]time.Duration) map[string]any {
+	t.Helper()
+
+	bindings, err := platform.ListStrategySignalBindings("strategy-bk-1d")
+	if err != nil {
+		t.Fatalf("list strategy signal bindings failed: %v", err)
+	}
+
+	sourceStates := make(map[string]any, len(bindings))
+	for _, binding := range bindings {
+		offset, ok := offsets[normalizeSignalSourceRole(binding.Role)]
+		if !ok {
+			continue
+		}
+		entry := map[string]any{
+			"sourceKey":   binding.SourceKey,
+			"role":        binding.Role,
+			"streamType":  binding.StreamType,
+			"symbol":      binding.Symbol,
+			"options":     cloneMetadata(binding.Options),
+			"lastEventAt": eventTime.Add(offset).Format(time.RFC3339),
+		}
+		if timeframe := signalBindingTimeframe(binding.SourceKey, binding.Options); timeframe != "" {
+			entry["timeframe"] = timeframe
+		}
+		sourceStates[signalBindingKey(binding)] = entry
+	}
+	return sourceStates
 }


### PR DESCRIPTION
## 目的
修复 runtime source gate 对 `feature` 绑定的阻断判断不一致问题。

当前系统在 runtime plan 阶段已经把 `feature` 绑定视为 optional，但在 `evaluateRuntimeSignalSourceReadiness()` 中仍把所有 binding 都当作 blocking source。结果是 `binance-order-book` 这类 feature 数据一旦 stale，就会把 session 置为 `waiting-source-states`，并提前截断本轮 decision event 记录。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [x] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [ ] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main)
- [ ] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？
- [ ] DB migration 是否具备向下兼容幂等性？
- [ ] 配置字段有没有无意被混改？

补充说明：
- 本次未修改 `internal/service/live*.go`、`execution_strategy.go`、部署配置或数据库迁移。
- 本次只调整 runtime source gate 的 blocking/advisory 分类，不改变下单、dispatch、reconcile 路径。

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

本地验证：
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`

## 变更说明
- `signal` / `trigger` 继续参与 blocking `missing` / `stale` 判定。
- `feature` 绑定改为只进入 `advisoryMissing` / `advisoryStale`，不再使 `ready=false`。
- 新增回归测试覆盖：
  - `feature missing` 不阻断 readiness
  - `feature stale` 不阻断 readiness
  - `trigger stale` 仍然阻断 readiness
