### PR TITLE
[codex] fix live order normalized quantity drift

### DIFF
--- a/internal/service/order.go
+++ b/internal/service/order.go
@@ -538,6 +538,7 @@ func (p *Platform) applyLiveSubmissionResult(
 	}
 	delete(order.Metadata, "liveSubmitError")
 	order.Status = firstNonEmpty(submission.Status, "ACCEPTED")
+	adoptNormalizedLiveSubmissionValues(&order, submission.Metadata)
 	order.Metadata["exchangeOrderId"] = submission.ExchangeOrderID
 	order.Metadata["acceptedAt"] = submission.AcceptedAt
 	order.Metadata["adapterSubmission"] = submission.Metadata
@@ -575,6 +576,29 @@ func (p *Platform) applyLiveSubmissionResult(
 		return settledOrder, nil
 	}
 	return updatedOrder, nil
+}
+
+func adoptNormalizedLiveSubmissionValues(order *domain.Order, submissionMetadata map[string]any) {
+	if order == nil {
+		return
+	}
+	submission := cloneMetadata(submissionMetadata)
+	if len(submission) == 0 {
+		return
+	}
+	normalization := mapValue(submission["normalization"])
+	if quantity := firstPositive(
+		parseFloatValue(submission["normalizedQuantity"]),
+		parseFloatValue(normalization["normalizedQuantity"]),
+	); quantity > 0 {
+		order.Quantity = quantity
+	}
+	if price := firstPositive(
+		parseFloatValue(submission["normalizedPrice"]),
+		parseFloatValue(normalization["normalizedPrice"]),
+	); price > 0 {
+		order.Price = price
+	}
 }
 
 func markLiveSettlementSyncRetry(order domain.Order, err error) domain.Order {
@@ -784,6 +808,7 @@ func (p *Platform) applyLiveSyncResult(account domain.Account, order domain.Orde
 		"symbol", NormalizeSymbol(order.Symbol),
 	)
 	order.Metadata = cloneMetadata(order.Metadata)
+	adoptNormalizedLiveSubmissionValues(&order, mapValue(order.Metadata["adapterSubmission"]))
 	applyExecutionMetadata(order.Metadata, map[string]any{
 		"lastSyncAt":           syncResult.SyncedAt,
 		"syncMode":             "adapter",

--- a/internal/service/order_test.go
+++ b/internal/service/order_test.go
@@ -738,6 +738,166 @@ func TestCreateLiveOrderImmediateFilledSubmissionSettlesReduceOnlyExit(t *testin
 	}
 }
 
+func TestCreateOrderAdoptsNormalizedLiveSubmissionValues(t *testing.T) {
+	store := memory.NewStore()
+	platform := NewPlatform(store)
+	adapter := &recordingLiveExecutionAdapter{
+		key: "test-normalized-submission-values",
+		submitResult: LiveOrderSubmission{
+			Status:          "ACCEPTED",
+			ExchangeOrderID: "exchange-order-normalized-1",
+			AcceptedAt:      "2026-04-22T10:00:00Z",
+			Metadata: map[string]any{
+				"adapterMode":        "rest",
+				"executionMode":      "rest",
+				"rawQuantity":        0.00213794,
+				"rawPriceReference":  68643.67,
+				"normalizedQuantity": 0.002,
+				"normalizedPrice":    68643.6,
+				"normalization": map[string]any{
+					"rawQuantity":        0.00213794,
+					"rawPriceReference":  68643.67,
+					"normalizedQuantity": 0.002,
+					"normalizedPrice":    68643.6,
+				},
+			},
+		},
+	}
+	platform.registerLiveAdapter(adapter)
+
+	account, err := platform.BindLiveAccount("live-main", map[string]any{
+		"adapterKey": adapter.key,
+	})
+	if err != nil {
+		t.Fatalf("bind live account failed: %v", err)
+	}
+
+	order, err := platform.CreateOrder(domain.Order{
+		AccountID:         account.ID,
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "BUY",
+		Type:              "LIMIT",
+		Quantity:          0.00213794,
+		Price:             68643.67,
+		Metadata: map[string]any{
+			"skipRuntimeCheck": true,
+			"executionProposal": map[string]any{
+				"role":       "entry",
+				"signalKind": "initial-entry-near",
+				"reason":     "Zero-Initial-Reentry",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("create order failed: %v", err)
+	}
+
+	if got := order.Status; got != "ACCEPTED" {
+		t.Fatalf("expected accepted order, got %s", got)
+	}
+	if got := order.Quantity; got != 0.002 {
+		t.Fatalf("expected stored quantity to adopt normalized value 0.002, got %v", got)
+	}
+	if got := order.Price; got != 68643.6 {
+		t.Fatalf("expected stored price to adopt normalized value 68643.6, got %v", got)
+	}
+
+	orders, err := store.ListOrders()
+	if err != nil {
+		t.Fatalf("list orders failed: %v", err)
+	}
+	if len(orders) != 1 {
+		t.Fatalf("expected one persisted order, got %d", len(orders))
+	}
+	if got := orders[0].Quantity; got != 0.002 {
+		t.Fatalf("expected persisted quantity to use normalized value 0.002, got %v", got)
+	}
+	if got := orders[0].Price; got != 68643.6 {
+		t.Fatalf("expected persisted price to use normalized value 68643.6, got %v", got)
+	}
+	submission := mapValue(order.Metadata["adapterSubmission"])
+	if got := parseFloatValue(submission["rawQuantity"]); got != 0.00213794 {
+		t.Fatalf("expected adapter submission to preserve raw quantity, got %v", got)
+	}
+	if got := parseFloatValue(submission["normalizedQuantity"]); got != 0.002 {
+		t.Fatalf("expected adapter submission normalizedQuantity 0.002, got %v", got)
+	}
+}
+
+func TestApplyLiveSyncResultHealsStoredQuantityFromNormalizedSubmission(t *testing.T) {
+	store := memory.NewStore()
+	platform := NewPlatform(store)
+
+	account, err := store.GetAccount("live-main")
+	if err != nil {
+		t.Fatalf("get live account failed: %v", err)
+	}
+	order, err := store.CreateOrder(domain.Order{
+		AccountID:         account.ID,
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "BUY",
+		Type:              "MARKET",
+		Quantity:          0.00213794,
+		Price:             68643.67,
+		Status:            "ACCEPTED",
+		Metadata: map[string]any{
+			"executionMode": "live",
+			"adapterSubmission": map[string]any{
+				"rawQuantity":        0.00213794,
+				"rawPriceReference":  68643.67,
+				"normalizedQuantity": 0.002,
+				"normalizedPrice":    68643.6,
+				"normalization": map[string]any{
+					"rawQuantity":        0.00213794,
+					"rawPriceReference":  68643.67,
+					"normalizedQuantity": 0.002,
+					"normalizedPrice":    68643.6,
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("create order failed: %v", err)
+	}
+
+	synced, err := platform.applyLiveSyncResult(account, order, LiveOrderSync{
+		Status:   "FILLED",
+		SyncedAt: "2026-04-22T10:00:01Z",
+		Fills: []LiveFillReport{{
+			Price:    68643.6,
+			Quantity: 0.002,
+			Fee:      0.01,
+			Metadata: map[string]any{
+				"exchangeOrderId": "exchange-order-normalized-2",
+				"tradeId":         "trade-normalized-2",
+				"tradeTime":       "2026-04-22T10:00:01Z",
+			},
+		}},
+		Terminal: true,
+	})
+	if err != nil {
+		t.Fatalf("apply live sync result failed: %v", err)
+	}
+
+	if got := synced.Quantity; got != 0.002 {
+		t.Fatalf("expected synced order quantity to heal to 0.002, got %v", got)
+	}
+	if got := synced.Price; got != 68643.6 {
+		t.Fatalf("expected synced order price to heal to 68643.6, got %v", got)
+	}
+	if got := synced.Status; got != "FILLED" {
+		t.Fatalf("expected healed order to settle FILLED, got %s", got)
+	}
+	if got := parseFloatValue(synced.Metadata["filledQuantity"]); got != 0.002 {
+		t.Fatalf("expected healed order filledQuantity 0.002, got %v", got)
+	}
+	if got := parseFloatValue(synced.Metadata["remainingQuantity"]); got != 0 {
+		t.Fatalf("expected healed order remainingQuantity 0, got %v", got)
+	}
+}
+
 func TestClosePositionImmediatelySettlesFilledLiveManualClose(t *testing.T) {
 	store := memory.NewStore()
 	platform := NewPlatform(store)


### PR DESCRIPTION
## 目的
修复 live reentry_size_schedule 下单后，系统本地订单主数量/主价格仍保留 raw proposal 值的问题。

这会带来两个直接现象：
- schedule 按 10% / 20% 算出来的 raw quantity 会带很多小数位，和 Binance stepSize / minQty 精度不一致
- 交易所实际接受的是 normalized quantity，但本地 `orders.quantity` 还是 raw quantity，导致后续 order sync 持续把它识别成漂移并反复同步

本次修复让系统在 live submission 成功后，直接采用交易所归一化后的 `normalizedQuantity` / `normalizedPrice` 作为订单主记录；同时在后续 sync 时，也会优先用已有 `adapterSubmission` 里的 normalized 值把历史脏单自愈回来，避免继续疯狂 sync。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [x] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main)
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？
- [x] DB migration 是否具备向下兼容幂等性？
- [x] 配置字段有没有无意被混改？

说明：
- `dispatchMode` 默认值没有变化
- 没有新增 mainnet 硬编码
- 没有 DB migration
- 仅修改 live order submission / sync 后的订单主字段回写，不改 schedule 算法本身、不改 Binance 规格归一化规则

## 验证方式与测试证据
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

已验证：
- `go test ./internal/service -run 'TestCreateOrderAdoptsNormalizedLiveSubmissionValues|TestApplyLiveSyncResultHealsStoredQuantityFromNormalizedSubmission|TestCreateLiveOrderImmediateFilledSubmissionSettlesReduceOnlyExit'`
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
- `/usr/local/bin/git diff --check`

新增测试：
- 新 submission 成功后，订单主数量/主价格应采用 normalized 值
- 已经写脏的订单在下一次 live sync 时，应先从 `adapterSubmission.normalizedQuantity` 自愈，再正常 settlement
