### PR TITLE
refactor: 提取公共 Summary 状态裁剪 Helper (#192)

### DIFF
--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -118,16 +118,7 @@ func (p *Platform) ListLiveSessionsSummary() ([]domain.LiveSession, error) {
 	stripped := make([]domain.LiveSession, len(items))
 	for i, item := range items {
 		newItem := item
-		if item.State != nil {
-			newState := make(map[string]any, len(item.State))
-			for k, v := range item.State {
-				if k == "sourceStates" || k == "signalBarStates" {
-					continue
-				}
-				newState[k] = v
-			}
-			newItem.State = newState
-		}
+		newItem.State = stripHeavyState(item.State)
 		stripped[i] = newItem
 	}
 	return stripped, nil

--- a/internal/service/signal_runtime_sessions.go
+++ b/internal/service/signal_runtime_sessions.go
@@ -42,16 +42,7 @@ func (p *Platform) ListSignalRuntimeSessionsSummary() []domain.SignalRuntimeSess
 	stripped := make([]domain.SignalRuntimeSession, len(items))
 	for i, item := range items {
 		newItem := item
-		if item.State != nil {
-			newState := make(map[string]any, len(item.State))
-			for k, v := range item.State {
-				if k == "sourceStates" || k == "signalBarStates" {
-					continue
-				}
-				newState[k] = v
-			}
-			newItem.State = newState
-		}
+		newItem.State = stripHeavyState(item.State)
 		stripped[i] = newItem
 	}
 	return stripped

--- a/internal/service/state_util.go
+++ b/internal/service/state_util.go
@@ -1,0 +1,18 @@
+package service
+
+// stripHeavyState removes large objects like sourceStates or signalBarStates
+// from a session state map to reduce the summary payload size. It returns a new
+// map and does not mutate the original input. If the input is nil, it returns nil.
+func stripHeavyState(state map[string]any) map[string]any {
+	if state == nil {
+		return nil
+	}
+	newState := make(map[string]any, len(state))
+	for k, v := range state {
+		if k == "sourceStates" || k == "signalBarStates" {
+			continue
+		}
+		newState[k] = v
+	}
+	return newState
+}

--- a/internal/service/state_util_test.go
+++ b/internal/service/state_util_test.go
@@ -1,0 +1,51 @@
+package service
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestStripHeavyState(t *testing.T) {
+	t.Run("nil state", func(t *testing.T) {
+		if got := stripHeavyState(nil); got != nil {
+			t.Errorf("expected nil, got %v", got)
+		}
+	})
+
+	t.Run("state without heavy fields", func(t *testing.T) {
+		input := map[string]any{
+			"status": "RUNNING",
+			"count":  10,
+		}
+		got := stripHeavyState(input)
+		if !reflect.DeepEqual(got, input) {
+			t.Errorf("expected %v, got %v", input, got)
+		}
+		// Modify returned map to ensure it's a copy
+		got["status"] = "STOPPED"
+		if input["status"] != "RUNNING" {
+			t.Errorf("expected original map to be unchanged")
+		}
+	})
+
+	t.Run("state with heavy fields", func(t *testing.T) {
+		input := map[string]any{
+			"status":          "RUNNING",
+			"count":           10,
+			"sourceStates":    map[string]any{"data": "heavy1"},
+			"signalBarStates": map[string]any{"data": "heavy2"},
+		}
+		got := stripHeavyState(input)
+		expected := map[string]any{
+			"status": "RUNNING",
+			"count":  10,
+		}
+		if !reflect.DeepEqual(got, expected) {
+			t.Errorf("expected %v, got %v", expected, got)
+		}
+		// Ensure original map is unchanged
+		if len(input) != 4 {
+			t.Errorf("expected original map to be unchanged, got len %d", len(input))
+		}
+	})
+}


### PR DESCRIPTION
## 目的
解决 #192 任务：Summary Helper 重构，避免裁剪逻辑多处散落维护。
- 新增 `stripHeavyState` 函数，集中剥离 `sourceStates` 与 `signalBarStates` 等大体积数据。
- 重构了 `live.go` 和 `signal_runtime_sessions.go` 的冗余 for 循环，改为单行工具调用。
- 完善配套单元测试，保证 nil 输入安全及原引用的浅拷贝不可变性。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [x] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main)
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？
- [x] DB migration 是否具备向下兼容幂等性？
- [x] 配置字段有没有无意被混改？

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩
(已增加 `TestStripHeavyState` 并通过全量 `go test ./internal/service/...` 验证)
