### PR TITLE
[codex] Fix Telegram trade-event dispatcher scan

### DIFF
--- a/db/migrations/023_telegram_trade_event_dispatch_indexes.sql
+++ b/db/migrations/023_telegram_trade_event_dispatch_indexes.sql
@@ -1,0 +1,10 @@
+create index if not exists idx_order_execution_events_telegram_trade_candidates
+    on order_execution_events (event_time asc, recorded_at asc, id asc)
+    where event_type = 'filled'
+      and failed = false
+      and coalesce(error, '') = '';
+
+create index if not exists idx_notification_deliveries_telegram_trade_event
+    on notification_deliveries ((metadata->>'eventId'))
+    where channel = 'telegram'
+      and metadata->>'kind' = 'trade-event';

--- a/internal/service/telegram.go
+++ b/internal/service/telegram.go
@@ -25,6 +25,8 @@ var telegramBeijingLocation = func() *time.Location {
 const (
 	telegramFlapSendGrace    = 45 * time.Second
 	telegramFlapRecoverGrace = 60 * time.Second
+	telegramTradeEventLimit  = 50
+	telegramTradeEventWindow = 24 * time.Hour
 )
 
 func (p *Platform) SendNotificationToTelegram(notificationID string) error {
@@ -309,7 +311,7 @@ func (p *Platform) DispatchTelegramTradeEvents(deliveryByID map[string]domain.No
 	if !config.Enabled || !config.TradeEventsEnabled || strings.TrimSpace(config.BotToken) == "" || strings.TrimSpace(config.ChatID) == "" {
 		return 0, nil
 	}
-	events, err := p.store.ListOrderExecutionEvents("")
+	events, err := p.store.ListTelegramTradeEventCandidates(telegramNow().Add(-telegramTradeEventWindow), telegramTradeEventLimit)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/service/telegram_test.go
+++ b/internal/service/telegram_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -156,6 +157,9 @@ func TestTelegramDispatchSendsFilledTradeEventsWithPnLAndDedup(t *testing.T) {
 
 	store := memory.NewStore()
 	now := time.Date(2026, 4, 22, 10, 0, 0, 0, time.UTC)
+	oldNow := telegramNow
+	telegramNow = func() time.Time { return now.Add(2 * time.Minute) }
+	defer func() { telegramNow = oldNow }()
 	_, err := store.CreateOrderExecutionEvent(domain.OrderExecutionEvent{
 		ID:              "open-event-1",
 		OrderID:         "order-open-1",
@@ -252,6 +256,9 @@ func TestTelegramDispatchDedupesSemanticDuplicateTradeEvents(t *testing.T) {
 
 	store := memory.NewStore()
 	now := time.Date(2026, 4, 22, 10, 0, 36, 0, time.UTC)
+	oldNow := telegramNow
+	telegramNow = func() time.Time { return now.Add(2 * time.Minute) }
+	defer func() { telegramNow = oldNow }()
 	baseEvent := domain.OrderExecutionEvent{
 		OrderID:         "order-dup-1",
 		ExchangeOrderID: "exchange-dup-1",
@@ -291,6 +298,156 @@ func TestTelegramDispatchDedupesSemanticDuplicateTradeEvents(t *testing.T) {
 	}
 	if len(messages) != 1 {
 		t.Fatalf("expected semantic duplicate trade events to send once, got %d: %#v", len(messages), messages)
+	}
+}
+
+func TestTelegramDispatchTradeEventsUsesBoundedRecentCandidates(t *testing.T) {
+	messages := make([]string, 0)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var p map[string]any
+		json.Unmarshal(body, &p)
+		messages = append(messages, p["text"].(string))
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"ok":true}`))
+	}))
+	defer server.Close()
+
+	oldURL := telegramBaseURL
+	telegramBaseURL = server.URL
+	defer func() { telegramBaseURL = oldURL }()
+
+	base := time.Date(2026, 4, 25, 10, 0, 0, 0, time.UTC)
+	oldNow := telegramNow
+	telegramNow = func() time.Time { return base.Add(2 * time.Hour) }
+	defer func() { telegramNow = oldNow }()
+
+	store := memory.NewStore()
+	_, err := store.CreateOrderExecutionEvent(domain.OrderExecutionEvent{
+		ID:        "old-event",
+		OrderID:   "old-order",
+		AccountID: "account-live-1",
+		Symbol:    "BTCUSDT",
+		Side:      "BUY",
+		EventType: "filled",
+		Status:    "FILLED",
+		Quantity:  1,
+		Price:     64000,
+		EventTime: base.Add(-25 * time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("create old event failed: %v", err)
+	}
+	_, err = store.CreateOrderExecutionEvent(domain.OrderExecutionEvent{
+		ID:        "failed-event",
+		OrderID:   "failed-order",
+		AccountID: "account-live-1",
+		Symbol:    "BTCUSDT",
+		Side:      "BUY",
+		EventType: "filled",
+		Status:    "FILLED",
+		Quantity:  1,
+		Price:     64000,
+		EventTime: base,
+		Failed:    true,
+	})
+	if err != nil {
+		t.Fatalf("create failed event failed: %v", err)
+	}
+	_, err = store.CreateOrderExecutionEvent(domain.OrderExecutionEvent{
+		ID:        "error-event",
+		OrderID:   "error-order",
+		AccountID: "account-live-1",
+		Symbol:    "BTCUSDT",
+		Side:      "BUY",
+		EventType: "filled",
+		Status:    "FILLED",
+		Quantity:  1,
+		Price:     64000,
+		EventTime: base,
+		Error:     "adapter failed",
+	})
+	if err != nil {
+		t.Fatalf("create error event failed: %v", err)
+	}
+	_, err = store.CreateOrderExecutionEvent(domain.OrderExecutionEvent{
+		ID:        "already-sent-event",
+		OrderID:   "already-sent-order",
+		AccountID: "account-live-1",
+		Symbol:    "BTCUSDT",
+		Side:      "BUY",
+		EventType: "filled",
+		Status:    "FILLED",
+		Quantity:  1,
+		Price:     64000,
+		EventTime: base,
+	})
+	if err != nil {
+		t.Fatalf("create sent event failed: %v", err)
+	}
+	_, _ = store.UpsertNotificationDelivery("trade-event:already-sent", "telegram", "sent", "", map[string]any{
+		"kind":    "trade-event",
+		"eventId": "already-sent-event",
+	})
+	_, err = store.CreateOrderExecutionEvent(domain.OrderExecutionEvent{
+		ID:        "already-failed-event",
+		OrderID:   "already-failed-order",
+		AccountID: "account-live-1",
+		Symbol:    "BTCUSDT",
+		Side:      "BUY",
+		EventType: "filled",
+		Status:    "FILLED",
+		Quantity:  1,
+		Price:     64000,
+		EventTime: base,
+	})
+	if err != nil {
+		t.Fatalf("create delivery-failed event failed: %v", err)
+	}
+	_, _ = store.UpsertNotificationDelivery("trade-event:already-failed", "telegram", "failed", "telegram send failed", map[string]any{
+		"kind":    "trade-event",
+		"eventId": "already-failed-event",
+	})
+	for i := 0; i < telegramTradeEventLimit+5; i++ {
+		_, err := store.CreateOrderExecutionEvent(domain.OrderExecutionEvent{
+			ID:        fmt.Sprintf("candidate-event-%02d", i),
+			OrderID:   fmt.Sprintf("candidate-order-%02d", i),
+			AccountID: "account-live-1",
+			Symbol:    "BTCUSDT",
+			Side:      "BUY",
+			EventType: "filled",
+			Status:    "FILLED",
+			Quantity:  1,
+			Price:     64000,
+			EventTime: base.Add(time.Duration(i) * time.Second),
+		})
+		if err != nil {
+			t.Fatalf("create candidate event %d failed: %v", i, err)
+		}
+	}
+
+	p := &Platform{
+		store: store,
+		telegramConfig: domain.TelegramConfig{
+			Enabled:            true,
+			BotToken:           "test-token",
+			ChatID:             "123",
+			SendLevels:         []string{},
+			TradeEventsEnabled: true,
+		},
+	}
+
+	if err := p.DispatchTelegramNotifications(); err != nil {
+		t.Fatalf("dispatch failed: %v", err)
+	}
+	if len(messages) != telegramTradeEventLimit {
+		t.Fatalf("expected bounded trade dispatch count %d, got %d", telegramTradeEventLimit, len(messages))
+	}
+	joined := strings.Join(messages, "\n")
+	for _, unexpected := range []string{"old-order", "failed-order", "error-order", "already-sent-order", "already-failed-order", "candidate-order-50"} {
+		if strings.Contains(joined, unexpected) {
+			t.Fatalf("unexpected trade event %s was sent: %s", unexpected, joined)
+		}
 	}
 }
 

--- a/internal/store/memory/store.go
+++ b/internal/store/memory/store.go
@@ -1034,6 +1034,46 @@ func (s *Store) ListOrderExecutionEvents(orderID string) ([]domain.OrderExecutio
 	return items, nil
 }
 
+func (s *Store) ListTelegramTradeEventCandidates(from time.Time, limit int) ([]domain.OrderExecutionEvent, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	items := make([]domain.OrderExecutionEvent, 0, limit)
+	deliveredEventIDs := make(map[string]struct{}, len(s.deliveries))
+	for _, delivery := range s.deliveries {
+		if !strings.EqualFold(delivery.Channel, "telegram") {
+			continue
+		}
+		if stringValue(delivery.Metadata["kind"]) != "trade-event" {
+			continue
+		}
+		if eventID := strings.TrimSpace(stringValue(delivery.Metadata["eventId"])); eventID != "" {
+			deliveredEventIDs[eventID] = struct{}{}
+		}
+	}
+	for _, item := range s.executionEvents {
+		if !from.IsZero() && item.EventTime.Before(from.UTC()) {
+			continue
+		}
+		if !strings.EqualFold(item.EventType, "filled") {
+			continue
+		}
+		if item.Failed || strings.TrimSpace(item.Error) != "" {
+			continue
+		}
+		if _, delivered := deliveredEventIDs[item.ID]; delivered {
+			continue
+		}
+		items = append(items, cloneJSONValue(item))
+	}
+	sort.SliceStable(items, func(i, j int) bool {
+		return domain.EventLessAsc(items[i].EventTime, items[i].RecordedAt, items[i].ID, items[j].EventTime, items[j].RecordedAt, items[j].ID)
+	})
+	if limit > 0 && len(items) > limit {
+		items = items[:limit]
+	}
+	return items, nil
+}
+
 func (s *Store) CreateOrderExecutionEvent(event domain.OrderExecutionEvent) (domain.OrderExecutionEvent, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/store/postgres/store.go
+++ b/internal/store/postgres/store.go
@@ -1516,6 +1516,82 @@ func (s *Store) ListOrderExecutionEvents(orderID string) ([]domain.OrderExecutio
 	return items, rows.Err()
 }
 
+func (s *Store) ListTelegramTradeEventCandidates(from time.Time, limit int) ([]domain.OrderExecutionEvent, error) {
+	if limit <= 0 || limit > 200 {
+		limit = 50
+	}
+	if from.IsZero() {
+		from = time.Now().UTC().Add(-24 * time.Hour)
+	}
+	rows, err := s.db.Query(`
+		select
+			e.id, e.order_id, e.exchange_order_id, e.live_session_id, e.decision_event_id, e.runtime_session_id, e.account_id,
+			e.strategy_version_id, e.symbol, e.side, e.order_type, e.event_type, e.status,
+			e.execution_strategy, e.execution_decision, e.execution_mode,
+			e.quantity, e.price, e.expected_price, e.price_drift_bps, e.raw_quantity, e.normalized_quantity,
+			e.raw_price_reference, e.normalized_price, e.spread_bps, e.book_imbalance,
+			e.submit_latency_ms, e.sync_latency_ms, e.fill_latency_ms, e.event_time, e.recorded_at,
+			e.fallback, e.post_only, e.reduce_only, e.failed, e.error,
+			e.runtime_preflight, e.dispatch_summary, e.adapter_submission, e.adapter_sync, e.normalization, e.symbol_rules, e.metadata
+		from order_execution_events e
+		where e.event_type = 'filled'
+			and e.failed = false
+			and coalesce(e.error, '') = ''
+			and e.event_time >= $1
+			and not exists (
+				select 1
+				from notification_deliveries d
+				where d.channel = 'telegram'
+					and d.metadata->>'kind' = 'trade-event'
+					and d.metadata->>'eventId' = e.id
+			)
+		order by e.event_time asc, e.recorded_at asc, e.id asc
+		limit $2
+	`, from.UTC(), limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	items := make([]domain.OrderExecutionEvent, 0, limit)
+	for rows.Next() {
+		var item domain.OrderExecutionEvent
+		var exchangeOrderID, liveSessionID, decisionEventID, runtimeSessionID, strategyVersionID sql.NullString
+		var executionStrategy, executionDecision, executionMode, errText sql.NullString
+		var runtimePreflightRaw, dispatchSummaryRaw, adapterSubmissionRaw, adapterSyncRaw, normalizationRaw, symbolRulesRaw, metadataRaw []byte
+		if err := rows.Scan(
+			&item.ID, &item.OrderID, &exchangeOrderID, &liveSessionID, &decisionEventID, &runtimeSessionID, &item.AccountID,
+			&strategyVersionID, &item.Symbol, &item.Side, &item.OrderType, &item.EventType, &item.Status,
+			&executionStrategy, &executionDecision, &executionMode,
+			&item.Quantity, &item.Price, &item.ExpectedPrice, &item.PriceDriftBps, &item.RawQuantity, &item.NormalizedQty,
+			&item.RawPriceReference, &item.NormalizedPrice, &item.SpreadBps, &item.BookImbalance,
+			&item.SubmitLatencyMs, &item.SyncLatencyMs, &item.FillLatencyMs, &item.EventTime, &item.RecordedAt,
+			&item.Fallback, &item.PostOnly, &item.ReduceOnly, &item.Failed, &errText,
+			&runtimePreflightRaw, &dispatchSummaryRaw, &adapterSubmissionRaw, &adapterSyncRaw, &normalizationRaw, &symbolRulesRaw, &metadataRaw,
+		); err != nil {
+			return nil, err
+		}
+		item.ExchangeOrderID = exchangeOrderID.String
+		item.LiveSessionID = liveSessionID.String
+		item.DecisionEventID = decisionEventID.String
+		item.RuntimeSessionID = runtimeSessionID.String
+		item.StrategyVersionID = strategyVersionID.String
+		item.ExecutionStrategy = executionStrategy.String
+		item.ExecutionDecision = executionDecision.String
+		item.ExecutionMode = executionMode.String
+		item.Error = errText.String
+		item.RuntimePreflight = unmarshalJSONMap(runtimePreflightRaw)
+		item.DispatchSummary = unmarshalJSONMap(dispatchSummaryRaw)
+		item.AdapterSubmission = unmarshalJSONMap(adapterSubmissionRaw)
+		item.AdapterSync = unmarshalJSONMap(adapterSyncRaw)
+		item.Normalization = unmarshalJSONMap(normalizationRaw)
+		item.SymbolRules = unmarshalJSONMap(symbolRulesRaw)
+		item.Metadata = unmarshalJSONMap(metadataRaw)
+		items = append(items, item)
+	}
+	return items, rows.Err()
+}
+
 func (s *Store) CreateOrderExecutionEvent(event domain.OrderExecutionEvent) (domain.OrderExecutionEvent, error) {
 	if event.ID == "" {
 		event.ID = fmt.Sprintf("order-execution-event-%d", time.Now().UTC().UnixNano())

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -2,7 +2,11 @@
 // 所有具体实现（内存/PostgreSQL）必须实现 Repository 接口。
 package store
 
-import "github.com/wuyaocheng/bktrader/internal/domain"
+import (
+	"time"
+
+	"github.com/wuyaocheng/bktrader/internal/domain"
+)
 
 // Repository 定义平台的数据持久化接口。
 // 支持可插拔的后端实现（memory/postgres），通过 STORE_BACKEND 配置切换。
@@ -126,6 +130,8 @@ type Repository interface {
 	CreateStrategyDecisionEvent(event domain.StrategyDecisionEvent) (domain.StrategyDecisionEvent, error)
 	// ListOrderExecutionEvents 获取指定订单的执行事件；orderID 为空时返回全部。
 	ListOrderExecutionEvents(orderID string) ([]domain.OrderExecutionEvent, error)
+	// ListTelegramTradeEventCandidates 获取 Telegram 开平事件通知候选，必须由底层存储限制扫描范围和返回条数。
+	ListTelegramTradeEventCandidates(from time.Time, limit int) ([]domain.OrderExecutionEvent, error)
 	// CreateOrderExecutionEvent 创建新的订单执行事件。
 	CreateOrderExecutionEvent(event domain.OrderExecutionEvent) (domain.OrderExecutionEvent, error)
 	// ListPositionAccountSnapshots 获取指定账户的仓位/账户快照；accountID 为空时返回全部。


### PR DESCRIPTION
## 目的
Fixes #208.

生产 `bktrader-notification-worker` 在 Telegram trade-event dispatch 周期内 OOM 重启。根因是 `DispatchTelegramTradeEvents` 每轮调用 `ListOrderExecutionEvents("")`，在生产规模下全量读取 `order_execution_events` 大表。

本 PR 将 trade-event dispatch 改成专用 bounded 查询：
- 只取最近 24 小时的 `filled` execution events
- 排除 `failed = true` 或有 `error` 的事件
- 排除已经存在 `notification_deliveries` trade-event 记录的 eventId，包括 `sent` 和 `failed`，避免失败事件 15 秒无限重试
- 单轮最多处理 50 条，避免历史积压一次性加载/发送
- 增加 PostgreSQL partial indexes 支撑候选事件查询和 delivery 去重

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [x] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) - 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？- 无
- [x] DB migration 是否具备向下兼容幂等性？- `create index if not exists`
- [x] 配置字段有没有无意被混改？- 无配置字段改动

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

本地验证：
```bash
go test ./internal/service ./internal/store/memory ./internal/store/postgres
go test ./...
go build ./cmd/platform-api
go build ./cmd/db-migrate
git diff --check
```

新增覆盖：
- trade-event 只发送 bounded recent candidates
- 过滤 failed / error events
- 排除已经存在 delivery 的 eventId，包括 `sent` 和 `failed`
- 单轮限制 50 条，避免一次性加载历史积压

生产库只读验证（`127.0.0.1:15432`）：
```sql
set statement_timeout = '15s';
select indexname, indexdef
from pg_indexes
where schemaname = 'public'
  and tablename in ('order_execution_events','notification_deliveries')
  and indexname in (
    'idx_order_execution_events_telegram_trade_candidates',
    'idx_notification_deliveries_telegram_trade_event',
    'idx_notification_deliveries_telegram_trade_event_sent'
  );

explain (analyze, buffers) ... bounded trade-event candidate query ...;
```

当前生产库尚未应用本 PR migration，上述索引查询返回 0 行；candidate query 仍为 seq scan，`Execution Time: 1193.345 ms`，`Buffers: shared hit=501 read=11572`。这确认 migration 需要随代码一并上线，索引应用后再恢复 `trade_events_enabled=true`。
