### PR TITLE
[codex] split runtime services for selective deploy

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,6 +2,11 @@ name: CD
 
 on:
   workflow_dispatch:
+    inputs:
+      deploy_services:
+        description: 'Space-separated compose services to deploy. Empty uses safe defaults.'
+        required: false
+        default: ''
   push:
     branches: [main]
     paths:
@@ -22,6 +27,8 @@ jobs:
     outputs:
       frontend_changed: ${{ steps.filter.outputs.frontend_changed }}
       backend_changed: ${{ steps.filter.outputs.backend_changed }}
+      deploy_services: ${{ steps.filter.outputs.deploy_services }}
+      live_runner_changed: ${{ steps.filter.outputs.live_runner_changed }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -34,10 +41,49 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           BEFORE_SHA: ${{ github.event.before }}
           CURRENT_SHA: ${{ github.sha }}
+          INPUT_DEPLOY_SERVICES: ${{ inputs.deploy_services }}
         run: |
+          add_service() {
+            service="$1"
+            case " $deploy_services " in
+              *" $service "*) ;;
+              *) deploy_services="${deploy_services:+$deploy_services }$service" ;;
+            esac
+          }
+
+          add_all_backend_services() {
+            add_service platform-api
+            add_service live-runner
+            add_service notification-worker
+          }
+
+          validate_deploy_services() {
+            for service in $1; do
+              case "$service" in
+                platform-api|live-runner|notification-worker) ;;
+                *)
+                  echo "Unsupported deploy_services entry: $service" >&2
+                  echo "Allowed services: platform-api live-runner notification-worker" >&2
+                  exit 2
+                  ;;
+              esac
+            done
+          }
+
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             echo "frontend_changed=true" >> "$GITHUB_OUTPUT"
             echo "backend_changed=true" >> "$GITHUB_OUTPUT"
+            if [ -n "${INPUT_DEPLOY_SERVICES:-}" ]; then
+              validate_deploy_services "$INPUT_DEPLOY_SERVICES"
+              deploy_services="$INPUT_DEPLOY_SERVICES"
+            else
+              deploy_services="platform-api notification-worker live-runner"
+            fi
+            echo "deploy_services=$deploy_services" >> "$GITHUB_OUTPUT"
+            case " $deploy_services " in
+              *" live-runner "*) echo "live_runner_changed=true" >> "$GITHUB_OUTPUT" ;;
+              *) echo "live_runner_changed=false" >> "$GITHUB_OUTPUT" ;;
+            esac
             exit 0
           fi
 
@@ -49,6 +95,8 @@ jobs:
 
           frontend_changed=false
           backend_changed=false
+          deploy_services=""
+          live_runner_changed=false
 
           while IFS= read -r file; do
             [ -z "$file" ] && continue
@@ -63,12 +111,49 @@ jobs:
                 backend_changed=true
                 ;;
             esac
+
+            case "$file" in
+              Dockerfile|.dockerignore|deployments/docker-compose.prod.yml|scripts/deploy.sh|internal/app/*|internal/config/*|internal/store/*|internal/domain/*|db/*)
+                add_all_backend_services
+                ;;
+            esac
+
+            case "$file" in
+              cmd/platform-api/*|internal/http/*)
+                add_service platform-api
+                ;;
+            esac
+
+            case "$file" in
+              internal/service/telegram*|internal/service/alerts.go|internal/http/signals.go|internal/domain/*|internal/store/*|db/*)
+                add_service notification-worker
+                ;;
+            esac
+
+            case "$file" in
+              cmd/platform-worker/*|internal/service/live*|internal/service/signal_runtime*|internal/service/order*|internal/service/execution_strategy.go|internal/service/precision_tolerance.go|internal/service/strategy_registry.go|internal/service/signal_source_registry.go|internal/service/signal_runtime_registry.go|internal/service/live_account_flow.go|internal/service/live_launch*|internal/service/live_trade*|internal/service/telemetry.go)
+                live_runner_changed=true
+                add_service live-runner
+                ;;
+            esac
+
+            case "$file" in
+              internal/service/*)
+                add_all_backend_services
+                ;;
+            esac
           done <<EOF
           $changed_files
           EOF
 
+          if [ "$backend_changed" = "true" ] && [ -z "$deploy_services" ]; then
+            add_all_backend_services
+          fi
+
           echo "frontend_changed=$frontend_changed" >> "$GITHUB_OUTPUT"
           echo "backend_changed=$backend_changed" >> "$GITHUB_OUTPUT"
+          echo "deploy_services=$deploy_services" >> "$GITHUB_OUTPUT"
+          echo "live_runner_changed=$live_runner_changed" >> "$GITHUB_OUTPUT"
 
   docker:
     name: Build and publish image
@@ -152,7 +237,7 @@ jobs:
   deploy:
     name: Deploy on Macmini runner
     needs: [changes, docker]
-    if: github.ref == 'refs/heads/main' && needs.changes.outputs.backend_changed == 'true' && needs.docker.result == 'success'
+    if: github.ref == 'refs/heads/main' && needs.changes.outputs.backend_changed == 'true' && needs.changes.outputs.deploy_services != '' && needs.docker.result == 'success'
     runs-on: [self-hosted, macOS, ARM64]
     steps:
       - name: Checkout
@@ -180,7 +265,12 @@ jobs:
           IMAGE_REPO: ghcr.io/${{ github.repository_owner }}/bktrader-app
           IMAGE_TAG: latest
           APP_ENV_FILE: /Users/fujun/services/bktrader/.env
+          DEPLOY_SERVICES: ${{ needs.changes.outputs.deploy_services }}
           GHCR_USERNAME: ${{ secrets.GHCR_USERNAME }}
           GHCR_TOKEN: ${{ secrets.GHCR_READ_TOKEN }}
         run: |
+          echo "Deploying services: $DEPLOY_SERVICES"
+          if [ "${{ needs.changes.outputs.live_runner_changed }}" = "true" ]; then
+            echo "live-runner related changes were detected; live-runner will be deployed automatically."
+          fi
           bash /Users/fujun/services/bktrader/scripts/deploy.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,12 +10,14 @@ COPY internal ./internal
 COPY configs ./configs
 COPY db ./db
 COPY research ./research
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -o /out/platform-api ./cmd/platform-api
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -o /out/platform-api ./cmd/platform-api \
+    && CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -o /out/platform-worker ./cmd/platform-worker
 
 FROM alpine:3.20
 WORKDIR /app
 RUN apk add --no-cache ca-certificates tzdata
 COPY --from=backend-builder /out/platform-api /usr/local/bin/platform-api
+COPY --from=backend-builder /out/platform-worker /usr/local/bin/platform-worker
 COPY configs/app.example.env ./configs/app.example.env
 EXPOSE 8080
 CMD ["platform-api"]

--- a/cmd/platform-worker/main.go
+++ b/cmd/platform-worker/main.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+
+	"github.com/wuyaocheng/bktrader/internal/app"
+	"github.com/wuyaocheng/bktrader/internal/config"
+	"github.com/wuyaocheng/bktrader/internal/logging"
+)
+
+func main() {
+	_ = config.LoadEnvFile()
+
+	cfg := config.Load()
+	role := strings.ToLower(strings.TrimSpace(os.Getenv("BKTRADER_ROLE")))
+	if role == "" {
+		role = "live-runner"
+	}
+	cfg.ProcessRole = role
+	if err := cfg.Validate(); err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "配置验证失败: %v\n", err)
+		os.Exit(1)
+	}
+	if err := logging.Configure(cfg); err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "日志配置失败: %v\n", err)
+		os.Exit(1)
+	}
+	if _, err := logging.BootstrapFromDisk(cfg.LogDir); err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "日志预热失败: %v\n", err)
+	}
+
+	switch role {
+	case "live-runner", "notification-worker":
+	default:
+		_, _ = fmt.Fprintf(os.Stderr, "platform-worker 不支持 BKTRADER_ROLE=%s\n", role)
+		os.Exit(1)
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	platform, err := app.NewPlatform(cfg)
+	if err != nil {
+		slog.Error("platform worker bootstrap failed", "role", role, "error", err)
+		os.Exit(1)
+	}
+	options := app.RuntimeOptionsForRole(role)
+	app.StartRuntimeComponents(ctx, platform, cfg, options)
+	slog.Info("platform worker started", "role", role)
+
+	<-ctx.Done()
+	slog.Info("platform worker stopped", "role", role)
+}

--- a/deployments/docker-compose.prod.yml
+++ b/deployments/docker-compose.prod.yml
@@ -1,7 +1,7 @@
 x-app-image: &app-image
     image: ${IMAGE_REPO:-ghcr.io/folgercn/bktrader-app}:${IMAGE_TAG:-latest}
-    mem_limit: ${APP_MEM_LIMIT:-1536m}
-    memswap_limit: ${APP_MEMSWAP_LIMIT:-2g}
+    mem_limit: ${APP_MEM_LIMIT:-768m}
+    memswap_limit: ${APP_MEMSWAP_LIMIT:-1g}
     restart: unless-stopped
     env_file:
       - ${APP_ENV_FILE:-./.env}
@@ -34,6 +34,8 @@ services:
     <<: *app-image
     container_name: bktrader-live-runner
     command: ["platform-worker"]
+    mem_limit: ${LIVE_RUNNER_MEM_LIMIT:-1536m}
+    memswap_limit: ${LIVE_RUNNER_MEMSWAP_LIMIT:-2g}
     environment:
       BKTRADER_ROLE: live-runner
       AUTO_MIGRATE: "false"
@@ -45,6 +47,8 @@ services:
     <<: *app-image
     container_name: bktrader-notification-worker
     command: ["platform-worker"]
+    mem_limit: ${NOTIFICATION_WORKER_MEM_LIMIT:-256m}
+    memswap_limit: ${NOTIFICATION_WORKER_MEMSWAP_LIMIT:-512m}
     environment:
       BKTRADER_ROLE: notification-worker
       AUTO_MIGRATE: "false"

--- a/deployments/docker-compose.prod.yml
+++ b/deployments/docker-compose.prod.yml
@@ -1,7 +1,5 @@
-services:
-  app:
+x-app-image: &app-image
     image: ${IMAGE_REPO:-ghcr.io/folgercn/bktrader-app}:${IMAGE_TAG:-latest}
-    container_name: bktrader-app
     mem_limit: ${APP_MEM_LIMIT:-512m}
     memswap_limit: ${APP_MEMSWAP_LIMIT:-512m}
     restart: unless-stopped
@@ -11,14 +9,48 @@ services:
       LOG_DIR: ${LOG_DIR:-/app/logs}
       LOG_RETENTION_DAYS: ${LOG_RETENTION_DAYS:-7}
       LOG_MAX_SIZE_MB: ${LOG_MAX_SIZE_MB:-100}
-    ports:
-      - "8080:8080"
     volumes:
       - ../logs:/app/logs
     depends_on:
       - postgres
       - redis
       - nats
+
+services:
+  platform-api:
+    <<: *app-image
+    container_name: bktrader-platform-api
+    command: ["platform-api"]
+    environment:
+      BKTRADER_ROLE: api
+      AUTO_MIGRATE: ${API_AUTO_MIGRATE:-true}
+      LOG_DIR: ${LOG_DIR:-/app/logs}
+      LOG_RETENTION_DAYS: ${LOG_RETENTION_DAYS:-7}
+      LOG_MAX_SIZE_MB: ${LOG_MAX_SIZE_MB:-100}
+    ports:
+      - "8080:8080"
+
+  live-runner:
+    <<: *app-image
+    container_name: bktrader-live-runner
+    command: ["platform-worker"]
+    environment:
+      BKTRADER_ROLE: live-runner
+      AUTO_MIGRATE: "false"
+      LOG_DIR: ${LOG_DIR:-/app/logs}
+      LOG_RETENTION_DAYS: ${LOG_RETENTION_DAYS:-7}
+      LOG_MAX_SIZE_MB: ${LOG_MAX_SIZE_MB:-100}
+
+  notification-worker:
+    <<: *app-image
+    container_name: bktrader-notification-worker
+    command: ["platform-worker"]
+    environment:
+      BKTRADER_ROLE: notification-worker
+      AUTO_MIGRATE: "false"
+      LOG_DIR: ${LOG_DIR:-/app/logs}
+      LOG_RETENTION_DAYS: ${LOG_RETENTION_DAYS:-7}
+      LOG_MAX_SIZE_MB: ${LOG_MAX_SIZE_MB:-100}
 
   postgres:
     image: postgres:16

--- a/docs/cicd-maintenance.md
+++ b/docs/cicd-maintenance.md
@@ -6,7 +6,7 @@
 
 项目目前包含两个主要的 GitHub Actions 工作流：
 - **CI (`ci.yml`)**: 自动执行后端 (Go) 格式检查、编译、前端 (Vite) 构建以及 Docker 镜像构建验证。
-- **CD (`cd.yml`)**: 自动构建并推送后端 Docker 镜像，在自托管 (Self-hosted) 的 Macmini 节点上执行后端部署脚本，并构建前端静态文件后同步到远端 Nginx 目录。
+- **CD (`cd.yml`)**: 自动构建并推送后端 Docker 镜像，在自托管 (Self-hosted) 的 Macmini 节点上执行后端部署脚本，并构建前端静态文件后同步到远端 Nginx 目录。生产 compose 将后端镜像拆成 `platform-api`、`live-runner`、`notification-worker` 三类进程。
 - **AI PR Review (`ai-review.yml`)**: 在自托管 Macmini runner 上调用已登录的 Codex CLI，按文件审查 PR diff，并把通过校验的结果写成 PR 行级评论。
 
 ---
@@ -97,6 +97,26 @@ gofmt -w .
 - 发布方式：`rsync -av --delete`
 - 线上访问：由 Nginx 提供静态资源，`/api/` 和 `/healthz` 反代到后端
 
+**当前后端进程角色**：
+
+- `platform-api`: 对外 HTTP API、控制台查询、配置与只读监控入口，监听 `8080`。
+- `live-runner`: 实盘 session 恢复、signal runtime、live sync / reconcile，不暴露 HTTP 端口。
+- `notification-worker`: Telegram 通知投递，不暴露 HTTP 端口。
+- `platform-api` 不设置 `BKTRADER_ROLE` 时仍为旧的 `monolith` 行为，便于本地开发和紧急回退；`platform-worker` 只接受 `live-runner` / `notification-worker`，避免生产误配出重复后台 worker。
+
+**后端选择性部署约定**：
+
+- 普通 push 会根据 diff 自动计算 `DEPLOY_SERVICES`，只重启需要更新的 compose 服务。
+- API / 配置 / 查询 / store / db 等改动默认部署 `platform-api`。
+- Dockerfile / compose / deploy script / app / config / store / domain / db 等共享层改动默认部署三类后端服务。
+- Telegram / alerts / notifications 相关改动默认部署 `notification-worker`。
+- `live-runner` 相关改动默认部署 `live-runner`，会自动重启交易运行时。
+- 如需手动指定部署范围，可使用 `workflow_dispatch` 填写 `deploy_services`，例如 `platform-api` 或 `live-runner`。
+- 部署脚本支持本地指定服务，例如：
+  ```bash
+  DEPLOY_SERVICES="platform-api notification-worker" bash scripts/deploy.sh
+  ```
+
 **常见原因**：
 
 - Runner SSH key 没有权限登录远端机器
@@ -112,7 +132,7 @@ gofmt -w .
 
 1. 确认 Nginx 的 `/api/` 和 `/healthz` 已反代到正确后端端口。
 2. 确认 FRP 隧道已建立，远端反代目标端口可访问。
-3. 确认后端容器内 `/healthz` 返回 200。
+3. 确认 `platform-api` 容器内 `/healthz` 返回 200。
 4. 确认前端生产构建没有把 API 地址写死成 `http://127.0.0.1:8080`。
 5. 如果开启了鉴权，确认浏览器请求带上了正确的登录态或 Bearer token。
 

--- a/docs/部署与网络架构.md
+++ b/docs/部署与网络架构.md
@@ -14,7 +14,9 @@
 2. **后端更新上线 (Macmini 自托管服务器完成)**：
    - GitHub Action 控制你的 Macmini 开始工作。
    - Macmini 使用本地的 `deploy.sh` 脚本和 `docker-compose.prod.yml`，把网上的最新镜像拉回本地。
-   - 借助 Docker Compose 启动容器，后端服务跑在你在 Macmini 的真实物理机上，监听 **`8080`** 端口。
+   - 借助 Docker Compose 启动拆分后的后台容器：`platform-api` 对外监听 **`8080`**，`live-runner` 负责实盘恢复 / 对账 / session runtime，`notification-worker` 负责 Telegram 告警投递。
+   - `platform-api` 使用 `BKTRADER_ROLE=api`，不启动 live 后台 worker；`live-runner` 使用 `BKTRADER_ROLE=live-runner`，不暴露 HTTP 端口。
+   - CD 会按 diff 计算 `DEPLOY_SERVICES`，后端改动默认只重启对应服务；`live-runner` 相关改动会自动重启交易运行时。
 
 3. **前端资源发布 (Macmini → IDC远端机)**：
    - 同上步骤，Macmini 本地从源码里进行 `npm run build` 编译项目。
@@ -48,7 +50,7 @@
   - 它通过加密隧道，悄悄穿越了防火墙，把 `3081` 接收到的任何字节原封不动地搬运到了你的内网 **Macmini 本机的 `8080` 端口**。
 
 - **第四棒：终点站 (Macmini - 后端)**
-  - 你的 Macmini 岁月静好，使用 `docker-compose.prod.yml` 正在默默跑着容器。它只知道自己的程序监听在 `8080` 端口。它解析收到的数据，计算后返回 `HTTPS 200` 结果。结果沿着旧路，顺着光缆返回给用户的浏览器。
+  - 你的 Macmini 使用 `docker-compose.prod.yml` 跑拆分后的后台服务。公网请求只进入 `platform-api:8080`；实盘运行、对账和告警由同一 compose 栈里的 worker 容器在后台处理。API 解析收到的数据后返回 `HTTPS 200`，结果沿着旧路返回给用户浏览器。
 
 ### 小结
 - **开发前端时**：API 基础地址配 `""`，保持相对路径最香，切忌写死 `127.0.0.1:8080`，不然公网用户访问网页时浏览器会去请求他们自己的电脑。

--- a/internal/app/server.go
+++ b/internal/app/server.go
@@ -19,13 +19,72 @@ import (
 
 // NewServer 根据配置创建 HTTP 服务实例，初始化存储层和平台服务。
 func NewServer(cfg config.Config) (*http.Server, error) {
+	return NewServerWithRuntimeOptions(cfg, RuntimeOptionsForRole(cfg.ProcessRole))
+}
+
+type RuntimeOptions struct {
+	WarmLiveMarketData bool
+	StartTelegram      bool
+	RecoverLiveTrading bool
+	StartLiveSync      bool
+	StartDashboard     bool
+}
+
+func RuntimeOptionsForRole(role string) RuntimeOptions {
+	switch strings.ToLower(strings.TrimSpace(role)) {
+	case "api":
+		return RuntimeOptions{StartDashboard: true}
+	case "live-runner":
+		return RuntimeOptions{
+			WarmLiveMarketData: true,
+			RecoverLiveTrading: true,
+			StartLiveSync:      true,
+		}
+	case "notification-worker":
+		return RuntimeOptions{StartTelegram: true}
+	default:
+		return RuntimeOptions{
+			WarmLiveMarketData: true,
+			StartTelegram:      true,
+			RecoverLiveTrading: true,
+			StartLiveSync:      true,
+			StartDashboard:     true,
+		}
+	}
+}
+
+// NewServerWithRuntimeOptions 创建 HTTP 服务，并按进程角色启动后台组件。
+func NewServerWithRuntimeOptions(cfg config.Config, runtime RuntimeOptions) (*http.Server, error) {
 	logger := slog.Default().With("component", "app.server")
 	logger.Info("initializing server",
 		"store_backend", cfg.StoreBackend,
 		"auto_migrate", cfg.AutoMigrate,
 		"paper_tick_interval_seconds", cfg.PaperTickInterval,
+		"process_role", cfg.ProcessRole,
 	)
 
+	platform, err := NewPlatform(cfg)
+	if err != nil {
+		return nil, err
+	}
+	StartRuntimeComponents(context.Background(), platform, cfg, runtime)
+	logger.Info("background workers configured",
+		"warm_live_market_data", runtime.WarmLiveMarketData,
+		"telegram", runtime.StartTelegram,
+		"live_recovery", runtime.RecoverLiveTrading,
+		"live_sync", runtime.StartLiveSync,
+		"dashboard", runtime.StartDashboard,
+	)
+
+	return &http.Server{
+		Addr:    cfg.HTTPAddr,
+		Handler: apihttp.NewRouter(cfg, platform),
+	}, nil
+}
+
+// NewPlatform initializes the shared service facade without starting HTTP.
+func NewPlatform(cfg config.Config) (*service.Platform, error) {
+	logger := slog.Default().With("component", "app.platform")
 	repository, err := buildRepository(cfg)
 	if err != nil {
 		logger.Error("build repository failed", "error", err)
@@ -53,23 +112,32 @@ func NewServer(cfg config.Config) (*http.Server, error) {
 	// ApplyRuntimeConfigOverrides 会根据字段业务语义进行严格校验 (>0 vs >=0)，
 	// 并且仅当环境变量明确设置时（指针非 nil）才执行覆盖。
 	platform.ApplyRuntimeConfigOverrides(cfg)
-	warmCtx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
-	if err := platform.WarmLiveMarketData(warmCtx); err != nil {
-		logger.Warn("warm live market data completed with errors", "error", err)
-	} else {
-		logger.Info("live market data warmed successfully")
-	}
-	cancel()
-	platform.StartTelegramDispatcher(context.Background())
-	go platform.RecoverLiveTradingOnStartup(context.Background())
-	go platform.StartLiveSyncDispatcher(context.Background())
-	platform.StartDashboardBroker(context.Background(), cfg)
-	logger.Info("background workers started")
+	return platform, nil
+}
 
-	return &http.Server{
-		Addr:    cfg.HTTPAddr,
-		Handler: apihttp.NewRouter(cfg, platform),
-	}, nil
+func StartRuntimeComponents(ctx context.Context, platform *service.Platform, cfg config.Config, runtime RuntimeOptions) {
+	logger := slog.Default().With("component", "app.runtime", "process_role", cfg.ProcessRole)
+	if runtime.WarmLiveMarketData {
+		warmCtx, cancel := context.WithTimeout(ctx, 20*time.Second)
+		if err := platform.WarmLiveMarketData(warmCtx); err != nil {
+			logger.Warn("warm live market data completed with errors", "error", err)
+		} else {
+			logger.Info("live market data warmed successfully")
+		}
+		cancel()
+	}
+	if runtime.StartTelegram {
+		platform.StartTelegramDispatcher(ctx)
+	}
+	if runtime.RecoverLiveTrading {
+		go platform.RecoverLiveTradingOnStartup(ctx)
+	}
+	if runtime.StartLiveSync {
+		go platform.StartLiveSyncDispatcher(ctx)
+	}
+	if runtime.StartDashboard {
+		platform.StartDashboardBroker(ctx, cfg)
+	}
 }
 
 // buildRepository 根据配置选择并初始化存储后端。

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	LogRetentionDays               int    // 日志保留天数
 	LogMaxSizeMB                   int    // 单个日志文件滚动前的最大体积（MB）
 	HTTPAddr                       string // HTTP 监听地址
+	ProcessRole                    string // 进程角色：monolith / api / live-runner / notification-worker
 	StoreBackend                   string // 存储后端类型（memory / postgres）
 	AutoMigrate                    bool   // 是否在启动时自动执行数据库迁移
 	PostgresDSN                    string // PostgreSQL 连接字符串
@@ -92,6 +93,7 @@ func Load() Config {
 		LogRetentionDays:               intFromEnv("LOG_RETENTION_DAYS", 7),
 		LogMaxSizeMB:                   intFromEnv("LOG_MAX_SIZE_MB", 100),
 		HTTPAddr:                       getenv("HTTP_ADDR", ":8080"),
+		ProcessRole:                    strings.ToLower(strings.TrimSpace(getenv("BKTRADER_ROLE", "monolith"))),
 		StoreBackend:                   getenv("STORE_BACKEND", "memory"),
 		AutoMigrate:                    boolFromEnv("AUTO_MIGRATE", true),
 		PostgresDSN:                    getenv("POSTGRES_DSN", "postgres://postgres:postgres@localhost:5432/bktrader?sslmode=disable"),
@@ -175,6 +177,11 @@ func (c Config) Validate() error {
 	if c.HTTPAddr == "" {
 		return fmt.Errorf("HTTP_ADDR 不能为空")
 	}
+	switch strings.ToLower(strings.TrimSpace(c.ProcessRole)) {
+	case "", "monolith", "api", "live-runner", "notification-worker":
+	default:
+		return fmt.Errorf("不支持的 BKTRADER_ROLE: %s（可选: monolith, api, live-runner, notification-worker）", c.ProcessRole)
+	}
 	if c.StoreBackend == "postgres" && c.PostgresDSN == "" {
 		return fmt.Errorf("STORE_BACKEND=postgres 时 POSTGRES_DSN 不能为空")
 	}
@@ -198,6 +205,17 @@ func (c Config) Validate() error {
 		}
 	}
 	return nil
+}
+
+// RuntimeActionsEnabled reports whether this process is allowed to execute
+// live runtime mutations such as start, dispatch, and explicit sync.
+func (c Config) RuntimeActionsEnabled() bool {
+	switch strings.ToLower(strings.TrimSpace(c.ProcessRole)) {
+	case "", "monolith", "live-runner":
+		return true
+	default:
+		return false
+	}
 }
 
 // getenv 读取环境变量，未设置时返回 fallback 默认值。

--- a/internal/http/live.go
+++ b/internal/http/live.go
@@ -7,11 +7,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/wuyaocheng/bktrader/internal/config"
 	"github.com/wuyaocheng/bktrader/internal/domain"
 	"github.com/wuyaocheng/bktrader/internal/service"
 )
 
-func registerLiveRoutes(mux *http.ServeMux, platform *service.Platform) {
+func registerLiveRoutes(mux *http.ServeMux, platform *service.Platform, cfg config.Config) {
 	mux.HandleFunc("/api/v1/live/sessions", func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
 		case http.MethodGet:
@@ -648,6 +649,10 @@ func registerLiveRoutes(mux *http.ServeMux, platform *service.Platform) {
 		action := parts[1]
 		switch action {
 		case "start":
+			if !cfg.RuntimeActionsEnabled() {
+				writeError(w, http.StatusConflict, "runtime action start is disabled for BKTRADER_ROLE="+cfg.ProcessRole)
+				return
+			}
 			item, err := platform.StartLiveSession(sessionID)
 			if err != nil {
 				writeError(w, http.StatusInternalServerError, err.Error())
@@ -655,6 +660,10 @@ func registerLiveRoutes(mux *http.ServeMux, platform *service.Platform) {
 			}
 			writeJSON(w, http.StatusOK, item)
 		case "stop":
+			if !cfg.RuntimeActionsEnabled() {
+				writeError(w, http.StatusConflict, "runtime action stop is disabled for BKTRADER_ROLE="+cfg.ProcessRole)
+				return
+			}
 			item, err := platform.StopLiveSessionWithForce(sessionID, queryFlagEnabled(r, "force"))
 			if err != nil {
 				if errors.Is(err, service.ErrActivePositionsOrOrders) {
@@ -666,6 +675,10 @@ func registerLiveRoutes(mux *http.ServeMux, platform *service.Platform) {
 			}
 			writeJSON(w, http.StatusOK, item)
 		case "dispatch":
+			if !cfg.RuntimeActionsEnabled() {
+				writeError(w, http.StatusConflict, "runtime action dispatch is disabled for BKTRADER_ROLE="+cfg.ProcessRole)
+				return
+			}
 			item, err := platform.DispatchLiveSessionIntent(sessionID)
 			if err != nil {
 				writeError(w, http.StatusBadRequest, err.Error())
@@ -673,6 +686,10 @@ func registerLiveRoutes(mux *http.ServeMux, platform *service.Platform) {
 			}
 			writeJSON(w, http.StatusOK, item)
 		case "sync":
+			if !cfg.RuntimeActionsEnabled() {
+				writeError(w, http.StatusConflict, "runtime action sync is disabled for BKTRADER_ROLE="+cfg.ProcessRole)
+				return
+			}
 			item, err := platform.SyncLiveSession(sessionID)
 			if err != nil {
 				writeError(w, http.StatusBadRequest, err.Error())

--- a/internal/http/router.go
+++ b/internal/http/router.go
@@ -53,10 +53,10 @@ func NewRouter(cfg config.Config, platform *service.Platform) http.Handler {
 	})
 
 	// 注册各模块路由
-	registerSignalRoutes(mux, platform)
+	registerSignalRoutes(mux, platform, cfg)
 	registerStrategyRoutes(mux, platform)
 	registerAccountRoutes(mux, platform)
-	registerLiveRoutes(mux, platform)
+	registerLiveRoutes(mux, platform, cfg)
 	registerOrderRoutes(mux, platform)
 	registerBacktestRoutes(mux, platform)
 	registerChartRoutes(mux, platform)

--- a/internal/http/session_safety_test.go
+++ b/internal/http/session_safety_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/wuyaocheng/bktrader/internal/config"
 	"github.com/wuyaocheng/bktrader/internal/domain"
 	"github.com/wuyaocheng/bktrader/internal/service"
 	"github.com/wuyaocheng/bktrader/internal/store/memory"
@@ -27,7 +28,7 @@ func TestLiveSessionStopRouteRespectsForceQuery(t *testing.T) {
 	}
 
 	mux := http.NewServeMux()
-	registerLiveRoutes(mux, platform)
+	registerLiveRoutes(mux, platform, config.Config{ProcessRole: "monolith"})
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/live/sessions/live-session-main/stop", nil)
@@ -41,6 +42,29 @@ func TestLiveSessionStopRouteRespectsForceQuery(t *testing.T) {
 	mux.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200 for forced stop, got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestLiveSessionRuntimeActionsDisabledForAPIRole(t *testing.T) {
+	cases := []string{
+		"/api/v1/live/sessions/live-session-main/start",
+		"/api/v1/live/sessions/live-session-main/stop",
+		"/api/v1/live/sessions/live-session-main/dispatch",
+		"/api/v1/live/sessions/live-session-main/sync",
+	}
+	for _, path := range cases {
+		t.Run(path, func(t *testing.T) {
+			platform := service.NewPlatform(memory.NewStore())
+			mux := http.NewServeMux()
+			registerLiveRoutes(mux, platform, config.Config{ProcessRole: "api"})
+
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodPost, path, nil)
+			mux.ServeHTTP(rec, req)
+			if rec.Code != http.StatusConflict {
+				t.Fatalf("expected 409 for api role runtime action, got %d body=%s", rec.Code, rec.Body.String())
+			}
+		})
 	}
 }
 

--- a/internal/http/signals.go
+++ b/internal/http/signals.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/wuyaocheng/bktrader/internal/config"
 	"github.com/wuyaocheng/bktrader/internal/domain"
 	"github.com/wuyaocheng/bktrader/internal/service"
 )
@@ -20,7 +21,7 @@ type runtimePolicyPatch struct {
 }
 
 // registerSignalRoutes 注册信号源相关路由。
-func registerSignalRoutes(mux *http.ServeMux, platform *service.Platform) {
+func registerSignalRoutes(mux *http.ServeMux, platform *service.Platform, cfg config.Config) {
 	// GET /api/v1/signal-sources — 获取信号源列表
 	mux.HandleFunc("/api/v1/signal-sources", func(w http.ResponseWriter, _ *http.Request) {
 		writeJSON(w, http.StatusOK, platform.SignalSourceCatalog())
@@ -315,6 +316,10 @@ func registerSignalRoutes(mux *http.ServeMux, platform *service.Platform) {
 		}
 		switch action {
 		case "start":
+			if !cfg.RuntimeActionsEnabled() {
+				writeError(w, http.StatusConflict, "runtime action start is disabled for BKTRADER_ROLE="+cfg.ProcessRole)
+				return
+			}
 			item, err := platform.StartSignalRuntimeSession(sessionID)
 			if err != nil {
 				writeError(w, http.StatusBadRequest, err.Error())
@@ -322,6 +327,10 @@ func registerSignalRoutes(mux *http.ServeMux, platform *service.Platform) {
 			}
 			writeJSON(w, http.StatusOK, item)
 		case "stop":
+			if !cfg.RuntimeActionsEnabled() {
+				writeError(w, http.StatusConflict, "runtime action stop is disabled for BKTRADER_ROLE="+cfg.ProcessRole)
+				return
+			}
 			item, err := platform.StopSignalRuntimeSessionWithForce(sessionID, queryFlagEnabled(r, "force"))
 			if err != nil {
 				writeError(w, http.StatusBadRequest, err.Error())

--- a/internal/http/signals_test.go
+++ b/internal/http/signals_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/wuyaocheng/bktrader/internal/config"
 	"github.com/wuyaocheng/bktrader/internal/service"
 	"github.com/wuyaocheng/bktrader/internal/store/memory"
 )
@@ -13,7 +14,7 @@ import (
 func TestRuntimePolicyPatchPreservesOmittedFieldsAndAllowsZeroHealthThresholds(t *testing.T) {
 	platform := service.NewPlatform(memory.NewStore())
 	mux := http.NewServeMux()
-	registerSignalRoutes(mux, platform)
+	registerSignalRoutes(mux, platform, config.Config{ProcessRole: "monolith"})
 
 	updateRequest := func(body string) {
 		t.Helper()
@@ -48,5 +49,26 @@ func TestRuntimePolicyPatchPreservesOmittedFieldsAndAllowsZeroHealthThresholds(t
 	}
 	if current.LiveAccountSyncFreshnessSecs != 0 {
 		t.Fatalf("expected live account sync freshness threshold to allow explicit zero, got %d", current.LiveAccountSyncFreshnessSecs)
+	}
+}
+
+func TestSignalRuntimeActionsDisabledForAPIRole(t *testing.T) {
+	cases := []string{
+		"/api/v1/signal-runtime/sessions/runtime-1/start",
+		"/api/v1/signal-runtime/sessions/runtime-1/stop",
+	}
+	for _, path := range cases {
+		t.Run(path, func(t *testing.T) {
+			platform := service.NewPlatform(memory.NewStore())
+			mux := http.NewServeMux()
+			registerSignalRoutes(mux, platform, config.Config{ProcessRole: "api"})
+
+			req := httptest.NewRequest(http.MethodPost, path, nil)
+			rec := httptest.NewRecorder()
+			mux.ServeHTTP(rec, req)
+			if rec.Code != http.StatusConflict {
+				t.Fatalf("expected 409 for api role runtime action, got %d body=%s", rec.Code, rec.Body.String())
+			}
+		})
 	}
 }

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -9,6 +9,7 @@ APP_ENV_FILE=${APP_ENV_FILE:-$DEPLOY_PATH/.env}
 IMAGE_REPO=${IMAGE_REPO:-ghcr.io/folgercn/bktrader-app}
 IMAGE_TAG=${IMAGE_TAG:-latest}
 DOCKER_CONFIG_DIR=${DOCKER_CONFIG_DIR:-$DEPLOY_PATH/.docker-ci}
+DEPLOY_SERVICES=${DEPLOY_SERVICES:-}
 
 if ! command -v docker >/dev/null 2>&1; then
   echo "docker command not found; install Docker Desktop or another Docker runtime on this Mac." >&2
@@ -47,9 +48,31 @@ fi
 
 export IMAGE_REPO IMAGE_TAG APP_ENV_FILE
 
-docker-compose -f "$COMPOSE_FILE" pull
+deploy_args=()
+if [[ -n "$DEPLOY_SERVICES" ]]; then
+  for service in $DEPLOY_SERVICES; do
+    case "$service" in
+      platform-api|live-runner|notification-worker)
+        deploy_args+=("$service")
+        ;;
+      *)
+        echo "Unsupported DEPLOY_SERVICES entry: $service" >&2
+        echo "Allowed services: platform-api live-runner notification-worker" >&2
+        exit 2
+        ;;
+    esac
+  done
+fi
 
-docker-compose -f "$COMPOSE_FILE" up -d
+if [[ ${#deploy_args[@]} -eq 0 ]]; then
+  echo "Deploying all compose services"
+  docker-compose -f "$COMPOSE_FILE" pull
+  docker-compose -f "$COMPOSE_FILE" up -d --remove-orphans
+else
+  echo "Deploying compose services: ${deploy_args[*]}"
+  docker-compose -f "$COMPOSE_FILE" pull "${deploy_args[@]}"
+  docker-compose -f "$COMPOSE_FILE" up -d --remove-orphans "${deploy_args[@]}"
+fi
 
 docker image prune -f >/dev/null 2>&1 || true
 


### PR DESCRIPTION
## 目的
实现后台进程职责拆分和 CD 选择性部署，避免普通 API / 通知改动重启整套后台，同时保留 live-runner 自动随 live 相关代码更新的能力。

本 PR 也承接 live-runner 进一步拆分的前置工作：新增 `platform-worker` 入口和 `BKTRADER_ROLE` 角色配置，让 `platform-api`、`live-runner`、`notification-worker` 可以使用同一镜像分别运行。

相关规划 issues：#199 #200 #201 #202 #203 #204

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [x] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 改动摘要
- 新增 `cmd/platform-worker`，支持无 HTTP 的后台 worker 入口。
- 新增 `BKTRADER_ROLE`：`monolith` / `api` / `live-runner` / `notification-worker`。
- `platform-api` 角色只启动 HTTP/dashboard，不启动 live recovery/sync/telegram。
- `live-runner` 角色启动 market warmup、live recovery、live sync，并继续承载当前 signal runtime。
- `notification-worker` 角色只启动 Telegram dispatcher。
- `platform-api` 角色下拒绝 live/signal runtime 的 start/stop/dispatch/sync 动作，避免 API 容器误执行 runtime action。
- 生产 compose 从单个 `app` 拆成 `platform-api`、`live-runner`、`notification-worker` 三个服务。
- CD 根据 diff 计算 `DEPLOY_SERVICES`，只重启相关 compose 服务；live 相关改动会自动部署 `live-runner`。
- `scripts/deploy.sh` 支持 `DEPLOY_SERVICES="platform-api notification-worker"` 形式的选择性部署，并校验服务名白名单。

## 行为变化
- 默认不设置 `BKTRADER_ROLE` 时仍是旧的 monolith 行为，便于本地开发和回退。
- 生产 compose 显式设置角色，API 与后台 worker 分进程运行。
- API / store / config / db 等改动默认部署 `platform-api`。
- Telegram / alerts / notifications 相关改动默认部署 `notification-worker`。
- live / signal runtime / order / execution strategy 相关改动默认部署 `live-runner`。

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) — 未变化。
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？— 未新增。
- [x] DB migration 是否具备向下兼容幂等性？— 本 PR 无 DB migration。
- [x] 配置字段有没有无意被混改？— 新增 `BKTRADER_ROLE`，默认 `monolith` 保持旧行为。

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

本地已执行：

```bash
go test ./...
go build ./cmd/platform-api ./cmd/platform-worker ./cmd/db-migrate
bash -n scripts/deploy.sh
ruby -e 'require "yaml"; YAML.load(File.read(".github/workflows/cd.yml")); YAML.load(File.read("deployments/docker-compose.prod.yml")); puts "yaml ok"'
git diff --check
```

补充测试：
- `BKTRADER_ROLE=api` 下 live session dispatch 返回 409。
- `BKTRADER_ROLE=api` 下 signal runtime start 返回 409。

## 已知限制 / 后续
- `signal-runtime-runner` 还没有独立拆出；当前 signal runtime 仍跟随 `live-runner`，因为 runtime session 仍需先做 DB-backed 状态与 event inbox。后续按 #199-#204 推进。
- 推送前尝试运行 graphify rebuild 失败：当前本地 Python 环境缺少 `graphify` 模块：`ModuleNotFoundError: No module named 'graphify'`。未产生 graphify 文件变更。
