### PR TITLE
[codex] format telegram times in beijing timezone

### DIFF
--- a/internal/service/telegram.go
+++ b/internal/service/telegram.go
@@ -14,6 +14,13 @@ import (
 
 var telegramBaseURL = "https://api.telegram.org"
 var telegramNow = func() time.Time { return time.Now().UTC() }
+var telegramBeijingLocation = func() *time.Location {
+	loc, err := time.LoadLocation("Asia/Shanghai")
+	if err != nil {
+		return time.FixedZone("CST", 8*3600)
+	}
+	return loc
+}()
 
 const (
 	telegramFlapSendGrace    = 45 * time.Second
@@ -103,7 +110,7 @@ func formatTelegramNotification(item domain.PlatformNotification) string {
 		lines = append(lines, fmt.Sprintf("模拟盘: %s", alert.PaperSessionID))
 	}
 	if !alert.EventTime.IsZero() {
-		lines = append(lines, fmt.Sprintf("时间: %s", alert.EventTime.Format(time.RFC3339)))
+		lines = append(lines, fmt.Sprintf("北京时间: %s", formatTelegramBeijingTime(alert.EventTime)))
 	}
 	return strings.Join(lines, "\n")
 }
@@ -447,7 +454,7 @@ func formatTelegramTradeEvent(event domain.OrderExecutionEvent) string {
 		lines = append(lines, fmt.Sprintf("实盘会话: %s", event.LiveSessionID))
 	}
 	if !event.EventTime.IsZero() {
-		lines = append(lines, fmt.Sprintf("时间: %s", event.EventTime.UTC().Format(time.RFC3339)))
+		lines = append(lines, fmt.Sprintf("北京时间: %s", formatTelegramBeijingTime(event.EventTime)))
 	}
 	return strings.Join(lines, "\n")
 }
@@ -467,7 +474,7 @@ func telegramTradeEventIsClose(event domain.OrderExecutionEvent) bool {
 func formatTelegramPositionReport(accounts []domain.Account, summaries map[string]domain.AccountSummary, bucket time.Time, intervalMinutes int) string {
 	lines := []string{
 		fmt.Sprintf("📊 *持仓定时播报* %d分钟", intervalMinutes),
-		fmt.Sprintf("时间: %s", bucket.UTC().Format(time.RFC3339)),
+		fmt.Sprintf("北京时间: %s", formatTelegramBeijingTime(bucket)),
 	}
 	for _, account := range accounts {
 		summary := summaries[account.ID]
@@ -556,6 +563,13 @@ func formatTelegramSignedNumber(value float64) string {
 		return "+" + formatTelegramNumber(value)
 	}
 	return formatTelegramNumber(value)
+}
+
+func formatTelegramBeijingTime(value time.Time) string {
+	if value.IsZero() {
+		return ""
+	}
+	return value.In(telegramBeijingLocation).Format("2006-01-02 15:04:05")
 }
 
 func telegramAlertNeedsFlapSuppression(alert domain.PlatformAlert) bool {

--- a/internal/service/telegram_test.go
+++ b/internal/service/telegram_test.go
@@ -220,6 +220,9 @@ func TestTelegramDispatchSendsFilledTradeEventsWithPnLAndDedup(t *testing.T) {
 	if !strings.Contains(joined, "数量: 0.2") || !strings.Contains(joined, "价格: 64000") {
 		t.Fatalf("expected open qty and price, got: %s", joined)
 	}
+	if !strings.Contains(joined, "北京时间: 2026-04-22 18:00:00") || !strings.Contains(joined, "北京时间: 2026-04-22 18:01:00") {
+		t.Fatalf("expected Beijing time in trade messages, got: %s", joined)
+	}
 	if !strings.Contains(joined, "*平仓成交* BTCUSDT SELL") || !strings.Contains(joined, "已实现盈亏: +100.5") {
 		t.Fatalf("expected close pnl message, got: %s", joined)
 	}
@@ -310,6 +313,9 @@ func TestTelegramPositionReportUsesThirtyMinuteBucketAndSkipsRecovery(t *testing
 	}
 	if !strings.Contains(messages[0], "*持仓定时播报* 30分钟") || !strings.Contains(messages[0], "ETHUSDT LONG 数量:1.5") || !strings.Contains(messages[0], "浮盈亏:+150") {
 		t.Fatalf("unexpected position report: %s", messages[0])
+	}
+	if !strings.Contains(messages[0], "北京时间: 2026-04-22 18:00:00") {
+		t.Fatalf("expected Beijing time in position report, got: %s", messages[0])
 	}
 	if err := p.DispatchTelegramNotifications(); err != nil {
 		t.Fatalf("second dispatch failed: %v", err)


### PR DESCRIPTION
## 目的
补充 Telegram 通知里的时间展示格式，将用户可见时间统一改为北京时间，避免继续显示 UTC `Z` 时间。

影响范围：
- 开平仓 Telegram 事件提醒
- 持仓定时播报
- 告警通知中的事件时间

## 本次改动风险定级 (参照 agent-risk-model.md)
- [x] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

Codex 参与实现、测试与 PR 整理。

## 风险点 checklist
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) - 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？- 无
- [x] DB migration 是否具备向下兼容幂等性？- 无新增 migration
- [x] 配置字段有没有无意被混改？- 无

## 验证方式与测试证据
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

已验证：
- `go test ./internal/service -run 'TestTelegram'`
- `go test ./...`
