### PR TITLE
[codex] Reduce live reconcile hot-path scans

### DIFF
--- a/db/migrations/021_live_hot_path_indexes.sql
+++ b/db/migrations/021_live_hot_path_indexes.sql
@@ -1,0 +1,15 @@
+create index if not exists idx_orders_account_status_created_at
+    on orders (account_id, status, created_at desc);
+
+create index if not exists idx_orders_live_session_created_at
+    on orders ((metadata->>'liveSessionId'), created_at asc);
+
+create index if not exists idx_orders_account_settlement_required
+    on orders (account_id, symbol, created_at desc)
+    where metadata->>'immediateFillSyncRequired' = 'true';
+
+create index if not exists idx_positions_account_symbol_updated_at
+    on positions (account_id, symbol, updated_at desc);
+
+create index if not exists idx_fills_order_created_at
+    on fills (order_id, created_at asc);

--- a/internal/domain/models.go
+++ b/internal/domain/models.go
@@ -190,9 +190,14 @@ type Order struct {
 
 // OrderQuery 定义订单查询条件。
 type OrderQuery struct {
-	LiveSessionID string
-	Limit         int
-	Offset        int
+	LiveSessionID      string
+	AccountID          string
+	Symbols            []string
+	Statuses           []string
+	ExcludeStatuses    []string
+	MetadataBoolEquals map[string]bool
+	Limit              int
+	Offset             int
 }
 
 // Fill 成交记录，每笔成交关联一个订单。
@@ -244,6 +249,7 @@ type Position struct {
 // PositionQuery 定义持仓查询条件。
 type PositionQuery struct {
 	AccountID string
+	Symbol    string
 }
 
 // BacktestRun 回测运行记录，保存参数和结果摘要。

--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -565,7 +565,7 @@ func (p *Platform) ReconcileLiveAccount(accountID string, options LiveAccountRec
 		return result, nil
 	}
 
-	orders, err := p.store.ListOrders()
+	orders, err := p.store.QueryOrders(domain.OrderQuery{AccountID: account.ID})
 	if err != nil {
 		return result, err
 	}
@@ -769,7 +769,7 @@ func normalizeLiveAccountReconcileOptions(options LiveAccountReconcileOptions) L
 func (p *Platform) collectLiveAccountReconcileSymbols(account domain.Account, lookbackHours int) ([]string, error) {
 	symbolSet := make(map[string]struct{})
 
-	positions, err := p.store.ListPositions()
+	positions, err := p.store.QueryPositions(domain.PositionQuery{AccountID: account.ID})
 	if err != nil {
 		return nil, err
 	}
@@ -2164,7 +2164,7 @@ func (p *Platform) recoverRunningLiveSession(session domain.LiveSession) (domain
 }
 
 func (p *Platform) reconcileLiveAccountPositions(account domain.Account, exchangePositions []map[string]any) (map[string]any, error) {
-	existing, err := p.store.ListPositions()
+	existing, err := p.store.QueryPositions(domain.PositionQuery{AccountID: account.ID})
 	if err != nil {
 		return nil, err
 	}
@@ -2379,7 +2379,12 @@ func (p *Platform) reconcileLiveAccountPositions(account domain.Account, exchang
 }
 
 func (p *Platform) liveSettlementPendingOrderSymbols(accountID string) (map[string]struct{}, error) {
-	orders, err := p.store.ListOrders()
+	orders, err := p.store.QueryOrders(domain.OrderQuery{
+		AccountID: accountID,
+		MetadataBoolEquals: map[string]bool{
+			liveSettlementSyncRequiredKey: true,
+		},
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -2490,7 +2495,10 @@ func livePositionReconcileAdoptScenario(mismatchFields []string) string {
 }
 
 func (p *Platform) liveWorkingOrderSymbols(accountID string) (map[string]struct{}, error) {
-	orders, err := p.store.ListOrders()
+	orders, err := p.store.QueryOrders(domain.OrderQuery{
+		AccountID:       accountID,
+		ExcludeStatuses: terminalLiveOrderStatuses(),
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -2504,6 +2512,16 @@ func (p *Platform) liveWorkingOrderSymbols(accountID string) (map[string]struct{
 		}
 	}
 	return symbols, nil
+}
+
+func terminalLiveOrderStatuses() []string {
+	return []string{
+		"FILLED",
+		"CANCELLED",
+		"REJECTED",
+		liveOrderStatusVirtualInitial,
+		liveOrderStatusVirtualExit,
+	}
 }
 
 func liveSyncSnapshotOpenOrderSymbols(snapshot map[string]any) map[string]struct{} {

--- a/internal/service/live_reconcile_test.go
+++ b/internal/service/live_reconcile_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -354,6 +355,72 @@ func TestCollectLiveAccountReconcileSymbolsExcludesHistoricalTerminalOrdersWitho
 	}
 }
 
+func TestReconcileLiveAccountPositionsUsesScopedQueries(t *testing.T) {
+	store := &testHotPathQueryStore{Store: memory.NewStore()}
+	platform := NewPlatform(store)
+
+	account, err := store.GetAccount("live-main")
+	if err != nil {
+		t.Fatalf("get account failed: %v", err)
+	}
+	account.Metadata = cloneMetadata(account.Metadata)
+	account.Metadata["liveSyncSnapshot"] = map[string]any{
+		"source":     "binance-rest-account-v3",
+		"openOrders": []map[string]any{},
+		"positions": []map[string]any{{
+			"symbol":      "BTCUSDT",
+			"positionAmt": 0.002,
+			"entryPrice":  50000.0,
+			"markPrice":   50100.0,
+		}},
+	}
+	account, err = store.UpdateAccount(account)
+	if err != nil {
+		t.Fatalf("update account failed: %v", err)
+	}
+	if _, err := store.SavePosition(domain.Position{
+		AccountID:         account.ID,
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "LONG",
+		Quantity:          0.002,
+		EntryPrice:        50000.0,
+		MarkPrice:         50100.0,
+	}); err != nil {
+		t.Fatalf("save position failed: %v", err)
+	}
+	if _, err := store.CreateOrder(domain.Order{
+		AccountID: "paper-main",
+		Symbol:    "ETHUSDT",
+		Side:      "BUY",
+		Type:      "MARKET",
+		Quantity:  1,
+		Price:     3000,
+		Metadata: map[string]any{
+			liveSettlementSyncRequiredKey: true,
+		},
+	}); err != nil {
+		t.Fatalf("create unrelated order failed: %v", err)
+	}
+
+	gate, err := platform.reconcileLiveAccountPositions(account, []map[string]any{{
+		"symbol":      "BTCUSDT",
+		"positionAmt": 0.002,
+		"entryPrice":  50000.0,
+		"markPrice":   50100.0,
+	}})
+	if err != nil {
+		t.Fatalf("reconcile live account positions failed: %v", err)
+	}
+	symbolGate := mapValue(mapValue(gate["symbols"])["BTCUSDT"])
+	if got := stringValue(symbolGate["status"]); got != livePositionReconcileGateStatusVerified {
+		t.Fatalf("expected scoped-query reconcile to verify BTCUSDT, got %s", got)
+	}
+	if boolValue(symbolGate["blocking"]) {
+		t.Fatal("expected scoped-query reconcile gate to be non-blocking")
+	}
+}
+
 func TestReconcileLiveAccountDefersPositionAdoptForPendingImmediateFilledSettlement(t *testing.T) {
 	store := memory.NewStore()
 	platform := NewPlatform(store)
@@ -653,6 +720,18 @@ func configureTestLiveRESTReconcileHistoryAdapter(
 	if _, err := platform.store.UpdateAccount(account); err != nil {
 		t.Fatalf("update live account failed: %v", err)
 	}
+}
+
+type testHotPathQueryStore struct {
+	*memory.Store
+}
+
+func (s *testHotPathQueryStore) ListOrders() ([]domain.Order, error) {
+	return nil, errors.New("unexpected full order scan")
+}
+
+func (s *testHotPathQueryStore) ListPositions() ([]domain.Position, error) {
+	return nil, errors.New("unexpected full position scan")
 }
 
 type testLiveAccountReconcileAdapter struct {

--- a/internal/store/memory/store.go
+++ b/internal/store/memory/store.go
@@ -482,6 +482,9 @@ func (s *Store) QueryOrders(query domain.OrderQuery) ([]domain.Order, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	items := make([]domain.Order, 0, len(s.orders))
+	symbolSet := stringSet(query.Symbols)
+	statusSet := upperStringSet(query.Statuses)
+	excludeStatusSet := upperStringSet(query.ExcludeStatuses)
 	for _, item := range s.orders {
 		if query.LiveSessionID != "" {
 			val, ok := item.Metadata["liveSessionId"].(string)
@@ -489,10 +492,41 @@ func (s *Store) QueryOrders(query domain.OrderQuery) ([]domain.Order, error) {
 				continue
 			}
 		}
+		if query.AccountID != "" && item.AccountID != query.AccountID {
+			continue
+		}
+		if len(symbolSet) > 0 {
+			if _, ok := symbolSet[strings.ToUpper(strings.TrimSpace(item.Symbol))]; !ok {
+				continue
+			}
+		}
+		status := strings.ToUpper(strings.TrimSpace(item.Status))
+		if len(statusSet) > 0 {
+			if _, ok := statusSet[status]; !ok {
+				continue
+			}
+		}
+		if len(excludeStatusSet) > 0 {
+			if _, blocked := excludeStatusSet[status]; blocked {
+				continue
+			}
+		}
+		if !metadataBoolMatches(item.Metadata, query.MetadataBoolEquals) {
+			continue
+		}
 		item.NormalizeExecutionFlags()
 		items = append(items, item)
 	}
 	sort.Slice(items, func(i, j int) bool { return items[i].CreatedAt.Before(items[j].CreatedAt) })
+	if query.Offset > 0 {
+		if query.Offset >= len(items) {
+			return []domain.Order{}, nil
+		}
+		items = items[query.Offset:]
+	}
+	if query.Limit > 0 && len(items) > query.Limit {
+		items = items[:query.Limit]
+	}
 	return items, nil
 }
 
@@ -655,10 +689,54 @@ func (s *Store) QueryPositions(query domain.PositionQuery) ([]domain.Position, e
 		if query.AccountID != "" && item.AccountID != query.AccountID {
 			continue
 		}
+		if query.Symbol != "" && !strings.EqualFold(strings.TrimSpace(item.Symbol), strings.TrimSpace(query.Symbol)) {
+			continue
+		}
 		items = append(items, item)
 	}
 	sort.Slice(items, func(i, j int) bool { return items[i].UpdatedAt.Before(items[j].UpdatedAt) })
 	return items, nil
+}
+
+func stringSet(values []string) map[string]struct{} {
+	out := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		normalized := strings.ToUpper(strings.TrimSpace(value))
+		if normalized != "" {
+			out[normalized] = struct{}{}
+		}
+	}
+	return out
+}
+
+func upperStringSet(values []string) map[string]struct{} {
+	return stringSet(values)
+}
+
+func metadataBoolMatches(metadata map[string]any, expected map[string]bool) bool {
+	if len(expected) == 0 {
+		return true
+	}
+	for key, want := range expected {
+		if strings.TrimSpace(key) == "" {
+			continue
+		}
+		if metadataBoolValue(metadata[key]) != want {
+			return false
+		}
+	}
+	return true
+}
+
+func metadataBoolValue(value any) bool {
+	switch typed := value.(type) {
+	case bool:
+		return typed
+	case string:
+		return strings.EqualFold(strings.TrimSpace(typed), "true")
+	default:
+		return false
+	}
 }
 
 func (s *Store) FindPosition(accountID, symbol string) (domain.Position, bool, error) {

--- a/internal/store/postgres/store.go
+++ b/internal/store/postgres/store.go
@@ -5,6 +5,8 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -613,18 +615,23 @@ func (s *Store) GetOrderByID(orderID string) (domain.Order, error) {
 }
 
 func (s *Store) QueryOrders(query domain.OrderQuery) ([]domain.Order, error) {
-	sqlQuery := `
-		select id, account_id, strategy_version_id, symbol, side, type, status, quantity, price, metadata, created_at
-		from orders
-	`
-	args := []any{}
-	if query.LiveSessionID != "" {
-		sqlQuery += ` where metadata->>'liveSessionId' = $1 `
-		args = append(args, query.LiveSessionID)
-	}
-	sqlQuery += ` order by created_at asc `
+	var builder strings.Builder
+	builder.WriteString(`
+			select id, account_id, strategy_version_id, symbol, side, type, status, quantity, price, metadata, created_at
+			from orders
+			where 1=1
+		`)
+	var args []any
+	appendQueryCondition(&builder, &args, "metadata->>'liveSessionId' = %s", strings.TrimSpace(query.LiveSessionID))
+	appendQueryCondition(&builder, &args, "account_id = %s", strings.TrimSpace(query.AccountID))
+	appendStringListCondition(&builder, &args, "upper(symbol)", normalizedUpperList(query.Symbols), true)
+	appendStringListCondition(&builder, &args, "upper(status)", normalizedUpperList(query.Statuses), true)
+	appendStringListCondition(&builder, &args, "upper(status)", normalizedUpperList(query.ExcludeStatuses), false)
+	appendMetadataBoolConditions(&builder, &args, query.MetadataBoolEquals)
+	builder.WriteString(` order by created_at asc `)
+	appendLimitOffsetCondition(&builder, &args, query.Limit, query.Offset)
 
-	rows, err := s.db.Query(sqlQuery, args...)
+	rows, err := s.db.Query(builder.String(), args...)
 	if err != nil {
 		return nil, err
 	}
@@ -934,18 +941,18 @@ func (s *Store) ListPositions() ([]domain.Position, error) {
 }
 
 func (s *Store) QueryPositions(query domain.PositionQuery) ([]domain.Position, error) {
-	sqlQuery := `
-		select id, account_id, strategy_version_id, symbol, side, quantity, entry_price, mark_price, updated_at
-		from positions
-	`
-	args := []any{}
-	if query.AccountID != "" {
-		sqlQuery += ` where account_id = $1 `
-		args = append(args, query.AccountID)
-	}
-	sqlQuery += ` order by updated_at asc `
+	var builder strings.Builder
+	builder.WriteString(`
+			select id, account_id, strategy_version_id, symbol, side, quantity, entry_price, mark_price, updated_at
+			from positions
+			where 1=1
+		`)
+	var args []any
+	appendQueryCondition(&builder, &args, "account_id = %s", strings.TrimSpace(query.AccountID))
+	appendQueryCondition(&builder, &args, "upper(symbol) = %s", strings.ToUpper(strings.TrimSpace(query.Symbol)))
+	builder.WriteString(` order by updated_at asc `)
 
-	rows, err := s.db.Query(sqlQuery, args...)
+	rows, err := s.db.Query(builder.String(), args...)
 	if err != nil {
 		return nil, err
 	}
@@ -1817,6 +1824,61 @@ func appendQueryTimeCondition(builder *strings.Builder, args *[]any, clause stri
 	builder.WriteString(fmt.Sprintf(" and "+clause, fmt.Sprintf("$%d", len(*args))))
 }
 
+func normalizedUpperList(values []string) []string {
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		normalized := strings.ToUpper(strings.TrimSpace(value))
+		if normalized == "" {
+			continue
+		}
+		out = append(out, normalized)
+	}
+	return out
+}
+
+func appendStringListCondition(builder *strings.Builder, args *[]any, expression string, values []string, include bool) {
+	if len(values) == 0 {
+		return
+	}
+	placeholders := make([]string, 0, len(values))
+	for _, value := range values {
+		if strings.TrimSpace(value) == "" {
+			continue
+		}
+		*args = append(*args, value)
+		placeholders = append(placeholders, fmt.Sprintf("$%d", len(*args)))
+	}
+	if len(placeholders) == 0 {
+		return
+	}
+	operator := "in"
+	if !include {
+		operator = "not in"
+	}
+	builder.WriteString(fmt.Sprintf(" and %s %s (%s)", expression, operator, strings.Join(placeholders, ", ")))
+}
+
+func appendMetadataBoolConditions(builder *strings.Builder, args *[]any, values map[string]bool) {
+	if len(values) == 0 {
+		return
+	}
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		if strings.TrimSpace(key) != "" {
+			keys = append(keys, key)
+		}
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		key = strings.TrimSpace(key)
+		builder.WriteString(fmt.Sprintf(" and metadata->>%s = %s", sqlStringLiteral(key), sqlStringLiteral(strconv.FormatBool(values[key]))))
+	}
+}
+
+func sqlStringLiteral(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "''") + "'"
+}
+
 func appendEventCursorCondition(builder *strings.Builder, args *[]any, cursor *domain.EventCursor) {
 	if cursor == nil {
 		return
@@ -1837,6 +1899,15 @@ func appendLimitCondition(builder *strings.Builder, args *[]any, limit int) {
 	}
 	*args = append(*args, limit)
 	builder.WriteString(fmt.Sprintf(" limit $%d", len(*args)))
+}
+
+func appendLimitOffsetCondition(builder *strings.Builder, args *[]any, limit, offset int) {
+	appendLimitCondition(builder, args, limit)
+	if offset <= 0 {
+		return
+	}
+	*args = append(*args, offset)
+	builder.WriteString(fmt.Sprintf(" offset $%d", len(*args)))
 }
 
 func (s *Store) CreatePositionAccountSnapshot(snapshot domain.PositionAccountSnapshot) (domain.PositionAccountSnapshot, error) {


### PR DESCRIPTION
## 目的
减少 live account reconcile / position reconcile 路径上的全表扫描：扩展 `OrderQuery`、`PositionQuery` 的筛选能力，把相关 hot path 从 `ListOrders/ListPositions` 改为按 account、status、metadata 条件查询，并补充对应索引。

Root cause：当前 reconcile 入口会在订单和持仓表增长后反复拉全量数据，再在内存中过滤；这类路径靠近 live sync / reconcile，长期会放大 DB 压力和限流排查难度。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [x] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) — 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？— 不涉及
- [x] DB migration 是否具备向下兼容幂等性？— 新增 `CREATE INDEX IF NOT EXISTS`，无 schema destructive change
- [x] 配置字段有没有无意被混改？— 不涉及配置默认值；只扩展查询条件和 hot-path 调用点

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

新增回归：`TestReconcileLiveAccountPositionsUsesScopedQueries` 使用会在 `ListOrders/ListPositions` 上报错的 store，防止 reconcile 回退到全表扫描。

验证命令：
- `go test ./internal/service ./internal/store/memory ./internal/store/postgres ./internal/domain ./internal/http`
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
- `bash scripts/check_high_risk_defaults.sh`
- `python3 scripts/check_migration_safety.py`（仅报历史 `018` migration 重号 advisory，新增 `021` 未触发安全告警）
