### PR TITLE
Throttle terminal order account sync

### DIFF
--- a/internal/service/live_execution.go
+++ b/internal/service/live_execution.go
@@ -848,9 +848,18 @@ func (p *Platform) syncLatestLiveSessionOrder(session domain.LiveSession, eventT
 		state["lastDispatchedOrderStatus"] = order.Status
 		state["lastExecutionDispatch"] = executionDispatchSummary(mapValue(order.Metadata["executionProposal"]), order, false)
 		updateExecutionEventStats(state, mapValue(order.Metadata["executionProposal"]), mapValue(state["lastExecutionDispatch"]))
-		if strings.EqualFold(order.Status, "FILLED") {
+		if shouldSyncLiveAccountAfterTerminalFilledOrder(order, state, eventTime) {
+			state["lastTerminalAccountSyncAttemptOrderId"] = order.ID
+			state["lastTerminalAccountSyncAttemptOrderStatus"] = order.Status
+			state["lastTerminalAccountSyncAttemptAt"] = eventTime.UTC().Format(time.RFC3339)
 			if _, syncErr := p.requestLiveAccountSync(session.AccountID, "live-terminal-order-sync"); syncErr != nil && !errors.Is(syncErr, ErrLiveAccountOperationInProgress) {
+				state["lastTerminalAccountSyncError"] = syncErr.Error()
 				p.logger("service.live_execution", "session_id", session.ID, "account_id", session.AccountID).Warn("live account sync failed after terminal order sync", "error", syncErr)
+			} else {
+				state["lastTerminalAccountSyncedOrderId"] = order.ID
+				state["lastTerminalAccountSyncedOrderStatus"] = order.Status
+				state["lastTerminalAccountSyncedAt"] = eventTime.UTC().Format(time.RFC3339)
+				delete(state, "lastTerminalAccountSyncError")
 			}
 		}
 		updated, err := p.store.UpdateLiveSessionState(session.ID, state)
@@ -956,6 +965,24 @@ func shouldBackfillTerminalFilledLiveOrder(order domain.Order, state map[string]
 		return true
 	}
 	return isLiveSessionBlockedByPositionReconcileGate(state)
+}
+
+func shouldSyncLiveAccountAfterTerminalFilledOrder(order domain.Order, state map[string]any, eventTime time.Time) bool {
+	if !strings.EqualFold(order.Status, "FILLED") {
+		return false
+	}
+	if stringValue(state["lastTerminalAccountSyncedOrderId"]) == order.ID &&
+		strings.EqualFold(stringValue(state["lastTerminalAccountSyncedOrderStatus"]), order.Status) {
+		return false
+	}
+	if stringValue(state["lastTerminalAccountSyncAttemptOrderId"]) == order.ID &&
+		strings.EqualFold(stringValue(state["lastTerminalAccountSyncAttemptOrderStatus"]), order.Status) {
+		lastAttemptAt := parseOptionalRFC3339(stringValue(state["lastTerminalAccountSyncAttemptAt"]))
+		if !lastAttemptAt.IsZero() && eventTime.UTC().Sub(lastAttemptAt.UTC()) < 30*time.Second {
+			return false
+		}
+	}
+	return true
 }
 
 func isTerminalOrderStatus(status string) bool {

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -5958,6 +5958,100 @@ func TestSyncLiveAccountAuthoritativeReconcileBypassesRecentReuseWindow(t *testi
 	}
 }
 
+func TestSyncLatestLiveSessionOrderDoesNotRepeatTerminalAccountSync(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	var syncCalls atomic.Int32
+	now := time.Date(2026, 4, 22, 3, 10, 0, 0, time.UTC)
+
+	platform.registerLiveAdapter(testLiveAccountSyncAdapter{
+		key: "test-terminal-account-sync",
+		syncSnapshotFunc: func(p *Platform, account domain.Account, binding map[string]any) (domain.Account, error) {
+			syncCalls.Add(1)
+			account.Metadata = cloneMetadata(account.Metadata)
+			account.Metadata["lastLiveSyncAt"] = now.Format(time.RFC3339)
+			return p.store.UpdateAccount(account)
+		},
+	})
+
+	account, err := platform.store.GetAccount("live-main")
+	if err != nil {
+		t.Fatalf("get account failed: %v", err)
+	}
+	account.Metadata = cloneMetadata(account.Metadata)
+	account.Metadata["liveBinding"] = map[string]any{
+		"adapterKey":     "test-terminal-account-sync",
+		"connectionMode": "mock",
+		"executionMode":  "rest",
+	}
+	if _, err := platform.store.UpdateAccount(account); err != nil {
+		t.Fatalf("update account failed: %v", err)
+	}
+
+	session, err := platform.CreateLiveSession("", "live-main", "strategy-bk-1d", map[string]any{
+		"symbol":          "BTCUSDT",
+		"signalTimeframe": "1d",
+	})
+	if err != nil {
+		t.Fatalf("create live session failed: %v", err)
+	}
+	order, err := platform.store.CreateOrder(domain.Order{
+		AccountID:         session.AccountID,
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "BUY",
+		Type:              "MARKET",
+		Status:            "FILLED",
+		Quantity:          0.01,
+		Price:             68000,
+		Metadata: map[string]any{
+			"source":          "live-session-intent",
+			"liveSessionId":   session.ID,
+			"exchangeOrderId": "exchange-order-terminal-filled",
+			"filledQuantity":  0.01,
+			"lastFilledAt":    now.Format(time.RFC3339),
+			"executionProposal": map[string]any{
+				"role":     "entry",
+				"side":     "BUY",
+				"symbol":   "BTCUSDT",
+				"quantity": 0.01,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("create filled order failed: %v", err)
+	}
+	order.Status = "FILLED"
+	order, err = platform.store.UpdateOrder(order)
+	if err != nil {
+		t.Fatalf("update filled order failed: %v", err)
+	}
+	state := cloneMetadata(session.State)
+	state["lastDispatchedOrderId"] = order.ID
+	state["lastDispatchedOrderStatus"] = "FILLED"
+	state["positionReconcileGateBlocking"] = false
+	state["positionReconcileGateStatus"] = "matched"
+	state["recoveryMode"] = ""
+	session, err = platform.store.UpdateLiveSessionState(session.ID, state)
+	if err != nil {
+		t.Fatalf("update live session state failed: %v", err)
+	}
+
+	session, err = platform.syncLatestLiveSessionOrder(session, now)
+	if err != nil {
+		t.Fatalf("first terminal order sync failed: %v", err)
+	}
+	session, err = platform.syncLatestLiveSessionOrder(session, now.Add(5*time.Second))
+	if err != nil {
+		t.Fatalf("second terminal order sync failed: %v", err)
+	}
+	if got := syncCalls.Load(); got != 1 {
+		t.Fatalf("expected repeated terminal order sync to reuse prior account refresh, got %d adapter calls", got)
+	}
+	if got := stringValue(session.State["lastTerminalAccountSyncedOrderId"]); got != order.ID {
+		t.Fatalf("expected terminal account sync marker for order %s, got %s", order.ID, got)
+	}
+}
+
 func TestCompactSourceGateEntriesPreservesStaleDetailFields(t *testing.T) {
 	items := compactSourceGateEntries([]map[string]any{
 		map[string]any{


### PR DESCRIPTION
## 目的
_修复终态订单 follow-up 反复触发 `live-terminal-order-sync`，导致同一 live account 在短时间内持续打 Binance REST 并触发 429 的问题。_

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [x] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main)
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？
- [x] DB migration 是否具备向下兼容幂等性？
- [x] 配置字段有没有无意被混改？

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

### Root Cause
- 新日志显示 `2026-04-22T02:52` 单分钟内 `live-terminal-order-sync` 触发约 301 次，`2026-04-22T02:58` 单分钟内触发约 280 次。
- `live-terminal-order-sync` 在 #136 中被设计为绕过 recent-result reuse，避免吞掉成交后的权威刷新。
- 但 `syncActiveLiveSessions` 会反复同步同一个 `lastDispatchedOrderId`，当该订单已经是 `FILLED` 时，`syncLatestLiveSessionOrder` 每次都会再次请求 live account sync。
- 结果是同一个已终态订单在 dispatcher 周期内持续触发账户同步，继续造成 Binance REST 429 和 stale 告警放大。

### 修改点
- 为 `FILLED` 终态订单后的账户刷新增加幂等标记：`lastTerminalAccountSyncedOrderId / Status / At`。
- 为失败或 in-progress 的账户刷新增加 attempt 标记，并在 30 秒内不重复尝试同一个订单状态。
- 保留首次终态订单账户刷新，不改变 `SyncLiveOrder`、成交回写、reconcile gate 或 dispatch 边界。

### 行为变化
- 同一个已 `FILLED` 的 `lastDispatchedOrderId` 不会在每次 `syncActiveLiveSessions` 扫描时重复触发 `live-terminal-order-sync`。
- 如果账户刷新失败，同一订单状态会最多按 30 秒节奏重试，避免 tight-loop 打 Binance。
- 新的 filled order 或订单状态变化仍会触发账户刷新。

### 新增测试
- `TestSyncLatestLiveSessionOrderDoesNotRepeatTerminalAccountSync`

### 验证
- `go test ./internal/service -run 'TestSyncLatestLiveSessionOrderDoesNotRepeatTerminalAccountSync|TestSyncLiveAccount'`
- `go test ./internal/service/...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
