### PR TITLE
[codex] Add monitor candle pagination

### DIFF
--- a/web/console/src/components/charts/SignalMonitorChart.tsx
+++ b/web/console/src/components/charts/SignalMonitorChart.tsx
@@ -4,13 +4,31 @@ import { SignalBarCandle, SessionMarker, SignalMonitorOverlay } from '../../type
 import { applyDefaultChartWindow } from '../../utils/derivation';
 import { normalizeChartData, normalizeLineSeriesRange } from '../../utils/chart';
 
-export function SignalMonitorChart(props: { candles: SignalBarCandle[]; markers: SessionMarker[]; overlays?: SignalMonitorOverlay[] }) {
+type VisibleLogicalRange = {
+  from: number;
+  to: number;
+  barCount: number;
+};
+
+export function SignalMonitorChart(props: {
+  candles: SignalBarCandle[];
+  markers: SessionMarker[];
+  overlays?: SignalMonitorOverlay[];
+  onVisibleLogicalRangeChange?: (range: VisibleLogicalRange) => void;
+}) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const chartRef = useRef<ReturnType<typeof createChart> | null>(null);
   const seriesRef = useRef<ReturnType<any> | null>(null);
   const markersRef = useRef<ReturnType<any> | null>(null);
   const overlaySeriesRefs = useRef<Array<ReturnType<any>>>([]);
   const isInitialRender = useRef(true);
+  const candleCountRef = useRef(props.candles.length);
+  const onVisibleLogicalRangeChangeRef = useRef(props.onVisibleLogicalRangeChange);
+
+  useEffect(() => {
+    candleCountRef.current = props.candles.length;
+    onVisibleLogicalRangeChangeRef.current = props.onVisibleLogicalRangeChange;
+  }, [props.candles.length, props.onVisibleLogicalRangeChange]);
 
   useEffect(() => {
     if (!containerRef.current) return;
@@ -51,7 +69,21 @@ export function SignalMonitorChart(props: { candles: SignalBarCandle[]; markers:
     seriesRef.current = series;
     markersRef.current = createSeriesMarkers(series, []);
 
+    const handleLogicalRangeChange = (range: { from: number; to: number } | null) => {
+      const barCount = candleCountRef.current;
+      if (!range || barCount <= 0) {
+        return;
+      }
+      onVisibleLogicalRangeChangeRef.current?.({
+        from: range.from,
+        to: range.to,
+        barCount,
+      });
+    };
+    chart.timeScale().subscribeVisibleLogicalRangeChange(handleLogicalRangeChange);
+
     return () => {
+      chart.timeScale().unsubscribeVisibleLogicalRangeChange(handleLogicalRangeChange);
       overlaySeriesRefs.current = [];
       chart.remove();
       chartRef.current = null;

--- a/web/console/src/pages/MonitorStage.tsx
+++ b/web/console/src/pages/MonitorStage.tsx
@@ -43,7 +43,7 @@ import { Input } from '../components/ui/input';
 import { Label } from '../components/ui/label';
 
 import { cn } from '../lib/utils';
-import type { ChartCandle } from '../types/domain';
+import type { ChartCandle, SignalBarCandle } from '../types/domain';
 
 const MONITOR_HISTORY_CANDLE_LIMIT = 240;
 const MONITOR_CANDLE_EDGE_THRESHOLD = 24;
@@ -109,6 +109,21 @@ function mergeMonitorCandles(existing: ChartCandle[], incoming: ChartCandle[], d
   return direction === "older"
     ? merged.slice(0, MONITOR_CANDLE_CACHE_LIMIT)
     : merged.slice(merged.length - MONITOR_CANDLE_CACHE_LIMIT);
+}
+
+function mergeSignalBars(fallbackBars: SignalBarCandle[], runtimeBars: SignalBarCandle[]) {
+  const byTime = new Map<string, SignalBarCandle>();
+  for (const item of fallbackBars) {
+    if (item.time) {
+      byTime.set(item.time, item);
+    }
+  }
+  for (const item of runtimeBars) {
+    if (item.time) {
+      byTime.set(item.time, item);
+    }
+  }
+  return Array.from(byTime.values()).sort((a, b) => Date.parse(a.time) - Date.parse(b.time));
 }
 
 type MonitorStageProps = {
@@ -249,7 +264,10 @@ export function MonitorStage({ syncLiveOrder, dockTab, onDockTabChange, dockCont
     () => mapChartCandlesToSignalBarCandles(monitorCandles, fallbackResolution),
     [monitorCandles, fallbackResolution]
   );
-  const displayMonitorBars = fallbackMonitorBars.length > 0 ? fallbackMonitorBars : monitorBars;
+  const displayMonitorBars = useMemo(
+    () => mergeSignalBars(fallbackMonitorBars, monitorBars),
+    [fallbackMonitorBars, monitorBars]
+  );
 
   useEffect(() => {
     const monitorSessionId = monitorSession?.id ?? "";
@@ -352,7 +370,11 @@ export function MonitorStage({ syncLiveOrder, dockTab, onDockTabChange, dockCont
         })
         .catch((error) => {
           console.warn(`Failed to expand monitor ${direction} candles`, error);
-          candleExpansionRequestKeyRef.current = "";
+        })
+        .finally(() => {
+          if (candleExpansionRequestKeyRef.current === requestKey) {
+            candleExpansionRequestKeyRef.current = "";
+          }
         });
     },
     [fallbackResolution, monitorCandles, monitorSymbol, setMonitorCandles]

--- a/web/console/src/pages/MonitorStage.tsx
+++ b/web/console/src/pages/MonitorStage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useUIStore } from '../store/useUIStore';
 import { useTradingStore } from '../store/useTradingStore';
 import { SignalMonitorChart } from '../components/charts/SignalMonitorChart';
@@ -45,6 +45,10 @@ import { Label } from '../components/ui/label';
 import { cn } from '../lib/utils';
 import type { ChartCandle } from '../types/domain';
 
+const MONITOR_HISTORY_CANDLE_LIMIT = 240;
+const MONITOR_CANDLE_EDGE_THRESHOLD = 24;
+const MONITOR_CANDLE_CACHE_LIMIT = 1500;
+
 function resolveMonitorFallbackResolution(timeframe: string) {
   const normalized = String(timeframe ?? "").trim().toLowerCase();
   const supported: Record<string, string> = {
@@ -57,6 +61,54 @@ function resolveMonitorFallbackResolution(timeframe: string) {
     "1d": "1D",
   };
   return supported[normalized] ?? "5";
+}
+
+function monitorResolutionSeconds(resolution: string) {
+  const normalized = String(resolution ?? "").trim().toUpperCase();
+  if (normalized === "1D") {
+    return 24 * 60 * 60;
+  }
+  const minutes = Number.parseInt(normalized, 10);
+  return Number.isFinite(minutes) && minutes > 0 ? minutes * 60 : 5 * 60;
+}
+
+function buildMonitorCandleRange(
+  anchorDate: Date,
+  resolution: string,
+  limit: number,
+  requestedRange: { from: number; to: number }
+) {
+  const anchor = Math.floor(anchorDate.getTime() / 1000);
+  const seconds = monitorResolutionSeconds(resolution);
+  const historyRange = {
+    from: anchor - seconds * Math.max(limit - 5, 1),
+    to: anchor + seconds * 5,
+  };
+  return {
+    from: Math.min(requestedRange.from, historyRange.from),
+    to: Math.max(requestedRange.to, historyRange.to),
+  };
+}
+
+function mergeMonitorCandles(existing: ChartCandle[], incoming: ChartCandle[], direction: "older" | "newer") {
+  const byTime = new Map<string, ChartCandle>();
+  for (const item of existing) {
+    if (item.time) {
+      byTime.set(item.time, item);
+    }
+  }
+  for (const item of incoming) {
+    if (item.time) {
+      byTime.set(item.time, item);
+    }
+  }
+  const merged = Array.from(byTime.values()).sort((a, b) => Date.parse(a.time) - Date.parse(b.time));
+  if (merged.length <= MONITOR_CANDLE_CACHE_LIMIT) {
+    return merged;
+  }
+  return direction === "older"
+    ? merged.slice(0, MONITOR_CANDLE_CACHE_LIMIT)
+    : merged.slice(merged.length - MONITOR_CANDLE_CACHE_LIMIT);
 }
 
 type MonitorStageProps = {
@@ -87,6 +139,7 @@ export function MonitorStage({ syncLiveOrder, dockTab, onDockTabChange, dockCont
   const timelineConfig = useUIStore(s => s.timelineConfig);
   const setTimelineConfig = useUIStore(s => s.setTimelineConfig);
   const fallbackRequestKeyRef = useRef<string>("");
+  const candleExpansionRequestKeyRef = useRef<string>("");
 
 
   // 1. 高亮会话选择逻辑
@@ -196,16 +249,11 @@ export function MonitorStage({ syncLiveOrder, dockTab, onDockTabChange, dockCont
     () => mapChartCandlesToSignalBarCandles(monitorCandles, fallbackResolution),
     [monitorCandles, fallbackResolution]
   );
-  const displayMonitorBars = monitorBars.length > 0 ? monitorBars : fallbackMonitorBars;
+  const displayMonitorBars = fallbackMonitorBars.length > 0 ? fallbackMonitorBars : monitorBars;
 
   useEffect(() => {
     const monitorSessionId = monitorSession?.id ?? "";
     if (!monitorSessionId || !monitorSymbol) {
-      fallbackRequestKeyRef.current = "";
-      setMonitorCandles([]);
-      return;
-    }
-    if (monitorBars.length > 0) {
       fallbackRequestKeyRef.current = "";
       setMonitorCandles([]);
       return;
@@ -227,11 +275,12 @@ export function MonitorStage({ syncLiveOrder, dockTab, onDockTabChange, dockCont
     setMonitorCandles([]);
 
     const anchorDate = resolveChartAnchor(monitorSession, orders);
-    const range = chartOverrideRange ?? buildTimeRange(anchorDate, timeWindow);
+    const requestedRange = chartOverrideRange ?? buildTimeRange(anchorDate, timeWindow);
+    const range = buildMonitorCandleRange(anchorDate, fallbackResolution, MONITOR_HISTORY_CANDLE_LIMIT, requestedRange);
 
     let active = true;
     fetchJSON<{ candles: ChartCandle[] }>(
-      `/api/v1/chart/candles?symbol=${encodeURIComponent(monitorSymbol)}&resolution=${fallbackResolution}&from=${range.from}&to=${range.to}&limit=240`
+      `/api/v1/chart/candles?symbol=${encodeURIComponent(monitorSymbol)}&resolution=${fallbackResolution}&from=${range.from}&to=${range.to}&limit=${MONITOR_HISTORY_CANDLE_LIMIT}`
     )
       .then((payload) => {
         if (!active) {
@@ -255,13 +304,76 @@ export function MonitorStage({ syncLiveOrder, dockTab, onDockTabChange, dockCont
   }, [
     chartOverrideRange,
     fallbackResolution,
-    monitorBars.length,
     monitorSession,
     monitorSymbol,
     orders,
     setMonitorCandles,
     timeWindow,
   ]);
+
+  const expandMonitorCandles = useCallback(
+    (direction: "older" | "newer") => {
+      if (!monitorSymbol || monitorCandles.length === 0) {
+        return;
+      }
+      const ordered = [...monitorCandles].sort((a, b) => Date.parse(a.time) - Date.parse(b.time));
+      const firstTime = Date.parse(ordered[0]?.time ?? "");
+      const lastTime = Date.parse(ordered[ordered.length - 1]?.time ?? "");
+      if (!Number.isFinite(firstTime) || !Number.isFinite(lastTime)) {
+        return;
+      }
+      const stepSeconds = monitorResolutionSeconds(fallbackResolution);
+      const stepMs = stepSeconds * 1000;
+      const fromMs =
+        direction === "older"
+          ? firstTime - stepMs * MONITOR_HISTORY_CANDLE_LIMIT
+          : lastTime + stepMs;
+      const toMs =
+        direction === "older"
+          ? firstTime - stepMs
+          : lastTime + stepMs * MONITOR_HISTORY_CANDLE_LIMIT;
+      const from = Math.floor(fromMs / 1000);
+      const to = Math.floor(toMs / 1000);
+      const requestKey = [monitorSymbol, fallbackResolution, direction, from, to].join(":");
+      if (candleExpansionRequestKeyRef.current === requestKey) {
+        return;
+      }
+      candleExpansionRequestKeyRef.current = requestKey;
+
+      fetchJSON<{ candles: ChartCandle[] }>(
+        `/api/v1/chart/candles?symbol=${encodeURIComponent(monitorSymbol)}&resolution=${fallbackResolution}&from=${from}&to=${to}&limit=${MONITOR_HISTORY_CANDLE_LIMIT}`
+      )
+        .then((payload) => {
+          const candles = Array.isArray(payload?.candles) ? payload.candles : [];
+          if (candles.length === 0) {
+            return;
+          }
+          setMonitorCandles((current) => mergeMonitorCandles(current, candles, direction));
+        })
+        .catch((error) => {
+          console.warn(`Failed to expand monitor ${direction} candles`, error);
+          candleExpansionRequestKeyRef.current = "";
+        });
+    },
+    [fallbackResolution, monitorCandles, monitorSymbol, setMonitorCandles]
+  );
+
+  const handleMonitorVisibleRangeChange = useCallback(
+    (range: { from: number; to: number; barCount: number }) => {
+      if (range.barCount <= 0) {
+        return;
+      }
+      if (range.from <= MONITOR_CANDLE_EDGE_THRESHOLD) {
+        expandMonitorCandles("older");
+        return;
+      }
+      if (range.to >= range.barCount - MONITOR_CANDLE_EDGE_THRESHOLD) {
+        expandMonitorCandles("newer");
+      }
+    },
+    [expandMonitorCandles]
+  );
+
   const monitorMarket = deriveRuntimeMarketSnapshot(
     getRecord(monitorRuntimeState.sourceStates),
     getRecord(monitorRuntimeState.lastEventSummary),
@@ -387,6 +499,7 @@ export function MonitorStage({ syncLiveOrder, dockTab, onDockTabChange, dockCont
                     candles={displayMonitorBars}
                     markers={monitorChartMarkers}
                     overlays={monitorDecorations.overlays}
+                    onVisibleLogicalRangeChange={handleMonitorVisibleRangeChange}
                   />
                 ) : (
                   <div className="absolute inset-0 flex flex-col items-center justify-center space-y-3 opacity-30">


### PR DESCRIPTION
## 目的
修复监控 K 线默认加载 240 根后，用户缩小或拖动到未覆盖区域时不会继续补历史/未来 K 线的问题。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] L0 - 文档/注释/测试数据，不影响运行
- [x] L1 - 前端监控展示行为调整，不改变交易执行语义
- [ ] L2 - 涉及执行链路、状态机、配置默认值、生产部署
- [ ] L3 - 可能直接影响 live 下单/资金安全

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

Codex assisted with this PR.

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] dispatchMode 默认值无变更
- [x] mainnet 无硬编码变更
- [x] DB migration 无变更
- [x] 配置字段无变更

## 修改内容
- K 线初始仍按 240 根窗口加载。
- 图表可见范围靠近左右边界时，按当前 resolution 自动补 older/newer candles。
- 补回来的 candles 做 time 去重、排序，并限制缓存上限，避免再次变成全量拉取。
- `SignalMonitorChart` 暴露 lightweight-charts visible logical range 变化回调，供监控页触发补数。

## 验证方式与测试证据
- [x] `cd web/console && /Users/fujun/.nvm/versions/node/v22.18.0/bin/npm run build`
- [x] `/usr/bin/git diff --check`
