### PR TITLE
[codex] scope live trade pair queries to related records

### DIFF
--- a/internal/service/live_trade_pairs.go
+++ b/internal/service/live_trade_pairs.go
@@ -87,18 +87,6 @@ func (p *Platform) ListLiveTradePairs(query domain.LiveTradePairQuery) ([]domain
 	if err != nil {
 		return nil, err
 	}
-	decisionEvents, err := p.queryStrategyDecisionEvents(domain.StrategyDecisionEventQuery{
-		LiveSessionID: liveSessionID,
-	})
-	if err != nil {
-		return nil, err
-	}
-	snapshots, err := p.queryPositionAccountSnapshots(domain.PositionAccountSnapshotQuery{
-		LiveSessionID: liveSessionID,
-	})
-	if err != nil {
-		return nil, err
-	}
 
 	orderByID := make(map[string]domain.Order)
 	for _, order := range orders {
@@ -107,17 +95,22 @@ func (p *Platform) ListLiveTradePairs(query domain.LiveTradePairQuery) ([]domain
 		}
 		orderByID[order.ID] = order
 	}
-
-	decisionByID := make(map[string]domain.StrategyDecisionEvent, len(decisionEvents))
-	for _, item := range decisionEvents {
-		decisionByID[item.ID] = item
-	}
-	snapshotByOrderID := latestPositionSnapshotByOrderID(snapshots)
-	currentPositionBySymbol := currentLivePositionBySymbol(session, positions)
-	fillEvents := buildLiveTradeFillEvents(fills, orderByID, decisionByID)
-	if len(fillEvents) == 0 {
+	filteredFills := liveTradePairRelevantFills(fills, orderByID)
+	if len(filteredFills) == 0 {
 		return filterAndLimitLiveTradePairs(nil, normalizeLiveTradePairStatus(query.Status), normalizeLiveTradePairLimit(query.Limit)), nil
 	}
+
+	decisionByID, err := p.fetchLiveTradeDecisionEvents(liveSessionID, orderByID)
+	if err != nil {
+		return nil, err
+	}
+	snapshotByOrderID, err := p.fetchLatestLiveTradeSnapshots(liveSessionID, orderByID)
+	if err != nil {
+		return nil, err
+	}
+
+	currentPositionBySymbol := currentLivePositionBySymbol(session, positions)
+	fillEvents := buildLiveTradeFillEvents(filteredFills, orderByID, decisionByID)
 
 	sort.SliceStable(fillEvents, func(i, j int) bool {
 		left := fillEvents[i]
@@ -205,6 +198,79 @@ func (p *Platform) ListLiveTradePairs(query domain.LiveTradePairQuery) ([]domain
 		}
 	})
 	return filterAndLimitLiveTradePairs(results, normalizeLiveTradePairStatus(query.Status), normalizeLiveTradePairLimit(query.Limit)), nil
+}
+
+func liveTradePairRelevantFills(fills []domain.Fill, orderByID map[string]domain.Order) []domain.Fill {
+	items := make([]domain.Fill, 0, len(fills))
+	for _, fill := range fills {
+		if _, ok := orderByID[fill.OrderID]; !ok {
+			continue
+		}
+		items = append(items, fill)
+	}
+	return items
+}
+
+func (p *Platform) fetchLiveTradeDecisionEvents(liveSessionID string, orderByID map[string]domain.Order) (map[string]domain.StrategyDecisionEvent, error) {
+	ids := make([]string, 0, len(orderByID))
+	seen := make(map[string]struct{})
+	for _, order := range orderByID {
+		decisionEventID := firstNonEmpty(
+			stringValue(order.Metadata["decisionEventId"]),
+			stringValue(mapValue(order.Metadata["executionProposal"])["decisionEventId"]),
+			stringValue(mapValue(mapValue(order.Metadata["executionProposal"])["metadata"])["decisionEventId"]),
+		)
+		decisionEventID = strings.TrimSpace(decisionEventID)
+		if decisionEventID == "" {
+			continue
+		}
+		if _, ok := seen[decisionEventID]; ok {
+			continue
+		}
+		seen[decisionEventID] = struct{}{}
+		ids = append(ids, decisionEventID)
+	}
+	sort.Strings(ids)
+	items := make(map[string]domain.StrategyDecisionEvent, len(ids))
+	for _, decisionEventID := range ids {
+		events, err := p.queryStrategyDecisionEvents(domain.StrategyDecisionEventQuery{
+			LiveSessionID:   liveSessionID,
+			DecisionEventID: decisionEventID,
+			Limit:           1,
+		})
+		if err != nil {
+			return nil, err
+		}
+		if len(events) == 0 {
+			continue
+		}
+		items[decisionEventID] = events[0]
+	}
+	return items, nil
+}
+
+func (p *Platform) fetchLatestLiveTradeSnapshots(liveSessionID string, orderByID map[string]domain.Order) (map[string]domain.PositionAccountSnapshot, error) {
+	orderIDs := make([]string, 0, len(orderByID))
+	for orderID := range orderByID {
+		orderIDs = append(orderIDs, orderID)
+	}
+	sort.Strings(orderIDs)
+	items := make(map[string]domain.PositionAccountSnapshot, len(orderIDs))
+	for _, orderID := range orderIDs {
+		snapshots, err := p.queryPositionAccountSnapshots(domain.PositionAccountSnapshotQuery{
+			LiveSessionID: liveSessionID,
+			OrderID:       orderID,
+			Limit:         1,
+		})
+		if err != nil {
+			return nil, err
+		}
+		if len(snapshots) == 0 {
+			continue
+		}
+		items[orderID] = snapshots[0]
+	}
+	return items, nil
 }
 
 func buildLiveTradeFillEvents(

--- a/internal/service/live_trade_pairs_test.go
+++ b/internal/service/live_trade_pairs_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"fmt"
 	"math"
 	"testing"
 	"time"
@@ -145,6 +146,52 @@ func TestListLiveTradePairsReturnsOpenTradeWithUnrealizedPnLAndAggregatedEntries
 	assertTradePairFloat(t, pair.NetPnL, pair.UnrealizedPnL-0.03)
 }
 
+func TestListLiveTradePairsUsesTargetedDecisionAndSnapshotQueries(t *testing.T) {
+	store := &liveTradePairTargetedQueryStore{Store: memory.NewStore()}
+	platform := NewPlatform(store)
+
+	account, err := platform.CreateAccount("Live Trade Pair", "LIVE", "binance-futures")
+	if err != nil {
+		t.Fatalf("create account: %v", err)
+	}
+	session, err := platform.CreateLiveSession("", account.ID, "strategy-bk-1d", map[string]any{
+		"symbol": "BTCUSDT",
+	})
+	if err != nil {
+		t.Fatalf("create live session: %v", err)
+	}
+
+	pair := createClosedLiveTradePairFixture(t, platform, session, liveTradeFixture{
+		entryPrice:        100,
+		exitPrice:         112,
+		quantity:          2,
+		entryFee:          0.2,
+		exitFee:           0.3,
+		exitReason:        "SL",
+		targetPriceSource: "trailing-stop",
+	})
+	if pair.ID == "" {
+		t.Fatal("expected trade pair fixture to be created")
+	}
+
+	if got := len(store.decisionQueries); got != 1 {
+		t.Fatalf("expected exactly 1 targeted decision query, got %d", got)
+	}
+	decisionQuery := store.decisionQueries[0]
+	if decisionQuery.LiveSessionID != session.ID || decisionQuery.DecisionEventID == "" || decisionQuery.Limit != 1 {
+		t.Fatalf("expected targeted decision query, got %+v", decisionQuery)
+	}
+
+	if got := len(store.snapshotQueries); got != 2 {
+		t.Fatalf("expected targeted snapshot queries per order, got %d", got)
+	}
+	for _, query := range store.snapshotQueries {
+		if query.LiveSessionID != session.ID || query.OrderID == "" || query.Limit != 1 {
+			t.Fatalf("expected targeted snapshot query, got %+v", query)
+		}
+	}
+}
+
 type liveTradeFixture struct {
 	entryPrice        float64
 	exitPrice         float64
@@ -166,6 +213,28 @@ type tradePairOrderFixture struct {
 	reduceOnly        bool
 	decisionEventID   string
 	targetPriceSource string
+}
+
+type liveTradePairTargetedQueryStore struct {
+	*memory.Store
+	decisionQueries []domain.StrategyDecisionEventQuery
+	snapshotQueries []domain.PositionAccountSnapshotQuery
+}
+
+func (s *liveTradePairTargetedQueryStore) QueryStrategyDecisionEvents(query domain.StrategyDecisionEventQuery) ([]domain.StrategyDecisionEvent, error) {
+	s.decisionQueries = append(s.decisionQueries, query)
+	if query.DecisionEventID == "" {
+		return nil, fmt.Errorf("expected targeted decision event query")
+	}
+	return s.Store.QueryStrategyDecisionEvents(query)
+}
+
+func (s *liveTradePairTargetedQueryStore) QueryPositionAccountSnapshots(query domain.PositionAccountSnapshotQuery) ([]domain.PositionAccountSnapshot, error) {
+	s.snapshotQueries = append(s.snapshotQueries, query)
+	if query.OrderID == "" {
+		return nil, fmt.Errorf("expected targeted position snapshot query")
+	}
+	return s.Store.QueryPositionAccountSnapshots(query)
 }
 
 func newLiveTradePairTestPlatform(t *testing.T) (*Platform, domain.LiveSession) {


### PR DESCRIPTION
## 目的
修复 live trade pair 审计窗口在 `GET /api/v1/live/sessions/:id/trade-pairs` 上对大 session 返回 502 的问题。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [x] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [ ] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main)
- [ ] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？
- [ ] DB migration 是否具备向下兼容幂等性？
- [ ] 配置字段有没有无意被混改？

## Root Cause
`ListLiveTradePairs` 原实现会在每次请求时按整个 `liveSessionId` 全量拉取：
- `strategy_decision_events`
- `position_account_snapshots`

事故 session `live-session-1776770563275995502` 当前真实数据量是：
- `strategy_decision_events = 1,470,305`
- `position_account_snapshots = 1,377,467`

但该 session 实际只需要追溯：
- `orders = 18`
- `fills = 20`

也就是说，trade pair 聚合为了不到 20 笔订单，反而把整条 session 的百万级事件全扫回来，导致接口在真实环境里被拖崩，前端最终看到 502。

## 修改点
- 先按 `liveSessionId` 过滤出相关 order，再过滤出相关 fill
- 只对这些相关订单的 `decisionEventId` 做定点 `QueryStrategyDecisionEvents(... Limit: 1)`
- 只对这些相关订单的 `orderId` 做定点 `QueryPositionAccountSnapshots(... Limit: 1)`
- 不再按整个 session 拉取全部决策事件与全部仓位快照
- 新增回归测试，锁死 trade pair 聚合必须使用 targeted query，而不是 broad session query

## 行为变化
- trade pair 接口的聚合结果语义不变
- 查询范围从“session 全量日志”收缩成“与相关 order/fill 直接关联的 decision/snapshot”
- 对于像 `live-session-1776770563275995502` 这种高频 session，接口不再需要扫描百万事件

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

已通过：
- `go test ./internal/service -run 'TestListLiveTradePairs(ClassifiesTrailingStopExitAsTSL|ClassifiesTakeProfitExitAsTP|ClassifiesInitialStopExitAsSL|ReturnsOpenTradeWithUnrealizedPnLAndAggregatedEntries|UsesTargetedDecisionAndSnapshotQueries)$'`
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
- `/usr/local/bin/git diff --check`
