### PR TITLE
[codex] Add dashboard stream payload metrics

### DIFF
--- a/internal/http/stream.go
+++ b/internal/http/stream.go
@@ -3,7 +3,10 @@ package http
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/http"
+	"reflect"
+	"sort"
 	"strings"
 	"time"
 
@@ -53,6 +56,13 @@ func registerStreamRoutes(mux *http.ServeMux, platform *service.Platform, cfg co
 
 		subID, ch := broker.Subscribe(64)
 		defer broker.Unsubscribe(subID)
+		streamLogger := slog.Default().With(
+			"component", "http.dashboard_stream",
+			"subscriber_id", subID,
+			"remote_addr", r.RemoteAddr,
+		)
+		streamStats := newDashboardStreamStats()
+		defer streamStats.logSummary(streamLogger, "closed", true)
 
 		_, _ = fmt.Fprint(w, ": connected\n\n")
 		flusher.Flush()
@@ -71,9 +81,12 @@ func registerStreamRoutes(mux *http.ServeMux, platform *service.Platform, cfg co
 				if !ok {
 					return
 				}
-				if err := writeDashboardSSEMessage(w, flusher, event); err != nil {
+				payloadBytes, wireBytes, err := writeDashboardSSEMessage(w, flusher, event)
+				if err != nil {
 					return
 				}
+				streamStats.record(event, payloadBytes, wireBytes)
+				streamStats.logSummary(streamLogger, "interval", false)
 			case <-ticker.C:
 				if _, err := fmt.Fprint(w, ": keepalive\n\n"); err != nil {
 					return
@@ -84,14 +97,116 @@ func registerStreamRoutes(mux *http.ServeMux, platform *service.Platform, cfg co
 	})
 }
 
-func writeDashboardSSEMessage(w http.ResponseWriter, flusher http.Flusher, event service.DashboardEvent) error {
+func writeDashboardSSEMessage(w http.ResponseWriter, flusher http.Flusher, event service.DashboardEvent) (int, int, error) {
 	payload, err := json.Marshal(event)
 	if err != nil {
-		return err
+		return 0, 0, err
 	}
-	if _, err := fmt.Fprintf(w, "event: %s\ndata: %s\n\n", event.Type, payload); err != nil {
-		return err
+	message := fmt.Sprintf("event: %s\ndata: %s\n\n", event.Type, payload)
+	written, err := fmt.Fprint(w, message)
+	if err != nil {
+		return len(payload), written, err
 	}
 	flusher.Flush()
-	return nil
+	return len(payload), written, nil
+}
+
+type dashboardStreamEventStats struct {
+	Events       int64
+	PayloadBytes int64
+	WireBytes    int64
+	PayloadItems int64
+}
+
+type dashboardStreamStats struct {
+	startedAt time.Time
+	lastLogAt time.Time
+	interval  map[string]dashboardStreamEventStats
+	total     map[string]dashboardStreamEventStats
+}
+
+func newDashboardStreamStats() *dashboardStreamStats {
+	now := time.Now()
+	return &dashboardStreamStats{
+		startedAt: now,
+		lastLogAt: now,
+		interval:  make(map[string]dashboardStreamEventStats),
+		total:     make(map[string]dashboardStreamEventStats),
+	}
+}
+
+func (s *dashboardStreamStats) record(event service.DashboardEvent, payloadBytes, wireBytes int) {
+	key := strings.TrimSpace(event.Type)
+	if key == "" {
+		key = "unknown"
+	}
+	itemCount := dashboardPayloadItemCount(event.Payload)
+	incrementDashboardStreamStats(s.interval, key, payloadBytes, wireBytes, itemCount)
+	incrementDashboardStreamStats(s.total, key, payloadBytes, wireBytes, itemCount)
+}
+
+func incrementDashboardStreamStats(stats map[string]dashboardStreamEventStats, key string, payloadBytes, wireBytes, itemCount int) {
+	item := stats[key]
+	item.Events++
+	item.PayloadBytes += int64(payloadBytes)
+	item.WireBytes += int64(wireBytes)
+	item.PayloadItems += int64(itemCount)
+	stats[key] = item
+}
+
+func (s *dashboardStreamStats) logSummary(logger *slog.Logger, reason string, force bool) {
+	now := time.Now()
+	if !force && now.Sub(s.lastLogAt) < 15*time.Second {
+		return
+	}
+	target := s.interval
+	if force {
+		target = s.total
+	}
+	if len(target) == 0 {
+		s.lastLogAt = now
+		return
+	}
+	for _, eventType := range sortedDashboardStreamEventTypes(target) {
+		item := target[eventType]
+		logger.Info("dashboard stream payload summary",
+			"reason", reason,
+			"event_type", eventType,
+			"events", item.Events,
+			"payload_bytes", item.PayloadBytes,
+			"wire_bytes", item.WireBytes,
+			"payload_items", item.PayloadItems,
+			"elapsed_ms", now.Sub(s.startedAt).Milliseconds(),
+		)
+	}
+	s.interval = make(map[string]dashboardStreamEventStats)
+	s.lastLogAt = now
+}
+
+func sortedDashboardStreamEventTypes(stats map[string]dashboardStreamEventStats) []string {
+	items := make([]string, 0, len(stats))
+	for key := range stats {
+		items = append(items, key)
+	}
+	sort.Strings(items)
+	return items
+}
+
+func dashboardPayloadItemCount(payload any) int {
+	if payload == nil {
+		return 0
+	}
+	value := reflect.ValueOf(payload)
+	for value.Kind() == reflect.Pointer || value.Kind() == reflect.Interface {
+		if value.IsNil() {
+			return 0
+		}
+		value = value.Elem()
+	}
+	switch value.Kind() {
+	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
+		return value.Len()
+	default:
+		return 1
+	}
 }

--- a/internal/http/stream.go
+++ b/internal/http/stream.go
@@ -92,6 +92,7 @@ func registerStreamRoutes(mux *http.ServeMux, platform *service.Platform, cfg co
 					return
 				}
 				flusher.Flush()
+				streamStats.logSummary(streamLogger, "interval", false)
 			}
 		}
 	})
@@ -164,6 +165,15 @@ func (s *dashboardStreamStats) logSummary(logger *slog.Logger, reason string, fo
 		target = s.total
 	}
 	if len(target) == 0 {
+		logger.Info("dashboard stream payload summary",
+			"reason", reason,
+			"event_type", "none",
+			"events", 0,
+			"payload_bytes", 0,
+			"wire_bytes", 0,
+			"payload_items", 0,
+			"elapsed_ms", now.Sub(s.startedAt).Milliseconds(),
+		)
 		s.lastLogAt = now
 		return
 	}
@@ -204,7 +214,7 @@ func dashboardPayloadItemCount(payload any) int {
 		value = value.Elem()
 	}
 	switch value.Kind() {
-	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
+	case reflect.Array, reflect.Map, reflect.Slice:
 		return value.Len()
 	default:
 		return 1


### PR DESCRIPTION
## 目的
为 dashboard SSE 增加按事件类型拆分的 payload 统计日志，用来定位浏览器里几十 MB EventSource 流量到底由哪些数据组成。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] L0 - 文档/注释/测试数据，不影响运行
- [x] L1 - 后端观测日志增强，不改变交易执行语义
- [ ] L2 - 涉及执行链路、状态机、配置默认值、生产部署
- [ ] L3 - 可能直接影响 live 下单/资金安全

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

Codex assisted with this PR.

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] dispatchMode 默认值无变更
- [x] mainnet 无硬编码变更
- [x] DB migration 无变更
- [x] 配置字段无变更

## 修改内容
- dashboard SSE 写出路径增加每 15 秒和连接关闭时的 payload 统计日志。
- 日志按 event_type 输出 events、payload_bytes、wire_bytes、payload_items，用于拆分 EventSource 流量来源。

## 验证方式与测试证据
- [x] `/opt/homebrew/bin/go test ./internal/http ./internal/service`
- [x] `/usr/bin/git diff --check`
