### PR TITLE
feat: audit pagination enhancement and trade review auth fix

### DIFF
--- a/web/console/src/components/live/ManualTradeReviewDialog.tsx
+++ b/web/console/src/components/live/ManualTradeReviewDialog.tsx
@@ -14,6 +14,7 @@ import { Button } from '../ui/button';
 import { toast } from 'sonner';
 import { LiveTradePair } from '../../types/domain';
 import { formatTime } from '../../utils/format';
+import { fetchJSON } from '../../utils/api';
 
 interface ManualTradeReviewDialogProps {
   pair: LiveTradePair | null;
@@ -44,16 +45,11 @@ export function ManualTradeReviewDialog({ pair, sessionId, onClose, onSuccess }:
 
     setIsVerifying(true);
     try {
-      const resp = await fetch(`/api/v1/live/sessions/${sessionId}/orders/${lastOrderId}/verifications`, {
+      await fetchJSON(`/api/v1/live/sessions/${sessionId}/orders/${lastOrderId}/verifications`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ notes: reviewNotes })
       });
-
-      if (!resp.ok) {
-        const err = await resp.text();
-        throw new Error(err || "请求失败");
-      }
 
       toast.success("复核成功，订单状态已同步");
       onSuccess();


### PR DESCRIPTION
## 目的
1. **审计面板增强**：在“事务审计与管理控制”中集成了“追溯 (Trade Pairs)”标签页，支持倒序排列、分页切换（每页 5/10/20/50/100 条）及页码跳转。
2. **鉴权错误修复**：修复了“人工复核平仓异常”弹窗中使用原生 `fetch` 导致 `authentication required` 的问题，统一改为 `fetchJSON` 并自动注入鉴权 Token。
3. **性能与一致性**：优化了 Session ID 派生逻辑，并设置获取上限为 200 条，确保跨页分页功能正常。
4. **规范更新**：在 `AGENTS.md` 中强化了静态类型检查的纪律，防止因滥用 `--skipLibCheck` 导致的类型隐患。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [x] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**

## AI Agent 参与声明
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了 (Antigravity 协助)

## 风险点 checklist
- [ ] `dispatchMode` 默认值有否变化？(无)
- [ ] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？(无)
- [ ] DB migration 是否具备向下兼容幂等性？(不涉及)
- [x] 配置字段有没有无意被混改？(已检查，无影响)

## 验证方式与测试证据
- 使用 `tsc` 进行静态类型校验 (`--moduleResolution Bundler`)，确保无类型错误。
- 本地验证审计面板分页切换正常。
- 验证人工复核接口请求头已包含 `Authorization`。
