### PR TITLE
[codex] fix reduce-only terminal sync settlement

### DIFF
--- a/internal/service/order.go
+++ b/internal/service/order.go
@@ -820,6 +820,7 @@ func (p *Platform) applyLiveSyncResult(account domain.Account, order domain.Orde
 		"lastExchangeUpdateAt": firstNonEmpty(syncResult.SyncedAt, time.Now().UTC().Format(time.RFC3339)),
 	})
 	order.Status = firstNonEmpty(syncResult.Status, order.Status)
+	adoptTerminalReduceOnlyFilledQuantity(&order, syncResult)
 	if strings.EqualFold(order.Status, "CANCELLED") || strings.EqualFold(order.Status, "REJECTED") {
 		markOrderLifecycle(order.Metadata, "filled", false)
 	}
@@ -851,6 +852,54 @@ func (p *Platform) applyLiveSyncResult(account domain.Account, order domain.Orde
 		logger.Warn("record live order sync event failed", "error", telemetryErr)
 	}
 	return updatedOrder, nil
+}
+
+func adoptTerminalReduceOnlyFilledQuantity(order *domain.Order, syncResult LiveOrderSync) {
+	if order == nil || !strings.EqualFold(strings.TrimSpace(syncResult.Status), "FILLED") {
+		return
+	}
+	if !order.EffectiveReduceOnly() && !order.EffectiveClosePosition() {
+		return
+	}
+	terminalQuantity := terminalFilledSyncQuantity(syncResult)
+	if !tradingQuantityPositive(terminalQuantity) {
+		return
+	}
+	if order.Quantity <= 0 || !tradingQuantityBelow(terminalQuantity, order.Quantity) {
+		return
+	}
+	if order.Metadata == nil {
+		order.Metadata = map[string]any{}
+	}
+	order.Metadata["terminalSyncOriginalQuantity"] = order.Quantity
+	order.Metadata["terminalSyncFilledQuantity"] = terminalQuantity
+	order.Metadata["terminalSyncQuantityAdjusted"] = true
+	order.Quantity = terminalQuantity
+}
+
+func terminalFilledSyncQuantity(syncResult LiveOrderSync) float64 {
+	metadata := mapValue(syncResult.Metadata)
+	quantity := firstPositive(
+		parseFloatValue(metadata["origQty"]),
+		firstPositive(
+			parseFloatValue(metadata["executedQty"]),
+			firstPositive(
+				parseFloatValue(metadata["cumQty"]),
+				parseFloatValue(metadata["filledQuantity"]),
+			),
+		),
+	)
+	if tradingQuantityPositive(quantity) {
+		return quantity
+	}
+	total := 0.0
+	for _, fill := range syncResult.Fills {
+		total += fill.Quantity
+	}
+	if tradingQuantityPositive(total) {
+		return total
+	}
+	return 0
 }
 
 func buildLiveSyncSettlement(order domain.Order, syncResult LiveOrderSync) ([]domain.Fill, float64, float64) {
@@ -1005,6 +1054,9 @@ func (p *Platform) finalizeExecutedOrder(account domain.Account, order domain.Or
 	orderCompletelyFilled := !tradingQuantityBelow(filledQuantity, order.Quantity)
 	if orderCompletelyFilled {
 		order.Status = "FILLED"
+		delete(order.Metadata, liveSettlementSyncRequiredKey)
+		delete(order.Metadata, liveSettlementSyncErrorKey)
+	} else if isTerminalOrderStatus(order.Status) && !strings.EqualFold(order.Status, "FILLED") {
 		delete(order.Metadata, liveSettlementSyncRequiredKey)
 		delete(order.Metadata, liveSettlementSyncErrorKey)
 	} else if filledQuantity > 0 {

--- a/internal/service/order.go
+++ b/internal/service/order.go
@@ -880,26 +880,24 @@ func adoptTerminalReduceOnlyFilledQuantity(order *domain.Order, syncResult LiveO
 func terminalFilledSyncQuantity(syncResult LiveOrderSync) float64 {
 	metadata := mapValue(syncResult.Metadata)
 	quantity := firstPositive(
-		parseFloatValue(metadata["origQty"]),
+		parseFloatValue(metadata["executedQty"]),
 		firstPositive(
-			parseFloatValue(metadata["executedQty"]),
+			parseFloatValue(metadata["cumQty"]),
 			firstPositive(
-				parseFloatValue(metadata["cumQty"]),
 				parseFloatValue(metadata["filledQuantity"]),
+				sumLiveFillReportQuantity(syncResult.Fills),
 			),
 		),
 	)
-	if tradingQuantityPositive(quantity) {
-		return quantity
-	}
+	return firstPositive(quantity, parseFloatValue(metadata["origQty"]))
+}
+
+func sumLiveFillReportQuantity(fills []LiveFillReport) float64 {
 	total := 0.0
-	for _, fill := range syncResult.Fills {
+	for _, fill := range fills {
 		total += fill.Quantity
 	}
-	if tradingQuantityPositive(total) {
-		return total
-	}
-	return 0
+	return total
 }
 
 func buildLiveSyncSettlement(order domain.Order, syncResult LiveOrderSync) ([]domain.Fill, float64, float64) {

--- a/internal/service/order_test.go
+++ b/internal/service/order_test.go
@@ -1129,6 +1129,7 @@ func TestApplyLiveSyncResultSettlesClippedReduceOnlyFallbackClose(t *testing.T) 
 			"binanceStatus":    "FILLED",
 			"exchangeOrderId":  "exchange-market-fallback",
 			"executedQty":      0.0091,
+			"origQty":          0.0129,
 			"tradeReportCount": 1,
 			"updateTime":       "2026-04-24T21:41:10Z",
 		},

--- a/internal/service/order_test.go
+++ b/internal/service/order_test.go
@@ -983,6 +983,201 @@ func TestApplyLiveSyncResultHealsStoredQuantityFromNormalizedSubmission(t *testi
 	}
 }
 
+func TestApplyLiveSyncResultSettlesClippedReduceOnlyFallbackClose(t *testing.T) {
+	store := memory.NewStore()
+	platform := NewPlatform(store)
+
+	account, err := store.GetAccount("live-main")
+	if err != nil {
+		t.Fatalf("get live account failed: %v", err)
+	}
+	if _, err := store.SavePosition(domain.Position{
+		AccountID:         account.ID,
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "LONG",
+		Quantity:          0.0129,
+		EntryPrice:        77620,
+		MarkPrice:         77597.7,
+	}); err != nil {
+		t.Fatalf("save live position failed: %v", err)
+	}
+
+	limitOrder, err := store.CreateOrder(domain.Order{
+		AccountID:         account.ID,
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "SELL",
+		Type:              "LIMIT",
+		Status:            "ACCEPTED",
+		Quantity:          0.0129,
+		Price:             77597.7,
+		ReduceOnly:        true,
+		Metadata: map[string]any{
+			"exchangeOrderId": "exchange-limit-exit",
+			"executionProposal": map[string]any{
+				"role":       "exit",
+				"reason":     "PT",
+				"reduceOnly": true,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("create limit close order failed: %v", err)
+	}
+	limitOrder, err = platform.applyLiveSyncResult(account, limitOrder, LiveOrderSync{
+		Status:   "CANCELLED",
+		SyncedAt: "2026-04-24T21:41:10Z",
+		Fills: []LiveFillReport{
+			{
+				Price:    77597.7,
+				Quantity: 0.001,
+				Fee:      0.01551954,
+				Metadata: map[string]any{
+					"exchangeOrderId": "exchange-limit-exit",
+					"tradeId":         "trade-limit-1",
+					"tradeTime":       "2026-04-24T21:41:06Z",
+				},
+			},
+			{
+				Price:    77597.7,
+				Quantity: 0.0014,
+				Fee:      0.02172735,
+				Metadata: map[string]any{
+					"exchangeOrderId": "exchange-limit-exit",
+					"tradeId":         "trade-limit-2",
+					"tradeTime":       "2026-04-24T21:41:08Z",
+				},
+			},
+			{
+				Price:    77597.7,
+				Quantity: 0.0014,
+				Fee:      0.02172735,
+				Metadata: map[string]any{
+					"exchangeOrderId": "exchange-limit-exit",
+					"tradeId":         "trade-limit-3",
+					"tradeTime":       "2026-04-24T21:41:09Z",
+				},
+			},
+		},
+		Metadata: map[string]any{
+			"binanceStatus":    "CANCELED",
+			"exchangeOrderId":  "exchange-limit-exit",
+			"executedQty":      0.0038,
+			"origQty":          0.0129,
+			"tradeReportCount": 3,
+			"updateTime":       "2026-04-24T21:41:10Z",
+		},
+		Terminal: true,
+	})
+	if err != nil {
+		t.Fatalf("settle cancelled limit close failed: %v", err)
+	}
+	if got := limitOrder.Status; got != "CANCELLED" {
+		t.Fatalf("expected partially-filled cancelled limit order to stay terminal, got %s", got)
+	}
+	if got := parseFloatValue(limitOrder.Metadata["filledQuantity"]); !tradingQuantityEqual(got, 0.0038) {
+		t.Fatalf("expected limit filledQuantity 0.0038, got %v", got)
+	}
+	position, found, err := store.FindPosition(account.ID, "BTCUSDT")
+	if err != nil {
+		t.Fatalf("find position after limit close failed: %v", err)
+	}
+	if !found {
+		t.Fatal("expected remaining position after cancelled partial close")
+	}
+	if !tradingQuantityEqual(position.Quantity, 0.0091) {
+		t.Fatalf("expected remaining position quantity 0.0091, got %v", position.Quantity)
+	}
+
+	fallbackOrder, err := store.CreateOrder(domain.Order{
+		AccountID:         account.ID,
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "SELL",
+		Type:              "MARKET",
+		Status:            "FILLED",
+		Quantity:          0.0129,
+		Price:             77593.4,
+		ReduceOnly:        true,
+		Metadata: map[string]any{
+			"exchangeOrderId": "exchange-market-fallback",
+			"executionProposal": map[string]any{
+				"role":       "exit",
+				"reason":     "PT-timeout-fallback",
+				"reduceOnly": true,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("create fallback close order failed: %v", err)
+	}
+	fallbackSync := LiveOrderSync{
+		Status:   "FILLED",
+		SyncedAt: "2026-04-24T21:41:10Z",
+		Fills: []LiveFillReport{{
+			Price:    77593.4,
+			Quantity: 0.0091,
+			Fee:      0.28243997,
+			Metadata: map[string]any{
+				"exchangeOrderId": "exchange-market-fallback",
+				"tradeId":         "trade-market-1",
+				"tradeTime":       "2026-04-24T21:41:10Z",
+			},
+		}},
+		Metadata: map[string]any{
+			"binanceStatus":    "FILLED",
+			"exchangeOrderId":  "exchange-market-fallback",
+			"executedQty":      0.0091,
+			"tradeReportCount": 1,
+			"updateTime":       "2026-04-24T21:41:10Z",
+		},
+		Terminal: true,
+	}
+	fallbackOrder, err = platform.applyLiveSyncResult(account, fallbackOrder, fallbackSync)
+	if err != nil {
+		t.Fatalf("settle market fallback close failed: %v", err)
+	}
+	if got := fallbackOrder.Status; got != "FILLED" {
+		t.Fatalf("expected clipped reduce-only fallback to settle FILLED, got %s", got)
+	}
+	if !tradingQuantityEqual(fallbackOrder.Quantity, 0.0091) {
+		t.Fatalf("expected fallback order quantity to heal to 0.0091, got %v", fallbackOrder.Quantity)
+	}
+	if got := parseFloatValue(fallbackOrder.Metadata["remainingQuantity"]); got != 0 {
+		t.Fatalf("expected fallback remainingQuantity 0, got %v", got)
+	}
+	if !boolValue(fallbackOrder.Metadata["terminalSyncQuantityAdjusted"]) {
+		t.Fatal("expected terminal sync quantity adjustment marker")
+	}
+	if _, found, err := store.FindPosition(account.ID, "BTCUSDT"); err != nil {
+		t.Fatalf("find position after fallback close failed: %v", err)
+	} else if found {
+		t.Fatal("expected fallback close to clear the remaining position")
+	}
+
+	fallbackOrder, err = platform.applyLiveSyncResult(account, fallbackOrder, fallbackSync)
+	if err != nil {
+		t.Fatalf("repeat fallback sync failed: %v", err)
+	}
+	if got := fallbackOrder.Status; got != "FILLED" {
+		t.Fatalf("expected repeated fallback sync to keep FILLED, got %s", got)
+	}
+	fills, err := store.ListFills()
+	if err != nil {
+		t.Fatalf("list fills failed: %v", err)
+	}
+	fallbackFillCount := 0
+	for _, fill := range fills {
+		if fill.OrderID == fallbackOrder.ID {
+			fallbackFillCount++
+		}
+	}
+	if fallbackFillCount != 1 {
+		t.Fatalf("expected repeated fallback sync to keep one fill, got %d", fallbackFillCount)
+	}
+}
+
 func TestClosePositionImmediatelySettlesFilledLiveManualClose(t *testing.T) {
 	store := memory.NewStore()
 	platform := NewPlatform(store)


### PR DESCRIPTION
## 目的
修复 reduceOnly 平仓拆单后订单主表卡在 `PARTIALLY_FILLED` 的状态收敛问题。

Root cause: LIMIT reduceOnly exit 部分成交后被取消，MARKET fallback 只成交剩余数量并由交易所返回 `FILLED`。本地 `finalizeExecutedOrder` 仍用 fallback 订单原始数量和本笔 fill 数量比较，把交易所终态 `FILLED` 重新压回 `PARTIALLY_FILLED`，导致 live session 持续重复 sync。

本次改动：
- 对 reduceOnly / closePosition 订单，收到交易所 `FILLED` 终态且终态成交量小于本地原始数量时，校正本地订单数量到交易所终态数量，并记录调整 metadata。
- 对 `CANCELLED` / `REJECTED` 这类终态订单，即使有部分 fill，也不再被 settlement 逻辑覆盖成 `PARTIALLY_FILLED`。
- 新增回归测试覆盖 LIMIT partial-fill cancel + MARKET fallback close 剩余仓位 + 重复 sync 幂等。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [x] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

Codex 参与：排查生产数据库卡点，确认交易所事实源已终态、仓位已平；实现订单状态收敛修复并补回归测试。

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) — 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？— 无
- [x] DB migration 是否具备向下兼容幂等性？— 无 DB migration
- [x] 配置字段有没有无意被混改？— 无配置改动

风险说明：本 PR 修改 live order sync / settlement 收口逻辑，属于实盘订单状态收敛路径。事实源仍以交易所 sync 返回的终态和已确认 fills 为准；未放宽 reduceOnly submit 边界，也未改变 auto-dispatch 默认行为。

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

已运行：
```sh
go test ./internal/service -run 'TestApplyLiveSyncResultSettlesClippedReduceOnlyFallbackClose|TestApplyLiveSyncResultHealsStoredQuantityFromNormalizedSubmission|TestImmediateFilledLiveOrderPartialSettlementKeepsRetryMarker|TestRecoverRunningLiveSessionPreservesRemainingQuantityAfterPartialFillRestart'
go test ./...
go build ./cmd/platform-api
go build ./cmd/db-migrate
```

push 前 harness 自动运行并通过：graphify rebuild、high-risk defaults check、env safety check、backend checks。