### PR TITLE
[codex] dedupe telegram trade event notifications

### DIFF
--- a/internal/service/order.go
+++ b/internal/service/order.go
@@ -1000,7 +1000,7 @@ func (p *Platform) finalizeExecutedOrder(account domain.Account, order domain.Or
 	if err != nil {
 		return domain.Order{}, err
 	}
-	if strings.EqualFold(account.Mode, "LIVE") {
+	if strings.EqualFold(account.Mode, "LIVE") && len(newFills) > 0 {
 		if telemetryErr := p.recordLiveOrderExecutionEvent(updatedOrder, "filled", parseOptionalRFC3339(stringValue(updatedOrder.Metadata["lastFilledAt"])), false, nil); telemetryErr != nil {
 			p.logger("service.order", "order_id", updatedOrder.ID).Warn("record live order fill event failed", "error", telemetryErr)
 		}

--- a/internal/service/order_test.go
+++ b/internal/service/order_test.go
@@ -114,6 +114,20 @@ func TestFinalizeExecutedOrderSkipsDuplicateExchangeTradeIDFills(t *testing.T) {
 	if position.Quantity != 0.1 {
 		t.Fatalf("expected duplicate sync to keep position quantity at 0.1, got %v", position.Quantity)
 	}
+
+	events, err := store.ListOrderExecutionEvents(order.ID)
+	if err != nil {
+		t.Fatalf("list order execution events failed: %v", err)
+	}
+	filledEventCount := 0
+	for _, item := range events {
+		if strings.EqualFold(item.EventType, "filled") {
+			filledEventCount++
+		}
+	}
+	if filledEventCount != 1 {
+		t.Fatalf("expected duplicate sync to keep one filled execution event, got %d", filledEventCount)
+	}
 }
 
 func TestFinalizeExecutedOrderSkipsDuplicateFallbackFillsWithoutExchangeTradeID(t *testing.T) {

--- a/internal/service/telegram.go
+++ b/internal/service/telegram.go
@@ -311,7 +311,7 @@ func (p *Platform) DispatchTelegramTradeEvents(deliveryByID map[string]domain.No
 		if event.Failed || strings.TrimSpace(event.Error) != "" {
 			continue
 		}
-		notificationID := "trade-event:" + event.ID
+		notificationID := tradeEventNotificationID(event)
 		if delivery, ok := deliveryByID[notificationID]; ok && strings.EqualFold(delivery.Status, "sent") {
 			continue
 		}
@@ -346,6 +346,27 @@ func (p *Platform) DispatchTelegramTradeEvents(deliveryByID map[string]domain.No
 		sent++
 	}
 	return sent, firstErr
+}
+
+func tradeEventNotificationID(event domain.OrderExecutionEvent) string {
+	anchor := firstNonEmpty(
+		strings.TrimSpace(event.OrderID),
+		strings.TrimSpace(event.ExchangeOrderID),
+		strings.TrimSpace(event.ID),
+	)
+	eventTime := ""
+	if !event.EventTime.IsZero() {
+		eventTime = event.EventTime.UTC().Format(time.RFC3339Nano)
+	}
+	return strings.Join([]string{
+		"trade-event",
+		anchor,
+		NormalizeSymbol(event.Symbol),
+		strings.ToUpper(strings.TrimSpace(event.Side)),
+		strings.ToLower(strings.TrimSpace(event.EventType)),
+		strings.ToUpper(strings.TrimSpace(event.Status)),
+		eventTime,
+	}, ":")
 }
 
 func (p *Platform) DispatchTelegramPositionReport(deliveryByID map[string]domain.NotificationDelivery, now time.Time) (int, error) {

--- a/internal/service/telegram_test.go
+++ b/internal/service/telegram_test.go
@@ -234,6 +234,66 @@ func TestTelegramDispatchSendsFilledTradeEventsWithPnLAndDedup(t *testing.T) {
 	}
 }
 
+func TestTelegramDispatchDedupesSemanticDuplicateTradeEvents(t *testing.T) {
+	messages := make([]string, 0)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var p map[string]any
+		json.Unmarshal(body, &p)
+		messages = append(messages, p["text"].(string))
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"ok":true}`))
+	}))
+	defer server.Close()
+
+	oldURL := telegramBaseURL
+	telegramBaseURL = server.URL
+	defer func() { telegramBaseURL = oldURL }()
+
+	store := memory.NewStore()
+	now := time.Date(2026, 4, 22, 10, 0, 36, 0, time.UTC)
+	baseEvent := domain.OrderExecutionEvent{
+		OrderID:         "order-dup-1",
+		ExchangeOrderID: "exchange-dup-1",
+		AccountID:       "account-live-1",
+		LiveSessionID:   "live-session-1",
+		Symbol:          "BTCUSDT",
+		Side:            "SELL",
+		EventType:       "filled",
+		Status:          "FILLED",
+		Quantity:        0.01304935,
+		Price:           77946.3,
+		EventTime:       now,
+		ExecutionMode:   "live",
+		DispatchSummary: map[string]any{"role": "entry"},
+	}
+	for _, id := range []string{"dup-event-1", "dup-event-2", "dup-event-3"} {
+		event := baseEvent
+		event.ID = id
+		if _, err := store.CreateOrderExecutionEvent(event); err != nil {
+			t.Fatalf("create duplicate event %s failed: %v", id, err)
+		}
+	}
+
+	p := &Platform{
+		store: store,
+		telegramConfig: domain.TelegramConfig{
+			Enabled:            true,
+			BotToken:           "test-token",
+			ChatID:             "123",
+			SendLevels:         []string{},
+			TradeEventsEnabled: true,
+		},
+	}
+
+	if err := p.DispatchTelegramNotifications(); err != nil {
+		t.Fatalf("dispatch failed: %v", err)
+	}
+	if len(messages) != 1 {
+		t.Fatalf("expected semantic duplicate trade events to send once, got %d: %#v", len(messages), messages)
+	}
+}
+
 func TestTelegramPositionReportUsesThirtyMinuteBucketAndSkipsRecovery(t *testing.T) {
 	messages := make([]string, 0)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Fix Telegram trade event duplicate sends by using a stable delivery key and by skipping duplicate filled execution events when no new fills were added.\n\nValidated with:\n- go test ./internal/service -run 'TestTelegram|TestFinalizeExecutedOrderSkipsDuplicateExchangeTradeIDFills'\n- go test ./internal/service