### PR TITLE
[codex] align live reentry gating with runtime bars

### DIFF
--- a/internal/service/execution_strategy.go
+++ b/internal/service/execution_strategy.go
@@ -66,6 +66,8 @@ type ExecutionStrategy interface {
 	BuildProposal(ctx ExecutionPlanningContext) (ExecutionProposal, error)
 }
 
+const liveSignalBarTradeLimitKeyField = "signalBarTradeLimitKey"
+
 func normalizeExecutionStrategyKey(raw string) string {
 	value := strings.TrimSpace(strings.ToLower(raw))
 	if value == "" {
@@ -563,6 +565,35 @@ func buildExecutionSignalSignature(intent SignalIntent) string {
 	}, "|")
 }
 
+func resolveSignalBarTradeLimitKey(signalBarState map[string]any, fallbackSymbol, fallbackTimeframe string) string {
+	current := mapValue(signalBarState["current"])
+	if current == nil {
+		return ""
+	}
+	barStart := resolveBreakoutSignalTime(current["barStart"], time.Time{})
+	if barStart.IsZero() {
+		return ""
+	}
+	symbol := NormalizeSymbol(firstNonEmpty(
+		stringValue(signalBarState["symbol"]),
+		stringValue(current["symbol"]),
+		fallbackSymbol,
+	))
+	timeframe := strings.ToLower(strings.TrimSpace(firstNonEmpty(
+		stringValue(signalBarState["timeframe"]),
+		stringValue(current["timeframe"]),
+		fallbackTimeframe,
+	)))
+	return strings.Join([]string{symbol, timeframe, barStart.UTC().Format(time.RFC3339)}, "|")
+}
+
+func effectiveSignalBarTradeLimitKey(metadata map[string]any) string {
+	if key := strings.TrimSpace(stringValue(metadata[liveSignalBarTradeLimitKeyField])); key != "" {
+		return key
+	}
+	return strings.TrimSpace(stringValue(metadata["signalBarStateKey"]))
+}
+
 func mergeExecutionDecisionContext(base map[string]any, extra map[string]any) map[string]any {
 	merged := cloneMetadata(base)
 	for key, value := range extra {
@@ -572,7 +603,7 @@ func mergeExecutionDecisionContext(base map[string]any, extra map[string]any) ma
 }
 
 func effectiveReentryCountForSizing(sessionState map[string]any, intentMetadata map[string]any) float64 {
-	currentBarKey := stringValue(intentMetadata["signalBarStateKey"])
+	currentBarKey := effectiveSignalBarTradeLimitKey(intentMetadata)
 	if currentBarKey != "" && currentBarKey != stringValue(sessionState["lastSignalBarStateKey"]) {
 		return 0
 	}

--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -2845,7 +2845,7 @@ func (p *Platform) evaluateLiveSignalDecision(session domain.LiveSession, summar
 		SourceStates:      cloneMetadata(sourceStates),
 		SignalBarStates:   cloneMetadata(signalBarStates),
 		CurrentPosition:   currentPosition,
-		SessionState:      cloneMetadata(session.State),
+		SessionState:      cloneMetadata(updatedState),
 		EventTime:         eventTime.UTC(),
 		NextPlannedEvent:  nextPlannedEvent.UTC(),
 		NextPlannedPrice:  nextPlannedPrice,
@@ -3968,6 +3968,7 @@ func deriveLiveSignalIntent(decision StrategySignalDecision, symbol string) *Sig
 	signalKind := stringValue(meta["signalKind"])
 	decisionState := stringValue(meta["decisionState"])
 	signalBarStateKey := stringValue(meta["signalBarStateKey"])
+	signalBarTradeLimitKey := stringValue(meta[liveSignalBarTradeLimitKeyField])
 	entryProximityBps := parseFloatValue(meta["entryProximityBps"])
 	spreadBps := parseFloatValue(meta["spreadBps"])
 	ma20 := parseFloatValue(signalBarDecision["ma20"])
@@ -3996,18 +3997,19 @@ func deriveLiveSignalIntent(decision StrategySignalDecision, symbol string) *Sig
 		PriceSource:    marketSource,
 		Quantity:       quantity,
 		Metadata: map[string]any{
-			"signalBarStateKey": signalBarStateKey,
-			"entryProximityBps": entryProximityBps,
-			"spreadBps":         spreadBps,
-			"ma20":              ma20,
-			"atr14":             atr14,
-			"liquidityBias":     liquidityBias,
-			"biasActionable":    biasActionable,
-			"bestBid":           bestBid,
-			"bestAsk":           bestAsk,
-			"bestBidQty":        bestBidQty,
-			"bestAskQty":        bestAskQty,
-			"bookImbalance":     parseFloatValue(meta["bookImbalance"]),
+			"signalBarStateKey":             signalBarStateKey,
+			liveSignalBarTradeLimitKeyField: signalBarTradeLimitKey,
+			"entryProximityBps":             entryProximityBps,
+			"spreadBps":                     spreadBps,
+			"ma20":                          ma20,
+			"atr14":                         atr14,
+			"liquidityBias":                 liquidityBias,
+			"biasActionable":                biasActionable,
+			"bestBid":                       bestBid,
+			"bestAsk":                       bestAsk,
+			"bestBidQty":                    bestBidQty,
+			"bestAskQty":                    bestAskQty,
+			"bookImbalance":                 parseFloatValue(meta["bookImbalance"]),
 		},
 	}
 }

--- a/internal/service/live_execution.go
+++ b/internal/service/live_execution.go
@@ -424,7 +424,7 @@ func validateLiveSignalBarEntryTradeLimit(session domain.LiveSession, proposalMa
 	if maxTradesPerBar <= 0 {
 		return nil
 	}
-	currentBarKey := liveProposalSignalBarStateKey(proposalMap)
+	currentBarKey := liveProposalSignalBarTradeLimitKey(proposalMap)
 	if currentBarKey == "" || currentBarKey != stringValue(session.State["lastSignalBarStateKey"]) {
 		return nil
 	}
@@ -450,6 +450,16 @@ func liveEntryCountsTowardSignalBarLimit(proposalMap map[string]any) bool {
 	default:
 		return false
 	}
+}
+
+func liveProposalSignalBarTradeLimitKey(proposalMap map[string]any) string {
+	if key := strings.TrimSpace(stringValue(proposalMap[liveSignalBarTradeLimitKeyField])); key != "" {
+		return key
+	}
+	if key := effectiveSignalBarTradeLimitKey(mapValue(proposalMap["metadata"])); key != "" {
+		return key
+	}
+	return strings.TrimSpace(stringValue(proposalMap["signalBarStateKey"]))
 }
 
 func liveProposalSignalBarStateKey(proposalMap map[string]any) string {
@@ -1026,7 +1036,7 @@ func maybeIncrementLiveSessionReentryCount(state map[string]any, proposalMap map
 		return
 	}
 
-	currentBarKey := stringValue(proposalMap["signalBarStateKey"])
+	currentBarKey := liveProposalSignalBarTradeLimitKey(proposalMap)
 	lastBarKey := stringValue(state["lastSignalBarStateKey"])
 	reentryCount := parseFloatValue(state["sessionReentryCount"])
 	if currentBarKey != "" && currentBarKey != lastBarKey {

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -145,6 +145,152 @@ func TestEvaluateSignalBarGateUsesSMA5ForIntradayReentry(t *testing.T) {
 	}
 }
 
+func TestEvaluateSignalRequiresZeroInitialWindowToBeOpen(t *testing.T) {
+	engine := bkStrategyEngine{}
+	signalState := map[string]any{
+		"symbol":    "BTCUSDT",
+		"timeframe": "30m",
+		"sma5":      100.0,
+		"current": map[string]any{
+			"barStart": time.Date(2026, 4, 22, 3, 0, 0, 0, time.UTC).Format(time.RFC3339),
+			"close":    98.5,
+			"high":     99.5,
+			"low":      97.8,
+		},
+		"prevBar1": map[string]any{
+			"high": 102.0,
+			"low":  98.0,
+		},
+		"prevBar2": map[string]any{
+			"high": 103.0,
+			"low":  99.0,
+		},
+	}
+	decision, err := engine.EvaluateSignal(StrategySignalEvaluationContext{
+		ExecutionContext: StrategyExecutionContext{
+			Symbol:          "BTCUSDT",
+			SignalTimeframe: "30m",
+			Parameters: map[string]any{
+				"symbol":                     "BTCUSDT",
+				"signalTimeframe":            "30m",
+				"signalDecisionMaxSpreadBps": 8.0,
+			},
+		},
+		TriggerSummary: map[string]any{
+			"role":   "trigger",
+			"symbol": "BTCUSDT",
+			"price":  99.0,
+		},
+		SourceStates: map[string]any{
+			"tick": map[string]any{
+				"streamType": "trade_tick",
+				"symbol":     "BTCUSDT",
+				"summary":    map[string]any{"price": 99.0},
+			},
+		},
+		SignalBarStates: map[string]any{
+			signalBindingMatchKey("binance-kline", "signal", "BTCUSDT", map[string]any{"timeframe": "30m"}): signalState,
+		},
+		CurrentPosition:   map[string]any{},
+		SessionState:      map[string]any{},
+		EventTime:         time.Date(2026, 4, 22, 3, 5, 0, 0, time.UTC),
+		NextPlannedEvent:  time.Date(2026, 4, 22, 3, 0, 0, 0, time.UTC),
+		NextPlannedPrice:  100.0,
+		NextPlannedSide:   "SELL",
+		NextPlannedRole:   "entry",
+		NextPlannedReason: "Zero-Initial-Reentry",
+	})
+	if err != nil {
+		t.Fatalf("evaluate signal failed: %v", err)
+	}
+	if decision.Action != "wait" || decision.Reason != "reentry-window-not-open" {
+		t.Fatalf("expected zero-initial reentry to wait for an opened window, got %+v", decision)
+	}
+	if boolValue(decision.Metadata["reentryWindowOpen"]) {
+		t.Fatalf("expected zero-initial reentry metadata to record closed window, got %+v", decision.Metadata)
+	}
+}
+
+func TestEvaluateSignalRequiresReentryTriggerWithinOpenWindow(t *testing.T) {
+	engine := bkStrategyEngine{}
+	barStart := time.Date(2026, 4, 22, 3, 0, 0, 0, time.UTC)
+	signalState := map[string]any{
+		"symbol":    "BTCUSDT",
+		"timeframe": "30m",
+		"sma5":      100.0,
+		"current": map[string]any{
+			"barStart": barStart.Format(time.RFC3339),
+			"close":    99.3,
+			"high":     100.2,
+			"low":      98.8,
+		},
+		"prevBar1": map[string]any{
+			"high": 102.0,
+			"low":  98.0,
+		},
+		"prevBar2": map[string]any{
+			"high": 103.0,
+			"low":  99.0,
+		},
+	}
+	sessionState := map[string]any{
+		livePendingZeroInitialWindowStateKey: map[string]any{
+			"side":            "SELL",
+			"symbol":          "BTCUSDT",
+			"signalTimeframe": "30m",
+			"armedAt":         barStart.Add(-5 * time.Minute).Format(time.RFC3339),
+			"signalBarStart":  barStart.Format(time.RFC3339),
+			"expiresAt":       barStart.Add(30 * time.Minute).Format(time.RFC3339),
+		},
+	}
+	decision, err := engine.EvaluateSignal(StrategySignalEvaluationContext{
+		ExecutionContext: StrategyExecutionContext{
+			Symbol:          "BTCUSDT",
+			SignalTimeframe: "30m",
+			Parameters: map[string]any{
+				"symbol":                     "BTCUSDT",
+				"signalTimeframe":            "30m",
+				"signalDecisionMaxSpreadBps": 8.0,
+			},
+		},
+		TriggerSummary: map[string]any{
+			"role":   "trigger",
+			"symbol": "BTCUSDT",
+			"price":  100.6,
+		},
+		SourceStates: map[string]any{
+			"tick": map[string]any{
+				"streamType": "trade_tick",
+				"symbol":     "BTCUSDT",
+				"summary":    map[string]any{"price": 100.6},
+			},
+		},
+		SignalBarStates: map[string]any{
+			signalBindingMatchKey("binance-kline", "signal", "BTCUSDT", map[string]any{"timeframe": "30m"}): signalState,
+		},
+		CurrentPosition:   map[string]any{},
+		SessionState:      sessionState,
+		EventTime:         barStart.Add(5 * time.Minute),
+		NextPlannedEvent:  barStart,
+		NextPlannedPrice:  100.0,
+		NextPlannedSide:   "SELL",
+		NextPlannedRole:   "entry",
+		NextPlannedReason: "Zero-Initial-Reentry",
+	})
+	if err != nil {
+		t.Fatalf("evaluate signal failed: %v", err)
+	}
+	if decision.Action != "wait" || decision.Reason != "reentry-trigger-not-reached" {
+		t.Fatalf("expected zero-initial reentry to wait until reentry trigger crosses planned price, got %+v", decision)
+	}
+	if !boolValue(decision.Metadata["reentryWindowOpen"]) {
+		t.Fatalf("expected pending window to be recognized as open, got %+v", decision.Metadata)
+	}
+	if boolValue(decision.Metadata["reentryTriggerReady"]) {
+		t.Fatalf("expected reentry trigger to stay false before price crosses planned level, got %+v", decision.Metadata)
+	}
+}
+
 func TestEvaluateSignalBarGateTracksCurrentPriceBreakoutPattern(t *testing.T) {
 	gate := evaluateSignalBarGate(map[string]any{
 		"ma20":  68000.0,
@@ -2311,6 +2457,27 @@ func TestMaybeIncrementLiveSessionReentryCountCountsZeroInitialWindowEntry(t *te
 	}
 }
 
+func TestMaybeIncrementLiveSessionReentryCountUsesPerBarIdentity(t *testing.T) {
+	state := map[string]any{
+		"lastSignalBarStateKey": "BTCUSDT|30m|2026-04-22T03:00:00Z",
+		"sessionReentryCount":   2.0,
+	}
+	proposal := map[string]any{
+		"reason":            "Zero-Initial-Reentry",
+		"signalBarStateKey": "binance-kline|signal|BTCUSDT|30m",
+		"metadata": map[string]any{
+			liveSignalBarTradeLimitKeyField: "BTCUSDT|30m|2026-04-22T03:30:00Z",
+		},
+	}
+	maybeIncrementLiveSessionReentryCount(state, proposal, "order-2", "FILLED")
+	if got := parseFloatValue(state["sessionReentryCount"]); got != 1 {
+		t.Fatalf("expected new per-bar identity to reset reentry count before increment, got %v", got)
+	}
+	if got := stringValue(state["lastSignalBarStateKey"]); got != "BTCUSDT|30m|2026-04-22T03:30:00Z" {
+		t.Fatalf("expected last signal bar key to track per-bar identity, got %s", got)
+	}
+}
+
 func TestShouldAutoDispatchLiveIntentBlocksEntryAfterMaxTradesPerSignalBar(t *testing.T) {
 	intent := map[string]any{
 		"action":            "entry",
@@ -2352,6 +2519,28 @@ func TestValidateLiveSignalBarEntryTradeLimitAllowsNewBar(t *testing.T) {
 	}
 	if err := validateLiveSignalBarEntryTradeLimit(session, proposal); err != nil {
 		t.Fatalf("expected a new signal bar to reset the entry limit, got %v", err)
+	}
+}
+
+func TestValidateLiveSignalBarEntryTradeLimitUsesPerBarIdentity(t *testing.T) {
+	session := domain.LiveSession{
+		ID: "live-session-1",
+		State: map[string]any{
+			"max_trades_per_bar":    2,
+			"lastSignalBarStateKey": "BTCUSDT|30m|2026-04-22T03:00:00Z",
+			"sessionReentryCount":   2.0,
+		},
+	}
+	proposal := map[string]any{
+		"role":              "entry",
+		"reason":            "Zero-Initial-Reentry",
+		"signalBarStateKey": "binance-kline|signal|BTCUSDT|30m",
+		"metadata": map[string]any{
+			liveSignalBarTradeLimitKeyField: "BTCUSDT|30m|2026-04-22T03:30:00Z",
+		},
+	}
+	if err := validateLiveSignalBarEntryTradeLimit(session, proposal); err != nil {
+		t.Fatalf("expected a new per-bar identity to reset the entry limit, got %v", err)
 	}
 }
 

--- a/internal/service/live_zero_initial.go
+++ b/internal/service/live_zero_initial.go
@@ -76,14 +76,14 @@ func prepareLivePlanStepForSignalEvaluation(
 		alignmentMode = "breakout-confirmed"
 	}
 	if staleExitReentry && longReady == shortReady {
-		// Stale PT/SL re-entry steps should first prefer a breakout-confirmed
-		// current direction, but may fall back to zero-initial reentry semantics
-		// when intraday structure is ready before a fresh breakout prints.
-		gate = evaluateSignalBarGate(signalBarState, "", "entry", "Zero-Initial-Reentry", breakoutPrice, breakoutPriceSource)
-		longReady = boolValue(gate["longReady"])
-		shortReady = boolValue(gate["shortReady"])
-		if longReady != shortReady {
-			alignmentMode = "structure-ready-no-breakout"
+		if alignedEvent, alignedPrice, alignedSide, ok := liveBootstrapPlanStepFromSignalBar(
+			signalBarState,
+			eventTime,
+			nextPlannedPrice,
+			boolValue(gate["longStructureReady"]),
+			boolValue(gate["shortStructureReady"]),
+		); ok {
+			return updatedState, alignedEvent, alignedPrice, alignedSide, "entry", "Initial"
 		}
 	}
 	if longReady == shortReady {
@@ -213,6 +213,55 @@ func clearLivePendingZeroInitialWindow(state map[string]any, eventTime time.Time
 		livePendingZeroInitialWindowStateKey: pending,
 		"reason":                             firstNonEmpty(strings.TrimSpace(reason), "consumed"),
 	})
+}
+
+func livePendingZeroInitialWindowOpen(sessionState map[string]any, symbol, signalTimeframe, side string, eventTime time.Time) bool {
+	pending := cloneMetadata(mapValue(sessionState[livePendingZeroInitialWindowStateKey]))
+	if len(pending) == 0 {
+		return false
+	}
+	if pendingSide := strings.ToUpper(strings.TrimSpace(stringValue(pending["side"]))); pendingSide != "" &&
+		pendingSide != strings.ToUpper(strings.TrimSpace(side)) {
+		return false
+	}
+	if pendingSymbol := NormalizeSymbol(stringValue(pending["symbol"])); pendingSymbol != "" &&
+		pendingSymbol != NormalizeSymbol(symbol) {
+		return false
+	}
+	if pendingTimeframe := strings.ToLower(strings.TrimSpace(stringValue(pending["signalTimeframe"]))); pendingTimeframe != "" &&
+		pendingTimeframe != strings.ToLower(strings.TrimSpace(signalTimeframe)) {
+		return false
+	}
+	expiresAt := parseOptionalRFC3339(stringValue(pending["expiresAt"]))
+	if !expiresAt.IsZero() && !eventTime.UTC().Before(expiresAt.UTC()) {
+		return false
+	}
+	return true
+}
+
+func liveBootstrapPlanStepFromSignalBar(
+	signalBarState map[string]any,
+	eventTime time.Time,
+	fallbackPrice float64,
+	longStructureReady, shortStructureReady bool,
+) (time.Time, float64, string, bool) {
+	if longStructureReady == shortStructureReady {
+		return time.Time{}, 0, "", false
+	}
+	current := mapValue(signalBarState["current"])
+	plannedEvent := parseOptionalRFC3339(stringValue(current["barStart"]))
+	if plannedEvent.IsZero() {
+		plannedEvent = eventTime.UTC()
+	}
+	price := parseFloatValue(current["close"])
+	if price <= 0 {
+		price = fallbackPrice
+	}
+	side := "BUY"
+	if shortStructureReady {
+		side = "SELL"
+	}
+	return plannedEvent.UTC(), price, side, true
 }
 
 func liveStaleExitReentryContext(

--- a/internal/service/live_zero_initial_test.go
+++ b/internal/service/live_zero_initial_test.go
@@ -123,30 +123,20 @@ func TestPrepareLivePlanStepForSignalEvaluationUsesZeroInitialSemanticsForStaleI
 		"entry",
 		"SL-Reentry",
 	)
-	if gotRole != "entry" || gotReason != "Zero-Initial-Reentry" || gotSide != "BUY" {
-		t.Fatalf("expected stale intraday SL-Reentry to fall back to zero-initial semantics, got side=%s role=%s reason=%s", gotSide, gotRole, gotReason)
+	if gotRole != "entry" || gotReason != "Initial" || gotSide != "BUY" {
+		t.Fatalf("expected stale intraday SL-Reentry without breakout to reset to initial watch, got side=%s role=%s reason=%s", gotSide, gotRole, gotReason)
 	}
-	if gotPrice != 97.0 {
-		t.Fatalf("expected stale intraday fallback price 97.0, got %.2f", gotPrice)
+	if gotPrice != 108.0 {
+		t.Fatalf("expected stale intraday bootstrap price 108.0, got %.2f", gotPrice)
 	}
 	if gotEvent != barStart {
 		t.Fatalf("expected stale intraday fallback planned event %s, got %s", barStart.Format(time.RFC3339), gotEvent.Format(time.RFC3339))
 	}
-	if pending := mapValue(state[livePendingZeroInitialWindowStateKey]); stringValue(pending["side"]) != "BUY" {
-		t.Fatalf("expected pending BUY window after stale intraday fallback, got %+v", pending)
+	if pending := mapValue(state[livePendingZeroInitialWindowStateKey]); len(pending) != 0 {
+		t.Fatalf("expected stale intraday fallback to avoid arming zero-initial window without breakout, got %+v", pending)
 	}
 	timeline := metadataList(state["timeline"])
-	if len(timeline) != 1 || stringValue(timeline[0]["title"]) != "zero-initial-window-armed" {
-		t.Fatalf("expected one zero-initial-window-armed event, got %+v", timeline)
-	}
-	context := mapValue(mapValue(timeline[0]["metadata"])["staleExitReentryContext"])
-	if stringValue(context["alignmentMode"]) != "structure-ready-no-breakout" {
-		t.Fatalf("expected structure-ready-no-breakout stale exit reentry context, got %+v", context)
-	}
-	if stringValue(context["plannedReason"]) != "SL-Reentry" || stringValue(context["plannedSide"]) != "SELL" {
-		t.Fatalf("expected stale intraday context to retain original plan info, got %+v", context)
-	}
-	if parseFloatValue(context["currentCloseDeviationBps"]) <= 0 || parseFloatValue(context["breakoutDeviationBps"]) <= 0 {
-		t.Fatalf("expected stale intraday context to record current-vs-planned deviations, got %+v", context)
+	if len(timeline) != 0 {
+		t.Fatalf("expected no zero-initial timeline event without breakout-backed window, got %+v", timeline)
 	}
 }

--- a/internal/service/signal_runtime_ws.go
+++ b/internal/service/signal_runtime_ws.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -801,21 +802,8 @@ func mergeSignalSourceState(existing any, summary map[string]any, eventTime time
 }
 
 func mergeSignalBarHistory(existing any, summary map[string]any, eventTime time.Time, limit int) []any {
-	items := make([]map[string]any, 0)
-	switch current := existing.(type) {
-	case []any:
-		for _, item := range current {
-			if entry := mapValue(item); entry != nil {
-				items = append(items, cloneMetadata(entry))
-			}
-		}
-	case []map[string]any:
-		for _, item := range current {
-			items = append(items, cloneMetadata(item))
-		}
-	}
-
-	bar := map[string]any{
+	items := normalizeSignalBarEntries(existing)
+	bar := normalizeSignalBarEntry(map[string]any{
 		"timeframe": signalBindingTimeframe(stringValue(summary["sourceKey"]), map[string]any{
 			"timeframe": stringValue(summary["timeframe"]),
 		}),
@@ -829,13 +817,12 @@ func mergeSignalBarHistory(existing any, summary map[string]any, eventTime time.
 		"volume":    stringValue(summary["volume"]),
 		"isClosed":  summary["isClosed"],
 		"updatedAt": eventTime.UTC().Format(time.RFC3339),
-	}
+	})
 
 	matchIndex := -1
-	barStart := stringValue(bar["barStart"])
-	timeframe := stringValue(bar["timeframe"])
+	barKey := signalBarHistoryKey(bar)
 	for i, item := range items {
-		if stringValue(item["barStart"]) == barStart && stringValue(item["timeframe"]) == timeframe {
+		if signalBarHistoryKey(item) == barKey && barKey != "" {
 			matchIndex = i
 			break
 		}
@@ -939,18 +926,65 @@ func finiteSignalBarIndicator(value float64) *float64 {
 	return &value
 }
 
+func canonicalSignalBarTimestamp(raw any) string {
+	if numeric, ok := toFloat64(raw); ok && numeric > 0 {
+		return strconv.FormatInt(int64(numeric), 10)
+	}
+	return strings.TrimSpace(stringValue(raw))
+}
+
+func normalizeSignalBarEntry(entry map[string]any) map[string]any {
+	if entry == nil {
+		return nil
+	}
+	normalized := cloneMetadata(entry)
+	normalized["symbol"] = NormalizeSymbol(stringValue(normalized["symbol"]))
+	normalized["timeframe"] = strings.ToLower(strings.TrimSpace(stringValue(normalized["timeframe"])))
+	normalized["barStart"] = canonicalSignalBarTimestamp(normalized["barStart"])
+	normalized["barEnd"] = canonicalSignalBarTimestamp(normalized["barEnd"])
+	return normalized
+}
+
+func signalBarHistoryKey(entry map[string]any) string {
+	barStart := canonicalSignalBarTimestamp(entry["barStart"])
+	timeframe := strings.ToLower(strings.TrimSpace(stringValue(entry["timeframe"])))
+	if barStart == "" || timeframe == "" {
+		return ""
+	}
+	return strings.Join([]string{
+		NormalizeSymbol(stringValue(entry["symbol"])),
+		timeframe,
+		barStart,
+	}, "|")
+}
+
 func normalizeSignalBarEntries(value any) []map[string]any {
 	out := make([]map[string]any, 0)
+	indexByKey := make(map[string]int)
+	appendEntry := func(entry map[string]any) {
+		normalized := normalizeSignalBarEntry(entry)
+		if normalized == nil {
+			return
+		}
+		if key := signalBarHistoryKey(normalized); key != "" {
+			if idx, exists := indexByKey[key]; exists {
+				out[idx] = normalized
+				return
+			}
+			indexByKey[key] = len(out)
+		}
+		out = append(out, normalized)
+	}
 	switch items := value.(type) {
 	case []any:
 		for _, item := range items {
 			if entry := mapValue(item); entry != nil {
-				out = append(out, cloneMetadata(entry))
+				appendEntry(entry)
 			}
 		}
 	case []map[string]any:
 		for _, item := range items {
-			out = append(out, cloneMetadata(item))
+			appendEntry(item)
 		}
 	}
 	return out
@@ -1018,8 +1052,8 @@ func summarizeSignalMessage(adapterKey string, payload []byte) map[string]any {
 			summary["event"] = "kline"
 			summary["symbol"] = firstNonEmpty(stringValue(kline["s"]), stringValue(body["s"]))
 			summary["timeframe"] = strings.ToLower(strings.TrimSpace(stringValue(kline["i"])))
-			summary["barStart"] = stringValue(kline["t"])
-			summary["barEnd"] = stringValue(kline["T"])
+			summary["barStart"] = canonicalSignalBarTimestamp(kline["t"])
+			summary["barEnd"] = canonicalSignalBarTimestamp(kline["T"])
 			summary["open"] = stringValue(kline["o"])
 			summary["high"] = stringValue(kline["h"])
 			summary["low"] = stringValue(kline["l"])

--- a/internal/service/signal_runtime_ws_test.go
+++ b/internal/service/signal_runtime_ws_test.go
@@ -291,6 +291,52 @@ func TestMergeSignalSourceStatePreservesSignalBarHistory(t *testing.T) {
 	}
 }
 
+func TestMergeSignalSourceStateCanonicalizesScientificBarTimestamps(t *testing.T) {
+	sourceStates := map[string]any{}
+	first := map[string]any{
+		"sourceKey":          "binance-kline",
+		"role":               "signal",
+		"streamType":         "signal_bar",
+		"symbol":             "BTCUSDT",
+		"subscriptionSymbol": "BTCUSDT",
+		"timeframe":          "30m",
+		"barStart":           "1776826800000",
+		"barEnd":             "1776828600000",
+		"open":               "77300",
+		"high":               "77400",
+		"low":                "77200",
+		"close":              "77350",
+		"volume":             "100",
+		"isClosed":           true,
+	}
+	second := cloneMetadata(first)
+	second["close"] = "77380"
+	second["barStart"] = "1.7768268e+12"
+	second["barEnd"] = "1.7768286e+12"
+
+	sourceStates = mergeSignalSourceState(sourceStates, first, time.Date(2026, 4, 22, 3, 0, 0, 0, time.UTC))
+	sourceStates = mergeSignalSourceState(sourceStates, second, time.Date(2026, 4, 22, 3, 0, 5, 0, time.UTC))
+
+	key := signalBindingMatchKey("binance-kline", "signal", "BTCUSDT", map[string]any{"timeframe": "30m"})
+	entry := mapValue(sourceStates[key])
+	if entry == nil {
+		t.Fatalf("expected source state entry, got %#v", sourceStates)
+	}
+	bars := normalizeSignalBarEntries(entry["bars"])
+	if len(bars) != 1 {
+		t.Fatalf("expected canonicalized duplicate bar to collapse into one entry, got %#v", bars)
+	}
+	if got := stringValue(bars[0]["barStart"]); got != "1776826800000" {
+		t.Fatalf("expected canonical barStart 1776826800000, got %#v", bars[0])
+	}
+	if got := stringValue(bars[0]["barEnd"]); got != "1776828600000" {
+		t.Fatalf("expected canonical barEnd 1776828600000, got %#v", bars[0])
+	}
+	if got := stringValue(bars[0]["close"]); got != "77380" {
+		t.Fatalf("expected later duplicate bar to win after normalization, got %#v", bars[0])
+	}
+}
+
 func TestDeriveSignalBarStatesUsesOpenCurrentBarWithClosedHistory(t *testing.T) {
 	key := signalBindingMatchKey("binance-kline", "signal", "BTCUSDT", map[string]any{"timeframe": "5m"})
 	base := time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC)
@@ -356,6 +402,67 @@ func TestDeriveSignalBarStatesUsesOpenCurrentBarWithClosedHistory(t *testing.T) 
 	}
 	if boolValue(gate["longBreakoutShapeReady"]) {
 		t.Fatalf("expected breakout shape to remain false for this monotonic sample, got %#v", gate)
+	}
+}
+
+func TestDeriveSignalBarStatesDedupesCanonicalBarHistory(t *testing.T) {
+	key := signalBindingMatchKey("binance-kline", "signal", "BTCUSDT", map[string]any{"timeframe": "30m"})
+	states := deriveSignalBarStates(map[string]any{
+		key: map[string]any{
+			"sourceKey":  "binance-kline",
+			"role":       "signal",
+			"streamType": "signal_bar",
+			"symbol":     "BTCUSDT",
+			"timeframe":  "30m",
+			"bars": []any{
+				map[string]any{
+					"symbol":    "BTCUSDT",
+					"timeframe": "30m",
+					"barStart":  "1776825000000",
+					"close":     77250.0,
+					"high":      77320.0,
+					"low":       77180.0,
+					"isClosed":  true,
+				},
+				map[string]any{
+					"symbol":    "BTCUSDT",
+					"timeframe": "30m",
+					"barStart":  "1776826800000",
+					"close":     77350.0,
+					"high":      77420.0,
+					"low":       77290.0,
+					"isClosed":  true,
+				},
+				map[string]any{
+					"symbol":    "BTCUSDT",
+					"timeframe": "30m",
+					"barStart":  "1.7768268e+12",
+					"close":     77360.0,
+					"high":      77430.0,
+					"low":       77295.0,
+					"isClosed":  true,
+				},
+				map[string]any{
+					"symbol":    "BTCUSDT",
+					"timeframe": "30m",
+					"barStart":  "1776828600000",
+					"close":     77410.0,
+					"high":      77480.0,
+					"low":       77340.0,
+					"isClosed":  false,
+				},
+			},
+		},
+	})
+	state := mapValue(states[key])
+	if state == nil {
+		t.Fatalf("expected signal bar state, got %#v", states)
+	}
+	if got := stringValue(mapValue(state["prevBar1"])["barStart"]); got != "1776826800000" {
+		t.Fatalf("expected prevBar1 to use the deduped latest closed bar, got %#v", state["prevBar1"])
+	}
+	if got := stringValue(mapValue(state["prevBar2"])["barStart"]); got != "1776825000000" {
+		t.Fatalf("expected prevBar2 to use the prior distinct closed bar, got %#v", state["prevBar2"])
 	}
 }
 

--- a/internal/service/strategy_optimization_test.go
+++ b/internal/service/strategy_optimization_test.go
@@ -128,6 +128,25 @@ func TestEffectiveReentryCountForSizingResetsOnNewSignalBar(t *testing.T) {
 	}
 }
 
+func TestEffectiveReentryCountForSizingUsesPerBarIdentity(t *testing.T) {
+	sessionState := map[string]any{
+		"sessionReentryCount":   2.0,
+		"lastSignalBarStateKey": "BTCUSDT|30m|2026-04-22T03:00:00Z",
+	}
+	if got := effectiveReentryCountForSizing(sessionState, map[string]any{
+		"signalBarStateKey":             "binance-kline|signal|BTCUSDT|30m",
+		liveSignalBarTradeLimitKeyField: "BTCUSDT|30m|2026-04-22T03:30:00Z",
+	}); got != 0 {
+		t.Fatalf("expected new per-bar identity to reset effective reentry count, got %v", got)
+	}
+	if got := effectiveReentryCountForSizing(sessionState, map[string]any{
+		"signalBarStateKey":             "binance-kline|signal|BTCUSDT|30m",
+		liveSignalBarTradeLimitKeyField: "BTCUSDT|30m|2026-04-22T03:00:00Z",
+	}); got != 2 {
+		t.Fatalf("expected matching per-bar identity to keep reentry count, got %v", got)
+	}
+}
+
 func TestResolveExecutionQuantityVolatilityAdjustedUsesStopDistance(t *testing.T) {
 	quantity, metadata := resolveExecutionQuantity(
 		domain.LiveSession{

--- a/internal/service/strategy_registry.go
+++ b/internal/service/strategy_registry.go
@@ -234,6 +234,7 @@ func (e bkStrategyEngine) EvaluateSignal(context StrategySignalEvaluationContext
 	maxDeviationBps := firstPositive(parseFloatValue(context.ExecutionContext.Parameters["signalDecisionMaxDeviationBps"]), 50)
 	maxSpreadBps := firstPositive(parseFloatValue(context.ExecutionContext.Parameters["signalDecisionMaxSpreadBps"]), 8)
 	effectivePlannedPrice := context.NextPlannedPrice
+	reasonTag := normalizeStrategyReasonTag(context.NextPlannedReason)
 	livePositionState := map[string]any{}
 	if signalBarState != nil {
 		watermarks := refreshLivePositionWatermarks(context.SessionState, currentPosition, marketPrice)
@@ -255,6 +256,37 @@ func (e bkStrategyEngine) EvaluateSignal(context StrategySignalEvaluationContext
 				action = "wait"
 				reason = firstNonEmpty(stringValue(livePositionState["waitReason"]), "exit-signal-not-ready")
 			}
+		}
+	}
+	reentryWindowOpen := true
+	if action == "advance-plan" &&
+		strings.EqualFold(strings.TrimSpace(context.NextPlannedRole), "entry") &&
+		reasonTag == "zero-initial-reentry" {
+		reentryWindowOpen = livePendingZeroInitialWindowOpen(
+			context.SessionState,
+			symbol,
+			context.ExecutionContext.SignalTimeframe,
+			context.NextPlannedSide,
+			context.EventTime,
+		)
+		if !reentryWindowOpen {
+			action = "wait"
+			reason = "reentry-window-not-open"
+		}
+	}
+	reentryTriggerPrice := firstPositive(breakoutPrice, marketPrice)
+	reentryTriggerPriceSource := breakoutPriceSource
+	if reentryTriggerPriceSource == "" && reentryTriggerPrice > 0 {
+		reentryTriggerPriceSource = marketSource
+	}
+	reentryTriggerReady := true
+	if action == "advance-plan" &&
+		strings.EqualFold(strings.TrimSpace(context.NextPlannedRole), "entry") &&
+		(reasonTag == "zero-initial-reentry" || reasonTag == "sl-reentry" || reasonTag == "pt-reentry") {
+		reentryTriggerReady = isReentryTriggerReached(context.NextPlannedSide, effectivePlannedPrice, reentryTriggerPrice)
+		if !reentryTriggerReady {
+			action = "wait"
+			reason = "reentry-trigger-not-reached"
 		}
 	}
 	deviationBps := 0.0
@@ -280,46 +312,52 @@ func (e bkStrategyEngine) EvaluateSignal(context StrategySignalEvaluationContext
 	entryProximityBps := computePriceProximityBps(effectivePlannedPrice, marketPrice)
 	exitProximityBps := entryProximityBps
 	signalKind := classifyStrategySignalKind(action, reason, context.NextPlannedRole, context.NextPlannedReason, currentPosition, positionPnLBps, entryProximityBps, exitProximityBps, orderBookStats.bias)
+	signalBarTradeLimitKey := resolveSignalBarTradeLimitKey(signalBarState, symbol, context.ExecutionContext.SignalTimeframe)
 	return StrategySignalDecision{
 		Action: action,
 		Reason: reason,
 		Metadata: map[string]any{
-			"decisionState":       decisionState,
-			"signalKind":          signalKind,
-			"trigger":             trigger,
-			"sourceStateCount":    len(sourceStates),
-			"signalBarStateCount": len(signalBarStates),
-			"currentPosition":     currentPosition,
-			"symbol":              symbol,
-			"triggerSymbol":       triggerSymbol,
-			"signalBarStateKey":   signalBarStateKey,
-			"signalBarState":      cloneMetadata(signalBarState),
-			"signalBarDecision":   signalBarDecision,
-			"livePositionState":   cloneMetadata(livePositionState),
-			"nextPlannedEvent":    formatOptionalRFC3339(context.NextPlannedEvent),
-			"nextPlannedPrice":    effectivePlannedPrice,
-			"nextPlannedSide":     context.NextPlannedSide,
-			"nextPlannedRole":     context.NextPlannedRole,
-			"nextPlannedReason":   context.NextPlannedReason,
-			"breakoutPrice":       breakoutPrice,
-			"breakoutPriceSource": breakoutPriceSource,
-			"marketPrice":         marketPrice,
-			"marketSource":        marketSource,
-			"bestBid":             orderBookStats.bestBid,
-			"bestAsk":             orderBookStats.bestAsk,
-			"bestBidQty":          orderBookStats.bestBidQty,
-			"bestAskQty":          orderBookStats.bestAskQty,
-			"spreadBps":           orderBookStats.spreadBps,
-			"bookImbalance":       orderBookStats.imbalance,
-			"liquidityBias":       orderBookStats.bias,
-			"biasActionable":      biasActionable,
-			"positionPnLBps":      positionPnLBps,
-			"entryProximityBps":   entryProximityBps,
-			"exitProximityBps":    exitProximityBps,
-			"maxDeviationBps":     maxDeviationBps,
-			"maxSpreadBps":        maxSpreadBps,
-			"deviationBps":        deviationBps,
-			"priceActionable":     strings.EqualFold(strings.TrimSpace(context.NextPlannedRole), "exit") || isPlannedPriceActionable(context.NextPlannedSide, effectivePlannedPrice, marketPrice, maxDeviationBps),
+			"decisionState":                 decisionState,
+			"signalKind":                    signalKind,
+			"trigger":                       trigger,
+			"sourceStateCount":              len(sourceStates),
+			"signalBarStateCount":           len(signalBarStates),
+			"currentPosition":               currentPosition,
+			"symbol":                        symbol,
+			"triggerSymbol":                 triggerSymbol,
+			"signalBarStateKey":             signalBarStateKey,
+			liveSignalBarTradeLimitKeyField: signalBarTradeLimitKey,
+			"signalBarState":                cloneMetadata(signalBarState),
+			"signalBarDecision":             signalBarDecision,
+			"livePositionState":             cloneMetadata(livePositionState),
+			"nextPlannedEvent":              formatOptionalRFC3339(context.NextPlannedEvent),
+			"nextPlannedPrice":              effectivePlannedPrice,
+			"nextPlannedSide":               context.NextPlannedSide,
+			"nextPlannedRole":               context.NextPlannedRole,
+			"nextPlannedReason":             context.NextPlannedReason,
+			"breakoutPrice":                 breakoutPrice,
+			"breakoutPriceSource":           breakoutPriceSource,
+			"marketPrice":                   marketPrice,
+			"marketSource":                  marketSource,
+			"reentryWindowOpen":             reentryWindowOpen,
+			"reentryTriggerPrice":           reentryTriggerPrice,
+			"reentryTriggerPriceSource":     reentryTriggerPriceSource,
+			"reentryTriggerReady":           reentryTriggerReady,
+			"bestBid":                       orderBookStats.bestBid,
+			"bestAsk":                       orderBookStats.bestAsk,
+			"bestBidQty":                    orderBookStats.bestBidQty,
+			"bestAskQty":                    orderBookStats.bestAskQty,
+			"spreadBps":                     orderBookStats.spreadBps,
+			"bookImbalance":                 orderBookStats.imbalance,
+			"liquidityBias":                 orderBookStats.bias,
+			"biasActionable":                biasActionable,
+			"positionPnLBps":                positionPnLBps,
+			"entryProximityBps":             entryProximityBps,
+			"exitProximityBps":              exitProximityBps,
+			"maxDeviationBps":               maxDeviationBps,
+			"maxSpreadBps":                  maxSpreadBps,
+			"deviationBps":                  deviationBps,
+			"priceActionable":               strings.EqualFold(strings.TrimSpace(context.NextPlannedRole), "exit") || isPlannedPriceActionable(context.NextPlannedSide, effectivePlannedPrice, marketPrice, maxDeviationBps),
 		},
 	}, nil
 }
@@ -453,6 +491,20 @@ func isPlannedPriceActionable(side string, plannedPrice, marketPrice, maxDeviati
 	}
 }
 
+func isReentryTriggerReached(side string, plannedPrice, triggerPrice float64) bool {
+	if plannedPrice <= 0 || triggerPrice <= 0 {
+		return false
+	}
+	switch strings.ToUpper(strings.TrimSpace(side)) {
+	case "BUY":
+		return triggerPrice >= plannedPrice
+	case "SELL", "SHORT":
+		return triggerPrice <= plannedPrice
+	default:
+		return false
+	}
+}
+
 func classifyStrategyDecisionState(action, reason, nextRole string) string {
 	if action == "advance-plan" {
 		switch strings.ToLower(strings.TrimSpace(nextRole)) {
@@ -475,7 +527,11 @@ func classifyStrategyDecisionState(action, reason, nextRole string) string {
 		return "waiting-time"
 	case "signal-filter-not-ready":
 		return "waiting-signal-filter"
+	case "reentry-window-not-open":
+		return "waiting-signal-filter"
 	case "price-not-actionable":
+		return "waiting-price"
+	case "reentry-trigger-not-reached":
 		return "waiting-price"
 	case "spread-too-wide":
 		return "waiting-liquidity"


### PR DESCRIPTION
## 目的
修复三类互相关联的 live/runtime 行为偏差：

1. `max_trades_per_bar` 之前按静态 `signalBarStateKey` 计数，导致新 bar 也会被误判成同一根 bar，出现 `advance-plan` 但 auto-dispatch 被静默拦住。
2. signal runtime 的 kline `barStart/barEnd` 既可能来自 bootstrap 的十进制毫秒字符串，也可能来自 WS 的科学计数法字符串，导致同一根 bar 无法去重，`prevBar1/prevBar2` 会重复。
3. live `zero-initial/sl-reentry/pt-reentry` 已经漂移出 research baseline：没有 breakout-backed window、甚至没有 reentry trigger 命中，也可能仅凭 `structure ready` 就进入 `entry-ready/advance-plan`。

这次改动把 live 行为重新收回到 research baseline：窗口必须先由 breakout 形态打开，reentry 必须等价格真正打到计划位后才允许推进。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [x] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main)
  未变化。
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？
  不存在。
- [x] DB migration 是否具备向下兼容幂等性？
  无 migration 变更。
- [x] 配置字段有没有无意被混改？
  无新增配置字段，只补了现有 runtime/decision metadata。

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

已执行：
- `gofmt -w internal/service/signal_runtime_ws.go internal/service/live_zero_initial.go internal/service/strategy_registry.go internal/service/live.go internal/service/signal_runtime_ws_test.go internal/service/live_zero_initial_test.go internal/service/live_test.go`
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`

新增/更新的回归覆盖：
- scientific-notation kline timestamp 会被归一化并正确去重，`prevBar1/prevBar2` 不再重复。
- `max_trades_per_bar` 改为按真实 per-bar identity 计数，新 bar 不再被上一根 bar 的 reentry 次数误拦。
- `zero-initial` 没有 breakout-backed window 时不会进入 `entry-ready`。
- 窗口已开但 reentry 价格未命中时，仍然保持 `wait`。
- stale `SL/PT-Reentry` 在没有 fresh breakout 的情况下，不会再偷偷 arm `zero-initial` window，而是回退到当前 bar 的 `Initial` watch。