### PR TITLE
feat: [Phase 3] fix full-dataset read on account-summaries and add summary view for sessions

### DIFF
--- a/internal/http/live.go
+++ b/internal/http/live.go
@@ -15,10 +15,14 @@ func registerLiveRoutes(mux *http.ServeMux, platform *service.Platform) {
 	mux.HandleFunc("/api/v1/live/sessions", func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
 		case http.MethodGet:
+			view := r.URL.Query().Get("view")
 			items, err := platform.ListLiveSessions()
 			if err != nil {
 				writeError(w, http.StatusInternalServerError, err.Error())
 				return
+			}
+			if view == "summary" {
+				items = stripLiveSessionHeavyState(items)
 			}
 			writeJSON(w, http.StatusOK, items)
 		case http.MethodPost:
@@ -676,4 +680,23 @@ func registerLiveRoutes(mux *http.ServeMux, platform *service.Platform) {
 			writeError(w, http.StatusNotFound, "unsupported live session action")
 		}
 	})
+}
+
+func stripLiveSessionHeavyState(items []domain.LiveSession) []domain.LiveSession {
+	stripped := make([]domain.LiveSession, len(items))
+	for i, item := range items {
+		newItem := item
+		if item.State != nil {
+			newState := make(map[string]any, len(item.State))
+			for k, v := range item.State {
+				if k == "sourceStates" || k == "signalBarStates" || k == "livePositionState" {
+					continue
+				}
+				newState[k] = v
+			}
+			newItem.State = newState
+		}
+		stripped[i] = newItem
+	}
+	return stripped
 }

--- a/internal/http/live.go
+++ b/internal/http/live.go
@@ -689,7 +689,7 @@ func stripLiveSessionHeavyState(items []domain.LiveSession) []domain.LiveSession
 		if item.State != nil {
 			newState := make(map[string]any, len(item.State))
 			for k, v := range item.State {
-				if k == "sourceStates" || k == "signalBarStates" || k == "livePositionState" {
+				if k == "sourceStates" || k == "signalBarStates" {
 					continue
 				}
 				newState[k] = v

--- a/internal/http/signals.go
+++ b/internal/http/signals.go
@@ -339,7 +339,7 @@ func stripRuntimeSessionHeavyState(items []domain.SignalRuntimeSession) []domain
 		if item.State != nil {
 			newState := make(map[string]any, len(item.State))
 			for k, v := range item.State {
-				if k == "sourceStates" || k == "signalBarStates" || k == "triggerSummary" {
+				if k == "sourceStates" || k == "signalBarStates" {
 					continue
 				}
 				newState[k] = v

--- a/internal/http/signals.go
+++ b/internal/http/signals.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/wuyaocheng/bktrader/internal/domain"
 	"github.com/wuyaocheng/bktrader/internal/service"
 )
 
@@ -243,7 +244,12 @@ func registerSignalRoutes(mux *http.ServeMux, platform *service.Platform) {
 	mux.HandleFunc("/api/v1/signal-runtime/sessions", func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
 		case http.MethodGet:
-			writeJSON(w, http.StatusOK, platform.ListSignalRuntimeSessions())
+			view := r.URL.Query().Get("view")
+			items := platform.ListSignalRuntimeSessions()
+			if view == "summary" {
+				items = stripRuntimeSessionHeavyState(items)
+			}
+			writeJSON(w, http.StatusOK, items)
 		case http.MethodPost:
 			var payload struct {
 				AccountID  string `json:"accountId"`
@@ -324,4 +330,23 @@ func registerSignalRoutes(mux *http.ServeMux, platform *service.Platform) {
 			writeError(w, http.StatusNotFound, "signal runtime session action not found")
 		}
 	})
+}
+
+func stripRuntimeSessionHeavyState(items []domain.SignalRuntimeSession) []domain.SignalRuntimeSession {
+	stripped := make([]domain.SignalRuntimeSession, len(items))
+	for i, item := range items {
+		newItem := item
+		if item.State != nil {
+			newState := make(map[string]any, len(item.State))
+			for k, v := range item.State {
+				if k == "sourceStates" || k == "signalBarStates" || k == "triggerSummary" {
+					continue
+				}
+				newState[k] = v
+			}
+			newItem.State = newState
+		}
+		stripped[i] = newItem
+	}
+	return stripped
 }

--- a/internal/service/strategy.go
+++ b/internal/service/strategy.go
@@ -326,6 +326,21 @@ func (p *Platform) ListAccountSummaries() ([]domain.AccountSummary, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	var liveSummaries []domain.AccountSummary
+	var paperAccounts []domain.Account
+	for _, account := range accounts {
+		if liveSummary, ok := buildLiveAccountSummaryFromSnapshot(account); ok {
+			liveSummaries = append(liveSummaries, liveSummary)
+		} else {
+			paperAccounts = append(paperAccounts, account)
+		}
+	}
+
+	if len(paperAccounts) == 0 {
+		return liveSummaries, nil
+	}
+
 	orders, err := p.store.ListOrders()
 	if err != nil {
 		return nil, err
@@ -374,11 +389,8 @@ func (p *Platform) ListAccountSummaries() ([]domain.AccountSummary, error) {
 	}
 
 	summaries := make([]domain.AccountSummary, 0, len(accounts))
-	for _, account := range accounts {
-		if liveSummary, ok := buildLiveAccountSummaryFromSnapshot(account); ok {
-			summaries = append(summaries, liveSummary)
-			continue
-		}
+	summaries = append(summaries, liveSummaries...)
+	for _, account := range paperAccounts {
 		summaries = append(summaries, buildAccountSummary(account, positions, startEquityByAccount, states, feesByAccount))
 	}
 	return summaries, nil

--- a/web/console/src/hooks/useDashboardRealtime.ts
+++ b/web/console/src/hooks/useDashboardRealtime.ts
@@ -34,7 +34,7 @@ export function useDashboardRealtime() {
       notificationData,
       monitorHealthData,
     ] = await Promise.all([
-      fetchJSON<LiveSession[]>("/api/v1/live/sessions"),
+      fetchJSON<LiveSession[]>("/api/v1/live/sessions?view=summary"),
       fetchJSON<Position[]>("/api/v1/positions"),
       fetchJSON<Order[]>("/api/v1/orders?limit=50"),
       fetchJSON<Fill[]>("/api/v1/fills?limit=50"),

--- a/web/console/src/hooks/useDashboardState.ts
+++ b/web/console/src/hooks/useDashboardState.ts
@@ -32,7 +32,7 @@ export function useDashboardState() {
     ] = await Promise.all([
       fetchJSON<AccountSummary[]>("/api/v1/account-summaries"),
       fetchJSON<AccountRecord[]>("/api/v1/accounts"),
-      fetchJSON<SignalRuntimeSession[]>("/api/v1/signal-runtime/sessions"),
+      fetchJSON<SignalRuntimeSession[]>("/api/v1/signal-runtime/sessions?view=summary"),
     ]);
 
     const normalizedSummaries = Array.isArray(summaryData) ? summaryData : [];


### PR DESCRIPTION
## 目的
[Phase 3] 专项整改：解决 Dashboard 高频轮询带来的全量数据读取与 OOM 风险（关联 Issue #177）。
- 针对 `/api/v1/account-summaries` 热路径进行优化，当系统中没有模拟盘（PAPER）时，跳过对 `orders` 和 `fills` 的全量读取，直接依赖实盘状态快照返回。
- 针对 `/api/v1/live/sessions` 和 `/api/v1/signal-runtime/sessions` 引入 `?view=summary` 轻量化视图，从响应中剔除了 `sourceStates`、`signalBarStates` 等极其庞大的内存树快照，大幅减小 HTTP 返回体积。
- 在前端 `useDashboardRealtime` 和 `useDashboardState` 中统一挂载 `view=summary` 标志。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [x] **L1** - 中风险 (新增无害接口、辅助工具扩容)

## AI Agent 参与声明
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) -> **无变化**
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？ -> **无**
- [x] DB migration 是否具备向下兼容幂等性？ -> **不涉及 DB migration**
- [x] 配置字段有没有无意被混改？ -> **无**

## 验证方式与测试证据
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩 -> **本地 `go test ./...` 已经全部通过，`tsc` 静态校验通过**
