### PR TITLE
[codex] add telegram trade and position reports

### DIFF
--- a/db/migrations/018_telegram_trade_position_reports.sql
+++ b/db/migrations/018_telegram_trade_position_reports.sql
@@ -1,0 +1,4 @@
+alter table telegram_configs
+  add column if not exists trade_events_enabled boolean not null default true,
+  add column if not exists position_report_enabled boolean not null default true,
+  add column if not exists position_report_interval_minutes integer not null default 30;

--- a/internal/domain/models.go
+++ b/internal/domain/models.go
@@ -482,11 +482,14 @@ type PlatformNotification struct {
 
 // TelegramConfig 保存 Telegram 通知通道配置。
 type TelegramConfig struct {
-	Enabled    bool      `json:"enabled"`
-	BotToken   string    `json:"botToken"`
-	ChatID     string    `json:"chatId"`
-	SendLevels []string  `json:"sendLevels"`
-	UpdatedAt  time.Time `json:"updatedAt"`
+	Enabled                       bool      `json:"enabled"`
+	BotToken                      string    `json:"botToken"`
+	ChatID                        string    `json:"chatId"`
+	SendLevels                    []string  `json:"sendLevels"`
+	TradeEventsEnabled            bool      `json:"tradeEventsEnabled"`
+	PositionReportEnabled         bool      `json:"positionReportEnabled"`
+	PositionReportIntervalMinutes int       `json:"positionReportIntervalMinutes"`
+	UpdatedAt                     time.Time `json:"updatedAt"`
 }
 
 // NotificationDelivery 记录通知通过外部通道的发送结果。

--- a/internal/http/signals.go
+++ b/internal/http/signals.go
@@ -130,16 +130,19 @@ func registerSignalRoutes(mux *http.ServeMux, platform *service.Platform) {
 			writeJSON(w, http.StatusOK, platform.TelegramConfigView())
 		case http.MethodPost:
 			var payload struct {
-				Enabled    bool     `json:"enabled"`
-				BotToken   string   `json:"botToken"`
-				ChatID     string   `json:"chatId"`
-				SendLevels []string `json:"sendLevels"`
+				Enabled                       bool     `json:"enabled"`
+				BotToken                      string   `json:"botToken"`
+				ChatID                        string   `json:"chatId"`
+				SendLevels                    []string `json:"sendLevels"`
+				TradeEventsEnabled            bool     `json:"tradeEventsEnabled"`
+				PositionReportEnabled         bool     `json:"positionReportEnabled"`
+				PositionReportIntervalMinutes int      `json:"positionReportIntervalMinutes"`
 			}
 			if err := decodeJSON(r, &payload); err != nil {
 				writeError(w, http.StatusBadRequest, err.Error())
 				return
 			}
-			item, err := platform.UpdateTelegramConfig(payload.Enabled, payload.BotToken, payload.ChatID, payload.SendLevels)
+			item, err := platform.UpdateTelegramConfig(payload.Enabled, payload.BotToken, payload.ChatID, payload.SendLevels, payload.TradeEventsEnabled, payload.PositionReportEnabled, payload.PositionReportIntervalMinutes)
 			if err != nil {
 				writeError(w, http.StatusBadRequest, err.Error())
 				return

--- a/internal/service/platform.go
+++ b/internal/service/platform.go
@@ -85,6 +85,13 @@ func NewPlatform(store store.Repository) *Platform {
 		signalSessions:      make(map[string]domain.SignalRuntimeSession),
 		liveMarketData:      make(map[string]liveMarketSnapshot),
 		logBroker:           logging.NewBroker(),
+		telegramConfig: domain.TelegramConfig{
+			SendLevels:                    []string{"critical", "warning"},
+			TradeEventsEnabled:            true,
+			PositionReportEnabled:         true,
+			PositionReportIntervalMinutes: 30,
+			UpdatedAt:                     time.Now().UTC(),
+		},
 		runtimePolicy: RuntimePolicy{
 			TradeTickFreshnessSeconds:      15,
 			OrderBookFreshnessSeconds:      10,
@@ -233,6 +240,9 @@ func (p *Platform) LoadPersistedRuntimePolicy() error {
 
 func (p *Platform) SetTelegramConfig(config domain.TelegramConfig) {
 	p.telegramConfig.Enabled = config.Enabled
+	p.telegramConfig.TradeEventsEnabled = config.TradeEventsEnabled
+	p.telegramConfig.PositionReportEnabled = config.PositionReportEnabled
+	p.telegramConfig.PositionReportIntervalMinutes = normalizeTelegramPositionReportInterval(config.PositionReportIntervalMinutes)
 	if strings.TrimSpace(config.BotToken) != "" {
 		p.telegramConfig.BotToken = strings.TrimSpace(config.BotToken)
 	}
@@ -256,18 +266,24 @@ func (p *Platform) SetTelegramConfig(config domain.TelegramConfig) {
 func (p *Platform) TelegramConfigView() map[string]any {
 	token := strings.TrimSpace(p.telegramConfig.BotToken)
 	return map[string]any{
-		"enabled":        p.telegramConfig.Enabled,
-		"chatId":         p.telegramConfig.ChatID,
-		"sendLevels":     append([]string(nil), p.telegramConfig.SendLevels...),
-		"hasBotToken":    token != "",
-		"maskedBotToken": maskTelegramToken(token),
-		"updatedAt":      p.telegramConfig.UpdatedAt,
+		"enabled":                       p.telegramConfig.Enabled,
+		"chatId":                        p.telegramConfig.ChatID,
+		"sendLevels":                    append([]string(nil), p.telegramConfig.SendLevels...),
+		"tradeEventsEnabled":            p.telegramConfig.TradeEventsEnabled,
+		"positionReportEnabled":         p.telegramConfig.PositionReportEnabled,
+		"positionReportIntervalMinutes": normalizeTelegramPositionReportInterval(p.telegramConfig.PositionReportIntervalMinutes),
+		"hasBotToken":                   token != "",
+		"maskedBotToken":                maskTelegramToken(token),
+		"updatedAt":                     p.telegramConfig.UpdatedAt,
 	}
 }
 
-func (p *Platform) UpdateTelegramConfig(enabled bool, botToken, chatID string, sendLevels []string) (map[string]any, error) {
+func (p *Platform) UpdateTelegramConfig(enabled bool, botToken, chatID string, sendLevels []string, tradeEventsEnabled, positionReportEnabled bool, positionReportIntervalMinutes int) (map[string]any, error) {
 	config := p.telegramConfig
 	config.Enabled = enabled
+	config.TradeEventsEnabled = tradeEventsEnabled
+	config.PositionReportEnabled = positionReportEnabled
+	config.PositionReportIntervalMinutes = normalizeTelegramPositionReportInterval(positionReportIntervalMinutes)
 	if strings.TrimSpace(botToken) != "" {
 		config.BotToken = strings.TrimSpace(botToken)
 	}
@@ -300,8 +316,12 @@ func (p *Platform) LoadPersistedTelegramConfig() error {
 	}
 	if !ok {
 		p.logger("service.platform").Debug("no persisted telegram config found")
+		if p.telegramConfig.PositionReportIntervalMinutes <= 0 {
+			p.telegramConfig.PositionReportIntervalMinutes = 30
+		}
 		return nil
 	}
+	config.PositionReportIntervalMinutes = normalizeTelegramPositionReportInterval(config.PositionReportIntervalMinutes)
 	p.telegramConfig = config
 	p.logger("service.platform").Info("persisted telegram config loaded",
 		"enabled", config.Enabled,
@@ -341,6 +361,19 @@ func normalizeTelegramSendLevels(levels []string) []string {
 		return []string{"critical", "warning"}
 	}
 	return out
+}
+
+func normalizeTelegramPositionReportInterval(minutes int) int {
+	if minutes <= 0 {
+		return 30
+	}
+	if minutes < 5 {
+		return 5
+	}
+	if minutes > 1440 {
+		return 1440
+	}
+	return minutes
 }
 
 func maskTelegramToken(token string) string {

--- a/internal/service/telegram.go
+++ b/internal/service/telegram.go
@@ -213,10 +213,22 @@ func (p *Platform) DispatchTelegramNotifications() error {
 		sentCount++
 	}
 
+	tradeEventCount, tradeEventErr := p.DispatchTelegramTradeEvents(deliveryByID)
+	if tradeEventErr != nil && firstErr == nil {
+		firstErr = tradeEventErr
+	}
+	positionReportCount, positionReportErr := p.DispatchTelegramPositionReport(deliveryByID, now)
+	if positionReportErr != nil && firstErr == nil {
+		firstErr = positionReportErr
+	}
+
 	// 恢复检测：遍历已发送的 delivery
 	recoveredCount := 0
 	for _, delivery := range deliveries {
 		if !strings.EqualFold(delivery.Channel, "telegram") {
+			continue
+		}
+		if telegramDeliveryIsOneShot(delivery.NotificationID) {
 			continue
 		}
 		if _, isActive := activeNotificationIDs[delivery.NotificationID]; isActive {
@@ -264,10 +276,268 @@ func (p *Platform) DispatchTelegramNotifications() error {
 		recoveredCount++
 	}
 
-	if sentCount > 0 || recoveredCount > 0 {
-		logger.Debug("telegram dispatch cycle completed", "sent", sentCount, "recovered", recoveredCount, "active", len(notifications))
+	if sentCount > 0 || recoveredCount > 0 || tradeEventCount > 0 || positionReportCount > 0 {
+		logger.Debug("telegram dispatch cycle completed", "sent", sentCount, "recovered", recoveredCount, "trade_events", tradeEventCount, "position_reports", positionReportCount, "active", len(notifications))
 	}
 	return firstErr
+}
+
+func telegramDeliveryIsOneShot(notificationID string) bool {
+	return strings.HasPrefix(notificationID, "trade-event:") || strings.HasPrefix(notificationID, "position-report:")
+}
+
+func (p *Platform) DispatchTelegramTradeEvents(deliveryByID map[string]domain.NotificationDelivery) (int, error) {
+	config := p.telegramConfig
+	if !config.Enabled || !config.TradeEventsEnabled || strings.TrimSpace(config.BotToken) == "" || strings.TrimSpace(config.ChatID) == "" {
+		return 0, nil
+	}
+	events, err := p.store.ListOrderExecutionEvents("")
+	if err != nil {
+		return 0, err
+	}
+	sent := 0
+	var firstErr error
+	for _, event := range events {
+		if !strings.EqualFold(event.EventType, "filled") {
+			continue
+		}
+		if event.Failed || strings.TrimSpace(event.Error) != "" {
+			continue
+		}
+		notificationID := "trade-event:" + event.ID
+		if delivery, ok := deliveryByID[notificationID]; ok && strings.EqualFold(delivery.Status, "sent") {
+			continue
+		}
+		message := formatTelegramTradeEvent(event)
+		if err := p.sendTelegramMessage(message); err != nil {
+			_, _ = p.store.UpsertNotificationDelivery(notificationID, "telegram", "failed", err.Error(), map[string]any{
+				"kind":      "trade-event",
+				"eventId":   event.ID,
+				"orderId":   event.OrderID,
+				"symbol":    event.Symbol,
+				"eventTime": event.EventTime.Format(time.RFC3339),
+			})
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		delivery, err := p.store.UpsertNotificationDelivery(notificationID, "telegram", "sent", "", map[string]any{
+			"kind":      "trade-event",
+			"eventId":   event.ID,
+			"orderId":   event.OrderID,
+			"symbol":    event.Symbol,
+			"eventTime": event.EventTime.Format(time.RFC3339),
+		})
+		if err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		deliveryByID[notificationID] = delivery
+		sent++
+	}
+	return sent, firstErr
+}
+
+func (p *Platform) DispatchTelegramPositionReport(deliveryByID map[string]domain.NotificationDelivery, now time.Time) (int, error) {
+	config := p.telegramConfig
+	if !config.Enabled || !config.PositionReportEnabled || strings.TrimSpace(config.BotToken) == "" || strings.TrimSpace(config.ChatID) == "" {
+		return 0, nil
+	}
+	intervalMinutes := normalizeTelegramPositionReportInterval(config.PositionReportIntervalMinutes)
+	interval := time.Duration(intervalMinutes) * time.Minute
+	bucket := now.UTC().Truncate(interval)
+	notificationID := fmt.Sprintf("position-report:%d:%d", intervalMinutes, bucket.Unix())
+	if delivery, ok := deliveryByID[notificationID]; ok && strings.EqualFold(delivery.Status, "sent") {
+		return 0, nil
+	}
+	accounts, err := p.store.ListAccounts()
+	if err != nil {
+		return 0, err
+	}
+	liveAccounts := make([]domain.Account, 0)
+	for _, account := range accounts {
+		if strings.EqualFold(account.Mode, "LIVE") {
+			liveAccounts = append(liveAccounts, account)
+		}
+	}
+	if len(liveAccounts) == 0 {
+		return 0, nil
+	}
+	summaries, err := p.ListAccountSummaries()
+	if err != nil {
+		return 0, err
+	}
+	summaryByAccount := make(map[string]domain.AccountSummary, len(summaries))
+	for _, summary := range summaries {
+		summaryByAccount[summary.AccountID] = summary
+	}
+	message := formatTelegramPositionReport(liveAccounts, summaryByAccount, bucket, intervalMinutes)
+	if err := p.sendTelegramMessage(message); err != nil {
+		_, _ = p.store.UpsertNotificationDelivery(notificationID, "telegram", "failed", err.Error(), map[string]any{
+			"kind":            "position-report",
+			"bucket":          bucket.Format(time.RFC3339),
+			"intervalMinutes": intervalMinutes,
+		})
+		return 0, err
+	}
+	delivery, err := p.store.UpsertNotificationDelivery(notificationID, "telegram", "sent", "", map[string]any{
+		"kind":            "position-report",
+		"bucket":          bucket.Format(time.RFC3339),
+		"intervalMinutes": intervalMinutes,
+	})
+	if err != nil {
+		return 0, err
+	}
+	deliveryByID[notificationID] = delivery
+	return 1, nil
+}
+
+func formatTelegramTradeEvent(event domain.OrderExecutionEvent) string {
+	action := "开仓"
+	if telegramTradeEventIsClose(event) {
+		action = "平仓"
+	}
+	price := firstPositiveTelegramFloat(event.Price, event.NormalizedPrice, event.ExpectedPrice, event.RawPriceReference)
+	realizedPnL := firstNonZeroFloat(
+		parseFloatValue(event.AdapterSync["totalRealizedPnl"]),
+		parseFloatValue(event.AdapterSync["realizedPnl"]),
+		parseFloatValue(event.DispatchSummary["realizedPnl"]),
+	)
+	fee := firstNonZeroFloat(parseFloatValue(event.AdapterSync["totalFee"]), parseFloatValue(event.DispatchSummary["fee"]))
+	lines := []string{
+		fmt.Sprintf("📌 *%s成交* %s %s", action, NormalizeSymbol(event.Symbol), strings.ToUpper(strings.TrimSpace(event.Side))),
+		fmt.Sprintf("数量: %s", formatTelegramNumber(event.Quantity)),
+		fmt.Sprintf("价格: %s", formatTelegramNumber(price)),
+		fmt.Sprintf("订单: %s", event.OrderID),
+	}
+	if event.ExchangeOrderID != "" {
+		lines = append(lines, fmt.Sprintf("交易所订单: %s", event.ExchangeOrderID))
+	}
+	if action == "平仓" {
+		lines = append(lines, fmt.Sprintf("已实现盈亏: %s", formatTelegramSignedNumber(realizedPnL)))
+	}
+	if fee != 0 {
+		lines = append(lines, fmt.Sprintf("手续费: %s", formatTelegramSignedNumber(-fee)))
+	}
+	if event.AccountID != "" {
+		lines = append(lines, fmt.Sprintf("账户: %s", event.AccountID))
+	}
+	if event.LiveSessionID != "" {
+		lines = append(lines, fmt.Sprintf("实盘会话: %s", event.LiveSessionID))
+	}
+	if !event.EventTime.IsZero() {
+		lines = append(lines, fmt.Sprintf("时间: %s", event.EventTime.UTC().Format(time.RFC3339)))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func telegramTradeEventIsClose(event domain.OrderExecutionEvent) bool {
+	if event.ReduceOnly {
+		return true
+	}
+	decision := strings.ToLower(strings.TrimSpace(event.ExecutionDecision))
+	if strings.Contains(decision, "exit") || strings.Contains(decision, "close") {
+		return true
+	}
+	role := strings.ToLower(firstNonEmpty(stringValue(event.DispatchSummary["role"]), stringValue(event.DispatchSummary["orderRole"]), stringValue(event.Metadata["role"])))
+	return strings.Contains(role, "exit") || strings.Contains(role, "close")
+}
+
+func formatTelegramPositionReport(accounts []domain.Account, summaries map[string]domain.AccountSummary, bucket time.Time, intervalMinutes int) string {
+	lines := []string{
+		fmt.Sprintf("📊 *持仓定时播报* %d分钟", intervalMinutes),
+		fmt.Sprintf("时间: %s", bucket.UTC().Format(time.RFC3339)),
+	}
+	for _, account := range accounts {
+		summary := summaries[account.ID]
+		lines = append(lines, "")
+		lines = append(lines, fmt.Sprintf("账户: %s", firstNonEmpty(account.Name, account.ID)))
+		lines = append(lines, fmt.Sprintf("净值: %s 可用: %s 未实现盈亏: %s", formatTelegramNumber(summary.NetEquity), formatTelegramNumber(summary.AvailableBalance), formatTelegramSignedNumber(summary.UnrealizedPnL)))
+		snapshot := mapValue(account.Metadata["liveSyncSnapshot"])
+		syncStatus := firstNonEmpty(stringValue(snapshot["syncStatus"]), account.Status)
+		if syncedAt := firstNonEmpty(stringValue(snapshot["syncedAt"]), stringValue(account.Metadata["lastLiveSyncAt"])); syncedAt != "" {
+			lines = append(lines, fmt.Sprintf("同步: %s %s", syncStatus, syncedAt))
+		} else {
+			lines = append(lines, fmt.Sprintf("同步: %s", syncStatus))
+		}
+		positions := metadataList(snapshot["positions"])
+		if len(positions) == 0 {
+			lines = append(lines, "持仓: 无")
+			continue
+		}
+		for _, position := range positions {
+			symbol := NormalizeSymbol(stringValue(position["symbol"]))
+			qty := firstNonZeroFloat(parseFloatValue(position["quantity"]), parseFloatValue(position["positionAmt"]))
+			side := firstNonEmpty(stringValue(position["side"]), stringValue(position["positionSide"]))
+			if side == "" {
+				if qty < 0 {
+					side = "SHORT"
+				} else {
+					side = "LONG"
+				}
+			}
+			if qty < 0 {
+				qty = -qty
+			}
+			entryPrice := parseFloatValue(position["entryPrice"])
+			markPrice := parseFloatValue(position["markPrice"])
+			unrealized := parseFloatValue(position["unrealizedProfit"])
+			if unrealized == 0 && entryPrice > 0 && markPrice > 0 && qty > 0 {
+				if strings.EqualFold(side, "SHORT") {
+					unrealized = (entryPrice - markPrice) * qty
+				} else {
+					unrealized = (markPrice - entryPrice) * qty
+				}
+			}
+			lines = append(lines, fmt.Sprintf("%s %s 数量:%s 入场:%s 标记:%s 浮盈亏:%s",
+				symbol,
+				strings.ToUpper(side),
+				formatTelegramNumber(qty),
+				formatTelegramNumber(entryPrice),
+				formatTelegramNumber(markPrice),
+				formatTelegramSignedNumber(unrealized),
+			))
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+func firstNonZeroFloat(values ...float64) float64 {
+	for _, value := range values {
+		if value != 0 {
+			return value
+		}
+	}
+	return 0
+}
+
+func firstPositiveTelegramFloat(values ...float64) float64 {
+	for _, value := range values {
+		if value > 0 {
+			return value
+		}
+	}
+	return 0
+}
+
+func formatTelegramNumber(value float64) string {
+	text := fmt.Sprintf("%.8f", value)
+	text = strings.TrimRight(text, "0")
+	text = strings.TrimRight(text, ".")
+	if text == "" || text == "-0" {
+		return "0"
+	}
+	return text
+}
+
+func formatTelegramSignedNumber(value float64) string {
+	if value > 0 {
+		return "+" + formatTelegramNumber(value)
+	}
+	return formatTelegramNumber(value)
 }
 
 func telegramAlertNeedsFlapSuppression(alert domain.PlatformAlert) bool {

--- a/internal/service/telegram.go
+++ b/internal/service/telegram.go
@@ -366,6 +366,9 @@ func (p *Platform) DispatchTelegramPositionReport(deliveryByID map[string]domain
 	if len(liveAccounts) == 0 {
 		return 0, nil
 	}
+	if !telegramAccountsHaveOpenPosition(liveAccounts) {
+		return 0, nil
+	}
 	summaries, err := p.ListAccountSummaries()
 	if err != nil {
 		return 0, err
@@ -393,6 +396,21 @@ func (p *Platform) DispatchTelegramPositionReport(deliveryByID map[string]domain
 	}
 	deliveryByID[notificationID] = delivery
 	return 1, nil
+}
+
+func telegramAccountsHaveOpenPosition(accounts []domain.Account) bool {
+	for _, account := range accounts {
+		for _, position := range metadataList(mapValue(account.Metadata["liveSyncSnapshot"])["positions"]) {
+			qty := firstNonZeroFloat(parseFloatValue(position["quantity"]), parseFloatValue(position["positionAmt"]))
+			if qty < 0 {
+				qty = -qty
+			}
+			if qty > 0 {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func formatTelegramTradeEvent(event domain.OrderExecutionEvent) string {

--- a/internal/service/telegram_test.go
+++ b/internal/service/telegram_test.go
@@ -331,6 +331,93 @@ func TestTelegramPositionReportUsesThirtyMinuteBucketAndSkipsRecovery(t *testing
 	}
 }
 
+func TestTelegramPositionReportSkipsEmptyPositions(t *testing.T) {
+	messages := make([]string, 0)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var p map[string]any
+		json.Unmarshal(body, &p)
+		messages = append(messages, p["text"].(string))
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"ok":true}`))
+	}))
+	defer server.Close()
+
+	oldURL := telegramBaseURL
+	telegramBaseURL = server.URL
+	defer func() { telegramBaseURL = oldURL }()
+
+	base := time.Date(2026, 4, 22, 10, 5, 0, 0, time.UTC)
+	oldNow := telegramNow
+	telegramNow = func() time.Time { return base }
+	defer func() { telegramNow = oldNow }()
+
+	store := memory.NewStore()
+	accounts, err := store.ListAccounts()
+	if err != nil {
+		t.Fatalf("list accounts failed: %v", err)
+	}
+	var account domain.Account
+	for _, item := range accounts {
+		if strings.EqualFold(item.Mode, "LIVE") {
+			account = item
+			break
+		}
+	}
+	if account.ID == "" {
+		t.Fatal("expected default live account")
+	}
+	account.Metadata = map[string]any{
+		"lastLiveSyncAt": base.Format(time.RFC3339),
+		"liveSyncSnapshot": map[string]any{
+			"syncStatus":            "SYNCED",
+			"syncedAt":              base.Format(time.RFC3339),
+			"totalMarginBalance":    12000.0,
+			"availableBalance":      8000.0,
+			"totalWalletBalance":    12000.0,
+			"totalUnrealizedProfit": 0.0,
+			"positions": []map[string]any{{
+				"symbol":       "ETHUSDT",
+				"positionAmt":  0.0,
+				"entryPrice":   0.0,
+				"markPrice":    0.0,
+				"positionSide": "BOTH",
+			}},
+		},
+	}
+	if _, err := store.UpdateAccount(account); err != nil {
+		t.Fatalf("update account failed: %v", err)
+	}
+
+	p := &Platform{
+		store: store,
+		telegramConfig: domain.TelegramConfig{
+			Enabled:                       true,
+			BotToken:                      "test-token",
+			ChatID:                        "123",
+			SendLevels:                    []string{},
+			PositionReportEnabled:         true,
+			PositionReportIntervalMinutes: 30,
+		},
+	}
+
+	if err := p.DispatchTelegramNotifications(); err != nil {
+		t.Fatalf("dispatch failed: %v", err)
+	}
+	if len(messages) != 0 {
+		t.Fatalf("expected empty position report to be skipped, got %#v", messages)
+	}
+	deliveries, err := store.ListNotificationDeliveries()
+	if err != nil {
+		t.Fatalf("list deliveries failed: %v", err)
+	}
+	for _, delivery := range deliveries {
+		if strings.HasPrefix(delivery.NotificationID, "position-report:") {
+			t.Fatalf("expected no position report delivery for empty positions, got %#v", delivery)
+		}
+	}
+}
+
 func TestTelegramDispatchSuppressesFlappingRuntimeStaleAlerts(t *testing.T) {
 	var messages []string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/service/telegram_test.go
+++ b/internal/service/telegram_test.go
@@ -138,6 +138,199 @@ func TestTelegramNotificationRecoveryRestart(t *testing.T) {
 	}
 }
 
+func TestTelegramDispatchSendsFilledTradeEventsWithPnLAndDedup(t *testing.T) {
+	messages := make([]string, 0)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var p map[string]any
+		json.Unmarshal(body, &p)
+		messages = append(messages, p["text"].(string))
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"ok":true}`))
+	}))
+	defer server.Close()
+
+	oldURL := telegramBaseURL
+	telegramBaseURL = server.URL
+	defer func() { telegramBaseURL = oldURL }()
+
+	store := memory.NewStore()
+	now := time.Date(2026, 4, 22, 10, 0, 0, 0, time.UTC)
+	_, err := store.CreateOrderExecutionEvent(domain.OrderExecutionEvent{
+		ID:              "open-event-1",
+		OrderID:         "order-open-1",
+		AccountID:       "account-live-1",
+		LiveSessionID:   "live-session-1",
+		Symbol:          "BTCUSDT",
+		Side:            "BUY",
+		EventType:       "filled",
+		Status:          "FILLED",
+		Quantity:        0.2,
+		Price:           64000,
+		EventTime:       now,
+		ExecutionMode:   "live",
+		DispatchSummary: map[string]any{"role": "entry"},
+	})
+	if err != nil {
+		t.Fatalf("create open event failed: %v", err)
+	}
+	_, err = store.CreateOrderExecutionEvent(domain.OrderExecutionEvent{
+		ID:              "close-event-1",
+		OrderID:         "order-close-1",
+		AccountID:       "account-live-1",
+		LiveSessionID:   "live-session-1",
+		Symbol:          "BTCUSDT",
+		Side:            "SELL",
+		EventType:       "filled",
+		Status:          "FILLED",
+		Quantity:        0.1,
+		Price:           65000,
+		EventTime:       now.Add(time.Minute),
+		ExecutionMode:   "live",
+		ReduceOnly:      true,
+		AdapterSync:     map[string]any{"totalRealizedPnl": 100.5, "totalFee": 1.25},
+		DispatchSummary: map[string]any{"role": "exit"},
+	})
+	if err != nil {
+		t.Fatalf("create close event failed: %v", err)
+	}
+
+	p := &Platform{
+		store: store,
+		telegramConfig: domain.TelegramConfig{
+			Enabled:                       true,
+			BotToken:                      "test-token",
+			ChatID:                        "123",
+			SendLevels:                    []string{},
+			TradeEventsEnabled:            true,
+			PositionReportIntervalMinutes: 30,
+		},
+	}
+
+	if err := p.DispatchTelegramNotifications(); err != nil {
+		t.Fatalf("dispatch failed: %v", err)
+	}
+	if len(messages) != 2 {
+		t.Fatalf("expected 2 trade messages, got %d: %#v", len(messages), messages)
+	}
+	joined := strings.Join(messages, "\n---\n")
+	if !strings.Contains(joined, "*开仓成交* BTCUSDT BUY") {
+		t.Fatalf("expected open trade message, got: %s", joined)
+	}
+	if !strings.Contains(joined, "数量: 0.2") || !strings.Contains(joined, "价格: 64000") {
+		t.Fatalf("expected open qty and price, got: %s", joined)
+	}
+	if !strings.Contains(joined, "*平仓成交* BTCUSDT SELL") || !strings.Contains(joined, "已实现盈亏: +100.5") {
+		t.Fatalf("expected close pnl message, got: %s", joined)
+	}
+	if err := p.DispatchTelegramNotifications(); err != nil {
+		t.Fatalf("second dispatch failed: %v", err)
+	}
+	if len(messages) != 2 {
+		t.Fatalf("expected trade delivery dedupe, got %d messages", len(messages))
+	}
+}
+
+func TestTelegramPositionReportUsesThirtyMinuteBucketAndSkipsRecovery(t *testing.T) {
+	messages := make([]string, 0)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var p map[string]any
+		json.Unmarshal(body, &p)
+		messages = append(messages, p["text"].(string))
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"ok":true}`))
+	}))
+	defer server.Close()
+
+	oldURL := telegramBaseURL
+	telegramBaseURL = server.URL
+	defer func() { telegramBaseURL = oldURL }()
+
+	base := time.Date(2026, 4, 22, 10, 5, 0, 0, time.UTC)
+	oldNow := telegramNow
+	telegramNow = func() time.Time { return base }
+	defer func() { telegramNow = oldNow }()
+
+	store := memory.NewStore()
+	accounts, err := store.ListAccounts()
+	if err != nil {
+		t.Fatalf("list accounts failed: %v", err)
+	}
+	var account domain.Account
+	for _, item := range accounts {
+		if strings.EqualFold(item.Mode, "LIVE") {
+			account = item
+			break
+		}
+	}
+	if account.ID == "" {
+		t.Fatal("expected default live account")
+	}
+	account.Metadata = map[string]any{
+		"lastLiveSyncAt": base.Format(time.RFC3339),
+		"liveSyncSnapshot": map[string]any{
+			"syncStatus":            "SYNCED",
+			"syncedAt":              base.Format(time.RFC3339),
+			"totalMarginBalance":    12000.0,
+			"availableBalance":      8000.0,
+			"totalWalletBalance":    11900.0,
+			"totalUnrealizedProfit": 100.0,
+			"positions": []map[string]any{{
+				"symbol":           "ETHUSDT",
+				"positionAmt":      1.5,
+				"entryPrice":       3000.0,
+				"markPrice":        3100.0,
+				"unrealizedProfit": 150.0,
+				"positionSide":     "LONG",
+			}},
+		},
+	}
+	if _, err := store.UpdateAccount(account); err != nil {
+		t.Fatalf("update account failed: %v", err)
+	}
+
+	p := &Platform{
+		store: store,
+		telegramConfig: domain.TelegramConfig{
+			Enabled:                       true,
+			BotToken:                      "test-token",
+			ChatID:                        "123",
+			SendLevels:                    []string{},
+			PositionReportEnabled:         true,
+			PositionReportIntervalMinutes: 30,
+		},
+	}
+
+	if err := p.DispatchTelegramNotifications(); err != nil {
+		t.Fatalf("dispatch failed: %v", err)
+	}
+	if len(messages) != 1 {
+		t.Fatalf("expected one position report, got %d: %#v", len(messages), messages)
+	}
+	if !strings.Contains(messages[0], "*持仓定时播报* 30分钟") || !strings.Contains(messages[0], "ETHUSDT LONG 数量:1.5") || !strings.Contains(messages[0], "浮盈亏:+150") {
+		t.Fatalf("unexpected position report: %s", messages[0])
+	}
+	if err := p.DispatchTelegramNotifications(); err != nil {
+		t.Fatalf("second dispatch failed: %v", err)
+	}
+	if len(messages) != 1 {
+		t.Fatalf("expected position report delivery dedupe, got %d messages", len(messages))
+	}
+	telegramNow = func() time.Time { return base.Add(31 * time.Minute) }
+	if err := p.DispatchTelegramNotifications(); err != nil {
+		t.Fatalf("third dispatch failed: %v", err)
+	}
+	if len(messages) != 2 {
+		t.Fatalf("expected next bucket position report, got %d messages", len(messages))
+	}
+	for _, msg := range messages {
+		if strings.Contains(msg, "[已恢复]") {
+			t.Fatalf("position report must not trigger recovery message: %s", msg)
+		}
+	}
+}
+
 func TestTelegramDispatchSuppressesFlappingRuntimeStaleAlerts(t *testing.T) {
 	var messages []string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/store/memory/store.go
+++ b/internal/store/memory/store.go
@@ -243,6 +243,9 @@ func (s *Store) GetTelegramConfig() (domain.TelegramConfig, bool, error) {
 func (s *Store) UpsertTelegramConfig(config domain.TelegramConfig) (domain.TelegramConfig, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if config.PositionReportIntervalMinutes <= 0 {
+		config.PositionReportIntervalMinutes = 30
+	}
 	config.UpdatedAt = time.Now().UTC()
 	copyConfig := config
 	s.telegramConfig = &copyConfig

--- a/internal/store/postgres/store.go
+++ b/internal/store/postgres/store.go
@@ -152,7 +152,7 @@ func (s *Store) GetTelegramConfig() (domain.TelegramConfig, bool, error) {
 	var item domain.TelegramConfig
 	var levelsRaw []byte
 	err := s.db.QueryRow(`
-		select enabled, bot_token, chat_id, send_levels, updated_at
+		select enabled, bot_token, chat_id, send_levels, trade_events_enabled, position_report_enabled, position_report_interval_minutes, updated_at
 		from telegram_configs
 		where id = 1
 	`).Scan(
@@ -160,6 +160,9 @@ func (s *Store) GetTelegramConfig() (domain.TelegramConfig, bool, error) {
 		&item.BotToken,
 		&item.ChatID,
 		&levelsRaw,
+		&item.TradeEventsEnabled,
+		&item.PositionReportEnabled,
+		&item.PositionReportIntervalMinutes,
 		&item.UpdatedAt,
 	)
 	if err != nil {
@@ -171,22 +174,31 @@ func (s *Store) GetTelegramConfig() (domain.TelegramConfig, bool, error) {
 	if len(levelsRaw) > 0 {
 		_ = json.Unmarshal(levelsRaw, &item.SendLevels)
 	}
+	if item.PositionReportIntervalMinutes <= 0 {
+		item.PositionReportIntervalMinutes = 30
+	}
 	return item, true, nil
 }
 
 func (s *Store) UpsertTelegramConfig(config domain.TelegramConfig) (domain.TelegramConfig, error) {
 	config.UpdatedAt = time.Now().UTC()
+	if config.PositionReportIntervalMinutes <= 0 {
+		config.PositionReportIntervalMinutes = 30
+	}
 	raw, _ := json.Marshal(config.SendLevels)
 	_, err := s.db.Exec(`
-		insert into telegram_configs (id, enabled, bot_token, chat_id, send_levels, updated_at)
-		values (1, $1, $2, $3, $4, $5)
+		insert into telegram_configs (id, enabled, bot_token, chat_id, send_levels, trade_events_enabled, position_report_enabled, position_report_interval_minutes, updated_at)
+		values (1, $1, $2, $3, $4, $5, $6, $7, $8)
 		on conflict (id) do update set
 			enabled = excluded.enabled,
 			bot_token = excluded.bot_token,
 			chat_id = excluded.chat_id,
 			send_levels = excluded.send_levels,
+			trade_events_enabled = excluded.trade_events_enabled,
+			position_report_enabled = excluded.position_report_enabled,
+			position_report_interval_minutes = excluded.position_report_interval_minutes,
 			updated_at = excluded.updated_at
-	`, config.Enabled, config.BotToken, config.ChatID, raw, config.UpdatedAt)
+	`, config.Enabled, config.BotToken, config.ChatID, raw, config.TradeEventsEnabled, config.PositionReportEnabled, config.PositionReportIntervalMinutes, config.UpdatedAt)
 	if err != nil {
 		return domain.TelegramConfig{}, err
 	}

--- a/web/console/src/hooks/useDashboard.ts
+++ b/web/console/src/hooks/useDashboard.ts
@@ -221,6 +221,9 @@ export function useDashboard() {
         botToken: "",
         chatId: String(telegramConfigData.chatId ?? ""),
         sendLevels: (telegramConfigData.sendLevels ?? []).join(",") || "critical,warning",
+        tradeEventsEnabled: Boolean(telegramConfigData.tradeEventsEnabled),
+        positionReportEnabled: Boolean(telegramConfigData.positionReportEnabled),
+        positionReportIntervalMinutes: String(telegramConfigData.positionReportIntervalMinutes ?? 30),
       });
     }
     setRuntimePolicyForm({

--- a/web/console/src/hooks/useTradingActions.ts
+++ b/web/console/src/hooks/useTradingActions.ts
@@ -937,6 +937,9 @@ export function useTradingActions(loadDashboard: () => Promise<void>) {
             .split(",")
             .map((item: string) => item.trim().toLowerCase())
             .filter(Boolean),
+          tradeEventsEnabled: telegramForm.tradeEventsEnabled,
+          positionReportEnabled: telegramForm.positionReportEnabled,
+          positionReportIntervalMinutes: Number(telegramForm.positionReportIntervalMinutes) || 30,
         }),
       });
       setTelegramConfig(updated);
@@ -944,7 +947,10 @@ export function useTradingActions(loadDashboard: () => Promise<void>) {
         ...current, 
         enabled: Boolean(updated.enabled),
         chatId: String(updated.chatId ?? ""),
-        botToken: "" 
+        botToken: "",
+        tradeEventsEnabled: Boolean(updated.tradeEventsEnabled),
+        positionReportEnabled: Boolean(updated.positionReportEnabled),
+        positionReportIntervalMinutes: String(updated.positionReportIntervalMinutes ?? 30),
       }));
       await loadDashboard();
       setError(null);

--- a/web/console/src/modals/TelegramModal.tsx
+++ b/web/console/src/modals/TelegramModal.tsx
@@ -91,6 +91,27 @@ export function TelegramModal({
             className="h-10 rounded-xl border-[var(--bk-border)] bg-[var(--bk-surface-overlay)] px-3"
           />
         </ModalField>
+        <ModalCheckboxField
+          label="开平事件提醒"
+          checked={telegramForm.tradeEventsEnabled}
+          onChange={(checked) => setTelegramForm((current) => ({ ...current, tradeEventsEnabled: checked }))}
+        />
+        <ModalCheckboxField
+          label="持仓定时播报"
+          checked={telegramForm.positionReportEnabled}
+          onChange={(checked) => setTelegramForm((current) => ({ ...current, positionReportEnabled: checked }))}
+        />
+        <ModalField label="持仓播报间隔">
+          <Input
+            type="number"
+            min={5}
+            max={1440}
+            step={5}
+            value={telegramForm.positionReportIntervalMinutes}
+            onChange={(event) => setTelegramForm((current) => ({ ...current, positionReportIntervalMinutes: event.target.value }))}
+            className="h-10 rounded-xl border-[var(--bk-border)] bg-[var(--bk-surface-overlay)] px-3"
+          />
+        </ModalField>
       </ModalFormGrid>
 
       <ModalActions>

--- a/web/console/src/store/useUIStore.ts
+++ b/web/console/src/store/useUIStore.ts
@@ -400,7 +400,7 @@ export const useUIStore = create<useUIStoreState>((set) => ({
     dispatchMode: "manual-review",
   },
   setRuntimePolicyForm: (valOrUpdater) => set((state) => ({ runtimePolicyForm: resolveUpdater(valOrUpdater, state.runtimePolicyForm) })),
-  telegramForm: { enabled: false, botToken: "", chatId: "", sendLevels: "critical,warning", },
+  telegramForm: { enabled: false, botToken: "", chatId: "", sendLevels: "critical,warning", tradeEventsEnabled: true, positionReportEnabled: true, positionReportIntervalMinutes: "30", },
   setTelegramForm: (valOrUpdater) => set((state) => ({ telegramForm: resolveUpdater(valOrUpdater, state.telegramForm) })),
   liveAccountError: null,
   setLiveAccountError: (valOrUpdater) => set((state) => ({ liveAccountError: resolveUpdater(valOrUpdater, state.liveAccountError) })),

--- a/web/console/src/types/domain.ts
+++ b/web/console/src/types/domain.ts
@@ -438,6 +438,9 @@ export type TelegramConfig = {
   enabled: boolean;
   chatId: string;
   sendLevels: string[];
+  tradeEventsEnabled: boolean;
+  positionReportEnabled: boolean;
+  positionReportIntervalMinutes: number;
   hasBotToken: boolean;
   maskedBotToken: string;
   updatedAt?: string;
@@ -655,6 +658,9 @@ export interface TelegramForm {
   botToken: string;
   chatId: string;
   sendLevels: string;
+  tradeEventsEnabled: boolean;
+  positionReportEnabled: boolean;
+  positionReportIntervalMinutes: string;
 }
 
 export interface LiveLaunchResult {


### PR DESCRIPTION
## 目的
实现 Telegram 开平事件提醒和持仓定时播报：
- 开平仓成交后发送 Telegram 事件消息，包含数量、价格、订单、实盘会话；平仓额外包含已实现盈亏和手续费。
- Telegram 配置支持开平事件开关、持仓播报开关、持仓播报间隔，默认 30 分钟。
- 持仓播报基于 live account REST sync snapshot / account summary，按时间桶去重，避免重复发送。
- 一次性交易事件和持仓播报 delivery 与现有告警恢复逻辑隔离，避免误发“已恢复”。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [x] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

Codex 参与实现、测试与 PR 整理。

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) - 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？- 无
- [x] DB migration 是否具备向下兼容幂等性？- 使用 `add column if not exists`
- [x] 配置字段有没有无意被混改？- 仅扩展 Telegram 配置字段

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

已验证：
- `go test ./internal/service -run 'TestTelegram'`
- `go test ./internal/http -run 'Test.*Notification|Test.*Telegram|TestCollectPolledStreamMessagesDetectsAlertAndTimelineDeltas'`
- `go test ./internal/service`
- `go test ./...`
- `npm run build`

备注：`npm run build` 通过，但 Vite 仍提示现有 chunk size warning。
