### PR TITLE
[codex] fix live decision churn and stale stop reuse

### DIFF
--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -2921,6 +2921,12 @@ func (p *Platform) evaluateLiveSessionOnSignal(session domain.LiveSession, runti
 			executionProposal = nil
 		}
 	}
+	recordedSignalIntent := cloneMetadata(mapValue(state["lastSignalIntent"]))
+	decisionEventFingerprint := buildStrategyDecisionEventFingerprint(executionContext, decision, sourceGate, recordedSignalIntent, executionProposal)
+	decisionEventIntentSignature := buildLiveIntentSignature(executionProposal)
+	if decisionEventIntentSignature == "" {
+		decisionEventIntentSignature = buildLiveIntentSignature(recordedSignalIntent)
+	}
 	decisionEvent, decisionEventErr := p.recordStrategyDecisionEvent(
 		session,
 		firstNonEmpty(runtimeSessionID, stringValue(state["signalRuntimeSessionId"])),
@@ -2931,7 +2937,7 @@ func (p *Platform) evaluateLiveSessionOnSignal(session domain.LiveSession, runti
 		sourceGate,
 		executionContext,
 		decision,
-		cloneMetadata(mapValue(state["lastSignalIntent"])),
+		recordedSignalIntent,
 		executionProposal,
 	)
 	if decisionEventErr != nil {
@@ -2939,6 +2945,8 @@ func (p *Platform) evaluateLiveSessionOnSignal(session domain.LiveSession, runti
 	} else {
 		delete(state, "lastStrategyDecisionEventError")
 		state["lastStrategyDecisionEventId"] = decisionEvent.ID
+		state["lastStrategyDecisionEventFingerprint"] = decisionEventFingerprint
+		state["lastStrategyDecisionEventIntentSignature"] = decisionEventIntentSignature
 		if len(executionProposal) > 0 {
 			executionProposal["decisionEventId"] = decisionEvent.ID
 			proposalMetadata := cloneMetadata(mapValue(executionProposal["metadata"]))
@@ -3050,6 +3058,9 @@ func liveSessionNonRegressiveFactKeys() []string {
 		"lastSignalBarStateKey",
 		"sessionReentryCount",
 		"lastCountedReentryOrderId",
+		"lastStrategyDecisionEventId",
+		"lastStrategyDecisionEventFingerprint",
+		"lastStrategyDecisionEventIntentSignature",
 	}
 }
 
@@ -4159,19 +4170,7 @@ func livePositionStateMatchesPositionSnapshot(positionSnapshot map[string]any, l
 func mergeLivePositionRiskState(positionSnapshot map[string]any, livePositionState map[string]any) map[string]any {
 	mergedPosition := cloneMetadata(positionSnapshot)
 	for _, key := range []string{
-		"baseStopLoss",
-		"stopLoss",
-		"stopLossSource",
-		"trailingStopConfigured",
-		"trailingStopActive",
-		"trailingActivationArmed",
-		"trailingStopCandidate",
 		"protected",
-		"protectionTrigger",
-		"prevHigh1",
-		"prevLow1",
-		"atr14",
-		"profitProtectATR",
 		"hwm",
 		"lwm",
 		"watermarkPositionKey",

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -3187,6 +3187,9 @@ func TestLiveSessionNonRegressiveFactKeysIncludeSignalBarTradeLimitFacts(t *test
 		"lastSignalBarStateKey",
 		"sessionReentryCount",
 		"lastCountedReentryOrderId",
+		"lastStrategyDecisionEventId",
+		"lastStrategyDecisionEventFingerprint",
+		"lastStrategyDecisionEventIntentSignature",
 	} {
 		found := false
 		for _, key := range keys {
@@ -3315,6 +3318,67 @@ func TestDispatchLiveSessionIntentRejectsEntryAfterMaxTradesPerSignalBar(t *test
 	}
 }
 
+func TestDispatchLiveSessionIntentRejectsThirdEntryAfterInterveningExitOnSameSignalBar(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	session, err := platform.CreateLiveSession("", "live-main", "strategy-bk-1d", map[string]any{
+		"symbol":              "BTCUSDT",
+		"signalTimeframe":     "30m",
+		"executionDataSource": "tick",
+	})
+	if err != nil {
+		t.Fatalf("create live session failed: %v", err)
+	}
+	barKey := "BTCUSDT|30m|2026-04-23T14:00:00Z"
+	exitIntentSignature := buildLiveIntentSignature(map[string]any{
+		"action":            "exit",
+		"side":              "SELL",
+		"symbol":            "BTCUSDT",
+		"signalKind":        "risk-exit",
+		"signalBarStateKey": "binance-kline|signal|BTCUSDT|30m",
+	})
+	state := cloneMetadata(session.State)
+	state["max_trades_per_bar"] = 2
+	state["lastSignalBarStateKey"] = barKey
+	state["sessionReentryCount"] = 2.0
+	state["signalRuntimeSessionId"] = "runtime-1"
+	state["lastDispatchedIntentSignature"] = exitIntentSignature
+	state["lastDispatchedAt"] = time.Now().UTC().Add(-time.Minute).Format(time.RFC3339)
+	state["lastDispatchedOrderStatus"] = "FILLED"
+	state["lastSyncedOrderStatus"] = "FILLED"
+	state["lastExecutionProposal"] = map[string]any{
+		"action":            "entry",
+		"role":              "entry",
+		"reason":            "Zero-Initial-Reentry",
+		"side":              "BUY",
+		"symbol":            "BTCUSDT",
+		"type":              "MARKET",
+		"quantity":          0.0065,
+		"priceHint":         77855.8,
+		"reduceOnly":        false,
+		"signalKind":        "zero-initial-reentry",
+		"signalBarStateKey": "binance-kline|signal|BTCUSDT|30m",
+		"status":            "dispatchable",
+		"metadata": map[string]any{
+			"executionMode": "live",
+			"executionContext": map[string]any{
+				"symbol":              "BTCUSDT",
+				"signalTimeframe":     "30m",
+				"executionDataSource": "tick",
+				"executionMode":       "live",
+			},
+			liveSignalBarTradeLimitKeyField: barKey,
+		},
+	}
+	session, err = platform.store.UpdateLiveSessionState(session.ID, state)
+	if err != nil {
+		t.Fatalf("update live session state failed: %v", err)
+	}
+	_, err = platform.dispatchLiveSessionIntent(session)
+	if err == nil || !strings.Contains(err.Error(), "max_trades_per_bar=2") {
+		t.Fatalf("expected third same-bar entry to stay blocked after intervening exit, got %v", err)
+	}
+}
+
 func TestResolveLiveSessionPositionSnapshotDoesNotMergeStaleLivePositionState(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
 	if _, err := platform.store.SavePosition(domain.Position{
@@ -3360,7 +3424,7 @@ func TestResolveLiveSessionPositionSnapshotDoesNotMergeStaleLivePositionState(t 
 	}
 }
 
-func TestResolveLiveSessionPositionSnapshotMergesMatchingRiskStateOnly(t *testing.T) {
+func TestResolveLiveSessionPositionSnapshotMergesMatchingPersistentRiskFactsOnly(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
 	if _, err := platform.store.SavePosition(domain.Position{
 		ID:                "position-1",
@@ -3396,11 +3460,14 @@ func TestResolveLiveSessionPositionSnapshotMergesMatchingRiskStateOnly(t *testin
 	if !found {
 		t.Fatal("expected real position to be found")
 	}
-	if got := parseFloatValue(snapshot["stopLoss"]); got != 76241.6 {
-		t.Fatalf("expected matching risk stopLoss to be merged, got %v", got)
+	if got := parseFloatValue(snapshot["stopLoss"]); got != 0 {
+		t.Fatalf("expected derived stopLoss to stay out of factual snapshot merge, got %v", got)
 	}
 	if got := stringValue(snapshot["watermarkPositionKey"]); got != key {
 		t.Fatalf("expected matching watermark key to be merged, got %s", got)
+	}
+	if !boolValue(snapshot["protected"]) {
+		t.Fatal("expected protected flag to be merged as a persistent risk fact")
 	}
 	if got := parseFloatValue(snapshot["quantity"]); got != 0.001 {
 		t.Fatalf("expected factual quantity to remain authoritative, got %v", got)

--- a/internal/service/strategy_optimization_test.go
+++ b/internal/service/strategy_optimization_test.go
@@ -609,6 +609,43 @@ func TestDeriveLivePositionStateUsesProvidedWatermarksForShort(t *testing.T) {
 	}
 }
 
+func TestDeriveLivePositionStateDoesNotReuseCachedTrailingStopWhenTrailingInactive(t *testing.T) {
+	parameters := map[string]any{
+		"trailing_stop_atr":               0.3,
+		"delayed_trailing_activation_atr": 0.5,
+		"stop_loss_atr":                   0.3,
+		"stop_mode":                       "atr",
+	}
+	signalBarState := map[string]any{
+		"atr14":    185.67857142857454,
+		"current":  map[string]any{"close": 78112.8},
+		"prevBar1": map[string]any{"high": 78415.6, "low": 78005.1},
+		"prevBar2": map[string]any{"high": 78580.0, "low": 77920.0},
+	}
+	currentPosition := map[string]any{
+		"found":      true,
+		"side":       "SHORT",
+		"entryPrice": 78112.8,
+		"stopLoss":   77993.63571428572,
+		"quantity":   0.0013,
+	}
+	watermarks := livePositionWatermarks{
+		PositionKey: "position-1|BTCUSDT|SHORT|78112.8",
+		HWM:         78112.8,
+		LWM:         78112.8,
+	}
+	state := deriveLivePositionState(parameters, currentPosition, signalBarState, 78112.8, watermarks)
+	if boolValue(state["trailingStopActive"]) {
+		t.Fatal("expected trailing stop to remain inactive before delayed activation is reached")
+	}
+	if got := stringValue(state["stopLossSource"]); got != "initial-stop" {
+		t.Fatalf("expected initial-stop source while trailing is inactive, got %s", got)
+	}
+	if got := parseFloatValue(state["stopLoss"]); tradingPriceDiffers(got, 78168.50357142858) {
+		t.Fatalf("expected base stop loss 78168.50357142858, got %v", got)
+	}
+}
+
 func TestResolveLivePositionWatermarksReturnsEmptyForInactiveSnapshot(t *testing.T) {
 	sessionState := map[string]any{
 		"hwm":                  52000.0,

--- a/internal/service/strategy_registry.go
+++ b/internal/service/strategy_registry.go
@@ -1141,10 +1141,7 @@ func deriveLivePositionState(parameters map[string]any, currentPosition map[stri
 		stopLossATR = 0.05
 	}
 	baseStopLoss := resolveStopPrice(side, entryPrice, sig, stopMode, stopLossATR)
-	stopLoss := parseFloatValue(currentPosition["stopLoss"])
-	if stopLoss <= 0 {
-		stopLoss = baseStopLoss
-	}
+	stopLoss := baseStopLoss
 	stopLossSource := "initial-stop"
 	if baseStopLoss > 0 {
 		switch side {

--- a/internal/service/telemetry.go
+++ b/internal/service/telemetry.go
@@ -28,6 +28,17 @@ func (p *Platform) recordStrategyDecisionEvent(
 	if intentSignature == "" && len(signalIntent) > 0 {
 		intentSignature = buildLiveIntentSignature(signalIntent)
 	}
+	fingerprint := buildStrategyDecisionEventFingerprint(executionContext, decision, sourceGate, signalIntent, executionProposal)
+	lastDecisionEventID := strings.TrimSpace(stringValue(session.State["lastStrategyDecisionEventId"]))
+	if lastDecisionEventID != "" {
+		existing, found, err := p.getStrategyDecisionEvent(session.ID, lastDecisionEventID)
+		if err != nil {
+			return domain.StrategyDecisionEvent{}, err
+		}
+		if found && strategyDecisionEventFingerprintFromRecorded(existing) == fingerprint && existing.IntentSignature == intentSignature {
+			return existing, nil
+		}
+	}
 
 	event := domain.StrategyDecisionEvent{
 		LiveSessionID:     session.ID,
@@ -41,21 +52,25 @@ func (p *Platform) recordStrategyDecisionEvent(
 			NormalizeSymbol(stringValue(signalIntent["symbol"])),
 			NormalizeSymbol(stringValue(session.State["symbol"])),
 		),
-		TriggerType:       firstNonEmpty(stringValue(triggerSummary["event"]), stringValue(triggerSummary["type"])),
-		Action:            firstNonEmpty(decision.Action, "wait"),
-		Reason:            firstNonEmpty(decision.Reason, "unspecified"),
-		SignalKind:        firstNonEmpty(stringValue(decision.Metadata["signalKind"]), stringValue(executionProposal["signalKind"])),
-		DecisionState:     firstNonEmpty(stringValue(decision.Metadata["decisionState"]), stringValue(executionProposal["decisionState"])),
-		IntentSignature:   intentSignature,
-		SourceGateReady:   boolValue(sourceGate["ready"]),
-		MissingCount:      len(metadataList(sourceGate["missing"])),
-		StaleCount:        len(metadataList(sourceGate["stale"])),
-		EventTime:         eventTime.UTC(),
-		TriggerSummary:    cloneMetadata(triggerSummary),
-		SourceGate:        cloneMetadata(sourceGate),
-		SourceStates:      cloneMetadata(sourceStates),
-		SignalBarStates:   cloneMetadata(signalBarStates),
-		PositionSnapshot:  cloneMetadata(mapValue(session.State["recoveredPosition"])),
+		TriggerType:     firstNonEmpty(stringValue(triggerSummary["event"]), stringValue(triggerSummary["type"])),
+		Action:          firstNonEmpty(decision.Action, "wait"),
+		Reason:          firstNonEmpty(decision.Reason, "unspecified"),
+		SignalKind:      firstNonEmpty(stringValue(decision.Metadata["signalKind"]), stringValue(executionProposal["signalKind"])),
+		DecisionState:   firstNonEmpty(stringValue(decision.Metadata["decisionState"]), stringValue(executionProposal["decisionState"])),
+		IntentSignature: intentSignature,
+		SourceGateReady: boolValue(sourceGate["ready"]),
+		MissingCount:    len(metadataList(sourceGate["missing"])),
+		StaleCount:      len(metadataList(sourceGate["stale"])),
+		EventTime:       eventTime.UTC(),
+		TriggerSummary:  cloneMetadata(triggerSummary),
+		SourceGate:      cloneMetadata(sourceGate),
+		SourceStates:    cloneMetadata(sourceStates),
+		SignalBarStates: cloneMetadata(signalBarStates),
+		PositionSnapshot: cloneMetadata(firstNonEmptyMapValue(
+			decision.Metadata["currentPosition"],
+			session.State["recoveredPosition"],
+			session.State["livePositionState"],
+		)),
 		DecisionMetadata:  cloneMetadata(decision.Metadata),
 		SignalIntent:      cloneMetadata(signalIntent),
 		ExecutionProposal: cloneMetadata(executionProposal),
@@ -77,6 +92,89 @@ func (p *Platform) recordStrategyDecisionEvent(
 		p.publishLogEvent(strategyDecisionToUnifiedLogEvent(recorded))
 	}
 	return recorded, err
+}
+
+func buildStrategyDecisionEventFingerprint(
+	executionContext StrategyExecutionContext,
+	decision StrategySignalDecision,
+	sourceGate map[string]any,
+	signalIntent map[string]any,
+	executionProposal map[string]any,
+) string {
+	subject := executionProposal
+	if len(subject) == 0 {
+		subject = signalIntent
+	}
+	metadata := mapValue(subject["metadata"])
+	return strings.Join([]string{
+		firstNonEmpty(decision.Action, "wait"),
+		firstNonEmpty(decision.Reason, "unspecified"),
+		firstNonEmpty(stringValue(decision.Metadata["signalKind"]), stringValue(subject["signalKind"])),
+		firstNonEmpty(stringValue(decision.Metadata["decisionState"]), stringValue(subject["decisionState"])),
+		fmt.Sprintf("%t", boolValue(sourceGate["ready"])),
+		fmt.Sprintf("%d", len(metadataList(sourceGate["missing"]))),
+		fmt.Sprintf("%d", len(metadataList(sourceGate["stale"]))),
+		NormalizeSymbol(firstNonEmpty(executionContext.Symbol, stringValue(subject["symbol"]))),
+		firstNonEmpty(executionContext.SignalTimeframe, stringValue(mapValue(metadata["executionContext"])["signalTimeframe"])),
+		firstNonEmpty(executionContext.ExecutionDataSource, stringValue(mapValue(metadata["executionContext"])["executionDataSource"])),
+		buildLiveIntentSignature(subject),
+		strings.ToLower(strings.TrimSpace(firstNonEmpty(stringValue(subject["status"]), "none"))),
+		normalizeExecutionStrategyKey(firstNonEmpty(stringValue(subject["executionStrategy"]), stringValue(metadata["executionStrategy"]))),
+		strings.ToLower(strings.TrimSpace(stringValue(metadata["executionDecision"]))),
+		fmt.Sprintf("%.8f", parseFloatValue(subject["quantity"])),
+		fmt.Sprintf("%t", boolValue(subject["reduceOnly"])),
+		fmt.Sprintf("%t", boolValue(metadata["fallbackFromTimeout"])),
+	}, "|")
+}
+
+func strategyDecisionEventFingerprintFromRecorded(event domain.StrategyDecisionEvent) string {
+	return buildStrategyDecisionEventFingerprint(
+		StrategyExecutionContext{
+			StrategyVersionID:   stringValue(event.EvaluationContext["strategyVersionId"]),
+			SignalTimeframe:     stringValue(event.EvaluationContext["signalTimeframe"]),
+			ExecutionDataSource: stringValue(event.EvaluationContext["executionDataSource"]),
+			Symbol:              stringValue(event.EvaluationContext["symbol"]),
+		},
+		StrategySignalDecision{
+			Action:   event.Action,
+			Reason:   event.Reason,
+			Metadata: cloneMetadata(event.DecisionMetadata),
+		},
+		event.SourceGate,
+		event.SignalIntent,
+		event.ExecutionProposal,
+	)
+}
+
+func (p *Platform) getStrategyDecisionEvent(liveSessionID, decisionEventID string) (domain.StrategyDecisionEvent, bool, error) {
+	decisionEventID = strings.TrimSpace(decisionEventID)
+	if decisionEventID == "" {
+		return domain.StrategyDecisionEvent{}, false, nil
+	}
+	if reader, ok := p.store.(strategyDecisionEventQueryReader); ok {
+		items, err := reader.QueryStrategyDecisionEvents(domain.StrategyDecisionEventQuery{
+			LiveSessionID:   strings.TrimSpace(liveSessionID),
+			DecisionEventID: decisionEventID,
+			Limit:           1,
+		})
+		if err != nil {
+			return domain.StrategyDecisionEvent{}, false, err
+		}
+		if len(items) > 0 {
+			return items[0], true, nil
+		}
+		return domain.StrategyDecisionEvent{}, false, nil
+	}
+	items, err := p.store.ListStrategyDecisionEvents(strings.TrimSpace(liveSessionID))
+	if err != nil {
+		return domain.StrategyDecisionEvent{}, false, err
+	}
+	for _, item := range items {
+		if strings.TrimSpace(item.ID) == decisionEventID {
+			return item, true, nil
+		}
+	}
+	return domain.StrategyDecisionEvent{}, false, nil
 }
 
 func (p *Platform) ensureStrategyDecisionEventForExecutionProposal(session domain.LiveSession, strategyVersionID string, proposalMap map[string]any, eventTime time.Time, trigger string) (map[string]any, error) {

--- a/internal/service/telemetry_test.go
+++ b/internal/service/telemetry_test.go
@@ -53,6 +53,192 @@ func TestEvaluateLiveSessionOnSignalPersistsStrategyDecisionEvent(t *testing.T) 
 	}
 }
 
+func TestRecordStrategyDecisionEventPrefersFreshCurrentPositionSnapshot(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	session := domain.LiveSession{
+		ID:         "live-session-main",
+		AccountID:  "live-main",
+		StrategyID: "strategy-main",
+		State: map[string]any{
+			"recoveredPosition": map[string]any{
+				"symbol":     "BTCUSDT",
+				"side":       "SHORT",
+				"entryPrice": 78025.6,
+				"stopLoss":   77986.4,
+			},
+		},
+	}
+	decision := StrategySignalDecision{
+		Action: "advance-plan",
+		Reason: "trigger-source-ready",
+		Metadata: map[string]any{
+			"signalKind":    "risk-exit",
+			"decisionState": "exit-ready",
+			"currentPosition": map[string]any{
+				"symbol":     "BTCUSDT",
+				"side":       "SHORT",
+				"entryPrice": 78112.8,
+				"stopLoss":   78168.5,
+			},
+		},
+	}
+	event, err := platform.recordStrategyDecisionEvent(
+		session,
+		"runtime-1",
+		time.Unix(0, 0).UTC(),
+		map[string]any{"event": "trade_tick"},
+		nil,
+		nil,
+		map[string]any{"ready": true},
+		StrategyExecutionContext{
+			StrategyEngineKey:   "bk-default",
+			StrategyVersionID:   "strategy-version-1",
+			SignalTimeframe:     "30m",
+			ExecutionDataSource: "tick",
+			Symbol:              "BTCUSDT",
+		},
+		decision,
+		nil,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("record strategy decision event failed: %v", err)
+	}
+	if got := parseFloatValue(event.PositionSnapshot["entryPrice"]); got != 78112.8 {
+		t.Fatalf("expected fresh current position entry price in event snapshot, got %v", got)
+	}
+	if got := parseFloatValue(event.PositionSnapshot["stopLoss"]); got != 78168.5 {
+		t.Fatalf("expected fresh current position stopLoss in event snapshot, got %v", got)
+	}
+}
+
+func TestEvaluateLiveSessionOnSignalReusesDuplicateStrategyDecisionEvent(t *testing.T) {
+	platform, session, runtimeSessionID, summary, eventTime := prepareLiveDecisionTelemetryFixture(t)
+
+	if err := platform.evaluateLiveSessionOnSignal(session, runtimeSessionID, summary, eventTime); err != nil {
+		t.Fatalf("first live session evaluation failed: %v", err)
+	}
+	updated, err := platform.store.GetLiveSession(session.ID)
+	if err != nil {
+		t.Fatalf("get updated live session failed: %v", err)
+	}
+	firstDecisionEventID := stringValue(updated.State["lastStrategyDecisionEventId"])
+	if firstDecisionEventID == "" {
+		t.Fatal("expected first decision event id to be recorded")
+	}
+	if got := stringValue(updated.State["lastStrategyDecisionEventFingerprint"]); got == "" {
+		t.Fatal("expected decision event fingerprint to be recorded")
+	}
+
+	if err := platform.evaluateLiveSessionOnSignal(updated, runtimeSessionID, summary, eventTime.Add(2*time.Second)); err != nil {
+		t.Fatalf("second live session evaluation failed: %v", err)
+	}
+	updated, err = platform.store.GetLiveSession(session.ID)
+	if err != nil {
+		t.Fatalf("get deduplicated live session failed: %v", err)
+	}
+	events, err := platform.store.ListStrategyDecisionEvents(session.ID)
+	if err != nil {
+		t.Fatalf("list strategy decision events failed: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("expected duplicate evaluation to reuse the prior decision event, got %d events", len(events))
+	}
+	if got := stringValue(updated.State["lastStrategyDecisionEventId"]); got != firstDecisionEventID {
+		t.Fatalf("expected duplicate evaluation to keep decision event id %s, got %s", firstDecisionEventID, got)
+	}
+}
+
+func TestRecordStrategyDecisionEventDoesNotReuseDifferentQuantityIntent(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	session := domain.LiveSession{
+		ID:         "live-session-main",
+		AccountID:  "live-main",
+		StrategyID: "strategy-main",
+		State:      map[string]any{},
+	}
+	executionContext := StrategyExecutionContext{
+		StrategyEngineKey:   "bk-default",
+		StrategyVersionID:   "strategy-version-1",
+		SignalTimeframe:     "30m",
+		ExecutionDataSource: "tick",
+		Symbol:              "BTCUSDT",
+	}
+	decision := StrategySignalDecision{
+		Action: "advance-plan",
+		Reason: "trigger-source-ready",
+		Metadata: map[string]any{
+			"signalKind":    "zero-initial-reentry",
+			"decisionState": "entry-ready",
+		},
+	}
+	sourceGate := map[string]any{"ready": true}
+	firstProposal := map[string]any{
+		"action":            "entry",
+		"role":              "entry",
+		"reason":            "Zero-Initial-Reentry",
+		"side":              "BUY",
+		"symbol":            "BTCUSDT",
+		"type":              "MARKET",
+		"quantity":          0.013,
+		"signalKind":        "zero-initial-reentry",
+		"signalBarStateKey": "binance-kline|signal|BTCUSDT|30m",
+		"status":            "dispatchable",
+		"metadata": map[string]any{
+			"executionDecision":             "direct-dispatch",
+			liveSignalBarTradeLimitKeyField: "BTCUSDT|30m|2026-04-24T01:30:00Z",
+		},
+	}
+	firstEvent, err := platform.recordStrategyDecisionEvent(
+		session,
+		"runtime-1",
+		time.Unix(0, 0).UTC(),
+		map[string]any{"event": "trade_tick"},
+		nil,
+		nil,
+		sourceGate,
+		executionContext,
+		decision,
+		nil,
+		firstProposal,
+	)
+	if err != nil {
+		t.Fatalf("record first strategy decision event failed: %v", err)
+	}
+	session.State["lastStrategyDecisionEventId"] = firstEvent.ID
+	session.State["lastStrategyDecisionEventFingerprint"] = buildStrategyDecisionEventFingerprint(executionContext, decision, sourceGate, nil, firstProposal)
+	session.State["lastStrategyDecisionEventIntentSignature"] = buildLiveIntentSignature(firstProposal)
+
+	secondProposal := cloneMetadata(firstProposal)
+	secondProposal["quantity"] = 0.0065
+	secondEvent, err := platform.recordStrategyDecisionEvent(
+		session,
+		"runtime-1",
+		time.Unix(1, 0).UTC(),
+		map[string]any{"event": "trade_tick"},
+		nil,
+		nil,
+		sourceGate,
+		executionContext,
+		decision,
+		nil,
+		secondProposal,
+	)
+	if err != nil {
+		t.Fatalf("record second strategy decision event failed: %v", err)
+	}
+	if secondEvent.ID == firstEvent.ID {
+		t.Fatalf("expected different quantity intent to create a new decision event, got reused id %s", secondEvent.ID)
+	}
+	events, err := platform.store.ListStrategyDecisionEvents(session.ID)
+	if err != nil {
+		t.Fatalf("list strategy decision events failed: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("expected two distinct strategy decision events, got %d", len(events))
+	}
+}
+
 func TestEvaluateLiveSessionOnSignalPersistsBreakoutHistory(t *testing.T) {
 	platform, session, runtimeSessionID, summary, eventTime := prepareLiveDecisionTelemetryFixture(t)
 	signalKey := signalBindingMatchKey("binance-kline", "signal", "BTCUSDT")


### PR DESCRIPTION
## 目的
修复昨晚到今早 live 交易里暴露出的两类问题：
- `session.State["livePositionState"]` 把 `stopLoss / stopLossSource / trailing*` 这类推导态混进事实仓位，后续评估又继续复用这份缓存出来的止损态，导致刚开仓就可能被旧的 `SL/TSL` 状态秒杀。
- `strategy_decision_events` 在相同 heartbeat 语义下持续重复落库，造成 `waiting-* / exit-ready` 日志风暴，抬高 DB 压力和排障噪音。

这次改动做了三件事：
- 只允许持久风险事实（如 `protected / hwm / lwm / watermarkPositionKey`）从 live risk cache 合并回事实仓位，不再把 `stopLoss / trailing*` 当事实继续透传；`stopLoss` 改成每次从当前参数和水位重新推导。
- `strategy decision event` 改成优先记录本次评估产生的 `currentPosition`，并对同语义 decision 做 event 复用，避免重复刷库；同时把去重锚点纳入 non-regressive facts，防止 stale evaluation state 覆盖。
- 补上历史事故回归：同一根 signal bar 连续开平后，第 3 次 entry 仍必须被 `max_trades_per_bar=2` 挡住；不同 quantity 的 decision 不能被误去重。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [x] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main)
  无变化，默认仍然是 `manual-review`。
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？
  无新增 mainnet 路由或凭证硬编码。
- [x] DB migration 是否具备向下兼容幂等性？
  无 migration。
- [x] 配置字段有没有无意被混改？
  没有新增/改写 live 配置字段，只有 session state 内部事实保护与 telemetry 去重锚点。

## 验证方式与测试证据
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

已执行：
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`

新增/更新覆盖：
- `TestResolveLiveSessionPositionSnapshotMergesMatchingPersistentRiskFactsOnly`
- `TestDeriveLivePositionStateDoesNotReuseCachedTrailingStopWhenTrailingInactive`
- `TestRecordStrategyDecisionEventPrefersFreshCurrentPositionSnapshot`
- `TestEvaluateLiveSessionOnSignalReusesDuplicateStrategyDecisionEvent`
- `TestRecordStrategyDecisionEventDoesNotReuseDifferentQuantityIntent`
- `TestDispatchLiveSessionIntentRejectsThirdEntryAfterInterveningExitOnSameSignalBar`
