### PR TITLE
[codex] fix stale live reentry alignment

### DIFF
--- a/internal/service/live_zero_initial.go
+++ b/internal/service/live_zero_initial.go
@@ -68,6 +68,14 @@ func prepareLivePlanStepForSignalEvaluation(
 	gate := evaluateSignalBarGate(signalBarState, "", "entry", "", breakoutPrice, breakoutPriceSource)
 	longReady := boolValue(gate["longReady"])
 	shortReady := boolValue(gate["shortReady"])
+	if liveExitReentryPlanStep(nextPlannedRole, nextPlannedReason) && longReady == shortReady {
+		// Stale PT/SL re-entry steps should first prefer a breakout-confirmed
+		// current direction, but may fall back to zero-initial reentry semantics
+		// when intraday structure is ready before a fresh breakout prints.
+		gate = evaluateSignalBarGate(signalBarState, "", "entry", "Zero-Initial-Reentry", breakoutPrice, breakoutPriceSource)
+		longReady = boolValue(gate["longReady"])
+		shortReady = boolValue(gate["shortReady"])
+	}
 	if longReady == shortReady {
 		return updatedState, nextPlannedEvent, nextPlannedPrice, nextPlannedSide, nextPlannedRole, nextPlannedReason
 	}

--- a/internal/service/live_zero_initial.go
+++ b/internal/service/live_zero_initial.go
@@ -40,9 +40,12 @@ func prepareLivePlanStepForSignalEvaluation(
 	}
 
 	updatedState = refreshLiveZeroInitialWindowState(updatedState, signalBarStates, symbol, signalTimeframe, currentPosition, eventTime)
-	// Replay only keeps PT/SL reentry eligible through the next signal bar.
-	// Once the planned step is stale, live should fall back to current-market alignment.
-	if liveExitReentryPlanStep(nextPlannedRole, nextPlannedReason) &&
+	staleExitReentry := liveExitReentryPlanStep(nextPlannedRole, nextPlannedReason)
+	// Replay only keeps PT/SL reentry eligible through the next signal bar. Once
+	// that boundary is crossed, live no longer trusts the historical trigger
+	// timing and must re-align using the current signal bar instead of replaying
+	// the stale plan step indefinitely.
+	if staleExitReentry &&
 		(hasActiveLivePositionSnapshot(currentPosition) || !isLivePlanStepStale(nextPlannedEvent, signalTimeframe, eventTime)) {
 		clearLivePendingZeroInitialWindow(updatedState, eventTime, "exit-reentry-priority")
 		return updatedState, nextPlannedEvent, nextPlannedPrice, nextPlannedSide, nextPlannedRole, nextPlannedReason
@@ -65,16 +68,23 @@ func prepareLivePlanStepForSignalEvaluation(
 	if signalBarState == nil {
 		return updatedState, nextPlannedEvent, nextPlannedPrice, nextPlannedSide, nextPlannedRole, nextPlannedReason
 	}
+	alignmentMode := ""
 	gate := evaluateSignalBarGate(signalBarState, "", "entry", "", breakoutPrice, breakoutPriceSource)
 	longReady := boolValue(gate["longReady"])
 	shortReady := boolValue(gate["shortReady"])
-	if liveExitReentryPlanStep(nextPlannedRole, nextPlannedReason) && longReady == shortReady {
+	if longReady != shortReady {
+		alignmentMode = "breakout-confirmed"
+	}
+	if staleExitReentry && longReady == shortReady {
 		// Stale PT/SL re-entry steps should first prefer a breakout-confirmed
 		// current direction, but may fall back to zero-initial reentry semantics
 		// when intraday structure is ready before a fresh breakout prints.
 		gate = evaluateSignalBarGate(signalBarState, "", "entry", "Zero-Initial-Reentry", breakoutPrice, breakoutPriceSource)
 		longReady = boolValue(gate["longReady"])
 		shortReady = boolValue(gate["shortReady"])
+		if longReady != shortReady {
+			alignmentMode = "structure-ready-no-breakout"
+		}
 	}
 	if longReady == shortReady {
 		return updatedState, nextPlannedEvent, nextPlannedPrice, nextPlannedSide, nextPlannedRole, nextPlannedReason
@@ -102,13 +112,29 @@ func prepareLivePlanStepForSignalEvaluation(
 		"expiresAt":       currentBarStart.UTC().Add(2 * step).Format(time.RFC3339),
 	}
 	updatedState[livePendingZeroInitialWindowStateKey] = pendingWindow
-	appendTimelineEvent(updatedState, "strategy", eventTime, "zero-initial-window-armed", map[string]any{
+	timelineMetadata := map[string]any{
 		livePendingZeroInitialWindowStateKey: cloneMetadata(pendingWindow),
 		"reason":                             "Zero-Initial-Reentry",
 		"side":                               side,
 		"symbol":                             NormalizeSymbol(symbol),
 		"signalTimeframe":                    strings.ToLower(strings.TrimSpace(signalTimeframe)),
-	})
+	}
+	if staleExitReentry {
+		timelineMetadata["staleExitReentryContext"] = liveStaleExitReentryContext(
+			signalBarState,
+			signalTimeframe,
+			eventTime,
+			breakoutPrice,
+			breakoutPriceSource,
+			nextPlannedEvent,
+			nextPlannedPrice,
+			nextPlannedSide,
+			nextPlannedRole,
+			nextPlannedReason,
+			alignmentMode,
+		)
+	}
+	appendTimelineEvent(updatedState, "strategy", eventTime, "zero-initial-window-armed", timelineMetadata)
 	updatedState, alignedEvent, alignedPrice, alignedSide, alignedRole, alignedReason, _ := liveZeroInitialWindowPlanStep(updatedState, parameters, signalBarStates, symbol, signalTimeframe, eventTime)
 	return updatedState, alignedEvent, alignedPrice, alignedSide, alignedRole, alignedReason
 }
@@ -187,6 +213,54 @@ func clearLivePendingZeroInitialWindow(state map[string]any, eventTime time.Time
 		livePendingZeroInitialWindowStateKey: pending,
 		"reason":                             firstNonEmpty(strings.TrimSpace(reason), "consumed"),
 	})
+}
+
+func liveStaleExitReentryContext(
+	signalBarState map[string]any,
+	signalTimeframe string,
+	eventTime time.Time,
+	breakoutPrice float64,
+	breakoutPriceSource string,
+	nextPlannedEvent time.Time,
+	nextPlannedPrice float64,
+	nextPlannedSide, nextPlannedRole, nextPlannedReason string,
+	alignmentMode string,
+) map[string]any {
+	context := map[string]any{
+		"alignmentMode":       strings.TrimSpace(alignmentMode),
+		"breakoutPrice":       breakoutPrice,
+		"breakoutPriceSource": strings.TrimSpace(breakoutPriceSource),
+		"plannedPrice":        nextPlannedPrice,
+		"plannedReason":       strings.TrimSpace(nextPlannedReason),
+		"plannedRole":         strings.ToLower(strings.TrimSpace(nextPlannedRole)),
+		"plannedSide":         strings.ToUpper(strings.TrimSpace(nextPlannedSide)),
+	}
+	if !nextPlannedEvent.IsZero() {
+		context["plannedEvent"] = nextPlannedEvent.UTC().Format(time.RFC3339)
+	}
+	step := resolutionToDuration(liveSignalResolution(signalTimeframe))
+	if step <= 0 {
+		step = 4 * time.Hour
+	}
+	context["staleWindowSeconds"] = step.Seconds()
+	if !nextPlannedEvent.IsZero() && eventTime.After(nextPlannedEvent) {
+		context["staleAgeSeconds"] = eventTime.Sub(nextPlannedEvent).Seconds()
+	}
+	current := mapValue(signalBarState["current"])
+	currentClose := parseFloatValue(current["close"])
+	if currentClose > 0 {
+		context["currentClose"] = currentClose
+	}
+	if currentBarStart := parseOptionalRFC3339(stringValue(current["barStart"])); !currentBarStart.IsZero() {
+		context["currentBarStart"] = currentBarStart.UTC().Format(time.RFC3339)
+	}
+	if nextPlannedPrice > 0 && currentClose > 0 {
+		context["currentCloseDeviationBps"] = computePriceProximityBps(nextPlannedPrice, currentClose)
+	}
+	if nextPlannedPrice > 0 && breakoutPrice > 0 {
+		context["breakoutDeviationBps"] = computePriceProximityBps(nextPlannedPrice, breakoutPrice)
+	}
+	return context
 }
 
 func liveZeroInitialWindowPlanStep(

--- a/internal/service/live_zero_initial_test.go
+++ b/internal/service/live_zero_initial_test.go
@@ -63,3 +63,62 @@ func TestPrepareLivePlanStepForSignalEvaluationExpiresStaleExitReentryWindow(t *
 		t.Fatalf("expected pending BUY window after stale SL-Reentry fallback, got %+v", pending)
 	}
 }
+
+func TestPrepareLivePlanStepForSignalEvaluationUsesZeroInitialSemanticsForStaleIntradayReentry(t *testing.T) {
+	barStart := time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC)
+	signalStates := map[string]any{
+		signalBindingMatchKey("binance-kline", "signal", "BTCUSDT", map[string]any{"timeframe": "30m"}): map[string]any{
+			"symbol":    "BTCUSDT",
+			"timeframe": "30m",
+			"sma5":      100.0,
+			"atr14":     20.0,
+			"current": map[string]any{
+				"barStart": barStart.Format(time.RFC3339),
+				"close":    108.0,
+				"high":     109.0,
+				"low":      104.0,
+			},
+			"prevBar1": map[string]any{
+				"high": 104.0,
+				"low":  95.0,
+			},
+			"prevBar2": map[string]any{
+				"high": 106.0,
+				"low":  96.0,
+			},
+		},
+	}
+
+	state, gotEvent, gotPrice, gotSide, gotRole, gotReason := prepareLivePlanStepForSignalEvaluation(
+		map[string]any{},
+		map[string]any{
+			"dir2_zero_initial": true,
+			"zero_initial_mode": "reentry_window",
+			"long_reentry_atr":  0.1,
+		},
+		signalStates,
+		"BTCUSDT",
+		"30m",
+		map[string]any{},
+		barStart.Add(45*time.Minute),
+		101.0,
+		"trade_tick.price",
+		barStart.Add(-2*time.Hour),
+		92.0,
+		"SELL",
+		"entry",
+		"SL-Reentry",
+	)
+	if gotRole != "entry" || gotReason != "Zero-Initial-Reentry" || gotSide != "BUY" {
+		t.Fatalf("expected stale intraday SL-Reentry to fall back to zero-initial semantics, got side=%s role=%s reason=%s", gotSide, gotRole, gotReason)
+	}
+	if gotPrice != 97.0 {
+		t.Fatalf("expected stale intraday fallback price 97.0, got %.2f", gotPrice)
+	}
+	if gotEvent != barStart {
+		t.Fatalf("expected stale intraday fallback planned event %s, got %s", barStart.Format(time.RFC3339), gotEvent.Format(time.RFC3339))
+	}
+	if pending := mapValue(state[livePendingZeroInitialWindowStateKey]); stringValue(pending["side"]) != "BUY" {
+		t.Fatalf("expected pending BUY window after stale intraday fallback, got %+v", pending)
+	}
+}

--- a/internal/service/live_zero_initial_test.go
+++ b/internal/service/live_zero_initial_test.go
@@ -62,6 +62,20 @@ func TestPrepareLivePlanStepForSignalEvaluationExpiresStaleExitReentryWindow(t *
 	if pending := mapValue(state[livePendingZeroInitialWindowStateKey]); stringValue(pending["side"]) != "BUY" {
 		t.Fatalf("expected pending BUY window after stale SL-Reentry fallback, got %+v", pending)
 	}
+	timeline := metadataList(state["timeline"])
+	if len(timeline) != 1 || stringValue(timeline[0]["title"]) != "zero-initial-window-armed" {
+		t.Fatalf("expected one zero-initial-window-armed event, got %+v", timeline)
+	}
+	context := mapValue(mapValue(timeline[0]["metadata"])["staleExitReentryContext"])
+	if stringValue(context["alignmentMode"]) != "breakout-confirmed" {
+		t.Fatalf("expected breakout-confirmed stale exit reentry context, got %+v", context)
+	}
+	if stringValue(context["plannedReason"]) != "SL-Reentry" || stringValue(context["breakoutPriceSource"]) != "trade_tick.price" {
+		t.Fatalf("expected stale exit reentry context to retain original plan and breakout source, got %+v", context)
+	}
+	if parseFloatValue(context["staleAgeSeconds"]) <= parseFloatValue(context["staleWindowSeconds"]) {
+		t.Fatalf("expected stale age to exceed stale window in context, got %+v", context)
+	}
 }
 
 func TestPrepareLivePlanStepForSignalEvaluationUsesZeroInitialSemanticsForStaleIntradayReentry(t *testing.T) {
@@ -120,5 +134,19 @@ func TestPrepareLivePlanStepForSignalEvaluationUsesZeroInitialSemanticsForStaleI
 	}
 	if pending := mapValue(state[livePendingZeroInitialWindowStateKey]); stringValue(pending["side"]) != "BUY" {
 		t.Fatalf("expected pending BUY window after stale intraday fallback, got %+v", pending)
+	}
+	timeline := metadataList(state["timeline"])
+	if len(timeline) != 1 || stringValue(timeline[0]["title"]) != "zero-initial-window-armed" {
+		t.Fatalf("expected one zero-initial-window-armed event, got %+v", timeline)
+	}
+	context := mapValue(mapValue(timeline[0]["metadata"])["staleExitReentryContext"])
+	if stringValue(context["alignmentMode"]) != "structure-ready-no-breakout" {
+		t.Fatalf("expected structure-ready-no-breakout stale exit reentry context, got %+v", context)
+	}
+	if stringValue(context["plannedReason"]) != "SL-Reentry" || stringValue(context["plannedSide"]) != "SELL" {
+		t.Fatalf("expected stale intraday context to retain original plan info, got %+v", context)
+	}
+	if parseFloatValue(context["currentCloseDeviationBps"]) <= 0 || parseFloatValue(context["breakoutDeviationBps"]) <= 0 {
+		t.Fatalf("expected stale intraday context to record current-vs-planned deviations, got %+v", context)
 	}
 }


### PR DESCRIPTION
## 目的
修复 live session 在 `SL/PT-Reentry` 计划步已经明显过期后，仍长期沿用历史 `SL-Reentry` 计划点的问题。这个问题会让策略日志持续显示 `sl-reentry-watch`，即使距离上一次真实止损已经过去很多根 signal bar。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [x] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
- [ ] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main)
- [ ] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？
- [ ] DB migration 是否具备向下兼容幂等性？
- [ ] 配置字段有没有无意被混改？

说明：本 PR 没有修改 `dispatchMode`、凭证路由、DB migration 或配置字段，仅调整 stale live reentry step 的当前市场对齐逻辑。

## Root Cause
`prepareLivePlanStepForSignalEvaluation()` 在处理 stale 的 `SL/PT-Reentry` 计划步时，会先尝试按当前市场重新对齐。如果当前 signal bar 已经结构就绪，但还没有新的 breakout，旧逻辑会继续保留历史 `SL-Reentry` step，导致 decision metadata 和日志长期停留在过期的 `sl-reentry-watch`。

## 修改点
- 对 stale 的 `SL/PT-Reentry` 计划步，仍优先使用严格 breakout 语义进行当前市场对齐。
- 只有在 strict gate 不能得出唯一方向时，才退回 `Zero-Initial-Reentry` 语义，以允许 intraday 场景在结构已就绪但 breakout 尚未刷新时从历史 plan step 脱离。
- 新增 30m 回归测试，覆盖 stale intraday `SL-Reentry` 切回 `Zero-Initial-Reentry` 的行为。

## 行为变化
- stale 的 `SL/PT-Reentry` 不会再无限保留为历史 `sl-reentry-watch`。
- 已有 breakout 的场景仍优先按 breakout 对齐。
- `Initial` 计划步仍然保留“没有当前 breakout 不提前 arm zero-initial window”的约束。

## 验证方式与测试证据
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

本地验证：
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
