### PR TITLE
feat(runtime): optimize tick trigger evaluation with 100ms throttle

### DIFF
--- a/internal/service/platform.go
+++ b/internal/service/platform.go
@@ -55,6 +55,7 @@ type Platform struct {
 	runtimePolicy          RuntimePolicy
 	telegramConfig         domain.TelegramConfig
 	telegramSentAlertCache sync.Map // notificationID -> alertTitle
+	tickEvalThrottle       sync.Map // runtimeSessionID -> *tickEvalThrottleState
 	logBroker              *logging.Broker
 }
 

--- a/internal/service/platform.go
+++ b/internal/service/platform.go
@@ -55,7 +55,7 @@ type Platform struct {
 	runtimePolicy          RuntimePolicy
 	telegramConfig         domain.TelegramConfig
 	telegramSentAlertCache sync.Map // notificationID -> alertTitle
-	tickEvalThrottle       sync.Map // runtimeSessionID -> *tickEvalThrottleState
+	tickEvalThrottle       sync.Map // runtimeSessionID or runtimeSessionID|symbol -> *tickEvalThrottleState
 	logBroker              *logging.Broker
 }
 

--- a/internal/service/signal_runtime_ws.go
+++ b/internal/service/signal_runtime_ws.go
@@ -353,7 +353,7 @@ func (p *Platform) setSessionTerminalError(sessionID string, err error) {
 		session.State = state
 		session.UpdatedAt = time.Now().UTC()
 	})
-	p.tickEvalThrottle.Delete(sessionID)
+	p.clearTickEvalThrottleSession(sessionID)
 }
 
 func (p *Platform) setSessionStopped(sessionID string) {
@@ -376,7 +376,7 @@ func (p *Platform) setSessionStopped(sessionID string) {
 		session.State = state
 		session.UpdatedAt = time.Now().UTC()
 	})
-	p.tickEvalThrottle.Delete(sessionID)
+	p.clearTickEvalThrottleSession(sessionID)
 }
 
 func configuredBinanceFuturesWSURL() string {
@@ -551,12 +551,7 @@ func (p *Platform) runExchangeWebsocketLoop(
 				if stringValue(state["lastDisconnectAt"]) != "" {
 					p.validateSignalBarContinuityAfterReconnect(state, summary)
 				}
-				if throttle, ok := p.tickEvalThrottle.Load(session.ID); ok {
-					ts := throttle.(*tickEvalThrottleState)
-					ts.mu.Lock()
-					state["tickEvalThrottledCount"] = ts.skippedCount
-					ts.mu.Unlock()
-				}
+				state["tickEvalThrottledCount"] = p.tickEvalThrottleSkippedCount(session.ID)
 				session.State = state
 				session.UpdatedAt = now
 			})
@@ -671,6 +666,47 @@ type tickEvalThrottleState struct {
 
 const minTickEvalInterval = 100 * time.Millisecond
 
+func tickEvalThrottleKey(runtimeSessionID string, targetSymbol string) string {
+	return runtimeSessionID + "|" + strings.TrimSpace(targetSymbol)
+}
+
+func (p *Platform) tickEvalThrottleSessionState(runtimeSessionID string) *tickEvalThrottleState {
+	val, _ := p.tickEvalThrottle.LoadOrStore(runtimeSessionID, &tickEvalThrottleState{})
+	return val.(*tickEvalThrottleState)
+}
+
+func (p *Platform) tickEvalThrottleSkippedCount(runtimeSessionID string) int64 {
+	val, ok := p.tickEvalThrottle.Load(runtimeSessionID)
+	if !ok {
+		return 0
+	}
+	state := val.(*tickEvalThrottleState)
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	return state.skippedCount
+}
+
+func (p *Platform) incrementTickEvalThrottleSkipped(runtimeSessionID string) {
+	state := p.tickEvalThrottleSessionState(runtimeSessionID)
+	state.mu.Lock()
+	state.skippedCount++
+	state.mu.Unlock()
+}
+
+func (p *Platform) clearTickEvalThrottleSession(runtimeSessionID string) {
+	prefix := runtimeSessionID + "|"
+	p.tickEvalThrottle.Range(func(key, _ any) bool {
+		keyStr, ok := key.(string)
+		if !ok {
+			return true
+		}
+		if keyStr == runtimeSessionID || strings.HasPrefix(keyStr, prefix) {
+			p.tickEvalThrottle.Delete(keyStr)
+		}
+		return true
+	})
+}
+
 func (p *Platform) shouldThrottleLiveEvaluation(runtimeSessionID string, summary map[string]any, eventTime time.Time, targetSymbol string) bool {
 	streamType := inferSignalRuntimeStreamType(summary)
 	if streamType != "trade_tick" {
@@ -681,12 +717,12 @@ func (p *Platform) shouldThrottleLiveEvaluation(runtimeSessionID string, summary
 	if price == "" {
 		return false
 	}
-
-	throttleKey := runtimeSessionID
-	if targetSymbol != "" {
-		throttleKey = runtimeSessionID + "|" + targetSymbol
+	targetSymbol = strings.TrimSpace(targetSymbol)
+	if targetSymbol == "" {
+		return false
 	}
 
+	throttleKey := tickEvalThrottleKey(runtimeSessionID, targetSymbol)
 	val, _ := p.tickEvalThrottle.LoadOrStore(throttleKey, &tickEvalThrottleState{})
 	state := val.(*tickEvalThrottleState)
 
@@ -695,11 +731,13 @@ func (p *Platform) shouldThrottleLiveEvaluation(runtimeSessionID string, summary
 
 	if state.lastPrice == price {
 		state.skippedCount++
+		p.incrementTickEvalThrottleSkipped(runtimeSessionID)
 		return true
 	}
 
 	if !state.lastEvalTime.IsZero() && eventTime.Sub(state.lastEvalTime) < minTickEvalInterval {
 		state.skippedCount++
+		p.incrementTickEvalThrottleSkipped(runtimeSessionID)
 		return true
 	}
 
@@ -713,11 +751,11 @@ func (p *Platform) handleSignalRuntimeMessage(runtimeSessionID string, summary m
 		return nil
 	}
 	targetSymbol := signalRuntimeSummarySymbol(summary)
-	if p.shouldThrottleLiveEvaluation(runtimeSessionID, summary, eventTime, targetSymbol) {
-		return nil
-	}
 	// Reject messages with unknown symbol — never broadcast to all sessions
 	if targetSymbol == "" {
+		return nil
+	}
+	if p.shouldThrottleLiveEvaluation(runtimeSessionID, summary, eventTime, targetSymbol) {
 		return nil
 	}
 	liveSessions, err := p.store.ListLiveSessions()

--- a/internal/service/signal_runtime_ws.go
+++ b/internal/service/signal_runtime_ws.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -352,6 +353,7 @@ func (p *Platform) setSessionTerminalError(sessionID string, err error) {
 		session.State = state
 		session.UpdatedAt = time.Now().UTC()
 	})
+	p.tickEvalThrottle.Delete(sessionID)
 }
 
 func (p *Platform) setSessionStopped(sessionID string) {
@@ -374,6 +376,7 @@ func (p *Platform) setSessionStopped(sessionID string) {
 		session.State = state
 		session.UpdatedAt = time.Now().UTC()
 	})
+	p.tickEvalThrottle.Delete(sessionID)
 }
 
 func configuredBinanceFuturesWSURL() string {
@@ -545,9 +548,14 @@ func (p *Platform) runExchangeWebsocketLoop(
 					"timeframe": stringValue(summary["timeframe"]),
 					"price":     stringValue(summary["price"]),
 				})
-				// Validate signal bar continuity after reconnect
 				if stringValue(state["lastDisconnectAt"]) != "" {
 					p.validateSignalBarContinuityAfterReconnect(state, summary)
+				}
+				if throttle, ok := p.tickEvalThrottle.Load(session.ID); ok {
+					ts := throttle.(*tickEvalThrottleState)
+					ts.mu.Lock()
+					state["tickEvalThrottledCount"] = ts.skippedCount
+					ts.mu.Unlock()
 				}
 				session.State = state
 				session.UpdatedAt = now
@@ -653,11 +661,61 @@ func maxInt64(a, b int64) int64 {
 	return b
 }
 
+// tickEvalThrottleState maintains the throttle state for strategy evaluation
+type tickEvalThrottleState struct {
+	mu           sync.Mutex
+	lastPrice    string
+	lastEvalTime time.Time
+	skippedCount int64
+}
+
+const minTickEvalInterval = 100 * time.Millisecond
+
+func (p *Platform) shouldThrottleLiveEvaluation(runtimeSessionID string, summary map[string]any, eventTime time.Time, targetSymbol string) bool {
+	streamType := inferSignalRuntimeStreamType(summary)
+	if streamType != "trade_tick" {
+		return false
+	}
+
+	price := strings.TrimSpace(stringValue(summary["price"]))
+	if price == "" {
+		return false
+	}
+
+	throttleKey := runtimeSessionID
+	if targetSymbol != "" {
+		throttleKey = runtimeSessionID + "|" + targetSymbol
+	}
+
+	val, _ := p.tickEvalThrottle.LoadOrStore(throttleKey, &tickEvalThrottleState{})
+	state := val.(*tickEvalThrottleState)
+
+	state.mu.Lock()
+	defer state.mu.Unlock()
+
+	if state.lastPrice == price {
+		state.skippedCount++
+		return true
+	}
+
+	if !state.lastEvalTime.IsZero() && eventTime.Sub(state.lastEvalTime) < minTickEvalInterval {
+		state.skippedCount++
+		return true
+	}
+
+	state.lastPrice = price
+	state.lastEvalTime = eventTime
+	return false
+}
+
 func (p *Platform) handleSignalRuntimeMessage(runtimeSessionID string, summary map[string]any, eventTime time.Time) error {
 	if !signalRuntimeSummaryShouldTriggerLiveEvaluation(summary) {
 		return nil
 	}
 	targetSymbol := signalRuntimeSummarySymbol(summary)
+	if p.shouldThrottleLiveEvaluation(runtimeSessionID, summary, eventTime, targetSymbol) {
+		return nil
+	}
 	// Reject messages with unknown symbol — never broadcast to all sessions
 	if targetSymbol == "" {
 		return nil

--- a/internal/service/signal_runtime_ws_test.go
+++ b/internal/service/signal_runtime_ws_test.go
@@ -1028,6 +1028,9 @@ func TestShouldThrottleLiveEvaluation_SamePriceSkipped(t *testing.T) {
 	if throttle.(*tickEvalThrottleState).skippedCount != 1 {
 		t.Fatalf("expected skipped count to be 1, got %d", throttle.(*tickEvalThrottleState).skippedCount)
 	}
+	if got := platform.tickEvalThrottleSkippedCount(sessionID); got != 1 {
+		t.Fatalf("expected session aggregate skipped count to be 1, got %d", got)
+	}
 }
 
 func TestShouldThrottleLiveEvaluation_PriceChangePassesThrough(t *testing.T) {
@@ -1152,6 +1155,7 @@ func TestShouldThrottleLiveEvaluation_ReplayTickNotThrottled(t *testing.T) {
 func TestTickEvalThrottleCleanedOnSessionStop(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
 	sessionID := "test-session"
+	otherSessionID := "other-session"
 
 	platform.signalSessions[sessionID] = domain.SignalRuntimeSession{
 		ID:     sessionID,
@@ -1159,25 +1163,104 @@ func TestTickEvalThrottleCleanedOnSessionStop(t *testing.T) {
 		State:  map[string]any{},
 	}
 
-	// Create throttle state
+	// Create aggregate and symbol-scoped throttle state.
 	platform.tickEvalThrottle.Store(sessionID, &tickEvalThrottleState{
+		skippedCount: 1,
+	})
+	platform.tickEvalThrottle.Store(tickEvalThrottleKey(sessionID, "BTCUSDT"), &tickEvalThrottleState{
 		lastPrice: "68000.5",
+	})
+	platform.tickEvalThrottle.Store(tickEvalThrottleKey(sessionID, "ETHUSDT"), &tickEvalThrottleState{
+		lastPrice: "3200.5",
+	})
+	platform.tickEvalThrottle.Store(tickEvalThrottleKey(otherSessionID, "BTCUSDT"), &tickEvalThrottleState{
+		lastPrice: "69000.5",
 	})
 
 	platform.setSessionStopped(sessionID)
 
 	if _, ok := platform.tickEvalThrottle.Load(sessionID); ok {
-		t.Fatal("expected throttle state to be cleaned up on setSessionStopped")
+		t.Fatal("expected aggregate throttle state to be cleaned up on setSessionStopped")
+	}
+	if _, ok := platform.tickEvalThrottle.Load(tickEvalThrottleKey(sessionID, "BTCUSDT")); ok {
+		t.Fatal("expected symbol-scoped throttle state to be cleaned up on setSessionStopped")
+	}
+	if _, ok := platform.tickEvalThrottle.Load(tickEvalThrottleKey(sessionID, "ETHUSDT")); ok {
+		t.Fatal("expected all symbol-scoped throttle state to be cleaned up on setSessionStopped")
+	}
+	if _, ok := platform.tickEvalThrottle.Load(tickEvalThrottleKey(otherSessionID, "BTCUSDT")); !ok {
+		t.Fatal("expected throttle state for other sessions to remain")
 	}
 
 	// Test TerminalError case
 	platform.tickEvalThrottle.Store(sessionID, &tickEvalThrottleState{
+		skippedCount: 2,
+	})
+	platform.tickEvalThrottle.Store(tickEvalThrottleKey(sessionID, "BTCUSDT"), &tickEvalThrottleState{
 		lastPrice: "68000.5",
 	})
 
 	platform.setSessionTerminalError(sessionID, errors.New("fatal"))
 
 	if _, ok := platform.tickEvalThrottle.Load(sessionID); ok {
-		t.Fatal("expected throttle state to be cleaned up on setSessionTerminalError")
+		t.Fatal("expected aggregate throttle state to be cleaned up on setSessionTerminalError")
+	}
+	if _, ok := platform.tickEvalThrottle.Load(tickEvalThrottleKey(sessionID, "BTCUSDT")); ok {
+		t.Fatal("expected symbol-scoped throttle state to be cleaned up on setSessionTerminalError")
+	}
+	if _, ok := platform.tickEvalThrottle.Load(tickEvalThrottleKey(otherSessionID, "BTCUSDT")); !ok {
+		t.Fatal("expected throttle state for other sessions to remain after terminal error cleanup")
+	}
+}
+
+func TestTickEvalThrottleSkippedCountTracksSessionAggregate(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	sessionID := "test-session"
+	eventTime := time.Now()
+
+	btcSummary := map[string]any{
+		"streamType": "trade_tick",
+		"price":      "68000.5",
+	}
+	if platform.shouldThrottleLiveEvaluation(sessionID, btcSummary, eventTime, "BTCUSDT") {
+		t.Fatal("expected first BTC eval to pass")
+	}
+	if !platform.shouldThrottleLiveEvaluation(sessionID, btcSummary, eventTime, "BTCUSDT") {
+		t.Fatal("expected second BTC eval with same price to be throttled")
+	}
+
+	ethSummary := map[string]any{
+		"streamType": "trade_tick",
+		"price":      "3200.5",
+	}
+	ethEventTime := eventTime.Add(300 * time.Millisecond)
+	if platform.shouldThrottleLiveEvaluation(sessionID, ethSummary, ethEventTime, "ETHUSDT") {
+		t.Fatal("expected first ETH eval to pass")
+	}
+	if !platform.shouldThrottleLiveEvaluation(sessionID, ethSummary, ethEventTime, "ETHUSDT") {
+		t.Fatal("expected second ETH eval with same price to be throttled")
+	}
+
+	if got := platform.tickEvalThrottleSkippedCount(sessionID); got != 2 {
+		t.Fatalf("expected session aggregate skipped count to be 2, got %d", got)
+	}
+}
+
+func TestShouldThrottleLiveEvaluation_EmptySymbolDoesNotCreateThrottleState(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	sessionID := "test-session"
+	summary := map[string]any{
+		"streamType": "trade_tick",
+		"price":      "68000.5",
+	}
+
+	if platform.shouldThrottleLiveEvaluation(sessionID, summary, time.Now(), "") {
+		t.Fatal("expected empty-symbol trade tick to bypass throttle")
+	}
+	if _, ok := platform.tickEvalThrottle.Load(sessionID); ok {
+		t.Fatal("expected empty-symbol trade tick to avoid session aggregate throttle state")
+	}
+	if _, ok := platform.tickEvalThrottle.Load(tickEvalThrottleKey(sessionID, "BTCUSDT")); ok {
+		t.Fatal("expected empty-symbol trade tick to avoid symbol-scoped throttle state")
 	}
 }

--- a/internal/service/signal_runtime_ws_test.go
+++ b/internal/service/signal_runtime_ws_test.go
@@ -1003,3 +1003,181 @@ func TestRunSignalRuntimeWithRecoveryReconnectMarksStaleSyncOnRESTMismatch(t *te
 		t.Fatal("expected stale reconnect mismatch to block close execution")
 	}
 }
+
+func TestShouldThrottleLiveEvaluation_SamePriceSkipped(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	sessionID := "test-session"
+	summary := map[string]any{
+		"streamType": "trade_tick",
+		"price":      "68000.5",
+	}
+	eventTime := time.Now()
+
+	if platform.shouldThrottleLiveEvaluation(sessionID, summary, eventTime, "BTCUSDT") {
+		t.Fatal("expected first eval to pass")
+	}
+
+	if !platform.shouldThrottleLiveEvaluation(sessionID, summary, eventTime, "BTCUSDT") {
+		t.Fatal("expected second eval with same price to be throttled")
+	}
+
+	throttle, ok := platform.tickEvalThrottle.Load(sessionID + "|BTCUSDT")
+	if !ok {
+		t.Fatal("expected throttle state to exist")
+	}
+	if throttle.(*tickEvalThrottleState).skippedCount != 1 {
+		t.Fatalf("expected skipped count to be 1, got %d", throttle.(*tickEvalThrottleState).skippedCount)
+	}
+}
+
+func TestShouldThrottleLiveEvaluation_PriceChangePassesThrough(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	sessionID := "test-session"
+	eventTime := time.Now()
+
+	summary1 := map[string]any{
+		"streamType": "trade_tick",
+		"price":      "68000.5",
+	}
+	if platform.shouldThrottleLiveEvaluation(sessionID, summary1, eventTime, "BTCUSDT") {
+		t.Fatal("expected first eval to pass")
+	}
+
+	summary2 := map[string]any{
+		"streamType": "trade_tick",
+		"price":      "68001.0",
+	}
+	eventTime2 := eventTime.Add(300 * time.Millisecond)
+	if platform.shouldThrottleLiveEvaluation(sessionID, summary2, eventTime2, "BTCUSDT") {
+		t.Fatal("expected second eval with different price to pass")
+	}
+}
+
+func TestShouldThrottleLiveEvaluation_MinIntervalEnforced(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	sessionID := "test-session"
+	eventTime := time.Now()
+
+	summary1 := map[string]any{
+		"streamType": "trade_tick",
+		"price":      "68000.5",
+	}
+	if platform.shouldThrottleLiveEvaluation(sessionID, summary1, eventTime, "BTCUSDT") {
+		t.Fatal("expected first eval to pass")
+	}
+
+	summary2 := map[string]any{
+		"streamType": "trade_tick",
+		"price":      "68001.0", // Price changed, but interval too short
+	}
+	// Event time is 50ms later, which is < 100ms
+	eventTime2 := eventTime.Add(50 * time.Millisecond)
+	if !platform.shouldThrottleLiveEvaluation(sessionID, summary2, eventTime2, "BTCUSDT") {
+		t.Fatal("expected second eval to be throttled due to min interval")
+	}
+}
+
+func TestShouldThrottleLiveEvaluation_IntervalExpiredPasses(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	sessionID := "test-session"
+	eventTime := time.Now()
+
+	summary1 := map[string]any{
+		"streamType": "trade_tick",
+		"price":      "68000.5",
+	}
+	if platform.shouldThrottleLiveEvaluation(sessionID, summary1, eventTime, "BTCUSDT") {
+		t.Fatal("expected first eval to pass")
+	}
+
+	summary2 := map[string]any{
+		"streamType": "trade_tick",
+		"price":      "68001.0", // Price changed, and interval expired
+	}
+	// Event time is 300ms later
+	eventTime2 := eventTime.Add(300 * time.Millisecond)
+	if platform.shouldThrottleLiveEvaluation(sessionID, summary2, eventTime2, "BTCUSDT") {
+		t.Fatal("expected second eval to pass after interval expired")
+	}
+}
+
+func TestShouldThrottleLiveEvaluation_NonTradeTickNotThrottled(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	sessionID := "test-session"
+	eventTime := time.Now()
+
+	// Create throttle state explicitly to test it doesn't block non-trade ticks
+	platform.tickEvalThrottle.Store(sessionID+"|BTCUSDT", &tickEvalThrottleState{
+		lastPrice:    "68000.5",
+		lastEvalTime: eventTime,
+	})
+
+	summary1 := map[string]any{
+		"streamType": "signal_bar",
+		"price":      "68000.5",
+	}
+	if platform.shouldThrottleLiveEvaluation(sessionID, summary1, eventTime, "BTCUSDT") {
+		t.Fatal("expected signal_bar to never be throttled")
+	}
+
+	summary2 := map[string]any{
+		"streamType": "order_book",
+		"price":      "68000.5",
+	}
+	if platform.shouldThrottleLiveEvaluation(sessionID, summary2, eventTime, "BTCUSDT") {
+		t.Fatal("expected order_book to never be throttled")
+	}
+}
+
+func TestShouldThrottleLiveEvaluation_ReplayTickNotThrottled(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	sessionID := "test-session"
+	eventTime := time.Now()
+
+	// Create throttle state explicitly to test it doesn't block
+	platform.tickEvalThrottle.Store(sessionID+"|BTCUSDT", &tickEvalThrottleState{
+		lastPrice:    "68000.5",
+		lastEvalTime: eventTime,
+	})
+
+	summary := map[string]any{
+		"streamType": "replay_tick",
+		"price":      "68000.5",
+	}
+	if platform.shouldThrottleLiveEvaluation(sessionID, summary, eventTime, "BTCUSDT") {
+		t.Fatal("expected replay_tick to never be throttled")
+	}
+}
+
+func TestTickEvalThrottleCleanedOnSessionStop(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	sessionID := "test-session"
+
+	platform.signalSessions[sessionID] = domain.SignalRuntimeSession{
+		ID:     sessionID,
+		Status: "RUNNING",
+		State:  map[string]any{},
+	}
+
+	// Create throttle state
+	platform.tickEvalThrottle.Store(sessionID, &tickEvalThrottleState{
+		lastPrice: "68000.5",
+	})
+
+	platform.setSessionStopped(sessionID)
+
+	if _, ok := platform.tickEvalThrottle.Load(sessionID); ok {
+		t.Fatal("expected throttle state to be cleaned up on setSessionStopped")
+	}
+
+	// Test TerminalError case
+	platform.tickEvalThrottle.Store(sessionID, &tickEvalThrottleState{
+		lastPrice: "68000.5",
+	})
+
+	platform.setSessionTerminalError(sessionID, errors.New("fatal"))
+
+	if _, ok := platform.tickEvalThrottle.Load(sessionID); ok {
+		t.Fatal("expected throttle state to be cleaned up on setSessionTerminalError")
+	}
+}


### PR DESCRIPTION
## 目的
- 为 `trade_tick` 增加价格去重与 `100ms` 最小评估间隔，减少重复 trigger evaluation。
- follow up 本轮 code review：补齐 `tickEvalThrottle` 的 session/symbol key 语义，避免 stop/error 后残留 symbol-scoped throttle state。
- 补上 session 级 `tickEvalThrottledCount` 聚合计数，保证该节流特性在 runtime health state 中可观测。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [x] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(本 PR 未改默认值)
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？(本 PR 未涉及)
- [x] DB migration 是否具备向下兼容幂等性？(本 PR 未涉及 migration)
- [x] 配置字段有没有无意被混改？(本 PR 未涉及配置字段修改)

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩
- `go test ./internal/service -run 'TestShouldThrottleLiveEvaluation_|TestTickEvalThrottle'`
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`

## 补充说明
- 本次 follow-up 只处理 review 指出的两个 throttle key 问题：session stop/error 清理不完整，以及 `tickEvalThrottledCount` 未正确透出。
- 未修改 `dispatchMode`、部署脚本、CI/CD、migration、mainnet/testnet 边界。