### PR TITLE
[codex] Fix live runtime sandbox drift and same-bar reentry regression

### DIFF
--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -2409,7 +2409,7 @@ func (p *Platform) triggerLiveSessionFromSignal(sessionID, runtimeSessionID stri
 	state["lastSignalRuntimeEvent"] = cloneMetadata(summary)
 	state["lastSignalRuntimeSessionId"] = runtimeSessionID
 	recordStrategyTriggerHealth(state, summary, eventTime)
-	updatedSession, err := p.updateLiveSessionStatePreservingSignalBarTradeLimit(session.ID, state)
+	updatedSession, err := p.updateLiveSessionStatePreservingNonRegressiveFacts(session.ID, state)
 	if err != nil {
 		return err
 	}
@@ -2417,7 +2417,7 @@ func (p *Platform) triggerLiveSessionFromSignal(sessionID, runtimeSessionID stri
 		state = cloneMetadata(updatedSession.State)
 		state["lastStrategyTriggerError"] = err.Error()
 		state["lastStrategyTriggerErrorAt"] = eventTime.UTC().Format(time.RFC3339)
-		_, _ = p.updateLiveSessionStatePreservingSignalBarTradeLimit(updatedSession.ID, state)
+		_, _ = p.updateLiveSessionStatePreservingNonRegressiveFacts(updatedSession.ID, state)
 		return err
 	}
 	return nil
@@ -2516,7 +2516,7 @@ func (p *Platform) evaluateLiveSessionOnSignal(session domain.LiveSession, runti
 			"missing": len(metadataList(sourceGate["missing"])),
 			"stale":   len(metadataList(sourceGate["stale"])),
 		})
-		_, err := p.updateLiveSessionStatePreservingSignalBarTradeLimit(session.ID, state)
+		_, err := p.updateLiveSessionStatePreservingNonRegressiveFacts(session.ID, state)
 		return err
 	}
 
@@ -2531,7 +2531,7 @@ func (p *Platform) evaluateLiveSessionOnSignal(session domain.LiveSession, runti
 		}
 		appendTimelineEvent(state, "strategy", eventTime, "decision-error", map[string]any{"error": err.Error()})
 		recordStrategyDecisionErrorHealth(state, eventTime, err)
-		_, updateErr := p.updateLiveSessionStatePreservingSignalBarTradeLimit(session.ID, state)
+		_, updateErr := p.updateLiveSessionStatePreservingNonRegressiveFacts(session.ID, state)
 		if updateErr != nil {
 			return updateErr
 		}
@@ -2600,7 +2600,7 @@ func (p *Platform) evaluateLiveSessionOnSignal(session domain.LiveSession, runti
 			state["lastExecutionProposalError"] = proposalErr.Error()
 			recordExecutionPlanningErrorHealth(state, eventTime, proposalErr)
 			appendTimelineEvent(state, "strategy", eventTime, "execution-planning-error", map[string]any{"error": proposalErr.Error()})
-			_, updateErr := p.updateLiveSessionStatePreservingSignalBarTradeLimit(session.ID, state)
+			_, updateErr := p.updateLiveSessionStatePreservingNonRegressiveFacts(session.ID, state)
 			if updateErr != nil {
 				return updateErr
 			}
@@ -2701,7 +2701,7 @@ func (p *Platform) evaluateLiveSessionOnSignal(session domain.LiveSession, runti
 	} else {
 		state["lastStrategyEvaluationStatus"] = "waiting-decision"
 	}
-	updatedSession, err := p.updateLiveSessionStatePreservingSignalBarTradeLimit(session.ID, state)
+	updatedSession, err := p.updateLiveSessionStatePreservingNonRegressiveFacts(session.ID, state)
 	if err != nil {
 		return err
 	}
@@ -2749,25 +2749,33 @@ func (p *Platform) evaluateLiveSessionOnSignal(session domain.LiveSession, runti
 	return nil
 }
 
-func (p *Platform) updateLiveSessionStatePreservingSignalBarTradeLimit(sessionID string, state map[string]any) (domain.LiveSession, error) {
+func (p *Platform) updateLiveSessionStatePreservingNonRegressiveFacts(sessionID string, state map[string]any) (domain.LiveSession, error) {
 	if latestSession, err := p.store.GetLiveSession(sessionID); err == nil {
-		preserveLiveSignalBarTradeLimitState(state, latestSession.State)
+		preserveLiveSessionNonRegressiveFacts(state, latestSession.State)
 	}
 	return p.store.UpdateLiveSessionState(sessionID, state)
 }
 
-func preserveLiveSignalBarTradeLimitState(state map[string]any, latest map[string]any) {
+// Some live session fields are confirmed facts / once-only guards and must not
+// regress when a stale strategy-evaluation snapshot overwrites session state.
+// Keep this list centralized so future monotonic/idempotency guards do not get
+// patched ad hoc in scattered call sites.
+func preserveLiveSessionNonRegressiveFacts(state map[string]any, latest map[string]any) {
 	if state == nil || latest == nil {
 		return
 	}
-	for _, key := range []string{
-		"lastSignalBarStateKey",
-		"sessionReentryCount",
-		"lastCountedReentryOrderId",
-	} {
+	for _, key := range liveSessionNonRegressiveFactKeys() {
 		if value, ok := latest[key]; ok {
 			state[key] = value
 		}
+	}
+}
+
+func liveSessionNonRegressiveFactKeys() []string {
+	return []string{
+		"lastSignalBarStateKey",
+		"sessionReentryCount",
+		"lastCountedReentryOrderId",
 	}
 }
 

--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -2409,7 +2409,7 @@ func (p *Platform) triggerLiveSessionFromSignal(sessionID, runtimeSessionID stri
 	state["lastSignalRuntimeEvent"] = cloneMetadata(summary)
 	state["lastSignalRuntimeSessionId"] = runtimeSessionID
 	recordStrategyTriggerHealth(state, summary, eventTime)
-	updatedSession, err := p.store.UpdateLiveSessionState(session.ID, state)
+	updatedSession, err := p.updateLiveSessionStatePreservingSignalBarTradeLimit(session.ID, state)
 	if err != nil {
 		return err
 	}
@@ -2417,7 +2417,7 @@ func (p *Platform) triggerLiveSessionFromSignal(sessionID, runtimeSessionID stri
 		state = cloneMetadata(updatedSession.State)
 		state["lastStrategyTriggerError"] = err.Error()
 		state["lastStrategyTriggerErrorAt"] = eventTime.UTC().Format(time.RFC3339)
-		_, _ = p.store.UpdateLiveSessionState(updatedSession.ID, state)
+		_, _ = p.updateLiveSessionStatePreservingSignalBarTradeLimit(updatedSession.ID, state)
 		return err
 	}
 	return nil
@@ -2516,7 +2516,7 @@ func (p *Platform) evaluateLiveSessionOnSignal(session domain.LiveSession, runti
 			"missing": len(metadataList(sourceGate["missing"])),
 			"stale":   len(metadataList(sourceGate["stale"])),
 		})
-		_, err := p.store.UpdateLiveSessionState(session.ID, state)
+		_, err := p.updateLiveSessionStatePreservingSignalBarTradeLimit(session.ID, state)
 		return err
 	}
 
@@ -2531,7 +2531,7 @@ func (p *Platform) evaluateLiveSessionOnSignal(session domain.LiveSession, runti
 		}
 		appendTimelineEvent(state, "strategy", eventTime, "decision-error", map[string]any{"error": err.Error()})
 		recordStrategyDecisionErrorHealth(state, eventTime, err)
-		_, updateErr := p.store.UpdateLiveSessionState(session.ID, state)
+		_, updateErr := p.updateLiveSessionStatePreservingSignalBarTradeLimit(session.ID, state)
 		if updateErr != nil {
 			return updateErr
 		}
@@ -2600,7 +2600,7 @@ func (p *Platform) evaluateLiveSessionOnSignal(session domain.LiveSession, runti
 			state["lastExecutionProposalError"] = proposalErr.Error()
 			recordExecutionPlanningErrorHealth(state, eventTime, proposalErr)
 			appendTimelineEvent(state, "strategy", eventTime, "execution-planning-error", map[string]any{"error": proposalErr.Error()})
-			_, updateErr := p.store.UpdateLiveSessionState(session.ID, state)
+			_, updateErr := p.updateLiveSessionStatePreservingSignalBarTradeLimit(session.ID, state)
 			if updateErr != nil {
 				return updateErr
 			}
@@ -2701,7 +2701,7 @@ func (p *Platform) evaluateLiveSessionOnSignal(session domain.LiveSession, runti
 	} else {
 		state["lastStrategyEvaluationStatus"] = "waiting-decision"
 	}
-	updatedSession, err := p.store.UpdateLiveSessionState(session.ID, state)
+	updatedSession, err := p.updateLiveSessionStatePreservingSignalBarTradeLimit(session.ID, state)
 	if err != nil {
 		return err
 	}
@@ -2747,6 +2747,28 @@ func (p *Platform) evaluateLiveSessionOnSignal(session domain.LiveSession, runti
 		return err
 	}
 	return nil
+}
+
+func (p *Platform) updateLiveSessionStatePreservingSignalBarTradeLimit(sessionID string, state map[string]any) (domain.LiveSession, error) {
+	if latestSession, err := p.store.GetLiveSession(sessionID); err == nil {
+		preserveLiveSignalBarTradeLimitState(state, latestSession.State)
+	}
+	return p.store.UpdateLiveSessionState(sessionID, state)
+}
+
+func preserveLiveSignalBarTradeLimitState(state map[string]any, latest map[string]any) {
+	if state == nil || latest == nil {
+		return
+	}
+	for _, key := range []string{
+		"lastSignalBarStateKey",
+		"sessionReentryCount",
+		"lastCountedReentryOrderId",
+	} {
+		if value, ok := latest[key]; ok {
+			state[key] = value
+		}
+	}
 }
 
 func (p *Platform) finalizeLiveSessionPlanExhausted(session domain.LiveSession, state map[string]any, plan []paperPlannedOrder, eventTime time.Time) error {

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -3085,6 +3085,58 @@ func TestMaybeIncrementLiveSessionReentryCountUsesPerBarIdentity(t *testing.T) {
 	}
 }
 
+func TestUpdateLiveSessionStatePreservingSignalBarTradeLimitKeepsLatestCountedBar(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	session, err := platform.CreateLiveSession("", "live-main", "strategy-bk-1d", map[string]any{
+		"symbol":          "BTCUSDT",
+		"signalTimeframe": "30m",
+	})
+	if err != nil {
+		t.Fatalf("create live session failed: %v", err)
+	}
+	session, err = platform.store.UpdateLiveSessionState(session.ID, map[string]any{
+		"symbol":                    "BTCUSDT",
+		"signalTimeframe":           "30m",
+		"max_trades_per_bar":        2,
+		"lastSignalBarStateKey":     "BTCUSDT|30m|2026-04-22T03:00:00Z",
+		"sessionReentryCount":       2.0,
+		"lastCountedReentryOrderId": "order-2",
+	})
+	if err != nil {
+		t.Fatalf("seed live session state failed: %v", err)
+	}
+
+	staleEvaluationState := cloneMetadata(session.State)
+	delete(staleEvaluationState, "lastSignalBarStateKey")
+	delete(staleEvaluationState, "sessionReentryCount")
+	delete(staleEvaluationState, "lastCountedReentryOrderId")
+	staleEvaluationState["lastStrategyEvaluationStatus"] = "intent-ready"
+
+	updated, err := platform.updateLiveSessionStatePreservingSignalBarTradeLimit(session.ID, staleEvaluationState)
+	if err != nil {
+		t.Fatalf("update live session state failed: %v", err)
+	}
+	if got := stringValue(updated.State["lastSignalBarStateKey"]); got != "BTCUSDT|30m|2026-04-22T03:00:00Z" {
+		t.Fatalf("expected latest signal bar key to survive stale evaluation write, got %q", got)
+	}
+	if got := parseFloatValue(updated.State["sessionReentryCount"]); got != 2 {
+		t.Fatalf("expected latest reentry count to survive stale evaluation write, got %v", got)
+	}
+	if got := stringValue(updated.State["lastCountedReentryOrderId"]); got != "order-2" {
+		t.Fatalf("expected last counted reentry order id to survive stale evaluation write, got %q", got)
+	}
+	proposal := map[string]any{
+		"role":   "entry",
+		"reason": "SL-Reentry",
+		"metadata": map[string]any{
+			liveSignalBarTradeLimitKeyField: "BTCUSDT|30m|2026-04-22T03:00:00Z",
+		},
+	}
+	if err := validateLiveSignalBarEntryTradeLimit(updated, proposal); err == nil {
+		t.Fatal("expected preserved per-bar reentry count to keep blocking same-bar entry")
+	}
+}
+
 func TestShouldAutoDispatchLiveIntentBlocksEntryAfterMaxTradesPerSignalBar(t *testing.T) {
 	intent := map[string]any{
 		"action":            "entry",

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -3085,7 +3085,7 @@ func TestMaybeIncrementLiveSessionReentryCountUsesPerBarIdentity(t *testing.T) {
 	}
 }
 
-func TestUpdateLiveSessionStatePreservingSignalBarTradeLimitKeepsLatestCountedBar(t *testing.T) {
+func TestUpdateLiveSessionStatePreservingNonRegressiveFactsKeepsLatestCountedBar(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
 	session, err := platform.CreateLiveSession("", "live-main", "strategy-bk-1d", map[string]any{
 		"symbol":          "BTCUSDT",
@@ -3112,7 +3112,7 @@ func TestUpdateLiveSessionStatePreservingSignalBarTradeLimitKeepsLatestCountedBa
 	delete(staleEvaluationState, "lastCountedReentryOrderId")
 	staleEvaluationState["lastStrategyEvaluationStatus"] = "intent-ready"
 
-	updated, err := platform.updateLiveSessionStatePreservingSignalBarTradeLimit(session.ID, staleEvaluationState)
+	updated, err := platform.updateLiveSessionStatePreservingNonRegressiveFacts(session.ID, staleEvaluationState)
 	if err != nil {
 		t.Fatalf("update live session state failed: %v", err)
 	}
@@ -3134,6 +3134,26 @@ func TestUpdateLiveSessionStatePreservingSignalBarTradeLimitKeepsLatestCountedBa
 	}
 	if err := validateLiveSignalBarEntryTradeLimit(updated, proposal); err == nil {
 		t.Fatal("expected preserved per-bar reentry count to keep blocking same-bar entry")
+	}
+}
+
+func TestLiveSessionNonRegressiveFactKeysIncludeSignalBarTradeLimitFacts(t *testing.T) {
+	keys := liveSessionNonRegressiveFactKeys()
+	for _, required := range []string{
+		"lastSignalBarStateKey",
+		"sessionReentryCount",
+		"lastCountedReentryOrderId",
+	} {
+		found := false
+		for _, key := range keys {
+			if key == required {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("expected non-regressive fact keys to include %s, got %#v", required, keys)
+		}
 	}
 }
 

--- a/internal/service/signal_runtime_registry.go
+++ b/internal/service/signal_runtime_registry.go
@@ -190,6 +190,7 @@ func (p *Platform) BuildSignalRuntimePlan(accountID, strategyID string) (map[str
 	if err != nil {
 		return nil, err
 	}
+	liveBinding := resolveLiveBinding(account)
 
 	strategyBindings, err := p.ListStrategySignalBindings(strategyID)
 	if err != nil {
@@ -259,6 +260,7 @@ func (p *Platform) BuildSignalRuntimePlan(accountID, strategyID string) (map[str
 		subscription := runtimeAdapter.BuildSubscription(source, binding)
 		subscription["environment"] = environment
 		subscription["accountMode"] = account.Mode
+		applyLiveBindingToSignalRuntimeSubscription(subscription, liveBinding)
 		matchedItem["subscription"] = subscription
 		subscriptions = append(subscriptions, subscription)
 		matched = append(matched, matchedItem)
@@ -327,4 +329,19 @@ func firstString(values []string) string {
 		return ""
 	}
 	return values[0]
+}
+
+func applyLiveBindingToSignalRuntimeSubscription(subscription map[string]any, liveBinding map[string]any) {
+	if subscription == nil || len(liveBinding) == 0 {
+		return
+	}
+	if _, exists := subscription["sandbox"]; !exists {
+		subscription["sandbox"] = boolValue(liveBinding["sandbox"])
+	}
+	if restBaseURL := strings.TrimSpace(stringValue(liveBinding["restBaseUrl"])); restBaseURL != "" {
+		subscription["restBaseUrl"] = restBaseURL
+	}
+	if wsBaseURL := strings.TrimSpace(stringValue(liveBinding["wsBaseUrl"])); wsBaseURL != "" {
+		subscription["wsBaseUrl"] = wsBaseURL
+	}
 }

--- a/internal/service/signal_runtime_registry.go
+++ b/internal/service/signal_runtime_registry.go
@@ -335,13 +335,15 @@ func applyLiveBindingToSignalRuntimeSubscription(subscription map[string]any, li
 	if subscription == nil || len(liveBinding) == 0 {
 		return
 	}
-	if _, exists := subscription["sandbox"]; !exists {
-		subscription["sandbox"] = boolValue(liveBinding["sandbox"])
-	}
+	subscription["sandbox"] = boolValue(liveBinding["sandbox"])
 	if restBaseURL := strings.TrimSpace(stringValue(liveBinding["restBaseUrl"])); restBaseURL != "" {
 		subscription["restBaseUrl"] = restBaseURL
+	} else {
+		delete(subscription, "restBaseUrl")
 	}
 	if wsBaseURL := strings.TrimSpace(stringValue(liveBinding["wsBaseUrl"])); wsBaseURL != "" {
 		subscription["wsBaseUrl"] = wsBaseURL
+	} else {
+		delete(subscription, "wsBaseUrl")
 	}
 }

--- a/internal/service/signal_runtime_registry_test.go
+++ b/internal/service/signal_runtime_registry_test.go
@@ -83,3 +83,53 @@ func TestBuildSignalRuntimePlanAllowsMissingFeatureBindings(t *testing.T) {
 		t.Fatalf("expected optional missing feature binding, got %#v", optional)
 	}
 }
+
+func TestBuildSignalRuntimePlanCarriesLiveBindingSandboxToSubscriptions(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	account, err := platform.store.CreateAccount("runtime-live", "LIVE", "binance-futures")
+	if err != nil {
+		t.Fatalf("create live account failed: %v", err)
+	}
+	strategy, err := platform.store.CreateStrategy("runtime-strategy", "runtime strategy", map[string]any{
+		"strategyEngine": "bk-default",
+	})
+	if err != nil {
+		t.Fatalf("create strategy failed: %v", err)
+	}
+	strategyID := strategy["id"].(string)
+	if _, err := platform.BindStrategySignalSource(strategyID, map[string]any{
+		"sourceKey": "binance-kline",
+		"role":      "signal",
+		"symbol":    "BTCUSDT",
+		"options":   map[string]any{"timeframe": "30m"},
+	}); err != nil {
+		t.Fatalf("bind strategy signal source failed: %v", err)
+	}
+	if _, err := platform.BindLiveAccount(account.ID, map[string]any{
+		"adapterKey":  "binance-futures",
+		"sandbox":     true,
+		"restBaseUrl": "https://testnet.binancefuture.com",
+		"wsBaseUrl":   "wss://stream.binancefuture.com/ws",
+	}); err != nil {
+		t.Fatalf("bind live account failed: %v", err)
+	}
+
+	plan, err := platform.BuildSignalRuntimePlan(account.ID, strategyID)
+	if err != nil {
+		t.Fatalf("build runtime plan failed: %v", err)
+	}
+	subscriptions := metadataList(plan["subscriptions"])
+	if len(subscriptions) != 1 {
+		t.Fatalf("expected one subscription, got %#v", subscriptions)
+	}
+	subscription := subscriptions[0]
+	if !boolValue(subscription["sandbox"]) {
+		t.Fatalf("expected sandbox=true on runtime subscription, got %#v", subscription)
+	}
+	if got := stringValue(subscription["restBaseUrl"]); got != "https://testnet.binancefuture.com" {
+		t.Fatalf("expected restBaseUrl to propagate to runtime subscription, got %q", got)
+	}
+	if got := stringValue(subscription["wsBaseUrl"]); got != "wss://stream.binancefuture.com/ws" {
+		t.Fatalf("expected wsBaseUrl to propagate to runtime subscription, got %q", got)
+	}
+}

--- a/internal/service/signal_runtime_registry_test.go
+++ b/internal/service/signal_runtime_registry_test.go
@@ -133,3 +133,23 @@ func TestBuildSignalRuntimePlanCarriesLiveBindingSandboxToSubscriptions(t *testi
 		t.Fatalf("expected wsBaseUrl to propagate to runtime subscription, got %q", got)
 	}
 }
+
+func TestApplyLiveBindingToSignalRuntimeSubscriptionOverridesStaleEnvironmentFields(t *testing.T) {
+	subscription := map[string]any{
+		"sandbox":     false,
+		"restBaseUrl": "https://fapi.binance.com",
+		"wsBaseUrl":   "wss://fstream.binance.com/ws",
+	}
+	applyLiveBindingToSignalRuntimeSubscription(subscription, map[string]any{
+		"sandbox": true,
+	})
+	if !boolValue(subscription["sandbox"]) {
+		t.Fatalf("expected live binding to override stale sandbox=false, got %#v", subscription)
+	}
+	if got := stringValue(subscription["restBaseUrl"]); got != "" {
+		t.Fatalf("expected empty live binding to clear stale restBaseUrl, got %q", got)
+	}
+	if got := stringValue(subscription["wsBaseUrl"]); got != "" {
+		t.Fatalf("expected empty live binding to clear stale wsBaseUrl, got %q", got)
+	}
+}

--- a/internal/service/signal_runtime_ws.go
+++ b/internal/service/signal_runtime_ws.go
@@ -92,11 +92,12 @@ func classifyDisconnectSeverity(err error) disconnectSeverity {
 }
 
 const (
-	defaultBinanceFuturesWSURL      = "wss://fstream.binance.com/ws"
-	defaultOKXPublicWSURL           = "wss://ws.okx.com:8443/ws/v5/public"
-	signalRuntimeWSHandshakeTimeout = 5 * time.Second
-	signalRuntimeWSPingInterval     = 10 * time.Second
-	signalRuntimeWSPingWriteTimeout = 3 * time.Second
+	defaultBinanceFuturesWSURL        = "wss://fstream.binance.com/ws"
+	defaultBinanceFuturesTestnetWSURL = "wss://stream.binancefuture.com/ws"
+	defaultOKXPublicWSURL             = "wss://ws.okx.com:8443/ws/v5/public"
+	signalRuntimeWSHandshakeTimeout   = 5 * time.Second
+	signalRuntimeWSPingInterval       = 10 * time.Second
+	signalRuntimeWSPingWriteTimeout   = 3 * time.Second
 )
 
 type signalRuntimeWSProfile struct {
@@ -278,8 +279,13 @@ func (p *Platform) runSignalRuntimeLoopOnce(ctx context.Context, sessionID strin
 	if err != nil {
 		return false, err
 	}
+	subscriptions := p.signalRuntimeSubscriptions(session)
+	if len(subscriptions) > 0 {
+		session.State = cloneMetadata(session.State)
+		session.State["subscriptions"] = subscriptions
+	}
 
-	wsURL, subscribeBuilder, err := signalRuntimeWebsocketConfig(session.RuntimeAdapter)
+	wsURL, subscribeBuilder, err := signalRuntimeWebsocketConfig(session.RuntimeAdapter, subscriptions)
 	if err != nil {
 		return false, err
 	}
@@ -287,15 +293,79 @@ func (p *Platform) runSignalRuntimeLoopOnce(ctx context.Context, sessionID strin
 	return p.runExchangeWebsocketLoop(ctx, session, wsURL, subscribeBuilder)
 }
 
-func signalRuntimeWebsocketConfig(runtimeAdapter string) (string, func([]map[string]any) (map[string]any, error), error) {
+func (p *Platform) signalRuntimeSubscriptions(session domain.SignalRuntimeSession) []map[string]any {
+	subscriptions := cloneMetadataList(metadataList(session.State["subscriptions"]))
+	if len(subscriptions) == 0 {
+		return subscriptions
+	}
+	account, err := p.store.GetAccount(session.AccountID)
+	if err != nil {
+		return subscriptions
+	}
+	liveBinding := resolveLiveBinding(account)
+	for _, subscription := range subscriptions {
+		applyLiveBindingToSignalRuntimeSubscription(subscription, liveBinding)
+	}
+	return subscriptions
+}
+
+func signalRuntimeWebsocketConfig(runtimeAdapter string, subscriptions []map[string]any) (string, func([]map[string]any) (map[string]any, error), error) {
 	switch runtimeAdapter {
 	case "binance-market-ws":
-		return configuredBinanceFuturesWSURL(), buildBinanceSubscribePayload, nil
+		wsURL, err := resolveBinanceSignalRuntimeWSURL(subscriptions)
+		if err != nil {
+			return "", nil, err
+		}
+		return wsURL, buildBinanceSubscribePayload, nil
 	case "okx-market-ws":
 		return configuredOKXPublicWSURL(), buildOKXSubscribePayload, nil
 	default:
 		return "", nil, fmt.Errorf("unsupported runtime adapter: %s", runtimeAdapter)
 	}
+}
+
+func resolveBinanceSignalRuntimeWSURL(subscriptions []map[string]any) (string, error) {
+	wsURL := ""
+	sandboxResolved := false
+	sandbox := false
+	for _, subscription := range subscriptions {
+		if subscription == nil {
+			continue
+		}
+		if candidate := strings.TrimSpace(stringValue(subscription["wsBaseUrl"])); candidate != "" {
+			if wsURL == "" {
+				wsURL = candidate
+			} else if wsURL != candidate {
+				return "", fmt.Errorf("binance runtime subscriptions require a single websocket base url: %s vs %s", wsURL, candidate)
+			}
+		}
+		subscriptionSandbox := binanceSignalRuntimeSubscriptionUsesTestnet(subscription)
+		if !sandboxResolved {
+			sandbox = subscriptionSandbox
+			sandboxResolved = true
+			continue
+		}
+		if sandbox != subscriptionSandbox {
+			return "", fmt.Errorf("binance runtime subscriptions mix sandbox and live market data environments")
+		}
+	}
+	if wsURL != "" {
+		return wsURL, nil
+	}
+	if sandboxResolved && sandbox {
+		return defaultBinanceFuturesTestnetWSURL, nil
+	}
+	return configuredBinanceFuturesWSURL(), nil
+}
+
+func binanceSignalRuntimeSubscriptionUsesTestnet(subscription map[string]any) bool {
+	if subscription == nil {
+		return false
+	}
+	if _, exists := subscription["sandbox"]; exists && boolValue(subscription["sandbox"]) {
+		return true
+	}
+	return strings.Contains(strings.ToLower(strings.TrimSpace(stringValue(subscription["restBaseUrl"]))), "testnet.binancefuture.com")
 }
 
 func minInt(a, b int) int {

--- a/internal/service/signal_runtime_ws.go
+++ b/internal/service/signal_runtime_ws.go
@@ -353,7 +353,7 @@ func resolveBinanceSignalRuntimeWSURL(subscriptions []map[string]any) (string, e
 		return wsURL, nil
 	}
 	if sandboxResolved && sandbox {
-		return defaultBinanceFuturesTestnetWSURL, nil
+		return configuredBinanceFuturesWSURLWithDefault(defaultBinanceFuturesTestnetWSURL), nil
 	}
 	return configuredBinanceFuturesWSURL(), nil
 }
@@ -450,9 +450,13 @@ func (p *Platform) setSessionStopped(sessionID string) {
 }
 
 func configuredBinanceFuturesWSURL() string {
+	return configuredBinanceFuturesWSURLWithDefault(defaultBinanceFuturesWSURL)
+}
+
+func configuredBinanceFuturesWSURLWithDefault(fallback string) string {
 	url := strings.TrimSpace(os.Getenv("BINANCE_FUTURES_WS_URL"))
 	if url == "" {
-		return defaultBinanceFuturesWSURL
+		return fallback
 	}
 	return url
 }

--- a/internal/service/signal_runtime_ws_test.go
+++ b/internal/service/signal_runtime_ws_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -126,6 +127,30 @@ func TestResolveBinanceSignalRuntimeWSURLUsesSandboxDefault(t *testing.T) {
 	}
 	if wsURL != defaultBinanceFuturesTestnetWSURL {
 		t.Fatalf("expected sandbox runtime to use testnet websocket url, got %s", wsURL)
+	}
+}
+
+func TestResolveBinanceSignalRuntimeWSURLKeepsEnvOverrideForSandboxSessions(t *testing.T) {
+	original := os.Getenv("BINANCE_FUTURES_WS_URL")
+	if err := os.Setenv("BINANCE_FUTURES_WS_URL", "wss://proxy.internal/ws"); err != nil {
+		t.Fatalf("set env failed: %v", err)
+	}
+	t.Cleanup(func() {
+		if original == "" {
+			_ = os.Unsetenv("BINANCE_FUTURES_WS_URL")
+			return
+		}
+		_ = os.Setenv("BINANCE_FUTURES_WS_URL", original)
+	})
+	wsURL, err := resolveBinanceSignalRuntimeWSURL([]map[string]any{{
+		"adapterKey": "binance-market-ws",
+		"sandbox":    true,
+	}})
+	if err != nil {
+		t.Fatalf("resolve sandbox websocket url with env override failed: %v", err)
+	}
+	if wsURL != "wss://proxy.internal/ws" {
+		t.Fatalf("expected sandbox runtime to keep BINANCE_FUTURES_WS_URL override, got %s", wsURL)
 	}
 }
 

--- a/internal/service/signal_runtime_ws_test.go
+++ b/internal/service/signal_runtime_ws_test.go
@@ -116,6 +116,70 @@ func TestSignalRuntimeWSProfileForAttemptExpandsReadTimeout(t *testing.T) {
 	}
 }
 
+func TestResolveBinanceSignalRuntimeWSURLUsesSandboxDefault(t *testing.T) {
+	wsURL, err := resolveBinanceSignalRuntimeWSURL([]map[string]any{{
+		"adapterKey": "binance-market-ws",
+		"sandbox":    true,
+	}})
+	if err != nil {
+		t.Fatalf("resolve sandbox websocket url failed: %v", err)
+	}
+	if wsURL != defaultBinanceFuturesTestnetWSURL {
+		t.Fatalf("expected sandbox runtime to use testnet websocket url, got %s", wsURL)
+	}
+}
+
+func TestResolveBinanceSignalRuntimeWSURLPrefersExplicitSubscriptionURL(t *testing.T) {
+	wsURL, err := resolveBinanceSignalRuntimeWSURL([]map[string]any{{
+		"adapterKey": "binance-market-ws",
+		"sandbox":    true,
+		"wsBaseUrl":  "wss://custom.binance.test/ws",
+	}})
+	if err != nil {
+		t.Fatalf("resolve explicit websocket url failed: %v", err)
+	}
+	if wsURL != "wss://custom.binance.test/ws" {
+		t.Fatalf("expected explicit runtime wsBaseUrl to win, got %s", wsURL)
+	}
+}
+
+func TestSignalRuntimeSubscriptionsOverlayLiveBindingForReconnect(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	account, err := platform.store.CreateAccount("runtime-reconnect-live", "LIVE", "binance-futures")
+	if err != nil {
+		t.Fatalf("create live account failed: %v", err)
+	}
+	if _, err := platform.BindLiveAccount(account.ID, map[string]any{
+		"adapterKey":  "binance-futures",
+		"sandbox":     true,
+		"restBaseUrl": "https://testnet.binancefuture.com",
+		"wsBaseUrl":   "wss://stream.binancefuture.com/ws",
+	}); err != nil {
+		t.Fatalf("bind live account failed: %v", err)
+	}
+
+	subscriptions := platform.signalRuntimeSubscriptions(domain.SignalRuntimeSession{
+		AccountID: account.ID,
+		State: map[string]any{
+			"subscriptions": []map[string]any{{
+				"adapterKey": "binance-market-ws",
+				"sourceKey":  "binance-kline",
+				"symbol":     "BTCUSDT",
+				"channel":    "btcusdt@kline_30m",
+			}},
+		},
+	})
+	if len(subscriptions) != 1 {
+		t.Fatalf("expected one subscription, got %#v", subscriptions)
+	}
+	if !boolValue(subscriptions[0]["sandbox"]) {
+		t.Fatalf("expected reconnect overlay to recover sandbox=true, got %#v", subscriptions[0])
+	}
+	if got := stringValue(subscriptions[0]["wsBaseUrl"]); got != "wss://stream.binancefuture.com/ws" {
+		t.Fatalf("expected reconnect overlay to recover wsBaseUrl, got %q", got)
+	}
+}
+
 func TestRunExchangeWebsocketLoopRecordsReconnectObservability(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
 	now := time.Now().UTC()


### PR DESCRIPTION
## 目的
修复 live runtime 的两个串联问题，避免策略在 testnet 执行时使用错环境行情源，并避免同一根 signal bar 的 reentry 限额被旧 session state 回写冲掉后再次进场。

根因拆成两条：
1. `BuildSignalRuntimePlan` / signal runtime websocket 连接没有继承 live account binding 的 `sandbox` / `wsBaseUrl`，导致 testnet REST 执行账户有机会配上 mainnet UM market data websocket。
2. live 策略评估路径会整包覆盖 `live_sessions.state`，把 `lastSignalBarStateKey` / `sessionReentryCount` / `lastCountedReentryOrderId` 这组事实态写旧，进而放过同 bar 的额外 reentry。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [x] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
- `dispatchMode` 默认值未变化。
- 未新增 `mainnet` 凭证硬编码；Binance futures websocket 仅在 `sandbox=true` 时才切到 testnet UM 默认地址，且允许被 binding 的 `wsBaseUrl` 显式覆盖。
- 无 DB migration。
- 改动范围只限 signal runtime 订阅/连接环境收敛，以及 live session same-bar reentry 事实态保护，没有顺手改 dispatch 语义或 recovery 状态机。

## 验证方式与测试证据
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

本地验证：
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`

新增回归覆盖：
- runtime plan 会把 live binding 的 `sandbox` / `restBaseUrl` / `wsBaseUrl` 传入 subscriptions
- Binance runtime websocket 会在 sandbox 订阅下默认选择 testnet UM websocket，并允许显式 `wsBaseUrl` 覆盖
- 即使旧的 signal runtime session state 没写 sandbox，runtime reconnect 前也会从 live binding 覆盖回正确环境
- live session 策略评估写回 state 时，会保留最新的 per-bar reentry 事实态，阻止 stale evaluation 覆盖后放过同 bar 第三次进场

行为变化：
- signal runtime 与 live execution 现在会对齐同一个 Binance environment source-of-truth，减少“执行在 testnet、决策价却来自另一套行情”的漂移
- 同一根 signal bar 内的已确认 reentry 次数不再被后续 evaluation 回写冲掉，`max_trades_per_bar` 会按最新事实态继续生效
- 已经运行中的 runtime session 在下次 websocket 重连时也会自动带回正确的 sandbox 订阅配置，不需要手工改库或删 session