### PR TITLE
[codex] Align research baseline defaults

### DIFF
--- a/internal/domain/strategy_baseline.go
+++ b/internal/domain/strategy_baseline.go
@@ -1,0 +1,11 @@
+package domain
+
+const (
+	ResearchBaselineDir2ZeroInitial = true
+	ResearchBaselineZeroInitialMode = "reentry_window"
+	ResearchBaselineMaxTradesPerBar = 2
+)
+
+func ResearchBaselineReentrySizeSchedule() []float64 {
+	return []float64{0.20, 0.10}
+}

--- a/internal/service/live_launch_templates.go
+++ b/internal/service/live_launch_templates.go
@@ -118,8 +118,8 @@ func (p *Platform) LiveLaunchTemplates() ([]LiveLaunchTemplate, error) {
 		if applyResearchBaseline {
 			liveOverrides["strategyEngine"] = firstNonEmpty(strategyEngine, "bk-default")
 			liveOverrides["positionSizingMode"] = "reentry_size_schedule"
-			liveOverrides["dir2_zero_initial"] = true
-			liveOverrides["zero_initial_mode"] = "reentry_window"
+			liveOverrides["dir2_zero_initial"] = domain.ResearchBaselineDir2ZeroInitial
+			liveOverrides["zero_initial_mode"] = domain.ResearchBaselineZeroInitialMode
 			liveOverrides["stop_mode"] = "atr"
 			liveOverrides["stop_loss_atr"] = 0.3
 			liveOverrides["profit_protect_atr"] = 1.0
@@ -127,8 +127,8 @@ func (p *Platform) LiveLaunchTemplates() ([]LiveLaunchTemplate, error) {
 			liveOverrides["delayed_trailing_activation_atr"] = 0.5
 			liveOverrides["long_reentry_atr"] = 0.1
 			liveOverrides["short_reentry_atr"] = 0.0
-			liveOverrides["max_trades_per_bar"] = 2
-			liveOverrides["reentry_size_schedule"] = []float64{0.20, 0.10}
+			liveOverrides["max_trades_per_bar"] = domain.ResearchBaselineMaxTradesPerBar
+			liveOverrides["reentry_size_schedule"] = domain.ResearchBaselineReentrySizeSchedule()
 			baselineNotes = append(baselineNotes,
 				"该模板已显式固化 intraday research baseline：dir2 zero initial + reentry_window + reentry_size_schedule=[0.20, 0.10] + max_trades_per_bar=2。",
 				"非 1d 周期默认使用 canonical SMA5 hard filter；止损与移动止损参数分别固定为 stop_loss_atr=0.3、trailing_stop_atr=0.3、profit_protect_atr=1.0、delayed_trailing_activation_atr=0.5。",

--- a/internal/service/strategy.go
+++ b/internal/service/strategy.go
@@ -649,14 +649,14 @@ func NormalizeBacktestParameters(parameters map[string]any) (map[string]any, err
 	normalized["executionDataSource"] = executionDataSource
 	normalized["symbol"] = symbol
 	normalized["strategyEngine"] = normalizeStrategyEngineKey(stringValue(normalized["strategyEngine"]))
-	dir2ZeroInitial := true
+	dir2ZeroInitial := domain.ResearchBaselineDir2ZeroInitial
 	if _, ok := normalized["dir2_zero_initial"]; ok {
 		dir2ZeroInitial = boolValue(normalized["dir2_zero_initial"])
 	}
 	normalized["dir2_zero_initial"] = dir2ZeroInitial
 	normalized["zero_initial_mode"] = resolveStrategyZeroInitialMode(dir2ZeroInitial, normalized["zero_initial_mode"])
-	normalized["max_trades_per_bar"] = maxIntValue(normalized["max_trades_per_bar"], 3)
-	normalized["reentry_size_schedule"] = normalizeBacktestFloatSlice(normalized["reentry_size_schedule"], []float64{0.20, 0.10})
+	normalized["max_trades_per_bar"] = maxIntValue(normalized["max_trades_per_bar"], domain.ResearchBaselineMaxTradesPerBar)
+	normalized["reentry_size_schedule"] = normalizeBacktestFloatSlice(normalized["reentry_size_schedule"], domain.ResearchBaselineReentrySizeSchedule())
 	stopLossATR := parseFloatValue(normalized["stop_loss_atr"])
 	if stopLossATR <= 0 {
 		stopLossATR = 0.05

--- a/internal/service/strategy_replay.go
+++ b/internal/service/strategy_replay.go
@@ -10,6 +10,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/wuyaocheng/bktrader/internal/domain"
 )
 
 type strategySignalBar struct {
@@ -1039,12 +1041,12 @@ func (e *strategyReplayEngine) summary(signals []strategySignalBar) map[string]a
 
 func buildStrategyReplayConfig(context StrategyExecutionContext) strategyReplayConfig {
 	parameters := context.Parameters
-	reentrySizes := normalizeBacktestFloatSlice(parameters["reentry_size_schedule"], []float64{0.20, 0.10})
+	reentrySizes := normalizeBacktestFloatSlice(parameters["reentry_size_schedule"], domain.ResearchBaselineReentrySizeSchedule())
 	stopMode := stringValue(parameters["stop_mode"])
 	if stopMode == "" {
 		stopMode = "atr"
 	}
-	dir2ZeroInitial := true
+	dir2ZeroInitial := domain.ResearchBaselineDir2ZeroInitial
 	if _, ok := parameters["dir2_zero_initial"]; ok {
 		dir2ZeroInitial = boolValue(parameters["dir2_zero_initial"])
 	}
@@ -1064,7 +1066,7 @@ func buildStrategyReplayConfig(context StrategyExecutionContext) strategyReplayC
 		ZeroInitialMode:      resolveStrategyZeroInitialMode(dir2ZeroInitial, parameters["zero_initial_mode"]),
 		FixedSlippage:        strategyReplaySlippage(context, parameters),
 		StopLossATR:          stopLossATR,
-		MaxTradesPerBar:      maxIntValue(parameters["max_trades_per_bar"], 3),
+		MaxTradesPerBar:      maxIntValue(parameters["max_trades_per_bar"], domain.ResearchBaselineMaxTradesPerBar),
 		ReentrySizeSchedule:  reentrySizes,
 		LongReentryATR:       parseFloatValue(firstNonNil(parameters["long_reentry_atr"], 0.1)),
 		ShortReentryATR:      parseFloatValue(firstNonNil(parameters["short_reentry_atr"], 0.0)),

--- a/internal/service/strategy_replay_test.go
+++ b/internal/service/strategy_replay_test.go
@@ -86,6 +86,13 @@ func TestNormalizeBacktestParametersDefaultsZeroInitialToReentryWindow(t *testin
 	if got := stringValue(normalized["zero_initial_mode"]); got != strategyZeroInitialModeReentryWindow {
 		t.Fatalf("expected zero_initial_mode=%s, got %s", strategyZeroInitialModeReentryWindow, got)
 	}
+	if got := maxIntValue(normalized["max_trades_per_bar"], 0); got != domain.ResearchBaselineMaxTradesPerBar {
+		t.Fatalf("expected max_trades_per_bar=%d, got %d", domain.ResearchBaselineMaxTradesPerBar, got)
+	}
+	schedule := normalizeBacktestFloatSlice(normalized["reentry_size_schedule"], nil)
+	if len(schedule) != 2 || schedule[0] != 0.20 || schedule[1] != 0.10 {
+		t.Fatalf("expected default schedule [0.20, 0.10], got %v", schedule)
+	}
 }
 
 func TestBuildSignalBarsSupportsFiveMinuteAggregation(t *testing.T) {
@@ -132,8 +139,8 @@ func TestBuildStrategyReplayConfigUsesUpdatedBaselineDefaults(t *testing.T) {
 			FundingIntervalHours: 8,
 		},
 	})
-	if cfg.MaxTradesPerBar != 3 {
-		t.Fatalf("expected max trades per bar 3, got %d", cfg.MaxTradesPerBar)
+	if cfg.MaxTradesPerBar != domain.ResearchBaselineMaxTradesPerBar {
+		t.Fatalf("expected max trades per bar %d, got %d", domain.ResearchBaselineMaxTradesPerBar, cfg.MaxTradesPerBar)
 	}
 	if len(cfg.ReentrySizeSchedule) != 2 || cfg.ReentrySizeSchedule[0] != 0.20 || cfg.ReentrySizeSchedule[1] != 0.10 {
 		t.Fatalf("expected default schedule [0.20, 0.10], got %v", cfg.ReentrySizeSchedule)

--- a/internal/service/strategy_zero_initial.go
+++ b/internal/service/strategy_zero_initial.go
@@ -1,10 +1,14 @@
 package service
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/wuyaocheng/bktrader/internal/domain"
+)
 
 const (
 	strategyZeroInitialModePosition      = "position"
-	strategyZeroInitialModeReentryWindow = "reentry_window"
+	strategyZeroInitialModeReentryWindow = domain.ResearchBaselineZeroInitialMode
 )
 
 func normalizeStrategyZeroInitialMode(value string) string {
@@ -32,7 +36,7 @@ func resolveStrategyZeroInitialMode(enabled bool, raw any) string {
 }
 
 func strategyZeroInitialReentryWindowEnabled(parameters map[string]any) bool {
-	enabled := true
+	enabled := domain.ResearchBaselineDir2ZeroInitial
 	if _, ok := parameters["dir2_zero_initial"]; ok {
 		enabled = boolValue(parameters["dir2_zero_initial"])
 	}

--- a/internal/store/memory/store.go
+++ b/internal/store/memory/store.go
@@ -104,8 +104,8 @@ func NewStore() *Store {
 		ExecutionTimeframe: "1m",
 		Parameters: map[string]any{
 			"strategyEngine":                  "bk-default",
-			"max_trades_per_bar":              3,
-			"reentry_size_schedule":           []float64{0.20, 0.10},
+			"max_trades_per_bar":              domain.ResearchBaselineMaxTradesPerBar,
+			"reentry_size_schedule":           domain.ResearchBaselineReentrySizeSchedule(),
 			"stop_mode":                       "atr",
 			"stop_loss_atr":                   0.05,
 			"profit_protect_atr":              1.0,


### PR DESCRIPTION
## 目的
统一项目当前约定的 research baseline 默认值：`dir2_zero_initial=true`、`zero_initial_mode=reentry_window`、`reentry_size_schedule=[0.20, 0.10]`、`max_trades_per_bar=2`。这次把 baseline 常量集中到 domain 层，避免 service、replay、memory seed、launch template 各处继续漂移。

Root cause：AGENTS 中已声明新的长期 baseline，但代码默认值仍有局部保留 `max_trades_per_bar=3` 或内联 schedule，容易让研究/回测入口拿到不一致默认参数。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [x] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) — 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？— 不涉及
- [x] DB migration 是否具备向下兼容幂等性？— 不涉及 migration
- [x] 配置字段有没有无意被混改？— 仅收敛 research baseline 相关默认值，保留显式参数覆盖

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

验证命令：
- `go test ./internal/service ./internal/store/memory ./internal/domain ./internal/http`
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
- `bash scripts/check_high_risk_defaults.sh`
