### PR TITLE
[codex] Fix live signal scope drift

### DIFF
--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -1809,10 +1809,22 @@ func (p *Platform) ensureLaunchLiveSession(accountID, strategyID string, overrid
 		if session.AccountID != accountID || session.StrategyID != strategyID {
 			continue
 		}
-		if targetSymbol != "" && NormalizeSymbol(stringValue(session.State["symbol"])) != targetSymbol {
+		rawSessionSymbol := strings.TrimSpace(firstNonEmpty(stringValue(session.State["symbol"]), stringValue(session.State["lastSymbol"])))
+		rawSessionTimeframe := strings.TrimSpace(firstNonEmpty(stringValue(session.State["signalTimeframe"]), stringValue(session.State["timeframe"])))
+		sessionSymbol := normalizeOptionalLiveScopeSymbol(rawSessionSymbol)
+		sessionTimeframe := normalizeSignalBarInterval(rawSessionTimeframe)
+		if rawSessionSymbol != "" || rawSessionTimeframe != "" {
+			sessionScope := p.canonicalizeLiveSessionOverridesForStrategy(strategyID, map[string]any{
+				"symbol":          rawSessionSymbol,
+				"signalTimeframe": rawSessionTimeframe,
+			})
+			sessionSymbol = normalizeOptionalLiveScopeSymbol(firstNonEmpty(stringValue(sessionScope["symbol"]), rawSessionSymbol))
+			sessionTimeframe = normalizeSignalBarInterval(firstNonEmpty(stringValue(sessionScope["signalTimeframe"]), rawSessionTimeframe))
+		}
+		if targetSymbol != "" && sessionSymbol != targetSymbol {
 			continue
 		}
-		if targetTimeframe != "" && normalizeSignalBarInterval(stringValue(session.State["signalTimeframe"])) != targetTimeframe {
+		if targetTimeframe != "" && sessionTimeframe != targetTimeframe {
 			continue
 		}
 		if len(normalizedOverrides) == 0 {

--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -149,7 +149,7 @@ func (p *Platform) UpdateLiveSession(sessionID, alias, accountID, strategyID str
 	// Always assign alias (trimmed) to support clearing an existing alias by providing an empty string.
 	session.Alias = strings.TrimSpace(alias)
 	state := cloneMetadata(session.State)
-	for key, value := range normalizeLiveSessionOverrides(overrides) {
+	for key, value := range p.canonicalizeLiveSessionOverridesForStrategy(session.StrategyID, overrides) {
 		state[key] = value
 	}
 	session.State = state
@@ -1454,7 +1454,7 @@ func (p *Platform) CreateLiveSession(alias, accountID, strategyID string, overri
 	}
 	if len(overrides) > 0 {
 		state := cloneMetadata(session.State)
-		for key, value := range normalizeLiveSessionOverrides(overrides) {
+		for key, value := range p.canonicalizeLiveSessionOverridesForStrategy(strategyID, overrides) {
 			state[key] = value
 		}
 		session, err = p.store.UpdateLiveSessionState(session.ID, state)
@@ -1798,7 +1798,7 @@ func (p *Platform) ensureLaunchRuntimeSession(accountID, strategyID string) (dom
 }
 
 func (p *Platform) ensureLaunchLiveSession(accountID, strategyID string, overrides map[string]any) (domain.LiveSession, bool, error) {
-	normalizedOverrides := normalizeLiveSessionOverrides(overrides)
+	normalizedOverrides := p.canonicalizeLiveSessionOverridesForStrategy(strategyID, overrides)
 	targetSymbol := NormalizeSymbol(stringValue(normalizedOverrides["symbol"]))
 	targetTimeframe := normalizeSignalBarInterval(stringValue(normalizedOverrides["signalTimeframe"]))
 	sessions, err := p.ListLiveSessions()
@@ -2566,6 +2566,12 @@ func (p *Platform) evaluateLiveSessionOnSignal(session domain.LiveSession, runti
 		"executionDataSource": executionContext.ExecutionDataSource,
 		"symbol":              executionContext.Symbol,
 	}
+	if executionContext.SignalTimeframe != "" {
+		state["signalTimeframe"] = executionContext.SignalTimeframe
+	}
+	if executionContext.Symbol != "" {
+		state["symbol"] = executionContext.Symbol
+	}
 	// P0-3: Inject ATR14 from signal bar state for volatility-adjusted sizing
 	if signalBarState := mapValue(decision.Metadata["signalBarState"]); len(signalBarState) > 0 {
 		if atr14 := parseFloatValue(signalBarState["atr14"]); atr14 > 0 {
@@ -2940,7 +2946,9 @@ func (p *Platform) syncLiveSessionRuntime(session domain.LiveSession) (domain.Li
 		return updated, err
 	}
 
-	required := len(metadataList(plan["requiredBindings"])) > 0
+	requiredBindings := metadataList(plan["requiredBindings"])
+	state = applyCanonicalLiveSignalScope(state, requiredBindings)
+	required := len(requiredBindings) > 0
 	state["signalRuntimePlan"] = plan
 	state["signalRuntimeMode"] = "linked"
 	state["signalRuntimeRequired"] = required
@@ -3908,8 +3916,147 @@ func (p *Platform) resolveLiveSessionParameters(session domain.LiveSession, vers
 			parameters[key] = value
 		}
 	}
+	parameters = applyCanonicalLiveSignalScope(parameters, resolveStrategySignalBindings(parameters))
 	parameters = applyLiveSafeStopDefaults(parameters)
 	return NormalizeBacktestParameters(parameters)
+}
+
+func (p *Platform) canonicalizeLiveSessionOverridesForStrategy(strategyID string, overrides map[string]any) map[string]any {
+	normalized := normalizeLiveSessionOverrides(overrides)
+	if len(normalized) == 0 || strings.TrimSpace(strategyID) == "" {
+		return normalized
+	}
+	version, err := p.resolveCurrentStrategyVersion(strategyID)
+	if err != nil {
+		return normalized
+	}
+	return applyCanonicalLiveSignalScope(normalized, resolveStrategySignalBindings(version.Parameters))
+}
+
+func applyCanonicalLiveSignalScope(scope map[string]any, bindings []map[string]any) map[string]any {
+	normalized := cloneMetadata(scope)
+	if normalized == nil {
+		normalized = map[string]any{}
+	}
+	symbol, timeframe := resolveCanonicalLiveSignalScope(bindings, normalized)
+	if symbol != "" {
+		normalized["symbol"] = symbol
+	}
+	if timeframe != "" {
+		normalized["signalTimeframe"] = timeframe
+	}
+	return normalized
+}
+
+func resolveCanonicalLiveSignalScope(bindings []map[string]any, scope map[string]any) (string, string) {
+	currentSymbol := normalizeOptionalLiveScopeSymbol(scope["symbol"])
+	currentTimeframe := normalizeSignalBarInterval(stringValue(scope["signalTimeframe"]))
+	candidates := collectLiveSignalBarBindings(bindings)
+	if len(candidates) == 0 {
+		return currentSymbol, currentTimeframe
+	}
+
+	symbolScopeResolved := false
+	if currentSymbol != "" {
+		matched := make([]map[string]any, 0, len(candidates))
+		for _, binding := range candidates {
+			if liveSignalBindingSymbol(binding) == currentSymbol {
+				matched = append(matched, binding)
+			}
+		}
+		if len(matched) > 0 {
+			candidates = matched
+			symbolScopeResolved = true
+		} else {
+			return currentSymbol, currentTimeframe
+		}
+	} else if uniqueSymbol := uniqueLiveSignalBindingValue(candidates, liveSignalBindingSymbol); uniqueSymbol != "" {
+		currentSymbol = uniqueSymbol
+		filtered := make([]map[string]any, 0, len(candidates))
+		for _, binding := range candidates {
+			if liveSignalBindingSymbol(binding) == uniqueSymbol {
+				filtered = append(filtered, binding)
+			}
+		}
+		if len(filtered) > 0 {
+			candidates = filtered
+		}
+		symbolScopeResolved = true
+	}
+
+	if currentTimeframe != "" {
+		matched := false
+		for _, binding := range candidates {
+			if liveSignalBindingTimeframe(binding) == currentTimeframe {
+				matched = true
+				break
+			}
+		}
+		if !matched && symbolScopeResolved {
+			if uniqueTimeframe := uniqueLiveSignalBindingValue(candidates, liveSignalBindingTimeframe); uniqueTimeframe != "" {
+				currentTimeframe = uniqueTimeframe
+			}
+		}
+	} else if uniqueTimeframe := uniqueLiveSignalBindingValue(candidates, liveSignalBindingTimeframe); uniqueTimeframe != "" {
+		currentTimeframe = uniqueTimeframe
+	}
+
+	return currentSymbol, currentTimeframe
+}
+
+func collectLiveSignalBarBindings(bindings []map[string]any) []map[string]any {
+	collected := make([]map[string]any, 0, len(bindings))
+	for _, binding := range bindings {
+		if normalizeSignalSourceRole(stringValue(binding["role"])) != "signal" {
+			continue
+		}
+		streamType := strings.ToLower(strings.TrimSpace(stringValue(binding["streamType"])))
+		if streamType == "" && normalizeSignalSourceKey(stringValue(binding["sourceKey"])) == "binance-kline" {
+			streamType = "signal_bar"
+		}
+		if streamType != "signal_bar" {
+			continue
+		}
+		collected = append(collected, binding)
+	}
+	return collected
+}
+
+func uniqueLiveSignalBindingValue(bindings []map[string]any, extract func(map[string]any) string) string {
+	unique := ""
+	for _, binding := range bindings {
+		value := strings.TrimSpace(extract(binding))
+		if value == "" {
+			continue
+		}
+		if unique == "" {
+			unique = value
+			continue
+		}
+		if unique != value {
+			return ""
+		}
+	}
+	return unique
+}
+
+func liveSignalBindingSymbol(binding map[string]any) string {
+	return normalizeOptionalLiveScopeSymbol(binding["symbol"])
+}
+
+func liveSignalBindingTimeframe(binding map[string]any) string {
+	if timeframe := normalizeSignalBarInterval(stringValue(binding["timeframe"])); timeframe != "" {
+		return timeframe
+	}
+	return signalBindingTimeframe(stringValue(binding["sourceKey"]), metadataValue(binding["options"]))
+}
+
+func normalizeOptionalLiveScopeSymbol(value any) string {
+	symbol := strings.TrimSpace(stringValue(value))
+	if symbol == "" {
+		return ""
+	}
+	return NormalizeSymbol(symbol)
 }
 
 const (

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -2859,7 +2859,18 @@ func TestEnsureLaunchLiveSessionCreatesDistinctSessionPerSymbolAndTimeframe(t *t
 
 func TestEnsureLaunchLiveSessionCanonicalizesSignalTimeframeFromStrategyBindings(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
-	if _, err := platform.BindStrategySignalSource("strategy-bk-1d", map[string]any{
+	account, err := platform.store.CreateAccount("launch-scope-live", "LIVE", "binance-futures")
+	if err != nil {
+		t.Fatalf("create live account failed: %v", err)
+	}
+	strategy, err := platform.store.CreateStrategy("launch-scope-strategy", "test", map[string]any{
+		"strategyEngine": "bk-default",
+	})
+	if err != nil {
+		t.Fatalf("create strategy failed: %v", err)
+	}
+	strategyID := strategy["id"].(string)
+	if _, err := platform.BindStrategySignalSource(strategyID, map[string]any{
 		"sourceKey": "binance-kline",
 		"role":      "signal",
 		"symbol":    "BTCUSDT",
@@ -2868,7 +2879,7 @@ func TestEnsureLaunchLiveSessionCanonicalizesSignalTimeframeFromStrategyBindings
 		t.Fatalf("bind strategy signal source failed: %v", err)
 	}
 
-	first, created, err := platform.ensureLaunchLiveSession("live-main", "strategy-bk-1d", map[string]any{
+	first, created, err := platform.ensureLaunchLiveSession(account.ID, strategyID, map[string]any{
 		"symbol":          "BTCUSDT",
 		"signalTimeframe": "1d",
 	})
@@ -2882,7 +2893,7 @@ func TestEnsureLaunchLiveSessionCanonicalizesSignalTimeframeFromStrategyBindings
 		t.Fatalf("expected created session signalTimeframe 30m, got %q", got)
 	}
 
-	reused, created, err := platform.ensureLaunchLiveSession("live-main", "strategy-bk-1d", map[string]any{
+	reused, created, err := platform.ensureLaunchLiveSession(account.ID, strategyID, map[string]any{
 		"symbol":          "BTCUSDT",
 		"signalTimeframe": "1d",
 	})
@@ -2894,6 +2905,58 @@ func TestEnsureLaunchLiveSessionCanonicalizesSignalTimeframeFromStrategyBindings
 	}
 	if reused.ID != first.ID {
 		t.Fatalf("expected reused live session %s, got %s", first.ID, reused.ID)
+	}
+	if got := stringValue(reused.State["signalTimeframe"]); got != "30m" {
+		t.Fatalf("expected reused session signalTimeframe 30m, got %q", got)
+	}
+}
+
+func TestEnsureLaunchLiveSessionReusesStoredSessionAfterCanonicalScopeRecovery(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	account, err := platform.store.CreateAccount("stale-launch-live", "LIVE", "binance-futures")
+	if err != nil {
+		t.Fatalf("create live account failed: %v", err)
+	}
+	strategy, err := platform.store.CreateStrategy("stale-launch-strategy", "test", map[string]any{
+		"strategyEngine": "bk-default",
+	})
+	if err != nil {
+		t.Fatalf("create strategy failed: %v", err)
+	}
+	strategyID := strategy["id"].(string)
+	if _, err := platform.BindStrategySignalSource(strategyID, map[string]any{
+		"sourceKey": "binance-kline",
+		"role":      "signal",
+		"symbol":    "BTCUSDT",
+		"options":   map[string]any{"timeframe": "30m"},
+	}); err != nil {
+		t.Fatalf("bind strategy signal source failed: %v", err)
+	}
+
+	staleSession, err := platform.store.CreateLiveSession(account.ID, strategyID)
+	if err != nil {
+		t.Fatalf("create stale live session failed: %v", err)
+	}
+	staleSession, err = platform.store.UpdateLiveSessionState(staleSession.ID, map[string]any{
+		"symbol":          "BTCUSDT",
+		"signalTimeframe": "1d",
+	})
+	if err != nil {
+		t.Fatalf("seed stale live session state failed: %v", err)
+	}
+
+	reused, created, err := platform.ensureLaunchLiveSession(account.ID, strategyID, map[string]any{
+		"symbol":          "BTCUSDT",
+		"signalTimeframe": "1d",
+	})
+	if err != nil {
+		t.Fatalf("ensure reused launch live session failed: %v", err)
+	}
+	if created {
+		t.Fatal("expected stale session to be reused after canonical scope recovery")
+	}
+	if reused.ID != staleSession.ID {
+		t.Fatalf("expected reused live session %s, got %s", staleSession.ID, reused.ID)
 	}
 	if got := stringValue(reused.State["signalTimeframe"]); got != "30m" {
 		t.Fatalf("expected reused session signalTimeframe 30m, got %q", got)

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -983,6 +983,42 @@ func TestResolveLiveSessionParametersDefaultsMissingStopsToTrailingForLive(t *te
 	}
 }
 
+func TestResolveLiveSessionParametersPrefersSignalBindingTimeframeOverStaleSessionState(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	if _, err := platform.BindStrategySignalSource("strategy-bk-1d", map[string]any{
+		"sourceKey": "binance-kline",
+		"role":      "signal",
+		"symbol":    "BTCUSDT",
+		"options":   map[string]any{"timeframe": "30m"},
+	}); err != nil {
+		t.Fatalf("bind strategy signal source failed: %v", err)
+	}
+
+	session, err := platform.store.GetLiveSession("live-session-main")
+	if err != nil {
+		t.Fatalf("get live session failed: %v", err)
+	}
+	session, err = platform.store.UpdateLiveSessionState(session.ID, map[string]any{
+		"symbol":          "BTCUSDT",
+		"signalTimeframe": "1d",
+	})
+	if err != nil {
+		t.Fatalf("seed stale live session state failed: %v", err)
+	}
+
+	version, err := platform.resolveCurrentStrategyVersion(session.StrategyID)
+	if err != nil {
+		t.Fatalf("resolve strategy version failed: %v", err)
+	}
+	parameters, err := platform.resolveLiveSessionParameters(session, version)
+	if err != nil {
+		t.Fatalf("resolve live session parameters failed: %v", err)
+	}
+	if got := stringValue(parameters["signalTimeframe"]); got != "30m" {
+		t.Fatalf("expected signalTimeframe to canonicalize to 30m, got %q", got)
+	}
+}
+
 func TestRefreshLiveMarketSnapshotFailsWithoutRESTWarmData(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
 	originalFetch := fetchLiveCandleRange
@@ -2818,6 +2854,49 @@ func TestEnsureLaunchLiveSessionCreatesDistinctSessionPerSymbolAndTimeframe(t *t
 	}
 	if reused.ID != first.ID {
 		t.Fatalf("expected reused live session %s, got %s", first.ID, reused.ID)
+	}
+}
+
+func TestEnsureLaunchLiveSessionCanonicalizesSignalTimeframeFromStrategyBindings(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	if _, err := platform.BindStrategySignalSource("strategy-bk-1d", map[string]any{
+		"sourceKey": "binance-kline",
+		"role":      "signal",
+		"symbol":    "BTCUSDT",
+		"options":   map[string]any{"timeframe": "30m"},
+	}); err != nil {
+		t.Fatalf("bind strategy signal source failed: %v", err)
+	}
+
+	first, created, err := platform.ensureLaunchLiveSession("live-main", "strategy-bk-1d", map[string]any{
+		"symbol":          "BTCUSDT",
+		"signalTimeframe": "1d",
+	})
+	if err != nil {
+		t.Fatalf("ensure launch live session failed: %v", err)
+	}
+	if !created {
+		t.Fatal("expected first canonicalized launch session to be created")
+	}
+	if got := stringValue(first.State["signalTimeframe"]); got != "30m" {
+		t.Fatalf("expected created session signalTimeframe 30m, got %q", got)
+	}
+
+	reused, created, err := platform.ensureLaunchLiveSession("live-main", "strategy-bk-1d", map[string]any{
+		"symbol":          "BTCUSDT",
+		"signalTimeframe": "1d",
+	})
+	if err != nil {
+		t.Fatalf("ensure reused launch live session failed: %v", err)
+	}
+	if created {
+		t.Fatal("expected canonicalized launch scope to reuse existing live session")
+	}
+	if reused.ID != first.ID {
+		t.Fatalf("expected reused live session %s, got %s", first.ID, reused.ID)
+	}
+	if got := stringValue(reused.State["signalTimeframe"]); got != "30m" {
+		t.Fatalf("expected reused session signalTimeframe 30m, got %q", got)
 	}
 }
 
@@ -8460,5 +8539,41 @@ func TestSyncLiveSessionRuntimePreservesConfiguredDispatchMode(t *testing.T) {
 	}
 	if got := stringValue(updated2.State["dispatchMode"]); got != "manual-review" {
 		t.Errorf("expected manual-review to be preserved, got %s", got)
+	}
+}
+
+func TestSyncLiveSessionRuntimeCanonicalizesSignalScopeFromBindings(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	if _, err := platform.BindStrategySignalSource("strategy-bk-1d", map[string]any{
+		"sourceKey": "binance-kline",
+		"role":      "signal",
+		"symbol":    "BTCUSDT",
+		"options":   map[string]any{"timeframe": "30m"},
+	}); err != nil {
+		t.Fatalf("bind strategy signal source failed: %v", err)
+	}
+
+	session, err := platform.store.GetLiveSession("live-session-main")
+	if err != nil {
+		t.Fatalf("get live session failed: %v", err)
+	}
+	session, err = platform.store.UpdateLiveSessionState(session.ID, map[string]any{
+		"symbol":          "BTCUSDT",
+		"signalTimeframe": "1d",
+		"dispatchMode":    "manual-review",
+	})
+	if err != nil {
+		t.Fatalf("seed stale live session state failed: %v", err)
+	}
+
+	updated, err := platform.syncLiveSessionRuntime(session)
+	if err != nil {
+		t.Fatalf("syncLiveSessionRuntime failed: %v", err)
+	}
+	if got := stringValue(updated.State["signalTimeframe"]); got != "30m" {
+		t.Fatalf("expected synced session signalTimeframe 30m, got %q", got)
+	}
+	if got := stringValue(updated.State["symbol"]); got != "BTCUSDT" {
+		t.Fatalf("expected synced session symbol BTCUSDT, got %q", got)
 	}
 }

--- a/web/console/src/pages/AccountStage.tsx
+++ b/web/console/src/pages/AccountStage.tsx
@@ -278,10 +278,12 @@ export function AccountStage({
       ) ??
       null
     : null;
+  const selectedRuntimeSignalTimeframeHint = String(selectedRuntimeSession?.state?.signalTimeframe ?? "").trim().toLowerCase();
   const selectedRuntimeSignalBarStateKey = String(selectedRuntimeSession?.state?.lastStrategyEvaluationSignalBarStateKey ?? "").trim();
   const selectedRuntimeSignalState = derivePrimarySignalBarState(selectedSignalBarStates, {
     fallbackStates: getRecord(selectedRuntimeSession?.state?.lastStrategyEvaluationSignalBarStates),
     targetSymbol: selectedRuntimeSymbol,
+    targetTimeframe: selectedRuntimeSignalTimeframeHint,
     targetStateKey: selectedRuntimeSignalBarStateKey,
   });
   const selectedRuntimeSignalSymbol = String(
@@ -504,10 +506,12 @@ export function AccountStage({
                 const accountSession = validLiveSessions.find((item) => item.accountId === account.id);
                 const accountSymbol = String(accountSession?.state?.symbol ?? activeRuntime?.state?.symbol ?? "").trim().toUpperCase();
                 const strategyBindings = (activeRuntime?.strategyId ? strategySignalBindingMap[activeRuntime.strategyId] : undefined) ?? strategySignalBindingMap[validLiveSessions.find((item) => item.accountId === account.id)?.strategyId ?? ""] ?? [];
+                const activeSignalTimeframeHint = String(accountSession?.state?.signalTimeframe ?? "").trim().toLowerCase();
                 const activeSignalBarStateKey = String(accountSession?.state?.lastStrategyEvaluationSignalBarStateKey ?? "").trim();
                 const activeSignalBarState = derivePrimarySignalBarState(getRecord(activeRuntimeState.signalBarStates), {
                   fallbackStates: getRecord(accountSession?.state?.lastStrategyEvaluationSignalBarStates),
                   targetSymbol: accountSymbol,
+                  targetTimeframe: activeSignalTimeframeHint,
                   targetStateKey: activeSignalBarStateKey,
                 });
                 const activeSignalSymbol = String(

--- a/web/console/src/pages/AccountStage.tsx
+++ b/web/console/src/pages/AccountStage.tsx
@@ -278,10 +278,23 @@ export function AccountStage({
       ) ??
       null
     : null;
-  const selectedRuntimeSignalTimeframe = String(selectedRuntimeSession?.state?.signalTimeframe ?? "").trim().toLowerCase();
   const selectedRuntimeSignalBarStateKey = String(selectedRuntimeSession?.state?.lastStrategyEvaluationSignalBarStateKey ?? "").trim();
-  const selectedSignalRuntimeSignalBars = deriveSignalBarCandles(selectedSignalRuntimeSourceStates, {
+  const selectedRuntimeSignalState = derivePrimarySignalBarState(selectedSignalBarStates, {
+    fallbackStates: getRecord(selectedRuntimeSession?.state?.lastStrategyEvaluationSignalBarStates),
     targetSymbol: selectedRuntimeSymbol,
+    targetStateKey: selectedRuntimeSignalBarStateKey,
+  });
+  const selectedRuntimeSignalSymbol = String(
+    selectedRuntimeSignalState.symbol ?? getRecord(selectedRuntimeSignalState.current).symbol ?? selectedRuntimeSymbol
+  ).trim().toUpperCase();
+  const selectedRuntimeSignalTimeframe = String(
+    selectedRuntimeSignalState.timeframe ??
+      getRecord(selectedRuntimeSignalState.current).timeframe ??
+      selectedRuntimeSession?.state?.signalTimeframe ??
+      ""
+  ).trim().toLowerCase();
+  const selectedSignalRuntimeSignalBars = deriveSignalBarCandles(selectedSignalRuntimeSourceStates, {
+    targetSymbol: selectedRuntimeSignalSymbol,
     targetTimeframe: selectedRuntimeSignalTimeframe,
     targetStateKey: selectedRuntimeSignalBarStateKey,
   });
@@ -489,17 +502,19 @@ export function AccountStage({
                 const activeRuntimeState = getRecord(activeRuntime?.state);
                 const activeRuntimeSummary = getRecord(activeRuntimeState.lastEventSummary);
                 const accountSession = validLiveSessions.find((item) => item.accountId === account.id);
-                 const accountSymbol = String(accountSession?.state?.symbol ?? activeRuntime?.state?.symbol ?? "").trim().toUpperCase();
-                 const activeRuntimeMarket = deriveRuntimeMarketSnapshot(getRecord(activeRuntimeState.sourceStates), activeRuntimeSummary, accountSymbol);
+                const accountSymbol = String(accountSession?.state?.symbol ?? activeRuntime?.state?.symbol ?? "").trim().toUpperCase();
                 const strategyBindings = (activeRuntime?.strategyId ? strategySignalBindingMap[activeRuntime.strategyId] : undefined) ?? strategySignalBindingMap[validLiveSessions.find((item) => item.accountId === account.id)?.strategyId ?? ""] ?? [];
-                const activeRuntimeSourceSummary = deriveRuntimeSourceSummary(getRecord(activeRuntimeState.sourceStates), runtimePolicy, accountSymbol);
-                const activeSignalTimeframe = String(accountSession?.state?.signalTimeframe ?? "").trim().toLowerCase();
                 const activeSignalBarStateKey = String(accountSession?.state?.lastStrategyEvaluationSignalBarStateKey ?? "").trim();
                 const activeSignalBarState = derivePrimarySignalBarState(getRecord(activeRuntimeState.signalBarStates), {
+                  fallbackStates: getRecord(accountSession?.state?.lastStrategyEvaluationSignalBarStates),
                   targetSymbol: accountSymbol,
-                  targetTimeframe: activeSignalTimeframe,
                   targetStateKey: activeSignalBarStateKey,
                 });
+                const activeSignalSymbol = String(
+                  activeSignalBarState.symbol ?? getRecord(activeSignalBarState.current).symbol ?? accountSymbol
+                ).trim().toUpperCase();
+                const activeRuntimeMarket = deriveRuntimeMarketSnapshot(getRecord(activeRuntimeState.sourceStates), activeRuntimeSummary, activeSignalSymbol || accountSymbol);
+                const activeRuntimeSourceSummary = deriveRuntimeSourceSummary(getRecord(activeRuntimeState.sourceStates), runtimePolicy, activeSignalSymbol || accountSymbol);
                 const activeSignalAction = deriveSignalActionSummary(activeSignalBarState);
                 const activeRuntimeTimeline = getList(activeRuntimeState.timeline);
                 const activeRuntimeReadiness = deriveRuntimeReadiness(activeRuntimeState, activeRuntimeSourceSummary, {

--- a/web/console/src/pages/MonitorStage.tsx
+++ b/web/console/src/pages/MonitorStage.tsx
@@ -152,22 +152,37 @@ export function MonitorStage({ syncLiveOrder, dockTab, onDockTabChange, dockCont
   const sessionSymbol = String(monitorSession?.state?.symbol ?? "").trim().toUpperCase();
   const monitorSignalContext = getRecord(monitorSessionState.lastStrategyEvaluationContext);
   const monitorDecisionMeta = getRecord(getRecord(monitorSession?.state?.lastStrategyDecision).metadata);
-  const monitorSignalTimeframe = String(
-    monitorSessionState.signalTimeframe ?? monitorSignalContext.signalTimeframe ?? monitorDecisionMeta.signalTimeframe ?? ""
-  )
-    .trim()
-    .toLowerCase();
   const monitorSignalBarStateKey = String(
     monitorSessionState.lastStrategyEvaluationSignalBarStateKey ?? monitorDecisionMeta.signalBarStateKey ?? ""
   ).trim();
+  const monitorSignalState = derivePrimarySignalBarState(
+    getRecord(highlightedLiveRuntimeState.signalBarStates),
+    {
+      fallbackStates: getRecord(monitorSessionState.lastStrategyEvaluationSignalBarStates),
+      targetSymbol: sessionSymbol,
+      targetStateKey: monitorSignalBarStateKey,
+    }
+  );
+  const monitorSignalSymbol = String(
+    monitorSignalState.symbol ?? getRecord(monitorSignalState.current).symbol ?? sessionSymbol
+  ).trim().toUpperCase();
+  const monitorSignalTimeframe = String(
+    monitorSignalState.timeframe ??
+      getRecord(monitorSignalState.current).timeframe ??
+      monitorSessionState.signalTimeframe ??
+      monitorSignalContext.signalTimeframe ??
+      monitorDecisionMeta.signalTimeframe ??
+      ""
+  ).trim().toLowerCase();
+  const monitorSymbol = monitorSignalSymbol || sessionSymbol;
 
   const monitorBars = useMemo(() => {
     return deriveSignalBarCandles(getRecord(highlightedLiveRuntimeState.sourceStates), {
-      targetSymbol: sessionSymbol,
+      targetSymbol: monitorSymbol,
       targetTimeframe: monitorSignalTimeframe,
       targetStateKey: monitorSignalBarStateKey,
     });
-  }, [highlightedLiveRuntimeState.sourceStates, sessionSymbol, monitorSignalTimeframe, monitorSignalBarStateKey]);
+  }, [highlightedLiveRuntimeState.sourceStates, monitorSymbol, monitorSignalTimeframe, monitorSignalBarStateKey]);
 
   const fallbackResolution = useMemo(
     () => resolveMonitorFallbackResolution(monitorSignalTimeframe),
@@ -181,7 +196,7 @@ export function MonitorStage({ syncLiveOrder, dockTab, onDockTabChange, dockCont
 
   useEffect(() => {
     const monitorSessionId = monitorSession?.id ?? "";
-    if (!monitorSessionId || !sessionSymbol) {
+    if (!monitorSessionId || !monitorSymbol) {
       fallbackRequestKeyRef.current = "";
       setMonitorCandles([]);
       return;
@@ -194,7 +209,7 @@ export function MonitorStage({ syncLiveOrder, dockTab, onDockTabChange, dockCont
 
     const requestKey = [
       monitorSessionId,
-      sessionSymbol,
+      monitorSymbol,
       fallbackResolution,
       timeWindow,
       chartOverrideRange?.from ?? "",
@@ -212,7 +227,7 @@ export function MonitorStage({ syncLiveOrder, dockTab, onDockTabChange, dockCont
 
     let active = true;
     fetchJSON<{ candles: ChartCandle[] }>(
-      `/api/v1/chart/candles?symbol=${encodeURIComponent(sessionSymbol)}&resolution=${fallbackResolution}&from=${range.from}&to=${range.to}&limit=240`
+      `/api/v1/chart/candles?symbol=${encodeURIComponent(monitorSymbol)}&resolution=${fallbackResolution}&from=${range.from}&to=${range.to}&limit=240`
     )
       .then((payload) => {
         if (!active) {
@@ -238,25 +253,15 @@ export function MonitorStage({ syncLiveOrder, dockTab, onDockTabChange, dockCont
     fallbackResolution,
     monitorBars.length,
     monitorSession,
+    monitorSymbol,
     orders,
-    sessionSymbol,
     setMonitorCandles,
     timeWindow,
   ]);
-
-  const monitorSignalState = derivePrimarySignalBarState(
-    getRecord(highlightedLiveRuntimeState.signalBarStates),
-    {
-      fallbackStates: getRecord(monitorSessionState.lastStrategyEvaluationSignalBarStates),
-      targetSymbol: sessionSymbol,
-      targetTimeframe: monitorSignalTimeframe,
-      targetStateKey: monitorSignalBarStateKey,
-    }
-  );
   const monitorMarket = deriveRuntimeMarketSnapshot(
     getRecord(monitorRuntimeState.sourceStates),
     getRecord(monitorRuntimeState.lastEventSummary),
-    sessionSymbol
+    monitorSymbol
   );
   const monitorSummary =
     monitorSession ? summaries.find((item) => item.accountId === monitorSession.accountId) ?? null : null;
@@ -289,7 +294,7 @@ export function MonitorStage({ syncLiveOrder, dockTab, onDockTabChange, dockCont
     : [];
   const monitorRuntimeReadiness = deriveRuntimeReadiness(
     highlightedLiveRuntimeState,
-    deriveRuntimeSourceSummary(getRecord(highlightedLiveRuntimeState.sourceStates), runtimePolicy, sessionSymbol),
+    deriveRuntimeSourceSummary(getRecord(highlightedLiveRuntimeState.sourceStates), runtimePolicy, monitorSymbol),
     { requireTick: true, requireOrderBook: false }
   );
   const monitorIntent = getRecord(monitorSession?.state?.lastStrategyIntent);
@@ -543,7 +548,7 @@ export function MonitorStage({ syncLiveOrder, dockTab, onDockTabChange, dockCont
               <CardTitle className="text-lg font-black text-[var(--bk-text-primary)]">行情遥测</CardTitle>
             </div>
             <Badge variant="metal" className="text-[var(--bk-text-muted)]">
-              {sessionSymbol || "NO SIGNAL"}
+              {monitorSymbol || "NO SIGNAL"}
             </Badge>
           </CardHeader>
           <CardContent className="p-5 flex-1 flex flex-col justify-center">

--- a/web/console/src/pages/MonitorStage.tsx
+++ b/web/console/src/pages/MonitorStage.tsx
@@ -152,6 +152,9 @@ export function MonitorStage({ syncLiveOrder, dockTab, onDockTabChange, dockCont
   const sessionSymbol = String(monitorSession?.state?.symbol ?? "").trim().toUpperCase();
   const monitorSignalContext = getRecord(monitorSessionState.lastStrategyEvaluationContext);
   const monitorDecisionMeta = getRecord(getRecord(monitorSession?.state?.lastStrategyDecision).metadata);
+  const monitorSignalTimeframeHint = String(
+    monitorSessionState.signalTimeframe ?? monitorSignalContext.signalTimeframe ?? monitorDecisionMeta.signalTimeframe ?? ""
+  ).trim().toLowerCase();
   const monitorSignalBarStateKey = String(
     monitorSessionState.lastStrategyEvaluationSignalBarStateKey ?? monitorDecisionMeta.signalBarStateKey ?? ""
   ).trim();
@@ -160,6 +163,7 @@ export function MonitorStage({ syncLiveOrder, dockTab, onDockTabChange, dockCont
     {
       fallbackStates: getRecord(monitorSessionState.lastStrategyEvaluationSignalBarStates),
       targetSymbol: sessionSymbol,
+      targetTimeframe: monitorSignalTimeframeHint,
       targetStateKey: monitorSignalBarStateKey,
     }
   );

--- a/web/console/src/utils/derivation.ts
+++ b/web/console/src/utils/derivation.ts
@@ -538,6 +538,7 @@ function resolveSignalBarEntry(
     }
   }
 
+  let symbolMatch: Record<string, unknown> = {};
   for (const value of Object.values(signalBarStates)) {
     const entry = getRecord(value);
     if (Object.keys(entry).length === 0) {
@@ -548,13 +549,15 @@ function resolveSignalBarEntry(
     if (targetSymbol && entrySymbol && entrySymbol !== targetSymbol) {
       continue;
     }
-    if (targetTimeframe && entryTimeframe && entryTimeframe !== targetTimeframe) {
-      continue;
+    if (Object.keys(symbolMatch).length === 0) {
+      symbolMatch = entry;
     }
-    return entry;
+    if (!targetTimeframe || !entryTimeframe || entryTimeframe === targetTimeframe) {
+      return entry;
+    }
   }
 
-  return {};
+  return symbolMatch;
 }
 
 export function deriveSignalBarCandles(


### PR DESCRIPTION
## 目的
修复 live session `signalTimeframe` / `symbol` 的 source-of-truth 漂移，避免策略运行时已经 warm 好的 signal bars 被错误过滤，导致后端误判 `missing-signal-bars`、前端监控误显示“没有 warmup”。

根因是 strategy version / session state 里的 `signalTimeframe` 可能漂移成旧值，而 signal runtime 与 signal bar states 实际来自 strategy signal bindings；两条链路使用了不同的 scope，后端评估和前端图表都会读错 timeframe。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [x] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
- `dispatchMode` 默认值未变化，仍保持现有默认行为。
- 无 `mainnet` 凭证或路由地址硬编码。
- 无 DB migration。
- 配置语义改动仅限 live session `symbol/signalTimeframe` 的 canonicalization：当 session scope 已匹配 signal binding，或 binding 可唯一推断 scope 时，统一收敛到 signal binding；避免 session/version/runtime 各自维护平行 truth。

## 验证方式与测试证据
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

本地验证：
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
- `cd web/console && npm run build`

新增回归覆盖：
- `resolveLiveSessionParameters` 会优先采用 signal binding 的 canonical timeframe，而不是 stale session state
- `ensureLaunchLiveSession` 在 launch scope 与 binding scope 对齐时会复用已有 session，不再因漂移错误新建/错配
- `syncLiveSessionRuntime` 会把旧 session 的脏 `signalTimeframe` / `symbol` 自愈回 canonical signal scope

行为变化：
- 后端在 live session create/update/launch/sync 以及策略评估回写时，统一通过 signal binding 收敛 signal scope
- 前端监控和账户页优先读取真实 signal bar state，再回退到 session/context metadata，避免把已 warm 的 bars 自己过滤掉
- 已运行的 live session 在部署后不需要手工改库；下一次 runtime sync 或 strategy evaluation 会自动回写正确 scope
