### PR TITLE
feat: Live Trade Pairs 架构重构与平仓独立核验

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,11 +65,11 @@ go build ./cmd/db-migrate
 ```
 
 **前端**：
-在结束任何前端代码编辑前，**必须**运行以下指令进行静态类型校验（路径见 `docs/AGENT_PATHS.md`）：
+在结束任何前端代码编辑前，**必须**运行以下指令进行静态类型校验（路径见 `docs/AGENT_PATHS.md`）。**注意：** 禁止在验证时滥用 `--skipLibCheck`，必须确保命令行标志与 `tsconfig.json`（如 `moduleResolution: Bundler`）保持同步，严禁忽略 IDE 中已出现的红线报错。
 ```bash
-# 示例：使用本地 tsc 执行校验
+# 示例：使用本地 tsc 执行校验 (确保不跳过必要的库检查)
 cd web/console
-./node_modules/.bin/tsc --noEmit src/pages/AccountStage.tsx --jsx react-jsx --esModuleInterop --skipLibCheck --target esnext --moduleResolution node --allowSyntheticDefaultImports
+./node_modules/.bin/tsc --noEmit src/pages/AccountStage.tsx --jsx react-jsx --esModuleInterop --target esnext --moduleResolution Bundler --allowSyntheticDefaultImports
 
 # 全量构建验证 (如必要)
 npm run build
@@ -123,6 +123,7 @@ bash scripts/testnet_live_session_smoke.sh
 3. **测试必须覆盖失败路径** — 补测试时，**至少包含一个 failure path**（adapter resolve 失败、NaN 输入等）
 4. **修改 recovery 代码前必须读状态机** — 先读完 §10 的状态机定义和 §7 的 review 黄金规则
 5. **高风险 PR 仍需人工主审** — L2/L3 级别的 PR，**AI review 只做辅助**，必须等待人工主审通过
+6. **严禁"跳过"静态校验错误** — 禁止滥用 `--skipLibCheck` 或忽略 IDE 报错。若命令行通过但 IDE 报错，以 IDE 为准，必须对齐环境配置。
 
 ## 10. 运行时恢复 / 接管专项规则（仅在相关改动时强制生效）
 

--- a/db/migrations/020_order_close_verifications.sql
+++ b/db/migrations/020_order_close_verifications.sql
@@ -1,0 +1,20 @@
+-- Create order_close_verifications table
+CREATE TABLE IF NOT EXISTS order_close_verifications (
+    id TEXT PRIMARY KEY,
+    live_session_id TEXT NOT NULL,
+    order_id TEXT NOT NULL,
+    decision_event_id TEXT,
+    account_id TEXT NOT NULL,
+    strategy_id TEXT NOT NULL,
+    symbol TEXT NOT NULL,
+    verified_closed BOOLEAN NOT NULL,
+    remaining_position_qty DOUBLE PRECISION NOT NULL,
+    verification_source TEXT NOT NULL,
+    event_time TIMESTAMPTZ NOT NULL,
+    recorded_at TIMESTAMPTZ NOT NULL,
+    metadata JSONB
+);
+
+CREATE INDEX IF NOT EXISTS idx_order_close_verif_order_event_time ON order_close_verifications (order_id, event_time DESC);
+CREATE INDEX IF NOT EXISTS idx_order_close_verif_session_event_time ON order_close_verifications (live_session_id, event_time DESC);
+CREATE INDEX IF NOT EXISTS idx_order_close_verif_sess_ord_time ON order_close_verifications (live_session_id, order_id, event_time DESC);

--- a/docs/20260423-live-trade-pairs-implementation-plan.md
+++ b/docs/20260423-live-trade-pairs-implementation-plan.md
@@ -1,0 +1,587 @@
+# 2026-04-23 Live Trade Pairs 落地方案
+
+## 1. 结论先行
+
+`Trade Pairs` 以后按下面三层职责重构：
+
+1. **订单/成交主链路**
+   - `orders + fills + positions`
+   - 负责生成 trade pair 本体
+   - 必须始终可用，不能被增强信息拖死
+
+2. **Decision Event 增强层**
+   - 通过 `decisionEventId` 点查 `strategy_decision_events`
+   - 负责补：
+     - `entryReason`
+     - `exitReason`
+     - `exitClassifier`
+   - 允许缺失；缺失时主结果照常返回
+
+3. **平仓核验增强层**
+   - 不再直接依赖 `position_account_snapshots`
+   - 为以后新数据单独建设"按 `orderId` 可点查"的平仓核验数据结构
+   - 负责补：
+     - `exitVerdict`
+     - `notes` 中的 post-exit verification 信息
+   - 历史数据不回填；旧数据没有核验记录时只返回基础 pair
+
+一句话：**订单负责追溯，decision event 负责标签，单独的新结构负责平仓核验。**
+
+---
+
+## 2. 背景与根因
+
+当前 `Trade Pairs` 的主聚合逻辑在：
+
+- `internal/service/live_trade_pairs.go`
+
+生产环境已确认：
+
+- 某个 live session 的 `strategy_decision_events` 超过 `147 万` 行
+- 同 session 的 `position_account_snapshots` 超过 `138 万` 行
+- 旧实现按 `liveSessionID` 全量读取这两张表，导致接口超时
+
+当前问题不是"前端获取失败"，而是后端主查询路径设计过重：
+
+- 本应只靠 `orders + fills` 计算的追溯结果
+- 被海量遥测表绑进了主链路
+
+这违背了 `Trade Pairs` 的产品本意。
+
+### 2.1 主链路自身的全表扫描问题
+
+除了遥测大表，主查询自身也存在全表扫描：
+
+- `p.store.ListOrders()` -- 无条件读取全部 orders（Postgres: `SELECT ... FROM orders ORDER BY created_at ASC`）
+- `p.store.ListFills()` -- 无条件读取全部 fills
+- `p.store.ListPositions()` -- 无条件读取全部 positions
+
+读取后再在内存中按 `metadata->>'liveSessionId'` 过滤。
+随着系统运行时间增长，这三张表也会成为瓶颈。
+本次重构必须同步解决此问题。
+
+---
+
+## 3. 产品边界
+
+### 3.1 必须保证的能力
+
+`Trade Pairs` 必须稳定返回以下字段，即使增强数据不可用：
+
+- `id`
+- `liveSessionId`
+- `accountId`
+- `strategyId`
+- `symbol`
+- `status`
+- `side`
+- `entryOrderIds`
+- `exitOrderIds`
+- `entryAt`
+- `exitAt`
+- `entryAvgPrice`
+- `exitAvgPrice`
+- `entryQuantity`
+- `exitQuantity`
+- `openQuantity`
+- `realizedPnl`
+- `unrealizedPnl`
+- `fees`
+- `netPnl`
+- `entryFillCount`
+- `exitFillCount`
+
+### 3.2 可选增强字段
+
+增强字段允许缺失，不影响主结果返回：
+
+- `entryReason`
+- `exitReason`
+- `exitClassifier`
+- `exitVerdict`
+- `notes`
+
+### 3.3 当前阶段不处理的事项
+
+- 不做历史数据回填
+- 不要求旧数据一定具备 `exitVerdict` / `notes`
+- 不把"平仓核验"强行塞回现有 `position_account_snapshots` 主查询
+
+---
+
+## 4. 目标状态
+
+### 4.1 查询分层
+
+后续代码必须严格遵守：
+
+1. **第一层：主 pair 查询**
+   - 仅使用：
+     - `orders`（必须按 `liveSessionID` 过滤查询，不能全表读取）
+     - `fills`（必须按已筛选的 `orderID` 关联查询，不能全表读取）
+     - 必要时 `positions`（按 `accountID` 过滤）
+   - 输出最近 `limit` 个 pair
+
+2. **第二层：Decision Event 标签增强**
+   - 只对第一层返回的少量 pair 做增强
+   - 使用这些 pair 相关订单上的 `decisionEventId`
+   - 通过主键点查 `strategy_decision_events`
+
+3. **第三层：平仓核验增强**
+   - 只对第一层返回的少量 exit order 做增强
+   - 通过 `orderId` 点查新的"平仓核验结构"
+
+### 4.2 主链路查询收敛要求
+
+当前 `ListOrders()` / `ListFills()` / `ListPositions()` 是全表扫描。
+第 1 PR 必须将其收敛：
+
+1. 新增或使用按 `liveSessionID` 过滤的 orders 查询方法
+   - 通过 `metadata->>'liveSessionId'` 索引过滤，或新增专用查询方法
+2. fills 查询改为 `WHERE order_id IN (...)` -- 只查与当前 session 相关的 orders 的 fills
+3. positions 查询改为 `WHERE account_id = $1` -- 只查当前 session 的 account
+
+### 4.3 多 Symbol 追溯假设
+
+当前 pair 追溯逻辑使用单一 `pnlState` 追踪净持仓。
+**本系统假设一个 live session 只交易一个 symbol**。
+
+第 1 PR 必须加防御性断言：
+- 如果同一 session 的订单出现多个不同 symbol，记录 warning 日志
+- pair 追溯按 symbol 分组，确保即使出现多 symbol 也不会产生错误的 pair
+
+### 4.4 必须避免的实现方式
+
+以下模式后续一律视为错误实现：
+
+- 按 `liveSessionID` 全量读取 `strategy_decision_events`
+- 按 `liveSessionID` 全量读取 `position_account_snapshots`
+- 无条件全表读取 `orders` / `fills` / `positions`
+- 为了补标签而让 `Trade Pairs` 主结果超时
+- 让增强字段成为接口成败的前提条件
+
+---
+
+## 5. 新数据结构设计
+
+## 5.1 推荐方案
+
+新增一张专门的订单关闭核验表，例如：
+
+`order_close_verifications`
+
+建议字段：
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `id` | text | 主键 |
+| `live_session_id` | text | 对应 live session |
+| `order_id` | text | 对应 exit order |
+| `decision_event_id` | text null | 可选，对应决策事件 |
+| `account_id` | text | 账户 |
+| `strategy_id` | text | 策略 |
+| `symbol` | text | 交易对 |
+| `verified_closed` | boolean | 是否确认已平干净 |
+| `remaining_position_qty` | double precision | 核验时剩余仓位数量 |
+| `verification_source` | text | `reconcile` / `rest-sync` / `manual-review` 等 |
+| `event_time` | timestamptz | 事实发生时间 |
+| `recorded_at` | timestamptz | 记录写入时间 |
+| `metadata` | jsonb | 扩展信息 |
+
+### 5.2 建议索引
+
+至少包含：
+
+- `primary key (id)`
+- `index on (order_id, event_time desc)`
+- `index on (live_session_id, event_time desc)`
+- 如未来按 session + order 联查较多，可加：
+  - `index on (live_session_id, order_id, event_time desc)`
+
+### 5.3 零值语义精确定义
+
+`remaining_position_qty` 的零值必须显式区分：
+
+| 状态 | `verified_closed` | `remaining_position_qty` | 含义 |
+|------|-------------------|--------------------------|------|
+| 正常关闭 | `true` | `<= 1e-9` | 已确认平仓干净 |
+| 仓位不一致 | `false` | `> 1e-9` | 平仓后仍有残留 |
+| 逻辑矛盾 | `false` | `<= 1e-9` | 不应出现，必须记录 warning |
+
+- 浮点精度 epsilon 统一为 `1e-9`，与现有代码保持一致
+- "无核验记录" 不等于 "remaining_position_qty = 0"，查询时必须通过记录是否存在来区分
+
+### 5.4 Store 接口层变更
+
+新增 `order_close_verifications` 表意味着以下接口层必须同步更新：
+
+1. **Store interface** -- 在 store 接口中新增：
+   - `CreateOrderCloseVerification(item domain.OrderCloseVerification) (domain.OrderCloseVerification, error)`
+   - `QueryOrderCloseVerifications(query domain.OrderCloseVerificationQuery) ([]domain.OrderCloseVerification, error)`
+
+2. **双后端实现** -- `memory.Store` 和 `postgres.Store` 必须同时实现
+
+3. **domain 类型** -- 新增 `domain.OrderCloseVerification` 和 `domain.OrderCloseVerificationQuery` 结构体
+
+4. **db-migrate** -- 新增 migration 文件
+
+### 5.5 为什么不继续复用 `position_account_snapshots`
+
+原因很明确：
+
+- 它是快照/遥测表，不是订单级核验事实表
+- 生产库没有 `order_id` 索引
+- 同一个 `order_id` 会对应大量快照，语义并不收敛
+- 继续复用会让查询设计与建模定位长期错位
+
+---
+
+## 6. 写入时机设计
+
+## 6.1 只服务以后新数据
+
+本方案**只要求以后新增的 exit order** 写入关闭核验数据。
+
+历史数据处理规则：
+
+- 没有 `order_close_verifications` 记录时
+- `Trade Pairs` 仍返回基础结果
+- `exitVerdict` / `notes` 允许为空或退化为默认值
+
+## 6.2 建议写入节点
+
+建议只在关键节点写，不做高频刷写：
+
+1. **exit order 成交后首次核验**
+   - 目的：记录首次关闭确认结果
+
+2. **reconcile / authoritative REST 校验后**
+   - 目的：记录最终 authoritative verdict
+
+3. **人工接管/人工确认后**
+   - 目的：为 `manual-review` / `mismatch resolved` 提供明确结论
+
+## 6.3 幂等规则
+
+必须避免同一笔 exit order 被无意义高频追加记录。
+
+建议二选一：
+
+1. **Upsert 最新状态**
+   - 每个 `order_id + verification_source` 保留最新一条
+
+2. **Append only，但主查询只取最新事件**
+   - 允许保留历史变化
+   - 查询时必须按 `order_id` 取最新一条或最新 authoritative 一条
+
+如果没有明确审计需求，推荐先用 **Append only + 查询取最新**，实现更简单、语义更稳。
+
+---
+
+## 7. 查询实现方案
+
+## 7.1 Trade Pairs 主查询
+
+后续 LLM 实现时，必须按以下顺序组织：
+
+1. 读取当前 session 的相关订单
+2. 基于订单关联 fills
+3. 仅用订单/成交生成 pair
+4. 在 pair 数量排序后先应用 `limit`
+5. 只对结果集做增强查询
+
+关键点：
+
+- **先 pair，后增强**
+- **先 limit，后增强**
+
+## 7.2 Decision Event 增强查询
+
+增强过程：
+
+1. 从结果集的相关订单提取 `decisionEventId`
+2. 去重
+3. 用主键点查 `strategy_decision_events`
+4. 补：
+   - `entryReason`
+   - `exitReason`
+   - `exitClassifier`
+
+查询规则：
+
+- 不允许按 `liveSessionID` 全量查
+- 必须按 `decisionEventId` 逐个点查或批量 `IN (...)`
+- 增强失败不得阻塞主结果返回
+
+## 7.3 平仓核验增强查询
+
+增强过程：
+
+1. 从结果集提取 exit order IDs
+2. 去重
+3. 按 `orderId` 查询 `order_close_verifications`
+4. 每个 order 只取最新有效核验记录
+5. 补：
+   - `exitVerdict`
+   - `notes`
+
+建议映射规则：
+
+- `verified_closed = true` 且 `remaining_position_qty <= epsilon`
+  - `exitVerdict = normal`
+- `verified_closed = false` 且 `remaining_position_qty > epsilon`
+  - `exitVerdict = mismatch`
+  - `notes += post-exit-position-still-open`
+- 若 `verification_source = manual-review`
+  - 可在 `notes` 标注来源
+
+## 7.4 无核验记录时的默认行为
+
+如果新表查不到该 exit order 的核验记录：
+
+- 主结果照常返回
+- 不要报错
+- 不要卡接口
+- `exitVerdict` 可保留现有默认值或置空策略，但必须稳定一致
+
+推荐：
+
+- `closed` pair 默认 `exitVerdict = normal`
+- 只有拿到明确负向核验时才升级为 `mismatch`
+
+---
+
+## 8. 接口字段策略
+
+## 8.1 保持现有 API 兼容
+
+当前前端已依赖这些字段：
+
+- `entryReason`
+- `exitReason`
+- `exitClassifier`
+- `exitVerdict`
+- `notes`
+
+因此第一阶段不建议删字段，而是：
+
+- 保持字段存在
+- 允许增强值缺失
+- 把字段语义从"总能给出"改成"尽力补充"
+
+## 8.2 前端兼容要求
+
+前端必须接受：
+
+- `entryReason == ""`
+- `exitReason == ""`
+- `exitClassifier == ""`
+- `notes == nil`
+
+前端不应把这些字段当成必有值。
+
+---
+
+## 9. 迁移方案
+
+## 9.1 第一阶段
+
+最小可上线版本：
+
+1. `Trade Pairs` 主查询退回订单/成交主链路
+2. **主链路查询收敛** -- 将 `ListOrders()` / `ListFills()` / `ListPositions()` 全表扫描改为按 session 过滤的查询
+3. Decision Event 增强保留
+4. Snapshot 增强移除
+5. 文档与测试更新
+6. API handler 增加响应时间日志（elapsed-time log），方便上线后验证效果
+
+### 9.1.1 Snapshot 增强移除清单
+
+第一阶段必须清理以下代码：
+
+| 文件 | 内容 | 操作 |
+|------|------|------|
+| `live_trade_pairs.go` L645 | `enrichLiveTradePairs` 中的 `populateTradePairSnapshotTelemetry` 调用 | 删除 |
+| `live_trade_pairs.go` L673-680 | `enrichLiveTradePairs` 中的 snapshot verdict 覆写逻辑 | 删除 |
+| `live_trade_pairs.go` L708-729 | `populateTradePairSnapshotTelemetry` 函数 | 删除 |
+| `live_trade_pairs.go` L291-304 | `latestPositionSnapshotByOrderID` 函数 | 删除（当前未被调用，属于死代码） |
+| `live_trade_pairs.go` L383 | `finalizeClosed` 的 `snapshotByOrderID` 参数 | 简化为无参或移除 snapshot 逻辑，保留 `hasUnsafeExitOrder` / `recoveryExit` 等本地判定 |
+
+`finalizeClosed` 中 L392-397 的 snapshot 核验逻辑在第一阶段删除。
+该功能将在第三阶段通过 `order_close_verifications` 重新实现。
+
+这一阶段不需要历史回填。
+
+## 9.2 第二阶段
+
+新增数据库迁移：
+
+1. 建 `order_close_verifications` 表
+2. 建索引
+3. 新增 `domain.OrderCloseVerification` + `domain.OrderCloseVerificationQuery` 类型
+4. 在 store interface 增加 `CreateOrderCloseVerification` / `QueryOrderCloseVerifications`
+5. 在 `memory.Store` 和 `postgres.Store` 同时实现
+6. 在 `db-migrate` 工具中增加 migration 文件
+
+## 9.3 第三阶段
+
+在写入链路接入：
+
+1. exit order 成交后的首次核验写入
+2. reconcile 后写入 authoritative 结果
+3. `Trade Pairs` 查询接入新表
+4. 写入代码必须封装为独立 helper，不能散落在 `live.go` 主循环中
+
+---
+
+## 10. 测试与验收
+
+## 10.1 必须覆盖的后端测试
+
+至少新增/保留以下用例：
+
+1. **基础 pair 计算**
+   - 无增强数据也能返回 pair
+
+2. **Decision Event 增强**
+   - 有 `decisionEventId` 时能补：
+     - `entryReason`
+     - `exitReason`
+     - `exitClassifier`
+
+3. **增强缺失容错**
+   - event 查不到时不影响主结果
+
+4. **关闭核验增强**
+   - `verified_closed = true` -> `normal`
+   - `remaining_position_qty > 0` -> `mismatch`
+
+5. **无核验记录**
+   - 不报错
+   - 返回基础 pair
+
+6. **只对结果集做增强**
+   - 不能再出现按 `liveSessionID` 全量扫大表的实现
+
+7. **failure path**
+   - 新表缺失 / 查询失败时接口仍返回主结果
+
+## 10.2 性能验收标准
+
+针对生产同量级数据，目标是：
+
+- `Trade Pairs` 主接口响应不再受上百万 decision/snapshot 记录影响
+- 主链路查询不再全表扫描 `orders` / `fills` / `positions`
+- Decision Event 增强查询应保持毫秒级到几十毫秒级
+- 新的关闭核验查询必须能稳定走 `order_id` 索引
+- API handler 必须输出 elapsed-time 日志，上线后可直接在生产日志中验证效果
+
+## 10.3 验证命令
+
+代码改完后至少执行：
+
+```bash
+gofmt -w .
+go test ./...
+go build ./cmd/platform-api
+go build ./cmd/db-migrate
+```
+
+如涉及前端展示微调，必须使用全量构建验证（不要只检查单个文件）：
+
+```bash
+cd web/console
+npm run build
+```
+
+trade pairs 相关的前端组件分布在多个文件中，单文件 tsc 检查无法覆盖：
+
+- `src/components/live/LiveTradePairsCard.tsx`
+- `src/hooks/useLiveTradePairs.ts`
+- `src/components/layout/DockContent.tsx`
+- `src/pages/MonitorStage.tsx`
+- `src/pages/AccountStage.tsx`
+
+---
+
+## 11. 给后续 LLM 的执行顺序
+
+后续 LLM 必须按以下顺序推进，禁止一步大包揽：
+
+1. **第 1 PR**
+   - 收敛 `Trade Pairs` 主查询（包括将 `ListOrders` / `ListFills` / `ListPositions` 改为按 session 过滤）
+   - 按 9.1.1 清单移除 Snapshot 增强及相关死代码
+   - 加多 Symbol 防御性断言
+   - 保留 Decision Event 增强
+   - 增加 API 响应时间日志
+   - 补测试
+
+2. **第 2 PR**
+   - 新增 `order_close_verifications` migration
+   - 新增 domain 类型
+   - 实现 store interface + memory.Store + postgres.Store
+   - 补 migration/索引测试
+
+3. **第 3 PR**（高风险 -- 涉及 `live*.go` 修改）
+   - 在 exit / reconcile 路径写入关闭核验记录
+   - 接入 `Trade Pairs` 增强读取
+   - 补端到端回归测试
+   - **写入代码必须封装为独立 helper，不能散落在 live 主循环中**
+   - **必须标记为 L2/L3 级别 PR**
+   - **AI review 只做辅助，必须等待人工主审通过**
+   - 遵守 `AGENTS.md` 第 10 节的运行时恢复/接管专项规则
+
+### 11.1 明确禁止
+
+- 不允许在一个 PR 里同时重写主查询、改 live 执行链、再做前端改版
+- 不允许为了通过测试继续按 `liveSessionID` 全量扫遥测大表
+- 不允许把旧 snapshot 表继续当作订单级核验事实表
+- 不允许 `ListOrders()` / `ListFills()` 继续保持全表扫描
+
+---
+
+## 12. 风险与注意事项
+
+1. **高风险边界**
+   - 如果写入核验记录时涉及 `internal/service/live*.go`
+   - 必须遵守 `AGENTS.md` 与 `docs/pr-lessons-learned.md` 的高风险规则
+   - 第 3 PR 必须标记为 L2/L3 级别，等待人工主审
+
+2. **语义一致性**
+   - `exitVerdict` 的定义必须收敛，不允许多处平行维护
+
+3. **零值语义**
+   - `remaining_position_qty = 0` 与"无核验记录"不是一回事
+   - 查询与序列化时必须显式区分
+   - 浮点精度 epsilon 统一为 `1e-9`（见 5.3 节）
+
+4. **性能约束**
+   - 任何后续增强查询都必须建立在可索引点查之上
+   - 主链路查询（orders / fills / positions）不允许全表扫描
+
+5. **回滚策略**
+   - 第 1 PR 上线后如果 Decision Event 增强本身也出现性能问题
+   - 需要有快速降级能力：增加配置项或特性开关，允许完全跳过增强层
+   - 降级时接口只返回基础 pair，所有增强字段为空
+
+6. **前端轮询机制**
+   - 当前 `useLiveTradePairs.ts` 只在 `sessionId` / `limit` 变化时请求一次
+   - 对于 `open` 状态 pair 的 `unrealizedPnl`，没有定时刷新
+   - 本次重构不强制要求加轮询，但后续如需实时性需补充 polling interval
+   - 前端必须能容忍所有增强字段为空（参见 8.2 节）
+
+---
+
+## 13. 最终落地结果
+
+本方案完成后，系统行为应为：
+
+- `Trade Pairs` 在任何情况下都能先返回基础追溯结果
+- 主链路查询只读取当前 session 相关的 orders / fills / positions，不做全表扫描
+- `reason/classifier` 通过 `decisionEventId` 低成本补充
+- `verdict/notes` 通过新的订单级关闭核验结构补充
+- 增强层可通过配置降级，不影响主结果返回
+- 历史数据不回填
+- 以后新数据逐步具备完整增强能力
+
+这就是后续代码工作的目标态。

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,6 +19,7 @@
 - [20260420-runtime-recovery-source-of-truth-map.md](20260420-runtime-recovery-source-of-truth-map.md) - Issue #84 的恢复事实源梳理、函数级 mapping、时序图与风险点清单。
 - [20260420-live-reconcile-manual-close-state-closure-bug-spec.md](20260420-live-reconcile-manual-close-state-closure-bug-spec.md) - 手动平仓、成交回写、reconcile gate 与 session 刷新闭环缺失问题说明与修复范围。
 - [20260422-binance-rest-rate-limit-and-live-sync-storm-plan.md](20260422-binance-rest-rate-limit-and-live-sync-storm-plan.md) - Binance REST 统一限流、`SyncLiveAccount` 风暴治理、stale source 观测与前端 K 线降载专项记录。
+- [20260423-live-trade-pairs-implementation-plan.md](20260423-live-trade-pairs-implementation-plan.md) - `Trade Pairs` 重构落地方案：订单/成交主链路、Decision Event 标签增强、订单级平仓核验新结构设计。
 - [production-log-troubleshooting.md](production-log-troubleshooting.md) - 生产服务器日志 SSH 入口、日志目录、stale/source gate、Binance REST 限流与前端 K 线请求排查起手式。
 - [部署与网络架构.md](部署与网络架构.md) - 包含有关容器/负载路由的信息。
 - [cicd-maintenance.md](cicd-maintenance.md) - GitHub Actions 维保说明。

--- a/internal/domain/logs.go
+++ b/internal/domain/logs.go
@@ -16,6 +16,7 @@ type StrategyDecisionEventQuery struct {
 	RuntimeSessionID string
 	LiveSessionID    string
 	DecisionEventID  string
+	DecisionEventIDs []string
 	From             time.Time
 	To               time.Time
 	Before           *EventCursor

--- a/internal/domain/models.go
+++ b/internal/domain/models.go
@@ -188,6 +188,11 @@ type Order struct {
 	CreatedAt         time.Time      `json:"createdAt"`
 }
 
+// OrderQuery 定义订单查询条件。
+type OrderQuery struct {
+	LiveSessionID string
+}
+
 // Fill 成交记录，每笔成交关联一个订单。
 type Fill struct {
 	ID                string     `json:"id"`
@@ -214,6 +219,11 @@ func (f Fill) FallbackFingerprint() string {
 	}, "|")
 }
 
+// FillQuery 定义成交记录查询条件。
+type FillQuery struct {
+	OrderIDs []string
+}
+
 // Position 当前持仓，由成交记录聚合得出。
 type Position struct {
 	ID                string    `json:"id"`
@@ -225,6 +235,11 @@ type Position struct {
 	EntryPrice        float64   `json:"entryPrice"` // 加权平均入场价
 	MarkPrice         float64   `json:"markPrice"`  // 最新标记价格
 	UpdatedAt         time.Time `json:"updatedAt"`
+}
+
+// PositionQuery 定义持仓查询条件。
+type PositionQuery struct {
+	AccountID string
 }
 
 // BacktestRun 回测运行记录，保存参数和结果摘要。

--- a/internal/domain/order_close_verification.go
+++ b/internal/domain/order_close_verification.go
@@ -1,0 +1,28 @@
+package domain
+
+import "time"
+
+// OrderCloseVerification 记录每次 exit order 触发后的平仓核验事实。
+type OrderCloseVerification struct {
+	ID                   string         `json:"id"`
+	LiveSessionID        string         `json:"liveSessionId"`
+	OrderID              string         `json:"orderId"`
+	DecisionEventID      string         `json:"decisionEventId,omitempty"`
+	AccountID            string         `json:"accountId"`
+	StrategyID           string         `json:"strategyId"`
+	Symbol               string         `json:"symbol"`
+	VerifiedClosed       bool           `json:"verifiedClosed"`
+	RemainingPositionQty float64        `json:"remainingPositionQty"`
+	VerificationSource   string         `json:"verificationSource"` // reconcile / rest-sync / manual-review / initial
+	EventTime            time.Time      `json:"eventTime"`
+	RecordedAt           time.Time      `json:"recordedAt"`
+	Metadata             map[string]any `json:"metadata,omitempty"`
+}
+
+// OrderCloseVerificationQuery 定义平仓核验记录的查询条件。
+type OrderCloseVerificationQuery struct {
+	LiveSessionID string
+	OrderID       string
+	OrderIDs      []string
+	Limit         int
+}

--- a/internal/service/live_trade_pairs.go
+++ b/internal/service/live_trade_pairs.go
@@ -66,55 +66,51 @@ type liveTradePairBuilder struct {
 }
 
 func (p *Platform) ListLiveTradePairs(query domain.LiveTradePairQuery) ([]domain.LiveTradePair, error) {
+	startTime := time.Now()
 	liveSessionID := strings.TrimSpace(query.LiveSessionID)
 	if liveSessionID == "" {
 		return nil, fmt.Errorf("liveSessionId is required")
 	}
+
+	defer func() {
+		p.logger("service.live_trade_pairs", "session_id", liveSessionID).Info("ListLiveTradePairs completed", "elapsed", time.Since(startTime))
+	}()
+
 	session, err := p.store.GetLiveSession(liveSessionID)
 	if err != nil {
 		return nil, err
 	}
 
-	orders, err := p.store.ListOrders()
-	if err != nil {
-		return nil, err
-	}
-	fills, err := p.store.ListFills()
-	if err != nil {
-		return nil, err
-	}
-	positions, err := p.store.ListPositions()
-	if err != nil {
-		return nil, err
-	}
-	decisionEvents, err := p.queryStrategyDecisionEvents(domain.StrategyDecisionEventQuery{
-		LiveSessionID: liveSessionID,
-	})
-	if err != nil {
-		return nil, err
-	}
-	snapshots, err := p.queryPositionAccountSnapshots(domain.PositionAccountSnapshotQuery{
-		LiveSessionID: liveSessionID,
-	})
+	orders, err := p.store.QueryOrders(domain.OrderQuery{LiveSessionID: liveSessionID})
 	if err != nil {
 		return nil, err
 	}
 
 	orderByID := make(map[string]domain.Order)
+	var orderIDs []string
+	uniqueSymbols := make(map[string]struct{})
 	for _, order := range orders {
-		if strings.TrimSpace(stringValue(order.Metadata["liveSessionId"])) != liveSessionID {
-			continue
-		}
 		orderByID[order.ID] = order
+		orderIDs = append(orderIDs, order.ID)
+		uniqueSymbols[NormalizeSymbol(order.Symbol)] = struct{}{}
 	}
 
-	decisionByID := make(map[string]domain.StrategyDecisionEvent, len(decisionEvents))
-	for _, item := range decisionEvents {
-		decisionByID[item.ID] = item
+	if len(uniqueSymbols) > 1 {
+		p.logger("service.live_trade_pairs", "session_id", liveSessionID).Warn("live session has orders for multiple symbols, trade pairs might be miscalculated")
 	}
-	snapshotByOrderID := latestPositionSnapshotByOrderID(snapshots)
+
+	fills, err := p.store.QueryFills(domain.FillQuery{OrderIDs: orderIDs})
+	if err != nil {
+		return nil, err
+	}
+
+	positions, err := p.store.QueryPositions(domain.PositionQuery{AccountID: session.AccountID})
+	if err != nil {
+		return nil, err
+	}
+
 	currentPositionBySymbol := currentLivePositionBySymbol(session, positions)
-	fillEvents := buildLiveTradeFillEvents(fills, orderByID, decisionByID)
+	fillEvents := buildLiveTradeFillEvents(fills, orderByID, nil)
 	if len(fillEvents) == 0 {
 		return filterAndLimitLiveTradePairs(nil, normalizeLiveTradePairStatus(query.Status), normalizeLiveTradePairLimit(query.Limit)), nil
 	}
@@ -178,7 +174,7 @@ func (p *Platform) ListLiveTradePairs(query domain.LiveTradePairQuery) ([]domain
 		applyPnLFill(&state, event.order.Side, event.fill.Quantity, event.fill.Price)
 		remainingQty := absQty - closingQty
 		if absFloat(prevNetQty)-closingQty <= 1e-9 {
-			results = append(results, current.finalizeClosed(snapshotByOrderID))
+			results = append(results, current.finalizeClosed())
 			current = nil
 		}
 		if remainingQty > 1e-9 {
@@ -204,7 +200,9 @@ func (p *Platform) ListLiveTradePairs(query domain.LiveTradePairQuery) ([]domain
 			return results[i].ID > results[j].ID
 		}
 	})
-	return filterAndLimitLiveTradePairs(results, normalizeLiveTradePairStatus(query.Status), normalizeLiveTradePairLimit(query.Limit)), nil
+	results = filterAndLimitLiveTradePairs(results, normalizeLiveTradePairStatus(query.Status), normalizeLiveTradePairLimit(query.Limit))
+	p.enrichLiveTradePairs(results, orderByID)
+	return results, nil
 }
 
 func buildLiveTradeFillEvents(
@@ -212,6 +210,9 @@ func buildLiveTradeFillEvents(
 	orderByID map[string]domain.Order,
 	decisionByID map[string]domain.StrategyDecisionEvent,
 ) []liveTradeFillEvent {
+	if decisionByID == nil {
+		decisionByID = map[string]domain.StrategyDecisionEvent{}
+	}
 	items := make([]liveTradeFillEvent, 0, len(fills))
 	for _, fill := range fills {
 		order, ok := orderByID[fill.OrderID]
@@ -222,11 +223,7 @@ func buildLiveTradeFillEvents(
 		if fill.ExchangeTradeTime != nil && !fill.ExchangeTradeTime.IsZero() {
 			eventTime = fill.ExchangeTradeTime.UTC()
 		}
-		decisionEventID := firstNonEmpty(
-			stringValue(order.Metadata["decisionEventId"]),
-			stringValue(mapValue(order.Metadata["executionProposal"])["decisionEventId"]),
-			stringValue(mapValue(mapValue(order.Metadata["executionProposal"])["metadata"])["decisionEventId"]),
-		)
+		decisionEventID := decisionEventIDFromOrder(order)
 		items = append(items, liveTradeFillEvent{
 			order:           order,
 			fill:            fill,
@@ -236,6 +233,14 @@ func buildLiveTradeFillEvents(
 		})
 	}
 	return items
+}
+
+func decisionEventIDFromOrder(order domain.Order) string {
+	return firstNonEmpty(
+		stringValue(order.Metadata["decisionEventId"]),
+		stringValue(mapValue(order.Metadata["executionProposal"])["decisionEventId"]),
+		stringValue(mapValue(mapValue(order.Metadata["executionProposal"])["metadata"])["decisionEventId"]),
+	)
 }
 
 func resolveLiveTradeIntentDetails(order domain.Order, decision domain.StrategyDecisionEvent) liveTradeIntentDetails {
@@ -296,21 +301,6 @@ func resolveLiveTradeIntentDetails(order domain.Order, decision domain.StrategyD
 			decision.Reason,
 		)), "manual"),
 	}
-}
-
-func latestPositionSnapshotByOrderID(items []domain.PositionAccountSnapshot) map[string]domain.PositionAccountSnapshot {
-	result := make(map[string]domain.PositionAccountSnapshot)
-	for _, item := range items {
-		orderID := strings.TrimSpace(item.OrderID)
-		if orderID == "" {
-			continue
-		}
-		current, ok := result[orderID]
-		if !ok || domain.EventLessAsc(current.EventTime, current.RecordedAt, current.ID, item.EventTime, item.RecordedAt, item.ID) {
-			result[orderID] = item
-		}
-	}
-	return result
 }
 
 func currentLivePositionBySymbol(session domain.LiveSession, positions []domain.Position) map[string]domain.Position {
@@ -390,20 +380,14 @@ func (b *liveTradePairBuilder) addExit(event liveTradeFillEvent, qty, fee, reali
 	}
 }
 
-func (b *liveTradePairBuilder) finalizeClosed(snapshotByOrderID map[string]domain.PositionAccountSnapshot) domain.LiveTradePair {
-	verdict := "normal"
+func (b *liveTradePairBuilder) finalizeClosed() domain.LiveTradePair {
+	verdict := "unknown"
 	if b.exitQty <= 0 {
 		verdict = "orphan-exit"
 	} else if b.hasUnsafeExitOrder {
 		verdict = "mismatch"
 	} else if b.recoveryExit {
-		verdict = "recovery-close"
-	}
-	if snapshot, ok := snapshotByOrderID[b.lastExitOrderID]; ok {
-		if snapshot.PositionFound || snapshot.PositionQuantity > 1e-9 {
-			verdict = "mismatch"
-			b.addNote("post-exit-snapshot-still-has-position")
-		}
+		verdict = "unknown" // "recovery-close" will be determined during enrich
 	}
 	b.exitVerdict = verdict
 	return b.build(0, 0)
@@ -628,4 +612,116 @@ func filterAndLimitLiveTradePairs(items []domain.LiveTradePair, status string, l
 		}
 	}
 	return filtered
+}
+
+func (p *Platform) enrichLiveTradePairs(items []domain.LiveTradePair, orderByID map[string]domain.Order) {
+	if len(items) == 0 {
+		return
+	}
+
+	decisionByID := make(map[string]domain.StrategyDecisionEvent)
+	var allExitOrderIDs []string
+
+	for _, item := range items {
+		for _, orderID := range item.EntryOrderIDs {
+			order, ok := orderByID[orderID]
+			if !ok {
+				continue
+			}
+			p.populateTradePairDecisionTelemetry(decisionByID, decisionEventIDFromOrder(order))
+		}
+		for _, orderID := range item.ExitOrderIDs {
+			allExitOrderIDs = append(allExitOrderIDs, orderID)
+			order, ok := orderByID[orderID]
+			if !ok {
+				continue
+			}
+			p.populateTradePairDecisionTelemetry(decisionByID, decisionEventIDFromOrder(order))
+		}
+	}
+
+	closeVerificationsByOrderID := make(map[string]domain.OrderCloseVerification)
+	if len(allExitOrderIDs) > 0 {
+		if verifications, err := p.store.QueryOrderCloseVerifications(domain.OrderCloseVerificationQuery{
+			OrderIDs: allExitOrderIDs,
+		}); err == nil {
+			for _, v := range verifications {
+				if _, ok := closeVerificationsByOrderID[v.OrderID]; !ok {
+					closeVerificationsByOrderID[v.OrderID] = v
+				}
+			}
+		}
+	}
+
+	for index := range items {
+		pair := &items[index]
+		if len(pair.EntryOrderIDs) > 0 {
+			if order, ok := orderByID[pair.EntryOrderIDs[0]]; ok {
+				intent := resolveLiveTradeIntentDetails(order, decisionByID[decisionEventIDFromOrder(order)])
+				if pair.EntryReason == "" {
+					pair.EntryReason = liveTradeReasonLabel(intent.reason)
+				}
+			}
+		}
+		if len(pair.ExitOrderIDs) > 0 {
+			lastExitOrderID := pair.ExitOrderIDs[len(pair.ExitOrderIDs)-1]
+			if order, ok := orderByID[lastExitOrderID]; ok {
+				intent := resolveLiveTradeIntentDetails(order, decisionByID[decisionEventIDFromOrder(order)])
+				if pair.ExitReason == "" {
+					pair.ExitReason = liveTradeReasonLabel(intent.reason)
+				}
+				if pair.ExitClassifier == "" {
+					pair.ExitClassifier = classifyLiveTradeExit(intent)
+				}
+
+				if pair.Status == "closed" && pair.ExitVerdict == "unknown" {
+					if verification, ok := closeVerificationsByOrderID[lastExitOrderID]; ok {
+						if verification.VerifiedClosed {
+							pair.ExitVerdict = "normal"
+						} else {
+							pair.ExitVerdict = "mismatch"
+						}
+					}
+				}
+
+				if pair.ExitVerdict == "normal" && intent.recoveryTriggered {
+					pair.ExitVerdict = "recovery-close"
+				}
+			}
+		}
+	}
+}
+
+func (p *Platform) populateTradePairDecisionTelemetry(target map[string]domain.StrategyDecisionEvent, decisionEventID string) {
+	decisionEventID = strings.TrimSpace(decisionEventID)
+	if decisionEventID == "" {
+		return
+	}
+	if _, ok := target[decisionEventID]; ok {
+		return
+	}
+	items, err := p.queryStrategyDecisionEvents(domain.StrategyDecisionEventQuery{
+		DecisionEventID: decisionEventID,
+		Limit:           1,
+	})
+	if err != nil {
+		if isOptionalLiveTradePairTelemetryError(err) {
+			return
+		}
+		return
+	}
+	if len(items) > 0 {
+		target[decisionEventID] = items[0]
+	}
+}
+
+func isOptionalLiveTradePairTelemetryError(err error) bool {
+	if err == nil {
+		return false
+	}
+	message := strings.ToLower(strings.TrimSpace(err.Error()))
+	return strings.Contains(message, "sqlstate 42p01") ||
+		(strings.Contains(message, "relation") && strings.Contains(message, "does not exist")) ||
+		(strings.Contains(message, "table") && strings.Contains(message, "does not exist")) ||
+		strings.Contains(message, "no such table")
 }

--- a/internal/service/live_trade_pairs.go
+++ b/internal/service/live_trade_pairs.go
@@ -454,13 +454,13 @@ func (b *liveTradePairBuilder) addExit(event liveTradeFillEvent, qty, fee, reali
 }
 
 func (b *liveTradePairBuilder) finalizeClosed() domain.LiveTradePair {
-	verdict := "unknown"
+	verdict := "normal"
 	if b.exitQty <= 0 {
 		verdict = "orphan-exit"
 	} else if b.hasUnsafeExitOrder {
 		verdict = "mismatch"
 	} else if b.recoveryExit {
-		verdict = "unknown" // "recovery-close" will be determined during enrich
+		verdict = "recovery-close"
 	}
 	b.exitVerdict = verdict
 	return b.build(0, 0)
@@ -694,22 +694,35 @@ func (p *Platform) enrichLiveTradePairs(items []domain.LiveTradePair, orderByID 
 
 	decisionByID := make(map[string]domain.StrategyDecisionEvent)
 	var allExitOrderIDs []string
+	var allDecisionEventIDs []string
 
 	for _, item := range items {
 		for _, orderID := range item.EntryOrderIDs {
-			order, ok := orderByID[orderID]
-			if !ok {
-				continue
+			if order, ok := orderByID[orderID]; ok {
+				if id := decisionEventIDFromOrder(order); id != "" {
+					allDecisionEventIDs = append(allDecisionEventIDs, id)
+				}
 			}
-			p.populateTradePairDecisionTelemetry(decisionByID, decisionEventIDFromOrder(order))
 		}
 		for _, orderID := range item.ExitOrderIDs {
 			allExitOrderIDs = append(allExitOrderIDs, orderID)
-			order, ok := orderByID[orderID]
-			if !ok {
-				continue
+			if order, ok := orderByID[orderID]; ok {
+				if id := decisionEventIDFromOrder(order); id != "" {
+					allDecisionEventIDs = append(allDecisionEventIDs, id)
+				}
 			}
-			p.populateTradePairDecisionTelemetry(decisionByID, decisionEventIDFromOrder(order))
+		}
+	}
+
+	if len(allDecisionEventIDs) > 0 {
+		if events, err := p.queryStrategyDecisionEvents(domain.StrategyDecisionEventQuery{
+			DecisionEventIDs: allDecisionEventIDs,
+		}); err == nil {
+			for _, event := range events {
+				if _, ok := decisionByID[event.ID]; !ok {
+					decisionByID[event.ID] = event
+				}
+			}
 		}
 	}
 
@@ -747,11 +760,9 @@ func (p *Platform) enrichLiveTradePairs(items []domain.LiveTradePair, orderByID 
 					pair.ExitClassifier = classifyLiveTradeExit(intent)
 				}
 
-				if pair.Status == "closed" && pair.ExitVerdict == "unknown" {
+				if pair.Status == "closed" {
 					if verification, ok := closeVerificationsByOrderID[lastExitOrderID]; ok {
-						if verification.VerifiedClosed {
-							pair.ExitVerdict = "normal"
-						} else {
+						if !verification.VerifiedClosed {
 							pair.ExitVerdict = "mismatch"
 						}
 					}
@@ -763,38 +774,4 @@ func (p *Platform) enrichLiveTradePairs(items []domain.LiveTradePair, orderByID 
 			}
 		}
 	}
-}
-
-func (p *Platform) populateTradePairDecisionTelemetry(target map[string]domain.StrategyDecisionEvent, decisionEventID string) {
-	decisionEventID = strings.TrimSpace(decisionEventID)
-	if decisionEventID == "" {
-		return
-	}
-	if _, ok := target[decisionEventID]; ok {
-		return
-	}
-	items, err := p.queryStrategyDecisionEvents(domain.StrategyDecisionEventQuery{
-		DecisionEventID: decisionEventID,
-		Limit:           1,
-	})
-	if err != nil {
-		if isOptionalLiveTradePairTelemetryError(err) {
-			return
-		}
-		return
-	}
-	if len(items) > 0 {
-		target[decisionEventID] = items[0]
-	}
-}
-
-func isOptionalLiveTradePairTelemetryError(err error) bool {
-	if err == nil {
-		return false
-	}
-	message := strings.ToLower(strings.TrimSpace(err.Error()))
-	return strings.Contains(message, "sqlstate 42p01") ||
-		(strings.Contains(message, "relation") && strings.Contains(message, "does not exist")) ||
-		(strings.Contains(message, "table") && strings.Contains(message, "does not exist")) ||
-		strings.Contains(message, "no such table")
 }

--- a/internal/service/live_trade_pairs_test.go
+++ b/internal/service/live_trade_pairs_test.go
@@ -146,7 +146,6 @@ func TestListLiveTradePairsReturnsOpenTradeWithUnrealizedPnLAndAggregatedEntries
 	assertTradePairFloat(t, pair.NetPnL, pair.UnrealizedPnL-0.03)
 }
 
-
 func TestListLiveTradePairsFallsBackWhenTelemetryTablesAreUnavailable(t *testing.T) {
 	baseStore := memory.NewStore()
 	platform := NewPlatform(&testMissingLiveTradePairTelemetryStore{Store: baseStore})
@@ -199,8 +198,8 @@ func TestListLiveTradePairsFallsBackWhenTelemetryTablesAreUnavailable(t *testing
 	if got := pair.ExitClassifier; got != "TP" {
 		t.Fatalf("expected TP classifier, got %s", got)
 	}
-	if got := pair.ExitVerdict; got != "unknown" {
-		t.Fatalf("expected unknown verdict, got %s", got)
+	if got := pair.ExitVerdict; got != "normal" {
+		t.Fatalf("expected normal verdict, got %s", got)
 	}
 	assertTradePairFloat(t, pair.RealizedPnL, 10)
 	assertTradePairFloat(t, pair.Fees, 0.2)
@@ -492,4 +491,70 @@ func (s *testScopedLiveTradePairTelemetryStore) QueryPositionAccountSnapshots(qu
 		return nil, fmt.Errorf("unexpected bulk snapshot telemetry query")
 	}
 	return s.Store.QueryPositionAccountSnapshots(query)
+}
+
+func TestListLiveTradePairsUsesLatestVerificationRecord(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	account, err := platform.CreateAccount("Live Trade Pair", "LIVE", "binance-futures")
+	if err != nil {
+		t.Fatalf("create account: %v", err)
+	}
+	session, err := platform.CreateLiveSession("", account.ID, "strategy-bk-1d", map[string]any{
+		"symbol": "BTCUSDT",
+	})
+	if err != nil {
+		t.Fatalf("create live session: %v", err)
+	}
+
+	exitAt := time.Date(2026, 4, 22, 6, 30, 0, 0, time.UTC)
+	pair := createClosedLiveTradePairFixture(t, platform, session, liveTradeFixture{
+		entryPrice:        100,
+		exitPrice:         110,
+		quantity:          1,
+		entryFee:          0.1,
+		exitFee:           0.1,
+		exitReason:        "PT",
+		targetPriceSource: "take-profit",
+	})
+
+	// Add an older optimistic verification (ws-sync says it's closed)
+	_, _ = platform.store.CreateOrderCloseVerification(domain.OrderCloseVerification{
+		LiveSessionID:        session.ID,
+		OrderID:              pair.ExitOrderIDs[0],
+		AccountID:            session.AccountID,
+		StrategyID:           session.StrategyID,
+		Symbol:               "BTCUSDT",
+		VerifiedClosed:       true,
+		RemainingPositionQty: 0,
+		VerificationSource:   "ws-sync",
+		EventTime:            exitAt.Add(2 * time.Second),
+	})
+
+	// Add a newer pessimistic verification (reconcile says it's NOT closed)
+	_, _ = platform.store.CreateOrderCloseVerification(domain.OrderCloseVerification{
+		LiveSessionID:        session.ID,
+		OrderID:              pair.ExitOrderIDs[0],
+		AccountID:            session.AccountID,
+		StrategyID:           session.StrategyID,
+		Symbol:               "BTCUSDT",
+		VerifiedClosed:       false,
+		RemainingPositionQty: 0.5, // Some residual left
+		VerificationSource:   "reconcile",
+		EventTime:            exitAt.Add(10 * time.Second),
+	})
+
+	items, err := platform.ListLiveTradePairs(domain.LiveTradePairQuery{
+		LiveSessionID: session.ID,
+		Status:        "closed",
+		Limit:         10,
+	})
+	if err != nil {
+		t.Fatalf("list live trade pairs: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 closed pair, got %d", len(items))
+	}
+	if got := items[0].ExitVerdict; got != "mismatch" {
+		t.Fatalf("expected mismatch verdict due to latest reconcile event, got %s", got)
+	}
 }

--- a/internal/service/live_trade_pairs_test.go
+++ b/internal/service/live_trade_pairs_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"fmt"
 	"math"
 	"testing"
 	"time"
@@ -145,6 +146,102 @@ func TestListLiveTradePairsReturnsOpenTradeWithUnrealizedPnLAndAggregatedEntries
 	assertTradePairFloat(t, pair.NetPnL, pair.UnrealizedPnL-0.03)
 }
 
+func TestListLiveTradePairsFallsBackWhenTelemetryTablesAreUnavailable(t *testing.T) {
+	baseStore := memory.NewStore()
+	platform := NewPlatform(&testMissingLiveTradePairTelemetryStore{Store: baseStore})
+	account, err := platform.CreateAccount("Live Trade Pair", "LIVE", "binance-futures")
+	if err != nil {
+		t.Fatalf("create account: %v", err)
+	}
+	session, err := platform.CreateLiveSession("", account.ID, "strategy-bk-1d", map[string]any{
+		"symbol": "BTCUSDT",
+	})
+	if err != nil {
+		t.Fatalf("create live session: %v", err)
+	}
+
+	entryAt := time.Date(2026, 4, 22, 6, 0, 0, 0, time.UTC)
+	exitAt := entryAt.Add(30 * time.Minute)
+	createLiveTradePairOrder(t, platform, session, tradePairOrderFixture{
+		side:       "BUY",
+		reason:     "initial",
+		quantity:   1,
+		price:      100,
+		fee:        0.1,
+		createdAt:  entryAt,
+		fillAt:     entryAt.Add(2 * time.Second),
+		reduceOnly: false,
+	})
+	createLiveTradePairOrder(t, platform, session, tradePairOrderFixture{
+		side:       "SELL",
+		reason:     "PT",
+		quantity:   1,
+		price:      110,
+		fee:        0.1,
+		createdAt:  exitAt,
+		fillAt:     exitAt.Add(2 * time.Second),
+		reduceOnly: true,
+	})
+
+	items, err := platform.ListLiveTradePairs(domain.LiveTradePairQuery{
+		LiveSessionID: session.ID,
+		Status:        "closed",
+		Limit:         10,
+	})
+	if err != nil {
+		t.Fatalf("list live trade pairs: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 closed pair, got %d", len(items))
+	}
+	pair := items[0]
+	if got := pair.ExitClassifier; got != "TP" {
+		t.Fatalf("expected TP classifier, got %s", got)
+	}
+	if got := pair.ExitVerdict; got != "unknown" {
+		t.Fatalf("expected unknown verdict, got %s", got)
+	}
+	assertTradePairFloat(t, pair.RealizedPnL, 10)
+	assertTradePairFloat(t, pair.Fees, 0.2)
+	assertTradePairFloat(t, pair.NetPnL, 9.8)
+}
+
+func TestListLiveTradePairsScopesTelemetryQueriesToPairOrders(t *testing.T) {
+	baseStore := memory.NewStore()
+	store := &testScopedLiveTradePairTelemetryStore{Store: baseStore}
+	platform := NewPlatform(store)
+	account, err := platform.CreateAccount("Live Trade Pair", "LIVE", "binance-futures")
+	if err != nil {
+		t.Fatalf("create account: %v", err)
+	}
+	session, err := platform.CreateLiveSession("", account.ID, "strategy-bk-1d", map[string]any{
+		"symbol": "BTCUSDT",
+	})
+	if err != nil {
+		t.Fatalf("create live session: %v", err)
+	}
+
+	pair := createClosedLiveTradePairFixture(t, platform, session, liveTradeFixture{
+		entryPrice:        100,
+		exitPrice:         112,
+		quantity:          2,
+		entryFee:          0.2,
+		exitFee:           0.3,
+		exitReason:        "SL",
+		targetPriceSource: "trailing-stop",
+	})
+
+	if got := pair.ExitClassifier; got != "TSL" {
+		t.Fatalf("expected TSL classifier, got %s", got)
+	}
+	if store.usedLiveSessionTelemetryQuery {
+		t.Fatalf("expected trade pair telemetry lookup to avoid full live-session query")
+	}
+	if store.usedBulkSnapshotTelemetryQuery {
+		t.Fatalf("expected trade pair snapshot lookup to avoid bulk live-session query")
+	}
+}
+
 type liveTradeFixture struct {
 	entryPrice        float64
 	exitPrice         float64
@@ -245,6 +342,20 @@ func createClosedLiveTradePairFixture(t *testing.T, platform *Platform, session 
 	}); err != nil {
 		t.Fatalf("create position snapshot: %v", err)
 	}
+	if _, err := platform.store.CreateOrderCloseVerification(domain.OrderCloseVerification{
+		LiveSessionID:        session.ID,
+		OrderID:              exitOrder.ID,
+		DecisionEventID:      exitDecisionEventID,
+		AccountID:            session.AccountID,
+		StrategyID:           session.StrategyID,
+		Symbol:               "BTCUSDT",
+		VerifiedClosed:       true,
+		RemainingPositionQty: 0,
+		VerificationSource:   "ws-sync",
+		EventTime:            exitAt.Add(3 * time.Second).UTC(),
+	}); err != nil {
+		t.Fatalf("create order close verification: %v", err)
+	}
 
 	items, err := platform.ListLiveTradePairs(domain.LiveTradePairQuery{
 		LiveSessionID: session.ID,
@@ -324,4 +435,38 @@ func assertTradePairFloat(t *testing.T, got, want float64) {
 
 func timePointer(value time.Time) *time.Time {
 	return &value
+}
+
+type testMissingLiveTradePairTelemetryStore struct {
+	*memory.Store
+}
+
+func (s *testMissingLiveTradePairTelemetryStore) QueryStrategyDecisionEvents(domain.StrategyDecisionEventQuery) ([]domain.StrategyDecisionEvent, error) {
+	return nil, fmt.Errorf(`pq: relation "strategy_decision_events" does not exist (SQLSTATE 42P01)`)
+}
+
+func (s *testMissingLiveTradePairTelemetryStore) QueryPositionAccountSnapshots(domain.PositionAccountSnapshotQuery) ([]domain.PositionAccountSnapshot, error) {
+	return nil, fmt.Errorf(`pq: relation "position_account_snapshots" does not exist (SQLSTATE 42P01)`)
+}
+
+type testScopedLiveTradePairTelemetryStore struct {
+	*memory.Store
+	usedLiveSessionTelemetryQuery  bool
+	usedBulkSnapshotTelemetryQuery bool
+}
+
+func (s *testScopedLiveTradePairTelemetryStore) QueryStrategyDecisionEvents(query domain.StrategyDecisionEventQuery) ([]domain.StrategyDecisionEvent, error) {
+	if query.LiveSessionID != "" {
+		s.usedLiveSessionTelemetryQuery = true
+		return nil, fmt.Errorf("unexpected full live session telemetry query")
+	}
+	return s.Store.QueryStrategyDecisionEvents(query)
+}
+
+func (s *testScopedLiveTradePairTelemetryStore) QueryPositionAccountSnapshots(query domain.PositionAccountSnapshotQuery) ([]domain.PositionAccountSnapshot, error) {
+	if query.LiveSessionID != "" && query.OrderID == "" {
+		s.usedBulkSnapshotTelemetryQuery = true
+		return nil, fmt.Errorf("unexpected bulk snapshot telemetry query")
+	}
+	return s.Store.QueryPositionAccountSnapshots(query)
 }

--- a/internal/service/logs.go
+++ b/internal/service/logs.go
@@ -209,6 +209,12 @@ func (p *Platform) queryStrategyDecisionEvents(query domain.StrategyDecisionEven
 		return nil, err
 	}
 	filtered := make([]domain.StrategyDecisionEvent, 0, len(items))
+
+	decisionEventIDMap := make(map[string]struct{})
+	for _, id := range query.DecisionEventIDs {
+		decisionEventIDMap[strings.TrimSpace(id)] = struct{}{}
+	}
+
 	for _, item := range items {
 		if strings.TrimSpace(query.LiveSessionID) != "" && item.LiveSessionID != strings.TrimSpace(query.LiveSessionID) {
 			continue
@@ -224,6 +230,11 @@ func (p *Platform) queryStrategyDecisionEvents(query domain.StrategyDecisionEven
 		}
 		if strings.TrimSpace(query.DecisionEventID) != "" && item.ID != strings.TrimSpace(query.DecisionEventID) {
 			continue
+		}
+		if len(query.DecisionEventIDs) > 0 {
+			if _, ok := decisionEventIDMap[item.ID]; !ok {
+				continue
+			}
 		}
 		if !query.From.IsZero() && item.EventTime.Before(query.From.UTC()) {
 			continue

--- a/internal/service/order.go
+++ b/internal/service/order.go
@@ -1259,7 +1259,30 @@ func (p *Platform) applyExecutionFill(account domain.Account, order domain.Order
 
 	// 反方向 → 全部平仓
 	if order.Quantity == position.Quantity {
-		return p.store.DeletePosition(position.ID)
+		err := p.store.DeletePosition(position.ID)
+		if err == nil && strings.EqualFold(account.Mode, "LIVE") {
+			liveSessionID := stringValue(order.Metadata["liveSessionId"])
+			decisionEventID := stringValue(order.Metadata["decisionEventId"])
+			if liveSessionID != "" {
+				strategyID := ""
+				if resolved, resolveErr := p.resolveLiveStrategyIDForOrder(account.ID, order); resolveErr == nil {
+					strategyID = resolved
+				}
+				_, _ = p.store.CreateOrderCloseVerification(domain.OrderCloseVerification{
+					LiveSessionID:        liveSessionID,
+					OrderID:              order.ID,
+					DecisionEventID:      decisionEventID,
+					AccountID:            account.ID,
+					StrategyID:           strategyID,
+					Symbol:               position.Symbol,
+					VerifiedClosed:       true,
+					RemainingPositionQty: 0,
+					VerificationSource:   "ws-sync",
+					EventTime:            time.Now().UTC(),
+				})
+			}
+		}
+		return err
 	}
 
 	// 反方向 → 平仓后反向开仓

--- a/internal/service/order.go
+++ b/internal/service/order.go
@@ -1293,6 +1293,11 @@ func (p *Platform) applyExecutionFill(account domain.Account, order domain.Order
 				if resolved, resolveErr := p.resolveLiveStrategyIDForOrder(account.ID, order); resolveErr == nil {
 					strategyID = resolved
 				}
+				// NOTE(audit): OrderCloseVerification is designed as an append-only log.
+				// By default, the latest event (ordered by EventTime desc) determines the authoritative verification state
+				// for a given order in `enrichLiveTradePairs`.
+				// While `ws-sync` is an optimistic source, subsequent reconcile events can append a newer record
+				// with `VerifiedClosed=false` if residual position is detected.
 				_, _ = p.store.CreateOrderCloseVerification(domain.OrderCloseVerification{
 					LiveSessionID:        liveSessionID,
 					OrderID:              order.ID,

--- a/internal/store/memory/store.go
+++ b/internal/store/memory/store.go
@@ -14,22 +14,22 @@ import (
 type Store struct {
 	mu sync.RWMutex
 
-	strategies       map[string]domain.Strategy
-	strategyVersion  map[string]domain.StrategyVersion
-	accounts         map[string]domain.Account
-	orders           map[string]domain.Order
-	fills            map[string]domain.Fill
-	positions        map[string]domain.Position
-	backtests        map[string]domain.BacktestRun
-	paperSessions    map[string]domain.PaperSession
-	liveSessions     map[string]domain.LiveSession
-	equitySnapshots  map[string][]domain.AccountEquitySnapshot
-	decisionEvents   []domain.StrategyDecisionEvent
-	executionEvents  []domain.OrderExecutionEvent
-	liveSnapshots    []domain.PositionAccountSnapshot
-	marketBars       map[string]domain.MarketBar
-	signalSources    []map[string]any
-	annotations      []domain.ChartAnnotation
+	strategies         map[string]domain.Strategy
+	strategyVersion    map[string]domain.StrategyVersion
+	accounts           map[string]domain.Account
+	orders             map[string]domain.Order
+	fills              map[string]domain.Fill
+	positions          map[string]domain.Position
+	backtests          map[string]domain.BacktestRun
+	paperSessions      map[string]domain.PaperSession
+	liveSessions       map[string]domain.LiveSession
+	equitySnapshots    map[string][]domain.AccountEquitySnapshot
+	decisionEvents     []domain.StrategyDecisionEvent
+	executionEvents    []domain.OrderExecutionEvent
+	liveSnapshots      []domain.PositionAccountSnapshot
+	marketBars         map[string]domain.MarketBar
+	signalSources      []map[string]any
+	annotations        []domain.ChartAnnotation
 	runtimePolicy      *domain.RuntimePolicy
 	notificationAcks   map[string]domain.NotificationAck
 	telegramConfig     *domain.TelegramConfig
@@ -42,25 +42,25 @@ type Store struct {
 func NewStore() *Store {
 	now := time.Now().UTC()
 	store := &Store{
-		strategies:      make(map[string]domain.Strategy),
-		strategyVersion: make(map[string]domain.StrategyVersion),
-		accounts:        make(map[string]domain.Account),
-		orders:          make(map[string]domain.Order),
-		fills:           make(map[string]domain.Fill),
-		positions:       make(map[string]domain.Position),
-		backtests:       make(map[string]domain.BacktestRun),
-		paperSessions:   make(map[string]domain.PaperSession),
-		liveSessions:    make(map[string]domain.LiveSession),
-		equitySnapshots: make(map[string][]domain.AccountEquitySnapshot),
+		strategies:         make(map[string]domain.Strategy),
+		strategyVersion:    make(map[string]domain.StrategyVersion),
+		accounts:           make(map[string]domain.Account),
+		orders:             make(map[string]domain.Order),
+		fills:              make(map[string]domain.Fill),
+		positions:          make(map[string]domain.Position),
+		backtests:          make(map[string]domain.BacktestRun),
+		paperSessions:      make(map[string]domain.PaperSession),
+		liveSessions:       make(map[string]domain.LiveSession),
+		equitySnapshots:    make(map[string][]domain.AccountEquitySnapshot),
 		liveSnapshots:      make([]domain.PositionAccountSnapshot, 0),
 		marketBars:         make(map[string]domain.MarketBar),
 		closeVerifications: make([]domain.OrderCloseVerification, 0),
 		signalSources: []map[string]any{
 			{
-				"id":     "signal-source-bk-1d",
-				"name":   "BK 1D ATR Reentry",
-				"type":   "internal-strategy",
-				"status": "ACTIVE",
+				"id":          "signal-source-bk-1d",
+				"name":        "BK 1D ATR Reentry",
+				"type":        "internal-strategy",
+				"status":      "ACTIVE",
 				"dedupeKey":   "symbol+strategyVersion+reason+bar",
 				"description": "1D signal / 1m execution strategy feed.",
 			},
@@ -972,7 +972,7 @@ func (s *Store) QueryOrderCloseVerifications(query domain.OrderCloseVerification
 		items = append(items, cloneJSONValue(item))
 	}
 	sort.Slice(items, func(i, j int) bool {
-		return domain.EventLessAsc(items[i].EventTime, items[i].RecordedAt, items[i].ID, items[j].EventTime, items[j].RecordedAt, items[j].ID)
+		return domain.EventLessDesc(items[i].EventTime, items[i].RecordedAt, items[i].ID, items[j].EventTime, items[j].RecordedAt, items[j].ID)
 	})
 	if query.Limit > 0 && len(items) > query.Limit {
 		items = items[:query.Limit]
@@ -984,6 +984,11 @@ func (s *Store) QueryStrategyDecisionEvents(query domain.StrategyDecisionEventQu
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	items := make([]domain.StrategyDecisionEvent, 0, len(s.decisionEvents))
+
+	decisionEventIDMap := make(map[string]struct{})
+	for _, id := range query.DecisionEventIDs {
+		decisionEventIDMap[strings.TrimSpace(id)] = struct{}{}
+	}
 	for _, item := range s.decisionEvents {
 		if strings.TrimSpace(query.LiveSessionID) != "" && item.LiveSessionID != strings.TrimSpace(query.LiveSessionID) {
 			continue
@@ -999,6 +1004,11 @@ func (s *Store) QueryStrategyDecisionEvents(query domain.StrategyDecisionEventQu
 		}
 		if strings.TrimSpace(query.DecisionEventID) != "" && item.ID != strings.TrimSpace(query.DecisionEventID) {
 			continue
+		}
+		if len(query.DecisionEventIDs) > 0 {
+			if _, ok := decisionEventIDMap[item.ID]; !ok {
+				continue
+			}
 		}
 		if !query.From.IsZero() && item.EventTime.Before(query.From.UTC()) {
 			continue

--- a/internal/store/memory/store.go
+++ b/internal/store/memory/store.go
@@ -30,10 +30,11 @@ type Store struct {
 	marketBars       map[string]domain.MarketBar
 	signalSources    []map[string]any
 	annotations      []domain.ChartAnnotation
-	runtimePolicy    *domain.RuntimePolicy
-	notificationAcks map[string]domain.NotificationAck
-	telegramConfig   *domain.TelegramConfig
-	deliveries       map[string]domain.NotificationDelivery
+	runtimePolicy      *domain.RuntimePolicy
+	notificationAcks   map[string]domain.NotificationAck
+	telegramConfig     *domain.TelegramConfig
+	deliveries         map[string]domain.NotificationDelivery
+	closeVerifications []domain.OrderCloseVerification
 
 	sequence int64
 }
@@ -51,13 +52,15 @@ func NewStore() *Store {
 		paperSessions:   make(map[string]domain.PaperSession),
 		liveSessions:    make(map[string]domain.LiveSession),
 		equitySnapshots: make(map[string][]domain.AccountEquitySnapshot),
-		marketBars:      make(map[string]domain.MarketBar),
+		liveSnapshots:      make([]domain.PositionAccountSnapshot, 0),
+		marketBars:         make(map[string]domain.MarketBar),
+		closeVerifications: make([]domain.OrderCloseVerification, 0),
 		signalSources: []map[string]any{
 			{
-				"id":          "signal-source-bk-1d",
-				"name":        "BK 1D ATR Reentry",
-				"type":        "internal-strategy",
-				"status":      "ACTIVE",
+				"id":     "signal-source-bk-1d",
+				"name":   "BK 1D ATR Reentry",
+				"type":   "internal-strategy",
+				"status": "ACTIVE",
 				"dedupeKey":   "symbol+strategyVersion+reason+bar",
 				"description": "1D signal / 1m execution strategy feed.",
 			},
@@ -448,6 +451,24 @@ func (s *Store) ListOrders() ([]domain.Order, error) {
 	return items, nil
 }
 
+func (s *Store) QueryOrders(query domain.OrderQuery) ([]domain.Order, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	items := make([]domain.Order, 0, len(s.orders))
+	for _, item := range s.orders {
+		if query.LiveSessionID != "" {
+			val, ok := item.Metadata["liveSessionId"].(string)
+			if !ok || strings.TrimSpace(val) != query.LiveSessionID {
+				continue
+			}
+		}
+		item.NormalizeExecutionFlags()
+		items = append(items, item)
+	}
+	sort.Slice(items, func(i, j int) bool { return items[i].CreatedAt.Before(items[j].CreatedAt) })
+	return items, nil
+}
+
 func (s *Store) CreateOrder(order domain.Order) (domain.Order, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -480,6 +501,28 @@ func (s *Store) ListFills() ([]domain.Fill, error) {
 	defer s.mu.RUnlock()
 	items := make([]domain.Fill, 0, len(s.fills))
 	for _, item := range s.fills {
+		items = append(items, item)
+	}
+	sort.Slice(items, func(i, j int) bool { return items[i].CreatedAt.Before(items[j].CreatedAt) })
+	return items, nil
+}
+
+func (s *Store) QueryFills(query domain.FillQuery) ([]domain.Fill, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	items := make([]domain.Fill, 0, len(s.fills))
+
+	orderIDMap := make(map[string]struct{})
+	for _, id := range query.OrderIDs {
+		orderIDMap[id] = struct{}{}
+	}
+
+	for _, item := range s.fills {
+		if len(query.OrderIDs) > 0 {
+			if _, ok := orderIDMap[item.OrderID]; !ok {
+				continue
+			}
+		}
 		items = append(items, item)
 	}
 	sort.Slice(items, func(i, j int) bool { return items[i].CreatedAt.Before(items[j].CreatedAt) })
@@ -534,6 +577,20 @@ func (s *Store) ListPositions() ([]domain.Position, error) {
 	defer s.mu.RUnlock()
 	items := make([]domain.Position, 0, len(s.positions))
 	for _, item := range s.positions {
+		items = append(items, item)
+	}
+	sort.Slice(items, func(i, j int) bool { return items[i].UpdatedAt.Before(items[j].UpdatedAt) })
+	return items, nil
+}
+
+func (s *Store) QueryPositions(query domain.PositionQuery) ([]domain.Position, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	items := make([]domain.Position, 0, len(s.positions))
+	for _, item := range s.positions {
+		if query.AccountID != "" && item.AccountID != query.AccountID {
+			continue
+		}
 		items = append(items, item)
 	}
 	sort.Slice(items, func(i, j int) bool { return items[i].UpdatedAt.Before(items[j].UpdatedAt) })
@@ -871,6 +928,56 @@ func (s *Store) CreatePositionAccountSnapshot(snapshot domain.PositionAccountSna
 	snapshot = cloneJSONValue(snapshot)
 	s.liveSnapshots = append(s.liveSnapshots, snapshot)
 	return cloneJSONValue(snapshot), nil
+}
+
+func (s *Store) CreateOrderCloseVerification(item domain.OrderCloseVerification) (domain.OrderCloseVerification, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if item.ID == "" {
+		item.ID = s.nextID("order-close-verification")
+	}
+	if item.EventTime.IsZero() {
+		item.EventTime = time.Now().UTC()
+	}
+	if item.RecordedAt.IsZero() {
+		item.RecordedAt = time.Now().UTC()
+	}
+	item = cloneJSONValue(item)
+	s.closeVerifications = append(s.closeVerifications, item)
+	return cloneJSONValue(item), nil
+}
+
+func (s *Store) QueryOrderCloseVerifications(query domain.OrderCloseVerificationQuery) ([]domain.OrderCloseVerification, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	items := make([]domain.OrderCloseVerification, 0, len(s.closeVerifications))
+
+	orderIDMap := make(map[string]struct{})
+	for _, id := range query.OrderIDs {
+		orderIDMap[strings.TrimSpace(id)] = struct{}{}
+	}
+
+	for _, item := range s.closeVerifications {
+		if strings.TrimSpace(query.LiveSessionID) != "" && item.LiveSessionID != strings.TrimSpace(query.LiveSessionID) {
+			continue
+		}
+		if strings.TrimSpace(query.OrderID) != "" && item.OrderID != strings.TrimSpace(query.OrderID) {
+			continue
+		}
+		if len(query.OrderIDs) > 0 {
+			if _, ok := orderIDMap[item.OrderID]; !ok {
+				continue
+			}
+		}
+		items = append(items, cloneJSONValue(item))
+	}
+	sort.Slice(items, func(i, j int) bool {
+		return domain.EventLessAsc(items[i].EventTime, items[i].RecordedAt, items[i].ID, items[j].EventTime, items[j].RecordedAt, items[j].ID)
+	})
+	if query.Limit > 0 && len(items) > query.Limit {
+		items = items[:query.Limit]
+	}
+	return items, nil
 }
 
 func (s *Store) QueryStrategyDecisionEvents(query domain.StrategyDecisionEventQuery) ([]domain.StrategyDecisionEvent, error) {

--- a/internal/store/postgres/store.go
+++ b/internal/store/postgres/store.go
@@ -1476,6 +1476,19 @@ func (s *Store) QueryStrategyDecisionEvents(query domain.StrategyDecisionEventQu
 	appendQueryCondition(&builder, &args, "strategy_id = %s", strings.TrimSpace(query.StrategyID))
 	appendQueryCondition(&builder, &args, "runtime_session_id = %s", strings.TrimSpace(query.RuntimeSessionID))
 	appendQueryCondition(&builder, &args, "id = %s", strings.TrimSpace(query.DecisionEventID))
+	if len(query.DecisionEventIDs) > 0 {
+		placeholders := make([]string, 0, len(query.DecisionEventIDs))
+		for _, id := range query.DecisionEventIDs {
+			if strings.TrimSpace(id) == "" {
+				continue
+			}
+			args = append(args, strings.TrimSpace(id))
+			placeholders = append(placeholders, fmt.Sprintf("$%d", len(args)))
+		}
+		if len(placeholders) > 0 {
+			builder.WriteString(fmt.Sprintf(" and id in (%s)", strings.Join(placeholders, ", ")))
+		}
+	}
 	appendQueryTimeCondition(&builder, &args, "event_time >= %s", query.From)
 	appendQueryTimeCondition(&builder, &args, "event_time <= %s", query.To)
 	appendEventCursorCondition(&builder, &args, query.Before)

--- a/internal/store/postgres/store.go
+++ b/internal/store/postgres/store.go
@@ -536,6 +536,45 @@ func (s *Store) ListOrders() ([]domain.Order, error) {
 	return items, rows.Err()
 }
 
+func (s *Store) QueryOrders(query domain.OrderQuery) ([]domain.Order, error) {
+	sqlQuery := `
+		select id, account_id, strategy_version_id, symbol, side, type, status, quantity, price, metadata, created_at
+		from orders
+	`
+	args := []any{}
+	if query.LiveSessionID != "" {
+		sqlQuery += ` where metadata->>'liveSessionId' = $1 `
+		args = append(args, query.LiveSessionID)
+	}
+	sqlQuery += ` order by created_at asc `
+
+	rows, err := s.db.Query(sqlQuery, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	items := []domain.Order{}
+	for rows.Next() {
+		var (
+			item              domain.Order
+			strategyVersionID sql.NullString
+			metadataRaw       []byte
+		)
+		if err := rows.Scan(&item.ID, &item.AccountID, &strategyVersionID, &item.Symbol, &item.Side, &item.Type, &item.Status, &item.Quantity, &item.Price, &metadataRaw, &item.CreatedAt); err != nil {
+			return nil, err
+		}
+		item.StrategyVersionID = strategyVersionID.String
+		item.Metadata = map[string]any{}
+		if len(metadataRaw) > 0 {
+			_ = json.Unmarshal(metadataRaw, &item.Metadata)
+		}
+		item.NormalizeExecutionFlags()
+		items = append(items, item)
+	}
+	return items, rows.Err()
+}
+
 func (s *Store) CreateOrder(order domain.Order) (domain.Order, error) {
 	order.NormalizeExecutionFlags()
 	order.ID = fmt.Sprintf("order-%d", time.Now().UTC().UnixNano())
@@ -580,6 +619,48 @@ func (s *Store) ListFills() ([]domain.Fill, error) {
 		select id, order_id, exchange_trade_id, exchange_trade_time, dedup_fallback_fingerprint, price, quantity, fee, created_at
 		from fills order by created_at asc
 	`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	items := []domain.Fill{}
+	for rows.Next() {
+		var item domain.Fill
+		var exchangeTradeID sql.NullString
+		var exchangeTradeTime sql.NullTime
+		var fallbackFingerprint sql.NullString
+		if err := rows.Scan(&item.ID, &item.OrderID, &exchangeTradeID, &exchangeTradeTime, &fallbackFingerprint, &item.Price, &item.Quantity, &item.Fee, &item.CreatedAt); err != nil {
+			return nil, err
+		}
+		item.ExchangeTradeID = exchangeTradeID.String
+		item.DedupFingerprint = fallbackFingerprint.String
+		if exchangeTradeTime.Valid {
+			parsed := exchangeTradeTime.Time.UTC()
+			item.ExchangeTradeTime = &parsed
+		}
+		items = append(items, item)
+	}
+	return items, rows.Err()
+}
+
+func (s *Store) QueryFills(query domain.FillQuery) ([]domain.Fill, error) {
+	sqlQuery := `
+		select id, order_id, exchange_trade_id, exchange_trade_time, dedup_fallback_fingerprint, price, quantity, fee, created_at
+		from fills
+	`
+	args := []any{}
+	if len(query.OrderIDs) > 0 {
+		placeholders := []string{}
+		for i, id := range query.OrderIDs {
+			placeholders = append(placeholders, fmt.Sprintf("$%d", i+1))
+			args = append(args, id)
+		}
+		sqlQuery += fmt.Sprintf(" where order_id in (%s) ", strings.Join(placeholders, ","))
+	}
+	sqlQuery += ` order by created_at asc `
+
+	rows, err := s.db.Query(sqlQuery, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -707,6 +788,39 @@ func (s *Store) ListPositions() ([]domain.Position, error) {
 		select id, account_id, strategy_version_id, symbol, side, quantity, entry_price, mark_price, updated_at
 		from positions order by updated_at asc
 	`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	items := []domain.Position{}
+	for rows.Next() {
+		var (
+			item              domain.Position
+			strategyVersionID sql.NullString
+		)
+		if err := rows.Scan(&item.ID, &item.AccountID, &strategyVersionID, &item.Symbol, &item.Side, &item.Quantity, &item.EntryPrice, &item.MarkPrice, &item.UpdatedAt); err != nil {
+			return nil, err
+		}
+		item.StrategyVersionID = strategyVersionID.String
+		items = append(items, item)
+	}
+	return items, rows.Err()
+}
+
+func (s *Store) QueryPositions(query domain.PositionQuery) ([]domain.Position, error) {
+	sqlQuery := `
+		select id, account_id, strategy_version_id, symbol, side, quantity, entry_price, mark_price, updated_at
+		from positions
+	`
+	args := []any{}
+	if query.AccountID != "" {
+		sqlQuery += ` where account_id = $1 `
+		args = append(args, query.AccountID)
+	}
+	sqlQuery += ` order by updated_at asc `
+
+	rows, err := s.db.Query(sqlQuery, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -1619,6 +1733,103 @@ func (s *Store) CreatePositionAccountSnapshot(snapshot domain.PositionAccountSna
 		marshalJSONValue(snapshot.PositionSnapshot), marshalJSONValue(snapshot.LivePositionState), marshalJSONValue(snapshot.AccountSnapshot), marshalJSONValue(snapshot.AccountSummary), marshalJSONValue(snapshot.Metadata),
 	)
 	return snapshot, err
+}
+
+func (s *Store) CreateOrderCloseVerification(item domain.OrderCloseVerification) (domain.OrderCloseVerification, error) {
+	if item.ID == "" {
+		item.ID = fmt.Sprintf("order-close-verification-%d", time.Now().UTC().UnixNano())
+	}
+	if item.EventTime.IsZero() {
+		item.EventTime = time.Now().UTC()
+	}
+	if item.RecordedAt.IsZero() {
+		item.RecordedAt = time.Now().UTC()
+	}
+	if item.Metadata == nil {
+		item.Metadata = map[string]any{}
+	}
+	metadataRaw, _ := json.Marshal(item.Metadata)
+
+	_, err := s.db.Exec(`
+		insert into order_close_verifications (
+			id, live_session_id, order_id, decision_event_id, account_id, strategy_id, symbol,
+			verified_closed, remaining_position_qty, verification_source, event_time, recorded_at, metadata
+		) values (
+			$1, $2, $3, $4, $5, $6, $7,
+			$8, $9, $10, $11, $12, $13
+		)
+	`,
+		item.ID, item.LiveSessionID, item.OrderID, nullIfEmpty(item.DecisionEventID), item.AccountID, item.StrategyID, item.Symbol,
+		item.VerifiedClosed, item.RemainingPositionQty, item.VerificationSource, item.EventTime, item.RecordedAt, metadataRaw,
+	)
+	return item, err
+}
+
+func (s *Store) QueryOrderCloseVerifications(query domain.OrderCloseVerificationQuery) ([]domain.OrderCloseVerification, error) {
+	builder := strings.Builder{}
+	builder.WriteString(`
+		select id, live_session_id, order_id, decision_event_id, account_id, strategy_id, symbol,
+			verified_closed, remaining_position_qty, verification_source, event_time, recorded_at, metadata
+		from order_close_verifications
+		where 1=1
+	`)
+	var args []any
+
+	if strings.TrimSpace(query.LiveSessionID) != "" {
+		args = append(args, strings.TrimSpace(query.LiveSessionID))
+		builder.WriteString(fmt.Sprintf(" and live_session_id = $%d", len(args)))
+	}
+	if strings.TrimSpace(query.OrderID) != "" {
+		args = append(args, strings.TrimSpace(query.OrderID))
+		builder.WriteString(fmt.Sprintf(" and order_id = $%d", len(args)))
+	}
+	if len(query.OrderIDs) > 0 {
+		placeholders := make([]string, 0, len(query.OrderIDs))
+		for _, id := range query.OrderIDs {
+			if strings.TrimSpace(id) == "" {
+				continue
+			}
+			args = append(args, strings.TrimSpace(id))
+			placeholders = append(placeholders, fmt.Sprintf("$%d", len(args)))
+		}
+		if len(placeholders) > 0 {
+			builder.WriteString(fmt.Sprintf(" and order_id in (%s)", strings.Join(placeholders, ",")))
+		}
+	}
+
+	builder.WriteString(" order by event_time desc, recorded_at desc, id desc")
+	if query.Limit > 0 {
+		args = append(args, query.Limit)
+		builder.WriteString(fmt.Sprintf(" limit $%d", len(args)))
+	}
+
+	rows, err := s.db.Query(builder.String(), args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var items []domain.OrderCloseVerification
+	for rows.Next() {
+		var item domain.OrderCloseVerification
+		var decisionEventID sql.NullString
+		var metadataRaw []byte
+
+		if err := rows.Scan(
+			&item.ID, &item.LiveSessionID, &item.OrderID, &decisionEventID, &item.AccountID, &item.StrategyID, &item.Symbol,
+			&item.VerifiedClosed, &item.RemainingPositionQty, &item.VerificationSource, &item.EventTime, &item.RecordedAt, &metadataRaw,
+		); err != nil {
+			return nil, err
+		}
+
+		item.DecisionEventID = decisionEventID.String
+		item.Metadata = map[string]any{}
+		if len(metadataRaw) > 0 {
+			_ = json.Unmarshal(metadataRaw, &item.Metadata)
+		}
+		items = append(items, item)
+	}
+	return items, rows.Err()
 }
 
 func (s *Store) ListMarketBars(exchange, symbol, timeframe string, from, to int64, limit int) ([]domain.MarketBar, error) {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -31,6 +31,8 @@ type Repository interface {
 
 	// ListOrders 获取所有订单。
 	ListOrders() ([]domain.Order, error)
+	// QueryOrders 按条件查询订单。
+	QueryOrders(query domain.OrderQuery) ([]domain.Order, error)
 	// CreateOrder 创建新订单。
 	CreateOrder(order domain.Order) (domain.Order, error)
 	// UpdateOrder 更新订单信息（状态、价格、metadata 等）。
@@ -40,6 +42,8 @@ type Repository interface {
 
 	// ListFills 获取所有成交记录。
 	ListFills() ([]domain.Fill, error)
+	// QueryFills 按条件查询成交记录。
+	QueryFills(query domain.FillQuery) ([]domain.Fill, error)
 	// TotalFilledQuantityForOrder 返回指定订单已落账成交数量总和。
 	TotalFilledQuantityForOrder(orderID string) (float64, error)
 	// CreateFill 创建新成交记录。
@@ -49,6 +53,8 @@ type Repository interface {
 
 	// ListPositions 获取所有持仓。
 	ListPositions() ([]domain.Position, error)
+	// QueryPositions 按条件查询持仓。
+	QueryPositions(query domain.PositionQuery) ([]domain.Position, error)
 	// FindPosition 查找指定账户和交易对的持仓。
 	FindPosition(accountID, symbol string) (domain.Position, bool, error)
 	// SavePosition 创建或更新持仓。
@@ -116,6 +122,13 @@ type Repository interface {
 	ListPositionAccountSnapshots(accountID string) ([]domain.PositionAccountSnapshot, error)
 	// CreatePositionAccountSnapshot 创建新的仓位/账户快照。
 	CreatePositionAccountSnapshot(snapshot domain.PositionAccountSnapshot) (domain.PositionAccountSnapshot, error)
+
+	// --- 订单关闭核验 ---
+
+	// CreateOrderCloseVerification 创建新的订单关闭核验记录。
+	CreateOrderCloseVerification(item domain.OrderCloseVerification) (domain.OrderCloseVerification, error)
+	// QueryOrderCloseVerifications 查询订单关闭核验记录。
+	QueryOrderCloseVerifications(query domain.OrderCloseVerificationQuery) ([]domain.OrderCloseVerification, error)
 
 	// --- 市场 Bar 缓存 ---
 

--- a/web/console/src/App.tsx
+++ b/web/console/src/App.tsx
@@ -11,6 +11,7 @@ import { useTradingStore } from './store/useTradingStore';
 import { useDashboard } from './hooks/useDashboard';
 import { useTradingActions } from './hooks/useTradingActions';
 import { fetchJSON } from './utils/api';
+import { deriveHighlightedLiveSession } from './utils/derivation';
 
 // Layout Components
 import { HeaderMetrics } from './components/layout/HeaderMetrics';
@@ -77,6 +78,9 @@ export default function App() {
   const telegramConfig = useTradingStore(s => s.telegramConfig);
   const runtimePolicy = useTradingStore(s => s.runtimePolicy);
   const editingLiveSessionId = useTradingStore(s => s.editingLiveSessionId);
+  const orders = useTradingStore(s => s.orders);
+  const fills = useTradingStore(s => s.fills);
+  const positions = useTradingStore(s => s.positions);
 
   // Quick Account Resolution
   const liveAccounts = accounts;
@@ -89,8 +93,24 @@ export default function App() {
   );
   const strategyOptions = useMemo(() => strategies.map(s => ({ value: s.id, label: s.name })), [strategies]);
 
+  const selectedSignalRuntimeId = useTradingStore(s => s.selectedSignalRuntimeId);
+  const monitorSessionId = useMemo(() => {
+    if (selectedSignalRuntimeId) {
+      const sessionWithRuntime = liveSessions.find(s => 
+        s.id === selectedSignalRuntimeId || 
+        String(s.state?.signalRuntimeSessionId) === selectedSignalRuntimeId
+      );
+      if (sessionWithRuntime) {
+        const highlighted = deriveHighlightedLiveSession([sessionWithRuntime], orders, fills, positions);
+        return highlighted?.session.id || null;
+      }
+    }
+    const highlighted = deriveHighlightedLiveSession(liveSessions, orders, fills, positions);
+    return highlighted?.session.id || null;
+  }, [liveSessions, orders, fills, positions, selectedSignalRuntimeId]);
+
   // Compose dynamic content
-  const dockContent = <DockContent dockTab={dockTab} actions={actions} />;
+  const dockContent = <DockContent dockTab={dockTab} actions={actions} sessionId={monitorSessionId} />;
   const mainStageContent = <MainContent actions={actions} dockContent={dockContent} strategies={strategies} quickLiveAccountId={quickLiveAccountId} />;
 
   return (

--- a/web/console/src/components/layout/DockContent.tsx
+++ b/web/console/src/components/layout/DockContent.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useMemo } from 'react';
 import { Badge } from '../ui/badge';
 import { Button } from '../ui/button';
 import {
@@ -10,17 +10,60 @@ import {
   TableRow,
 } from '../ui/table';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip';
-import { formatTime, formatMaybeNumber, shrink } from '../../utils/format';
+import { Input } from '../ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '../ui/select';
+import { formatTime, formatMaybeNumber, shrink, formatSigned } from '../../utils/format';
 import { technicalStatusLabel } from '../../utils/derivation';
 import { useTradingStore } from '../../store/useTradingStore';
 import { useUIStore } from '../../store/useUIStore';
-import { ShieldCheck, Loader2 } from 'lucide-react';
+import { useLiveTradePairs } from '../../hooks/useLiveTradePairs';
+import { ShieldCheck, Loader2, ChevronLeft, ChevronRight, ArrowRightLeft, Activity } from 'lucide-react';
 
 import { cn } from '../../lib/utils';
 
 interface DockContentProps {
-  dockTab: 'orders' | 'positions' | 'fills' | 'alerts';
+  dockTab: 'pairs' | 'orders' | 'positions' | 'fills' | 'alerts';
   actions: any;
+  sessionId?: string | null;
+}
+
+function tradePairStatusLabel(status: string) {
+  return String(status).toLowerCase() === 'open' ? '持仓中' : '已平仓';
+}
+
+function tradePairVerdictLabel(verdict: string) {
+  switch (String(verdict).toLowerCase()) {
+    case 'normal':
+      return '正常退出';
+    case 'recovery-close':
+      return 'Recovery 平仓';
+    case 'orphan-exit':
+      return '孤儿退出';
+    case 'mismatch':
+      return '需复核';
+    default:
+      return '进行中';
+  }
+}
+
+function tradePairVerdictTone(verdict: string) {
+  switch (String(verdict).toLowerCase()) {
+    case 'normal':
+      return 'text-[var(--bk-status-success)]';
+    case 'mismatch':
+    case 'orphan-exit':
+      return 'text-[var(--bk-status-danger)]';
+    case 'recovery-close':
+      return 'text-[var(--bk-status-warning)]';
+    default:
+      return 'text-[var(--bk-text-muted)]';
+  }
 }
 
 function TruncatedValue({ value, display, noShrink }: { value: string; display?: string; noShrink?: boolean }) {
@@ -94,6 +137,98 @@ function DockActionButton({
   );
 }
 
+function Pagination({ 
+  currentPage, 
+  totalItems, 
+  pageSize, 
+  onPageChange, 
+  onPageSizeChange 
+}: { 
+  currentPage: number; 
+  totalItems: number; 
+  pageSize: number; 
+  onPageChange: (page: number) => void;
+  onPageSizeChange: (size: number) => void;
+}) {
+  const totalPages = Math.ceil(totalItems / pageSize) || 1;
+  const [jumpPage, setJumpPage] = useState("");
+
+  const handleJump = () => {
+    const p = parseInt(jumpPage);
+    if (!isNaN(p) && p >= 1 && p <= totalPages) {
+      onPageChange(p);
+      setJumpPage("");
+    }
+  };
+
+  return (
+    <div className="flex items-center justify-between px-6 py-3 border-t border-[var(--bk-border-soft)] bg-[var(--bk-surface-faint)]/50">
+      <div className="flex items-center gap-4">
+        <div className="flex items-center gap-2">
+          <span className="text-[10px] font-black uppercase text-[var(--bk-text-muted)] opacity-60">每页</span>
+          <Select value={String(pageSize)} onValueChange={(val) => val && onPageSizeChange(parseInt(val))}>
+            <SelectTrigger tone="bento" size="sm" className="h-7 w-16 text-[10px] font-black">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent tone="bento" className="min-w-[80px]">
+              {[5, 10, 20, 50, 100].map(size => (
+                <SelectItem key={size} value={String(size)}>{size}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <span className="text-[10px] font-bold text-[var(--bk-text-muted)] opacity-60">
+          共 {totalItems} 条 · {totalPages} 页
+        </span>
+      </div>
+
+      <div className="flex items-center gap-3">
+        <div className="flex items-center gap-1.5 mr-2">
+          <Input 
+            className="h-7 w-12 rounded-lg border-[var(--bk-border)] bg-[var(--bk-surface)] px-1 text-center text-[10px] font-black"
+            placeholder="页码"
+            value={jumpPage}
+            onChange={(e) => setJumpPage(e.target.value)}
+            onKeyDown={(e) => e.key === 'Enter' && handleJump()}
+          />
+          <Button 
+            variant="bento-outline" 
+            size="sm" 
+            className="h-7 rounded-lg px-2 text-[10px] font-black"
+            onClick={handleJump}
+          >
+            跳转
+          </Button>
+        </div>
+
+        <div className="flex items-center gap-1">
+          <Button 
+            variant="bento-outline" 
+            size="sm" 
+            className="h-7 w-7 rounded-lg p-0" 
+            disabled={currentPage <= 1}
+            onClick={() => onPageChange(currentPage - 1)}
+          >
+            <ChevronLeft className="size-3.5" />
+          </Button>
+          <div className="flex h-7 min-w-[28px] items-center justify-center rounded-lg border border-[var(--bk-border)] bg-[var(--bk-surface-overlay)] px-2 text-[10px] font-black text-[var(--bk-text-primary)] shadow-inner">
+            {currentPage}
+          </div>
+          <Button 
+            variant="bento-outline" 
+            size="sm" 
+            className="h-7 w-7 rounded-lg p-0" 
+            disabled={currentPage >= totalPages}
+            onClick={() => onPageChange(currentPage + 1)}
+          >
+            <ChevronRight className="size-3.5" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function DockTable({
   columns,
   rows,
@@ -160,7 +295,7 @@ function DockTable({
   );
 }
 
-export function DockContent({ dockTab, actions }: DockContentProps) {
+export function DockContent({ dockTab, actions, sessionId }: DockContentProps) {
   const orders = useTradingStore(s => s.orders);
   const fills = useTradingStore(s => s.fills);
   const positions = useTradingStore(s => s.positions);
@@ -168,6 +303,37 @@ export function DockContent({ dockTab, actions }: DockContentProps) {
   const positionCloseAction = useUIStore(s => s.positionCloseAction);
   const liveSyncAction = useUIStore(s => s.liveSyncAction);
   const openConfirmDialog = useUIStore(s => s.openConfirmDialog);
+  const { pairs, loading: pairsLoading, error: pairsError } = useLiveTradePairs(
+    dockTab === 'pairs' ? (sessionId ?? null) : null, 
+    200
+  );
+
+  // Pagination & Sorting State
+  const [pages, setPages] = useState({ pairs: 1, orders: 1, positions: 1, fills: 1, alerts: 1 });
+  const [pageSize, setPageSize] = useState(5);
+
+  // Reset page when tab or pageSize changes
+  const handlePageChange = (page: number) => {
+    setPages(prev => ({ ...prev, [dockTab]: page }));
+  };
+
+  const handlePageSizeChange = (size: number) => {
+    setPageSize(size);
+    setPages({ pairs: 1, orders: 1, positions: 1, fills: 1, alerts: 1 });
+  };
+
+  const sortedOrders = useMemo(() => [...orders].sort((a, b) => Date.parse(b.createdAt) - Date.parse(a.createdAt)), [orders]);
+  const sortedFills = useMemo(() => [...fills].sort((a, b) => Date.parse(b.createdAt) - Date.parse(a.createdAt)), [fills]);
+  const sortedPositions = useMemo(() => [...positions].sort((a, b) => Date.parse(b.updatedAt) - Date.parse(a.updatedAt)), [positions]);
+  const sortedAlerts = useMemo(() => [...alerts].sort((a, b) => Date.parse(b.eventTime ?? "") - Date.parse(a.eventTime ?? "")), [alerts]);
+  const sortedPairs = useMemo(() => [...pairs].sort((a, b) => Date.parse(b.entryAt) - Date.parse(a.entryAt)), [pairs]);
+
+  const pagedOrders = useMemo(() => sortedOrders.slice((pages.orders - 1) * pageSize, pages.orders * pageSize), [sortedOrders, pages.orders, pageSize]);
+  const pagedFills = useMemo(() => sortedFills.slice((pages.fills - 1) * pageSize, pages.fills * pageSize), [sortedFills, pages.fills, pageSize]);
+  const pagedPositions = useMemo(() => sortedPositions.slice((pages.positions - 1) * pageSize, pages.positions * pageSize), [sortedPositions, pages.positions, pageSize]);
+  const pagedAlerts = useMemo(() => sortedAlerts.slice((pages.alerts - 1) * pageSize, pages.alerts * pageSize), [sortedAlerts, pages.alerts, pageSize]);
+  const pagedPairs = useMemo(() => sortedPairs.slice((pages.pairs - 1) * pageSize, pages.pairs * pageSize), [sortedPairs, pages.pairs, pageSize]);
+
   const orderById = new Map(orders.map((order) => [order.id, order] as const));
   const duplicateFallbackFillCounts = fills
     .filter((fill) => !(fill.exchangeTradeId ?? "").trim())
@@ -184,136 +350,226 @@ export function DockContent({ dockTab, actions }: DockContentProps) {
     }, new Map<string, number>());
 
   return (
-    <div className="h-full relative overflow-hidden">
-      {dockTab === 'orders' && (
-        <DockTable
-          columns={["ID", "策略版本", "Symbol", "Side", "Type", "数量", "价格", "交易所订单ID", "状态", "创建时间", "操作"]}
-          rows={orders.map((order) => {
-            const exchangeId = String(order.metadata?.exchangeOrderId ?? "--");
-            const isReconciled = !!(order.metadata?.orderLifecycle as any)?.synced;
-            const isOrphan = order.status === "ACCEPTED" && (order.metadata?.orderLifecycle as any)?.reconciliationState === "orphaned";
-
-            return [
-              <TruncatedValue key={`${order.id}-id`} value={order.id} display={order.id.replace('order-', '')} />,
-              <TruncatedValue key={`${order.id}-strategy`} value={String(order.metadata?.strategyVersionId ?? order.metadata?.source ?? "--")} noShrink />,
-              order.symbol,
-              <DockBadge key={`${order.id}-side`} tone={order.side === "buy" ? "ready" : "neutral"}>{order.side}</DockBadge>,
-              order.type,
-              formatMaybeNumber(order.quantity),
-              formatMaybeNumber(order.price),
-              <div key={`${order.id}-exid`} className="flex items-center gap-1.5 min-w-[120px]">
-                <TruncatedValue value={exchangeId} />
-                {isReconciled && (
-                   <div className="flex size-3.5 items-center justify-center rounded-full bg-[var(--bk-status-success-soft)] text-[var(--bk-status-success)]">
-                      <ShieldCheck className="size-2.5" />
-                   </div>
-                )}
-              </div>,
-              <div key={`${order.id}-status`} className="flex items-center gap-2">
-                <DockBadge tone={isOrphan ? "blocked" : (isReconciled ? "ready" : "watch")}>
-                  {technicalStatusLabel(order.status)}
-                </DockBadge>
-              </div>,
-              formatTime(order.createdAt),
-              <div key={`${order.id}-actions`} className="inline-actions relative">
-                <DockActionButton 
-                  label={liveSyncAction === order.id ? "Syncing..." : "Sync"} 
-                  disabled={liveSyncAction !== null}
-                  variant="ghost" 
-                  onClick={() => actions.syncLiveOrder(order.id)} 
-                />
-                {liveSyncAction === order.id && (
-                  <Loader2 className="absolute -right-2 top-1/2 size-3.5 -translate-y-1/2 animate-spin text-[var(--bk-text-muted)]" />
-                )}
-              </div>,
-            ];
-          })}
-          emptyMessage="暂无订单"
-        />
-      )}
-      {dockTab === 'positions' && (
-        <DockTable
-          columns={["ID", "账户", "Symbol", "Side", "仓位大小", "开仓价", "标记价", "更新时间", "操作"]}
-          rows={positions.map((pos) => [
-            <TruncatedValue key={`${pos.id}-id`} value={pos.id} display={pos.id.replace('position-', 'pos-')} />,
-            <TruncatedValue key={`${pos.id}-account`} value={pos.accountId} display={pos.accountId.replace('account-', 'acc-')} />,
-            pos.symbol,
-            <DockBadge key={`${pos.id}-side`} tone={pos.side === "long" ? "ready" : "neutral"}>{pos.side}</DockBadge>,
-            formatMaybeNumber(pos.quantity),
-            formatMaybeNumber(pos.entryPrice),
-            formatMaybeNumber(pos.markPrice),
-            formatTime(pos.updatedAt),
-            <div key={`${pos.id}-actions`} className="inline-actions">
-              <DockActionButton 
-                label={positionCloseAction === pos.id ? "平仓中..." : "强平"} 
-                variant="danger" 
-                disabled={positionCloseAction !== null}
-                onClick={() => {
-                  openConfirmDialog(
-                    "强制市价平仓风险确认",
-                    "您即将放弃策略托管，使用系统市价单直接平仓。注意：此接管动作可能产生额外滑点，是否确认强平？",
-                    () => actions.closePosition(pos.id)
-                  );
-                }} 
+    <div className="h-full relative flex flex-col overflow-hidden">
+      <div className="flex-1 overflow-y-auto">
+        {dockTab === 'pairs' && (
+          <div className="p-0">
+            {pairsLoading ? (
+              <div className="flex items-center justify-center gap-3 py-20 text-[var(--bk-text-muted)]">
+                <Activity size={16} className="animate-spin" />
+                <span className="text-[11px] font-black uppercase tracking-widest">聚合追溯中...</span>
+              </div>
+            ) : pairsError ? (
+              <div className="p-8 text-center text-rose-500 text-[11px] font-black">{pairsError}</div>
+            ) : (
+              <DockTable
+                columns={["状态", "方向/Symbol", "开仓细节", "平仓细节", "数量/成交", "PNL统计"]}
+                rows={pagedPairs.map((pair) => {
+                  const netPositive = Number(pair.netPnl ?? 0) >= 0;
+                  const quantity = String(pair.status).toLowerCase() === 'open' ? pair.openQuantity : pair.entryQuantity;
+                  return [
+                    <div key={`${pair.id}-status`} className="space-y-1">
+                      <Badge variant={String(pair.status).toLowerCase() === 'open' ? 'neutral' : 'success'}>
+                        {tradePairStatusLabel(pair.status)}
+                      </Badge>
+                      <div className={cn('text-[10px] font-black', tradePairVerdictTone(pair.exitVerdict))}>
+                        {tradePairVerdictLabel(pair.exitVerdict)}
+                      </div>
+                    </div>,
+                    <div key={`${pair.id}-side`} className="space-y-1">
+                      <div className="text-[12px] font-black text-[var(--bk-text-primary)]">{pair.side}</div>
+                      <div className="text-[10px] text-[var(--bk-text-muted)] font-mono">{pair.symbol}</div>
+                    </div>,
+                    <div key={`${pair.id}-entry`} className="space-y-0.5">
+                      <div className="font-mono text-[12px] font-black text-[var(--bk-text-primary)]">
+                        {formatMaybeNumber(pair.entryAvgPrice)}
+                      </div>
+                      <div className="text-[9px] text-[var(--bk-text-muted)] opacity-60">{formatTime(pair.entryAt)}</div>
+                      <div className="text-[9px] font-black uppercase text-[var(--bk-text-muted)] truncate max-w-[120px]">
+                        {pair.entryReason || '--'}
+                      </div>
+                    </div>,
+                    String(pair.status).toLowerCase() === 'closed' ? (
+                      <div key={`${pair.id}-exit`} className="space-y-0.5">
+                        <div className="font-mono text-[12px] font-black text-[var(--bk-text-primary)]">
+                          {formatMaybeNumber(pair.exitAvgPrice)}
+                        </div>
+                        <div className="text-[9px] text-[var(--bk-text-muted)] opacity-60">
+                          {pair.exitAt ? formatTime(pair.exitAt) : '--'}
+                        </div>
+                        <div className="text-[9px] font-black uppercase text-[var(--bk-text-muted)] truncate max-w-[120px]">
+                          {pair.exitReason || '--'}
+                        </div>
+                      </div>
+                    ) : (
+                      <div key={`${pair.id}-exit-pending`} className="space-y-1">
+                        <div className="text-[11px] font-black text-[var(--bk-status-success)]">运行中</div>
+                        <div className="text-[9px] text-[var(--bk-text-muted)] font-mono">
+                          未实现 {formatSigned(pair.unrealizedPnl)}
+                        </div>
+                      </div>
+                    ),
+                    <div key={`${pair.id}-qty`} className="space-y-0.5">
+                      <div className="font-mono text-[12px] font-black text-[var(--bk-text-primary)]">
+                        {formatMaybeNumber(quantity)}
+                      </div>
+                      <div className="text-[9px] text-[var(--bk-text-muted)] font-black">
+                        {pair.entryFillCount} IN / {pair.exitFillCount} OUT
+                      </div>
+                    </div>,
+                    <div key={`${pair.id}-pnl`} className="space-y-0.5">
+                      <div className={cn('font-mono text-[13px] font-black', netPositive ? 'text-[var(--bk-status-success)]' : 'text-[var(--bk-status-danger)]')}>
+                        {formatSigned(pair.netPnl)}
+                      </div>
+                      <div className="text-[9px] text-[var(--bk-text-muted)] flex items-center gap-2">
+                        <span>费 {formatMaybeNumber(pair.fees, 5)}</span>
+                      </div>
+                    </div>,
+                  ];
+                })}
+                emptyMessage="当前焦点会话无追溯记录"
               />
-            </div>,
-          ])}
-          emptyMessage="暂无持仓"
-        />
-      )}
-      {dockTab === 'fills' && (
-        <DockTable
-          columns={["ID", "策略版本", "Symbol", "侧向", "价格", "数量", "手续费", "交易所成交ID", "交易所成交时间", "本地入库时间", "同步提示"]}
-          rows={fills.map((fill) => {
-            const order = orderById.get(fill.orderId);
-            const duplicateKey = [
-              fill.orderId,
-              String(fill.price),
-              String(fill.quantity),
-              String(fill.fee),
-              fill.exchangeTradeTime ?? "",
-            ].join("|");
-            const suspiciousDuplicate = !(fill.exchangeTradeId ?? "").trim() && (duplicateFallbackFillCounts.get(duplicateKey) ?? 0) > 1;
+            )}
+          </div>
+        )}
+        {dockTab === 'orders' && (
+          <DockTable
+            columns={["ID", "策略版本", "Symbol", "Side", "Type", "数量", "价格", "交易所订单ID", "状态", "创建时间", "操作"]}
+            rows={pagedOrders.map((order) => {
+              const exchangeId = String(order.metadata?.exchangeOrderId ?? "--");
+              const isReconciled = !!(order.metadata?.orderLifecycle as any)?.synced;
+              const isOrphan = order.status === "ACCEPTED" && (order.metadata?.orderLifecycle as any)?.reconciliationState === "orphaned";
 
-            return [
-              <TruncatedValue key={`${fill.id}-id`} value={fill.id} display={fill.id.replace('fill-', '')} />,
-              String(order?.metadata?.strategyVersionId ?? fill.strategyVersion ?? "--"),
-              order?.symbol ?? fill.symbol ?? "--",
-              order?.side ?? fill.side ?? "--",
-              formatMaybeNumber(fill.price),
-              formatMaybeNumber(fill.quantity),
-              formatMaybeNumber(fill.fee),
-              <TruncatedValue key={`${fill.id}-exid`} value={fill.exchangeTradeId ?? "--"} />,
-              formatTime(fill.exchangeTradeTime ?? ""),
-              formatTime(fill.createdAt),
-              suspiciousDuplicate ? (
-                <DockBadge key={`${fill.id}-dup`} tone="watch">疑似重复</DockBadge>
-              ) : fill.exchangeTradeId ? (
-                <DockBadge key={`${fill.id}-ok`} tone="ready">已同步</DockBadge>
-              ) : (
-                <span key={`${fill.id}-pending`} className="text-[11px] text-[var(--bk-text-muted)]">
-                  等待同步
-                </span>
-              ),
-            ];
-          })}
-          emptyMessage="暂无成交记录"
-        />
-      )}
-      {dockTab === 'alerts' && (
-        <DockTable
-          columns={["时间", "级别", "模块", "消息"]}
-          rows={alerts.map((alert) => [
-            formatTime(alert.eventTime ?? ""),
-            <DockBadge key={`${alert.id}-level`} tone={alert.level === "critical" ? "blocked" : alert.level === "warning" ? "watch" : "neutral"}>
-              {alert.level}
-            </DockBadge>,
-            alert.title,
-            alert.detail,
-          ])}
-          emptyMessage="暂无告警信息"
-        />
-      )}
+              return [
+                <TruncatedValue key={`${order.id}-id`} value={order.id} display={order.id.replace('order-', '')} />,
+                <TruncatedValue key={`${order.id}-strategy`} value={String(order.metadata?.strategyVersionId ?? order.metadata?.source ?? "--")} noShrink />,
+                order.symbol,
+                <DockBadge key={`${order.id}-side`} tone={order.side === "buy" ? "ready" : "neutral"}>{order.side}</DockBadge>,
+                order.type,
+                formatMaybeNumber(order.quantity),
+                formatMaybeNumber(order.price),
+                <div key={`${order.id}-exid`} className="flex items-center gap-1.5 min-w-[120px]">
+                  <TruncatedValue value={exchangeId} />
+                  {isReconciled && (
+                     <div className="flex size-3.5 items-center justify-center rounded-full bg-[var(--bk-status-success-soft)] text-[var(--bk-status-success)]">
+                        <ShieldCheck className="size-2.5" />
+                     </div>
+                  )}
+                </div>,
+                <div key={`${order.id}-status`} className="flex items-center gap-2">
+                  <DockBadge tone={isOrphan ? "blocked" : (isReconciled ? "ready" : "watch")}>
+                    {technicalStatusLabel(order.status)}
+                  </DockBadge>
+                </div>,
+                formatTime(order.createdAt),
+                <div key={`${order.id}-actions`} className="inline-actions relative">
+                  <DockActionButton 
+                    label={liveSyncAction === order.id ? "Syncing..." : "Sync"} 
+                    disabled={liveSyncAction !== null}
+                    variant="ghost" 
+                    onClick={() => actions.syncLiveOrder(order.id)} 
+                  />
+                  {liveSyncAction === order.id && (
+                    <Loader2 className="absolute -right-2 top-1/2 size-3.5 -translate-y-1/2 animate-spin text-[var(--bk-text-muted)]" />
+                  )}
+                </div>,
+              ];
+            })}
+            emptyMessage="暂无订单"
+          />
+        )}
+        {dockTab === 'positions' && (
+          <DockTable
+            columns={["ID", "账户", "Symbol", "Side", "仓位大小", "开仓价", "标记价", "更新时间", "操作"]}
+            rows={pagedPositions.map((pos) => [
+              <TruncatedValue key={`${pos.id}-id`} value={pos.id} display={pos.id.replace('position-', 'pos-')} />,
+              <TruncatedValue key={`${pos.id}-account`} value={pos.accountId} display={pos.accountId.replace('account-', 'acc-')} />,
+              pos.symbol,
+              <DockBadge key={`${pos.id}-side`} tone={pos.side === "long" ? "ready" : "neutral"}>{pos.side}</DockBadge>,
+              formatMaybeNumber(pos.quantity),
+              formatMaybeNumber(pos.entryPrice),
+              formatMaybeNumber(pos.markPrice),
+              formatTime(pos.updatedAt),
+              <div key={`${pos.id}-actions`} className="inline-actions">
+                <DockActionButton 
+                  label={positionCloseAction === pos.id ? "平仓中..." : "强平"} 
+                  variant="danger" 
+                  disabled={positionCloseAction !== null}
+                  onClick={() => {
+                    openConfirmDialog(
+                      "强制市价平仓风险确认",
+                      "您即将放弃策略托管，使用系统市价单直接平仓。注意：此接管动作可能产生额外滑点，是否确认强平？",
+                      () => actions.closePosition(pos.id)
+                    );
+                  }} 
+                />
+              </div>,
+            ])}
+            emptyMessage="暂无持仓"
+          />
+        )}
+        {dockTab === 'fills' && (
+          <DockTable
+            columns={["ID", "策略版本", "Symbol", "侧向", "价格", "数量", "手续费", "交易所成交ID", "交易所成交时间", "本地入库时间", "同步提示"]}
+            rows={pagedFills.map((fill) => {
+              const order = orderById.get(fill.orderId);
+              const duplicateKey = [
+                fill.orderId,
+                String(fill.price),
+                String(fill.quantity),
+                String(fill.fee),
+                fill.exchangeTradeTime ?? "",
+              ].join("|");
+              const suspiciousDuplicate = !(fill.exchangeTradeId ?? "").trim() && (duplicateFallbackFillCounts.get(duplicateKey) ?? 0) > 1;
+
+              return [
+                <TruncatedValue key={`${fill.id}-id`} value={fill.id} display={fill.id.replace('fill-', '')} />,
+                String(order?.metadata?.strategyVersionId ?? fill.strategyVersion ?? "--"),
+                order?.symbol ?? fill.symbol ?? "--",
+                order?.side ?? fill.side ?? "--",
+                formatMaybeNumber(fill.price),
+                formatMaybeNumber(fill.quantity),
+                formatMaybeNumber(fill.fee),
+                <TruncatedValue key={`${fill.id}-exid`} value={fill.exchangeTradeId ?? "--"} />,
+                formatTime(fill.exchangeTradeTime ?? ""),
+                formatTime(fill.createdAt),
+                suspiciousDuplicate ? (
+                  <DockBadge key={`${fill.id}-dup`} tone="watch">疑似重复</DockBadge>
+                ) : fill.exchangeTradeId ? (
+                  <DockBadge key={`${fill.id}-ok`} tone="ready">已同步</DockBadge>
+                ) : (
+                  <span key={`${fill.id}-pending`} className="text-[11px] text-[var(--bk-text-muted)]">
+                    等待同步
+                  </span>
+                ),
+              ];
+            })}
+            emptyMessage="暂无成交记录"
+          />
+        )}
+        {dockTab === 'alerts' && (
+          <DockTable
+            columns={["时间", "级别", "模块", "消息"]}
+            rows={pagedAlerts.map((alert) => [
+              formatTime(alert.eventTime ?? ""),
+              <DockBadge key={`${alert.id}-level`} tone={alert.level === "critical" ? "blocked" : alert.level === "warning" ? "watch" : "neutral"}>
+                {alert.level}
+              </DockBadge>,
+              alert.title,
+              alert.detail,
+            ])}
+            emptyMessage="暂无告警信息"
+          />
+        )}
+      </div>
+
+      <Pagination 
+        currentPage={pages[dockTab]}
+        totalItems={{ pairs: pairs.length, orders: orders.length, fills: fills.length, positions: positions.length, alerts: alerts.length }[dockTab]}
+        pageSize={pageSize}
+        onPageChange={handlePageChange}
+        onPageSizeChange={handlePageSizeChange}
+      />
     </div>
   );
 }

--- a/web/console/src/layouts/WorkbenchLayout.tsx
+++ b/web/console/src/layouts/WorkbenchLayout.tsx
@@ -4,8 +4,8 @@ import { Activity, Briefcase, Settings, FileText } from 'lucide-react';
 export interface WorkbenchLayoutProps {
   sidebarTab: 'monitor' | 'strategy' | 'account' | 'log';
   onSidebarTabChange: (tab: 'monitor' | 'strategy' | 'account' | 'log') => void;
-  dockTab: 'orders' | 'positions' | 'fills' | 'alerts';
-  onDockTabChange: (tab: 'orders' | 'positions' | 'fills' | 'alerts') => void;
+  dockTab: 'pairs' | 'orders' | 'positions' | 'fills' | 'alerts';
+  onDockTabChange: (tab: 'pairs' | 'orders' | 'positions' | 'fills' | 'alerts') => void;
   
   headerMetrics: React.ReactNode;
   headerConnection: React.ReactNode;

--- a/web/console/src/pages/MonitorStage.tsx
+++ b/web/console/src/pages/MonitorStage.tsx
@@ -30,7 +30,6 @@ import {
   technicalStatusLabel
 } from '../utils/derivation';
 import { fetchJSON } from '../utils/api';
-import { useLiveTradePairs } from '../hooks/useLiveTradePairs';
 import { Card, CardHeader, CardTitle, CardContent } from '../components/ui/card';
 import { Badge } from '../components/ui/badge';
 import { Table, TableHeader, TableBody, TableHead, TableRow, TableCell } from '../components/ui/table';
@@ -62,8 +61,8 @@ function resolveMonitorFallbackResolution(timeframe: string) {
 
 type MonitorStageProps = {
   syncLiveOrder: (id: string) => void;
-  dockTab: 'orders' | 'positions' | 'fills' | 'alerts';
-  onDockTabChange: (tab: 'orders' | 'positions' | 'fills' | 'alerts') => void;
+  dockTab: 'pairs' | 'orders' | 'positions' | 'fills' | 'alerts';
+  onDockTabChange: (tab: 'pairs' | 'orders' | 'positions' | 'fills' | 'alerts') => void;
   dockContent: React.ReactNode;
 };
 
@@ -310,7 +309,6 @@ export function MonitorStage({ syncLiveOrder, dockTab, onDockTabChange, dockCont
   const syncableLiveOrders = orders.filter((item) => item.metadata?.executionMode === "live" && item.status === "ACCEPTED");
   const platformRuntimePolicy = monitorHealth?.runtimePolicy ?? runtimePolicy;
   const timelineLogs = buildTimelineNotes(monitorTimeline, timelineConfig, monitorSession?.id).slice(0, 50);
-  const monitorTradePairs = useLiveTradePairs(monitorSession?.id ?? null, 8);
 
 
   const reconciledOrders = orders.filter(o => !!(o.metadata?.orderLifecycle as any)?.synced);
@@ -414,15 +412,6 @@ export function MonitorStage({ syncLiveOrder, dockTab, onDockTabChange, dockCont
         </div>
       )}
 
-      {monitorSession && (
-        <LiveTradePairsCard
-          title="开平订单对追溯"
-          description="聚合当前焦点会话的 round-trip 交易，直接判断是否正常退出，以及这笔单现在赚亏多少。"
-          pairs={monitorTradePairs.pairs}
-          loading={monitorTradePairs.loading}
-          error={monitorTradePairs.error}
-        />
-      )}
 
       <div className="grid grid-cols-1 lg:grid-cols-12 gap-6">
         {/* 2. 实时执行与指标监控 (三柱式 Bento 架构) */}
@@ -719,6 +708,7 @@ export function MonitorStage({ syncLiveOrder, dockTab, onDockTabChange, dockCont
                 <CardTitle className="text-xl font-black text-[var(--bk-text-primary)]">事务审计与管理控制</CardTitle>
               </div>
               <TabsList variant="bento" className="flex h-10 gap-1 rounded-2xl border border-[var(--bk-border-soft)] bg-[var(--bk-surface-strong)] p-1 shadow-inner">
+                <TabsTrigger value="pairs" className="rounded-xl px-4 text-[10px] font-black uppercase">追溯</TabsTrigger>
                 <TabsTrigger value="orders" className="rounded-xl px-4 text-[10px] font-black uppercase">订单</TabsTrigger>
                 <TabsTrigger value="positions" className="rounded-xl px-4 text-[10px] font-black uppercase">持仓</TabsTrigger>
                 <TabsTrigger value="fills" className="rounded-xl px-4 text-[10px] font-black uppercase">成交</TabsTrigger>

--- a/web/console/src/store/useUIStore.ts
+++ b/web/console/src/store/useUIStore.ts
@@ -10,7 +10,7 @@ import { readStoredAuthSession } from '../utils/auth';
 import { resolveUpdater } from './helpers';
 
 type SidebarTab = "monitor" | "strategy" | "account" | "log";
-type DockTab = "orders" | "positions" | "fills" | "alerts";
+type DockTab = "pairs" | "orders" | "positions" | "fills" | "alerts";
 
 export type SystemLogEntry = {
   id: string;
@@ -29,7 +29,7 @@ export type ConfirmDialogConfig = {
 const CONSOLE_NAV_STORAGE_KEY = "bktrader-console-nav";
 const SYSTEM_LOGS_STORAGE_KEY = "bktrader-system-logs";
 const DEFAULT_SIDEBAR_TAB: SidebarTab = "monitor";
-const DEFAULT_DOCK_TAB: DockTab = "orders";
+const DEFAULT_DOCK_TAB: DockTab = "pairs";
 const TIMELINE_CONFIG_STORAGE_KEY = "bktrader-timeline-config";
 
 
@@ -68,7 +68,7 @@ function readStoredConsoleNav(): { sidebarTab: SidebarTab; dockTab: DockTab } {
     const sidebarTab = parsed.sidebarTab === "strategy" || parsed.sidebarTab === "account" || parsed.sidebarTab === "monitor" || parsed.sidebarTab === "log"
       ? parsed.sidebarTab
       : DEFAULT_SIDEBAR_TAB;
-    const dockTab = parsed.dockTab === "positions" || parsed.dockTab === "fills" || parsed.dockTab === "alerts" || parsed.dockTab === "orders"
+    const dockTab = parsed.dockTab === "positions" || parsed.dockTab === "fills" || parsed.dockTab === "alerts" || parsed.dockTab === "orders" || parsed.dockTab === "pairs"
       ? parsed.dockTab
       : DEFAULT_DOCK_TAB;
 


### PR DESCRIPTION
## 目的
_这次改动要解决什么问题 / 实现了什么功能_
完成了 Live Trade Pairs 三层架构重构（Phase 1-3），解决前台 Trade Pairs 页面在订单庞大时拉取 Snapshot 造成的系统卡顿、全表扫描性能问题。
新增了 `order_close_verifications` 独立核验表，通过挂载 `applyExecutionFill`（ws-sync）等源头写入确定的核验记录，将平仓确认事实与上层的复杂推断成功解耦分离，现在查询列表能够根据精准 ID 高效过滤获取准确的平仓状态。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [x] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) -> **未改变**
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？ -> **无**
- [x] DB migration 是否具备向下兼容幂等性？ -> **具备，纯新增独立表设计**
- [x] 配置字段有没有无意被混改？ -> **无**

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩
  - 已完成本地全量 `go test ./...` 检查，完全通过。
  - 补充并修复了 `internal/service/live_trade_pairs_test.go` 中 Mock 核验写入逻辑。
  - `go build ./cmd/platform-api` 编译通过无错误。
