### PR TITLE
[codex] add live trade pair audit trail

### DIFF
--- a/internal/domain/live_trade_pair.go
+++ b/internal/domain/live_trade_pair.go
@@ -1,0 +1,41 @@
+package domain
+
+import "time"
+
+// LiveTradePair 描述同一 live session 内一笔完整或进行中的开平仓回合。
+type LiveTradePair struct {
+	ID             string     `json:"id"`
+	LiveSessionID  string     `json:"liveSessionId"`
+	AccountID      string     `json:"accountId"`
+	StrategyID     string     `json:"strategyId"`
+	Symbol         string     `json:"symbol"`
+	Status         string     `json:"status"` // open / closed
+	Side           string     `json:"side"`   // LONG / SHORT
+	EntryOrderIDs  []string   `json:"entryOrderIds"`
+	ExitOrderIDs   []string   `json:"exitOrderIds,omitempty"`
+	EntryAt        time.Time  `json:"entryAt"`
+	ExitAt         *time.Time `json:"exitAt,omitempty"`
+	EntryAvgPrice  float64    `json:"entryAvgPrice"`
+	ExitAvgPrice   float64    `json:"exitAvgPrice"`
+	EntryQuantity  float64    `json:"entryQuantity"`
+	ExitQuantity   float64    `json:"exitQuantity"`
+	OpenQuantity   float64    `json:"openQuantity"`
+	EntryReason    string     `json:"entryReason,omitempty"`
+	ExitReason     string     `json:"exitReason,omitempty"`
+	ExitClassifier string     `json:"exitClassifier,omitempty"` // SL / TSL / TP / manual / recovery
+	ExitVerdict    string     `json:"exitVerdict"`              // open / normal / recovery-close / orphan-exit / mismatch
+	RealizedPnL    float64    `json:"realizedPnl"`
+	UnrealizedPnL  float64    `json:"unrealizedPnl"`
+	Fees           float64    `json:"fees"`
+	NetPnL         float64    `json:"netPnl"`
+	EntryFillCount int        `json:"entryFillCount"`
+	ExitFillCount  int        `json:"exitFillCount"`
+	Notes          []string   `json:"notes,omitempty"`
+}
+
+// LiveTradePairQuery 定义 live trade pair 聚合接口的过滤条件。
+type LiveTradePairQuery struct {
+	LiveSessionID string
+	Status        string
+	Limit         int
+}

--- a/internal/http/live.go
+++ b/internal/http/live.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/wuyaocheng/bktrader/internal/domain"
 	"github.com/wuyaocheng/bktrader/internal/service"
 )
 
@@ -253,6 +254,28 @@ func registerLiveRoutes(mux *http.ServeMux, platform *service.Platform) {
 	mux.HandleFunc("/api/v1/live/sessions/", func(w http.ResponseWriter, r *http.Request) {
 		path := strings.TrimPrefix(r.URL.Path, "/api/v1/live/sessions/")
 		parts := strings.Split(strings.Trim(path, "/"), "/")
+		if r.Method == http.MethodGet {
+			if len(parts) == 2 && parts[0] != "" && parts[1] == "trade-pairs" {
+				limit, err := parseOptionalPositiveInt(r.URL.Query().Get("limit"))
+				if err != nil {
+					writeError(w, http.StatusBadRequest, "invalid limit")
+					return
+				}
+				items, err := platform.ListLiveTradePairs(domain.LiveTradePairQuery{
+					LiveSessionID: parts[0],
+					Status:        r.URL.Query().Get("status"),
+					Limit:         limit,
+				})
+				if err != nil {
+					writeError(w, http.StatusBadRequest, err.Error())
+					return
+				}
+				writeJSON(w, http.StatusOK, items)
+				return
+			}
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
 		if r.Method == http.MethodPut {
 			if len(parts) != 1 || parts[0] == "" {
 				writeError(w, http.StatusNotFound, "live session route not found")

--- a/internal/service/live_trade_pairs.go
+++ b/internal/service/live_trade_pairs.go
@@ -1,0 +1,631 @@
+package service
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/wuyaocheng/bktrader/internal/domain"
+)
+
+const (
+	defaultLiveTradePairLimit = 20
+	maxLiveTradePairLimit     = 200
+)
+
+type liveTradeFillEvent struct {
+	order           domain.Order
+	fill            domain.Fill
+	eventTime       time.Time
+	intent          liveTradeIntentDetails
+	decisionEventID string
+}
+
+type liveTradeIntentDetails struct {
+	role              string
+	reason            string
+	signalKind        string
+	targetPriceSource string
+	stopLossSource    string
+	recoveryTriggered bool
+	manualTriggered   bool
+}
+
+type liveTradePairBuilder struct {
+	index              int
+	liveSessionID      string
+	accountID          string
+	strategyID         string
+	symbol             string
+	side               string
+	entryAt            time.Time
+	exitAt             time.Time
+	entryQty           float64
+	exitQty            float64
+	entryNotional      float64
+	exitNotional       float64
+	realizedPnL        float64
+	unrealizedPnL      float64
+	fees               float64
+	entryReason        string
+	exitReason         string
+	exitClassifier     string
+	exitVerdict        string
+	entryFillCount     int
+	exitFillCount      int
+	entryOrderIDs      []string
+	exitOrderIDs       []string
+	entryOrderSeen     map[string]struct{}
+	exitOrderSeen      map[string]struct{}
+	notes              []string
+	notesSeen          map[string]struct{}
+	recoveryExit       bool
+	hasUnsafeExitOrder bool
+	lastExitOrderID    string
+}
+
+func (p *Platform) ListLiveTradePairs(query domain.LiveTradePairQuery) ([]domain.LiveTradePair, error) {
+	liveSessionID := strings.TrimSpace(query.LiveSessionID)
+	if liveSessionID == "" {
+		return nil, fmt.Errorf("liveSessionId is required")
+	}
+	session, err := p.store.GetLiveSession(liveSessionID)
+	if err != nil {
+		return nil, err
+	}
+
+	orders, err := p.store.ListOrders()
+	if err != nil {
+		return nil, err
+	}
+	fills, err := p.store.ListFills()
+	if err != nil {
+		return nil, err
+	}
+	positions, err := p.store.ListPositions()
+	if err != nil {
+		return nil, err
+	}
+	decisionEvents, err := p.queryStrategyDecisionEvents(domain.StrategyDecisionEventQuery{
+		LiveSessionID: liveSessionID,
+	})
+	if err != nil {
+		return nil, err
+	}
+	snapshots, err := p.queryPositionAccountSnapshots(domain.PositionAccountSnapshotQuery{
+		LiveSessionID: liveSessionID,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	orderByID := make(map[string]domain.Order)
+	for _, order := range orders {
+		if strings.TrimSpace(stringValue(order.Metadata["liveSessionId"])) != liveSessionID {
+			continue
+		}
+		orderByID[order.ID] = order
+	}
+
+	decisionByID := make(map[string]domain.StrategyDecisionEvent, len(decisionEvents))
+	for _, item := range decisionEvents {
+		decisionByID[item.ID] = item
+	}
+	snapshotByOrderID := latestPositionSnapshotByOrderID(snapshots)
+	currentPositionBySymbol := currentLivePositionBySymbol(session, positions)
+	fillEvents := buildLiveTradeFillEvents(fills, orderByID, decisionByID)
+	if len(fillEvents) == 0 {
+		return filterAndLimitLiveTradePairs(nil, normalizeLiveTradePairStatus(query.Status), normalizeLiveTradePairLimit(query.Limit)), nil
+	}
+
+	sort.SliceStable(fillEvents, func(i, j int) bool {
+		left := fillEvents[i]
+		right := fillEvents[j]
+		switch {
+		case left.eventTime.Before(right.eventTime):
+			return true
+		case left.eventTime.After(right.eventTime):
+			return false
+		case left.order.CreatedAt.Before(right.order.CreatedAt):
+			return true
+		case left.order.CreatedAt.After(right.order.CreatedAt):
+			return false
+		default:
+			return left.fill.ID < right.fill.ID
+		}
+	})
+
+	state := pnlState{}
+	results := make([]domain.LiveTradePair, 0, len(fillEvents))
+	var current *liveTradePairBuilder
+	pairIndex := 0
+	for _, event := range fillEvents {
+		signedQty := tradePairSignedQuantity(event.order.Side, event.fill.Quantity)
+		if signedQty == 0 {
+			continue
+		}
+		absQty := absFloat(signedQty)
+		remainingFee := event.fill.Fee
+		prevNetQty := state.netQty
+		if prevNetQty == 0 || sameSign(prevNetQty, signedQty) {
+			if current == nil {
+				pairIndex++
+				current = newLiveTradePairBuilder(pairIndex, session, event.order.Symbol, liveTradeSideFromSignedQty(signedQty))
+			}
+			current.addEntry(event, absQty, remainingFee)
+			applyPnLFill(&state, event.order.Side, event.fill.Quantity, event.fill.Price)
+			continue
+		}
+
+		closingQty := minFloat(absFloat(prevNetQty), absQty)
+		if current == nil {
+			pairIndex++
+			current = newLiveTradePairBuilder(pairIndex, session, event.order.Symbol, liveTradeSideFromSignedQty(prevNetQty))
+			current.addNote("missing-entry-fill-history")
+			current.exitVerdict = "orphan-exit"
+		}
+		closingFee := proportionalFee(event.fill.Fee, closingQty, absQty)
+		remainingFee -= closingFee
+		realizedPnL := 0.0
+		if prevNetQty > 0 {
+			realizedPnL = (event.fill.Price - state.avgPrice) * closingQty
+		} else {
+			realizedPnL = (state.avgPrice - event.fill.Price) * closingQty
+		}
+		current.addExit(event, closingQty, closingFee, realizedPnL)
+
+		applyPnLFill(&state, event.order.Side, event.fill.Quantity, event.fill.Price)
+		remainingQty := absQty - closingQty
+		if absFloat(prevNetQty)-closingQty <= 1e-9 {
+			results = append(results, current.finalizeClosed(snapshotByOrderID))
+			current = nil
+		}
+		if remainingQty > 1e-9 {
+			pairIndex++
+			current = newLiveTradePairBuilder(pairIndex, session, event.order.Symbol, liveTradeSideFromSignedQty(signedQty))
+			current.addEntry(event, remainingQty, remainingFee)
+		}
+	}
+
+	if current != nil {
+		results = append(results, current.finalizeOpen(currentPositionBySymbol[current.symbol]))
+	}
+
+	sort.SliceStable(results, func(i, j int) bool {
+		leftTime := results[i].EntryAt
+		rightTime := results[j].EntryAt
+		switch {
+		case leftTime.After(rightTime):
+			return true
+		case leftTime.Before(rightTime):
+			return false
+		default:
+			return results[i].ID > results[j].ID
+		}
+	})
+	return filterAndLimitLiveTradePairs(results, normalizeLiveTradePairStatus(query.Status), normalizeLiveTradePairLimit(query.Limit)), nil
+}
+
+func buildLiveTradeFillEvents(
+	fills []domain.Fill,
+	orderByID map[string]domain.Order,
+	decisionByID map[string]domain.StrategyDecisionEvent,
+) []liveTradeFillEvent {
+	items := make([]liveTradeFillEvent, 0, len(fills))
+	for _, fill := range fills {
+		order, ok := orderByID[fill.OrderID]
+		if !ok {
+			continue
+		}
+		eventTime := fill.CreatedAt
+		if fill.ExchangeTradeTime != nil && !fill.ExchangeTradeTime.IsZero() {
+			eventTime = fill.ExchangeTradeTime.UTC()
+		}
+		decisionEventID := firstNonEmpty(
+			stringValue(order.Metadata["decisionEventId"]),
+			stringValue(mapValue(order.Metadata["executionProposal"])["decisionEventId"]),
+			stringValue(mapValue(mapValue(order.Metadata["executionProposal"])["metadata"])["decisionEventId"]),
+		)
+		items = append(items, liveTradeFillEvent{
+			order:           order,
+			fill:            fill,
+			eventTime:       eventTime.UTC(),
+			decisionEventID: decisionEventID,
+			intent:          resolveLiveTradeIntentDetails(order, decisionByID[decisionEventID]),
+		})
+	}
+	return items
+}
+
+func resolveLiveTradeIntentDetails(order domain.Order, decision domain.StrategyDecisionEvent) liveTradeIntentDetails {
+	metadata := cloneMetadata(order.Metadata)
+	proposal := cloneMetadata(mapValue(firstNonEmptyMapValue(metadata["executionProposal"], metadata["intent"])))
+	proposalMeta := cloneMetadata(mapValue(proposal["metadata"]))
+	eventProposal := cloneMetadata(mapValue(decision.ExecutionProposal))
+	eventProposalMeta := cloneMetadata(mapValue(eventProposal["metadata"]))
+	eventIntent := cloneMetadata(mapValue(decision.SignalIntent))
+	eventIntentMeta := cloneMetadata(mapValue(eventIntent["metadata"]))
+	decisionMeta := cloneMetadata(mapValue(decision.DecisionMetadata))
+	signalBarDecision := cloneMetadata(mapValue(decisionMeta["signalBarDecision"]))
+	currentPosition := firstNonEmptyMapValue(
+		proposalMeta["currentPosition"],
+		eventIntentMeta["currentPosition"],
+		eventProposalMeta["currentPosition"],
+	)
+	targetPriceSource := firstNonEmpty(
+		stringValue(signalBarDecision["targetPriceSource"]),
+		stringValue(proposalMeta["targetPriceSource"]),
+		stringValue(eventIntentMeta["targetPriceSource"]),
+		stringValue(eventProposalMeta["targetPriceSource"]),
+	)
+	stopLossSource := firstNonEmpty(
+		stringValue(signalBarDecision["stopLossSource"]),
+		stringValue(currentPosition["stopLossSource"]),
+		stringValue(proposalMeta["stopLossSource"]),
+		stringValue(eventProposalMeta["stopLossSource"]),
+	)
+	return liveTradeIntentDetails{
+		role: firstNonEmpty(
+			stringValue(proposal["role"]),
+			stringValue(eventProposal["role"]),
+			stringValue(eventIntent["role"]),
+			liveOrderRoleFromOrder(order),
+		),
+		reason: firstNonEmpty(
+			stringValue(proposal["reason"]),
+			stringValue(eventProposal["reason"]),
+			stringValue(eventIntent["reason"]),
+			decision.Reason,
+			stringValue(metadata["reason"]),
+		),
+		signalKind: firstNonEmpty(
+			stringValue(proposal["signalKind"]),
+			stringValue(eventProposal["signalKind"]),
+			stringValue(eventIntent["signalKind"]),
+			decision.SignalKind,
+		),
+		targetPriceSource: targetPriceSource,
+		stopLossSource:    stopLossSource,
+		recoveryTriggered: boolValue(metadata["recoveryTriggered"]) ||
+			boolValue(proposalMeta["recoveryTriggered"]) ||
+			boolValue(eventProposalMeta["recoveryTriggered"]),
+		manualTriggered: strings.Contains(strings.ToLower(firstNonEmpty(
+			stringValue(proposal["reason"]),
+			stringValue(eventProposal["reason"]),
+			decision.Reason,
+		)), "manual"),
+	}
+}
+
+func latestPositionSnapshotByOrderID(items []domain.PositionAccountSnapshot) map[string]domain.PositionAccountSnapshot {
+	result := make(map[string]domain.PositionAccountSnapshot)
+	for _, item := range items {
+		orderID := strings.TrimSpace(item.OrderID)
+		if orderID == "" {
+			continue
+		}
+		current, ok := result[orderID]
+		if !ok || domain.EventLessAsc(current.EventTime, current.RecordedAt, current.ID, item.EventTime, item.RecordedAt, item.ID) {
+			result[orderID] = item
+		}
+	}
+	return result
+}
+
+func currentLivePositionBySymbol(session domain.LiveSession, positions []domain.Position) map[string]domain.Position {
+	result := make(map[string]domain.Position)
+	for _, item := range positions {
+		if item.AccountID != session.AccountID {
+			continue
+		}
+		result[NormalizeSymbol(item.Symbol)] = item
+	}
+	return result
+}
+
+func newLiveTradePairBuilder(index int, session domain.LiveSession, symbol, side string) *liveTradePairBuilder {
+	return &liveTradePairBuilder{
+		index:          index,
+		liveSessionID:  session.ID,
+		accountID:      session.AccountID,
+		strategyID:     session.StrategyID,
+		symbol:         NormalizeSymbol(symbol),
+		side:           side,
+		entryOrderSeen: make(map[string]struct{}),
+		exitOrderSeen:  make(map[string]struct{}),
+		notesSeen:      make(map[string]struct{}),
+		exitVerdict:    "open",
+	}
+}
+
+func (b *liveTradePairBuilder) addEntry(event liveTradeFillEvent, qty, fee float64) {
+	if b == nil || qty <= 0 {
+		return
+	}
+	if b.entryAt.IsZero() || event.eventTime.Before(b.entryAt) {
+		b.entryAt = event.eventTime
+	}
+	if b.symbol == "" {
+		b.symbol = NormalizeSymbol(event.order.Symbol)
+	}
+	if b.side == "" {
+		b.side = liveTradeSideFromOrder(event.order.Side)
+	}
+	b.entryQty += qty
+	b.entryNotional += qty * event.fill.Price
+	b.fees += fee
+	b.entryFillCount++
+	b.appendEntryOrderID(event.order.ID)
+	if b.entryReason == "" {
+		b.entryReason = liveTradeReasonLabel(event.intent.reason)
+	}
+}
+
+func (b *liveTradePairBuilder) addExit(event liveTradeFillEvent, qty, fee, realizedPnL float64) {
+	if b == nil || qty <= 0 {
+		return
+	}
+	if b.exitAt.IsZero() || event.eventTime.After(b.exitAt) {
+		b.exitAt = event.eventTime
+	}
+	b.exitQty += qty
+	b.exitNotional += qty * event.fill.Price
+	b.realizedPnL += realizedPnL
+	b.fees += fee
+	b.exitFillCount++
+	b.appendExitOrderID(event.order.ID)
+	b.lastExitOrderID = event.order.ID
+	b.exitReason = liveTradeReasonLabel(event.intent.reason)
+	b.exitClassifier = classifyLiveTradeExit(event.intent)
+	b.recoveryExit = b.recoveryExit || event.intent.recoveryTriggered
+	if !event.order.EffectiveReduceOnly() && !event.order.EffectiveClosePosition() {
+		b.hasUnsafeExitOrder = true
+		b.addNote("exit-order-without-reduce-only")
+	}
+	if strings.TrimSpace(strings.ToLower(event.intent.role)) != "exit" &&
+		!event.order.EffectiveReduceOnly() &&
+		!event.order.EffectiveClosePosition() {
+		b.addNote("closing-fill-came-from-entry-order")
+	}
+}
+
+func (b *liveTradePairBuilder) finalizeClosed(snapshotByOrderID map[string]domain.PositionAccountSnapshot) domain.LiveTradePair {
+	verdict := "normal"
+	if b.exitQty <= 0 {
+		verdict = "orphan-exit"
+	} else if b.hasUnsafeExitOrder {
+		verdict = "mismatch"
+	} else if b.recoveryExit {
+		verdict = "recovery-close"
+	}
+	if snapshot, ok := snapshotByOrderID[b.lastExitOrderID]; ok {
+		if snapshot.PositionFound || snapshot.PositionQuantity > 1e-9 {
+			verdict = "mismatch"
+			b.addNote("post-exit-snapshot-still-has-position")
+		}
+	}
+	b.exitVerdict = verdict
+	return b.build(0, 0)
+}
+
+func (b *liveTradePairBuilder) finalizeOpen(position domain.Position) domain.LiveTradePair {
+	openQty := b.entryQty - b.exitQty
+	if openQty < 0 {
+		openQty = 0
+	}
+	if NormalizeSymbol(position.Symbol) == b.symbol &&
+		strings.EqualFold(position.AccountID, b.accountID) &&
+		strings.EqualFold(position.Side, b.side) &&
+		position.MarkPrice > 0 &&
+		openQty > 0 &&
+		b.entryAvgPrice() > 0 {
+		switch strings.ToUpper(strings.TrimSpace(b.side)) {
+		case "SHORT":
+			b.unrealizedPnL = (b.entryAvgPrice() - position.MarkPrice) * openQty
+		default:
+			b.unrealizedPnL = (position.MarkPrice - b.entryAvgPrice()) * openQty
+		}
+	} else if openQty > 0 {
+		b.addNote("live-position-snapshot-unavailable")
+	}
+	b.exitVerdict = "open"
+	return b.build(openQty, b.unrealizedPnL)
+}
+
+func (b *liveTradePairBuilder) build(openQty, unrealizedPnL float64) domain.LiveTradePair {
+	status := "closed"
+	var exitAt *time.Time
+	if openQty > 1e-9 || b.exitAt.IsZero() {
+		status = "open"
+	} else {
+		exitTime := b.exitAt.UTC()
+		exitAt = &exitTime
+	}
+	netPnL := b.realizedPnL + unrealizedPnL - b.fees
+	return domain.LiveTradePair{
+		ID:             fmt.Sprintf("trade-pair-%s-%s-%d", b.liveSessionID, b.symbol, b.index),
+		LiveSessionID:  b.liveSessionID,
+		AccountID:      b.accountID,
+		StrategyID:     b.strategyID,
+		Symbol:         b.symbol,
+		Status:         status,
+		Side:           b.side,
+		EntryOrderIDs:  append([]string(nil), b.entryOrderIDs...),
+		ExitOrderIDs:   append([]string(nil), b.exitOrderIDs...),
+		EntryAt:        b.entryAt.UTC(),
+		ExitAt:         exitAt,
+		EntryAvgPrice:  b.entryAvgPrice(),
+		ExitAvgPrice:   b.exitAvgPrice(),
+		EntryQuantity:  b.entryQty,
+		ExitQuantity:   b.exitQty,
+		OpenQuantity:   openQty,
+		EntryReason:    b.entryReason,
+		ExitReason:     b.exitReason,
+		ExitClassifier: b.exitClassifier,
+		ExitVerdict:    b.exitVerdict,
+		RealizedPnL:    b.realizedPnL,
+		UnrealizedPnL:  unrealizedPnL,
+		Fees:           b.fees,
+		NetPnL:         netPnL,
+		EntryFillCount: b.entryFillCount,
+		ExitFillCount:  b.exitFillCount,
+		Notes:          append([]string(nil), b.notes...),
+	}
+}
+
+func (b *liveTradePairBuilder) entryAvgPrice() float64 {
+	if b == nil || b.entryQty <= 0 {
+		return 0
+	}
+	return b.entryNotional / b.entryQty
+}
+
+func (b *liveTradePairBuilder) exitAvgPrice() float64 {
+	if b == nil || b.exitQty <= 0 {
+		return 0
+	}
+	return b.exitNotional / b.exitQty
+}
+
+func (b *liveTradePairBuilder) appendEntryOrderID(orderID string) {
+	orderID = strings.TrimSpace(orderID)
+	if orderID == "" {
+		return
+	}
+	if _, ok := b.entryOrderSeen[orderID]; ok {
+		return
+	}
+	b.entryOrderSeen[orderID] = struct{}{}
+	b.entryOrderIDs = append(b.entryOrderIDs, orderID)
+}
+
+func (b *liveTradePairBuilder) appendExitOrderID(orderID string) {
+	orderID = strings.TrimSpace(orderID)
+	if orderID == "" {
+		return
+	}
+	if _, ok := b.exitOrderSeen[orderID]; ok {
+		return
+	}
+	b.exitOrderSeen[orderID] = struct{}{}
+	b.exitOrderIDs = append(b.exitOrderIDs, orderID)
+}
+
+func (b *liveTradePairBuilder) addNote(note string) {
+	note = strings.TrimSpace(note)
+	if note == "" {
+		return
+	}
+	if _, ok := b.notesSeen[note]; ok {
+		return
+	}
+	b.notesSeen[note] = struct{}{}
+	b.notes = append(b.notes, note)
+}
+
+func proportionalFee(totalFee, partialQty, totalQty float64) float64 {
+	if totalFee == 0 || partialQty <= 0 || totalQty <= 0 {
+		return 0
+	}
+	if partialQty >= totalQty {
+		return totalFee
+	}
+	return totalFee * (partialQty / totalQty)
+}
+
+func tradePairSignedQuantity(side string, qty float64) float64 {
+	switch strings.ToUpper(strings.TrimSpace(side)) {
+	case "SELL", "SHORT":
+		return -qty
+	default:
+		return qty
+	}
+}
+
+func liveTradeSideFromOrder(side string) string {
+	switch strings.ToUpper(strings.TrimSpace(side)) {
+	case "SELL", "SHORT":
+		return "SHORT"
+	default:
+		return "LONG"
+	}
+}
+
+func liveTradeSideFromSignedQty(qty float64) string {
+	if qty < 0 {
+		return "SHORT"
+	}
+	return "LONG"
+}
+
+func classifyLiveTradeExit(details liveTradeIntentDetails) string {
+	if details.recoveryTriggered {
+		return "recovery"
+	}
+	if details.manualTriggered {
+		return "manual"
+	}
+	switch normalizeStrategyReasonTag(details.reason) {
+	case "pt":
+		return "TP"
+	case "sl":
+		if strings.EqualFold(details.targetPriceSource, "trailing-stop") || strings.EqualFold(details.stopLossSource, "trailing-stop") {
+			return "TSL"
+		}
+		return "SL"
+	default:
+		return strings.ToUpper(strings.TrimSpace(details.reason))
+	}
+}
+
+func liveTradeReasonLabel(reason string) string {
+	tag := normalizeStrategyReasonTag(reason)
+	switch tag {
+	case "":
+		return ""
+	case "pt":
+		return "PT"
+	case "sl":
+		return "SL"
+	default:
+		return strings.ToUpper(strings.ReplaceAll(tag, "_", "-"))
+	}
+}
+
+func normalizeLiveTradePairStatus(raw string) string {
+	value := strings.ToLower(strings.TrimSpace(raw))
+	switch value {
+	case "", "all":
+		return ""
+	case "open", "closed":
+		return value
+	default:
+		return ""
+	}
+}
+
+func normalizeLiveTradePairLimit(limit int) int {
+	switch {
+	case limit <= 0:
+		return defaultLiveTradePairLimit
+	case limit > maxLiveTradePairLimit:
+		return maxLiveTradePairLimit
+	default:
+		return limit
+	}
+}
+
+func filterAndLimitLiveTradePairs(items []domain.LiveTradePair, status string, limit int) []domain.LiveTradePair {
+	filtered := make([]domain.LiveTradePair, 0, len(items))
+	for _, item := range items {
+		if status != "" && !strings.EqualFold(item.Status, status) {
+			continue
+		}
+		filtered = append(filtered, item)
+		if len(filtered) >= limit {
+			break
+		}
+	}
+	return filtered
+}

--- a/internal/service/live_trade_pairs_test.go
+++ b/internal/service/live_trade_pairs_test.go
@@ -1,0 +1,327 @@
+package service
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/wuyaocheng/bktrader/internal/domain"
+	"github.com/wuyaocheng/bktrader/internal/store/memory"
+)
+
+func TestListLiveTradePairsClassifiesTrailingStopExitAsTSL(t *testing.T) {
+	platform, session := newLiveTradePairTestPlatform(t)
+	pair := createClosedLiveTradePairFixture(t, platform, session, liveTradeFixture{
+		entryPrice:        100,
+		exitPrice:         112,
+		quantity:          2,
+		entryFee:          0.2,
+		exitFee:           0.3,
+		exitReason:        "SL",
+		targetPriceSource: "trailing-stop",
+	})
+
+	if got := pair.ExitClassifier; got != "TSL" {
+		t.Fatalf("expected TSL classifier, got %s", got)
+	}
+	if got := pair.ExitVerdict; got != "normal" {
+		t.Fatalf("expected normal verdict, got %s", got)
+	}
+	assertTradePairFloat(t, pair.RealizedPnL, 24)
+	assertTradePairFloat(t, pair.Fees, 0.5)
+	assertTradePairFloat(t, pair.NetPnL, 23.5)
+}
+
+func TestListLiveTradePairsClassifiesTakeProfitExitAsTP(t *testing.T) {
+	platform, session := newLiveTradePairTestPlatform(t)
+	pair := createClosedLiveTradePairFixture(t, platform, session, liveTradeFixture{
+		entryPrice:        200,
+		exitPrice:         215,
+		quantity:          1.5,
+		entryFee:          0.15,
+		exitFee:           0.2,
+		exitReason:        "PT",
+		targetPriceSource: "structure-profit",
+	})
+
+	if got := pair.ExitClassifier; got != "TP" {
+		t.Fatalf("expected TP classifier, got %s", got)
+	}
+	if got := pair.ExitVerdict; got != "normal" {
+		t.Fatalf("expected normal verdict, got %s", got)
+	}
+	assertTradePairFloat(t, pair.RealizedPnL, 22.5)
+	assertTradePairFloat(t, pair.NetPnL, 22.15)
+}
+
+func TestListLiveTradePairsClassifiesInitialStopExitAsSL(t *testing.T) {
+	platform, session := newLiveTradePairTestPlatform(t)
+	pair := createClosedLiveTradePairFixture(t, platform, session, liveTradeFixture{
+		entryPrice:        150,
+		exitPrice:         140,
+		quantity:          1.2,
+		entryFee:          0.12,
+		exitFee:           0.18,
+		exitReason:        "SL",
+		targetPriceSource: "initial-stop",
+	})
+
+	if got := pair.ExitClassifier; got != "SL" {
+		t.Fatalf("expected SL classifier, got %s", got)
+	}
+	if got := pair.ExitVerdict; got != "normal" {
+		t.Fatalf("expected normal verdict, got %s", got)
+	}
+	assertTradePairFloat(t, pair.RealizedPnL, -12)
+	assertTradePairFloat(t, pair.NetPnL, -12.3)
+}
+
+func TestListLiveTradePairsReturnsOpenTradeWithUnrealizedPnLAndAggregatedEntries(t *testing.T) {
+	platform, session := newLiveTradePairTestPlatform(t)
+	entryAt := time.Date(2026, 4, 22, 6, 0, 0, 0, time.UTC)
+
+	firstEntry := createLiveTradePairOrder(t, platform, session, tradePairOrderFixture{
+		side:       "BUY",
+		reason:     "initial",
+		quantity:   0.001,
+		price:      100,
+		fee:        0.01,
+		createdAt:  entryAt,
+		fillAt:     entryAt.Add(2 * time.Second),
+		reduceOnly: false,
+	})
+	secondEntry := createLiveTradePairOrder(t, platform, session, tradePairOrderFixture{
+		side:       "BUY",
+		reason:     "sl-reentry",
+		quantity:   0.002,
+		price:      105,
+		fee:        0.02,
+		createdAt:  entryAt.Add(5 * time.Minute),
+		fillAt:     entryAt.Add(5*time.Minute + 2*time.Second),
+		reduceOnly: false,
+	})
+	_ = firstEntry
+	_ = secondEntry
+
+	if _, err := platform.store.SavePosition(domain.Position{
+		AccountID:         session.AccountID,
+		StrategyVersionID: "strategy-version-test",
+		Symbol:            "BTCUSDT",
+		Side:              "LONG",
+		Quantity:          0.003,
+		EntryPrice:        (100*0.001 + 105*0.002) / 0.003,
+		MarkPrice:         110,
+		UpdatedAt:         entryAt.Add(10 * time.Minute),
+	}); err != nil {
+		t.Fatalf("save position: %v", err)
+	}
+
+	items, err := platform.ListLiveTradePairs(domain.LiveTradePairQuery{
+		LiveSessionID: session.ID,
+		Status:        "open",
+		Limit:         10,
+	})
+	if err != nil {
+		t.Fatalf("list live trade pairs: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 open pair, got %d", len(items))
+	}
+	pair := items[0]
+	if got := pair.Status; got != "open" {
+		t.Fatalf("expected open status, got %s", got)
+	}
+	if got := pair.Side; got != "LONG" {
+		t.Fatalf("expected LONG side, got %s", got)
+	}
+	if got := len(pair.EntryOrderIDs); got != 2 {
+		t.Fatalf("expected 2 aggregated entry orders, got %d", got)
+	}
+	assertTradePairFloat(t, pair.EntryQuantity, 0.003)
+	assertTradePairFloat(t, pair.OpenQuantity, 0.003)
+	assertTradePairFloat(t, pair.EntryAvgPrice, (100*0.001+105*0.002)/0.003)
+	assertTradePairFloat(t, pair.UnrealizedPnL, (110-pair.EntryAvgPrice)*0.003)
+	assertTradePairFloat(t, pair.Fees, 0.03)
+	assertTradePairFloat(t, pair.NetPnL, pair.UnrealizedPnL-0.03)
+}
+
+type liveTradeFixture struct {
+	entryPrice        float64
+	exitPrice         float64
+	quantity          float64
+	entryFee          float64
+	exitFee           float64
+	exitReason        string
+	targetPriceSource string
+}
+
+type tradePairOrderFixture struct {
+	side              string
+	reason            string
+	quantity          float64
+	price             float64
+	fee               float64
+	createdAt         time.Time
+	fillAt            time.Time
+	reduceOnly        bool
+	decisionEventID   string
+	targetPriceSource string
+}
+
+func newLiveTradePairTestPlatform(t *testing.T) (*Platform, domain.LiveSession) {
+	t.Helper()
+	platform := NewPlatform(memory.NewStore())
+	account, err := platform.CreateAccount("Live Trade Pair", "LIVE", "binance-futures")
+	if err != nil {
+		t.Fatalf("create account: %v", err)
+	}
+	session, err := platform.CreateLiveSession("", account.ID, "strategy-bk-1d", map[string]any{
+		"symbol": "BTCUSDT",
+	})
+	if err != nil {
+		t.Fatalf("create live session: %v", err)
+	}
+	return platform, session
+}
+
+func createClosedLiveTradePairFixture(t *testing.T, platform *Platform, session domain.LiveSession, fixture liveTradeFixture) domain.LiveTradePair {
+	t.Helper()
+	entryAt := time.Date(2026, 4, 22, 6, 0, 0, 0, time.UTC)
+	exitAt := entryAt.Add(30 * time.Minute)
+	exitDecisionEventID := "decision-event-exit-" + normalizeStrategyReasonTag(fixture.exitReason)
+
+	createLiveTradePairOrder(t, platform, session, tradePairOrderFixture{
+		side:       "BUY",
+		reason:     "initial",
+		quantity:   fixture.quantity,
+		price:      fixture.entryPrice,
+		fee:        fixture.entryFee,
+		createdAt:  entryAt,
+		fillAt:     entryAt.Add(2 * time.Second),
+		reduceOnly: false,
+	})
+	exitOrder := createLiveTradePairOrder(t, platform, session, tradePairOrderFixture{
+		side:              "SELL",
+		reason:            fixture.exitReason,
+		quantity:          fixture.quantity,
+		price:             fixture.exitPrice,
+		fee:               fixture.exitFee,
+		createdAt:         exitAt,
+		fillAt:            exitAt.Add(2 * time.Second),
+		reduceOnly:        true,
+		decisionEventID:   exitDecisionEventID,
+		targetPriceSource: fixture.targetPriceSource,
+	})
+
+	if _, err := platform.store.CreateStrategyDecisionEvent(domain.StrategyDecisionEvent{
+		ID:            exitDecisionEventID,
+		LiveSessionID: session.ID,
+		AccountID:     session.AccountID,
+		StrategyID:    session.StrategyID,
+		Symbol:        "BTCUSDT",
+		Action:        "advance-plan",
+		Reason:        fixture.exitReason,
+		SignalKind:    "risk-exit",
+		EventTime:     exitAt.UTC(),
+		DecisionMetadata: map[string]any{
+			"signalBarDecision": map[string]any{
+				"targetPriceSource": fixture.targetPriceSource,
+			},
+		},
+	}); err != nil {
+		t.Fatalf("create strategy decision event: %v", err)
+	}
+	if _, err := platform.store.CreatePositionAccountSnapshot(domain.PositionAccountSnapshot{
+		LiveSessionID:    session.ID,
+		DecisionEventID:  exitDecisionEventID,
+		OrderID:          exitOrder.ID,
+		AccountID:        session.AccountID,
+		StrategyID:       session.StrategyID,
+		Symbol:           "BTCUSDT",
+		Trigger:          "order-filled",
+		PositionFound:    false,
+		PositionQuantity: 0,
+		EventTime:        exitAt.Add(3 * time.Second).UTC(),
+	}); err != nil {
+		t.Fatalf("create position snapshot: %v", err)
+	}
+
+	items, err := platform.ListLiveTradePairs(domain.LiveTradePairQuery{
+		LiveSessionID: session.ID,
+		Status:        "closed",
+		Limit:         10,
+	})
+	if err != nil {
+		t.Fatalf("list live trade pairs: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 closed pair, got %d", len(items))
+	}
+	return items[0]
+}
+
+func createLiveTradePairOrder(t *testing.T, platform *Platform, session domain.LiveSession, fixture tradePairOrderFixture) domain.Order {
+	t.Helper()
+	role := "entry"
+	if fixture.reduceOnly {
+		role = "exit"
+	}
+	orderMeta := map[string]any{
+		"liveSessionId": session.ID,
+		"executionMode": "live",
+		"executionProposal": map[string]any{
+			"role":     role,
+			"reason":   fixture.reason,
+			"side":     fixture.side,
+			"symbol":   "BTCUSDT",
+			"quantity": fixture.quantity,
+			"status":   "dispatchable",
+			"metadata": map[string]any{
+				"targetPriceSource": fixture.targetPriceSource,
+			},
+		},
+	}
+	if fixture.decisionEventID != "" {
+		orderMeta["decisionEventId"] = fixture.decisionEventID
+		mapValue(orderMeta["executionProposal"])["decisionEventId"] = fixture.decisionEventID
+	}
+
+	order, err := platform.store.CreateOrder(domain.Order{
+		AccountID:         session.AccountID,
+		StrategyVersionID: "strategy-version-test",
+		Symbol:            "BTCUSDT",
+		Side:              fixture.side,
+		Type:              "MARKET",
+		Status:            "FILLED",
+		Quantity:          fixture.quantity,
+		Price:             fixture.price,
+		ReduceOnly:        fixture.reduceOnly,
+		Metadata:          orderMeta,
+		CreatedAt:         fixture.createdAt.UTC(),
+	})
+	if err != nil {
+		t.Fatalf("create order: %v", err)
+	}
+	if _, err := platform.store.CreateFill(domain.Fill{
+		OrderID:           order.ID,
+		Price:             fixture.price,
+		Quantity:          fixture.quantity,
+		Fee:               fixture.fee,
+		ExchangeTradeTime: timePointer(fixture.fillAt.UTC()),
+		CreatedAt:         fixture.fillAt.UTC(),
+	}); err != nil {
+		t.Fatalf("create fill: %v", err)
+	}
+	return order
+}
+
+func assertTradePairFloat(t *testing.T, got, want float64) {
+	t.Helper()
+	if math.Abs(got-want) > 1e-9 {
+		t.Fatalf("expected %.12f, got %.12f", want, got)
+	}
+}
+
+func timePointer(value time.Time) *time.Time {
+	return &value
+}

--- a/web/console/src/components/live/LiveTradePairsCard.tsx
+++ b/web/console/src/components/live/LiveTradePairsCard.tsx
@@ -1,0 +1,207 @@
+import React from 'react';
+import { ArrowRightLeft, Activity } from 'lucide-react';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../ui/card';
+import { Badge } from '../ui/badge';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../ui/table';
+import { LiveTradePair } from '../../types/domain';
+import { formatMaybeNumber, formatSigned, formatTime, shrink } from '../../utils/format';
+import { cn } from '../../lib/utils';
+
+type LiveTradePairsCardProps = {
+  title: string;
+  description: string;
+  pairs: LiveTradePair[];
+  loading: boolean;
+  error: string | null;
+  className?: string;
+};
+
+function tradePairStatusLabel(status: string) {
+  return String(status).toLowerCase() === 'open' ? '持仓中' : '已平仓';
+}
+
+function tradePairVerdictLabel(verdict: string) {
+  switch (String(verdict).toLowerCase()) {
+    case 'normal':
+      return '正常退出';
+    case 'recovery-close':
+      return 'Recovery 平仓';
+    case 'orphan-exit':
+      return '孤儿退出';
+    case 'mismatch':
+      return '需复核';
+    default:
+      return '进行中';
+  }
+}
+
+function tradePairVerdictTone(verdict: string) {
+  switch (String(verdict).toLowerCase()) {
+    case 'normal':
+      return 'text-[var(--bk-status-success)]';
+    case 'mismatch':
+    case 'orphan-exit':
+      return 'text-[var(--bk-status-danger)]';
+    case 'recovery-close':
+      return 'text-[var(--bk-status-warning)]';
+    default:
+      return 'text-[var(--bk-text-muted)]';
+  }
+}
+
+export function LiveTradePairsCard({
+  title,
+  description,
+  pairs,
+  loading,
+  error,
+  className,
+}: LiveTradePairsCardProps) {
+  return (
+    <Card tone="bento" className={cn('rounded-[24px] shadow-[var(--bk-shadow-card)]', className)}>
+      <CardHeader className="pb-4">
+        <div className="flex items-center justify-between">
+          <div className="space-y-1">
+            <div className="flex items-center gap-2">
+              <ArrowRightLeft size={16} className="text-[var(--bk-status-success)]" />
+              <CardTitle className="text-lg font-black text-[var(--bk-text-primary)]">{title}</CardTitle>
+            </div>
+            <CardDescription className="text-[11px] font-medium text-[var(--bk-text-muted)]">
+              {description}
+            </CardDescription>
+          </div>
+          <Badge variant="metal">{pairs.length} 笔</Badge>
+        </div>
+      </CardHeader>
+      <CardContent>
+        {loading ? (
+          <div className="flex items-center justify-center gap-3 rounded-[20px] border border-[var(--bk-border)] bg-[var(--bk-surface-faint)] p-10 text-[var(--bk-text-muted)]">
+            <Activity size={16} className="animate-pulse" />
+            <span className="text-xs font-bold">正在聚合开平订单对…</span>
+          </div>
+        ) : error ? (
+          <div className="rounded-[20px] border border-[var(--bk-status-danger-soft)] bg-[color:color-mix(in_srgb,var(--bk-status-danger)_8%,transparent)] p-4 text-[11px] font-medium text-[var(--bk-status-danger)]">
+            {error}
+          </div>
+        ) : pairs.length === 0 ? (
+          <div className="rounded-[20px] border border-dashed border-[var(--bk-border)] p-10 text-center text-[11px] font-medium text-[var(--bk-text-muted)]">
+            当前会话还没有可追溯的开平订单对。
+          </div>
+        ) : (
+          <div className="overflow-hidden rounded-[20px] border border-[var(--bk-border)] bg-[var(--bk-surface-strong)]">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>状态</TableHead>
+                  <TableHead>方向</TableHead>
+                  <TableHead>开仓</TableHead>
+                  <TableHead>平仓</TableHead>
+                  <TableHead>数量</TableHead>
+                  <TableHead>退出</TableHead>
+                  <TableHead>PnL</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {pairs.map((pair) => {
+                  const netPositive = Number(pair.netPnl ?? 0) >= 0;
+                  const quantity = String(pair.status).toLowerCase() === 'open' ? pair.openQuantity : pair.entryQuantity;
+                  return (
+                    <TableRow key={pair.id}>
+                      <TableCell className="align-top">
+                        <div className="space-y-1">
+                          <Badge variant={String(pair.status).toLowerCase() === 'open' ? 'neutral' : 'success'}>
+                            {tradePairStatusLabel(pair.status)}
+                          </Badge>
+                          <div className={cn('text-[10px] font-black', tradePairVerdictTone(pair.exitVerdict))}>
+                            {tradePairVerdictLabel(pair.exitVerdict)}
+                          </div>
+                        </div>
+                      </TableCell>
+                      <TableCell className="align-top">
+                        <div className="space-y-1">
+                          <div className="text-[12px] font-black text-[var(--bk-text-primary)]">{pair.side}</div>
+                          <div className="text-[10px] text-[var(--bk-text-muted)]">{pair.symbol}</div>
+                        </div>
+                      </TableCell>
+                      <TableCell className="align-top">
+                        <div className="space-y-1">
+                          <div className="font-mono text-[12px] font-black text-[var(--bk-text-primary)]">
+                            {formatMaybeNumber(pair.entryAvgPrice)}
+                          </div>
+                          <div className="text-[10px] text-[var(--bk-text-muted)]">{formatTime(pair.entryAt)}</div>
+                          <div className="text-[10px] font-bold uppercase text-[var(--bk-text-muted)]">
+                            {pair.entryReason || '--'}
+                          </div>
+                        </div>
+                      </TableCell>
+                      <TableCell className="align-top">
+                        {String(pair.status).toLowerCase() === 'closed' ? (
+                          <div className="space-y-1">
+                            <div className="font-mono text-[12px] font-black text-[var(--bk-text-primary)]">
+                              {formatMaybeNumber(pair.exitAvgPrice)}
+                            </div>
+                            <div className="text-[10px] text-[var(--bk-text-muted)]">
+                              {pair.exitAt ? formatTime(pair.exitAt) : '--'}
+                            </div>
+                            <div className="text-[10px] font-bold uppercase text-[var(--bk-text-muted)]">
+                              {pair.exitReason || '--'}
+                            </div>
+                          </div>
+                        ) : (
+                          <div className="space-y-1">
+                            <div className="text-[11px] font-black text-[var(--bk-text-primary)]">持仓中</div>
+                            <div className="text-[10px] text-[var(--bk-text-muted)]">
+                              未实现 {formatSigned(pair.unrealizedPnl)}
+                            </div>
+                          </div>
+                        )}
+                      </TableCell>
+                      <TableCell className="align-top">
+                        <div className="space-y-1">
+                          <div className="font-mono text-[12px] font-black text-[var(--bk-text-primary)]">
+                            {formatMaybeNumber(quantity)}
+                          </div>
+                          <div className="text-[10px] text-[var(--bk-text-muted)]">
+                            开 {pair.entryFillCount} / 平 {pair.exitFillCount}
+                          </div>
+                        </div>
+                      </TableCell>
+                      <TableCell className="align-top">
+                        <div className="space-y-1">
+                          <div className="text-[12px] font-black text-[var(--bk-text-primary)]">
+                            {pair.exitClassifier || '--'}
+                          </div>
+                          <div className="text-[10px] text-[var(--bk-text-muted)]">
+                            费 {formatMaybeNumber(pair.fees, 6)}
+                          </div>
+                          {pair.notes && pair.notes.length > 0 && (
+                            <div className="text-[10px] text-[var(--bk-text-muted)]">
+                              {shrink(pair.notes.join(', '))}
+                            </div>
+                          )}
+                        </div>
+                      </TableCell>
+                      <TableCell className="align-top">
+                        <div className="space-y-1">
+                          <div className={cn('font-mono text-[12px] font-black', netPositive ? 'text-[var(--bk-status-success)]' : 'text-[var(--bk-status-danger)]')}>
+                            {formatSigned(pair.netPnl)}
+                          </div>
+                          <div className="text-[10px] text-[var(--bk-text-muted)]">
+                            已实 {formatSigned(pair.realizedPnl)}
+                          </div>
+                          <div className="text-[10px] text-[var(--bk-text-muted)]">
+                            未实 {formatSigned(pair.unrealizedPnl)}
+                          </div>
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/web/console/src/hooks/useLiveTradePairs.ts
+++ b/web/console/src/hooks/useLiveTradePairs.ts
@@ -1,0 +1,49 @@
+import { useEffect, useState } from 'react';
+import { LiveTradePair } from '../types/domain';
+import { fetchJSON } from '../utils/api';
+
+export function useLiveTradePairs(sessionId: string | null, limit = 8) {
+  const [pairs, setPairs] = useState<LiveTradePair[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!sessionId) {
+      setPairs([]);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+    let active = true;
+    setLoading(true);
+    setError(null);
+    fetchJSON<LiveTradePair[]>(
+      `/api/v1/live/sessions/${encodeURIComponent(sessionId)}/trade-pairs?limit=${limit}`
+    )
+      .then((items) => {
+        if (!active) {
+          return;
+        }
+        setPairs(Array.isArray(items) ? items : []);
+      })
+      .catch((err) => {
+        if (!active) {
+          return;
+        }
+        console.warn('Failed to load live trade pairs', err);
+        setPairs([]);
+        setError(err instanceof Error ? err.message : '加载失败');
+      })
+      .finally(() => {
+        if (active) {
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [limit, sessionId]);
+
+  return { pairs, loading, error };
+}

--- a/web/console/src/pages/AccountStage.tsx
+++ b/web/console/src/pages/AccountStage.tsx
@@ -3,6 +3,8 @@ import { HelpCircle, Zap, Edit3, Square, Trash2, Play, ArrowRight, ShieldCheck, 
 import { useUIStore } from '../store/useUIStore';
 import { useTradingStore } from '../store/useTradingStore';
 import { SignalBarChart } from '../components/charts/SignalBarChart';
+import { LiveTradePairsCard } from '../components/live/LiveTradePairsCard';
+import { useLiveTradePairs } from '../hooks/useLiveTradePairs';
 import { formatTime, formatMaybeNumber, shrink } from '../utils/format';
 import { 
   getRecord, 
@@ -247,6 +249,7 @@ export function AccountStage({
     primaryLiveSessionRuntimeReadiness,
     primaryLiveSessionIntent
   );
+  const primaryTradePairs = useLiveTradePairs(primaryLiveSession?.id ?? null, 6);
   
   const strategyOptions = useMemo(() => strategies.map((strategy) => ({
     value: strategy.id,
@@ -1058,6 +1061,18 @@ export function AccountStage({
 
           </CardContent>
         </Card>
+
+        <LiveTradePairsCard
+          title="开平订单对追溯"
+          description={
+            primaryLiveSession
+              ? `聚合焦点会话 ${primaryLiveSession.alias || shrink(primaryLiveSession.id)} 的 round-trip 交易，直接判断退出是否正常。`
+              : '选中一个活跃实盘会话后，这里会显示可追溯的开平订单对与盈亏。'
+          }
+          pairs={primaryTradePairs.pairs}
+          loading={primaryTradePairs.loading}
+          error={primaryTradePairs.error}
+        />
       </div>
 
       <AlertDialog 

--- a/web/console/src/pages/MonitorStage.tsx
+++ b/web/console/src/pages/MonitorStage.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useRef } from 'react';
 import { useUIStore } from '../store/useUIStore';
 import { useTradingStore } from '../store/useTradingStore';
 import { SignalMonitorChart } from '../components/charts/SignalMonitorChart';
+import { LiveTradePairsCard } from '../components/live/LiveTradePairsCard';
 import { formatMoney, formatSigned, formatMaybeNumber, formatTime, shrink } from '../utils/format';
 import { 
   getRecord, 
@@ -29,6 +30,7 @@ import {
   technicalStatusLabel
 } from '../utils/derivation';
 import { fetchJSON } from '../utils/api';
+import { useLiveTradePairs } from '../hooks/useLiveTradePairs';
 import { Card, CardHeader, CardTitle, CardContent } from '../components/ui/card';
 import { Badge } from '../components/ui/badge';
 import { Table, TableHeader, TableBody, TableHead, TableRow, TableCell } from '../components/ui/table';
@@ -308,6 +310,7 @@ export function MonitorStage({ syncLiveOrder, dockTab, onDockTabChange, dockCont
   const syncableLiveOrders = orders.filter((item) => item.metadata?.executionMode === "live" && item.status === "ACCEPTED");
   const platformRuntimePolicy = monitorHealth?.runtimePolicy ?? runtimePolicy;
   const timelineLogs = buildTimelineNotes(monitorTimeline, timelineConfig, monitorSession?.id).slice(0, 50);
+  const monitorTradePairs = useLiveTradePairs(monitorSession?.id ?? null, 8);
 
 
   const reconciledOrders = orders.filter(o => !!(o.metadata?.orderLifecycle as any)?.synced);
@@ -409,6 +412,16 @@ export function MonitorStage({ syncLiveOrder, dockTab, onDockTabChange, dockCont
            <CandlestickChart className="size-12 text-[var(--bk-text-muted)]" />
            <p className="text-sm font-black uppercase tracking-wider italic text-[var(--bk-text-muted)]">需选择活跃焦点会话以同步实时 K 线数据</p>
         </div>
+      )}
+
+      {monitorSession && (
+        <LiveTradePairsCard
+          title="开平订单对追溯"
+          description="聚合当前焦点会话的 round-trip 交易，直接判断是否正常退出，以及这笔单现在赚亏多少。"
+          pairs={monitorTradePairs.pairs}
+          loading={monitorTradePairs.loading}
+          error={monitorTradePairs.error}
+        />
       )}
 
       <div className="grid grid-cols-1 lg:grid-cols-12 gap-6">

--- a/web/console/src/types/domain.ts
+++ b/web/console/src/types/domain.ts
@@ -481,6 +481,36 @@ export type LiveSessionExecutionSummary = {
   position: Position | null;
 };
 
+export type LiveTradePair = {
+  id: string;
+  liveSessionId: string;
+  accountId: string;
+  strategyId: string;
+  symbol: string;
+  status: string;
+  side: string;
+  entryOrderIds: string[];
+  exitOrderIds: string[];
+  entryAt: string;
+  exitAt?: string;
+  entryAvgPrice: number;
+  exitAvgPrice: number;
+  entryQuantity: number;
+  exitQuantity: number;
+  openQuantity: number;
+  entryReason?: string;
+  exitReason?: string;
+  exitClassifier?: string;
+  exitVerdict: string;
+  realizedPnl: number;
+  unrealizedPnl: number;
+  fees: number;
+  netPnl: number;
+  entryFillCount: number;
+  exitFillCount: number;
+  notes?: string[];
+};
+
 export type LiveSessionHealth = {
   status: "ready" | "active" | "waiting-sync" | "error" | "idle" | "neutral";
   detail: string;


### PR DESCRIPTION
## 目的
补上 live session 的“开平订单对”追溯能力，让平台能直接回答一笔单是否正常退出、属于 SL/TSL/TP 哪类退出，以及该笔 round-trip 的 realized / unrealized / fee / net PnL。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [x] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
- [x] `dispatchMode` 默认值无变化
- [x] 不涉及 `mainnet` 凭证或路由硬编码
- [x] 无 DB migration
- [x] 未混改 live dispatch / reconcile 默认行为

## 修改内容
- 后端新增 `LiveTradePair` 聚合模型与只读聚合服务，从 `orders/fills/strategy_decision_events/position_account_snapshots` 还原 live round-trip 交易。
- 新增 session 级接口：`GET /api/v1/live/sessions/:id/trade-pairs?limit=...`。
- 退出分类支持 `SL / TSL / TP / recovery / manual`，并给出 `normal / recovery-close / orphan-exit / mismatch` verdict。
- 前端在 Monitor / Account 两个 live session 入口新增“开平订单对追溯”卡片，展示开仓/平仓时间、均价、数量、退出类型、是否正常退出、realized/unrealized/net PnL。
- 新增后端测试覆盖 `SL / TSL / TP` closed trade，以及 open trade 的 unrealized PnL 和多次 entry 聚合。

## Root Cause
现有平台只有“最新订单 / 最新成交 / 当前持仓”维度，没有把同一笔 live trade 的 entry、exit、decision 和 snapshot 聚成一个可追溯对象，因此无法直接判断这笔单是否正常退出，也看不到该 round-trip 的盈亏归因。

## 验证方式与测试证据
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

已执行：
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
- `./node_modules/.bin/tsc --noEmit src/pages/AccountStage.tsx src/pages/MonitorStage.tsx src/components/live/LiveTradePairsCard.tsx src/hooks/useLiveTradePairs.ts --jsx react-jsx --esModuleInterop --skipLibCheck --target esnext --module esnext --moduleResolution node --allowSyntheticDefaultImports --types vite/client`
- `npm run build`
- `/usr/local/bin/git diff --check`

## 行为边界
本期仍然基于本地已落账的 live order/fill lineage 聚合 trade pair；如果是交易所先有仓位、系统后 takeover 但本地没有对应 fill 历史，暂时不会生成完整 synthetic pair，后续可再单独扩展。