### PR TITLE
[codex] clarify monitor chart marker labels

### DIFF
--- a/web/console/src/types/domain.ts
+++ b/web/console/src/types/domain.ts
@@ -63,12 +63,15 @@ export type AccountEquitySnapshot = {
 export type Order = {
   id: string;
   accountId: string;
+  strategyVersionId?: string;
   symbol: string;
   side: string;
   type: string;
   status: string;
   quantity: number;
   price: number;
+  reduceOnly?: boolean;
+  closePosition?: boolean;
   metadata?: Record<string, unknown>;
   bindings?: any;
   createdAt: string;

--- a/web/console/src/utils/derivation.test.ts
+++ b/web/console/src/utils/derivation.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import { deriveSessionMarkers, deriveSignalMonitorDecorations, markerText } from "./derivation";
+import { ChartAnnotation, Order, Position, SignalBarCandle } from "../types/domain";
+
+describe("monitor chart marker labels", () => {
+  it("distinguishes long and short entry/exit order markers", () => {
+    const session = { id: "live-1", strategyId: "strategy-1" } as any;
+    const orders: Order[] = [
+      order("o1", "BUY", 100, false, "2026-04-24T00:00:00Z"),
+      order("o2", "SELL", 101, false, "2026-04-24T00:01:00Z"),
+      order("o3", "SELL", 102, true, "2026-04-24T00:02:00Z", "SL"),
+      order("o4", "BUY", 103, true, "2026-04-24T00:03:00Z", "PT"),
+    ];
+
+    const markers = deriveSessionMarkers(session, orders, []);
+
+    expect(markers.map((item) => item.text)).toEqual([
+      "开多 100.00",
+      "开空 101.00",
+      "平多 SL 102.00",
+      "平空 TP 103.00",
+    ]);
+  });
+
+  it("adds direction to breakout and stop monitor decorations", () => {
+    const candles: SignalBarCandle[] = [
+      candle("2026-04-24T00:00:00Z"),
+      candle("2026-04-24T00:01:00Z"),
+      candle("2026-04-24T00:02:00Z"),
+    ];
+    const session = {
+      id: "live-1",
+      strategyId: "strategy-1",
+      state: {
+        breakoutHistory: [
+          { barTime: "2026-04-24T00:00:00Z", level: 100, side: "BUY" },
+          { barTime: "2026-04-24T00:01:00Z", level: 99, side: "SELL" },
+        ],
+        livePositionState: {
+          found: true,
+          side: "SHORT",
+          stopLoss: 104,
+          trailingStopActive: true,
+        },
+      },
+    } as any;
+    const position = {
+      id: "position-1",
+      accountId: "account-1",
+      symbol: "BTCUSDT",
+      side: "SHORT",
+      quantity: 0.01,
+      entryPrice: 101,
+      markPrice: 100,
+      updatedAt: "2026-04-24T00:02:00Z",
+    } as Position;
+
+    const { markers } = deriveSignalMonitorDecorations(session, candles, position, [], []);
+
+    expect(markers.map((item) => item.text)).toEqual(["多 BO", "空 BO", "空 TSL"]);
+  });
+
+  it("adds direction to annotation marker labels when order side is available", () => {
+    const annotation = {
+      id: "a1",
+      source: "live",
+      type: "exit-pt",
+      symbol: "BTCUSDT",
+      time: "2026-04-24T00:00:00Z",
+      price: 100,
+      label: "PT",
+      metadata: { orderSide: "SELL", reason: "PT" },
+    } satisfies ChartAnnotation;
+
+    expect(markerText(annotation)).toBe("平多 TP");
+  });
+});
+
+function order(id: string, side: string, price: number, reduceOnly: boolean, createdAt: string, reason = ""): Order {
+  return {
+    id,
+    accountId: "account-1",
+    symbol: "BTCUSDT",
+    side,
+    type: "MARKET",
+    status: "FILLED",
+    quantity: 0.01,
+    price,
+    reduceOnly,
+    metadata: {
+      liveSessionId: "live-1",
+      reduceOnly,
+      executionProposal: {
+        role: reduceOnly ? "exit" : "entry",
+        reason,
+        reduceOnly,
+      },
+    },
+    createdAt,
+  };
+}
+
+function candle(time: string): SignalBarCandle {
+  return {
+    time,
+    open: 100,
+    high: 101,
+    low: 99,
+    close: 100,
+    timeframe: "1m",
+    isClosed: true,
+  };
+}

--- a/web/console/src/utils/derivation.ts
+++ b/web/console/src/utils/derivation.ts
@@ -310,7 +310,27 @@ export function markerColor(item: ChartAnnotation, highlighted = false) {
 }
 
 export function markerText(item: ChartAnnotation, highlighted = false) {
-  return highlighted ? `★ ${item.label}` : item.label;
+  const text = annotationMarkerText(item);
+  return highlighted ? `★ ${text}` : text;
+}
+
+function annotationMarkerText(item: ChartAnnotation): string {
+  const type = String(item.type ?? "").trim().toLowerCase();
+  const metadata = getRecord(item.metadata);
+  const metadataSide = String(metadata.orderSide ?? metadata.side ?? metadata.eventType ?? "").trim().toUpperCase();
+  const isEntry = type.includes("entry");
+  const isExit = type.includes("exit");
+  const positionSide =
+    type.includes("short") ? "SHORT" :
+    type.includes("long") ? "LONG" :
+    executionOrderPositionSide(metadataSide, isExit);
+  const actionLabel = isEntry ? "开" : isExit ? "平" : "";
+  const sideLabel = positionSide === "SHORT" ? "空" : positionSide === "LONG" ? "多" : "";
+  const reasonLabel = compactExecutionReasonLabel(
+    String(metadata.reason ?? item.label ?? type).trim()
+  ) || compactExecutionReasonLabel(type);
+  const directionalText = actionLabel || sideLabel ? [actionLabel + sideLabel, reasonLabel].filter(Boolean).join(" ") : "";
+  return directionalText || item.label;
 }
 
 export function annotationTone(item: ChartAnnotation) {
@@ -1051,14 +1071,90 @@ export function deriveSessionMarkers(session: LiveSession | PaperSession | null,
     const fill = fillByOrderId.get(order.id);
     const side = String(order.side ?? "").toUpperCase();
     const isBuy = side === "BUY";
+    const markerText = executionOrderMarkerText(order);
     return {
       time: fill?.createdAt || order.createdAt,
       position: isBuy ? "belowBar" : "aboveBar",
       color: isBuy ? "#0e6d60" : "#b04a37",
       shape: isBuy ? "arrowUp" : "arrowDown",
-      text: `${isBuy ? "开" : "平"} ${formatMaybeNumber(order.price)}`,
+      text: `${markerText} ${formatMaybeNumber(order.price)}`,
     };
   });
+}
+
+function executionOrderMarkerText(order: Order): string {
+  const side = String(order.side ?? "").trim().toUpperCase();
+  const isExit = isExitOrderMarker(order);
+  const positionSide = executionOrderPositionSide(side, isExit);
+  const action = isExit ? "平" : "开";
+  const sideLabel = positionSide === "SHORT" ? "空" : positionSide === "LONG" ? "多" : "";
+  const reasonLabel = compactExecutionReasonLabel(executionOrderReason(order));
+  return [action + sideLabel, reasonLabel].filter(Boolean).join(" ");
+}
+
+function isExitOrderMarker(order: Order): boolean {
+  const metadata = getRecord(order.metadata);
+  const proposal = getRecord(metadata.executionProposal ?? metadata.intent);
+  const role = String(metadata.orderRole ?? proposal.role ?? "").trim().toLowerCase();
+  const reason = normalizeExecutionReasonTag(executionOrderReason(order));
+  return (
+    order.reduceOnly === true ||
+    order.closePosition === true ||
+    metadata.reduceOnly === true ||
+    metadata.closePosition === true ||
+    proposal.reduceOnly === true ||
+    proposal.closePosition === true ||
+    role === "exit" ||
+    reason === "sl" ||
+    reason === "pt" ||
+    reason === "tp"
+  );
+}
+
+function executionOrderReason(order: Order): string {
+  const metadata = getRecord(order.metadata);
+  const proposal = getRecord(metadata.executionProposal ?? metadata.intent);
+  return String(metadata.reason ?? proposal.reason ?? order.type ?? "").trim();
+}
+
+function executionOrderPositionSide(side: string, isExit: boolean): "LONG" | "SHORT" | "" {
+  if (side === "BUY") {
+    return isExit ? "SHORT" : "LONG";
+  }
+  if (side === "SELL") {
+    return isExit ? "LONG" : "SHORT";
+  }
+  return "";
+}
+
+function normalizeExecutionReasonTag(reason: string): string {
+  return reason.trim().toLowerCase().replace(/_/g, "-");
+}
+
+function compactExecutionReasonLabel(reason: string): string {
+  const normalized = normalizeExecutionReasonTag(reason);
+  if (normalized === "pt" || normalized === "tp" || normalized === "take-profit") {
+    return "TP";
+  }
+  if (normalized === "sl" || normalized === "stop-loss") {
+    return "SL";
+  }
+  if (normalized === "tsl" || normalized === "trailing-stop") {
+    return "TSL";
+  }
+  if (normalized.includes("zero-initial-reentry")) {
+    return "ZIR";
+  }
+  if (normalized.includes("sl-reentry")) {
+    return "SLR";
+  }
+  if (normalized.includes("pt-reentry") || normalized.includes("tp-reentry")) {
+    return "TPR";
+  }
+  if (normalized === "initial") {
+    return "INI";
+  }
+  return "";
 }
 
 function resolveSessionOrders(session: LiveSession | PaperSession | null, orders: Order[]) {
@@ -1140,7 +1236,7 @@ export function deriveSignalMonitorDecorations(
       position: breakoutSide === "SELL" ? "aboveBar" : "belowBar",
       color: breakoutColor,
       shape: "circle",
-      text: "BO",
+      text: `${breakoutSide === "SELL" ? "空" : "多"} BO`,
     });
   }
 
@@ -1187,7 +1283,7 @@ export function deriveSignalMonitorDecorations(
     position: stopMarkerPosition,
     color: stopMarkerColor,
     shape: "square",
-    text: trailingActive ? "TSL" : "SL",
+    text: `${normalizedSide === "SHORT" ? "空" : "多"} ${trailingActive ? "TSL" : "SL"}`,
   });
 
   return { markers, overlays };


### PR DESCRIPTION
## 目的
主监控图表原先只显示 `开` / `平` / `BO` / `SL` / `TP` / `TSL`，同一根 K 线同时出现开平时无法区分是开多、平多、开空还是平空。本次将 marker 文案改成方向明确的标签，减少实盘复盘时误读。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [x] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) — 未变化。
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？— 无。
- [x] DB migration 是否具备向下兼容幂等性？— 无 migration。
- [x] 配置字段有没有无意被混改？— 仅补充前端 Order 类型字段并调整 marker 派生逻辑。

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

验证已通过：
- `npm test`
- `./node_modules/.bin/tsc --noEmit src/pages/AccountStage.tsx --jsx react-jsx --esModuleInterop --target esnext --module esnext --moduleResolution Bundler --allowSyntheticDefaultImports --types vite/client`
- `npm run build`
- pre-push harness: graphify rebuild、high risk defaults check、env safety check、frontend build all passed

## 主要改动
- 主监控订单 marker 根据 `reduceOnly`、`orderRole`、`executionProposal.role`、`reason` 判断 entry/exit，再结合 BUY/SELL 显示 `开多`、`开空`、`平多`、`平空`。
- BO / SL / TSL 装饰 marker 增加多空方向，例如 `多 BO`、`空 BO`、`空 TSL`。
- 图表 annotation marker 在有 order side 信息时也显示方向化标签。
- 新增前端单测覆盖长短方向、出入场、BO/TSL 文案。
