### PR TITLE
feat: manual trade verification for mismatch orders

### DIFF
--- a/docs/AGENT_PATHS.md
+++ b/docs/AGENT_PATHS.md
@@ -13,8 +13,9 @@
 
 ## 2. 协作与版本控制 (CLI Tools)
 
-- **GitHub CLI (gh)**: `/usr/local/bin/gh`
-- **Git**: `/usr/local/bin/git`
+- **GitHub CLI (gh)**: `/opt/homebrew/bin/gh`
+- **Git**: `/usr/bin/git`
+- **PostgreSQL (psql)**: `/opt/homebrew/bin/psql`
 
 ## 3. 环境变量加载
 
@@ -23,4 +24,4 @@
 source ~/.zshrc && <your_command>
 ```
 ---
-*上次更新时间: 2026-04-16*
+*上次更新时间: 2026-04-23 (Antigravity 路径修正)*

--- a/internal/http/live.go
+++ b/internal/http/live.go
@@ -561,6 +561,51 @@ func registerLiveRoutes(mux *http.ServeMux, platform *service.Platform) {
 				return
 			}
 
+			// 安全校验 1：归属确认 (Metadata 标识)
+			// 注意：domain.Order 本身不直接持有 LiveSessionID 字段，关联关系存储在 Metadata 中
+			orderSessionID, _ := order.Metadata["liveSessionId"].(string)
+			if orderSessionID != sessionID {
+				writeError(w, http.StatusForbidden, "order does not belong to this session (metadata mismatch)")
+				return
+			}
+
+			// 业务校验：仅允许复核退出类订单
+			if !order.EffectiveReduceOnly() && !order.EffectiveClosePosition() {
+				writeError(w, http.StatusForbidden, "only exit/reduce-only orders can be manually verified")
+				return
+			}
+
+			// 状态校验：仅允许复核 mismatch 或 orphan-exit 状态的交易对
+			pairs, err := platform.ListLiveTradePairs(domain.LiveTradePairQuery{LiveSessionID: sessionID})
+			if err != nil {
+				writeError(w, http.StatusInternalServerError, "failed to analyze trade pairs: "+err.Error())
+				return
+			}
+
+			var targetPair *domain.LiveTradePair
+			for _, p := range pairs {
+				for _, eid := range p.ExitOrderIDs {
+					if eid == orderID {
+						targetPair = &p
+						break
+					}
+				}
+				if targetPair != nil {
+					break
+				}
+			}
+
+			if targetPair == nil {
+				writeError(w, http.StatusNotFound, "trade pair containing this exit order not found")
+				return
+			}
+
+			verdict := strings.ToLower(targetPair.ExitVerdict)
+			if verdict != "mismatch" && verdict != "orphan-exit" {
+				writeError(w, http.StatusForbidden, fmt.Sprintf("manual verification only allowed for mismatch/orphan-exit states (current: %s)", verdict))
+				return
+			}
+
 			// 创建核验记录
 			verification := domain.OrderCloseVerification{
 				ID:                   fmt.Sprintf("manual-%d", time.Now().UnixNano()),

--- a/internal/http/live.go
+++ b/internal/http/live.go
@@ -2,8 +2,10 @@ package http
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/wuyaocheng/bktrader/internal/domain"
 	"github.com/wuyaocheng/bktrader/internal/service"
@@ -530,12 +532,67 @@ func registerLiveRoutes(mux *http.ServeMux, platform *service.Platform) {
 			w.WriteHeader(http.StatusMethodNotAllowed)
 			return
 		}
+		sessionID := parts[0]
+		if len(parts) == 4 && parts[1] == "orders" && parts[3] == "verifications" {
+			if r.Method != http.MethodPost {
+				w.WriteHeader(http.StatusMethodNotAllowed)
+				return
+			}
+			orderID := parts[2]
+			var payload struct {
+				Notes string `json:"notes"`
+			}
+			if err := decodeJSON(r, &payload); err != nil {
+				writeError(w, http.StatusBadRequest, err.Error())
+				return
+			}
+
+			// 获取订单详情以补全核验记录所需信息
+			order, err := platform.GetOrder(orderID)
+			if err != nil {
+				writeError(w, http.StatusNotFound, "order not found: "+err.Error())
+				return
+			}
+
+			// 获取会话以补全 StrategyID
+			session, err := platform.GetLiveSession(sessionID)
+			if err != nil {
+				writeError(w, http.StatusNotFound, "live session not found: "+err.Error())
+				return
+			}
+
+			// 创建核验记录
+			verification := domain.OrderCloseVerification{
+				ID:                   fmt.Sprintf("manual-%d", time.Now().UnixNano()),
+				LiveSessionID:        sessionID,
+				OrderID:              orderID,
+				AccountID:            order.AccountID,
+				StrategyID:           session.StrategyID,
+				Symbol:               order.Symbol,
+				VerifiedClosed:       true,
+				RemainingPositionQty: 0,
+				VerificationSource:   "manual-review",
+				EventTime:            time.Now().UTC(),
+				RecordedAt:           time.Now().UTC(),
+				Metadata: map[string]any{
+					"notes": payload.Notes,
+				},
+			}
+
+			if _, err := platform.CreateOrderCloseVerification(verification); err != nil {
+				writeError(w, http.StatusInternalServerError, err.Error())
+				return
+			}
+
+			writeJSON(w, http.StatusCreated, verification)
+			return
+		}
+
 		if len(parts) != 2 {
 			writeError(w, http.StatusNotFound, "live session route not found")
 			return
 		}
 
-		sessionID := parts[0]
 		action := parts[1]
 		switch action {
 		case "start":

--- a/internal/service/live_trade_pairs.go
+++ b/internal/service/live_trade_pairs.go
@@ -65,6 +65,10 @@ type liveTradePairBuilder struct {
 	lastExitOrderID    string
 }
 
+func (p *Platform) CreateOrderCloseVerification(v domain.OrderCloseVerification) (domain.OrderCloseVerification, error) {
+	return p.store.CreateOrderCloseVerification(v)
+}
+
 func (p *Platform) ListLiveTradePairs(query domain.LiveTradePairQuery) ([]domain.LiveTradePair, error) {
 	startTime := time.Now()
 	liveSessionID := strings.TrimSpace(query.LiveSessionID)

--- a/internal/service/strategy.go
+++ b/internal/service/strategy.go
@@ -289,7 +289,9 @@ func (p *Platform) ListStrategySignalBindings(strategyID string) ([]domain.Accou
 	return items, nil
 }
 
-// --- 账户管理服务方法 ---
+func (p *Platform) GetLiveSession(sessionID string) (domain.LiveSession, error) {
+	return p.store.GetLiveSession(sessionID)
+}
 
 // ListAccounts 获取所有账户列表。
 func (p *Platform) ListAccounts() ([]domain.Account, error) {

--- a/web/console/src/components/layout/DockContent.tsx
+++ b/web/console/src/components/layout/DockContent.tsx
@@ -33,7 +33,7 @@ import {
   DialogFooter,
   DialogClose
 } from '../ui/dialog';
-import { Textarea } from '../ui/textarea';
+import { ManualTradeReviewDialog } from '../live/ManualTradeReviewDialog';
 import { toast } from 'sonner';
 
 import { cn } from '../../lib/utils';
@@ -319,42 +319,7 @@ export function DockContent({ dockTab, actions, sessionId }: DockContentProps) {
     200
   );
 
-  // Manual Review State
   const [selectedPairForReview, setSelectedPairForReview] = useState<any | null>(null);
-  const [reviewNotes, setReviewNotes] = useState("人工审核对账完毕，确认无持仓。");
-  const [isVerifying, setIsVerifying] = useState(false);
-
-  const handleManualVerify = async () => {
-    if (!selectedPairForReview || !sessionId) return;
-    
-    const lastOrderId = selectedPairForReview.exitOrderIds?.[selectedPairForReview.exitOrderIds.length - 1];
-    if (!lastOrderId) {
-      toast.error("找不到有效的出场订单 ID，无法核验");
-      return;
-    }
-
-    setIsVerifying(true);
-    try {
-      const resp = await fetch(`/api/v1/live/sessions/${sessionId}/orders/${lastOrderId}/verifications`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ notes: reviewNotes })
-      });
-
-      if (!resp.ok) {
-        const err = await resp.text();
-        throw new Error(err || "请求失败");
-      }
-
-      toast.success("复核成功");
-      setSelectedPairForReview(null);
-      refetchPairs?.();
-    } catch (err: any) {
-      toast.error(`复核失败: ${err.message}`);
-    } finally {
-      setIsVerifying(false);
-    }
-  };
 
   // Pagination & Sorting State
   const [pages, setPages] = useState({ pairs: 1, orders: 1, positions: 1, fills: 1, alerts: 1 });
@@ -424,16 +389,17 @@ export function DockContent({ dockTab, actions, sessionId }: DockContentProps) {
                         className={cn(
                           'text-[10px] font-black', 
                           tradePairVerdictTone(pair.exitVerdict),
-                          String(pair.exitVerdict).toLowerCase() === 'mismatch' && "cursor-pointer hover:underline flex items-center gap-1"
+                          (String(pair.exitVerdict).toLowerCase() === 'mismatch' || String(pair.exitVerdict).toLowerCase() === 'orphan-exit') && "cursor-pointer hover:underline flex items-center gap-1"
                         )}
                         onClick={() => {
-                          if (String(pair.exitVerdict).toLowerCase() === 'mismatch') {
+                          const v = String(pair.exitVerdict).toLowerCase();
+                          if (v === 'mismatch' || v === 'orphan-exit') {
                             setSelectedPairForReview(pair);
                           }
                         }}
                       >
                         {tradePairVerdictLabel(pair.exitVerdict)}
-                        {String(pair.exitVerdict).toLowerCase() === 'mismatch' && <AlertCircle size={10} />}
+                        {(String(pair.exitVerdict).toLowerCase() === 'mismatch' || String(pair.exitVerdict).toLowerCase() === 'orphan-exit') && <AlertCircle size={10} />}
                       </div>
                     </div>,
                     <div key={`${pair.id}-side`} className="space-y-1">
@@ -631,75 +597,12 @@ export function DockContent({ dockTab, actions, sessionId }: DockContentProps) {
         onPageSizeChange={handlePageSizeChange}
       />
 
-      {/* Manual Review Dialog */}
-      <Dialog open={!!selectedPairForReview} onOpenChange={(open) => !open && setSelectedPairForReview(null)}>
-        <DialogContent tone="bento" className="max-w-md rounded-[32px] border-[var(--bk-border)] bg-[var(--bk-surface-overlay-strong)] p-0 overflow-hidden shadow-2xl">
-          <div className="bg-[var(--bk-surface-muted)]/30 px-6 py-5 border-b border-[var(--bk-border-soft)]">
-            <DialogHeader>
-              <div className="flex items-center gap-3 mb-1">
-                <div className="flex size-8 items-center justify-center rounded-xl bg-amber-500/10 text-amber-500">
-                  <CheckCircle2 size={18} />
-                </div>
-                <DialogTitle className="text-lg font-black text-[var(--bk-text-primary)]">人工复核平仓异常</DialogTitle>
-              </div>
-              <DialogDescription className="text-[11px] font-medium text-[var(--bk-text-muted)]">
-                您正在手动标记一笔交易为“已核验”。请确保交易所内该币种已无实际持仓。
-              </DialogDescription>
-            </DialogHeader>
-          </div>
-
-          <div className="p-6 space-y-4">
-            {selectedPairForReview && (
-              <div className="rounded-2xl border border-[var(--bk-border-soft)] bg-[var(--bk-surface-faint)]/50 p-4 space-y-2">
-                <div className="flex justify-between text-[11px]">
-                  <span className="font-bold text-[var(--bk-text-muted)]">交易对</span>
-                  <span className="font-black text-[var(--bk-text-primary)]">{selectedPairForReview.symbol} {selectedPairForReview.side}</span>
-                </div>
-                <div className="flex justify-between text-[11px]">
-                  <span className="font-bold text-[var(--bk-text-muted)]">开仓时间</span>
-                  <span className="font-mono text-[var(--bk-text-primary)]">{formatTime(selectedPairForReview.entryAt)}</span>
-                </div>
-                <div className="flex justify-between text-[11px]">
-                  <span className="font-bold text-[var(--bk-text-muted)]">成交数量</span>
-                  <span className="font-mono font-black text-[var(--bk-text-primary)]">{selectedPairForReview.entryQuantity}</span>
-                </div>
-              </div>
-            )}
-
-            <div className="space-y-2">
-              <label className="text-[10px] font-black uppercase tracking-wider text-[var(--bk-text-muted)] opacity-70">复核备注</label>
-              <Textarea 
-                className="min-h-[80px] rounded-2xl text-[12px] font-medium resize-none"
-                placeholder="请输入核验说明..."
-                value={reviewNotes}
-                onChange={(e) => setReviewNotes(e.target.value)}
-              />
-            </div>
-          </div>
-
-          <DialogFooter className="bg-[var(--bk-surface-muted)]/30 px-6 py-4 border-t border-[var(--bk-border-soft)] flex items-center justify-end gap-3">
-            <DialogClose
-              render={
-                <Button variant="ghost" className="h-10 rounded-xl px-4 text-[12px] font-black" />
-              }
-            >
-              取消
-            </DialogClose>
-            <Button 
-              disabled={isVerifying}
-              onClick={handleManualVerify}
-              className="h-10 rounded-xl px-6 bg-[var(--bk-status-success)] hover:bg-[var(--bk-status-success)]/90 text-white text-[12px] font-black shadow-lg shadow-emerald-500/20"
-            >
-              {isVerifying ? (
-                <>
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                  提交中...
-                </>
-              ) : "确认无持仓并平账"}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      <ManualTradeReviewDialog 
+        pair={selectedPairForReview}
+        sessionId={sessionId}
+        onClose={() => setSelectedPairForReview(null)}
+        onSuccess={() => refetchPairs?.()}
+      />
     </div>
   );
 }

--- a/web/console/src/components/layout/DockContent.tsx
+++ b/web/console/src/components/layout/DockContent.tsx
@@ -23,7 +23,18 @@ import { technicalStatusLabel } from '../../utils/derivation';
 import { useTradingStore } from '../../store/useTradingStore';
 import { useUIStore } from '../../store/useUIStore';
 import { useLiveTradePairs } from '../../hooks/useLiveTradePairs';
-import { ShieldCheck, Loader2, ChevronLeft, ChevronRight, ArrowRightLeft, Activity } from 'lucide-react';
+import { ShieldCheck, Loader2, ChevronLeft, ChevronRight, ArrowRightLeft, Activity, CheckCircle2, AlertCircle } from 'lucide-react';
+import { 
+  Dialog, 
+  DialogContent, 
+  DialogHeader, 
+  DialogTitle, 
+  DialogDescription, 
+  DialogFooter,
+  DialogClose
+} from '../ui/dialog';
+import { Textarea } from '../ui/textarea';
+import { toast } from 'sonner';
 
 import { cn } from '../../lib/utils';
 
@@ -303,10 +314,47 @@ export function DockContent({ dockTab, actions, sessionId }: DockContentProps) {
   const positionCloseAction = useUIStore(s => s.positionCloseAction);
   const liveSyncAction = useUIStore(s => s.liveSyncAction);
   const openConfirmDialog = useUIStore(s => s.openConfirmDialog);
-  const { pairs, loading: pairsLoading, error: pairsError } = useLiveTradePairs(
+  const { pairs, loading: pairsLoading, error: pairsError, refetch: refetchPairs } = useLiveTradePairs(
     dockTab === 'pairs' ? (sessionId ?? null) : null, 
     200
   );
+
+  // Manual Review State
+  const [selectedPairForReview, setSelectedPairForReview] = useState<any | null>(null);
+  const [reviewNotes, setReviewNotes] = useState("人工审核对账完毕，确认无持仓。");
+  const [isVerifying, setIsVerifying] = useState(false);
+
+  const handleManualVerify = async () => {
+    if (!selectedPairForReview || !sessionId) return;
+    
+    const lastOrderId = selectedPairForReview.exitOrderIds?.[selectedPairForReview.exitOrderIds.length - 1];
+    if (!lastOrderId) {
+      toast.error("找不到有效的出场订单 ID，无法核验");
+      return;
+    }
+
+    setIsVerifying(true);
+    try {
+      const resp = await fetch(`/api/v1/live/sessions/${sessionId}/orders/${lastOrderId}/verifications`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ notes: reviewNotes })
+      });
+
+      if (!resp.ok) {
+        const err = await resp.text();
+        throw new Error(err || "请求失败");
+      }
+
+      toast.success("复核成功");
+      setSelectedPairForReview(null);
+      refetchPairs?.();
+    } catch (err: any) {
+      toast.error(`复核失败: ${err.message}`);
+    } finally {
+      setIsVerifying(false);
+    }
+  };
 
   // Pagination & Sorting State
   const [pages, setPages] = useState({ pairs: 1, orders: 1, positions: 1, fills: 1, alerts: 1 });
@@ -372,8 +420,20 @@ export function DockContent({ dockTab, actions, sessionId }: DockContentProps) {
                       <Badge variant={String(pair.status).toLowerCase() === 'open' ? 'neutral' : 'success'}>
                         {tradePairStatusLabel(pair.status)}
                       </Badge>
-                      <div className={cn('text-[10px] font-black', tradePairVerdictTone(pair.exitVerdict))}>
+                      <div 
+                        className={cn(
+                          'text-[10px] font-black', 
+                          tradePairVerdictTone(pair.exitVerdict),
+                          String(pair.exitVerdict).toLowerCase() === 'mismatch' && "cursor-pointer hover:underline flex items-center gap-1"
+                        )}
+                        onClick={() => {
+                          if (String(pair.exitVerdict).toLowerCase() === 'mismatch') {
+                            setSelectedPairForReview(pair);
+                          }
+                        }}
+                      >
                         {tradePairVerdictLabel(pair.exitVerdict)}
+                        {String(pair.exitVerdict).toLowerCase() === 'mismatch' && <AlertCircle size={10} />}
                       </div>
                     </div>,
                     <div key={`${pair.id}-side`} className="space-y-1">
@@ -570,6 +630,76 @@ export function DockContent({ dockTab, actions, sessionId }: DockContentProps) {
         onPageChange={handlePageChange}
         onPageSizeChange={handlePageSizeChange}
       />
+
+      {/* Manual Review Dialog */}
+      <Dialog open={!!selectedPairForReview} onOpenChange={(open) => !open && setSelectedPairForReview(null)}>
+        <DialogContent tone="bento" className="max-w-md rounded-[32px] border-[var(--bk-border)] bg-[var(--bk-surface-overlay-strong)] p-0 overflow-hidden shadow-2xl">
+          <div className="bg-[var(--bk-surface-muted)]/30 px-6 py-5 border-b border-[var(--bk-border-soft)]">
+            <DialogHeader>
+              <div className="flex items-center gap-3 mb-1">
+                <div className="flex size-8 items-center justify-center rounded-xl bg-amber-500/10 text-amber-500">
+                  <CheckCircle2 size={18} />
+                </div>
+                <DialogTitle className="text-lg font-black text-[var(--bk-text-primary)]">人工复核平仓异常</DialogTitle>
+              </div>
+              <DialogDescription className="text-[11px] font-medium text-[var(--bk-text-muted)]">
+                您正在手动标记一笔交易为“已核验”。请确保交易所内该币种已无实际持仓。
+              </DialogDescription>
+            </DialogHeader>
+          </div>
+
+          <div className="p-6 space-y-4">
+            {selectedPairForReview && (
+              <div className="rounded-2xl border border-[var(--bk-border-soft)] bg-[var(--bk-surface-faint)]/50 p-4 space-y-2">
+                <div className="flex justify-between text-[11px]">
+                  <span className="font-bold text-[var(--bk-text-muted)]">交易对</span>
+                  <span className="font-black text-[var(--bk-text-primary)]">{selectedPairForReview.symbol} {selectedPairForReview.side}</span>
+                </div>
+                <div className="flex justify-between text-[11px]">
+                  <span className="font-bold text-[var(--bk-text-muted)]">开仓时间</span>
+                  <span className="font-mono text-[var(--bk-text-primary)]">{formatTime(selectedPairForReview.entryAt)}</span>
+                </div>
+                <div className="flex justify-between text-[11px]">
+                  <span className="font-bold text-[var(--bk-text-muted)]">成交数量</span>
+                  <span className="font-mono font-black text-[var(--bk-text-primary)]">{selectedPairForReview.entryQuantity}</span>
+                </div>
+              </div>
+            )}
+
+            <div className="space-y-2">
+              <label className="text-[10px] font-black uppercase tracking-wider text-[var(--bk-text-muted)] opacity-70">复核备注</label>
+              <Textarea 
+                className="min-h-[80px] rounded-2xl text-[12px] font-medium resize-none"
+                placeholder="请输入核验说明..."
+                value={reviewNotes}
+                onChange={(e) => setReviewNotes(e.target.value)}
+              />
+            </div>
+          </div>
+
+          <DialogFooter className="bg-[var(--bk-surface-muted)]/30 px-6 py-4 border-t border-[var(--bk-border-soft)] flex items-center justify-end gap-3">
+            <DialogClose
+              render={
+                <Button variant="ghost" className="h-10 rounded-xl px-4 text-[12px] font-black" />
+              }
+            >
+              取消
+            </DialogClose>
+            <Button 
+              disabled={isVerifying}
+              onClick={handleManualVerify}
+              className="h-10 rounded-xl px-6 bg-[var(--bk-status-success)] hover:bg-[var(--bk-status-success)]/90 text-white text-[12px] font-black shadow-lg shadow-emerald-500/20"
+            >
+              {isVerifying ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  提交中...
+                </>
+              ) : "确认无持仓并平账"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/web/console/src/components/live/LiveTradePairsCard.tsx
+++ b/web/console/src/components/live/LiveTradePairsCard.tsx
@@ -1,8 +1,20 @@
-import React from 'react';
-import { ArrowRightLeft, Activity } from 'lucide-react';
+import * as React from 'react';
+import { ArrowRightLeft, Activity, CheckCircle2, AlertCircle, Loader2 } from 'lucide-react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../ui/card';
 import { Badge } from '../ui/badge';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../ui/table';
+import { 
+  Dialog, 
+  DialogContent, 
+  DialogHeader, 
+  DialogTitle, 
+  DialogDescription, 
+  DialogFooter,
+  DialogClose
+} from '../ui/dialog';
+import { Textarea } from '../ui/textarea';
+import { Button } from '../ui/button';
+import { toast } from 'sonner';
 import { LiveTradePair } from '../../types/domain';
 import { formatMaybeNumber, formatSigned, formatTime, shrink } from '../../utils/format';
 import { cn } from '../../lib/utils';
@@ -13,6 +25,8 @@ type LiveTradePairsCardProps = {
   pairs: LiveTradePair[];
   loading: boolean;
   error: string | null;
+  sessionId?: string | null;
+  onRefresh?: () => void;
   className?: string;
 };
 
@@ -55,8 +69,47 @@ export function LiveTradePairsCard({
   pairs,
   loading,
   error,
+  sessionId,
+  onRefresh,
   className,
 }: LiveTradePairsCardProps) {
+  // Manual Review State
+  const [selectedPairForReview, setSelectedPairForReview] = React.useState<any | null>(null);
+  const [reviewNotes, setReviewNotes] = React.useState("人工审核对账完毕，确认无持仓。");
+  const [isVerifying, setIsVerifying] = React.useState(false);
+
+  const handleManualVerify = async () => {
+    if (!selectedPairForReview || !sessionId) return;
+    
+    const lastOrderId = selectedPairForReview.exitOrderIds?.[selectedPairForReview.exitOrderIds.length - 1];
+    if (!lastOrderId) {
+      toast.error("找不到有效的出场订单 ID，无法核验");
+      return;
+    }
+
+    setIsVerifying(true);
+    try {
+      const resp = await fetch(`/api/v1/live/sessions/${sessionId}/orders/${lastOrderId}/verifications`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ notes: reviewNotes })
+      });
+
+      if (!resp.ok) {
+        const err = await resp.text();
+        throw new Error(err || "请求失败");
+      }
+
+      toast.success("复核成功");
+      setSelectedPairForReview(null);
+      onRefresh?.();
+    } catch (err: any) {
+      toast.error(`复核失败: ${err.message}`);
+    } finally {
+      setIsVerifying(false);
+    }
+  };
+
   return (
     <Card tone="bento" className={cn('rounded-[24px] shadow-[var(--bk-shadow-card)]', className)}>
       <CardHeader className="pb-4">
@@ -112,8 +165,20 @@ export function LiveTradePairsCard({
                           <Badge variant={String(pair.status).toLowerCase() === 'open' ? 'neutral' : 'success'}>
                             {tradePairStatusLabel(pair.status)}
                           </Badge>
-                          <div className={cn('text-[10px] font-black', tradePairVerdictTone(pair.exitVerdict))}>
+                          <div 
+                            className={cn(
+                              'text-[10px] font-black', 
+                              tradePairVerdictTone(pair.exitVerdict),
+                              String(pair.exitVerdict).toLowerCase() === 'mismatch' && "cursor-pointer hover:underline flex items-center gap-1"
+                            )}
+                            onClick={() => {
+                              if (String(pair.exitVerdict).toLowerCase() === 'mismatch') {
+                                setSelectedPairForReview(pair);
+                              }
+                            }}
+                          >
                             {tradePairVerdictLabel(pair.exitVerdict)}
+                            {String(pair.exitVerdict).toLowerCase() === 'mismatch' && <AlertCircle size={10} />}
                           </div>
                         </div>
                       </TableCell>
@@ -202,6 +267,76 @@ export function LiveTradePairsCard({
           </div>
         )}
       </CardContent>
+
+      {/* Manual Review Dialog */}
+      <Dialog open={!!selectedPairForReview} onOpenChange={(open) => !open && setSelectedPairForReview(null)}>
+        <DialogContent tone="bento" className="max-w-md rounded-[32px] border-[var(--bk-border)] bg-[var(--bk-surface-overlay-strong)] p-0 overflow-hidden shadow-2xl">
+          <div className="bg-[var(--bk-surface-muted)]/30 px-6 py-5 border-b border-[var(--bk-border-soft)]">
+            <DialogHeader>
+              <div className="flex items-center gap-3 mb-1">
+                <div className="flex size-8 items-center justify-center rounded-xl bg-amber-500/10 text-amber-500">
+                  <CheckCircle2 size={18} />
+                </div>
+                <DialogTitle className="text-lg font-black text-[var(--bk-text-primary)]">人工复核平仓异常</DialogTitle>
+              </div>
+              <DialogDescription className="text-[11px] font-medium text-[var(--bk-text-muted)]">
+                您正在手动标记一笔交易为“已核验”。请确保交易所内该币种已无实际持仓。
+              </DialogDescription>
+            </DialogHeader>
+          </div>
+
+          <div className="p-6 space-y-4">
+            {selectedPairForReview && (
+              <div className="rounded-2xl border border-[var(--bk-border-soft)] bg-[var(--bk-surface-faint)]/50 p-4 space-y-2">
+                <div className="flex justify-between text-[11px]">
+                  <span className="font-bold text-[var(--bk-text-muted)]">交易对</span>
+                  <span className="font-black text-[var(--bk-text-primary)]">{selectedPairForReview.symbol} {selectedPairForReview.side}</span>
+                </div>
+                <div className="flex justify-between text-[11px]">
+                  <span className="font-bold text-[var(--bk-text-muted)]">开仓时间</span>
+                  <span className="font-mono text-[var(--bk-text-primary)]">{formatTime(selectedPairForReview.entryAt)}</span>
+                </div>
+                <div className="flex justify-between text-[11px]">
+                  <span className="font-bold text-[var(--bk-text-muted)]">成交数量</span>
+                  <span className="font-mono font-black text-[var(--bk-text-primary)]">{selectedPairForReview.entryQuantity}</span>
+                </div>
+              </div>
+            )}
+
+            <div className="space-y-2">
+              <label className="text-[10px] font-black uppercase tracking-wider text-[var(--bk-text-muted)] opacity-70">复核备注</label>
+              <Textarea 
+                className="min-h-[80px] rounded-2xl text-[12px] font-medium resize-none"
+                placeholder="请输入核验说明..."
+                value={reviewNotes}
+                onChange={(e) => setReviewNotes(e.target.value)}
+              />
+            </div>
+          </div>
+
+          <DialogFooter className="bg-[var(--bk-surface-muted)]/30 px-6 py-4 border-t border-[var(--bk-border-soft)] flex items-center justify-end gap-3">
+            <DialogClose
+              render={
+                <Button variant="ghost" className="h-10 rounded-xl px-4 text-[12px] font-black" />
+              }
+            >
+              取消
+            </DialogClose>
+            <Button 
+              disabled={isVerifying}
+              onClick={handleManualVerify}
+              className="h-10 rounded-xl px-6 bg-[var(--bk-status-success)] hover:bg-[var(--bk-status-success)]/90 text-white text-[12px] font-black shadow-lg shadow-emerald-500/20"
+            >
+              {isVerifying ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  提交中...
+                </>
+              ) : "确认无持仓并平账"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </Card>
   );
 }

--- a/web/console/src/components/live/LiveTradePairsCard.tsx
+++ b/web/console/src/components/live/LiveTradePairsCard.tsx
@@ -12,8 +12,7 @@ import {
   DialogFooter,
   DialogClose
 } from '../ui/dialog';
-import { Textarea } from '../ui/textarea';
-import { Button } from '../ui/button';
+import { ManualTradeReviewDialog } from './ManualTradeReviewDialog';
 import { toast } from 'sonner';
 import { LiveTradePair } from '../../types/domain';
 import { formatMaybeNumber, formatSigned, formatTime, shrink } from '../../utils/format';
@@ -73,42 +72,7 @@ export function LiveTradePairsCard({
   onRefresh,
   className,
 }: LiveTradePairsCardProps) {
-  // Manual Review State
-  const [selectedPairForReview, setSelectedPairForReview] = React.useState<any | null>(null);
-  const [reviewNotes, setReviewNotes] = React.useState("人工审核对账完毕，确认无持仓。");
-  const [isVerifying, setIsVerifying] = React.useState(false);
-
-  const handleManualVerify = async () => {
-    if (!selectedPairForReview || !sessionId) return;
-    
-    const lastOrderId = selectedPairForReview.exitOrderIds?.[selectedPairForReview.exitOrderIds.length - 1];
-    if (!lastOrderId) {
-      toast.error("找不到有效的出场订单 ID，无法核验");
-      return;
-    }
-
-    setIsVerifying(true);
-    try {
-      const resp = await fetch(`/api/v1/live/sessions/${sessionId}/orders/${lastOrderId}/verifications`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ notes: reviewNotes })
-      });
-
-      if (!resp.ok) {
-        const err = await resp.text();
-        throw new Error(err || "请求失败");
-      }
-
-      toast.success("复核成功");
-      setSelectedPairForReview(null);
-      onRefresh?.();
-    } catch (err: any) {
-      toast.error(`复核失败: ${err.message}`);
-    } finally {
-      setIsVerifying(false);
-    }
-  };
+  const [selectedPairForReview, setSelectedPairForReview] = React.useState<LiveTradePair | null>(null);
 
   return (
     <Card tone="bento" className={cn('rounded-[24px] shadow-[var(--bk-shadow-card)]', className)}>
@@ -169,16 +133,17 @@ export function LiveTradePairsCard({
                             className={cn(
                               'text-[10px] font-black', 
                               tradePairVerdictTone(pair.exitVerdict),
-                              String(pair.exitVerdict).toLowerCase() === 'mismatch' && "cursor-pointer hover:underline flex items-center gap-1"
+                              (String(pair.exitVerdict).toLowerCase() === 'mismatch' || String(pair.exitVerdict).toLowerCase() === 'orphan-exit') && "cursor-pointer hover:underline flex items-center gap-1"
                             )}
                             onClick={() => {
-                              if (String(pair.exitVerdict).toLowerCase() === 'mismatch') {
+                              const v = String(pair.exitVerdict).toLowerCase();
+                              if (v === 'mismatch' || v === 'orphan-exit') {
                                 setSelectedPairForReview(pair);
                               }
                             }}
                           >
                             {tradePairVerdictLabel(pair.exitVerdict)}
-                            {String(pair.exitVerdict).toLowerCase() === 'mismatch' && <AlertCircle size={10} />}
+                            {(String(pair.exitVerdict).toLowerCase() === 'mismatch' || String(pair.exitVerdict).toLowerCase() === 'orphan-exit') && <AlertCircle size={10} />}
                           </div>
                         </div>
                       </TableCell>
@@ -268,75 +233,12 @@ export function LiveTradePairsCard({
         )}
       </CardContent>
 
-      {/* Manual Review Dialog */}
-      <Dialog open={!!selectedPairForReview} onOpenChange={(open) => !open && setSelectedPairForReview(null)}>
-        <DialogContent tone="bento" className="max-w-md rounded-[32px] border-[var(--bk-border)] bg-[var(--bk-surface-overlay-strong)] p-0 overflow-hidden shadow-2xl">
-          <div className="bg-[var(--bk-surface-muted)]/30 px-6 py-5 border-b border-[var(--bk-border-soft)]">
-            <DialogHeader>
-              <div className="flex items-center gap-3 mb-1">
-                <div className="flex size-8 items-center justify-center rounded-xl bg-amber-500/10 text-amber-500">
-                  <CheckCircle2 size={18} />
-                </div>
-                <DialogTitle className="text-lg font-black text-[var(--bk-text-primary)]">人工复核平仓异常</DialogTitle>
-              </div>
-              <DialogDescription className="text-[11px] font-medium text-[var(--bk-text-muted)]">
-                您正在手动标记一笔交易为“已核验”。请确保交易所内该币种已无实际持仓。
-              </DialogDescription>
-            </DialogHeader>
-          </div>
-
-          <div className="p-6 space-y-4">
-            {selectedPairForReview && (
-              <div className="rounded-2xl border border-[var(--bk-border-soft)] bg-[var(--bk-surface-faint)]/50 p-4 space-y-2">
-                <div className="flex justify-between text-[11px]">
-                  <span className="font-bold text-[var(--bk-text-muted)]">交易对</span>
-                  <span className="font-black text-[var(--bk-text-primary)]">{selectedPairForReview.symbol} {selectedPairForReview.side}</span>
-                </div>
-                <div className="flex justify-between text-[11px]">
-                  <span className="font-bold text-[var(--bk-text-muted)]">开仓时间</span>
-                  <span className="font-mono text-[var(--bk-text-primary)]">{formatTime(selectedPairForReview.entryAt)}</span>
-                </div>
-                <div className="flex justify-between text-[11px]">
-                  <span className="font-bold text-[var(--bk-text-muted)]">成交数量</span>
-                  <span className="font-mono font-black text-[var(--bk-text-primary)]">{selectedPairForReview.entryQuantity}</span>
-                </div>
-              </div>
-            )}
-
-            <div className="space-y-2">
-              <label className="text-[10px] font-black uppercase tracking-wider text-[var(--bk-text-muted)] opacity-70">复核备注</label>
-              <Textarea 
-                className="min-h-[80px] rounded-2xl text-[12px] font-medium resize-none"
-                placeholder="请输入核验说明..."
-                value={reviewNotes}
-                onChange={(e) => setReviewNotes(e.target.value)}
-              />
-            </div>
-          </div>
-
-          <DialogFooter className="bg-[var(--bk-surface-muted)]/30 px-6 py-4 border-t border-[var(--bk-border-soft)] flex items-center justify-end gap-3">
-            <DialogClose
-              render={
-                <Button variant="ghost" className="h-10 rounded-xl px-4 text-[12px] font-black" />
-              }
-            >
-              取消
-            </DialogClose>
-            <Button 
-              disabled={isVerifying}
-              onClick={handleManualVerify}
-              className="h-10 rounded-xl px-6 bg-[var(--bk-status-success)] hover:bg-[var(--bk-status-success)]/90 text-white text-[12px] font-black shadow-lg shadow-emerald-500/20"
-            >
-              {isVerifying ? (
-                <>
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                  提交中...
-                </>
-              ) : "确认无持仓并平账"}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      <ManualTradeReviewDialog 
+        pair={selectedPairForReview}
+        sessionId={sessionId}
+        onClose={() => setSelectedPairForReview(null)}
+        onSuccess={() => onRefresh?.()}
+      />
     </Card>
   );
 }

--- a/web/console/src/components/live/ManualTradeReviewDialog.tsx
+++ b/web/console/src/components/live/ManualTradeReviewDialog.tsx
@@ -1,0 +1,139 @@
+import * as React from 'react';
+import { CheckCircle2, Loader2 } from 'lucide-react';
+import { 
+  Dialog, 
+  DialogContent, 
+  DialogHeader, 
+  DialogTitle, 
+  DialogDescription, 
+  DialogFooter,
+  DialogClose
+} from '../ui/dialog';
+import { Textarea } from '../ui/textarea';
+import { Button } from '../ui/button';
+import { toast } from 'sonner';
+import { LiveTradePair } from '../../types/domain';
+import { formatTime } from '../../utils/format';
+
+interface ManualTradeReviewDialogProps {
+  pair: LiveTradePair | null;
+  sessionId: string | null | undefined;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+export function ManualTradeReviewDialog({ pair, sessionId, onClose, onSuccess }: ManualTradeReviewDialogProps) {
+  const [reviewNotes, setReviewNotes] = React.useState("人工审核对账完毕，确认无持仓。");
+  const [isVerifying, setIsVerifying] = React.useState(false);
+
+  // Reset notes when pair changes
+  React.useEffect(() => {
+    if (pair) {
+      setReviewNotes("人工审核对账完毕，确认无持仓。");
+    }
+  }, [pair]);
+
+  const handleManualVerify = async () => {
+    if (!pair || !sessionId) return;
+    
+    const lastOrderId = pair.exitOrderIds?.[pair.exitOrderIds.length - 1];
+    if (!lastOrderId) {
+      toast.error("找不到有效的出场订单 ID，无法核验");
+      return;
+    }
+
+    setIsVerifying(true);
+    try {
+      const resp = await fetch(`/api/v1/live/sessions/${sessionId}/orders/${lastOrderId}/verifications`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ notes: reviewNotes })
+      });
+
+      if (!resp.ok) {
+        const err = await resp.text();
+        throw new Error(err || "请求失败");
+      }
+
+      toast.success("复核成功，订单状态已同步");
+      onSuccess();
+      onClose();
+    } catch (err) {
+      console.error('Manual verification failed', err);
+      toast.error(err instanceof Error ? err.message : "核验提交失败");
+    } finally {
+      setIsVerifying(false);
+    }
+  };
+
+  return (
+    <Dialog open={!!pair} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent tone="bento" className="max-w-md rounded-[32px] border-[var(--bk-border)] bg-[var(--bk-surface-overlay-strong)] p-0 overflow-hidden shadow-2xl">
+        <div className="bg-[var(--bk-surface-muted)]/30 px-6 py-5 border-b border-[var(--bk-border-soft)]">
+          <DialogHeader>
+            <div className="flex items-center gap-3 mb-1">
+              <div className="flex size-8 items-center justify-center rounded-xl bg-amber-500/10 text-amber-500">
+                <CheckCircle2 size={18} />
+              </div>
+              <DialogTitle className="text-lg font-black text-[var(--bk-text-primary)]">人工复核平仓异常</DialogTitle>
+            </div>
+            <DialogDescription className="text-[11px] font-medium text-[var(--bk-text-muted)]">
+              您正在手动标记一笔交易为“已核验”。请确保交易所内该币种已无实际持仓。
+            </DialogDescription>
+          </DialogHeader>
+        </div>
+
+        <div className="p-6 space-y-4">
+          {pair && (
+            <div className="rounded-2xl border border-[var(--bk-border-soft)] bg-[var(--bk-surface-faint)]/50 p-4 space-y-2">
+              <div className="flex justify-between text-[11px]">
+                <span className="font-bold text-[var(--bk-text-muted)]">交易对</span>
+                <span className="font-black text-[var(--bk-text-primary)]">{pair.symbol} {pair.side}</span>
+              </div>
+              <div className="flex justify-between text-[11px]">
+                <span className="font-bold text-[var(--bk-text-muted)]">开仓时间</span>
+                <span className="font-mono text-[var(--bk-text-primary)]">{formatTime(pair.entryAt)}</span>
+              </div>
+              <div className="flex justify-between text-[11px]">
+                <span className="font-bold text-[var(--bk-text-muted)]">成交数量</span>
+                <span className="font-mono font-black text-[var(--bk-text-primary)]">{pair.entryQuantity}</span>
+              </div>
+            </div>
+          )}
+
+          <div className="space-y-2">
+            <label className="text-[10px] font-black uppercase tracking-wider text-[var(--bk-text-muted)] opacity-70">复核备注</label>
+            <Textarea 
+              className="min-h-[80px] rounded-2xl text-[12px] font-medium resize-none"
+              placeholder="请输入核验说明..."
+              value={reviewNotes}
+              onChange={(e) => setReviewNotes(e.target.value)}
+            />
+          </div>
+        </div>
+
+        <DialogFooter className="bg-[var(--bk-surface-muted)]/30 px-6 py-4 border-t border-[var(--bk-border-soft)] flex items-center justify-end gap-3">
+          <DialogClose
+            render={
+              <Button variant="ghost" className="h-10 rounded-xl px-4 text-[12px] font-black" />
+            }
+          >
+            取消
+          </DialogClose>
+          <Button 
+            disabled={isVerifying}
+            onClick={handleManualVerify}
+            className="h-10 rounded-xl px-6 bg-[var(--bk-status-success)] hover:bg-[var(--bk-status-success)]/90 text-white text-[12px] font-black shadow-lg shadow-emerald-500/20"
+          >
+            {isVerifying ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                提交中...
+              </>
+            ) : "确认无持仓并平账"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/console/src/hooks/useLiveTradePairs.ts
+++ b/web/console/src/hooks/useLiveTradePairs.ts
@@ -7,43 +7,34 @@ export function useLiveTradePairs(sessionId: string | null, limit = 8) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
+  const fetchData = () => {
     if (!sessionId) {
       setPairs([]);
       setLoading(false);
       setError(null);
       return;
     }
-    let active = true;
     setLoading(true);
     setError(null);
     fetchJSON<LiveTradePair[]>(
       `/api/v1/live/sessions/${encodeURIComponent(sessionId)}/trade-pairs?limit=${limit}`
     )
       .then((items) => {
-        if (!active) {
-          return;
-        }
         setPairs(Array.isArray(items) ? items : []);
       })
       .catch((err) => {
-        if (!active) {
-          return;
-        }
         console.warn('Failed to load live trade pairs', err);
         setPairs([]);
         setError(err instanceof Error ? err.message : '加载失败');
       })
       .finally(() => {
-        if (active) {
-          setLoading(false);
-        }
+        setLoading(false);
       });
+  };
 
-    return () => {
-      active = false;
-    };
+  useEffect(() => {
+    fetchData();
   }, [limit, sessionId]);
 
-  return { pairs, loading, error };
+  return { pairs, loading, error, refetch: fetchData };
 }

--- a/web/console/src/hooks/useLiveTradePairs.ts
+++ b/web/console/src/hooks/useLiveTradePairs.ts
@@ -7,34 +7,46 @@ export function useLiveTradePairs(sessionId: string | null, limit = 8) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const fetchData = () => {
+  const [refreshKey, setRefreshKey] = useState(0);
+
+  useEffect(() => {
+    let active = true;
+
     if (!sessionId) {
       setPairs([]);
       setLoading(false);
       setError(null);
       return;
     }
+
     setLoading(true);
     setError(null);
     fetchJSON<LiveTradePair[]>(
       `/api/v1/live/sessions/${encodeURIComponent(sessionId)}/trade-pairs?limit=${limit}`
     )
       .then((items) => {
+        if (!active) return;
         setPairs(Array.isArray(items) ? items : []);
       })
       .catch((err) => {
+        if (!active) return;
         console.warn('Failed to load live trade pairs', err);
         setPairs([]);
         setError(err instanceof Error ? err.message : '加载失败');
       })
       .finally(() => {
-        setLoading(false);
+        if (active) setLoading(false);
       });
+
+    return () => {
+      active = false;
+    };
+  }, [limit, sessionId, refreshKey]);
+
+  return { 
+    pairs, 
+    loading, 
+    error, 
+    refetch: () => setRefreshKey(prev => prev + 1) 
   };
-
-  useEffect(() => {
-    fetchData();
-  }, [limit, sessionId]);
-
-  return { pairs, loading, error, refetch: fetchData };
 }

--- a/web/console/src/pages/AccountStage.tsx
+++ b/web/console/src/pages/AccountStage.tsx
@@ -1099,6 +1099,8 @@ export function AccountStage({
           pairs={primaryTradePairs.pairs}
           loading={primaryTradePairs.loading}
           error={primaryTradePairs.error}
+          sessionId={primaryLiveSession?.id}
+          onRefresh={primaryTradePairs.refetch}
         />
       </div>
 


### PR DESCRIPTION
## 目的
实现实盘订单对追溯中的“需复核”手动对账功能。当系统判定出场订单存在 mismatch 或为 orphan-exit 时，用户可以通过 UI 弹窗手动确认平账并记录备注。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [x] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**

## AI Agent 参与声明
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
- [x] `dispatchMode` 默认值有否变化？(无变化)
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？(否)
- [x] DB migration 是否具备向下兼容幂等性？(不涉及)
- [x] 配置字段有没有无意被混改？(否)

## 验证方式与测试证据
- [x] 后端编译通过 (`go build ./cmd/platform-api`)
- [x] 前端通过 `tsc` 类型检查
- [x] 在 DockContent 和 LiveTradePairsCard 中均已绑定交互逻辑，提交后支持 refetch 自动刷新。