### PR TITLE
[codex] fix live template baseline sizing

### DIFF
--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -1797,6 +1797,43 @@ func applyLaunchTemplateContext(state map[string]any, context liveLaunchTemplate
 	state["launchTemplateAppliedAt"] = time.Now().UTC().Format(time.RFC3339)
 }
 
+func applyLaunchTemplateBaselineState(state map[string]any) map[string]any {
+	if !liveIntradayResearchBaselineStateMatchesTemplate(state) {
+		return state
+	}
+	normalized := cloneMetadata(state)
+	for key, value := range liveIntradayResearchBaselineOverrides(stringValue(normalized["strategyEngine"])) {
+		normalized[key] = value
+	}
+	normalized["launchTemplateBaseline"] = "intraday-research"
+	return normalized
+}
+
+func liveIntradayResearchBaselineStateMatchesTemplate(state map[string]any) bool {
+	key := strings.ToLower(strings.TrimSpace(stringValue(state["launchTemplateKey"])))
+	if !liveIntradayResearchBaselineTemplateKey(key) {
+		return false
+	}
+	symbol := NormalizeSymbol(firstNonEmpty(
+		stringValue(state["launchTemplateSymbol"]),
+		stringValue(state["symbol"]),
+		stringValue(state["lastSymbol"]),
+	))
+	timeframe := normalizeSignalBarInterval(firstNonEmpty(
+		stringValue(state["launchTemplateTimeframe"]),
+		stringValue(state["signalTimeframe"]),
+		stringValue(state["timeframe"]),
+	))
+	switch key {
+	case "binance-testnet-btc-15m":
+		return symbol == "BTCUSDT" && timeframe == "15m"
+	case "binance-testnet-btc-30m":
+		return symbol == "BTCUSDT" && timeframe == "30m"
+	default:
+		return false
+	}
+}
+
 func (p *Platform) updateSignalRuntimeLaunchTemplateContext(sessionID string, context liveLaunchTemplateContext) (domain.SignalRuntimeSession, error) {
 	if strings.TrimSpace(sessionID) == "" || !context.hasMetadata() {
 		return domain.SignalRuntimeSession{}, nil
@@ -3293,6 +3330,7 @@ func (p *Platform) syncLiveSessionRuntime(session domain.LiveSession) (domain.Li
 
 	requiredBindings := metadataList(plan["requiredBindings"])
 	state = applyCanonicalLiveSignalScope(state, requiredBindings)
+	state = applyLaunchTemplateBaselineState(state)
 	required := len(requiredBindings) > 0
 	state["signalRuntimePlan"] = plan
 	state["signalRuntimeMode"] = "linked"
@@ -4656,6 +4694,9 @@ func normalizeLiveSessionOverrides(overrides map[string]any) map[string]any {
 		}
 		if maxSpread := parseFloatValue(overrides[prefix+"MaxSpreadBps"]); maxSpread > 0 {
 			normalized[prefix+"MaxSpreadBps"] = maxSpread
+		}
+		if maxSlippage := parseFloatValue(overrides[prefix+"MaxSlippageBps"]); maxSlippage > 0 {
+			normalized[prefix+"MaxSlippageBps"] = maxSlippage
 		}
 		if mode := strings.TrimSpace(stringValue(overrides[prefix+"WideSpreadMode"])); mode != "" {
 			normalized[prefix+"WideSpreadMode"] = mode

--- a/internal/service/live_execution.go
+++ b/internal/service/live_execution.go
@@ -496,6 +496,227 @@ func liveProposalSignalBarStateKey(proposalMap map[string]any) string {
 	return strings.TrimSpace(stringValue(mapValue(proposalMap["metadata"])["signalBarStateKey"]))
 }
 
+const (
+	liveDispatchRejectedEntrySlippageExceeded = "ENTRY_SLIPPAGE_EXCEEDED"
+	liveEntrySubmissionSlippageGuardKey       = "entrySubmissionSlippageGuard"
+)
+
+func (p *Platform) applyLiveEntrySubmissionSlippageGuard(session domain.LiveSession, proposalMap map[string]any, eventTime time.Time) (map[string]any, error) {
+	if !liveEntrySubmissionSlippageGuardApplies(proposalMap) {
+		return proposalMap, nil
+	}
+	maxSlippageBps := liveEntrySubmissionMaxSlippageBps(session, proposalMap)
+	if maxSlippageBps <= 0 {
+		return proposalMap, nil
+	}
+
+	checked := cloneMetadata(proposalMap)
+	metadata := cloneMetadata(mapValue(checked["metadata"]))
+	if metadata == nil {
+		metadata = map[string]any{}
+	}
+	side := strings.ToUpper(strings.TrimSpace(stringValue(checked["side"])))
+	expectedPrice := firstPositive(parseFloatValue(checked["limitPrice"]), parseFloatValue(checked["priceHint"]))
+	guard := map[string]any{
+		"status":         "evaluating",
+		"checkedAt":      eventTime.UTC().Format(time.RFC3339),
+		"maxSlippageBps": maxSlippageBps,
+		"side":           side,
+		"expectedPrice":  expectedPrice,
+	}
+	block := func(reason string) (map[string]any, error) {
+		guard["status"] = "blocked"
+		guard["reason"] = reason
+		metadata[liveEntrySubmissionSlippageGuardKey] = guard
+		checked["metadata"] = metadata
+		return checked, fmt.Errorf("live session %s entry submission slippage guard blocked: %s", session.ID, reason)
+	}
+
+	if expectedPrice <= 0 {
+		return block("missing-expected-price")
+	}
+	if side != "BUY" && side != "SELL" {
+		return block("unsupported-entry-side")
+	}
+	book, bookMetadata, ok := p.latestLiveOrderBookStatsForProposal(session, checked)
+	if !ok {
+		return block("missing-current-order-book")
+	}
+	currentPrice := book.bestAsk
+	if side == "SELL" {
+		currentPrice = book.bestBid
+	}
+	guard["currentPrice"] = currentPrice
+	guard["currentBook"] = bookMetadata
+	guard["currentSpreadBps"] = book.spreadBps
+	if currentPrice <= 0 {
+		return block("missing-current-executable-price")
+	}
+
+	adverseDriftBps := liveEntryAdverseSubmissionDriftBps(side, expectedPrice, currentPrice)
+	guard["adverseDriftBps"] = adverseDriftBps
+	if (precisionToleranceSpec{absolute: 1e-9}).exceeds(adverseDriftBps, maxSlippageBps) {
+		guard["status"] = "blocked"
+		guard["reason"] = "slippage-too-wide"
+		metadata[liveEntrySubmissionSlippageGuardKey] = guard
+		checked["metadata"] = metadata
+		return checked, fmt.Errorf(
+			"live session %s entry submission slippage %.4fbps exceeds max %.4fbps",
+			session.ID,
+			adverseDriftBps,
+			maxSlippageBps,
+		)
+	}
+
+	guard["status"] = "passed"
+	metadata[liveEntrySubmissionSlippageGuardKey] = guard
+	checked["metadata"] = metadata
+	return checked, nil
+}
+
+func liveEntrySubmissionSlippageGuardApplies(proposalMap map[string]any) bool {
+	if !strings.EqualFold(strings.TrimSpace(stringValue(proposalMap["role"])), "entry") {
+		return false
+	}
+	metadata := mapValue(proposalMap["metadata"])
+	if boolValue(proposalMap["reduceOnly"]) || boolValue(metadata["reduceOnly"]) {
+		return false
+	}
+	orderType := strings.ToUpper(strings.TrimSpace(firstNonEmpty(stringValue(proposalMap["type"]), "MARKET")))
+	return orderType == "MARKET"
+}
+
+func liveEntrySubmissionMaxSlippageBps(session domain.LiveSession, proposalMap map[string]any) float64 {
+	metadata := mapValue(proposalMap["metadata"])
+	executionContext := mapValue(metadata["executionContext"])
+	return firstPositive(
+		parseFloatValue(session.State["executionEntryMaxSlippageBps"]),
+		firstPositive(
+			parseFloatValue(executionContext["executionEntryMaxSlippageBps"]),
+			parseFloatValue(metadata["executionEntryMaxSlippageBps"]),
+		),
+	)
+}
+
+func (p *Platform) latestLiveOrderBookStatsForProposal(session domain.LiveSession, proposalMap map[string]any) (orderBookDecisionStats, map[string]any, bool) {
+	metadata := mapValue(proposalMap["metadata"])
+	runtimeSessionID := firstNonEmpty(
+		stringValue(metadata["runtimeSessionId"]),
+		stringValue(session.State["signalRuntimeSessionId"]),
+		stringValue(session.State["lastSignalRuntimeSessionId"]),
+	)
+	if strings.TrimSpace(runtimeSessionID) == "" {
+		return orderBookDecisionStats{}, nil, false
+	}
+	runtimeSession, err := p.GetSignalRuntimeSession(runtimeSessionID)
+	if err != nil {
+		return orderBookDecisionStats{}, nil, false
+	}
+	sourceStates := mapValue(runtimeSession.State["sourceStates"])
+	symbol := NormalizeSymbol(firstNonEmpty(stringValue(proposalMap["symbol"]), stringValue(session.State["symbol"]), stringValue(session.State["lastSymbol"])))
+	return latestOrderBookStatsFromSourceStates(runtimeSessionID, symbol, sourceStates)
+}
+
+func latestOrderBookStatsFromSourceStates(runtimeSessionID, symbol string, sourceStates map[string]any) (orderBookDecisionStats, map[string]any, bool) {
+	var selected orderBookDecisionStats
+	var selectedMeta map[string]any
+	var selectedAt time.Time
+	found := false
+	for _, raw := range sourceStates {
+		entry := mapValue(raw)
+		if entry == nil {
+			continue
+		}
+		if strings.ToLower(strings.TrimSpace(stringValue(entry["streamType"]))) != "order_book" {
+			continue
+		}
+		if symbol != "" && NormalizeSymbol(stringValue(entry["symbol"])) != symbol {
+			continue
+		}
+		summary := mapValue(entry["summary"])
+		bestBid := parseFloatValue(summary["bestBid"])
+		bestAsk := parseFloatValue(summary["bestAsk"])
+		if bestBid <= 0 && bestAsk <= 0 {
+			continue
+		}
+		eventAt := parseOptionalRFC3339(stringValue(entry["lastEventAt"]))
+		if found && !eventAt.IsZero() && !selectedAt.IsZero() && !eventAt.After(selectedAt) {
+			continue
+		}
+		spreadBps := parseFloatValue(summary["spreadBps"])
+		if spreadBps <= 0 && bestBid > 0 && bestAsk > 0 {
+			mid := (bestBid + bestAsk) / 2
+			if mid > 0 {
+				spreadBps = (bestAsk - bestBid) / mid * 10000
+			}
+		}
+		selected = orderBookDecisionStats{
+			bestBid:    bestBid,
+			bestAsk:    bestAsk,
+			bestBidQty: parseFloatValue(summary["bestBidQty"]),
+			bestAskQty: parseFloatValue(summary["bestAskQty"]),
+			spreadBps:  spreadBps,
+			imbalance:  parseFloatValue(summary["bookImbalance"]),
+			bias:       stringValue(summary["liquidityBias"]),
+		}
+		selectedMeta = map[string]any{
+			"runtimeSessionId": runtimeSessionID,
+			"sourceKey":        stringValue(entry["sourceKey"]),
+			"symbol":           NormalizeSymbol(stringValue(entry["symbol"])),
+			"lastEventAt":      stringValue(entry["lastEventAt"]),
+			"bestBid":          bestBid,
+			"bestAsk":          bestAsk,
+			"bestBidQty":       selected.bestBidQty,
+			"bestAskQty":       selected.bestAskQty,
+			"spreadBps":        spreadBps,
+		}
+		selectedAt = eventAt
+		found = true
+	}
+	return selected, selectedMeta, found
+}
+
+func liveEntryAdverseSubmissionDriftBps(side string, expectedPrice, currentPrice float64) float64 {
+	if expectedPrice <= 0 || currentPrice <= 0 {
+		return 0
+	}
+	switch strings.ToUpper(strings.TrimSpace(side)) {
+	case "BUY":
+		if currentPrice <= expectedPrice {
+			return 0
+		}
+		return (currentPrice/expectedPrice - 1) * 10000
+	case "SELL":
+		if currentPrice >= expectedPrice {
+			return 0
+		}
+		return (expectedPrice - currentPrice) / expectedPrice * 10000
+	default:
+		return 0
+	}
+}
+
+func (p *Platform) recordLiveDispatchPreflightRejection(session domain.LiveSession, proposalMap map[string]any, status string, rejectionErr error, eventTime time.Time) {
+	state := cloneMetadata(session.State)
+	if eventTime.IsZero() {
+		eventTime = time.Now().UTC()
+	}
+	state["lastDispatchRejectedAt"] = eventTime.UTC().Format(time.RFC3339)
+	state["lastDispatchRejectedStatus"] = status
+	state["lastAutoDispatchError"] = rejectionErr.Error()
+	state["lastAutoDispatchAttemptAt"] = eventTime.UTC().Format(time.RFC3339)
+	state["lastExecutionProposal"] = cloneMetadata(proposalMap)
+	if guard := cloneMetadata(mapValue(mapValue(proposalMap["metadata"])[liveEntrySubmissionSlippageGuardKey])); len(guard) > 0 {
+		state["lastExecutionSubmissionGuard"] = guard
+	}
+	appendTimelineEvent(state, "order", eventTime, "live-dispatch-preflight-rejected", map[string]any{
+		"status": status,
+		"error":  rejectionErr.Error(),
+		"guard":  cloneMetadata(mapValue(state["lastExecutionSubmissionGuard"])),
+	})
+	_, _ = p.store.UpdateLiveSessionState(session.ID, state)
+}
+
 func (p *Platform) dispatchLiveSessionIntent(session domain.LiveSession) (domain.Order, error) {
 	if !strings.EqualFold(session.Status, "RUNNING") && !strings.EqualFold(session.Status, "READY") {
 		return domain.Order{}, fmt.Errorf("live session %s is not dispatchable in status %s", session.ID, session.Status)
@@ -532,6 +753,12 @@ func (p *Platform) dispatchLiveSessionIntent(session domain.LiveSession) (domain
 	dispatchStartedAt := time.Now().UTC()
 	proposalMap, err = p.ensureStrategyDecisionEventForExecutionProposal(session, version.ID, proposalMap, dispatchStartedAt, "dispatch-preflight")
 	if err != nil {
+		return domain.Order{}, err
+	}
+	proposal = executionProposalFromMap(proposalMap)
+	proposalMap, err = p.applyLiveEntrySubmissionSlippageGuard(session, proposalMap, dispatchStartedAt)
+	if err != nil {
+		p.recordLiveDispatchPreflightRejection(session, proposalMap, liveDispatchRejectedEntrySlippageExceeded, err, dispatchStartedAt)
 		return domain.Order{}, err
 	}
 	proposal = executionProposalFromMap(proposalMap)

--- a/internal/service/live_execution.go
+++ b/internal/service/live_execution.go
@@ -601,8 +601,8 @@ func liveEntrySubmissionMaxSlippageBps(session domain.LiveSession, proposalMap m
 func (p *Platform) latestLiveOrderBookStatsForProposal(session domain.LiveSession, proposalMap map[string]any) (orderBookDecisionStats, map[string]any, bool) {
 	metadata := mapValue(proposalMap["metadata"])
 	runtimeSessionID := firstNonEmpty(
-		stringValue(metadata["runtimeSessionId"]),
 		stringValue(session.State["signalRuntimeSessionId"]),
+		stringValue(metadata["runtimeSessionId"]),
 		stringValue(session.State["lastSignalRuntimeSessionId"]),
 	)
 	if strings.TrimSpace(runtimeSessionID) == "" {
@@ -640,7 +640,10 @@ func latestOrderBookStatsFromSourceStates(runtimeSessionID, symbol string, sourc
 			continue
 		}
 		eventAt := parseOptionalRFC3339(stringValue(entry["lastEventAt"]))
-		if found && !eventAt.IsZero() && !selectedAt.IsZero() && !eventAt.After(selectedAt) {
+		if eventAt.IsZero() {
+			continue
+		}
+		if found && !eventAt.After(selectedAt) {
 			continue
 		}
 		spreadBps := parseFloatValue(summary["spreadBps"])

--- a/internal/service/live_launch_flow_template_test.go
+++ b/internal/service/live_launch_flow_template_test.go
@@ -204,6 +204,95 @@ func TestLaunchLiveFlowTemplateSwitchReplacesBindingsAndRefreshesRuntimePlan(t *
 	}
 }
 
+func TestSyncLiveSessionRuntimeReconcilesIntradayLaunchTemplateBaseline(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+
+	for _, payload := range []map[string]any{
+		{
+			"sourceKey": "binance-kline",
+			"role":      "signal",
+			"symbol":    "BTCUSDT",
+			"options":   map[string]any{"timeframe": "30m"},
+		},
+		{
+			"sourceKey": "binance-trade-tick",
+			"role":      "trigger",
+			"symbol":    "BTCUSDT",
+		},
+		{
+			"sourceKey": "binance-order-book",
+			"role":      "feature",
+			"symbol":    "BTCUSDT",
+		},
+	} {
+		if _, err := platform.BindStrategySignalSource("strategy-bk-1d", payload); err != nil {
+			t.Fatalf("bind strategy source failed: %v", err)
+		}
+	}
+
+	session, err := platform.CreateLiveSession("", "live-main", "strategy-bk-1d", map[string]any{
+		"symbol":               "BTCUSDT",
+		"signalTimeframe":      "30m",
+		"positionSizingMode":   "fixed_quantity",
+		"defaultOrderQuantity": 0.001,
+	})
+	if err != nil {
+		t.Fatalf("create live session failed: %v", err)
+	}
+	state := cloneMetadata(session.State)
+	state["launchTemplateKey"] = "binance-testnet-btc-30m"
+	state["launchTemplateName"] = "Binance Testnet BTCUSDT 30m"
+	state["positionSizingMode"] = "fixed_quantity"
+	state["reentry_size_schedule"] = []any{0.20, 0.10}
+	session, err = platform.store.UpdateLiveSessionState(session.ID, state)
+	if err != nil {
+		t.Fatalf("seed stale template state failed: %v", err)
+	}
+
+	synced, err := platform.syncLiveSessionRuntime(session)
+	if err != nil {
+		t.Fatalf("sync live session runtime failed: %v", err)
+	}
+	if got := stringValue(synced.State["positionSizingMode"]); got != "reentry_size_schedule" {
+		t.Fatalf("expected template baseline positionSizingMode=reentry_size_schedule, got %s", got)
+	}
+	schedule := normalizeBacktestFloatSlice(synced.State["reentry_size_schedule"], nil)
+	if len(schedule) != 2 || schedule[0] != 0.20 || schedule[1] != 0.10 {
+		t.Fatalf("expected template baseline schedule [0.20, 0.10], got %#v", synced.State["reentry_size_schedule"])
+	}
+	if !boolValue(synced.State["dir2_zero_initial"]) {
+		t.Fatal("expected template baseline dir2_zero_initial=true")
+	}
+	if got := stringValue(synced.State["zero_initial_mode"]); got != "reentry_window" {
+		t.Fatalf("expected template baseline zero_initial_mode=reentry_window, got %s", got)
+	}
+	if got := maxIntValue(synced.State["max_trades_per_bar"], 0); got != 1 {
+		t.Fatalf("expected template baseline max_trades_per_bar=1, got %d", got)
+	}
+	if got := stringValue(synced.State["launchTemplateBaseline"]); got != "intraday-research" {
+		t.Fatalf("expected intraday research baseline marker, got %s", got)
+	}
+	if got := stringValue(synced.State["dispatchMode"]); got != "manual-review" {
+		t.Fatalf("expected dispatchMode to remain manual-review, got %s", got)
+	}
+}
+
+func TestLaunchTemplateBaselineRequiresMatchingScope(t *testing.T) {
+	state := map[string]any{
+		"launchTemplateKey":  "binance-testnet-btc-30m",
+		"symbol":             "BTCUSDT",
+		"signalTimeframe":    "4h",
+		"positionSizingMode": "fixed_quantity",
+	}
+	updated := applyLaunchTemplateBaselineState(state)
+	if got := stringValue(updated["positionSizingMode"]); got != "fixed_quantity" {
+		t.Fatalf("expected mismatched template scope to keep fixed_quantity, got %s", got)
+	}
+	if _, ok := updated["launchTemplateBaseline"]; ok {
+		t.Fatalf("expected mismatched template scope not to mark baseline, got %#v", updated["launchTemplateBaseline"])
+	}
+}
+
 func TestSyncSignalRuntimeSessionPlanRefreshesStateWithoutStartingRuntime(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
 

--- a/internal/service/live_launch_templates.go
+++ b/internal/service/live_launch_templates.go
@@ -101,6 +101,7 @@ func (p *Platform) LiveLaunchTemplates() ([]LiveLaunchTemplate, error) {
 			"executionStrategy":                       "book-aware-v1",
 			"executionEntryOrderType":                 "MARKET",
 			"executionEntryMaxSpreadBps":              8,
+			"executionEntryMaxSlippageBps":            8,
 			"executionEntryWideSpreadMode":            "limit-maker",
 			"executionEntryRestingTimeoutSeconds":     15,
 			"executionEntryTimeoutFallbackOrderType":  "MARKET",
@@ -116,21 +117,11 @@ func (p *Platform) LiveLaunchTemplates() ([]LiveLaunchTemplate, error) {
 		}
 		baselineNotes := []string{}
 		if applyResearchBaseline {
-			liveOverrides["strategyEngine"] = firstNonEmpty(strategyEngine, "bk-default")
-			liveOverrides["positionSizingMode"] = "reentry_size_schedule"
-			liveOverrides["dir2_zero_initial"] = domain.ResearchBaselineDir2ZeroInitial
-			liveOverrides["zero_initial_mode"] = domain.ResearchBaselineZeroInitialMode
-			liveOverrides["stop_mode"] = "atr"
-			liveOverrides["stop_loss_atr"] = 0.3
-			liveOverrides["profit_protect_atr"] = 1.0
-			liveOverrides["trailing_stop_atr"] = 0.3
-			liveOverrides["delayed_trailing_activation_atr"] = 0.5
-			liveOverrides["long_reentry_atr"] = 0.1
-			liveOverrides["short_reentry_atr"] = 0.0
-			liveOverrides["max_trades_per_bar"] = domain.ResearchBaselineMaxTradesPerBar
-			liveOverrides["reentry_size_schedule"] = domain.ResearchBaselineReentrySizeSchedule()
+			for key, value := range liveIntradayResearchBaselineOverrides(strategyEngine) {
+				liveOverrides[key] = value
+			}
 			baselineNotes = append(baselineNotes,
-				"该模板已显式固化 intraday research baseline：dir2 zero initial + reentry_window + reentry_size_schedule=[0.20, 0.10] + max_trades_per_bar=2。",
+				"该模板已显式固化 intraday research baseline：dir2 zero initial + reentry_window + reentry_size_schedule=[0.20, 0.10] + max_trades_per_bar=1。",
 				"非 1d 周期默认使用 canonical SMA5 hard filter；止损与移动止损参数分别固定为 stop_loss_atr=0.3、trailing_stop_atr=0.3、profit_protect_atr=1.0、delayed_trailing_activation_atr=0.5。",
 				"当前 research baseline 只提升 BTCUSDT 15m/30m；BTCUSDT 5m 暂保留为通用模板，因为现阶段 5m 对执行摩擦更敏感，尚不作为默认 intraday baseline 候选。",
 			)
@@ -200,6 +191,34 @@ func liveLaunchTemplateDispatchModeOptions() []string {
 
 func liveLaunchTemplateAutoDispatchMode() string {
 	return strings.Join([]string{"auto", "dispatch"}, "-")
+}
+
+func liveIntradayResearchBaselineTemplateKey(key string) bool {
+	switch strings.ToLower(strings.TrimSpace(key)) {
+	case "binance-testnet-btc-15m", "binance-testnet-btc-30m":
+		return true
+	default:
+		return false
+	}
+}
+
+func liveIntradayResearchBaselineOverrides(strategyEngine string) map[string]any {
+	return map[string]any{
+		"strategyEngine":                  firstNonEmpty(strategyEngine, "bk-default"),
+		"positionSizingMode":              "reentry_size_schedule",
+		"dir2_zero_initial":               domain.ResearchBaselineDir2ZeroInitial,
+		"zero_initial_mode":               domain.ResearchBaselineZeroInitialMode,
+		"stop_mode":                       "atr",
+		"stop_loss_atr":                   0.3,
+		"profit_protect_atr":              1.0,
+		"trailing_stop_atr":               0.3,
+		"delayed_trailing_activation_atr": 0.5,
+		"long_reentry_atr":                0.1,
+		"short_reentry_atr":               0.0,
+		"max_trades_per_bar":              1,
+		"reentry_size_schedule":           domain.ResearchBaselineReentrySizeSchedule(),
+		"executionEntryMaxSlippageBps":    8,
+	}
 }
 
 func (p *Platform) resolvePrimaryLiveTemplateStrategy() (string, string, string, string, error) {

--- a/internal/service/live_launch_templates_test.go
+++ b/internal/service/live_launch_templates_test.go
@@ -89,6 +89,9 @@ func TestLiveLaunchTemplatesExposeEightBinanceTestnetVariants(t *testing.T) {
 		if got := stringValue(item.LaunchPayload.LiveSessionOverrides["executionStrategy"]); got != "book-aware-v1" {
 			t.Fatalf("expected executionStrategy=book-aware-v1, got %s", got)
 		}
+		if got := parseFloatValue(item.LaunchPayload.LiveSessionOverrides["executionEntryMaxSlippageBps"]); got != 8 {
+			t.Fatalf("expected executionEntryMaxSlippageBps=8 for %s, got %v", item.Key, got)
+		}
 		if _, ok := item.LaunchPayload.LiveSessionOverrides["dispatchMode"]; ok {
 			t.Fatalf("expected dispatchMode to stay configurable and not be hardcoded in launch payload: %#v", item.LaunchPayload.LiveSessionOverrides)
 		}
@@ -129,8 +132,8 @@ func TestLiveLaunchTemplatesExposeEightBinanceTestnetVariants(t *testing.T) {
 			if got := parseFloatValue(item.LaunchPayload.LiveSessionOverrides["short_reentry_atr"]); got != 0.0 {
 				t.Fatalf("expected short_reentry_atr=0.0 for %s, got %v", item.Key, got)
 			}
-			if got := maxIntValue(item.LaunchPayload.LiveSessionOverrides["max_trades_per_bar"], 0); got != 2 {
-				t.Fatalf("expected max_trades_per_bar=2 for %s, got %d", item.Key, got)
+			if got := maxIntValue(item.LaunchPayload.LiveSessionOverrides["max_trades_per_bar"], 0); got != 1 {
+				t.Fatalf("expected max_trades_per_bar=1 for %s, got %d", item.Key, got)
 			}
 			schedule := normalizeBacktestFloatSlice(item.LaunchPayload.LiveSessionOverrides["reentry_size_schedule"], nil)
 			if len(schedule) != 2 || schedule[0] != 0.20 || schedule[1] != 0.10 {

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -2355,6 +2355,102 @@ func TestDispatchLiveSessionIntentRejectsEntryWhenSubmissionSlippageTooWide(t *t
 	}
 }
 
+func TestLiveEntrySubmissionSlippageGuardPrefersActiveRuntimeOverProposalMetadata(t *testing.T) {
+	platform, session, staleRuntimeSessionID, _, eventTime := prepareLiveDecisionTelemetryFixture(t)
+	activeRuntime, err := platform.CreateSignalRuntimeSession(session.AccountID, session.StrategyID)
+	if err != nil {
+		t.Fatalf("create replacement runtime failed: %v", err)
+	}
+	activeRuntimeAt := eventTime.Add(time.Second)
+	bookKey := signalBindingMatchKey("binance-order-book", "feature", "BTCUSDT")
+	if err := platform.updateSignalRuntimeSessionState(activeRuntime.ID, func(runtimeSession *domain.SignalRuntimeSession) {
+		runtimeSession.Status = "RUNNING"
+		state := cloneMetadata(runtimeSession.State)
+		state["lastEventAt"] = activeRuntimeAt.Format(time.RFC3339)
+		state["lastHeartbeatAt"] = activeRuntimeAt.Format(time.RFC3339)
+		state["sourceStates"] = map[string]any{
+			bookKey: map[string]any{
+				"sourceKey":   "binance-order-book",
+				"role":        "feature",
+				"symbol":      "BTCUSDT",
+				"streamType":  "order_book",
+				"lastEventAt": activeRuntimeAt.Format(time.RFC3339),
+				"summary": map[string]any{
+					"bestBid":    99.98,
+					"bestAsk":    100.04,
+					"bestBidQty": 1.0,
+					"bestAskQty": 1.0,
+				},
+			},
+		}
+		runtimeSession.State = state
+		runtimeSession.UpdatedAt = activeRuntimeAt
+	}); err != nil {
+		t.Fatalf("refresh active runtime source states failed: %v", err)
+	}
+
+	state := cloneMetadata(session.State)
+	state["signalRuntimeSessionId"] = activeRuntime.ID
+	state["lastSignalRuntimeSessionId"] = staleRuntimeSessionID
+	state["executionEntryMaxSlippageBps"] = 8.0
+	session, err = platform.store.UpdateLiveSessionState(session.ID, state)
+	if err != nil {
+		t.Fatalf("update live session state failed: %v", err)
+	}
+
+	proposal := map[string]any{
+		"role":      "entry",
+		"side":      "BUY",
+		"symbol":    "BTCUSDT",
+		"type":      "MARKET",
+		"priceHint": 100.0,
+		"metadata": map[string]any{
+			"runtimeSessionId": staleRuntimeSessionID,
+		},
+	}
+	checked, err := platform.applyLiveEntrySubmissionSlippageGuard(session, proposal, activeRuntimeAt)
+	if err != nil {
+		t.Fatalf("expected active runtime order book to pass guard, got %v", err)
+	}
+	guard := mapValue(mapValue(checked["metadata"])[liveEntrySubmissionSlippageGuardKey])
+	if got := stringValue(guard["status"]); got != "passed" {
+		t.Fatalf("expected passed guard status, got %#v", guard)
+	}
+	currentBook := mapValue(guard["currentBook"])
+	if got := stringValue(currentBook["runtimeSessionId"]); got != activeRuntime.ID {
+		t.Fatalf("expected guard to use active runtime %s, got %s", activeRuntime.ID, got)
+	}
+}
+
+func TestLatestOrderBookStatsFromSourceStatesSkipsUntimestampedBooks(t *testing.T) {
+	sourceStates := map[string]any{
+		"empty-time": map[string]any{
+			"sourceKey":  "binance-order-book",
+			"role":       "feature",
+			"symbol":     "BTCUSDT",
+			"streamType": "order_book",
+			"summary": map[string]any{
+				"bestBid": 99.90,
+				"bestAsk": 100.10,
+			},
+		},
+		"invalid-time": map[string]any{
+			"sourceKey":   "binance-order-book",
+			"role":        "feature",
+			"symbol":      "BTCUSDT",
+			"streamType":  "order_book",
+			"lastEventAt": "not-a-timestamp",
+			"summary": map[string]any{
+				"bestBid": 99.95,
+				"bestAsk": 100.05,
+			},
+		},
+	}
+	if stats, metadata, found := latestOrderBookStatsFromSourceStates("runtime-1", "BTCUSDT", sourceStates); found {
+		t.Fatalf("expected untimestamped order books to be skipped, got stats=%#v metadata=%#v", stats, metadata)
+	}
+}
+
 func TestLiveEntrySubmissionSlippageGuardSkipsReduceOnlyExit(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
 	session := domain.LiveSession{

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -2257,6 +2257,128 @@ func TestDispatchLiveSessionIntentRejectsNonDispatchableProposal(t *testing.T) {
 	}
 }
 
+func TestDispatchLiveSessionIntentRejectsEntryWhenSubmissionSlippageTooWide(t *testing.T) {
+	platform, session, runtimeSessionID, _, _ := prepareLiveDecisionTelemetryFixture(t)
+	eventTime := time.Now().UTC()
+	bookKey := signalBindingMatchKey("binance-order-book", "feature", "BTCUSDT")
+	if err := platform.updateSignalRuntimeSessionState(runtimeSessionID, func(runtimeSession *domain.SignalRuntimeSession) {
+		state := cloneMetadata(runtimeSession.State)
+		sourceStates := cloneMetadata(mapValue(state["sourceStates"]))
+		sourceStates[bookKey] = map[string]any{
+			"sourceKey":   "binance-order-book",
+			"role":        "feature",
+			"symbol":      "BTCUSDT",
+			"streamType":  "order_book",
+			"lastEventAt": eventTime.Format(time.RFC3339),
+			"summary": map[string]any{
+				"bestBid":    99.90,
+				"bestAsk":    100.20,
+				"bestBidQty": 1.0,
+				"bestAskQty": 1.0,
+			},
+		}
+		state["sourceStates"] = sourceStates
+		runtimeSession.State = state
+		runtimeSession.UpdatedAt = eventTime
+	}); err != nil {
+		t.Fatalf("update runtime source states failed: %v", err)
+	}
+
+	state := cloneMetadata(session.State)
+	state["executionEntryMaxSlippageBps"] = 8.0
+	state["lastExecutionProposal"] = executionProposalToMap(ExecutionProposal{
+		Action:            "entry",
+		Role:              "entry",
+		Reason:            "Zero-Initial-Reentry",
+		Side:              "BUY",
+		Symbol:            "BTCUSDT",
+		Type:              "MARKET",
+		Quantity:          0.001,
+		PriceHint:         100.0,
+		PriceSource:       "order_book.bestAsk",
+		SignalKind:        "zero-initial-reentry",
+		DecisionState:     "entry-ready",
+		SignalBarStateKey: "bar-1",
+		ExecutionStrategy: "book-aware-v1",
+		Status:            "dispatchable",
+		Metadata: map[string]any{
+			"runtimeSessionId":  runtimeSessionID,
+			"executionMode":     "live",
+			"executionDecision": "direct-dispatch",
+			"executionContext": map[string]any{
+				"strategyVersionId":   "strategy-version-bk-1d-v010",
+				"symbol":              "BTCUSDT",
+				"signalTimeframe":     "1d",
+				"executionDataSource": "tick",
+				"executionMode":       "live",
+			},
+		},
+	})
+	session, err := platform.store.UpdateLiveSessionState(session.ID, state)
+	if err != nil {
+		t.Fatalf("update live session state failed: %v", err)
+	}
+
+	order, err := platform.dispatchLiveSessionIntent(session)
+	if err == nil {
+		t.Fatal("expected entry dispatch to be blocked by submission slippage guard")
+	}
+	if order.ID != "" {
+		t.Fatalf("expected no order to be created after preflight rejection, got %s", order.ID)
+	}
+	if !strings.Contains(err.Error(), "entry submission slippage") {
+		t.Fatalf("expected entry submission slippage error, got %v", err)
+	}
+	orders, err := platform.ListOrders()
+	if err != nil {
+		t.Fatalf("list orders failed: %v", err)
+	}
+	if len(orders) != 0 {
+		t.Fatalf("expected no persisted orders after slippage preflight rejection, got %#v", orders)
+	}
+	updatedSession, err := platform.store.GetLiveSession(session.ID)
+	if err != nil {
+		t.Fatalf("get updated live session failed: %v", err)
+	}
+	if got := stringValue(updatedSession.State["lastDispatchRejectedStatus"]); got != liveDispatchRejectedEntrySlippageExceeded {
+		t.Fatalf("expected rejected status %s, got %s", liveDispatchRejectedEntrySlippageExceeded, got)
+	}
+	guard := mapValue(updatedSession.State["lastExecutionSubmissionGuard"])
+	if got := stringValue(guard["status"]); got != "blocked" {
+		t.Fatalf("expected blocked guard status, got %#v", guard)
+	}
+	if got := stringValue(guard["reason"]); got != "slippage-too-wide" {
+		t.Fatalf("expected slippage-too-wide guard reason, got %#v", guard)
+	}
+	if got := parseFloatValue(guard["adverseDriftBps"]); got <= 8.0 {
+		t.Fatalf("expected adverse drift above 8bps, got %v", got)
+	}
+}
+
+func TestLiveEntrySubmissionSlippageGuardSkipsReduceOnlyExit(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	session := domain.LiveSession{
+		ID: "live-session-1",
+		State: map[string]any{
+			"executionEntryMaxSlippageBps": 1.0,
+		},
+	}
+	proposal := map[string]any{
+		"role":       "exit",
+		"side":       "SELL",
+		"type":       "MARKET",
+		"reduceOnly": true,
+		"priceHint":  100.0,
+	}
+	checked, err := platform.applyLiveEntrySubmissionSlippageGuard(session, proposal, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("expected reduce-only exit to skip entry slippage guard, got %v", err)
+	}
+	if guard := mapValue(mapValue(checked["metadata"])[liveEntrySubmissionSlippageGuardKey]); len(guard) > 0 {
+		t.Fatalf("expected reduce-only exit not to carry entry slippage guard, got %#v", guard)
+	}
+}
+
 func TestDispatchLiveSessionIntentBackfillsMissingDecisionEventReference(t *testing.T) {
 	platform, session, runtimeSessionID, _, _ := prepareLiveDecisionTelemetryFixture(t)
 	platform.registerLiveAdapter(testLiveAccountSyncAdapter{key: "test-decision-event-backfill"})
@@ -2616,6 +2738,7 @@ func TestNormalizeLiveSessionOverridesIncludesExecutionControls(t *testing.T) {
 		"executionTimeInForce":                "ioc",
 		"executionPostOnly":                   true,
 		"executionMaxSpreadBps":               6.5,
+		"executionEntryMaxSlippageBps":        8.0,
 		"executionWideSpreadMode":             "limit-maker",
 		"executionRestingTimeoutSeconds":      25,
 		"executionTimeoutFallbackOrderType":   "market",
@@ -2640,6 +2763,9 @@ func TestNormalizeLiveSessionOverridesIncludesExecutionControls(t *testing.T) {
 	}
 	if got := parseFloatValue(overrides["executionMaxSpreadBps"]); got != 6.5 {
 		t.Fatalf("expected execution max spread override, got %v", got)
+	}
+	if got := parseFloatValue(overrides["executionEntryMaxSlippageBps"]); got != 8.0 {
+		t.Fatalf("expected execution entry max slippage override, got %v", got)
 	}
 	if got := stringValue(overrides["executionWideSpreadMode"]); got != "limit-maker" {
 		t.Fatalf("expected wide spread mode override, got %s", got)

--- a/web/console/src/pages/AccountStage.tsx
+++ b/web/console/src/pages/AccountStage.tsx
@@ -200,7 +200,9 @@ export function AccountStage({
   const confirmActionPending = liveSessionDeleteAction !== null || liveFlowAction !== null;
 
   const activeLiveSession = liveSessions.find(s => s.accountId === quickLiveAccountId);
-  const activeTemplateKey = (activeLiveSession?.metadata as any)?.launchTemplateKey;
+  const activeTemplateKey = String(
+    activeLiveSession?.state?.launchTemplateKey ?? (activeLiveSession?.metadata as any)?.launchTemplateKey ?? ""
+  );
 
   const openConfirm = (title: string, description: string, onConfirm: () => Promise<void> | void) => {
     setConfirmConfig({ open: true, title, description, onConfirm });


### PR DESCRIPTION
## 目的
修复 BTC 15m/30m 一键启动模板应用后 live session 仍可能停留在 `positionSizingMode=fixed_quantity` 的问题，并把这轮 live 模板安全档收紧为 `max_trades_per_bar=1`。同时新增 entry MARKET 单最终提交前的盘口滑点二次校验，避免 proposal 生成后盘口已经明显漂移仍继续提交。

Root cause:
- 模板 payload 虽然带有 research baseline sizing，但已存在或旧状态的 live session 在 runtime sync 时没有按 `launchTemplateKey` 重新收敛 baseline state。
- 页面 RUNNING 模板标记只读 `metadata.launchTemplateKey`，而后端实际写在 `state.launchTemplateKey`。
- 原有执行保护主要在 proposal 阶段检查 spread，最终 submit 前没有针对 entry MARKET 单用最新 order book 再校验 proposal price drift。

Behavior changes:
- `binance-testnet-btc-15m` / `binance-testnet-btc-30m` 且 scope 匹配时，runtime sync 会收敛到 `positionSizingMode=reentry_size_schedule`、`reentry_size_schedule=[0.20,0.10]`、`max_trades_per_bar=1`。
- 模板 payload 增加 `executionEntryMaxSlippageBps=8`。
- entry MARKET 单提交前读取当前 runtime order book；若 adverse drift 超过阈值，则不创建订单，写入 `lastDispatchRejectedStatus=ENTRY_SLIPPAGE_EXCEEDED` 和 `lastExecutionSubmissionGuard`。
- reduce-only / exit 路径跳过 entry slippage guard，不阻断 SL/recovered passive close。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [x] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) — 未改变，模板默认仍为 `manual-review`。
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？— 未新增。
- [x] DB migration 是否具备向下兼容幂等性？— 无 DB migration。
- [x] 配置字段有没有无意被混改？— 新增模板字段 `executionEntryMaxSlippageBps`，并补 normalize 覆盖测试。

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

本地已验证：
- `/usr/local/go/bin/go test ./...`
- `/usr/local/go/bin/go build -o /tmp/bktrader-platform-api ./cmd/platform-api`
- `/usr/local/go/bin/go build -o /tmp/bktrader-db-migrate ./cmd/db-migrate`
- `./node_modules/.bin/tsc --noEmit src/pages/AccountStage.tsx --jsx react-jsx --esModuleInterop --target esnext --module esnext --moduleResolution Bundler --allowSyntheticDefaultImports --types vite/client`
- `npm run build`（通过；仅保留既有 Vite chunk size warning）
- push 前 hook 自动执行 graphify rebuild 与 safety sensors，均通过。

Notes:
- 工作树里仍有未提交的 `AGENTS.md` / `docs/AGENT_PATHS.md` / `docs/production-log-troubleshooting.md` 文档改动，未纳入本 PR。