### PR TITLE
[codex] require breakout proof for live zero-initial windows

### DIFF
--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -241,6 +241,8 @@ func TestEvaluateSignalRequiresReentryTriggerWithinOpenWindow(t *testing.T) {
 			"armedAt":         barStart.Add(-5 * time.Minute).Format(time.RFC3339),
 			"signalBarStart":  barStart.Format(time.RFC3339),
 			"expiresAt":       barStart.Add(30 * time.Minute).Format(time.RFC3339),
+			"breakoutBacked":  true,
+			"openReason":      liveZeroInitialWindowOpenReasonBreakoutLocked,
 		},
 	}
 	decision, err := engine.EvaluateSignal(StrategySignalEvaluationContext{
@@ -288,6 +290,84 @@ func TestEvaluateSignalRequiresReentryTriggerWithinOpenWindow(t *testing.T) {
 	}
 	if boolValue(decision.Metadata["reentryTriggerReady"]) {
 		t.Fatalf("expected reentry trigger to stay false before price crosses planned level, got %+v", decision.Metadata)
+	}
+}
+
+func TestEvaluateSignalRejectsZeroInitialWindowWithoutBreakoutProof(t *testing.T) {
+	engine := bkStrategyEngine{}
+	barStart := time.Date(2026, 4, 22, 6, 0, 0, 0, time.UTC)
+	signalState := map[string]any{
+		"symbol":    "BTCUSDT",
+		"timeframe": "30m",
+		"sma5":      77800.0,
+		"atr14":     416.0,
+		"current": map[string]any{
+			"barStart": barStart.Format(time.RFC3339),
+			"close":    77966.3,
+			"high":     77978.0,
+			"low":      77930.0,
+		},
+		"prevBar1": map[string]any{
+			"high": 78335.7,
+			"low":  77928.6,
+		},
+		"prevBar2": map[string]any{
+			"high": 78447.5,
+			"low":  77406.0,
+		},
+	}
+	sessionState := map[string]any{
+		livePendingZeroInitialWindowStateKey: map[string]any{
+			"side":            "BUY",
+			"symbol":          "BTCUSDT",
+			"signalTimeframe": "30m",
+			"armedAt":         barStart.Add(-time.Minute).Format(time.RFC3339),
+			"signalBarStart":  barStart.Format(time.RFC3339),
+			"expiresAt":       barStart.Add(30 * time.Minute).Format(time.RFC3339),
+		},
+	}
+	decision, err := engine.EvaluateSignal(StrategySignalEvaluationContext{
+		ExecutionContext: StrategyExecutionContext{
+			Symbol:          "BTCUSDT",
+			SignalTimeframe: "30m",
+			Parameters: map[string]any{
+				"symbol":                     "BTCUSDT",
+				"signalTimeframe":            "30m",
+				"signalDecisionMaxSpreadBps": 8.0,
+			},
+		},
+		TriggerSummary: map[string]any{
+			"role":   "trigger",
+			"symbol": "BTCUSDT",
+			"price":  77974.3,
+		},
+		SourceStates: map[string]any{
+			"tick": map[string]any{
+				"streamType": "trade_tick",
+				"symbol":     "BTCUSDT",
+				"summary":    map[string]any{"price": 77974.3},
+			},
+		},
+		SignalBarStates: map[string]any{
+			signalBindingMatchKey("binance-kline", "signal", "BTCUSDT", map[string]any{"timeframe": "30m"}): signalState,
+		},
+		CurrentPosition:   map[string]any{},
+		SessionState:      sessionState,
+		EventTime:         barStart.Add(35 * time.Second),
+		NextPlannedEvent:  barStart,
+		NextPlannedPrice:  77970.28,
+		NextPlannedSide:   "BUY",
+		NextPlannedRole:   "entry",
+		NextPlannedReason: "Zero-Initial-Reentry",
+	})
+	if err != nil {
+		t.Fatalf("evaluate signal failed: %v", err)
+	}
+	if decision.Action != "wait" || decision.Reason != "reentry-window-not-open" {
+		t.Fatalf("expected unproven zero-initial window to stay blocked, got %+v", decision)
+	}
+	if boolValue(decision.Metadata["reentryWindowOpen"]) {
+		t.Fatalf("expected unproven pending window to be treated as closed, got %+v", decision.Metadata)
 	}
 }
 
@@ -457,6 +537,9 @@ func TestPrepareLivePlanStepForSignalEvaluationUsesZeroInitialWindowAcrossTwoBar
 	if stringValue(pending["side"]) != "BUY" {
 		t.Fatalf("expected pending BUY window, got %+v", pending)
 	}
+	if !boolValue(pending["breakoutBacked"]) || stringValue(pending["openReason"]) != liveZeroInitialWindowOpenReasonBreakoutLocked {
+		t.Fatalf("expected pending window to carry breakout proof, got %+v", pending)
+	}
 	timeline := metadataList(state["timeline"])
 	if len(timeline) != 1 {
 		t.Fatalf("expected one zero initial window timeline event, got %+v", timeline)
@@ -468,6 +551,9 @@ func TestPrepareLivePlanStepForSignalEvaluationUsesZeroInitialWindowAcrossTwoBar
 	pendingFromTimeline := mapValue(timelineMetadata[livePendingZeroInitialWindowStateKey])
 	if stringValue(pendingFromTimeline["side"]) != "BUY" || stringValue(pendingFromTimeline["symbol"]) != "BTCUSDT" {
 		t.Fatalf("expected pending window snapshot in timeline metadata, got %+v", pendingFromTimeline)
+	}
+	if !boolValue(pendingFromTimeline["breakoutBacked"]) || stringValue(pendingFromTimeline["openReason"]) != liveZeroInitialWindowOpenReasonBreakoutLocked {
+		t.Fatalf("expected timeline pending window snapshot to retain breakout proof, got %+v", pendingFromTimeline)
 	}
 
 	nextBarStart := barStart.Add(24 * time.Hour)
@@ -554,6 +640,8 @@ func TestPrepareLivePlanStepForSignalEvaluationPrioritizesExitReentryOverZeroIni
 			"armedAt":         eventTime.Add(-time.Minute).Format(time.RFC3339),
 			"signalBarStart":  eventTime.Truncate(24 * time.Hour).Format(time.RFC3339),
 			"expiresAt":       eventTime.Truncate(24 * time.Hour).Add(48 * time.Hour).Format(time.RFC3339),
+			"breakoutBacked":  true,
+			"openReason":      liveZeroInitialWindowOpenReasonBreakoutLocked,
 		},
 	}
 	signalStates := map[string]any{
@@ -4107,6 +4195,8 @@ func TestEvaluateLiveSessionOnSignalUsesZeroInitialReentryWindowInsteadOfVirtual
 	}
 	if pending := mapValue(updated.State[livePendingZeroInitialWindowStateKey]); stringValue(pending["side"]) != "BUY" {
 		t.Fatalf("expected pending BUY zero initial window in session state, got %+v", pending)
+	} else if !boolValue(pending["breakoutBacked"]) || stringValue(pending["openReason"]) != liveZeroInitialWindowOpenReasonBreakoutLocked {
+		t.Fatalf("expected pending zero initial window to carry breakout proof, got %+v", pending)
 	}
 
 	reentryTime := eventTime.Add(5 * time.Second)
@@ -4796,6 +4886,8 @@ func TestRefreshLiveSessionPositionContextRebuildsLivePositionState(t *testing.T
 		"armedAt":         time.Date(2026, 4, 17, 1, 0, 0, 0, time.UTC).Format(time.RFC3339),
 		"signalBarStart":  time.Date(2026, 4, 17, 0, 0, 0, 0, time.UTC).Format(time.RFC3339),
 		"expiresAt":       time.Date(2026, 4, 19, 0, 0, 0, 0, time.UTC).Format(time.RFC3339),
+		"breakoutBacked":  true,
+		"openReason":      liveZeroInitialWindowOpenReasonBreakoutLocked,
 	}
 	session, err = platform.store.UpdateLiveSessionState(session.ID, state)
 	if err != nil {

--- a/internal/service/live_zero_initial.go
+++ b/internal/service/live_zero_initial.go
@@ -5,7 +5,10 @@ import (
 	"time"
 )
 
-const livePendingZeroInitialWindowStateKey = "pendingZeroInitialWindow"
+const (
+	livePendingZeroInitialWindowStateKey          = "pendingZeroInitialWindow"
+	liveZeroInitialWindowOpenReasonBreakoutLocked = "breakout-confirmed"
+)
 
 func prepareLivePlanStepForSignalEvaluation(
 	sessionState map[string]any,
@@ -104,12 +107,26 @@ func prepareLivePlanStepForSignalEvaluation(
 		side = "SELL"
 	}
 	pendingWindow := map[string]any{
-		"side":            side,
-		"symbol":          NormalizeSymbol(symbol),
-		"signalTimeframe": strings.ToLower(strings.TrimSpace(signalTimeframe)),
-		"armedAt":         eventTime.UTC().Format(time.RFC3339),
-		"signalBarStart":  currentBarStart.UTC().Format(time.RFC3339),
-		"expiresAt":       currentBarStart.UTC().Add(2 * step).Format(time.RFC3339),
+		"side":                      side,
+		"symbol":                    NormalizeSymbol(symbol),
+		"signalTimeframe":           strings.ToLower(strings.TrimSpace(signalTimeframe)),
+		"armedAt":                   eventTime.UTC().Format(time.RFC3339),
+		"signalBarStart":            currentBarStart.UTC().Format(time.RFC3339),
+		"expiresAt":                 currentBarStart.UTC().Add(2 * step).Format(time.RFC3339),
+		"breakoutBacked":            true,
+		"openReason":                liveZeroInitialWindowOpenReasonBreakoutLocked,
+		"breakoutPrice":             breakoutPrice,
+		"breakoutPriceSource":       strings.TrimSpace(breakoutPriceSource),
+		"longStructureReady":        boolValue(gate["longStructureReady"]),
+		"shortStructureReady":       boolValue(gate["shortStructureReady"]),
+		"longBreakoutReady":         boolValue(gate["longBreakoutReady"]),
+		"shortBreakoutReady":        boolValue(gate["shortBreakoutReady"]),
+		"longBreakoutPriceReady":    boolValue(gate["longBreakoutPriceReady"]),
+		"shortBreakoutPriceReady":   boolValue(gate["shortBreakoutPriceReady"]),
+		"longBreakoutShapeReady":    boolValue(gate["longBreakoutShapeReady"]),
+		"shortBreakoutShapeReady":   boolValue(gate["shortBreakoutShapeReady"]),
+		"longBreakoutPatternReady":  boolValue(gate["longBreakoutPatternReady"]),
+		"shortBreakoutPatternReady": boolValue(gate["shortBreakoutPatternReady"]),
 	}
 	updatedState[livePendingZeroInitialWindowStateKey] = pendingWindow
 	timelineMetadata := map[string]any{
@@ -157,6 +174,10 @@ func refreshLiveZeroInitialWindowState(
 	}
 	pending := cloneMetadata(mapValue(state[livePendingZeroInitialWindowStateKey]))
 	if len(pending) == 0 {
+		return state
+	}
+	if !liveZeroInitialWindowHasBreakoutProof(pending) {
+		clearLivePendingZeroInitialWindow(state, eventTime, "zero-initial-window-missing-breakout-proof")
 		return state
 	}
 	if pendingSymbol := NormalizeSymbol(stringValue(pending["symbol"])); pendingSymbol != "" && pendingSymbol != NormalizeSymbol(symbol) {
@@ -215,9 +236,19 @@ func clearLivePendingZeroInitialWindow(state map[string]any, eventTime time.Time
 	})
 }
 
+func liveZeroInitialWindowHasBreakoutProof(pending map[string]any) bool {
+	if !boolValue(pending["breakoutBacked"]) {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(stringValue(pending["openReason"])), liveZeroInitialWindowOpenReasonBreakoutLocked)
+}
+
 func livePendingZeroInitialWindowOpen(sessionState map[string]any, symbol, signalTimeframe, side string, eventTime time.Time) bool {
 	pending := cloneMetadata(mapValue(sessionState[livePendingZeroInitialWindowStateKey]))
 	if len(pending) == 0 {
+		return false
+	}
+	if !liveZeroInitialWindowHasBreakoutProof(pending) {
 		return false
 	}
 	if pendingSide := strings.ToUpper(strings.TrimSpace(stringValue(pending["side"]))); pendingSide != "" &&
@@ -323,6 +354,10 @@ func liveZeroInitialWindowPlanStep(
 	state := cloneMetadata(sessionState)
 	pending := cloneMetadata(mapValue(state[livePendingZeroInitialWindowStateKey]))
 	if len(pending) == 0 {
+		return state, time.Time{}, 0, "", "", "", false
+	}
+	if !liveZeroInitialWindowHasBreakoutProof(pending) {
+		clearLivePendingZeroInitialWindow(state, eventTime, "zero-initial-window-missing-breakout-proof")
 		return state, time.Time{}, 0, "", "", "", false
 	}
 	side := strings.ToUpper(strings.TrimSpace(stringValue(pending["side"])))

--- a/internal/service/live_zero_initial_test.go
+++ b/internal/service/live_zero_initial_test.go
@@ -61,6 +61,8 @@ func TestPrepareLivePlanStepForSignalEvaluationExpiresStaleExitReentryWindow(t *
 	}
 	if pending := mapValue(state[livePendingZeroInitialWindowStateKey]); stringValue(pending["side"]) != "BUY" {
 		t.Fatalf("expected pending BUY window after stale SL-Reentry fallback, got %+v", pending)
+	} else if !boolValue(pending["breakoutBacked"]) || stringValue(pending["openReason"]) != liveZeroInitialWindowOpenReasonBreakoutLocked {
+		t.Fatalf("expected stale fallback window to carry breakout proof, got %+v", pending)
 	}
 	timeline := metadataList(state["timeline"])
 	if len(timeline) != 1 || stringValue(timeline[0]["title"]) != "zero-initial-window-armed" {
@@ -75,6 +77,76 @@ func TestPrepareLivePlanStepForSignalEvaluationExpiresStaleExitReentryWindow(t *
 	}
 	if parseFloatValue(context["staleAgeSeconds"]) <= parseFloatValue(context["staleWindowSeconds"]) {
 		t.Fatalf("expected stale age to exceed stale window in context, got %+v", context)
+	}
+}
+
+func TestPrepareLivePlanStepForSignalEvaluationClearsUnprovenZeroInitialWindow(t *testing.T) {
+	barStart := time.Date(2026, 4, 22, 6, 0, 0, 0, time.UTC)
+	state := map[string]any{
+		livePendingZeroInitialWindowStateKey: map[string]any{
+			"side":            "BUY",
+			"symbol":          "BTCUSDT",
+			"signalTimeframe": "30m",
+			"armedAt":         barStart.Add(-time.Minute).Format(time.RFC3339),
+			"signalBarStart":  barStart.Format(time.RFC3339),
+			"expiresAt":       barStart.Add(30 * time.Minute).Format(time.RFC3339),
+		},
+	}
+	signalStates := map[string]any{
+		signalBindingMatchKey("binance-kline", "signal", "BTCUSDT", map[string]any{"timeframe": "30m"}): map[string]any{
+			"symbol":    "BTCUSDT",
+			"timeframe": "30m",
+			"sma5":      77800.0,
+			"atr14":     416.0,
+			"current": map[string]any{
+				"barStart": barStart.Format(time.RFC3339),
+				"close":    77966.3,
+				"high":     77978.0,
+				"low":      77930.0,
+			},
+			"prevBar1": map[string]any{
+				"high": 78335.7,
+				"low":  77928.6,
+			},
+			"prevBar2": map[string]any{
+				"high": 78447.5,
+				"low":  77406.0,
+			},
+		},
+	}
+
+	updated, _, _, gotSide, gotRole, gotReason := prepareLivePlanStepForSignalEvaluation(
+		state,
+		map[string]any{
+			"dir2_zero_initial": true,
+			"zero_initial_mode": "reentry_window",
+			"long_reentry_atr":  0.1,
+		},
+		signalStates,
+		"BTCUSDT",
+		"30m",
+		map[string]any{},
+		barStart.Add(35*time.Second),
+		77974.3,
+		"trade_tick.price",
+		barStart,
+		77970.28,
+		"BUY",
+		"entry",
+		"Initial",
+	)
+	if gotRole != "entry" || gotReason != "Initial" || gotSide != "BUY" {
+		t.Fatalf("expected unproven zero-initial window to fall back to original plan, got side=%s role=%s reason=%s", gotSide, gotRole, gotReason)
+	}
+	if pending := mapValue(updated[livePendingZeroInitialWindowStateKey]); len(pending) != 0 {
+		t.Fatalf("expected unproven zero-initial window to be cleared, got %+v", pending)
+	}
+	timeline := metadataList(updated["timeline"])
+	if len(timeline) != 1 || stringValue(timeline[0]["title"]) != "zero-initial-window-consumed" {
+		t.Fatalf("expected unproven window clear timeline event, got %+v", timeline)
+	}
+	if got := stringValue(mapValue(timeline[0]["metadata"])["reason"]); got != "zero-initial-window-missing-breakout-proof" {
+		t.Fatalf("expected missing breakout proof clear reason, got %s", got)
 	}
 }
 


### PR DESCRIPTION
## 目的
修复 live `Zero-Initial-Reentry` 在只有结构 ready、没有真实 breakout 形态时仍可能被旧 pending window 放行的问题。

数据库排查到的最新错误订单不是下单层 side 反转，而是策略决策层先生成了 `BUY / Zero-Initial-Reentry`：当时 `longStructureReady=true`，但 `longBreakoutReady=false`、`longBreakoutPriceReady=false`，旧的 pending window 仍被视为打开，价格触发后直接进入 `advance-plan`。

本 PR 收紧 live/research baseline 对齐逻辑：zero-initial reentry window 必须由当前真实 breakout 打开，并带有 `breakoutBacked=true` 与 `openReason=breakout-confirmed` 证明；缺证明的旧窗口会被清理，evaluator 不再接受它作为可交易窗口。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [x] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) - 未变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？- 不存在
- [x] DB migration 是否具备向下兼容幂等性？- 不涉及 migration
- [x] 配置字段有没有无意被混改？- 未混改配置字段

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

已验证：
- `go test ./internal/service -run 'TestPrepareLivePlanStepForSignalEvaluation|TestEvaluateSignalRequires|TestEvaluateSignalRejects|TestEvaluateLiveSessionOnSignalUsesZeroInitialReentryWindow|TestRefreshLiveSessionPositionContextRebuildsLivePositionState'`
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
- push 前 pre-push harness 通过：high-risk defaults、env safety、backend checks

Root cause:
- live evaluator 对 `zero-initial-reentry` 允许结构级 reentry ready，这是 research baseline 的一部分；但 live pending window 没有记录自己是否由真实 breakout 打开，导致旧/无证明窗口也能把结构 ready 转成实盘 entry。

行为变化:
- 新 zero-initial window 会记录 breakout proof 与 gate audit 字段。
- 旧的或缺少 proof 的 pending window 会被清理为 `zero-initial-window-missing-breakout-proof`。
- `Zero-Initial-Reentry` 在 evaluator 中必须看到 breakout-backed window，否则保持 `wait / reentry-window-not-open`。
