### PR TITLE
[codex] preserve live zero-initial window until reentry consumption

### DIFF
--- a/internal/service/live_recovery.go
+++ b/internal/service/live_recovery.go
@@ -129,9 +129,6 @@ func (p *Platform) refreshLiveSessionPositionContext(session domain.LiveSession,
 	state["hasRecoveredVirtualPosition"] = hasVirtualPosition
 	state["lastRecoveredPositionAt"] = eventTime.UTC().Format(time.RFC3339)
 	state["positionRecoverySource"] = firstNonEmpty(source, "live-position-refresh")
-	if hasRealPositionContext {
-		clearLivePendingZeroInitialWindow(state, eventTime, "real-position-confirmed")
-	}
 	if !hasRealPositionContext && !hasVirtualPosition {
 		clearLiveWatchdogExitState(state)
 		clearLivePositionWatermarks(state)

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -5163,21 +5163,14 @@ func TestRefreshLiveSessionPositionContextRebuildsLivePositionState(t *testing.T
 	if got := stringValue(updated.State["positionRecoveryStatus"]); got != "protected-open-position" {
 		t.Fatalf("expected protected-open-position, got %s", got)
 	}
-	if pending := mapValue(updated.State[livePendingZeroInitialWindowStateKey]); len(pending) != 0 {
-		t.Fatalf("expected real position refresh to consume pending zero initial window, got %+v", pending)
+	if pending := mapValue(updated.State[livePendingZeroInitialWindowStateKey]); stringValue(pending["side"]) != "BUY" {
+		t.Fatalf("expected real position refresh to preserve pending zero initial window, got %+v", pending)
 	}
-	var consumed map[string]any
 	for _, item := range metadataList(updated.State["timeline"]) {
-		if stringValue(item["title"]) == "zero-initial-window-consumed" {
-			consumed = item
-			break
+		if stringValue(item["title"]) == "zero-initial-window-consumed" &&
+			stringValue(mapValue(item["metadata"])["reason"]) == "real-position-confirmed" {
+			t.Fatalf("expected active real position refresh to stop consuming pending zero initial window, got %+v", item)
 		}
-	}
-	if consumed == nil {
-		t.Fatalf("expected zero initial window consumed timeline event, got %+v", metadataList(updated.State["timeline"]))
-	}
-	if got := stringValue(mapValue(consumed["metadata"])["reason"]); got != "real-position-confirmed" {
-		t.Fatalf("expected real-position-confirmed consume reason, got %s", got)
 	}
 }
 

--- a/internal/service/live_zero_initial.go
+++ b/internal/service/live_zero_initial.go
@@ -25,6 +25,7 @@ func prepareLivePlanStepForSignalEvaluation(
 	nextPlannedSide, nextPlannedRole, nextPlannedReason string,
 ) (map[string]any, time.Time, float64, string, string, string) {
 	updatedState := cloneMetadata(sessionState)
+	hasActivePosition := hasActiveLivePositionSnapshot(currentPosition)
 	if !strategyZeroInitialReentryWindowEnabled(parameters) {
 		alignedEvent, alignedPrice, alignedSide, alignedRole, alignedReason := alignLivePlanStepToCurrentMarket(
 			signalBarStates,
@@ -48,9 +49,14 @@ func prepareLivePlanStepForSignalEvaluation(
 	// that boundary is crossed, live no longer trusts the historical trigger
 	// timing and must re-align using the current signal bar instead of replaying
 	// the stale plan step indefinitely.
-	if staleExitReentry &&
-		(hasActiveLivePositionSnapshot(currentPosition) || !isLivePlanStepStale(nextPlannedEvent, signalTimeframe, eventTime)) {
+	if staleExitReentry && hasActivePosition {
+		return updatedState, nextPlannedEvent, nextPlannedPrice, nextPlannedSide, nextPlannedRole, nextPlannedReason
+	}
+	if staleExitReentry && !isLivePlanStepStale(nextPlannedEvent, signalTimeframe, eventTime) {
 		clearLivePendingZeroInitialWindow(updatedState, eventTime, "exit-reentry-priority")
+		return updatedState, nextPlannedEvent, nextPlannedPrice, nextPlannedSide, nextPlannedRole, nextPlannedReason
+	}
+	if hasActivePosition {
 		return updatedState, nextPlannedEvent, nextPlannedPrice, nextPlannedSide, nextPlannedRole, nextPlannedReason
 	}
 	if updatedState, alignedEvent, alignedPrice, alignedSide, alignedRole, alignedReason, ok := liveZeroInitialWindowPlanStep(
@@ -167,10 +173,6 @@ func refreshLiveZeroInitialWindowState(
 	state := cloneMetadata(sessionState)
 	if state == nil {
 		state = map[string]any{}
-	}
-	if hasActiveLivePositionSnapshot(currentPosition) {
-		clearLivePendingZeroInitialWindow(state, eventTime, "real-position-confirmed")
-		return state
 	}
 	pending := cloneMetadata(mapValue(state[livePendingZeroInitialWindowStateKey]))
 	if len(pending) == 0 {

--- a/internal/service/live_zero_initial_test.go
+++ b/internal/service/live_zero_initial_test.go
@@ -212,3 +212,108 @@ func TestPrepareLivePlanStepForSignalEvaluationUsesZeroInitialSemanticsForStaleI
 		t.Fatalf("expected no zero-initial timeline event without breakout-backed window, got %+v", timeline)
 	}
 }
+
+func TestPrepareLivePlanStepForSignalEvaluationKeepsPendingWindowLatentWhilePositionActive(t *testing.T) {
+	barStart := time.Date(2026, 4, 22, 6, 0, 0, 0, time.UTC)
+	state := map[string]any{
+		livePendingZeroInitialWindowStateKey: map[string]any{
+			"side":            "BUY",
+			"symbol":          "BTCUSDT",
+			"signalTimeframe": "30m",
+			"armedAt":         barStart.Add(-time.Minute).Format(time.RFC3339),
+			"signalBarStart":  barStart.Format(time.RFC3339),
+			"expiresAt":       barStart.Add(30 * time.Minute).Format(time.RFC3339),
+			"breakoutBacked":  true,
+			"openReason":      liveZeroInitialWindowOpenReasonBreakoutLocked,
+		},
+	}
+	signalStates := map[string]any{
+		signalBindingMatchKey("binance-kline", "signal", "BTCUSDT", map[string]any{"timeframe": "30m"}): map[string]any{
+			"symbol":    "BTCUSDT",
+			"timeframe": "30m",
+			"sma5":      77800.0,
+			"atr14":     416.0,
+			"current": map[string]any{
+				"barStart": barStart.Format(time.RFC3339),
+				"close":    77966.3,
+				"high":     77978.0,
+				"low":      77930.0,
+			},
+			"prevBar1": map[string]any{
+				"high": 78335.7,
+				"low":  77928.6,
+			},
+			"prevBar2": map[string]any{
+				"high": 78447.5,
+				"low":  77406.0,
+			},
+		},
+	}
+
+	updated, gotEvent, gotPrice, gotSide, gotRole, gotReason := prepareLivePlanStepForSignalEvaluation(
+		state,
+		map[string]any{
+			"dir2_zero_initial": true,
+			"zero_initial_mode": "reentry_window",
+			"long_reentry_atr":  0.1,
+		},
+		signalStates,
+		"BTCUSDT",
+		"30m",
+		map[string]any{
+			"id":         "position-1",
+			"symbol":     "BTCUSDT",
+			"side":       "LONG",
+			"quantity":   0.0128,
+			"entryPrice": 77974.3,
+			"found":      true,
+		},
+		barStart.Add(5*time.Minute),
+		77974.3,
+		"trade_tick.price",
+		barStart.Add(5*time.Minute),
+		77850.0,
+		"SELL",
+		"exit",
+		"SL",
+	)
+	if gotRole != "exit" || gotReason != "SL" || gotSide != "SELL" {
+		t.Fatalf("expected active position to keep exit plan, got side=%s role=%s reason=%s", gotSide, gotRole, gotReason)
+	}
+	if gotPrice != 77850.0 || gotEvent != barStart.Add(5*time.Minute) {
+		t.Fatalf("expected exit plan step to stay untouched while position active, got event=%s price=%v", gotEvent.Format(time.RFC3339), gotPrice)
+	}
+	if pending := mapValue(updated[livePendingZeroInitialWindowStateKey]); stringValue(pending["side"]) != "BUY" {
+		t.Fatalf("expected pending zero initial window to remain latent while position active, got %+v", pending)
+	}
+	if timeline := metadataList(updated["timeline"]); len(timeline) != 0 {
+		t.Fatalf("expected no consume timeline event while position is still active, got %+v", timeline)
+	}
+
+	reactivated, _, _, gotSide, gotRole, gotReason := prepareLivePlanStepForSignalEvaluation(
+		updated,
+		map[string]any{
+			"dir2_zero_initial": true,
+			"zero_initial_mode": "reentry_window",
+			"long_reentry_atr":  0.1,
+		},
+		signalStates,
+		"BTCUSDT",
+		"30m",
+		map[string]any{},
+		barStart.Add(6*time.Minute),
+		77974.3,
+		"trade_tick.price",
+		barStart,
+		77970.28,
+		"BUY",
+		"entry",
+		"Initial",
+	)
+	if gotRole != "entry" || gotReason != "Zero-Initial-Reentry" || gotSide != "BUY" {
+		t.Fatalf("expected latent pending window to reactivate once flat, got side=%s role=%s reason=%s", gotSide, gotRole, gotReason)
+	}
+	if pending := mapValue(reactivated[livePendingZeroInitialWindowStateKey]); stringValue(pending["side"]) != "BUY" {
+		t.Fatalf("expected pending zero initial window to remain available until a real reentry consumes it, got %+v", pending)
+	}
+}


### PR DESCRIPTION
## 目的
修复 live `zero_initial_mode=reentry_window` 与 research baseline 的语义漂移：当前 live 会在第一笔真实持仓确认后立刻消费 `pendingZeroInitialWindow`，导致同一根 signal bar 内如果先成交 20% 首笔、随后止损回到 flat，就再也没有 breakout-backed window 可供第二次真实下单使用，`reentry_size_schedule` 的 10% 第二档也因此永远走不到。

## Root Cause
research baseline 会把 `pending_zero_initial_side` 保留到窗口真正被消费为止；只有在真实 reentry 触发并使用后才清空，所以同一根 bar 内 first real order -> `20%`，second real order -> `10%` 的 schedule 才能成立。

live 现状有两处提前消费：
- `prepareLivePlanStepForSignalEvaluation` / `refreshLiveZeroInitialWindowState`
- `refreshLiveSessionPositionContext`

它们都会在 `real-position-confirmed` 或 active position refresh 时清掉 pending window。结果是第一笔成交后 window 就丢了，后续同 bar 回 flat 也回不到 `Zero-Initial-Reentry`。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [x] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 修改点
- 持仓存在时，不再因为 `real-position-confirmed` 提前消费 `pendingZeroInitialWindow`
- active position 存在时，zero-initial window 仅保持 latent，不会覆盖当前 exit / existing plan
- 持仓回到 flat 且窗口仍有效时，live 可重新回到 `Zero-Initial-Reentry`
- recovery position refresh 不再顺手把 pending zero-initial window 清掉

## 行为变化
- 第一笔 `20%` 成交后，window 会保留到真正被 real reentry 消费为止
- 持仓期间，系统继续优先执行当前 exit / existing plan，不会被 pending window 抢走
- 同一根 signal bar 内如果止损回 flat，仍可再次进入 `Zero-Initial-Reentry`，下一笔真实下单可落到 schedule 第二档 `10%`
- 不改 dispatchMode 默认值，不改 reconcile gate，不改下单 sizing 公式

## 风险点 checklist
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main)
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？
- [x] DB migration 是否具备向下兼容幂等性？
- [x] 配置字段有没有无意被混改？

说明：以上均未涉及；本 PR 只改 live zero-initial window 的持久化与激活时机。

## 验证方式与测试证据
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

已通过：
- `go test ./internal/service -run 'TestPrepareLivePlanStepForSignalEvaluation(KeepsPendingWindowLatentWhilePositionActive|UsesZeroInitialSemanticsForStaleIntradayReentry|ClearsUnprovenZeroInitialWindow|ExpiresStaleExitReentryWindow)$|TestRefreshLiveSessionPositionContextRebuildsLivePositionState$'`
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
- `/usr/local/bin/git diff --check`

新增/更新测试：
- `TestPrepareLivePlanStepForSignalEvaluationKeepsPendingWindowLatentWhilePositionActive`
- `TestRefreshLiveSessionPositionContextRebuildsLivePositionState`

## 用户/开发者影响
合并后，live 的 `reentry_window + reentry_size_schedule=[0.20, 0.10] + max_trades_per_bar=2` 将重新对齐当前 research baseline，不再出现“看起来配置了 20%/10%，但实盘永远只会出第一档 20%”的漂移。