### PR TITLE
[codex] normalize live exit intent side

### DIFF
--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -3984,6 +3984,7 @@ func deriveLiveSignalIntent(decision StrategySignalDecision, symbol string) *Sig
 	reason := stringValue(meta["nextPlannedReason"])
 	currentPosition := cloneMetadata(mapValue(meta["currentPosition"]))
 	if role == "exit" {
+		nextSide = normalizeLiveExitIntentSide(nextSide, currentPosition)
 		quantity = firstPositive(math.Abs(parseFloatValue(currentPosition["quantity"])), quantity)
 	}
 
@@ -4016,6 +4017,18 @@ func deriveLiveSignalIntent(decision StrategySignalDecision, symbol string) *Sig
 			"currentPosition":               currentPosition,
 			"bookImbalance":                 parseFloatValue(meta["bookImbalance"]),
 		},
+	}
+}
+
+func normalizeLiveExitIntentSide(plannedSide string, currentPosition map[string]any) string {
+	positionSide := strings.ToUpper(strings.TrimSpace(stringValue(currentPosition["side"])))
+	switch positionSide {
+	case "LONG":
+		return "SELL"
+	case "SHORT":
+		return "BUY"
+	default:
+		return plannedSide
 	}
 }
 

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -60,6 +60,78 @@ func TestDeriveLiveSignalIntentUsesNextPlannedStep(t *testing.T) {
 	}
 }
 
+func TestDeriveLiveSignalIntentNormalizesExitSideFromCurrentPosition(t *testing.T) {
+	decision := StrategySignalDecision{
+		Action: "advance-plan",
+		Metadata: map[string]any{
+			"signalBarDecision": map[string]any{
+				"ready": true,
+			},
+			"marketPrice":       78490.2,
+			"marketSource":      "order_book.bestBid",
+			"signalKind":        "risk-exit",
+			"decisionState":     "exit-ready",
+			"signalBarStateKey": "binance|BTCUSDT|signal|30m",
+			"currentPosition": map[string]any{
+				"found":      true,
+				"symbol":     "BTCUSDT",
+				"side":       "LONG",
+				"quantity":   0.0128,
+				"entryPrice": 78845.459375,
+			},
+			"nextPlannedSide":   "BUY",
+			"nextPlannedRole":   "exit",
+			"nextPlannedReason": "SL",
+			"nextPlannedEvent":  time.Date(2026, 4, 22, 22, 39, 47, 0, time.UTC).Format(time.RFC3339),
+			"nextPlannedPrice":  78729.46008928573,
+		},
+	}
+
+	intent := deriveLiveSignalIntent(decision, "BTCUSDT")
+	if intent == nil {
+		t.Fatal("expected exit intent")
+	}
+	if got := intent.Side; got != "SELL" {
+		t.Fatalf("expected LONG exit intent to normalize to SELL, got %s", got)
+	}
+}
+
+func TestDeriveLiveSignalIntentNormalizesShortExitSideFromCurrentPosition(t *testing.T) {
+	decision := StrategySignalDecision{
+		Action: "advance-plan",
+		Metadata: map[string]any{
+			"signalBarDecision": map[string]any{
+				"ready": true,
+			},
+			"marketPrice":       78490.2,
+			"marketSource":      "order_book.bestAsk",
+			"signalKind":        "risk-exit",
+			"decisionState":     "exit-ready",
+			"signalBarStateKey": "binance|BTCUSDT|signal|30m",
+			"currentPosition": map[string]any{
+				"found":      true,
+				"symbol":     "BTCUSDT",
+				"side":       "SHORT",
+				"quantity":   0.0128,
+				"entryPrice": 78845.459375,
+			},
+			"nextPlannedSide":   "SELL",
+			"nextPlannedRole":   "exit",
+			"nextPlannedReason": "SL",
+			"nextPlannedEvent":  time.Date(2026, 4, 22, 22, 39, 47, 0, time.UTC).Format(time.RFC3339),
+			"nextPlannedPrice":  78729.46008928573,
+		},
+	}
+
+	intent := deriveLiveSignalIntent(decision, "BTCUSDT")
+	if intent == nil {
+		t.Fatal("expected exit intent")
+	}
+	if got := intent.Side; got != "BUY" {
+		t.Fatalf("expected SHORT exit intent to normalize to BUY, got %s", got)
+	}
+}
+
 func TestEvaluateSignalBarGateRequiresLongBreakoutAlignmentWithResearch(t *testing.T) {
 	gate := evaluateSignalBarGate(map[string]any{
 		"ma20":  68000.0,


### PR DESCRIPTION
## 目的
修复 live 正常退出链路会盲信 `nextPlannedSide`，导致 `LONG` 持仓在 `role=exit` 场景下仍可能生成 `BUY` intent，正常 `SL/TP/TSL` 无法按持仓方向平仓，最后退化成 `recovery-watchdog` fallback。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [x] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [ ] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main)
- [ ] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？
- [ ] DB migration 是否具备向下兼容幂等性？
- [ ] 配置字段有没有无意被混改？

## Root Cause
- `strategy_decision_events` 在本次事故里连续产出 `role=exit + nextPlannedSide=BUY + currentPosition.side=LONG`
- `deriveLiveSignalIntent` 直接把这个 `nextPlannedSide` 透传给 execution proposal
- `bookAwareExecutionStrategy` 不会再基于持仓方向纠正 exit side，导致正常 `risk-exit` proposal 持续变成错误方向
- 真正能落单的只剩 `live_recovery.go` 里的 fallback 路径，因为它会显式按持仓方向取反生成平仓 side

## 修改点
- 在 `deriveLiveSignalIntent` 中，当 `role=exit` 时按 `currentPosition.side` 规范化意图方向：`LONG -> SELL`，`SHORT -> BUY`
- 保留原有 `nextPlannedSide` 作为无持仓上下文时的兜底，不扩大修改到 recovery 状态机或 execution strategy
- 新增 LONG / SHORT 两条回归测试，锁住 exit intent side 不能再被错误 `nextPlannedSide` 带歪

## 行为变化
- live 正常退出路径在 `SL / TP / TSL` 场景下会优先服从当前持仓方向，而不是盲信 plan side
- 如果当前持仓是 `LONG`，exit intent 将始终归一为 `SELL`
- 如果当前持仓是 `SHORT`，exit intent 将始终归一为 `BUY`
- recovery fallback 逻辑不变

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

已通过：
- `go test ./internal/service -run 'TestDeriveLiveSignalIntent(UsesNextPlannedStep|NormalizesExitSideFromCurrentPosition|NormalizesShortExitSideFromCurrentPosition)$'`
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
- `/usr/local/bin/git diff --check`
