### PR TITLE
Document production log troubleshooting access

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,8 @@ This project has a graphify knowledge graph at `graphify-out/`.
 3. [CONTRIBUTING.md](CONTRIBUTING.md): wuyaocheng 和 folgercn 两位主核心贡献者的协作纪律
 4. `graphify-out/GRAPH_REPORT.md` (如有必要): 理解项目具体实现的依赖拓扑。
 
+若任务是线上告警 / 生产日志 / `stale-source-states` / Binance REST 限流排查，必须优先阅读 [docs/production-log-troubleshooting.md](docs/production-log-troubleshooting.md)，其中记录了生产服务器 SSH 入口与日志目录。
+
 ## 5. 常规验证手段
 
 你在提交代码后必须做以下自查（若相关）：
@@ -213,4 +215,3 @@ AI 修改本范围代码时必须输出：
 
 - [docs/runtime-recovery-stabilization-summary.md](docs/runtime-recovery-stabilization-summary.md)
 - [docs/runtime-recovery-extension-coding-rules.md](docs/runtime-recovery-extension-coding-rules.md)
-

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,6 +18,7 @@
 - [20260420-runtime-recovery-source-of-truth-map.md](20260420-runtime-recovery-source-of-truth-map.md) - Issue #84 的恢复事实源梳理、函数级 mapping、时序图与风险点清单。
 - [20260420-live-reconcile-manual-close-state-closure-bug-spec.md](20260420-live-reconcile-manual-close-state-closure-bug-spec.md) - 手动平仓、成交回写、reconcile gate 与 session 刷新闭环缺失问题说明与修复范围。
 - [20260422-binance-rest-rate-limit-and-live-sync-storm-plan.md](20260422-binance-rest-rate-limit-and-live-sync-storm-plan.md) - Binance REST 统一限流、`SyncLiveAccount` 风暴治理、stale source 观测与前端 K 线降载专项记录。
+- [production-log-troubleshooting.md](production-log-troubleshooting.md) - 生产服务器日志 SSH 入口、日志目录、stale/source gate、Binance REST 限流与前端 K 线请求排查起手式。
 - [部署与网络架构.md](部署与网络架构.md) - 包含有关容器/负载路由的信息。
 - [cicd-maintenance.md](cicd-maintenance.md) - GitHub Actions 维保说明。
 - [frontend-live-reconcile-collab.md](frontend-live-reconcile-collab.md) - Live 账户全量对账的前端协作文档与 API 接入约定。

--- a/docs/production-log-troubleshooting.md
+++ b/docs/production-log-troubleshooting.md
@@ -1,0 +1,115 @@
+# Production Log Troubleshooting
+
+本文档是生产环境日志排查入口。Agent 遇到线上告警、Telegram 噪声、`stale-source-states`、Binance `429`、live sync 风暴、runtime 异常时，应优先按本文档进入日志，而不是只看本地下载的片段。
+
+## 1. 远程入口
+
+生产服务器：
+
+```bash
+ssh fujun@192.168.100.89
+```
+
+服务日志目录：
+
+```bash
+/Users/fujun/services/bktrader/logs
+```
+
+建议先只读排查，不要修改生产文件：
+
+```bash
+ssh fujun@192.168.100.89 'ls -lht /Users/fujun/services/bktrader/logs | head -20'
+```
+
+## 2. 推荐起手式
+
+确认最新日志文件：
+
+```bash
+ssh fujun@192.168.100.89 'ls -t /Users/fujun/services/bktrader/logs | head'
+```
+
+查看最近错误和告警：
+
+```bash
+ssh fujun@192.168.100.89 "cd /Users/fujun/services/bktrader/logs && rg -n 'stale-source-states|runtime source gate|rate-limited|429|live account sync|telegram dispatch|chart/candles' . | tail -200"
+```
+
+如果需要拉回本地分析：
+
+```bash
+scp fujun@192.168.100.89:/Users/fujun/services/bktrader/logs/<log-file> /Users/fujun/Downloads/
+```
+
+## 3. stale-source-states 排查顺序
+
+遇到 Telegram 报：
+
+- `stale-source-states`
+- `数据源过期`
+- `runtime-stale-*`
+- `live-warning-stale-source-states-*`
+
+不要先调 Telegram 去抖窗口。按以下顺序查：
+
+1. 查 `runtime source gate blocked`
+   - 重点字段：`runtime_session_id`、`stale_sources`、`sourceKey`、`streamType`、`symbol`、`lastEventAt`、`maxAgeSec`。
+   - 目标：确认到底是哪一路 source stale，例如 `binance-order-book` 或 `binance-kline`。
+2. 查 `runtime source gate recovered`
+   - 目标：判断是短暂抖动还是持续阻塞。
+3. 查 `live account sync request`
+   - 重点字段：`trigger`、`coalesced`、`waited_for_inflight`、`reused_recent_result`、`result_error`。
+   - 目标：确认是否仍有某条 trigger 在高频触发账户同步。
+4. 查 Binance REST 限流
+   - 关键字：`429 Too Many Requests`、`temporarily rate-limited`、`Retry-After`。
+   - 目标：确认 stale 是否和 REST 压力、sync 风暴同时间发生。
+
+常用命令：
+
+```bash
+ssh fujun@192.168.100.89 "cd /Users/fujun/services/bktrader/logs && rg -n 'runtime source gate (blocked|recovered)|stale_sources|sourceKey|live account sync request|429 Too Many|temporarily rate-limited' . | tail -300"
+```
+
+## 4. Binance REST 压力排查
+
+如果怀疑交易所 API 被打爆，先聚合这些关键字：
+
+```bash
+ssh fujun@192.168.100.89 "cd /Users/fujun/services/bktrader/logs && rg -n '429 Too Many|temporarily rate-limited|binance request failed|live account sync request executing|live account sync request completed|syncing live account|/api/v1/chart/candles' . | tail -300"
+```
+
+重点判断：
+
+- 是否有 `live-terminal-order-sync` 在短时间内大量出现。
+- 是否有 `sync-active-live-accounts` 被合并或复用。
+- 是否仍有前端请求 `/api/v1/chart/candles?symbol=BTCUSDT&resolution=1&limit=840`。
+- 是否同一时间出现 `runtime source gate blocked`。
+
+## 5. 前端 K 线请求检查
+
+Monitor 主图应优先使用 runtime `sourceStates.signal_bar`。生产日志中不应再持续出现固定高频的：
+
+```text
+/api/v1/chart/candles?symbol=BTCUSDT&resolution=1&...&limit=840
+```
+
+如果仍然出现，优先判断：
+
+- 线上前端是否还没部署包含 PR #138 的版本。
+- 是否有旧浏览器页面未刷新。
+- 是否有其他页面仍在调用旧 candles 链路。
+
+## 6. 安全边界
+
+生产日志排查默认只读：
+
+- 不要在 SSH 会话中修改配置、重启服务或删除日志，除非人类明确要求。
+- 不要把生产日志里的密钥、token、账户敏感字段复制进 PR 或公开 issue。
+- 涉及 `internal/service/live*.go`、reconcile、dispatch、执行策略的修复仍按 AGENTS 高风险规则执行。
+
+## 7. 相关文档
+
+- [20260422-binance-rest-rate-limit-and-live-sync-storm-plan.md](20260422-binance-rest-rate-limit-and-live-sync-storm-plan.md)
+- [live-safety-invariants.md](live-safety-invariants.md)
+- [agent-risk-model.md](agent-risk-model.md)


### PR DESCRIPTION
## 目的
_沉淀生产服务器日志排查入口，让后续 Agent/LLM 遇到线上告警、stale-source-states、Binance 429 或 live sync 风暴时能直接知道从哪里查。_

## 本次改动风险定级 (参照 agent-risk-model.md)
- [x] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main)
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？
- [x] DB migration 是否具备向下兼容幂等性？
- [x] 配置字段有没有无意被混改？

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [x] 无需跑后端或无需编译的文档性修改
- [ ] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

### 改动说明
- 新增 `docs/production-log-troubleshooting.md`，记录生产 SSH 入口、日志目录和只读排查命令。
- `docs/index.md` 增加生产日志排查文档入口。
- `AGENTS.md` 增加规则：线上告警 / 生产日志 / stale-source-states / Binance REST 限流排查时，优先阅读该文档。

### 验证
- 文档-only 改动，未运行后端或前端构建。
