### PR TITLE
[codex] fix reconcile gate adopt bootstrap ordering

### DIFF
--- a/docs/20260424-reconcile-gate-self-heal-and-bootstrap-ordering.md
+++ b/docs/20260424-reconcile-gate-self-heal-and-bootstrap-ordering.md
@@ -1,0 +1,294 @@
+# Reconcile Gate 自愈与启动恢复顺序修正治理计划
+> **事故日期**: 2026-04-23
+> **事故现象**: BTCUSDT LONG 仓位 DB=0.013 vs Exchange=0.0065 → `quantity-mismatch` → `reconcile-gate-blocked` → session 永久卡死
+> **临时修复**: 手工改库 DB position 对齐交易所后 stop/start
+---
+## Root Cause 分析
+### 直接原因
+`reconcileLiveAccountPositions()` ([live.go:2113-2295](file:///Users/fujun/node/bktrader/internal/service/live.go#L2113-L2295)) 在检测到 `quantity-mismatch` 时，会写入 `conflict` + `blocking=true`。但下游所有恢复路径都没有针对 **"side 一致、交易所 authoritative、无 pending settlement 的纯 quantity 偏差"** 提供自动收敛逻辑。
+### 代码级证据
+1. **`livePositionReconcileGateCanSelfHeal()`** ([live.go:601-604](file:///Users/fujun/node/bktrader/internal/service/live.go#L601-L604)) 仅覆盖 `stale` + `db-position-exchange-missing`，不覆盖 `conflict` + `quantity-mismatch`
+2. **`attemptLiveAccountReconcileSelfHeal()`** ([live.go:622-638](file:///Users/fujun/node/bktrader/internal/service/live.go#L622-L638)) 依赖上述函数，因此 `quantity-mismatch` 场景直接 `return account, false, nil`
+3. **`StartLiveSession()`** ([live.go:1899-1933](file:///Users/fujun/node/bktrader/internal/service/live.go#L1899-L1933)) 和 **`recoverRunningLiveSession()`** ([live.go:2065-2088](file:///Users/fujun/node/bktrader/internal/service/live.go#L2065-L2088)) 都调用 `attemptLiveAccountReconcileSelfHeal`，但因为 `canSelfHeal` 返回 false，直接走到 `enterRecoveredLiveSessionReconcileGateBlocked`
+4. 一旦进入 `reconcile-gate-blocked`，**没有任何定时重试或事件驱动的再次评估路径**
+### 叠加原因：启动顺序
+`recoverRunningLiveSession()` 在 source gate 检查之前就可能因 reconcile gate 触发 blocked，而 signal runtime WS 此时还没连上。日志表现为 "runtime source gate blocked" 先于 "signal runtime websocket connected"。
+---
+## Issue A: Reconcile Gate 自愈 / Adopt 路径
+### 目标
+把"可判定的单一事实冲突"从永久 `conflict` 收敛为 `adopted` → `verified`，不需要人工改库。
+### 允许自动 Adopt 的最小边界（动作矩阵）
+| 条件 | 要求 |
+|------|------|
+| 交易所 REST snapshot | `authoritative = true` |
+| symbol | 唯一匹配（DB 与 exchange 同一 symbol） |
+| side | **一致**（DB side == exchange side） |
+| 冲突字段 | 仅限 `quantity` 和/或 `entryPrice`（不含 `side`） |
+| pending settlement | **无**（`liveSettlementPendingOrderSymbols` 为空） |
+| open orders | 无本系统未完成的 entry/exit order 影响仓位归因 |
+| reconcile 证据来源 | 当前 authoritative position snapshot（非历史 external terminal orders） |
+### 禁止自动 Adopt 的场景（继续 conflict + 人工处理）
+| 场景 | 原因 |
+|------|------|
+| side mismatch | 方向不一致说明可能存在外部操作或系统 bug |
+| multi-field-mismatch 含 side | 同上 |
+| 存在 pending settlement | fill 未结算前 quantity 不可信 |
+| 存在本系统 open order | 正在执行的订单可能导致仓位变化 |
+| exchange snapshot 不是 authoritative | 弱事实不能覆盖 DB |
+| symbol/account 归属不唯一 | 需要人工确认 |
+### 具体改动点
+#### 1. 扩展 `livePositionReconcileGateCanSelfHeal()` ([live.go:601](file:///Users/fujun/node/bktrader/internal/service/live.go#L601))
+**现状**：只认 `stale` + `db-position-exchange-missing`
+**改为**：增加以下判定：
+- `conflict` + `quantity-mismatch` → 可自愈
+- `conflict` + `entry-price-mismatch` → 可自愈
+- `conflict` + `multi-field-mismatch` 但 mismatchFields 不含 `side` → 可自愈
+> [!IMPORTANT]
+> 要读 gate 里的 `mismatchFields`，检查是否包含 `side`。如果包含 `side`，必须返回 false。
+#### 2. 新增 `adoptLivePositionFromExchangeTruth()` helper
+**职责**（单一入口，禁止在多处各自改 DB）：
+```
+func (p *Platform) adoptLivePositionFromExchangeTruth(
+    account domain.Account,
+    symbol string,
+    exchangePosition map[string]any,
+    gate map[string]any,
+) (domain.Account, error)
+```
+流程：
+1. 前置检查：`side` 一致、无 pending settlement、无 open orders、authoritative
+2. 从 gate 的 `exchangePosition` 读取 quantity/entryPrice/markPrice
+3. 用 precision helper（`internal/service/precision_tolerance.go`）对齐 stepSize
+4. 更新本地 `positions` 表（通过 `p.store.SavePosition`）
+5. 重新调用 `refreshLiveAccountPositionReconcileGate(account)` 刷新 gate
+6. 验证刷新后 gate status 变为 `verified` 或 `adopted`
+7. 写 timeline event：`reconcile_adopt_applied`，携带完整上下文
+> [!WARNING]
+> 步骤 3 必须使用 `precision_tolerance.go` 的统一 helper，不能散落 `math.Abs` 比较。这是 PR review 黄金规则 #11。
+#### 3. 修改 `reconcileLiveAccountPositions()` ([live.go:2225-2234](file:///Users/fujun/node/bktrader/internal/service/live.go#L2225-L2234))
+**现状**：发现 `mismatchFields > 0` 就直接记 `conflict` + `blocking=true`
+**改为**：
+- 如果 mismatchFields **不含 `side`** 且 **无 pending settlement** 且 **无 open orders**：
+  - 调用 `adoptLivePositionFromExchangeTruth()` 修正 DB
+  - 记 gate 为 `adopted` + `blocking=false`
+  - scenario 为 `exchange-truth-adopted-quantity` 或 `exchange-truth-adopted-entry-price`
+- 否则保持现有 `conflict` + `blocking=true` 行为
+> [!CAUTION]
+> 这里有一个与你原始计划的**分歧点**。你建议在 `resolveLivePositionReconcileGate` 和 `ensureLiveExecutionPlan` 等入口处做 adopt。但我认为**正确的收口位置是 `reconcileLiveAccountPositions()`**，原因如下：
+> 1. `reconcileLiveAccountPositions` 是唯一同时持有 DB position 和 exchange position 的完整上下文的位置
+> 2. 在这里直接做 adopt，下游 `resolveLivePositionReconcileGate` 读到的就已经是 `adopted`/`verified`，不需要再二次处理
+> 3. 避免了多入口各自改库的风险（review 黄金规则 #1：统一 helper）
+>
+> 如果你倾向于在 `StartLiveSession` 入口处做（作为"启动前最后一次尝试"），可以保留 `attemptLiveAccountReconcileSelfHeal` 的调用，但让它在内部触发一次完整的 `ReconcileLiveAccount`（已经在做了），然后由 `reconcileLiveAccountPositions` 内部的 adopt 逻辑完成修正。两者不矛盾。
+#### 4. 清理 session state 残留
+`enterRecoveredLiveSessionReconcileGateBlocked()` ([live.go:3630-3657](file:///Users/fujun/node/bktrader/internal/service/live.go#L3630-L3657)) 写入了大量 session state 字段。当 adopt 成功后，必须确保这些字段被清除：
+- `recoveryMode`
+- `recoveryBlockedReason` / `recoveryBlockedDetail` / `recoveryBlockedAt`
+- `positionReconcileGateStatus` → 改为 `verified`
+- `positionReconcileGateBlocking` → false
+- `lastStrategyEvaluationStatus` → 清除 `reconcile-gate-blocked`
+**现有代码 `completeRecoveredLiveSessionMetadata()` ([live.go:3505-3553](file:///Users/fujun/node/bktrader/internal/service/live.go#L3505-L3553)) 在 position quantity ≤ 0 时已有清理逻辑**，但 adopt 后 position 仍 > 0，不会走这个分支。需要在 adopt 成功路径上补一个显式的 state cleanup。
+---
+## Issue B: 启动恢复顺序修正
+### 目标
+把 "先 blocked 再等 WS ready" 改成 "先 warmup → 再 gate ready → 最后 session RUNNING"。
+### 当前启动顺序（问题所在）
+```
+StartLiveSession / recoverRunningLiveSession
+  ├─ triggerAuthoritativeLiveAccountReconcile (REST sync)
+  ├─ completeRecoveredLiveSessionMetadata
+  ├─ resolveLivePositionReconcileGate ← 可能因 stale source 提前 blocked
+  ├─ syncLiveSessionRuntime
+  │   └─ bootstrapSignalRuntimeSourceStates ← 依赖 liveMarketSnapshot
+  │       └─ liveMarketSnapshot ← 可能还没 warm cache
+  ├─ ensureLiveSessionSignalRuntimeStarted
+  │   └─ StartSignalRuntimeSession
+  │       └─ runSignalRuntimeWithRecovery (goroutine) ← WS 此时才开始连接
+  ├─ awaitLiveSignalRuntimeReadiness (轮询等待)
+  └─ UpdateLiveSessionStatus("RUNNING")
+```
+**问题**：`bootstrapSignalRuntimeSourceStates()` ([signal_runtime_sessions.go:280-324](file:///Users/fujun/node/bktrader/internal/service/signal_runtime_sessions.go#L280-L324)) 调用 `liveMarketSnapshot()` 取缓存数据。如果缓存为空（冷启动/docker 重启后），bootstrap 返回空 sourceStates，导致 source gate 在 WS 连接之前就被判定为 stale/blocked。
+### 目标顺序
+```
+StartLiveSession / recoverRunningLiveSession
+  ├─ 1. triggerAuthoritativeLiveAccountReconcile (REST sync)
+  ├─ 2. completeRecoveredLiveSessionMetadata
+  ├─ 3. reconcile gate resolve + adopt (如适用)
+  ├─ 4. 显式 market warmup (refreshLiveMarketSnapshot)  ← 新增
+  ├─ 5. syncLiveSessionRuntime
+  │   └─ bootstrapSignalRuntimeSourceStates (此时缓存已有)
+  ├─ 6. ensureLiveSessionSignalRuntimeStarted
+  │   └─ StartSignalRuntimeSession + WS connect
+  ├─ 7. awaitLiveSignalRuntimeReadiness
+  └─ 8. UpdateLiveSessionStatus("RUNNING")
+```
+### 具体改动点
+#### 1. 在 `StartLiveSession()` 和 `recoverRunningLiveSession()` 中插入显式 warmup
+在 `syncLiveSessionRuntime()` 之前，增加：
+```go
+// 显式预热 market data cache，确保 bootstrap 有数据可用
+symbol := NormalizeSymbol(firstNonEmpty(
+    stringValue(session.State["symbol"]),
+    stringValue(session.State["lastSymbol"]),
+))
+if symbol != "" {
+    if _, warmupErr := p.refreshLiveMarketSnapshot(symbol); warmupErr != nil {
+        logger.Warn("market data warmup failed", "symbol", symbol, "error", warmupErr)
+        // 非致命：继续执行，bootstrap 会用空数据但不会崩
+    }
+}
+```
+> [!NOTE]
+> `refreshLiveMarketSnapshot` 已存在于 `live_market_data.go`，它会拉历史 bars 填充缓存。这里只是把调用时机前移。
+#### 2. 增强 `bootstrapSignalRuntimeSourceStates()` 的容错
+**现状** ([signal_runtime_sessions.go:291-298](file:///Users/fujun/node/bktrader/internal/service/signal_runtime_sessions.go#L291-L298))：snapshot 取不到就 `continue`，导致 sourceStates 为空
+**改为**：如果 `liveMarketSnapshot` 返回空，主动调用 `refreshLiveMarketSnapshot` 做一次回填尝试：
+```go
+snapshot, err := p.liveMarketSnapshot(symbol)
+if err != nil || len(snapshot.SignalBars) == 0 {
+    // fallback: 尝试主动刷新
+    snapshot, err = p.refreshLiveMarketSnapshot(symbol)
+    if err != nil {
+        continue
+    }
+}
+```
+#### 3. 日志区分 bootstrap-pending vs source-gate-blocked
+在 `logRuntimeSourceGateState()` ([live.go:340-374](file:///Users/fujun/node/bktrader/internal/service/live.go#L340-L374)) 中，增加一个标记来区分：
+- `bootstrap-pending`：启动预热阶段，数据尚未就绪，不是故障
+- `source-gate-blocked`：预热完成后，数据源仍不满足要求
+通过检查 session state 中是否存在 `startedAt` 来判断。
+---
+## 与原始计划的差异和补充意见
+### 同意的部分
+1. ✅ 拆成两个连续 issue，不做"大自愈重构"
+2. ✅ gate 状态语义 `stale → conflict → adopted → verified` 的定义
+3. ✅ 单一 adopt helper 收口，禁止多入口改库
+4. ✅ 禁止 side mismatch 自动 adopt
+5. ✅ 禁止 pending settlement 时 adopt
+6. ✅ 启动顺序改为固定流水线
+7. ✅ 不做项清单（不改 dispatchMode、不放宽未对账限制等）
+### 补充建议
+#### 1. Adopt 的收口位置建议下沉到 `reconcileLiveAccountPositions`
+你的原始计划建议改 `resolveLivePositionReconcileGate` → `ensureLiveExecutionPlan` → `StartLiveSession` 这条链。我建议**核心修改下沉到 `reconcileLiveAccountPositions()`**，因为：
+- 这是唯一同时持有双方完整数据的位置
+- 上游 `ReconcileLiveAccount` → `refreshLiveAccountPositionReconcileGate` 已经调用它
+- 改这一处，所有上游调用者（包括 `triggerAuthoritativeLiveAccountReconcile`）都自动受益
+- `attemptLiveAccountReconcileSelfHeal` 需要的唯一改动是扩展 `livePositionReconcileGateCanSelfHeal` 的判定范围
+#### 2. 需要增加"open orders 检查"作为 adopt 前置条件
+你的原始计划提到了"当前没有本系统未完成 open order / exit order 会影响仓位归因"，但没有指出具体的实现位置。
+建议在 `reconcileLiveAccountPositions` 的 adopt 路径上，复用 `liveSettlementPendingOrderSymbols` 的逻辑，扩展为同时检查任何 non-terminal 状态的 order：
+```go
+// 除了 settlement pending，还要检查是否有 working orders
+workingOrderSymbols, err := p.liveWorkingOrderSymbols(account.ID)
+```
+#### 3. Adopt 后是否自动恢复 RUNNING 需要明确
+你的不做项里写了 "不把 session 在 reconcile 成功后自动从 BLOCKED 恢复成 RUNNING"。但在 `recoverRunningLiveSession()` 流程中（docker 重启自动恢复），adopt 如果在 `triggerAuthoritativeLiveAccountReconcile` 内部完成，下游 `resolveLivePositionReconcileGate` 返回的 gate 就不再 blocking，session 会自然走完启动流程到 `RUNNING`。
+**建议行为**：
+- `recoverRunningLiveSession`：adopt 后继续正常流程，最终到 `RUNNING` ← 无需人工干预
+- `StartLiveSession`：同上
+- 如果 session 已经处于 `BLOCKED` 状态：需要显式 `stop?force=true` + `start` ← 不自动恢复
+这与现有语义一致：`recoverRunningLiveSession` 本来就是为了自动恢复设计的。
+#### 4. entryPrice mismatch 的 adopt 需要额外考量
+`quantity-mismatch` 的 adopt 逻辑比较直观（交易所是事实源）。但 `entryPrice-mismatch` 更微妙：
+- 交易所的 entryPrice 可能因为 ADL、资金费率等原因与 DB 不同
+- 但 DB 的 entryPrice 可能是"加权平均入场价"，有策略语义
+**建议**：
+- `quantity` adopt：直接以交易所为准
+- `entryPrice` adopt：以交易所为准，但在 timeline event 中额外记录 `dbEntryPrice`（保留审计线索）
+- 如果未来需要保留策略侧的加权入场价，可以在 position metadata 中增加 `strategyEntryPrice` 字段（不在本次 scope 内）
+---
+## 回归测试矩阵
+### Issue A: Reconcile Gate Adopt
+| # | 测试场景 | DB Position | Exchange Position | 前置条件 | 期望结果 |
+|---|---------|-------------|-------------------|----------|----------|
+| A1 | quantity-mismatch adopt 正例 | LONG 0.013 | LONG 0.0065 | authoritative, 无 pending settlement, 无 open orders | DB→0.0065, gate→adopted→verified, start 成功 |
+| A2 | entryPrice-mismatch adopt 正例 | LONG 0.0065 @ 60000 | LONG 0.0065 @ 59500 | 同上 | DB entryPrice→59500, gate→verified |
+| A3 | side-mismatch 反例 | LONG 0.0065 | SHORT 0.0065 | - | 仍 conflict, DB 不改, session BLOCKED |
+| A4 | multi-field 含 side 反例 | LONG 0.013 | SHORT 0.0065 | - | 仍 conflict |
+| A5 | pending settlement 护栏 | LONG 0.013 | LONG 0.0065 | 有 pending settlement order | 不 adopt, 保持 stale/conflict |
+| A6 | working orders 护栏 | LONG 0.013 | LONG 0.0065 | 有 non-terminal open order | 不 adopt, 保持 conflict |
+| A7 | 非 authoritative 护栏 | LONG 0.013 | LONG 0.0065 | snapshot source = platform-live-reconciliation | 不 adopt |
+| A8 | 已有 self-heal 路径不回退 | DB 有仓, exchange 无仓 | - | `db-position-exchange-missing` | 现有 self-heal 路径正常工作 |
+| A9 | precision/stepSize 边界 | LONG 0.00650001 | LONG 0.0065 | precision helper 判定为相等 | gate→verified（不触发 adopt，直接 match） |
+| A10 | docker 重启端到端 | LONG 0.013（旧） | LONG 0.0065 | docker restart | 自动 adopt→verified→session RUNNING |
+### Issue B: 启动顺序
+| # | 测试场景 | 前置条件 | 期望结果 |
+|---|---------|----------|----------|
+| B1 | 冷启动正例 | 无 market cache | 先 warm snapshot→bootstrap 有数据→source gate ready→start 成功 |
+| B2 | warmup 失败容错 | market data 不可用 | start 不因 warmup 失败崩溃，降级为空 sourceStates |
+| B3 | 不先记录 blocked source gate | 冷启动 | 日志中不出现 "runtime source gate blocked" 先于 WS connected |
+| B4 | bootstrap-pending 日志区分 | 启动阶段 | 日志标记为 bootstrap-pending 而非 source-gate-blocked |
+---
+## 日志/可观测性要求
+每个关键路径必须携带以下字段：
+| 事件名 | 必需字段 |
+|--------|----------|
+| `reconcile_adopt_attempted` | session_id, account_id, symbol, db_qty, exchange_qty, db_side, exchange_side, mismatch_fields |
+| `reconcile_adopt_applied` | 同上 + gate_status_before, gate_status_after, reason |
+| `reconcile_adopt_rejected` | 同上 + rejection_reason（side-mismatch / pending-settlement / working-orders / non-authoritative） |
+| `start_bootstrap_market_warmup` | session_id, symbol, cache_hit, bars_count |
+| `start_bootstrap_runtime_ready` | session_id, source_states_count, missing_count |
+| `start_source_gate_ready` | session_id, ready, stale_count |
+---
+## 不做项
+- ❌ 不改默认 `dispatchMode`
+- ❌ 不放宽未对账自动交易限制
+- ❌ 不把 WS 当最终事实源
+- ❌ 不新增 "side mismatch 也自动 adopt"
+- ❌ 不靠历史 external terminal orders 自愈当前仓位
+- ❌ 不改 `internal/service/execution_strategy.go`
+- ❌ 不改 WS 重连策略
+- ❌ 不改 dispatch 默认值
+- ❌ 不改被动平仓语义
+---
+## 交付物与执行顺序
+### Phase 1: Issue A（Reconcile Gate Adopt）
+1. 扩展 `livePositionReconcileGateCanSelfHeal` 判定范围
+2. 在 `reconcileLiveAccountPositions` 中增加 safe adopt 路径
+3. 新增 `adoptLivePositionFromExchangeTruth` helper
+4. 补充 open orders 检查
+5. 补 A1-A10 回归测试
+6. 确保 `go test ./internal/service/...` 通过
+7. 确保 `go build ./cmd/platform-api` 通过
+### Phase 2: Issue B（启动顺序）
+1. 在 `StartLiveSession` 和 `recoverRunningLiveSession` 中插入显式 market warmup
+2. 增强 `bootstrapSignalRuntimeSourceStates` 容错
+3. 日志区分 bootstrap-pending vs source-gate-blocked
+4. 补 B1-B4 回归测试
+5. 全量 `go test ./internal/service/...`
+
+### 当前执行状态（2026-04-24）
+
+#### 已完成
+
+- `livePositionReconcileGateCanSelfHeal` 已扩展到 `quantity-mismatch` / `entry-price-mismatch` / 不含 `side` 的 `multi-field-mismatch`。
+- `reconcileLiveAccountPositions` 已新增 safe adopt 路径，收口到 `adoptLivePositionFromExchangeTruth`。
+- adopt 前置护栏已覆盖：authoritative、pending settlement、working orders、exchange open orders、side mismatch。
+- `StartLiveSession` / `recoverRunningLiveSession` 已在 `syncLiveSessionRuntime` 前增加 market snapshot warmup。
+- `bootstrapSignalRuntimeSourceStates` 已支持冷缓存时主动刷新 market snapshot。
+- 已补回归测试：
+  - quantity mismatch 自动 adopt 到交易所数量。
+  - pending settlement 时禁止 adopt。
+  - side mismatch 继续保持 conflict 并阻断。
+  - 冷缓存 bootstrap 会主动刷新 market data。
+- 已通过验证：
+  - `go test ./internal/service`
+  - `go test ./...`
+  - `go build ./cmd/platform-api`
+  - `go build ./cmd/db-migrate`
+
+#### 本轮未完全覆盖
+
+- A2 entryPrice mismatch 单独测试尚未补，当前逻辑已支持，但缺独立断言。
+- A6 working orders 护栏尚未补独立测试，当前逻辑已支持，但缺独立断言。
+- A7 非 authoritative 护栏尚未补独立测试，当前逻辑已支持，但缺独立断言。
+- B3 / B4 的日志顺序与 `bootstrap-pending` 细分尚未完整落地；当前只完成 warmup 前移和冷缓存刷新。
+
+#### 建议 PR 拆法
+
+- PR 1：先合并当前 safe adopt + warmup 前移，解决本次线上卡死主问题。
+- PR 2：补齐剩余边界测试和日志细分，尤其是 entryPrice、working orders、non-authoritative、bootstrap-pending/source-gate-blocked 的可观测性。
+
+### 一句话摘要（给执行 LLM）
+> 只修 authoritative REST 下的 quantity/entryPrice mismatch auto-adopt（收口在 `reconcileLiveAccountPositions`）和 start bootstrap ordering（warmup 前移），不放宽 unresolved recovery gate，不把历史 external orders 当自愈依据，side mismatch 必须继续 block，先补 service-level regression tests 再改逻辑。adopt 核心改动在 `live.go` 的 `reconcileLiveAccountPositions` 和 `livePositionReconcileGateCanSelfHeal` 两处，启动顺序改动在 `StartLiveSession` / `recoverRunningLiveSession` 中增加 `refreshLiveMarketSnapshot` warmup。

--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"math"
 	"reflect"
 	"sort"
@@ -599,8 +600,21 @@ func (p *Platform) ReconcileLiveAccount(accountID string, options LiveAccountRec
 }
 
 func livePositionReconcileGateCanSelfHeal(gate map[string]any) bool {
-	return strings.EqualFold(strings.TrimSpace(stringValue(gate["status"])), livePositionReconcileGateStatusStale) &&
-		strings.EqualFold(strings.TrimSpace(stringValue(gate["scenario"])), "db-position-exchange-missing")
+	status := strings.TrimSpace(stringValue(gate["status"]))
+	scenario := strings.TrimSpace(stringValue(gate["scenario"]))
+	if strings.EqualFold(status, livePositionReconcileGateStatusStale) &&
+		strings.EqualFold(scenario, "db-position-exchange-missing") {
+		return true
+	}
+	if !strings.EqualFold(status, livePositionReconcileGateStatusConflict) {
+		return false
+	}
+	switch scenario {
+	case "quantity-mismatch", "entry-price-mismatch", "multi-field-mismatch":
+		return !livePositionReconcileMismatchIncludes(livePositionReconcileMismatchFields(gate["mismatchFields"]), "side")
+	default:
+		return false
+	}
 }
 
 func (p *Platform) supportsLiveAccountReconcile(account domain.Account) bool {
@@ -1947,6 +1961,7 @@ func (p *Platform) StartLiveSession(sessionID string) (domain.LiveSession, error
 		return domain.LiveSession{}, fmt.Errorf("live session %s is blocked in %s mode", session.ID, liveRecoveryModeReconcileGateBlocked)
 	}
 
+	p.warmLiveSessionMarketSnapshot(session, logger)
 	session, err = p.syncLiveSessionRuntime(session)
 	if err != nil {
 		logger.Warn("sync live session runtime failed", "error", err)
@@ -2045,6 +2060,7 @@ func (p *Platform) shouldRefreshLiveAccountSync(account domain.Account, eventTim
 }
 
 func (p *Platform) recoverRunningLiveSession(session domain.LiveSession) (domain.LiveSession, error) {
+	logger := p.logger("service.live", "session_id", session.ID)
 	account, err := p.store.GetAccount(session.AccountID)
 	if err != nil {
 		return domain.LiveSession{}, err
@@ -2098,6 +2114,7 @@ func (p *Platform) recoverRunningLiveSession(session domain.LiveSession) (domain
 	if boolValue(gate["blocking"]) {
 		return p.enterRecoveredLiveSessionReconcileGateBlocked(session, recoveredPosition, gate)
 	}
+	p.warmLiveSessionMarketSnapshot(session, logger)
 	session, err = p.syncLiveSessionRuntime(session)
 	if err != nil {
 		if recoveredPosition.Quantity > 0 {
@@ -2138,6 +2155,13 @@ func (p *Platform) reconcileLiveAccountPositions(account domain.Account, exchang
 	if err != nil {
 		return nil, err
 	}
+	workingOrderSymbols, err := p.liveWorkingOrderSymbols(account.ID)
+	if err != nil {
+		return nil, err
+	}
+	snapshot := cloneMetadata(mapValue(account.Metadata["liveSyncSnapshot"]))
+	openOrderSymbols := liveSyncSnapshotOpenOrderSymbols(snapshot)
+	authoritative := liveProtectionSnapshotIsAuthoritative(snapshot)
 
 	syncedAt := time.Now().UTC()
 	symbols := make(map[string]any)
@@ -2235,14 +2259,27 @@ func (p *Platform) reconcileLiveAccountPositions(account domain.Account, exchang
 			mismatchFields = append(mismatchFields, "entryPrice")
 		}
 		if len(mismatchFields) > 0 {
-			recordGate(symbol, map[string]any{
+			gate := map[string]any{
 				"status":           livePositionReconcileGateStatusConflict,
 				"scenario":         classifyLivePositionReconcileScenario(mismatchFields),
 				"blocking":         true,
 				"mismatchFields":   mismatchFields,
 				"dbPosition":       dbSnapshot,
 				"exchangePosition": exchangeSnapshot,
-			})
+			}
+			if adopted, adoptGate, adoptErr := p.adoptLivePositionFromExchangeTruth(account, position, exchangeSnapshot, gate, livePositionAdoptGuard{
+				authoritative:             authoritative,
+				pendingSettlement:         symbolInSet(pendingSettlementSymbols, symbol),
+				workingOrders:             symbolInSet(workingOrderSymbols, symbol),
+				exchangeOpenOrders:        symbolInSet(openOrderSymbols, symbol),
+				strategyVersionIDFallback: strategyVersionID,
+			}); adoptErr != nil {
+				return nil, adoptErr
+			} else if adopted {
+				recordGate(symbol, adoptGate)
+				continue
+			}
+			recordGate(symbol, gate)
 			continue
 		}
 		position.AccountID = account.ID
@@ -2300,7 +2337,7 @@ func (p *Platform) reconcileLiveAccountPositions(account domain.Account, exchang
 	return map[string]any{
 		"source":              "binance-position-reconcile",
 		"syncedAt":            syncedAt.Format(time.RFC3339),
-		"authoritative":       true,
+		"authoritative":       authoritative,
 		"blockingSymbolCount": blockingCount,
 		"symbols":             symbols,
 	}, nil
@@ -2323,6 +2360,135 @@ func (p *Platform) liveSettlementPendingOrderSymbols(accountID string) (map[stri
 	return symbols, nil
 }
 
+type livePositionAdoptGuard struct {
+	authoritative             bool
+	pendingSettlement         bool
+	workingOrders             bool
+	exchangeOpenOrders        bool
+	strategyVersionIDFallback string
+}
+
+func (p *Platform) adoptLivePositionFromExchangeTruth(account domain.Account, position domain.Position, exchangePosition map[string]any, gate map[string]any, guard livePositionAdoptGuard) (bool, map[string]any, error) {
+	symbol := NormalizeSymbol(firstNonEmpty(stringValue(exchangePosition["symbol"]), position.Symbol))
+	mismatchFields := livePositionReconcileMismatchFields(gate["mismatchFields"])
+	logger := p.logger("service.live_reconcile", "account_id", account.ID, "symbol", symbol)
+	logContext := []any{
+		"db_qty", position.Quantity,
+		"exchange_qty", parseFloatValue(exchangePosition["quantity"]),
+		"db_side", position.Side,
+		"exchange_side", stringValue(exchangePosition["side"]),
+		"mismatch_fields", mismatchFields,
+	}
+	logger.Info("reconcile_adopt_attempted", logContext...)
+	reject := func(reason string) (bool, map[string]any, error) {
+		logger.Warn("reconcile_adopt_rejected", append(logContext, "rejection_reason", reason)...)
+		return false, nil, nil
+	}
+	if !guard.authoritative {
+		return reject("non-authoritative")
+	}
+	if guard.pendingSettlement {
+		return reject("pending-settlement")
+	}
+	if guard.workingOrders {
+		return reject("working-orders")
+	}
+	if guard.exchangeOpenOrders {
+		return reject("exchange-open-orders")
+	}
+	if livePositionReconcileMismatchIncludes(mismatchFields, "side") {
+		return reject("side-mismatch")
+	}
+	if !strings.EqualFold(strings.TrimSpace(position.Side), strings.TrimSpace(stringValue(exchangePosition["side"]))) {
+		return reject("side-mismatch")
+	}
+	if len(mismatchFields) == 0 {
+		return reject("no-mismatch")
+	}
+	for _, field := range mismatchFields {
+		switch stringValue(field) {
+		case "quantity", "entryPrice":
+		default:
+			return reject("unsupported-mismatch")
+		}
+	}
+
+	dbSnapshot := buildRecoveredLivePositionStateSnapshot(position)
+	position.AccountID = account.ID
+	position.StrategyVersionID = firstNonEmpty(position.StrategyVersionID, guard.strategyVersionIDFallback)
+	position.Symbol = symbol
+	position.Side = strings.ToUpper(strings.TrimSpace(stringValue(exchangePosition["side"])))
+	position.Quantity = math.Abs(parseFloatValue(exchangePosition["quantity"]))
+	position.EntryPrice = parseFloatValue(exchangePosition["entryPrice"])
+	position.MarkPrice = firstPositive(parseFloatValue(exchangePosition["markPrice"]), position.EntryPrice)
+	saved, err := p.store.SavePosition(position)
+	if err != nil {
+		return false, nil, err
+	}
+
+	adoptGate := cloneMetadata(gate)
+	adoptGate["status"] = livePositionReconcileGateStatusAdopted
+	adoptGate["scenario"] = livePositionReconcileAdoptScenario(mismatchFields)
+	adoptGate["blocking"] = false
+	adoptGate["dbPosition"] = dbSnapshot
+	adoptGate["adoptedPosition"] = buildRecoveredLivePositionStateSnapshot(saved)
+	adoptGate["exchangePosition"] = cloneMetadata(exchangePosition)
+	logger.Info("reconcile_adopt_applied", append(logContext,
+		"gate_status_before", firstNonEmpty(stringValue(gate["status"]), livePositionReconcileGateStatusConflict),
+		"gate_status_after", livePositionReconcileGateStatusAdopted,
+		"reason", stringValue(adoptGate["scenario"]),
+	)...)
+	return true, adoptGate, nil
+}
+
+func livePositionReconcileAdoptScenario(mismatchFields []string) string {
+	if len(mismatchFields) == 1 {
+		switch mismatchFields[0] {
+		case "quantity":
+			return "exchange-truth-adopted-quantity"
+		case "entryPrice":
+			return "exchange-truth-adopted-entry-price"
+		}
+	}
+	return "exchange-truth-adopted-position"
+}
+
+func (p *Platform) liveWorkingOrderSymbols(accountID string) (map[string]struct{}, error) {
+	orders, err := p.store.ListOrders()
+	if err != nil {
+		return nil, err
+	}
+	symbols := make(map[string]struct{})
+	for _, order := range orders {
+		if order.AccountID != accountID || isTerminalOrderStatus(order.Status) {
+			continue
+		}
+		if symbol := NormalizeSymbol(order.Symbol); symbol != "" {
+			symbols[symbol] = struct{}{}
+		}
+	}
+	return symbols, nil
+}
+
+func liveSyncSnapshotOpenOrderSymbols(snapshot map[string]any) map[string]struct{} {
+	symbols := make(map[string]struct{})
+	for _, item := range metadataList(snapshot["openOrders"]) {
+		status := firstNonEmpty(mapBinanceOrderStatus(stringValue(item["status"])), stringValue(item["status"]))
+		if isTerminalOrderStatus(status) {
+			continue
+		}
+		if symbol := NormalizeSymbol(stringValue(item["symbol"])); symbol != "" {
+			symbols[symbol] = struct{}{}
+		}
+	}
+	return symbols
+}
+
+func symbolInSet(symbols map[string]struct{}, symbol string) bool {
+	_, ok := symbols[NormalizeSymbol(symbol)]
+	return ok
+}
+
 func resolveRecoveredLiveEntryPrice(primary, secondary, fallback float64) float64 {
 	return firstPositive(primary, firstPositive(secondary, fallback))
 }
@@ -2341,8 +2507,65 @@ func classifyLivePositionReconcileScenario(mismatchFields []any) string {
 	return "multi-field-mismatch"
 }
 
+func livePositionReconcileMismatchIncludes(mismatchFields []string, target string) bool {
+	for _, field := range mismatchFields {
+		if strings.EqualFold(strings.TrimSpace(field), target) {
+			return true
+		}
+	}
+	return false
+}
+
+func livePositionReconcileMismatchFields(value any) []string {
+	switch items := value.(type) {
+	case []string:
+		out := make([]string, 0, len(items))
+		for _, item := range items {
+			if field := strings.TrimSpace(item); field != "" {
+				out = append(out, field)
+			}
+		}
+		return out
+	case []any:
+		out := make([]string, 0, len(items))
+		for _, item := range items {
+			if field := strings.TrimSpace(stringValue(item)); field != "" {
+				out = append(out, field)
+			}
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
 func (p *Platform) resolveLivePositionStrategyVersionID(accountID, symbol string) string {
 	return p.inferReconcileStrategyVersionID(accountID, symbol)
+}
+
+func (p *Platform) warmLiveSessionMarketSnapshot(session domain.LiveSession, logger *slog.Logger) {
+	symbol := NormalizeSymbol(firstNonEmpty(
+		stringValue(session.State["symbol"]),
+		stringValue(session.State["lastSymbol"]),
+	))
+	if symbol == "" {
+		return
+	}
+	p.liveMarketMu.RLock()
+	cached, cacheHit := p.liveMarketData[symbol]
+	p.liveMarketMu.RUnlock()
+	if err := p.refreshLiveMarketSnapshot(symbol); err != nil {
+		logger.Warn("start_bootstrap_market_warmup", "symbol", symbol, "cache_hit", cacheHit && len(cached.MinuteBars) > 0, "error", err)
+		return
+	}
+	p.liveMarketMu.RLock()
+	snapshot := p.liveMarketData[symbol]
+	p.liveMarketMu.RUnlock()
+	barsCount := len(snapshot.MinuteBars)
+	for _, bars := range snapshot.SignalBars {
+		barsCount += len(bars)
+	}
+	logger.Info("start_bootstrap_market_warmup", "symbol", symbol, "cache_hit", cacheHit && len(cached.MinuteBars) > 0, "bars_count", barsCount)
 }
 
 func (p *Platform) StopLiveSession(sessionID string) (domain.LiveSession, error) {

--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -611,7 +611,7 @@ func livePositionReconcileGateCanSelfHeal(gate map[string]any) bool {
 	}
 	switch scenario {
 	case "quantity-mismatch", "entry-price-mismatch", "multi-field-mismatch":
-		return !livePositionReconcileMismatchIncludes(livePositionReconcileMismatchFields(gate["mismatchFields"]), "side")
+		return livePositionReconcileMismatchFieldsCanSelfHeal(livePositionReconcileMismatchFields(gate["mismatchFields"]))
 	default:
 		return false
 	}
@@ -2180,6 +2180,7 @@ func (p *Platform) reconcileLiveAccountPositions(account domain.Account, exchang
 		}
 		gate = cloneMetadata(gate)
 		gate["symbol"] = symbol
+		gate["authoritative"] = authoritative
 		gate["comparedAt"] = firstNonEmpty(stringValue(gate["comparedAt"]), syncedAt.Format(time.RFC3339))
 		if boolValue(gate["blocking"]) {
 			blockingCount++
@@ -2228,6 +2229,16 @@ func (p *Platform) reconcileLiveAccountPositions(account domain.Account, exchang
 			continue
 		}
 		if position.ID == "" || position.Quantity <= 0 {
+			if !authoritative {
+				recordGate(symbol, map[string]any{
+					"status":           livePositionReconcileGateStatusError,
+					"scenario":         "exchange-truth-unavailable",
+					"blocking":         true,
+					"dbPosition":       buildRecoveredLivePositionStateSnapshot(position),
+					"exchangePosition": exchangeSnapshot,
+				})
+				continue
+			}
 			position.AccountID = account.ID
 			position.StrategyVersionID = firstNonEmpty(strategyVersionID, position.StrategyVersionID)
 			position.Symbol = symbol
@@ -2429,6 +2440,7 @@ func (p *Platform) adoptLivePositionFromExchangeTruth(account domain.Account, po
 	adoptGate := cloneMetadata(gate)
 	adoptGate["status"] = livePositionReconcileGateStatusAdopted
 	adoptGate["scenario"] = livePositionReconcileAdoptScenario(mismatchFields)
+	adoptGate["authoritative"] = true
 	adoptGate["blocking"] = false
 	adoptGate["dbPosition"] = dbSnapshot
 	adoptGate["adoptedPosition"] = buildRecoveredLivePositionStateSnapshot(saved)
@@ -2514,6 +2526,21 @@ func livePositionReconcileMismatchIncludes(mismatchFields []string, target strin
 		}
 	}
 	return false
+}
+
+func livePositionReconcileMismatchFieldsCanSelfHeal(mismatchFields []string) bool {
+	if len(mismatchFields) == 0 {
+		return false
+	}
+	for _, field := range mismatchFields {
+		switch strings.TrimSpace(field) {
+		case "quantity", "entryPrice":
+			continue
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 func livePositionReconcileMismatchFields(value any) []string {

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -1038,6 +1038,50 @@ func TestRefreshLiveMarketSnapshotFailsWithoutRESTWarmData(t *testing.T) {
 	}
 }
 
+func TestBootstrapSignalRuntimeSourceStatesRefreshesColdMarketCache(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	originalFetch := fetchLiveCandleRange
+	fetchCalls := 0
+	fetchLiveCandleRange = func(symbol, resolution string, from, to time.Time) ([]candleBar, error) {
+		fetchCalls++
+		start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+		step := time.Hour
+		if resolution == "1" {
+			step = time.Minute
+		}
+		bars := make([]candleBar, 0, 40)
+		for i := 0; i < 40; i++ {
+			open := 100.0 + float64(i)
+			bars = append(bars, candleBar{
+				Time:   start.Add(time.Duration(i) * step),
+				Open:   open,
+				High:   open + 2,
+				Low:    open - 2,
+				Close:  open + 1,
+				Volume: 10,
+			})
+		}
+		return bars, nil
+	}
+	t.Cleanup(func() {
+		fetchLiveCandleRange = originalFetch
+	})
+
+	sourceStates := platform.bootstrapSignalRuntimeSourceStates([]map[string]any{{
+		"sourceKey":  "binance-kline",
+		"role":       "signal",
+		"streamType": "signal_bar",
+		"symbol":     "BTCUSDT",
+		"options":    map[string]any{"timeframe": "1d"},
+	}})
+	if len(sourceStates) == 0 {
+		t.Fatal("expected cold bootstrap to refresh market cache and return source states")
+	}
+	if fetchCalls == 0 {
+		t.Fatal("expected cold bootstrap to call live market refresh")
+	}
+}
+
 func TestEvaluateLiveExitStateRequiresProtectionBeforePT(t *testing.T) {
 	state := evaluateLiveExitState(map[string]any{
 		"profit_protect_atr": 1.0,
@@ -7419,6 +7463,126 @@ func TestRecoverRunningLiveSessionAllowsTakeoverAfterVerifiedReconcileMatch(t *t
 	}
 }
 
+func TestRecoverRunningLiveSessionAdoptsExchangeQuantityMismatch(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	configureTestLiveRESTReconcileAdapter(t, platform, "test-reconcile-quantity-adopt", []map[string]any{
+		{
+			"symbol":      "BTCUSDT",
+			"positionAmt": 0.0065,
+			"entryPrice":  68000.0,
+			"markPrice":   68100.0,
+		},
+	})
+	session, err := platform.CreateLiveSession("", "live-main", "strategy-bk-1d", map[string]any{
+		"symbol":          "BTCUSDT",
+		"signalTimeframe": "1d",
+	})
+	if err != nil {
+		t.Fatalf("create live session failed: %v", err)
+	}
+	if _, err := platform.store.SavePosition(domain.Position{
+		AccountID:         session.AccountID,
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "LONG",
+		Quantity:          0.013,
+		EntryPrice:        68000,
+		MarkPrice:         68100,
+	}); err != nil {
+		t.Fatalf("save position failed: %v", err)
+	}
+
+	recovered, err := platform.recoverRunningLiveSession(session)
+	if err != nil {
+		t.Fatalf("recover running live session failed: %v", err)
+	}
+	if recovered.Status != "RUNNING" {
+		t.Fatalf("expected quantity adopt recovery to proceed, got %s", recovered.Status)
+	}
+	if got := stringValue(recovered.State["positionReconcileGateStatus"]); got != livePositionReconcileGateStatusAdopted {
+		t.Fatalf("expected adopted reconcile gate status, got %s", got)
+	}
+	if got := stringValue(recovered.State["positionReconcileGateScenario"]); got != "exchange-truth-adopted-quantity" {
+		t.Fatalf("expected exchange-truth-adopted-quantity scenario, got %s", got)
+	}
+	position, found, err := platform.store.FindPosition(session.AccountID, "BTCUSDT")
+	if err != nil {
+		t.Fatalf("find position failed: %v", err)
+	}
+	if !found {
+		t.Fatal("expected adopted position to remain in store")
+	}
+	if position.Side != "LONG" || tradingQuantityDiffers(position.Quantity, 0.0065) {
+		t.Fatalf("expected local position to adopt exchange truth LONG 0.0065, got side=%s qty=%v", position.Side, position.Quantity)
+	}
+}
+
+func TestRecoverRunningLiveSessionDoesNotAdoptQuantityMismatchWithPendingSettlement(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	configureTestLiveRESTReconcileAdapter(t, platform, "test-reconcile-quantity-pending", []map[string]any{
+		{
+			"symbol":      "BTCUSDT",
+			"positionAmt": 0.0065,
+			"entryPrice":  68000.0,
+			"markPrice":   68100.0,
+		},
+	})
+	session, err := platform.CreateLiveSession("", "live-main", "strategy-bk-1d", map[string]any{
+		"symbol":          "BTCUSDT",
+		"signalTimeframe": "1d",
+	})
+	if err != nil {
+		t.Fatalf("create live session failed: %v", err)
+	}
+	position, err := platform.store.SavePosition(domain.Position{
+		AccountID:         session.AccountID,
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "LONG",
+		Quantity:          0.013,
+		EntryPrice:        68000,
+		MarkPrice:         68100,
+	})
+	if err != nil {
+		t.Fatalf("save position failed: %v", err)
+	}
+	if _, err := platform.store.CreateOrder(domain.Order{
+		AccountID: session.AccountID,
+		Symbol:    "BTCUSDT",
+		Side:      "SELL",
+		Type:      "MARKET",
+		Status:    "FILLED",
+		Quantity:  0.0065,
+		Metadata: map[string]any{
+			liveSettlementSyncRequiredKey: true,
+			"filledQuantity":              0.003,
+		},
+	}); err != nil {
+		t.Fatalf("create pending settlement order failed: %v", err)
+	}
+
+	recovered, err := platform.recoverRunningLiveSession(session)
+	if err != nil {
+		t.Fatalf("recover running live session failed: %v", err)
+	}
+	if recovered.Status != "BLOCKED" {
+		t.Fatalf("expected pending settlement recovery to stay BLOCKED, got %s", recovered.Status)
+	}
+	if got := stringValue(recovered.State["positionReconcileGateScenario"]); got != "order-settlement-pending" {
+		t.Fatalf("expected order-settlement-pending scenario, got %s", got)
+	}
+	stored, found, err := platform.store.FindPosition(session.AccountID, "BTCUSDT")
+	if err != nil {
+		t.Fatalf("find position failed: %v", err)
+	}
+	if !found {
+		t.Fatal("expected local position to remain")
+	}
+	if stored.ID != position.ID || tradingQuantityDiffers(stored.Quantity, 0.013) {
+		t.Fatalf("expected local position to remain unchanged, got id=%s qty=%v", stored.ID, stored.Quantity)
+	}
+}
+
 func TestRecoverRunningLiveSessionBlocksWhenDBPositionMissingOnExchange(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
 	configureTestLiveRESTReconcileAdapter(t, platform, "test-reconcile-stale", []map[string]any{})
@@ -7576,7 +7740,7 @@ func TestUnresolvedReconcileMismatchPreventsAutoDispatch(t *testing.T) {
 	configureTestLiveRESTReconcileAdapter(t, platform, "test-reconcile-auto-dispatch", []map[string]any{
 		{
 			"symbol":      "BTCUSDT",
-			"positionAmt": 0.02,
+			"positionAmt": -0.02,
 			"entryPrice":  68000.0,
 			"markPrice":   67950.0,
 		},
@@ -7605,8 +7769,8 @@ func TestUnresolvedReconcileMismatchPreventsAutoDispatch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("recover running live session failed: %v", err)
 	}
-	if got := stringValue(recovered.State["positionReconcileGateScenario"]); got != "quantity-mismatch" {
-		t.Fatalf("expected quantity-mismatch scenario, got %s", got)
+	if got := stringValue(recovered.State["positionReconcileGateScenario"]); got != "multi-field-mismatch" {
+		t.Fatalf("expected multi-field-mismatch scenario, got %s", got)
 	}
 	intent := map[string]any{
 		"action":   "exit",

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -7517,6 +7517,57 @@ func TestRecoverRunningLiveSessionAdoptsExchangeQuantityMismatch(t *testing.T) {
 	}
 }
 
+func TestRecoverRunningLiveSessionAdoptsExchangeEntryPriceMismatch(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	configureTestLiveRESTReconcileAdapter(t, platform, "test-reconcile-entry-price-adopt", []map[string]any{
+		{
+			"symbol":      "BTCUSDT",
+			"positionAmt": 0.0065,
+			"entryPrice":  59500.0,
+			"markPrice":   68100.0,
+		},
+	})
+	session, err := platform.CreateLiveSession("", "live-main", "strategy-bk-1d", map[string]any{
+		"symbol":          "BTCUSDT",
+		"signalTimeframe": "1d",
+	})
+	if err != nil {
+		t.Fatalf("create live session failed: %v", err)
+	}
+	if _, err := platform.store.SavePosition(domain.Position{
+		AccountID:         session.AccountID,
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "LONG",
+		Quantity:          0.0065,
+		EntryPrice:        60000,
+		MarkPrice:         68100,
+	}); err != nil {
+		t.Fatalf("save position failed: %v", err)
+	}
+
+	recovered, err := platform.recoverRunningLiveSession(session)
+	if err != nil {
+		t.Fatalf("recover running live session failed: %v", err)
+	}
+	if recovered.Status != "RUNNING" {
+		t.Fatalf("expected entry price adopt recovery to proceed, got %s", recovered.Status)
+	}
+	if got := stringValue(recovered.State["positionReconcileGateScenario"]); got != "exchange-truth-adopted-entry-price" {
+		t.Fatalf("expected exchange-truth-adopted-entry-price scenario, got %s", got)
+	}
+	position, found, err := platform.store.FindPosition(session.AccountID, "BTCUSDT")
+	if err != nil {
+		t.Fatalf("find position failed: %v", err)
+	}
+	if !found {
+		t.Fatal("expected adopted position to remain in store")
+	}
+	if tradingPriceDiffers(position.EntryPrice, 59500) {
+		t.Fatalf("expected local entry price to adopt exchange truth 59500, got %v", position.EntryPrice)
+	}
+}
+
 func TestRecoverRunningLiveSessionDoesNotAdoptQuantityMismatchWithPendingSettlement(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
 	configureTestLiveRESTReconcileAdapter(t, platform, "test-reconcile-quantity-pending", []map[string]any{
@@ -7580,6 +7631,116 @@ func TestRecoverRunningLiveSessionDoesNotAdoptQuantityMismatchWithPendingSettlem
 	}
 	if stored.ID != position.ID || tradingQuantityDiffers(stored.Quantity, 0.013) {
 		t.Fatalf("expected local position to remain unchanged, got id=%s qty=%v", stored.ID, stored.Quantity)
+	}
+}
+
+func TestRecoverRunningLiveSessionDoesNotAdoptQuantityMismatchWithExchangeOpenOrder(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	configureTestLiveRESTReconcileAdapterWithOpenOrders(t, platform, "test-reconcile-quantity-open-order", []map[string]any{
+		{
+			"symbol":      "BTCUSDT",
+			"positionAmt": 0.0065,
+			"entryPrice":  68000.0,
+			"markPrice":   68100.0,
+		},
+	}, []map[string]any{
+		{
+			"symbol": "BTCUSDT",
+			"status": "NEW",
+		},
+	})
+	session, err := platform.CreateLiveSession("", "live-main", "strategy-bk-1d", map[string]any{
+		"symbol":          "BTCUSDT",
+		"signalTimeframe": "1d",
+	})
+	if err != nil {
+		t.Fatalf("create live session failed: %v", err)
+	}
+	if _, err := platform.store.SavePosition(domain.Position{
+		AccountID:         session.AccountID,
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "LONG",
+		Quantity:          0.013,
+		EntryPrice:        68000,
+		MarkPrice:         68100,
+	}); err != nil {
+		t.Fatalf("save position failed: %v", err)
+	}
+
+	recovered, err := platform.recoverRunningLiveSession(session)
+	if err != nil {
+		t.Fatalf("recover running live session failed: %v", err)
+	}
+	if recovered.Status != "BLOCKED" {
+		t.Fatalf("expected exchange open order recovery to stay BLOCKED, got %s", recovered.Status)
+	}
+	if got := stringValue(recovered.State["positionReconcileGateScenario"]); got != "quantity-mismatch" {
+		t.Fatalf("expected quantity-mismatch scenario, got %s", got)
+	}
+	position, found, err := platform.store.FindPosition(session.AccountID, "BTCUSDT")
+	if err != nil {
+		t.Fatalf("find position failed: %v", err)
+	}
+	if !found {
+		t.Fatal("expected local position to remain")
+	}
+	if tradingQuantityDiffers(position.Quantity, 0.013) {
+		t.Fatalf("expected local quantity to remain 0.013, got %v", position.Quantity)
+	}
+}
+
+func TestRecoverRunningLiveSessionDoesNotAdoptQuantityMismatchWithoutAuthoritativeSnapshot(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	configureTestLiveRESTReconcileAdapterWithSnapshotSource(t, platform, "test-reconcile-quantity-nonauth", "platform-live-reconciliation", []map[string]any{
+		{
+			"symbol":      "BTCUSDT",
+			"positionAmt": 0.0065,
+			"entryPrice":  68000.0,
+			"markPrice":   68100.0,
+		},
+	}, nil)
+	session, err := platform.CreateLiveSession("", "live-main", "strategy-bk-1d", map[string]any{
+		"symbol":          "BTCUSDT",
+		"signalTimeframe": "1d",
+	})
+	if err != nil {
+		t.Fatalf("create live session failed: %v", err)
+	}
+	if _, err := platform.store.SavePosition(domain.Position{
+		AccountID:         session.AccountID,
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "LONG",
+		Quantity:          0.013,
+		EntryPrice:        68000,
+		MarkPrice:         68100,
+	}); err != nil {
+		t.Fatalf("save position failed: %v", err)
+	}
+
+	recovered, err := platform.recoverRunningLiveSession(session)
+	if err != nil {
+		t.Fatalf("recover running live session failed: %v", err)
+	}
+	if recovered.Status != "BLOCKED" {
+		t.Fatalf("expected non-authoritative recovery to stay BLOCKED, got %s", recovered.Status)
+	}
+	if got := stringValue(recovered.State["positionReconcileGateStatus"]); got != livePositionReconcileGateStatusError {
+		t.Fatalf("expected error gate status, got %s", got)
+	}
+	if got := stringValue(recovered.State["positionReconcileGateScenario"]); got != "exchange-truth-unavailable" {
+		t.Fatalf("expected exchange-truth-unavailable scenario, got %s", got)
+	}
+	position, found, err := platform.store.FindPosition(session.AccountID, "BTCUSDT")
+	if err != nil {
+		t.Fatalf("find position failed: %v", err)
+	}
+	if !found {
+		t.Fatal("expected local position to remain")
+	}
+	if tradingQuantityDiffers(position.Quantity, 0.013) {
+		t.Fatalf("expected local quantity to remain 0.013, got %v", position.Quantity)
 	}
 }
 
@@ -8664,13 +8825,26 @@ func (a testLiveAccountSyncAdapter) SyncAccountSnapshot(platform *Platform, acco
 
 func configureTestLiveRESTReconcileAdapter(t *testing.T, platform *Platform, adapterKey string, exchangePositions []map[string]any) {
 	t.Helper()
+	configureTestLiveRESTReconcileAdapterWithSnapshotSource(t, platform, adapterKey, "binance-rest-account-v3", exchangePositions, nil)
+}
+
+func configureTestLiveRESTReconcileAdapterWithOpenOrders(t *testing.T, platform *Platform, adapterKey string, exchangePositions []map[string]any, openOrders []map[string]any) {
+	t.Helper()
+	configureTestLiveRESTReconcileAdapterWithSnapshotSource(t, platform, adapterKey, "binance-rest-account-v3", exchangePositions, openOrders)
+}
+
+func configureTestLiveRESTReconcileAdapterWithSnapshotSource(t *testing.T, platform *Platform, adapterKey string, source string, exchangePositions []map[string]any, openOrders []map[string]any) {
+	t.Helper()
+	if strings.TrimSpace(source) == "" {
+		source = "binance-rest-account-v3"
+	}
 	platform.registerLiveAdapter(testLiveAccountSyncAdapter{
 		key: adapterKey,
 		syncSnapshotFunc: func(p *Platform, account domain.Account, binding map[string]any) (domain.Account, error) {
 			previousSuccessAt := parseOptionalRFC3339(stringValue(account.Metadata["lastLiveSyncAt"]))
 			account.Metadata = cloneMetadata(account.Metadata)
 			account.Metadata["liveSyncSnapshot"] = map[string]any{
-				"source":          "binance-rest-account-v3",
+				"source":          source,
 				"adapterKey":      normalizeLiveAdapterKey(stringValue(binding["adapterKey"])),
 				"syncedAt":        time.Now().UTC().Format(time.RFC3339),
 				"bindingMode":     stringValue(binding["connectionMode"]),
@@ -8678,7 +8852,7 @@ func configureTestLiveRESTReconcileAdapter(t *testing.T, platform *Platform, ada
 				"syncStatus":      "SYNCED",
 				"accountExchange": account.Exchange,
 				"positions":       exchangePositions,
-				"openOrders":      []map[string]any{},
+				"openOrders":      openOrders,
 			}
 			var err error
 			account, err = p.persistLiveAccountSyncSuccess(account, binding, previousSuccessAt)

--- a/internal/service/signal_runtime_sessions.go
+++ b/internal/service/signal_runtime_sessions.go
@@ -289,8 +289,14 @@ func (p *Platform) bootstrapSignalRuntimeSourceStates(subscriptions []map[string
 			continue
 		}
 		snapshot, err := p.liveMarketSnapshot(symbol)
-		if err != nil {
-			continue
+		if err != nil || len(snapshot.SignalBars) == 0 {
+			if refreshErr := p.refreshLiveMarketSnapshot(symbol); refreshErr != nil {
+				continue
+			}
+			snapshot, err = p.liveMarketSnapshot(symbol)
+			if err != nil {
+				continue
+			}
 		}
 		bars := snapshot.SignalBars[strings.ToLower(strings.TrimSpace(timeframe))]
 		if len(bars) == 0 {


### PR DESCRIPTION
## 目的
修复 docker/进程重启后 live session 因 DB position 与交易所真实仓位数量不一致进入 `reconcile-gate-blocked` 后无法自愈的问题，并前移启动阶段 market snapshot warmup，降低 cold bootstrap 时 source gate 抢跑进入 stale/blocked 的概率。

Root cause：`quantity-mismatch` / `entryPrice-mismatch` 原来只会进入 `conflict + blocking`，`attemptLiveAccountReconcileSelfHeal` 只覆盖 `db-position-exchange-missing`，导致 side 一致且交易所 REST authoritative 的纯仓位漂移也会永久卡住。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [x] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 改动摘要
- 在 `reconcileLiveAccountPositions` 增加 safe adopt 路径：仅当 REST snapshot authoritative、side 一致、无 pending settlement、无本地 working orders、无交易所 open orders 时，用交易所 position 覆盖本地 DB position。
- 扩展 `livePositionReconcileGateCanSelfHeal`，允许 `quantity-mismatch`、`entry-price-mismatch`、不含 side 的 `multi-field-mismatch` 进入 reconcile self-heal 重试。
- 在 `StartLiveSession` / `recoverRunningLiveSession` 的 runtime sync 前增加 market snapshot warmup。
- 让 `bootstrapSignalRuntimeSourceStates` 在冷缓存时主动 refresh market snapshot。
- 更新治理计划文档，记录当前已完成项、未覆盖项和建议 PR 拆法。

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) - 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？- 无
- [x] DB migration 是否具备向下兼容幂等性？- 未涉及 migration
- [x] 配置字段有没有无意被混改？- 未改配置字段

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

已通过：

```sh
go test ./internal/service
go test ./...
go build ./cmd/platform-api
go build ./cmd/db-migrate
```

新增/调整测试覆盖：
- quantity mismatch 自动 adopt 到交易所数量。
- pending settlement 时禁止 adopt。
- side mismatch 继续保持 conflict 并阻断 auto-dispatch。
- 冷缓存 bootstrap 会主动刷新 market data。
