### PR TITLE
feat: 为 Stream Token JTI 引入 UUID 以保障唯一性 (#193)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,8 @@ module github.com/wuyaocheng/bktrader
 go 1.22
 
 require (
-	github.com/gorilla/websocket v1.5.3 // indirect
-	github.com/lib/pq v1.12.2 // indirect
+	github.com/google/uuid v1.6.0
+	github.com/gorilla/websocket v1.5.3
+	github.com/lib/pq v1.12.2
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/lib/pq v1.12.2 h1:ajJNv84limnK3aPbDIhLtcjrUbqAw/5XNdkuI6KNe/Q=

--- a/internal/http/auth.go
+++ b/internal/http/auth.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/wuyaocheng/bktrader/internal/config"
 )
 
@@ -66,7 +67,7 @@ func registerAuthRoutes(mux *http.ServeMux, cfg config.Config) {
 			return
 		}
 
-		jti := fmt.Sprintf("%d-%s", time.Now().UnixNano(), claims.Username)
+		jti := uuid.NewString()
 		token, expiresAt, err := issueToken(cfg, claims.Username, "dashboard_stream", jti, 1*time.Minute)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, err.Error())


### PR DESCRIPTION
## 目的
解决 #193 任务：为 stream token JTI 引入 UUID 唯一性机制。
- 使用 `github.com/google/uuid` 生成 `jti`，彻底杜绝极端高并发请求下可能造成的 JTI 碰撞（之前使用的时间戳加 username 可能在同纳秒内重复）。
- 为后续支持精确撤销 (revoke)、幂等控制或审计追踪建立可靠的安全基础。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [x] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main)
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？
- [x] DB migration 是否具备向下兼容幂等性？
- [x] 配置字段有没有无意被混改？

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩
(已在本地执行 `go test ./internal/http` 验证 token 签发与解析逻辑完全通过)
