### PR TITLE
[codex] suppress transient runtime recovery alerts

### DIFF
--- a/internal/service/alerts.go
+++ b/internal/service/alerts.go
@@ -267,8 +267,12 @@ func (p *Platform) ListAlerts() ([]domain.PlatformAlert, error) {
 		}
 		readiness := p.evaluateLiveRuntimeReadiness(strategyBindings, activeRuntime)
 		if readiness.status == "blocked" {
+			alertID := fmt.Sprintf("live-preflight-%s", account.ID)
+			if readiness.reason == "runtime-error" {
+				alertID = fmt.Sprintf("live-preflight-runtime-error-%s", account.ID)
+			}
 			appendAlert(domain.PlatformAlert{
-				ID:               fmt.Sprintf("live-preflight-%s", account.ID),
+				ID:               alertID,
 				Scope:            "live",
 				Level:            "critical",
 				Title:            "实盘预检受阻",
@@ -280,6 +284,9 @@ func (p *Platform) ListAlerts() ([]domain.PlatformAlert, error) {
 				RuntimeSessionID: activeRuntime.ID,
 				Anchor:           "live",
 				EventTime:        parseOptionalRFC3339(stringValue(activeRuntime.State["lastEventAt"])),
+				Metadata: map[string]any{
+					"reason": readiness.reason,
+				},
 			})
 		} else if readiness.status == "warning" {
 			alertID := fmt.Sprintf("live-warning-%s", account.ID)

--- a/internal/service/telegram.go
+++ b/internal/service/telegram.go
@@ -271,10 +271,7 @@ func (p *Platform) DispatchTelegramNotifications() error {
 }
 
 func telegramAlertNeedsFlapSuppression(alert domain.PlatformAlert) bool {
-	if alert.Scope == "runtime" && alert.ID != "" && strings.HasPrefix(alert.ID, "runtime-stale-") {
-		return true
-	}
-	return alert.Scope == "live" && alert.ID != "" && strings.HasPrefix(alert.ID, "live-warning-stale-source-states-")
+	return telegramFlapSuppressionKeyForAlert(alert) != ""
 }
 
 func telegramDeliveryNeedsFlapSuppression(delivery domain.NotificationDelivery) bool {
@@ -284,10 +281,44 @@ func telegramDeliveryNeedsFlapSuppression(delivery domain.NotificationDelivery) 
 	if strings.HasPrefix(delivery.NotificationID, "runtime-stale-") {
 		return true
 	}
+	if strings.HasPrefix(delivery.NotificationID, "runtime-recovering-") {
+		return true
+	}
+	if strings.HasPrefix(delivery.NotificationID, "live-preflight-runtime-error-") {
+		return true
+	}
 	if delivery.Metadata == nil {
 		return false
 	}
-	return stringValue(delivery.Metadata["flapSuppressionKey"]) == "live-warning-stale-source-states"
+	return telegramFlapSuppressionKeyIsKnown(stringValue(delivery.Metadata["flapSuppressionKey"]))
+}
+
+func telegramFlapSuppressionKeyForAlert(alert domain.PlatformAlert) string {
+	if alert.ID == "" {
+		return ""
+	}
+	if alert.Scope == "runtime" && strings.HasPrefix(alert.ID, "runtime-stale-") {
+		return "runtime-stale"
+	}
+	if alert.Scope == "runtime" && strings.HasPrefix(alert.ID, "runtime-recovering-") {
+		return "runtime-recovering"
+	}
+	if alert.Scope == "live" && strings.HasPrefix(alert.ID, "live-warning-stale-source-states-") {
+		return "live-warning-stale-source-states"
+	}
+	if alert.Scope == "live" && strings.HasPrefix(alert.ID, "live-preflight-runtime-error-") {
+		return "live-preflight-runtime-error"
+	}
+	return ""
+}
+
+func telegramFlapSuppressionKeyIsKnown(key string) bool {
+	switch key {
+	case "runtime-stale", "runtime-recovering", "live-warning-stale-source-states", "live-preflight-runtime-error":
+		return true
+	default:
+		return false
+	}
 }
 
 func (p *Platform) advanceTelegramFlapSuppressedActiveDelivery(
@@ -304,8 +335,8 @@ func (p *Platform) advanceTelegramFlapSuppressedActiveDelivery(
 	metadata["scope"] = item.Alert.Scope
 	metadata["detail"] = item.Alert.Detail
 	metadata["firstActiveAt"] = firstNonEmpty(stringValue(metadata["firstActiveAt"]), now.Format(time.RFC3339))
-	if strings.HasPrefix(item.Alert.ID, "live-warning-stale-source-states-") {
-		metadata["flapSuppressionKey"] = "live-warning-stale-source-states"
+	if key := telegramFlapSuppressionKeyForAlert(item.Alert); key != "" {
+		metadata["flapSuppressionKey"] = key
 	}
 	delete(metadata, "resolveObservedAt")
 

--- a/internal/service/telegram.go
+++ b/internal/service/telegram.go
@@ -331,6 +331,11 @@ func (p *Platform) advanceTelegramFlapSuppressedActiveDelivery(
 	if metadata == nil {
 		metadata = map[string]any{}
 	}
+	if !hasDelivery || (!strings.EqualFold(delivery.Status, "pending") &&
+		!strings.EqualFold(delivery.Status, "sent") &&
+		!strings.EqualFold(delivery.Status, "resolve_pending")) {
+		delete(metadata, "firstActiveAt")
+	}
 	metadata["title"] = item.Alert.Title
 	metadata["scope"] = item.Alert.Scope
 	metadata["detail"] = item.Alert.Detail

--- a/internal/service/telegram_test.go
+++ b/internal/service/telegram_test.go
@@ -254,6 +254,63 @@ func TestTelegramDispatchSuppressesFlappingRuntimeStaleAlerts(t *testing.T) {
 	}
 }
 
+func TestTelegramDispatchSuppressesTransientRuntimeRecoveringAlert(t *testing.T) {
+	var messages []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var p map[string]any
+		_ = json.Unmarshal(body, &p)
+		messages = append(messages, p["text"].(string))
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"ok":true}`))
+	}))
+	defer server.Close()
+
+	oldURL := telegramBaseURL
+	telegramBaseURL = server.URL
+	defer func() { telegramBaseURL = oldURL }()
+
+	store := memory.NewStore()
+	p := &Platform{store: store}
+	base := time.Date(2026, 4, 22, 3, 51, 53, 0, time.UTC)
+	item := domain.PlatformNotification{
+		ID:     "runtime-recovering-signal-runtime-1",
+		Status: "active",
+		Alert: domain.PlatformAlert{
+			ID:               "runtime-recovering-signal-runtime-1",
+			Scope:            "runtime",
+			Level:            "warning",
+			Title:            "运行时恢复中",
+			Detail:           "尝试次数 1/3: unexpected EOF",
+			RuntimeSessionID: "signal-runtime-1",
+			EventTime:        base,
+		},
+		UpdatedAt: base,
+	}
+
+	pending, shouldSend, err := p.advanceTelegramFlapSuppressedActiveDelivery(item, domain.NotificationDelivery{}, false, base)
+	if err != nil {
+		t.Fatalf("seed runtime recovering pending delivery failed: %v", err)
+	}
+	if shouldSend {
+		t.Fatal("expected transient runtime recovering alert to stay pending")
+	}
+
+	recovered, sentRecovery, err := p.advanceTelegramFlapSuppressedRecoveredDelivery(pending, base.Add(15*time.Second))
+	if err != nil {
+		t.Fatalf("recover pending runtime recovering delivery failed: %v", err)
+	}
+	if sentRecovery {
+		t.Fatal("expected unsent pending runtime recovering alert to recover silently")
+	}
+	if recovered.Status != "recovered" {
+		t.Fatalf("expected recovered status, got %s", recovered.Status)
+	}
+	if len(messages) != 0 {
+		t.Fatalf("expected no telegram messages for transient runtime recovering flap, got %#v", messages)
+	}
+}
+
 func TestTelegramAlertNeedsFlapSuppressionUsesStableLiveWarningID(t *testing.T) {
 	alert := domain.PlatformAlert{
 		ID:     "live-warning-stale-source-states-account-1",
@@ -268,5 +325,22 @@ func TestTelegramAlertNeedsFlapSuppressionUsesStableLiveWarningID(t *testing.T) 
 	alert.ID = "live-warning-account-1"
 	if telegramAlertNeedsFlapSuppression(alert) {
 		t.Fatal("expected generic live warning id not to enable flap suppression")
+	}
+}
+
+func TestTelegramAlertNeedsFlapSuppressionForTransientRuntimeRecoveryIDs(t *testing.T) {
+	cases := []domain.PlatformAlert{
+		{ID: "runtime-recovering-signal-runtime-1", Scope: "runtime"},
+		{ID: "live-preflight-runtime-error-account-1", Scope: "live"},
+	}
+	for _, alert := range cases {
+		if !telegramAlertNeedsFlapSuppression(alert) {
+			t.Fatalf("expected %s to enable flap suppression", alert.ID)
+		}
+	}
+
+	nonSuppressed := domain.PlatformAlert{ID: "live-preflight-account-1", Scope: "live"}
+	if telegramAlertNeedsFlapSuppression(nonSuppressed) {
+		t.Fatal("expected generic live preflight alert not to enable flap suppression")
 	}
 }

--- a/internal/service/telegram_test.go
+++ b/internal/service/telegram_test.go
@@ -254,6 +254,92 @@ func TestTelegramDispatchSuppressesFlappingRuntimeStaleAlerts(t *testing.T) {
 	}
 }
 
+func TestTelegramFlapSuppressionResetsFirstActiveAtAfterRecoveredDelivery(t *testing.T) {
+	var messages []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var p map[string]any
+		_ = json.Unmarshal(body, &p)
+		messages = append(messages, p["text"].(string))
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"ok":true}`))
+	}))
+	defer server.Close()
+
+	oldURL := telegramBaseURL
+	telegramBaseURL = server.URL
+	defer func() { telegramBaseURL = oldURL }()
+
+	store := memory.NewStore()
+	p := &Platform{
+		store: store,
+		telegramConfig: domain.TelegramConfig{
+			Enabled:    true,
+			BotToken:   "test-token",
+			ChatID:     "123",
+			SendLevels: []string{"warning", "error"},
+		},
+	}
+	oldActiveAt := time.Date(2026, 4, 22, 3, 59, 25, 0, time.UTC)
+	newActiveAt := oldActiveAt.Add(6 * time.Minute)
+	item := domain.PlatformNotification{
+		ID:     "runtime-stale-signal-runtime-1",
+		Status: "active",
+		Alert: domain.PlatformAlert{
+			ID:               "runtime-stale-signal-runtime-1",
+			Scope:            "runtime",
+			Level:            "warning",
+			Title:            "数据源过期",
+			Detail:           "1 个数据源状态已陈旧",
+			RuntimeSessionID: "signal-runtime-1",
+			EventTime:        newActiveAt,
+		},
+		UpdatedAt: newActiveAt,
+	}
+	recoveredDelivery := domain.NotificationDelivery{
+		NotificationID: item.ID,
+		Channel:        "telegram",
+		Status:         "recovered",
+		Metadata: map[string]any{
+			"firstActiveAt": oldActiveAt.Format(time.RFC3339),
+			"title":         "数据源过期",
+		},
+	}
+
+	pending, shouldSend, err := p.advanceTelegramFlapSuppressedActiveDelivery(item, recoveredDelivery, true, newActiveAt)
+	if err != nil {
+		t.Fatalf("reactivate recovered delivery failed: %v", err)
+	}
+	if shouldSend {
+		t.Fatal("expected reactivated recovered delivery to reset grace window")
+	}
+	if pending.Status != "pending" {
+		t.Fatalf("expected pending status, got %s", pending.Status)
+	}
+	if got := stringValue(pending.Metadata["firstActiveAt"]); got != newActiveAt.Format(time.RFC3339) {
+		t.Fatalf("expected firstActiveAt reset to new active time, got %s", got)
+	}
+
+	pending, shouldSend, err = p.advanceTelegramFlapSuppressedActiveDelivery(item, pending, true, newActiveAt.Add(30*time.Second))
+	if err != nil {
+		t.Fatalf("refresh reactivated pending delivery failed: %v", err)
+	}
+	if shouldSend {
+		t.Fatal("expected reactivated alert to remain pending before fresh grace window")
+	}
+	if len(messages) != 0 {
+		t.Fatalf("expected no telegram message before fresh grace window, got %#v", messages)
+	}
+
+	_, shouldSend, err = p.advanceTelegramFlapSuppressedActiveDelivery(item, pending, true, newActiveAt.Add(50*time.Second))
+	if err != nil {
+		t.Fatalf("send reactivated pending delivery failed: %v", err)
+	}
+	if !shouldSend {
+		t.Fatal("expected reactivated alert to send after fresh grace window")
+	}
+}
+
 func TestTelegramDispatchSuppressesTransientRuntimeRecoveringAlert(t *testing.T) {
 	var messages []string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## 目的
这次改动解决生产上短暂 `signal_runtime unexpected EOF` 被立即推送 Telegram 的噪声问题。日志显示 `2026-04-22T03:51:53Z` runtime 进入 recovering 后，`运行时恢复中` 与 `实盘预检受阻/runtime-error` 在一个 dispatcher tick 内发送，并约 15 秒后恢复；不是 Binance REST 429 或 live account sync 风暴复发。

本 PR 将 `runtime-recovering-*` 与 `live-preflight-runtime-error-*` 接入已有 Telegram flap suppression 状态机：首次命中先 pending，超过发送窗口才外发；未发送前恢复则静默 recovered；已发送后的恢复继续走稳定窗口。

同时把 live preflight 的 `runtime-error` 告警 ID 从泛化 `live-preflight-{account}` 收敛为稳定原因 ID `live-preflight-runtime-error-{account}`，避免依赖标题/展示文案匹配。其他 preflight blocked 原因仍保持原 ID 与立即发送路径。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [x] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) - 未变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？- 不涉及
- [x] DB migration 是否具备向下兼容幂等性？- 不涉及
- [x] 配置字段有没有无意被混改？- 未变化

## 行为变化
- `runtime-recovering-*`：短暂 recovering 不再立即发 Telegram；持续超过现有 flap send grace 才发。
- `live-preflight-runtime-error-*`：runtime 短暂 recovering 导致的 preflight block 不再立即发 Telegram；恢复也遵循现有恢复稳定窗口。
- `live-preflight-{account}` 其他 blocked 原因不进入 suppression，仍按原路径外发。
- 不改变 runtime/live 健康判定，不改变交易执行、dispatch、REST reconcile 或 WebSocket 恢复逻辑。

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

已执行：
- `go test ./internal/service -run 'TestTelegram'`\n- `go test ./internal/service/...`\n- `go build ./cmd/platform-api`\n- `go build ./cmd/db-migrate`\n\n生产日志只读核对：这次告警窗口没有 Binance 429；`live-terminal-order-sync` 风暴未复现，只有 `sync-active-live-accounts` 常规周期同步。