### PR TITLE
[codex] support live reentry sizing and verified takeover auto-close

### DIFF
--- a/internal/http/live.go
+++ b/internal/http/live.go
@@ -25,6 +25,7 @@ func registerLiveRoutes(mux *http.ServeMux, platform *service.Platform) {
 				StrategyID                                string `json:"strategyId"`
 				PositionSizingMode                        string `json:"positionSizingMode"`
 				DefaultOrderFraction                      any    `json:"defaultOrderFraction"`
+				ReentrySizeSchedule                       any    `json:"reentry_size_schedule"`
 				SignalTimeframe                           string `json:"signalTimeframe"`
 				ExecutionDataSource                       string `json:"executionDataSource"`
 				ExecutionStrategy                         string `json:"executionStrategy"`
@@ -92,6 +93,9 @@ func registerLiveRoutes(mux *http.ServeMux, platform *service.Platform) {
 			}
 			if payload.DefaultOrderFraction != nil {
 				overrides["defaultOrderFraction"] = payload.DefaultOrderFraction
+			}
+			if payload.ReentrySizeSchedule != nil {
+				overrides["reentry_size_schedule"] = payload.ReentrySizeSchedule
 			}
 			if payload.ExecutionDataSource != "" {
 				overrides["executionDataSource"] = payload.ExecutionDataSource
@@ -260,6 +264,7 @@ func registerLiveRoutes(mux *http.ServeMux, platform *service.Platform) {
 				StrategyID                                string `json:"strategyId"`
 				PositionSizingMode                        string `json:"positionSizingMode"`
 				DefaultOrderFraction                      any    `json:"defaultOrderFraction"`
+				ReentrySizeSchedule                       any    `json:"reentry_size_schedule"`
 				SignalTimeframe                           string `json:"signalTimeframe"`
 				ExecutionDataSource                       string `json:"executionDataSource"`
 				ExecutionStrategy                         string `json:"executionStrategy"`
@@ -320,6 +325,9 @@ func registerLiveRoutes(mux *http.ServeMux, platform *service.Platform) {
 			}
 			if payload.DefaultOrderFraction != nil {
 				overrides["defaultOrderFraction"] = payload.DefaultOrderFraction
+			}
+			if payload.ReentrySizeSchedule != nil {
+				overrides["reentry_size_schedule"] = payload.ReentrySizeSchedule
 			}
 			if payload.ExecutionDataSource != "" {
 				overrides["executionDataSource"] = payload.ExecutionDataSource

--- a/internal/service/execution_strategy.go
+++ b/internal/service/execution_strategy.go
@@ -351,6 +351,8 @@ func normalizePositionSizingMode(raw any) string {
 		return "fixed_quantity"
 	case "fixed-fraction", "fixed_fraction", "fraction", "percent", "percentage":
 		return "fixed_fraction"
+	case "reentry-size-schedule", "reentry_size_schedule", "reentry-schedule", "reentry_schedule", "schedule":
+		return "reentry_size_schedule"
 	case "volatility-adjusted", "volatility_adjusted", "vol_adjusted", "atr_adjusted":
 		return "volatility_adjusted"
 	default:
@@ -377,6 +379,12 @@ func resolveExecutionQuantity(session domain.LiveSession, account domain.Account
 	}
 	if fixedFraction > 0 {
 		metadata["configuredOrderFraction"] = fixedFraction
+	}
+	if quantity, ok := resolveExitPositionQuantity(intent, metadata); ok {
+		return quantity, metadata
+	}
+	if quantity, ok := resolveReentryScheduleQuantity(session, account, parameters, intent, priceHint, mode, metadata); ok {
+		return quantity, metadata
 	}
 	if mode == "fixed_fraction" && fixedFraction > 0 && priceHint > 0 {
 		if balance, basis := resolveLiveSizingBalance(account); balance > 0 {
@@ -429,6 +437,75 @@ func resolveExecutionQuantity(session domain.LiveSession, account domain.Account
 		metadata["sizingBalanceBasis"] = "default_minimum"
 	}
 	return quantity, metadata
+}
+
+func resolveExitPositionQuantity(intent SignalIntent, metadata map[string]any) (float64, bool) {
+	if !strings.EqualFold(strings.TrimSpace(intent.Role), "exit") {
+		return 0, false
+	}
+	currentPosition := mapValue(intent.Metadata["currentPosition"])
+	if quantity := math.Abs(parseFloatValue(currentPosition["quantity"])); quantity > 0 {
+		metadata["sizingMethod"] = "exit_position_quantity"
+		metadata["sizingPositionQuantity"] = quantity
+		metadata["sizingComputedQuantity"] = quantity
+		return quantity, true
+	}
+	if intent.Quantity > 0 {
+		metadata["sizingMethod"] = "exit_intent_quantity"
+		metadata["sizingComputedQuantity"] = intent.Quantity
+		return intent.Quantity, true
+	}
+	return 0, false
+}
+
+func resolveReentryScheduleQuantity(session domain.LiveSession, account domain.Account, parameters map[string]any, intent SignalIntent, priceHint float64, mode string, metadata map[string]any) (float64, bool) {
+	if !strings.EqualFold(strings.TrimSpace(intent.Role), "entry") {
+		return 0, false
+	}
+	reasonTag := normalizeStrategyReasonTag(intent.Reason)
+	if reasonTag != "zero-initial-reentry" && reasonTag != "sl-reentry" && reasonTag != "pt-reentry" {
+		return 0, false
+	}
+	if mode != "reentry_size_schedule" {
+		metadata["reentryScheduleSizingSkippedReason"] = "position_sizing_mode_" + firstNonEmpty(mode, "fixed_quantity")
+		return 0, false
+	}
+	schedule := normalizeBacktestFloatSlice(parameters["reentry_size_schedule"], nil)
+	if len(schedule) == 0 {
+		return 0, false
+	}
+	index := int(effectiveReentryCountForSizing(session.State, intent.Metadata))
+	if index < 0 {
+		index = 0
+	}
+	if index >= len(schedule) {
+		index = len(schedule) - 1
+	}
+	fraction := schedule[index]
+	metadata["sizingReentryReason"] = reasonTag
+	metadata["sizingReentrySchedule"] = append([]float64(nil), schedule...)
+	metadata["sizingReentryScheduleIndex"] = index
+	metadata["sizingReentryFraction"] = fraction
+	if fraction <= 0 {
+		metadata["sizingMethod"] = "reentry_size_schedule"
+		metadata["sizingFallbackReason"] = "reentry_schedule_non_positive_fraction"
+		return 0, true
+	}
+	if priceHint <= 0 {
+		metadata["reentryScheduleSizingSkippedReason"] = "missing_price"
+		return 0, false
+	}
+	balance, basis := resolveLiveSizingBalance(account)
+	if balance <= 0 {
+		metadata["reentryScheduleSizingSkippedReason"] = "missing_balance"
+		return 0, false
+	}
+	quantity := balance * fraction / priceHint
+	metadata["sizingMethod"] = "reentry_size_schedule"
+	metadata["sizingBalance"] = balance
+	metadata["sizingBalanceBasis"] = basis
+	metadata["sizingComputedQuantity"] = quantity
+	return quantity, true
 }
 
 func resolveLiveSizingBalance(account domain.Account) (float64, string) {

--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -3982,6 +3982,10 @@ func deriveLiveSignalIntent(decision StrategySignalDecision, symbol string) *Sig
 	quantity := firstPositive(parseFloatValue(meta["suggestedQuantity"]), 0.001)
 	role := strings.ToLower(strings.TrimSpace(firstNonEmpty(stringValue(meta["nextPlannedRole"]), "entry")))
 	reason := stringValue(meta["nextPlannedReason"])
+	currentPosition := cloneMetadata(mapValue(meta["currentPosition"]))
+	if role == "exit" {
+		quantity = firstPositive(math.Abs(parseFloatValue(currentPosition["quantity"])), quantity)
+	}
 
 	return &SignalIntent{
 		Action:         role,
@@ -4009,6 +4013,7 @@ func deriveLiveSignalIntent(decision StrategySignalDecision, symbol string) *Sig
 			"bestAsk":                       bestAsk,
 			"bestBidQty":                    bestBidQty,
 			"bestAskQty":                    bestAskQty,
+			"currentPosition":               currentPosition,
 			"bookImbalance":                 parseFloatValue(meta["bookImbalance"]),
 		},
 	}

--- a/internal/service/live_execution.go
+++ b/internal/service/live_execution.go
@@ -395,7 +395,9 @@ func shouldBlockAutoDispatchForRecoveryIntent(session domain.LiveSession, intent
 		return true
 	}
 	recoveryActions := currentLiveRecoveryActionMatrix(session.State)
-	if boolValue(session.State["recoveryTakeoverActive"]) && !recoveryActions.AutoDispatch {
+	if boolValue(session.State["recoveryTakeoverActive"]) &&
+		!recoveryActions.AutoDispatch &&
+		!shouldAllowAutoDispatchRecoveredClose(session, intent, recoveryActions) {
 		return true
 	}
 	if !isRecoveryTriggeredPassiveCloseProposal(intent) {
@@ -410,6 +412,31 @@ func shouldBlockAutoDispatchForRecoveryIntent(session domain.LiveSession, intent
 	}
 	proposalMap := assembleLiveExecutionProposalMetadata(session, "", intent)
 	return validateLiveExecutionProposalMetadata(session, proposalMap) != nil
+}
+
+// Verified takeover sessions may auto-dispatch close intents so recovered
+// positions can be exited without reopening manual-review debt. Entry/protection
+// intents remain blocked until the recovery state clears.
+func shouldAllowAutoDispatchRecoveredClose(session domain.LiveSession, intent map[string]any, recoveryActions liveRecoveryActionMatrix) bool {
+	if !boolValue(session.State["recoveryTakeoverActive"]) || recoveryActions.CloseExistingPosition == false {
+		return false
+	}
+	if strings.TrimSpace(stringValue(session.State["recoveryTakeoverState"])) != liveRecoveryTakeoverStateMonitoring {
+		return false
+	}
+	switch strings.TrimSpace(stringValue(session.State["positionReconcileGateStatus"])) {
+	case livePositionReconcileGateStatusVerified, livePositionReconcileGateStatusAdopted:
+	default:
+		return false
+	}
+	if resolveLiveRecoveryIntentAction(intent) != "close-existing-position" {
+		return false
+	}
+	if !boolValue(session.State["hasRecoveredPosition"]) && !boolValue(session.State["hasRecoveredRealPosition"]) {
+		return false
+	}
+	proposalMap := assembleLiveExecutionProposalMetadata(session, "", intent)
+	return validateLiveExecutionProposalMetadata(session, proposalMap) == nil
 }
 
 func shouldBlockAutoDispatchForLiveEntryTradeLimit(session domain.LiveSession, intent map[string]any) bool {

--- a/internal/service/live_launch_templates.go
+++ b/internal/service/live_launch_templates.go
@@ -117,6 +117,7 @@ func (p *Platform) LiveLaunchTemplates() ([]LiveLaunchTemplate, error) {
 		baselineNotes := []string{}
 		if applyResearchBaseline {
 			liveOverrides["strategyEngine"] = firstNonEmpty(strategyEngine, "bk-default")
+			liveOverrides["positionSizingMode"] = "reentry_size_schedule"
 			liveOverrides["dir2_zero_initial"] = true
 			liveOverrides["zero_initial_mode"] = "reentry_window"
 			liveOverrides["stop_mode"] = "atr"

--- a/internal/service/live_launch_templates_test.go
+++ b/internal/service/live_launch_templates_test.go
@@ -96,6 +96,9 @@ func TestLiveLaunchTemplatesExposeEightBinanceTestnetVariants(t *testing.T) {
 			t.Fatalf("expected defaultOrderQuantity=%v, got %v", want.quantity, got)
 		}
 		if want.researchBaseline {
+			if got := stringValue(item.LaunchPayload.LiveSessionOverrides["positionSizingMode"]); got != "reentry_size_schedule" {
+				t.Fatalf("expected positionSizingMode=reentry_size_schedule for %s, got %s", item.Key, got)
+			}
 			if got := stringValue(item.LaunchPayload.LiveSessionOverrides["strategyEngine"]); got == "" {
 				t.Fatalf("expected explicit strategyEngine for %s", item.Key)
 			}

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -27,6 +27,13 @@ func TestDeriveLiveSignalIntentUsesNextPlannedStep(t *testing.T) {
 			"signalKind":        "protect-exit",
 			"decisionState":     "exit-ready",
 			"signalBarStateKey": "binance|BTCUSDT|trigger|4h",
+			"currentPosition": map[string]any{
+				"found":      true,
+				"symbol":     "BTCUSDT",
+				"side":       "LONG",
+				"quantity":   0.008,
+				"entryPrice": 25000.0,
+			},
 			"nextPlannedSide":   "SELL",
 			"nextPlannedRole":   "exit",
 			"nextPlannedReason": "PT",
@@ -47,6 +54,9 @@ func TestDeriveLiveSignalIntentUsesNextPlannedStep(t *testing.T) {
 	}
 	if got := intent.Reason; got != "PT" {
 		t.Fatalf("expected PT reason, got %v", got)
+	}
+	if got := intent.Quantity; got != 0.008 {
+		t.Fatalf("expected exit intent quantity to match current position, got %v", got)
 	}
 }
 
@@ -1369,6 +1379,187 @@ func TestBookAwareExecutionStrategyBuildsProposalFromBalanceFraction(t *testing.
 	}
 }
 
+func TestBookAwareExecutionStrategyUsesReentrySizeScheduleForLiveEntry(t *testing.T) {
+	strategy := bookAwareExecutionStrategy{}
+	account := domain.Account{
+		Metadata: map[string]any{
+			"liveSyncSnapshot": map[string]any{
+				"availableBalance": 1000.0,
+			},
+		},
+	}
+	execution := StrategyExecutionContext{
+		Parameters: map[string]any{
+			"executionMaxSpreadBps": 8.0,
+			"reentry_size_schedule": []float64{0.20, 0.10},
+		},
+	}
+	baseIntent := SignalIntent{
+		Action:        "entry",
+		Role:          "entry",
+		Reason:        "Zero-Initial-Reentry",
+		Side:          "BUY",
+		Symbol:        "BTCUSDT",
+		SignalKind:    "zero-initial-reentry",
+		DecisionState: "entry-ready",
+		PriceHint:     25000,
+		PriceSource:   "trade_tick.price",
+		Metadata: map[string]any{
+			"bestBid":                       24999.5,
+			"bestAsk":                       25000.0,
+			"spreadBps":                     0.1,
+			"signalBarStateKey":             "state-schedule",
+			liveSignalBarTradeLimitKeyField: "BTCUSDT|30m|2026-04-22T06:00:00Z",
+		},
+	}
+
+	fixed, err := strategy.BuildProposal(ExecutionPlanningContext{
+		Session: domain.LiveSession{
+			State: map[string]any{
+				"positionSizingMode":   "fixed_quantity",
+				"defaultOrderQuantity": 0.002,
+			},
+		},
+		Account:   account,
+		Execution: execution,
+		Intent:    baseIntent,
+	})
+	if err != nil {
+		t.Fatalf("unexpected fixed proposal error: %v", err)
+	}
+	if fixed.Quantity != 0.002 {
+		t.Fatalf("expected fixed_quantity mode to ignore reentry schedule, got %v", fixed.Quantity)
+	}
+	if got := stringValue(fixed.Metadata["reentryScheduleSizingSkippedReason"]); got != "position_sizing_mode_fixed_quantity" {
+		t.Fatalf("expected fixed mode skip reason, got %s", got)
+	}
+
+	first, err := strategy.BuildProposal(ExecutionPlanningContext{
+		Session: domain.LiveSession{
+			State: map[string]any{
+				"positionSizingMode":   "reentry_size_schedule",
+				"defaultOrderQuantity": 0.002,
+			},
+		},
+		Account:   account,
+		Execution: execution,
+		Intent:    baseIntent,
+	})
+	if err != nil {
+		t.Fatalf("unexpected first proposal error: %v", err)
+	}
+	if first.Quantity != 0.008 {
+		t.Fatalf("expected first reentry to use 20%% of balance, got %v", first.Quantity)
+	}
+	if got := stringValue(first.Metadata["sizingMethod"]); got != "reentry_size_schedule" {
+		t.Fatalf("expected reentry schedule sizing method, got %s", got)
+	}
+	if got := parseFloatValue(first.Metadata["sizingReentryFraction"]); got != 0.20 {
+		t.Fatalf("expected first schedule fraction 0.20, got %v", got)
+	}
+	if got := parseFloatValue(first.Metadata["configuredOrderQuantity"]); got != 0.002 {
+		t.Fatalf("expected fixed quantity fallback metadata to remain visible, got %v", got)
+	}
+
+	second, err := strategy.BuildProposal(ExecutionPlanningContext{
+		Session: domain.LiveSession{
+			State: map[string]any{
+				"positionSizingMode":    "reentry_size_schedule",
+				"defaultOrderQuantity":  0.002,
+				"lastSignalBarStateKey": "BTCUSDT|30m|2026-04-22T06:00:00Z",
+				"sessionReentryCount":   1.0,
+				"max_trades_per_bar":    2,
+			},
+		},
+		Account:   account,
+		Execution: execution,
+		Intent:    baseIntent,
+	})
+	if err != nil {
+		t.Fatalf("unexpected second proposal error: %v", err)
+	}
+	if second.Quantity != 0.004 {
+		t.Fatalf("expected second reentry to use 10%% of balance, got %v", second.Quantity)
+	}
+	if got := parseFloatValue(second.Metadata["sizingReentryScheduleIndex"]); got != 1 {
+		t.Fatalf("expected second schedule index 1, got %v", got)
+	}
+	if got := parseFloatValue(second.Metadata["sizingReentryFraction"]); got != 0.10 {
+		t.Fatalf("expected second schedule fraction 0.10, got %v", got)
+	}
+}
+
+func TestBookAwareExecutionStrategyUsesPositionQuantityForScheduledReentryExits(t *testing.T) {
+	strategy := bookAwareExecutionStrategy{}
+	for _, tc := range []struct {
+		name             string
+		reason           string
+		positionQuantity float64
+	}{
+		{name: "pt after 20 percent entry", reason: "PT", positionQuantity: 0.008},
+		{name: "sl after 10 percent entry", reason: "SL", positionQuantity: 0.004},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			proposal, err := strategy.BuildProposal(ExecutionPlanningContext{
+				Session: domain.LiveSession{
+					State: map[string]any{
+						"positionSizingMode":   "reentry_size_schedule",
+						"defaultOrderQuantity": 0.002,
+					},
+				},
+				Account: domain.Account{
+					Metadata: map[string]any{
+						"liveSyncSnapshot": map[string]any{
+							"availableBalance": 1000.0,
+						},
+					},
+				},
+				Execution: StrategyExecutionContext{
+					Parameters: map[string]any{
+						"executionMaxSpreadBps": 8.0,
+						"reentry_size_schedule": []float64{0.20, 0.10},
+					},
+				},
+				Intent: SignalIntent{
+					Action:        "exit",
+					Role:          "exit",
+					Reason:        tc.reason,
+					Side:          "SELL",
+					Symbol:        "BTCUSDT",
+					SignalKind:    "risk-exit",
+					DecisionState: "exit-ready",
+					PriceHint:     26000,
+					PriceSource:   "trade_tick.price",
+					Metadata: map[string]any{
+						"bestBid":   25999.5,
+						"bestAsk":   26000.0,
+						"spreadBps": 0.1,
+						"currentPosition": map[string]any{
+							"found":      true,
+							"symbol":     "BTCUSDT",
+							"side":       "LONG",
+							"quantity":   tc.positionQuantity,
+							"entryPrice": 25000.0,
+						},
+					},
+				},
+			})
+			if err != nil {
+				t.Fatalf("unexpected proposal error: %v", err)
+			}
+			if proposal.Quantity != tc.positionQuantity {
+				t.Fatalf("expected %s exit quantity to match open position %.6f, got %v", tc.reason, tc.positionQuantity, proposal.Quantity)
+			}
+			if !proposal.ReduceOnly {
+				t.Fatalf("expected %s exit to be reduceOnly", tc.reason)
+			}
+			if got := stringValue(proposal.Metadata["sizingMethod"]); got != "exit_position_quantity" {
+				t.Fatalf("expected exit_position_quantity sizing, got %s", got)
+			}
+		})
+	}
+}
+
 func TestBookAwareExecutionStrategyUsesReduceOnlyMakerProfileForPTExit(t *testing.T) {
 	strategy := bookAwareExecutionStrategy{}
 	proposal, err := strategy.BuildProposal(ExecutionPlanningContext{
@@ -2231,12 +2422,26 @@ func TestNormalizeLiveSessionOverridesIncludesPositionSizing(t *testing.T) {
 	overrides := normalizeLiveSessionOverrides(map[string]any{
 		"positionSizingMode":   "fixed-fraction",
 		"defaultOrderFraction": 0.12,
+		"reentry_size_schedule": []any{
+			0.20,
+			0.10,
+		},
 	})
 	if got := stringValue(overrides["positionSizingMode"]); got != "fixed_fraction" {
 		t.Fatalf("expected fixed_fraction mode, got %s", got)
 	}
 	if got := parseFloatValue(overrides["defaultOrderFraction"]); got != 0.12 {
 		t.Fatalf("expected default order fraction 0.12, got %v", got)
+	}
+	schedule := normalizeBacktestFloatSlice(overrides["reentry_size_schedule"], nil)
+	if len(schedule) != 2 || schedule[0] != 0.20 || schedule[1] != 0.10 {
+		t.Fatalf("expected reentry size schedule [0.20, 0.10], got %#v", overrides["reentry_size_schedule"])
+	}
+	scheduleMode := normalizeLiveSessionOverrides(map[string]any{
+		"positionSizingMode": "reentry-size-schedule",
+	})
+	if got := stringValue(scheduleMode["positionSizingMode"]); got != "reentry_size_schedule" {
+		t.Fatalf("expected reentry_size_schedule mode, got %s", got)
 	}
 }
 

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -3249,15 +3249,17 @@ func TestEnsureLiveExecutionPlanBlocksCloseOnlyTakeoverFreshEntry(t *testing.T) 
 	}
 }
 
-func TestRecoveryMonitoringDisablesAutoDispatch(t *testing.T) {
+func TestRecoveryMonitoringStillDisablesEntryAutoDispatch(t *testing.T) {
 	now := time.Now().UTC()
 	session := domain.LiveSession{
 		State: map[string]any{
-			"dispatchMode":             "auto-dispatch",
-			"recoveryTakeoverActive":   true,
-			"positionRecoveryStatus":   "protected-open-position",
-			"hasRecoveredPosition":     true,
-			"hasRecoveredRealPosition": true,
+			"dispatchMode":                "auto-dispatch",
+			"recoveryTakeoverActive":      true,
+			"recoveryTakeoverState":       liveRecoveryTakeoverStateMonitoring,
+			"positionRecoveryStatus":      "protected-open-position",
+			"positionReconcileGateStatus": livePositionReconcileGateStatusVerified,
+			"hasRecoveredPosition":        true,
+			"hasRecoveredRealPosition":    true,
 		},
 	}
 	intent := map[string]any{
@@ -3269,6 +3271,51 @@ func TestRecoveryMonitoringDisablesAutoDispatch(t *testing.T) {
 	}
 	if shouldAutoDispatchLiveIntent(session, intent, now) {
 		t.Fatal("expected recovery-monitoring takeover to stay manual")
+	}
+}
+
+func TestRecoveryMonitoringAllowsVerifiedCloseAutoDispatch(t *testing.T) {
+	now := time.Now().UTC()
+	session := domain.LiveSession{
+		ID: "live-session-1",
+		State: map[string]any{
+			"dispatchMode":                "auto-dispatch",
+			"recoveryTakeoverActive":      true,
+			"recoveryTakeoverState":       liveRecoveryTakeoverStateMonitoring,
+			"positionRecoveryStatus":      livePositionRecoveryStatusClosingPending,
+			"positionReconcileGateStatus": livePositionReconcileGateStatusVerified,
+			"hasRecoveredPosition":        true,
+			"hasRecoveredRealPosition":    true,
+			"strategyVersionId":           "strategy-version-bk-1d-v010",
+			"signalTimeframe":             "30m",
+			"executionDataSource":         "tick",
+			"symbol":                      "BTCUSDT",
+		},
+	}
+	intent := map[string]any{
+		"action":            "risk-exit-fallback",
+		"role":              "exit",
+		"reason":            "sl-breached-fallback",
+		"side":              "SELL",
+		"symbol":            "BTCUSDT",
+		"status":            "dispatchable",
+		"quantity":          0.002,
+		"reduceOnly":        true,
+		"signalKind":        "recovery-watchdog",
+		"strategyVersionId": "strategy-version-bk-1d-v010",
+		"metadata": map[string]any{
+			"runtimeSessionId": "runtime-1",
+			"executionContext": map[string]any{
+				"strategyVersionId":   "strategy-version-bk-1d-v010",
+				"signalTimeframe":     "30m",
+				"executionDataSource": "tick",
+				"executionMode":       "live",
+				"symbol":              "BTCUSDT",
+			},
+		},
+	}
+	if !shouldAutoDispatchLiveIntent(session, intent, now) {
+		t.Fatal("expected verified recovery-monitoring takeover close to auto-dispatch")
 	}
 }
 

--- a/web/console/src/hooks/useTradingActions.ts
+++ b/web/console/src/hooks/useTradingActions.ts
@@ -101,6 +101,51 @@ export function useTradingActions(loadDashboard: () => Promise<void>) {
     return strategyIds.has(candidate) ? candidate : fallback;
   }
 
+  function normalizeLivePositionSizingMode(candidate: unknown, schedule: unknown) {
+    const value = String(candidate ?? "").trim().toLowerCase().replaceAll("-", "_");
+    if (value === "reentry_size_schedule" || value === "reentry_schedule" || value === "schedule") {
+      return "reentry_size_schedule";
+    }
+    if (value === "fixed_quantity" || value === "fixed_size" || value === "fixed") {
+      return "fixed_quantity";
+    }
+    if (value === "fixed_fraction" || value === "fraction" || value === "percent" || value === "percentage") {
+      return "fixed_fraction";
+    }
+    if (value === "volatility_adjusted" || value === "vol_adjusted" || value === "atr_adjusted") {
+      return "volatility_adjusted";
+    }
+    if (Array.isArray(schedule) && schedule.length >= 2 && schedule.some((item) => Number(item) > 0)) {
+      return "reentry_size_schedule";
+    }
+    return "fixed_quantity";
+  }
+
+  function readReentrySizeSchedule(raw: unknown): [string, string] {
+    if (!Array.isArray(raw)) {
+      return ["0.20", "0.10"];
+    }
+    const first = Number(raw[0]);
+    const second = Number(raw[1]);
+    return [
+      Number.isFinite(first) && first > 0 ? String(first) : "0.20",
+      Number.isFinite(second) && second > 0 ? String(second) : "0.10",
+    ];
+  }
+
+  function buildLiveSessionSizingPayload() {
+    const first = Number(liveSessionForm.reentrySizeScheduleFirst);
+    const second = Number(liveSessionForm.reentrySizeScheduleSecond);
+    return {
+      positionSizingMode: liveSessionForm.positionSizingMode || "fixed_quantity",
+      defaultOrderQuantity: Number(liveSessionForm.defaultOrderQuantity) || 0.001,
+      reentry_size_schedule: [
+        Number.isFinite(first) && first > 0 ? first : 0.20,
+        Number.isFinite(second) && second > 0 ? second : 0.10,
+      ],
+    };
+  }
+
   function selectQuickLiveAccount(accountId: string) {
     setLiveBindingForm((current: any) => ({ ...current, accountId }));
     setLiveSessionForm((current: any) => ({ ...current, accountId }));
@@ -399,7 +444,7 @@ export function useTradingActions(loadDashboard: () => Promise<void>) {
           signalTimeframe: liveSessionForm.signalTimeframe,
           executionDataSource: liveSessionForm.executionDataSource,
           symbol: liveSessionForm.symbol,
-          defaultOrderQuantity: Number(liveSessionForm.defaultOrderQuantity) || 0.001,
+          ...buildLiveSessionSizingPayload(),
           executionEntryOrderType: liveSessionForm.executionEntryOrderType,
           executionEntryMaxSpreadBps: Number(liveSessionForm.executionEntryMaxSpreadBps) || undefined,
           executionEntryWideSpreadMode: liveSessionForm.executionEntryWideSpreadMode,
@@ -453,7 +498,7 @@ export function useTradingActions(loadDashboard: () => Promise<void>) {
           signalTimeframe: liveSessionForm.signalTimeframe,
           executionDataSource: liveSessionForm.executionDataSource,
           symbol: liveSessionForm.symbol,
-          defaultOrderQuantity: Number(liveSessionForm.defaultOrderQuantity) || 0.001,
+          ...buildLiveSessionSizingPayload(),
           executionEntryOrderType: liveSessionForm.executionEntryOrderType,
           executionEntryMaxSpreadBps: Number(liveSessionForm.executionEntryMaxSpreadBps) || undefined,
           executionEntryWideSpreadMode: liveSessionForm.executionEntryWideSpreadMode,
@@ -568,7 +613,7 @@ export function useTradingActions(loadDashboard: () => Promise<void>) {
             signalTimeframe: liveSessionForm.signalTimeframe,
             executionDataSource: liveSessionForm.executionDataSource,
             symbol: liveSessionForm.symbol,
-            defaultOrderQuantity: Number(liveSessionForm.defaultOrderQuantity) || 0.001,
+            ...buildLiveSessionSizingPayload(),
             dispatchMode: liveSessionForm.dispatchMode,
             dispatchCooldownSeconds: Number(liveSessionForm.dispatchCooldownSeconds) || 30,
           },
@@ -1037,6 +1082,8 @@ export function useTradingActions(loadDashboard: () => Promise<void>) {
     const nextStrategyId = normalizeStrategyId(session?.strategyId ?? "", strategies[0]?.id || "");
     const sessionState = getRecord(session?.state);
     const isEditingExistingSession = Boolean(session);
+    const [reentrySizeScheduleFirst, reentrySizeScheduleSecond] = readReentrySizeSchedule(sessionState.reentry_size_schedule);
+    const positionSizingMode = normalizeLivePositionSizingMode(sessionState.positionSizingMode, sessionState.reentry_size_schedule);
     if (nextAccountId) {
       selectQuickLiveAccount(nextAccountId);
     }
@@ -1047,8 +1094,19 @@ export function useTradingActions(loadDashboard: () => Promise<void>) {
       signalTimeframe: String(sessionState.signalTimeframe ?? (isEditingExistingSession ? "" : current.signalTimeframe ?? "1d")),
       executionDataSource: String(sessionState.executionDataSource ?? (isEditingExistingSession ? "" : current.executionDataSource ?? "tick")),
       symbol: String(sessionState.symbol ?? (isEditingExistingSession ? "" : current.symbol ?? "BTCUSDT")),
+      positionSizingMode: String(
+        sessionState.positionSizingMode != null || Array.isArray(sessionState.reentry_size_schedule)
+          ? positionSizingMode
+          : (isEditingExistingSession ? "fixed_quantity" : current.positionSizingMode ?? "fixed_quantity")
+      ),
       defaultOrderQuantity: String(
         sessionState.defaultOrderQuantity ?? (isEditingExistingSession ? "" : current.defaultOrderQuantity ?? "0.001")
+      ),
+      reentrySizeScheduleFirst: String(
+        sessionState.reentry_size_schedule != null ? reentrySizeScheduleFirst : current.reentrySizeScheduleFirst ?? "0.20"
+      ),
+      reentrySizeScheduleSecond: String(
+        sessionState.reentry_size_schedule != null ? reentrySizeScheduleSecond : current.reentrySizeScheduleSecond ?? "0.10"
       ),
       executionEntryOrderType: String(
         sessionState.executionEntryOrderType ?? (isEditingExistingSession ? "" : current.executionEntryOrderType ?? "MARKET")

--- a/web/console/src/modals/LiveSessionModal.tsx
+++ b/web/console/src/modals/LiveSessionModal.tsx
@@ -211,13 +211,43 @@ export function LiveSessionModal({
                   onChange={(event) => setLiveSessionForm((current) => ({ ...current, symbol: event.target.value.toUpperCase() }))}
                 />
               </ModalField>
-              <ModalField label="默认下单量">
+              <LiveSelectField
+                label="数量模式"
+                value={liveSessionForm.positionSizingMode}
+                onValueChange={(value) => setLiveSessionForm((current) => ({ ...current, positionSizingMode: value }))}
+                options={[
+                  { value: "fixed_quantity", label: "自定义固定数量" },
+                  { value: "reentry_size_schedule", label: "按 Reentry Schedule" },
+                ]}
+              />
+              <ModalField label={liveSessionForm.positionSizingMode === "reentry_size_schedule" ? "固定回退数量" : "固定下单量"}>
                 <ModalInput
                   placeholder="0.00"
                   value={liveSessionForm.defaultOrderQuantity}
                   onChange={(event) => setLiveSessionForm((current) => ({ ...current, defaultOrderQuantity: event.target.value }))}
                 />
               </ModalField>
+              {liveSessionForm.positionSizingMode === "reentry_size_schedule" && (
+                <>
+                  <ModalField label="首笔 Reentry 比例">
+                    <ModalInput
+                      placeholder="0.20"
+                      value={liveSessionForm.reentrySizeScheduleFirst}
+                      onChange={(event) => setLiveSessionForm((current) => ({ ...current, reentrySizeScheduleFirst: event.target.value }))}
+                    />
+                  </ModalField>
+                  <ModalField label="次笔 Reentry 比例">
+                    <ModalInput
+                      placeholder="0.10"
+                      value={liveSessionForm.reentrySizeScheduleSecond}
+                      onChange={(event) => setLiveSessionForm((current) => ({ ...current, reentrySizeScheduleSecond: event.target.value }))}
+                    />
+                  </ModalField>
+                  <div className="md:col-span-3 rounded-2xl border border-[var(--bk-border-soft)] bg-[var(--bk-surface-overlay)] px-4 py-3 text-[11px] font-semibold leading-relaxed text-[var(--bk-text-muted)]">
+                    Reentry schedule 使用账户可用余额按比例换算下单量，例如 0.20 / 0.10 表示同一 signal bar 内第 1 笔真实 reentry 使用 20%，第 2 笔使用 10%；SL/PT 仍按当前持仓数量 reduceOnly 平仓。
+                  </div>
+                </>
+              )}
             </ModalFormGrid>
           </ModalGroup>
 

--- a/web/console/src/store/useUIStore.ts
+++ b/web/console/src/store/useUIStore.ts
@@ -379,7 +379,7 @@ export const useUIStore = create<useUIStoreState>((set) => ({
   setLiveBindingForm: (valOrUpdater) => set((state) => ({ liveBindingForm: resolveUpdater(valOrUpdater, state.liveBindingForm) })),
   liveOrderForm: { accountId: "", strategyVersionId: "", symbol: "BTCUSDT", side: "BUY", type: "LIMIT", quantity: "0.001", price: "", },
   setLiveOrderForm: (valOrUpdater) => set((state) => ({ liveOrderForm: resolveUpdater(valOrUpdater, state.liveOrderForm) })),
-  liveSessionForm: { alias: "", accountId: "", strategyId: "", signalTimeframe: "1d", executionDataSource: "tick", symbol: "BTCUSDT", defaultOrderQuantity: "0.001", executionEntryOrderType: "MARKET", executionEntryMaxSpreadBps: "8", executionEntryWideSpreadMode: "limit-maker", executionEntryTimeoutFallbackOrderType: "MARKET", executionPTExitOrderType: "LIMIT", executionPTExitTimeInForce: "GTX", executionPTExitPostOnly: true, executionPTExitTimeoutFallbackOrderType: "MARKET", executionSLExitOrderType: "MARKET", executionSLExitMaxSpreadBps: "999", dispatchMode: "manual-review", dispatchCooldownSeconds: "30", freshnessOverrideSignalBarFreshnessSeconds: "", freshnessOverrideTradeTickFreshnessSeconds: "", freshnessOverrideOrderBookFreshnessSeconds: "", freshnessOverrideRuntimeQuietSeconds: "", },
+  liveSessionForm: { alias: "", accountId: "", strategyId: "", signalTimeframe: "1d", executionDataSource: "tick", symbol: "BTCUSDT", positionSizingMode: "fixed_quantity", defaultOrderQuantity: "0.001", reentrySizeScheduleFirst: "0.20", reentrySizeScheduleSecond: "0.10", executionEntryOrderType: "MARKET", executionEntryMaxSpreadBps: "8", executionEntryWideSpreadMode: "limit-maker", executionEntryTimeoutFallbackOrderType: "MARKET", executionPTExitOrderType: "LIMIT", executionPTExitTimeInForce: "GTX", executionPTExitPostOnly: true, executionPTExitTimeoutFallbackOrderType: "MARKET", executionSLExitOrderType: "MARKET", executionSLExitMaxSpreadBps: "999", dispatchMode: "manual-review", dispatchCooldownSeconds: "30", freshnessOverrideSignalBarFreshnessSeconds: "", freshnessOverrideTradeTickFreshnessSeconds: "", freshnessOverrideOrderBookFreshnessSeconds: "", freshnessOverrideRuntimeQuietSeconds: "", },
   setLiveSessionForm: (valOrUpdater) => set((state) => ({ liveSessionForm: resolveUpdater(valOrUpdater, state.liveSessionForm) })),
   strategySignalForm: { strategyId: "", sourceKey: "", role: "trigger", symbol: "BTCUSDT", timeframe: "1d", },
   setStrategySignalForm: (valOrUpdater) => set((state) => ({ strategySignalForm: resolveUpdater(valOrUpdater, state.strategySignalForm) })),
@@ -445,4 +445,3 @@ export const useUIStore = create<useUIStoreState>((set) => ({
     return { timelineConfig: next };
   }),
 }));
-

--- a/web/console/src/types/domain.ts
+++ b/web/console/src/types/domain.ts
@@ -583,7 +583,10 @@ export interface LiveSessionForm {
   signalTimeframe: string;
   executionDataSource: string;
   symbol: string;
+  positionSizingMode: string;
   defaultOrderQuantity: string;
+  reentrySizeScheduleFirst: string;
+  reentrySizeScheduleSecond: string;
   executionEntryOrderType: string;
   executionEntryMaxSpreadBps: string;
   executionEntryWideSpreadMode: string;


### PR DESCRIPTION
## 目的
- 为实盘会话配置弹窗补齐数量模式配置，可在 `fixed_quantity` 与 `reentry_size_schedule` 间切换，并可编辑两档 `reentry_size_schedule`
- 让“更新会话配置”把 `positionSizingMode` 与 `reentry_size_schedule` 正确写回当前 live session
- 修复 schedule 模式下 SL/TP 退出单 `OrderQuantity` 可能误用计划数量/回退数量，而不是当前持仓数量的问题
- 修复 verified takeover 场景下 recovered close 仍被强制留在 manual review，导致接管后的 SL / TSL / TP 不能自动平仓
- 对齐 research baseline 的 live launch template，默认使用 `reentry_size_schedule=[0.20, 0.10]`

## Root Cause
- 之前 live session UI 只支持固定数量，前端无法显式维护 `reentry_size_schedule` 配置
- 执行层在 reentry schedule 场景下没有把 exit sizing 优先绑定到当前持仓数量，导致 SL/TP 的数量语义不够稳
- recovery auto-dispatch 门禁过去按 takeover 状态一刀切阻断，连已经通过 authoritative reconcile 的 `close-existing-position` 也一起被挡住了

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [x] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
- [x] `dispatchMode` 默认值无变化
- [x] 不存在直接调用 `mainnet` 凭证或路由地址的硬编码
- [x] 无 DB migration 变更
- [x] 已核对配置字段变更仅包含 `positionSizingMode`、`reentry_size_schedule` 及相关前后端透传
- [x] recovery 仅放开 `verified/adopted + close-existing-position` 的 auto-dispatch，未放开自动开新仓

## 行为变化
- 实盘会话弹窗新增数量模式选择，并在 schedule 模式下允许编辑首笔/次笔 reentry 比例
- `create/update/launch` live session 时会同时透传 `positionSizingMode`、`defaultOrderQuantity`、`reentry_size_schedule`
- 仅 entry reentry 按 `reentry_size_schedule` 计算下单量；SL/PT exit 强制优先使用 `currentPosition.quantity` 并保持 `reduceOnly`
- verified / adopted 的 takeover session 在 `recovery-monitoring` 下，若 intent 属于 `close-existing-position`，允许 auto-dispatch 自动平仓；entry 和未完成对账的 close 仍然保持阻断
- 上述 close-existing-position 放行覆盖 SL、TSL、TP，只要最终 proposal 通过现有执行元数据校验

## 验证方式与测试证据
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
- `./node_modules/.bin/tsc --noEmit src/modals/LiveSessionModal.tsx src/hooks/useTradingActions.ts src/store/useUIStore.ts src/types/domain.ts --jsx react-jsx --esModuleInterop --skipLibCheck --target esnext --module esnext --moduleResolution node --allowSyntheticDefaultImports --types vite/client`
- `npm run build`
- `go test ./internal/service -run 'Test(RecoveryMonitoringStillDisablesEntryAutoDispatch|RecoveryMonitoringAllowsVerifiedCloseAutoDispatch|ShouldAutoDispatchLiveIntentBlocksUnresolvedRecoveryWatchdogClose|RecoverRunningLiveSessionAllowsTakeoverAfterVerifiedReconcileMatch|UnresolvedReconcileMismatchPreventsAutoDispatch)'`

## 新增测试
- `TestBookAwareExecutionStrategyUsesReentrySizeScheduleForLiveEntry`
- `TestBookAwareExecutionStrategyUsesPositionQuantityForScheduledReentryExits`
- `TestNormalizeLiveSessionOverridesIncludesPositionSizing`
- `TestDeriveLiveSignalIntentUsesNextPlannedStep` 补充 exit quantity 断言
- `TestRecoveryMonitoringStillDisablesEntryAutoDispatch`
- `TestRecoveryMonitoringAllowsVerifiedCloseAutoDispatch`
