### PR TITLE
[codex] fix live stop flow

### DIFF
--- a/internal/http/accounts.go
+++ b/internal/http/accounts.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"errors"
 	"net/http"
 	"strings"
 
@@ -146,6 +147,17 @@ func registerAccountRoutes(mux *http.ServeMux, platform *service.Platform) {
 			}
 			item, err := platform.LaunchLiveFlow(accountID, payload)
 			if err != nil {
+				writeError(w, http.StatusBadRequest, err.Error())
+				return
+			}
+			writeJSON(w, http.StatusOK, item)
+		case "stop":
+			item, err := platform.StopLiveFlowWithForce(accountID, queryFlagEnabled(r, "force"))
+			if err != nil {
+				if errors.Is(err, service.ErrActivePositionsOrOrders) {
+					writeError(w, http.StatusBadRequest, err.Error())
+					return
+				}
 				writeError(w, http.StatusBadRequest, err.Error())
 				return
 			}

--- a/internal/http/session_safety_test.go
+++ b/internal/http/session_safety_test.go
@@ -44,6 +44,64 @@ func TestLiveSessionStopRouteRespectsForceQuery(t *testing.T) {
 	}
 }
 
+func TestLiveAccountStopRouteStopsRunningFlow(t *testing.T) {
+	store := memory.NewStore()
+	platform := service.NewPlatform(store)
+
+	if _, err := platform.BindStrategySignalSource("strategy-bk-1d", map[string]any{
+		"sourceKey": "binance-kline",
+		"role":      "signal",
+		"symbol":    "BTCUSDT",
+		"options":   map[string]any{"timeframe": "1d"},
+	}); err != nil {
+		t.Fatalf("bind strategy signal failed: %v", err)
+	}
+
+	session, err := store.UpdateLiveSessionStatus("live-session-main", "RUNNING")
+	if err != nil {
+		t.Fatalf("set live session running failed: %v", err)
+	}
+	runtime, err := platform.CreateSignalRuntimeSession("live-main", "strategy-bk-1d")
+	if err != nil {
+		t.Fatalf("create runtime failed: %v", err)
+	}
+	if _, err := platform.StartSignalRuntimeSession(runtime.ID); err != nil {
+		t.Fatalf("start runtime failed: %v", err)
+	}
+	state := map[string]any{
+		"signalRuntimeSessionId": runtime.ID,
+	}
+	if _, err := store.UpdateLiveSessionState(session.ID, state); err != nil {
+		t.Fatalf("update live session state failed: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	registerAccountRoutes(mux, platform)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/live/accounts/live-main/stop", nil)
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 for account stop, got %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	updatedSession, err := store.GetLiveSession("live-session-main")
+	if err != nil {
+		t.Fatalf("load live session failed: %v", err)
+	}
+	if updatedSession.Status != "STOPPED" {
+		t.Fatalf("expected live session to be stopped, got %s", updatedSession.Status)
+	}
+
+	updatedRuntime, err := platform.GetSignalRuntimeSession(runtime.ID)
+	if err != nil {
+		t.Fatalf("load runtime failed: %v", err)
+	}
+	if updatedRuntime.Status != "STOPPED" {
+		t.Fatalf("expected runtime to be stopped, got %s", updatedRuntime.Status)
+	}
+}
+
 func TestPositionCloseAndOrderDetailRoutes(t *testing.T) {
 	store := memory.NewStore()
 	platform := service.NewPlatform(store)

--- a/internal/service/live_account_flow.go
+++ b/internal/service/live_account_flow.go
@@ -1,0 +1,88 @@
+package service
+
+import (
+	"fmt"
+	"strings"
+)
+
+type StopLiveFlowResult struct {
+	AccountID                string   `json:"accountId"`
+	StoppedLiveSessionIDs    []string `json:"stoppedLiveSessionIds"`
+	StoppedRuntimeSessionIDs []string `json:"stoppedRuntimeSessionIds"`
+}
+
+func (p *Platform) StopLiveFlowWithForce(accountID string, force bool) (StopLiveFlowResult, error) {
+	accountID = strings.TrimSpace(accountID)
+	if accountID == "" {
+		return StopLiveFlowResult{}, fmt.Errorf("accountId is required")
+	}
+	if _, err := p.store.GetAccount(accountID); err != nil {
+		return StopLiveFlowResult{}, err
+	}
+
+	liveSessions, err := p.ListLiveSessions()
+	if err != nil {
+		return StopLiveFlowResult{}, err
+	}
+	runtimeSessions := p.ListSignalRuntimeSessions()
+
+	runningLiveSessions := make([]string, 0)
+	runningRuntimeSessions := make([]string, 0)
+	strategyIDs := make(map[string]struct{})
+	seenRuntimeIDs := make(map[string]struct{})
+
+	for _, session := range liveSessions {
+		if !strings.EqualFold(strings.TrimSpace(session.AccountID), accountID) {
+			continue
+		}
+		if strings.EqualFold(strings.TrimSpace(session.Status), "RUNNING") {
+			runningLiveSessions = append(runningLiveSessions, session.ID)
+		}
+		if strategyID := strings.TrimSpace(session.StrategyID); strategyID != "" {
+			strategyIDs[strategyID] = struct{}{}
+		}
+	}
+	for _, session := range runtimeSessions {
+		if !strings.EqualFold(strings.TrimSpace(session.AccountID), accountID) {
+			continue
+		}
+		if strategyID := strings.TrimSpace(session.StrategyID); strategyID != "" {
+			strategyIDs[strategyID] = struct{}{}
+		}
+		if !strings.EqualFold(strings.TrimSpace(session.Status), "RUNNING") {
+			continue
+		}
+		if _, exists := seenRuntimeIDs[session.ID]; exists {
+			continue
+		}
+		seenRuntimeIDs[session.ID] = struct{}{}
+		runningRuntimeSessions = append(runningRuntimeSessions, session.ID)
+	}
+
+	if !force {
+		for strategyID := range strategyIDs {
+			if err := p.ensureNoActivePositionsOrOrders(accountID, strategyID); err != nil {
+				return StopLiveFlowResult{}, err
+			}
+		}
+	}
+
+	result := StopLiveFlowResult{
+		AccountID:                accountID,
+		StoppedLiveSessionIDs:    make([]string, 0, len(runningLiveSessions)),
+		StoppedRuntimeSessionIDs: make([]string, 0, len(runningRuntimeSessions)),
+	}
+	for _, sessionID := range runningLiveSessions {
+		if _, err := p.StopLiveSessionWithForce(sessionID, true); err != nil {
+			return StopLiveFlowResult{}, err
+		}
+		result.StoppedLiveSessionIDs = append(result.StoppedLiveSessionIDs, sessionID)
+	}
+	for _, sessionID := range runningRuntimeSessions {
+		if _, err := p.StopSignalRuntimeSessionWithForce(sessionID, true); err != nil {
+			return StopLiveFlowResult{}, err
+		}
+		result.StoppedRuntimeSessionIDs = append(result.StoppedRuntimeSessionIDs, sessionID)
+	}
+	return result, nil
+}

--- a/internal/service/safety_checks_test.go
+++ b/internal/service/safety_checks_test.go
@@ -151,6 +151,61 @@ func TestSignalRuntimeSessionForceActionsRespectSafetyLock(t *testing.T) {
 	}
 }
 
+func TestStopLiveFlowWithForceSucceedsWhenLiveStopAlreadyStoppedLinkedRuntime(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	if _, err := platform.BindStrategySignalSource("strategy-bk-1d", map[string]any{
+		"sourceKey": "binance-kline",
+		"role":      "signal",
+		"symbol":    "BTCUSDT",
+		"options":   map[string]any{"timeframe": "1d"},
+	}); err != nil {
+		t.Fatalf("bind strategy signal failed: %v", err)
+	}
+
+	session, err := platform.store.UpdateLiveSessionStatus("live-session-main", "RUNNING")
+	if err != nil {
+		t.Fatalf("set live session running failed: %v", err)
+	}
+	runtime, err := platform.CreateSignalRuntimeSession("live-main", "strategy-bk-1d")
+	if err != nil {
+		t.Fatalf("create runtime failed: %v", err)
+	}
+	if _, err := platform.StartSignalRuntimeSession(runtime.ID); err != nil {
+		t.Fatalf("start runtime failed: %v", err)
+	}
+	if _, err := platform.store.UpdateLiveSessionState(session.ID, map[string]any{
+		"signalRuntimeSessionId": runtime.ID,
+	}); err != nil {
+		t.Fatalf("link runtime into live session state failed: %v", err)
+	}
+
+	result, err := platform.StopLiveFlowWithForce("live-main", false)
+	if err != nil {
+		t.Fatalf("StopLiveFlowWithForce failed: %v", err)
+	}
+	if len(result.StoppedLiveSessionIDs) != 1 || result.StoppedLiveSessionIDs[0] != session.ID {
+		t.Fatalf("expected stopped live session %s, got %#v", session.ID, result.StoppedLiveSessionIDs)
+	}
+	if len(result.StoppedRuntimeSessionIDs) != 1 || result.StoppedRuntimeSessionIDs[0] != runtime.ID {
+		t.Fatalf("expected stopped runtime session %s, got %#v", runtime.ID, result.StoppedRuntimeSessionIDs)
+	}
+
+	updatedSession, err := platform.store.GetLiveSession(session.ID)
+	if err != nil {
+		t.Fatalf("reload live session failed: %v", err)
+	}
+	if updatedSession.Status != "STOPPED" {
+		t.Fatalf("expected live session STOPPED, got %s", updatedSession.Status)
+	}
+	updatedRuntime, err := platform.GetSignalRuntimeSession(runtime.ID)
+	if err != nil {
+		t.Fatalf("reload runtime failed: %v", err)
+	}
+	if updatedRuntime.Status != "STOPPED" {
+		t.Fatalf("expected runtime STOPPED, got %s", updatedRuntime.Status)
+	}
+}
+
 func TestClosePositionCreatesReduceOnlyMarketOrder(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
 	account, err := platform.CreateAccount("Paper Close", "PAPER", "binance-futures")

--- a/web/console/src/hooks/useTradingActions.ts
+++ b/web/console/src/hooks/useTradingActions.ts
@@ -300,14 +300,20 @@ export function useTradingActions(loadDashboard: () => Promise<void>) {
     }
   }
 
-  async function stopLiveFlow(accountId: string) {
+  async function stopLiveFlow(accountId: string, force = false) {
     setLiveFlowAction(accountId);
     try {
-      await fetchJSON(`/api/v1/live/accounts/${accountId}/stop`, { method: "POST" });
+      await fetchJSON(`/api/v1/live/accounts/${accountId}/stop${force ? '?force=true' : ''}`, { method: "POST" });
       await loadDashboard();
+      setNotification({
+        type: 'success',
+        message: force ? "已强制停止账户实盘流程" : "已安全停止账户实盘流程",
+      });
       setError(null);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to stop live flow");
+      const message = err instanceof Error ? err.message : "Failed to stop live flow";
+      setError(message);
+      setNotification({ type: 'error', message: `停止实盘流程失败: ${message}` });
     } finally {
       setLiveFlowAction(null);
     }

--- a/web/console/src/pages/AccountStage.tsx
+++ b/web/console/src/pages/AccountStage.tsx
@@ -81,7 +81,7 @@ interface AccountStageProps {
   openLiveSessionModal: (session?: LiveSession | null) => void;
   openMonitorStage: () => void;
   launchLiveFlow: (account: AccountRecord) => void;
-  stopLiveFlow: (accountId: string) => void;
+  stopLiveFlow: (accountId: string, force?: boolean) => Promise<void>;
   runLiveSessionAction: (id: string, action: "start" | "stop") => void;
   dispatchLiveSessionIntent: (id: string) => void;
   syncLiveSession: (id: string) => void;
@@ -197,12 +197,16 @@ export function AccountStage({
     onConfirm: () => Promise<void> | void;
   }>({ open: false, title: "", description: "", onConfirm: () => {} });
 
+  const confirmActionPending = liveSessionDeleteAction !== null || liveFlowAction !== null;
+
   const activeLiveSession = liveSessions.find(s => s.accountId === quickLiveAccountId);
   const activeTemplateKey = (activeLiveSession?.metadata as any)?.launchTemplateKey;
 
   const openConfirm = (title: string, description: string, onConfirm: () => Promise<void> | void) => {
     setConfirmConfig({ open: true, title, description, onConfirm });
   };
+
+  const activeOrderStatuses = useMemo(() => new Set(["NEW", "PARTIALLY_FILLED", "ACCEPTED"]), []);
 
   // Derived states
   const highlightedLiveSession = useMemo(
@@ -477,6 +481,9 @@ export function AccountStage({
                 const binding = (account.metadata?.liveBinding as Record<string, unknown> | undefined) ?? {};
                 const syncSnapshot = getRecord(getRecord(account.metadata).liveSyncSnapshot);
                 const summary = summaries.find(s => s.accountId === account.id);
+                const openPositionCount = positions.filter((item) => item.accountId === account.id && Number(item.quantity) > 0).length;
+                const activeOrderCount = orders.filter((item) => item.accountId === account.id && activeOrderStatuses.has(String(item.status).toUpperCase())).length;
+                const hasOpenExposure = openPositionCount > 0 || activeOrderCount > 0;
                 const runtimeSessionsForAccount = signalRuntimeSessions.filter((item) => item.accountId === account.id);
                 const activeRuntime = runtimeSessionsForAccount.find((item) => item.status === "RUNNING") ?? runtimeSessionsForAccount[0] ?? null;
                 const activeRuntimeState = getRecord(activeRuntime?.state);
@@ -506,6 +513,26 @@ export function AccountStage({
                 const liveNextAction = deriveLiveNextAction(livePreflight);
                 const liveAlerts = deriveLiveAlerts(account, activeRuntimeState, activeRuntimeSourceSummary, activeRuntimeReadiness, activeSignalAction, runtimePolicy);
                 const accountDetailOpen = expandedAccountId === account.id;
+                const handleStopLiveFlow = () => {
+                  if (!hasOpenExposure) {
+                    openConfirm(
+                      "确认停止实盘流程？",
+                      "系统会按安全停止路径关闭该账户下的运行时与实盘会话。若交易所侧随后出现未识别仓单，下次启动前仍建议先做一次同步或 reconcile。",
+                      () => stopLiveFlow(account.id)
+                    );
+                    return;
+                  }
+                  openConfirm(
+                    "安全停止已阻断",
+                    `检测到账户仍有 ${openPositionCount} 笔未平仓 / ${activeOrderCount} 笔活动订单。默认停止不会继续执行。若要继续，下一步将进入强制停止确认。`,
+                    () =>
+                      openConfirm(
+                        "确认强制停止？",
+                        "强制停止会立刻切断本地托管链路，但不会替你平掉交易所上的真实仓位或撤掉挂单。之后重新启动将进入恢复校验，可能出现 close-only、reconcile blocked 或 error 状态。",
+                        () => stopLiveFlow(account.id, true)
+                      )
+                  );
+                };
 
                 return (
                   <div key={account.id} className="group overflow-hidden rounded-[24px] border border-[var(--bk-border)] bg-[var(--bk-surface-strong)] shadow-sm transition-all duration-300 hover:translate-y-[-2px] hover:shadow-xl">
@@ -585,7 +612,7 @@ export function AccountStage({
                             variant={isLiveFlowRunning ? "bento-danger" : "bento"}
                             className="h-11 w-full rounded-xl text-xs font-black shadow-md transition-transform active:scale-95"
                             disabled={liveFlowAction !== null || liveBindAction || signalRuntimeAction !== null}
-                            onClick={() => isLiveFlowRunning ? stopLiveFlow(account.id) : launchLiveFlow(account)}
+                            onClick={() => isLiveFlowRunning ? handleStopLiveFlow() : launchLiveFlow(account)}
                           >
                              {isLiveFlowRunning ? (
                                <div className="flex items-center gap-2"><Square size={14} fill="currentColor" /> 停止实盘流程</div>
@@ -1078,7 +1105,7 @@ export function AccountStage({
       <AlertDialog 
         open={confirmConfig.open} 
         onOpenChange={(open) => {
-          if (!open && liveSessionDeleteAction !== null) return;
+          if (!open && confirmActionPending) return;
           if (!open) setConfirmConfig(c => ({ ...c, open: false }));
         }}
       >
@@ -1091,14 +1118,14 @@ export function AccountStage({
           </AlertDialogHeader>
           <AlertDialogFooter className="pt-6">
             <AlertDialogCancel 
-              disabled={liveSessionDeleteAction !== null}
+              disabled={confirmActionPending}
               variant="bento-outline"
               className="h-11 rounded-xl px-6 font-bold"
             >
               取消
             </AlertDialogCancel>
             <Button 
-              loading={liveSessionDeleteAction !== null}
+              loading={confirmActionPending}
               onClick={async () => {
                 await confirmConfig.onConfirm();
                 setConfirmConfig(c => ({ ...c, open: false }));


### PR DESCRIPTION
## 目的
修复 AccountStage 的“停止实盘流程”链路，让账户卡片的 stop 按钮真正命中后端停止接口，并把前端交互改成“安全停止 -> 强制停止”的两段式确认，避免用户在仍有未平仓/活动订单时误以为只是普通暂停。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [x] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main)
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？
- [x] DB migration 是否具备向下兼容幂等性？
- [x] 配置字段有没有无意被混改？

说明：本 PR 不修改 dispatch 默认值、不触碰 mainnet 凭证/路由、不包含 DB migration、不改运行时配置字段。

## root cause
账户卡片上的前端 stop 按钮一直调用 `POST /api/v1/live/accounts/:id/stop`，但后端此前没有提供这个账户级 stop 路由，导致用户点击“停止实盘流程”后并未真正停止账户下的 live session / signal runtime，刷新后又表现为继续运行。

## 修改点
- 新增账户级 `POST /api/v1/live/accounts/:id/stop` 路由。
- 新增 `StopLiveFlowWithForce`，对账户下关联策略先做安全检查，再统一停止运行中的 live session 和 signal runtime。
- 新增 HTTP 回归测试，覆盖账户级 stop 路由会真正停止 live session/runtime。
- 前端 stop 交互改成两段式：
  - 无持仓/活动订单时，先确认再走安全停止。
  - 有持仓/活动订单时，先提示“安全停止已阻断”，再二次确认才走 `force=true`。
- 前端补充 stop 成功/失败通知，并让确认弹窗在 stop 执行时显示 loading。

## 行为变化
- 账户卡片的“停止实盘流程”现在会真正停止该账户下正在运行的托管链路。
- 默认停止仍然不允许在存在未平仓/活动订单时直接停掉。
- 只有用户明确经过第二次确认时，前端才会发起强制停止。

## 新增测试
- `TestLiveAccountStopRouteStopsRunningFlow`

## 验证方式与测试证据
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

本地验证：
- `go test ./internal/http -run 'TestLive(SessionStopRouteRespectsForceQuery|AccountStopRouteStopsRunningFlow)$'`
- `go test ./internal/service -run 'TestStartSignalRuntimeSessionIncludesAllBoundTimeframes$'`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
- `cd web/console && npm run build`

提交：`23f021f fix live stop flow`
