### PR TITLE
Document Binance request reduction and retry monitor fallback

### DIFF
--- a/web/console/src/pages/MonitorStage.tsx
+++ b/web/console/src/pages/MonitorStage.tsx
@@ -225,6 +225,7 @@ export function MonitorStage({ syncLiveOrder, dockTab, onDockTabChange, dockCont
           return;
         }
         console.warn("Failed to load monitor fallback candles", error);
+        fallbackRequestKeyRef.current = "";
         setMonitorCandles([]);
       });
 


### PR DESCRIPTION
## 目的
_补上监控图 fallback candles 的失败重试边界，并沉淀本轮 Binance REST 降压、SyncLiveAccount 风暴治理、stale source 观测与前端 K 线降载专项文档。_

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [x] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main)
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？
- [x] DB migration 是否具备向下兼容幂等性？
- [x] 配置字段有没有无意被混改？

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

### 改动说明
- 当 monitor fallback `/api/v1/chart/candles` 请求失败时，清空 `fallbackRequestKeyRef`。
- 这样同一 `session/symbol/time window/range` 上下文下，后续仍允许再次尝试 fallback，而不是被一次失败永久卡住。
- 新增 `docs/20260422-binance-rest-rate-limit-and-live-sync-storm-plan.md`，记录 #135/#136/#137/#138/#141 的完成状态、边界和后续排查手册。
- `docs/index.md` 增加专项文档入口。
- `README.md` 补充 Monitor 主图的数据源与 fallback 规则。

### 验证
- `cd web/console && ./node_modules/.bin/tsc --noEmit`
- `cd web/console && npm run build`
