### PR TITLE
[codex] Trim live-sessions SSE summary payload

### DIFF
--- a/internal/service/state_util.go
+++ b/internal/service/state_util.go
@@ -1,18 +1,56 @@
 package service
 
-// stripHeavyState removes large objects like sourceStates or signalBarStates
-// from a session state map to reduce the summary payload size. It returns a new
-// map and does not mutate the original input. If the input is nil, it returns nil.
+const (
+	liveSessionSummaryTimelineLimit        = 50
+	liveSessionSummaryBreakoutHistoryLimit = 12
+)
+
+var liveSessionSummaryOmittedStateKeys = map[string]struct{}{
+	"sourceStates":                          {},
+	"signalBarStates":                       {},
+	"lastStrategyEvaluationSourceStates":    {},
+	"lastStrategyEvaluationSignalBarStates": {},
+}
+
+// stripHeavyState removes large objects from a session state map to reduce the
+// live-sessions summary payload size. It returns a new map and does not mutate
+// the original input. If the input is nil, it returns nil.
 func stripHeavyState(state map[string]any) map[string]any {
 	if state == nil {
 		return nil
 	}
 	newState := make(map[string]any, len(state))
 	for k, v := range state {
-		if k == "sourceStates" || k == "signalBarStates" {
+		if _, omitted := liveSessionSummaryOmittedStateKeys[k]; omitted {
 			continue
+		}
+		switch k {
+		case "timeline":
+			v = trimStateList(v, liveSessionSummaryTimelineLimit)
+		case "breakoutHistory":
+			v = trimStateList(v, liveSessionSummaryBreakoutHistoryLimit)
 		}
 		newState[k] = v
 	}
 	return newState
+}
+
+func trimStateList(value any, limit int) any {
+	if limit <= 0 {
+		return value
+	}
+	switch items := value.(type) {
+	case []any:
+		if len(items) <= limit {
+			return items
+		}
+		return append([]any(nil), items[len(items)-limit:]...)
+	case []map[string]any:
+		if len(items) <= limit {
+			return items
+		}
+		return append([]map[string]any(nil), items[len(items)-limit:]...)
+	default:
+		return value
+	}
 }

--- a/internal/service/state_util.go
+++ b/internal/service/state_util.go
@@ -42,12 +42,12 @@ func trimStateList(value any, limit int) any {
 	switch items := value.(type) {
 	case []any:
 		if len(items) <= limit {
-			return items
+			return append([]any(nil), items...)
 		}
 		return append([]any(nil), items[len(items)-limit:]...)
 	case []map[string]any:
 		if len(items) <= limit {
-			return items
+			return append([]map[string]any(nil), items...)
 		}
 		return append([]map[string]any(nil), items[len(items)-limit:]...)
 	default:

--- a/internal/service/state_util_test.go
+++ b/internal/service/state_util_test.go
@@ -30,10 +30,14 @@ func TestStripHeavyState(t *testing.T) {
 
 	t.Run("state with heavy fields", func(t *testing.T) {
 		input := map[string]any{
-			"status":          "RUNNING",
-			"count":           10,
-			"sourceStates":    map[string]any{"data": "heavy1"},
-			"signalBarStates": map[string]any{"data": "heavy2"},
+			"status":                             "RUNNING",
+			"count":                              10,
+			"sourceStates":                       map[string]any{"data": "heavy1"},
+			"signalBarStates":                    map[string]any{"data": "heavy2"},
+			"lastStrategyEvaluationSourceStates": map[string]any{"data": "heavy3"},
+			"lastStrategyEvaluationSignalBarStates": map[string]any{
+				"data": "heavy4",
+			},
 		}
 		got := stripHeavyState(input)
 		expected := map[string]any{
@@ -44,8 +48,53 @@ func TestStripHeavyState(t *testing.T) {
 			t.Errorf("expected %v, got %v", expected, got)
 		}
 		// Ensure original map is unchanged
-		if len(input) != 4 {
+		if len(input) != 6 {
 			t.Errorf("expected original map to be unchanged, got len %d", len(input))
+		}
+	})
+
+	t.Run("trims timeline and breakout history", func(t *testing.T) {
+		timeline := make([]any, 55)
+		for i := range timeline {
+			timeline[i] = map[string]any{"idx": i}
+		}
+		breakoutHistory := make([]any, 15)
+		for i := range breakoutHistory {
+			breakoutHistory[i] = map[string]any{"idx": i}
+		}
+		input := map[string]any{
+			"timeline":        timeline,
+			"breakoutHistory": breakoutHistory,
+			"lastBreakoutSignal": map[string]any{
+				"idx": "latest",
+			},
+		}
+
+		got := stripHeavyState(input)
+
+		gotTimeline, ok := got["timeline"].([]any)
+		if !ok {
+			t.Fatalf("expected timeline []any, got %#v", got["timeline"])
+		}
+		if len(gotTimeline) != liveSessionSummaryTimelineLimit {
+			t.Fatalf("expected timeline limit %d, got %d", liveSessionSummaryTimelineLimit, len(gotTimeline))
+		}
+		if first := gotTimeline[0].(map[string]any)["idx"]; first != 5 {
+			t.Fatalf("expected timeline to keep tail from 5, got %v", first)
+		}
+
+		gotBreakoutHistory, ok := got["breakoutHistory"].([]any)
+		if !ok {
+			t.Fatalf("expected breakoutHistory []any, got %#v", got["breakoutHistory"])
+		}
+		if len(gotBreakoutHistory) != liveSessionSummaryBreakoutHistoryLimit {
+			t.Fatalf("expected breakoutHistory limit %d, got %d", liveSessionSummaryBreakoutHistoryLimit, len(gotBreakoutHistory))
+		}
+		if first := gotBreakoutHistory[0].(map[string]any)["idx"]; first != 3 {
+			t.Fatalf("expected breakoutHistory to keep tail from 3, got %v", first)
+		}
+		if len(timeline) != 55 || len(breakoutHistory) != 15 {
+			t.Fatalf("expected original slices to stay unchanged, got timeline=%d breakoutHistory=%d", len(timeline), len(breakoutHistory))
 		}
 	})
 }

--- a/internal/service/state_util_test.go
+++ b/internal/service/state_util_test.go
@@ -97,4 +97,33 @@ func TestStripHeavyState(t *testing.T) {
 			t.Fatalf("expected original slices to stay unchanged, got timeline=%d breakoutHistory=%d", len(timeline), len(breakoutHistory))
 		}
 	})
+
+	t.Run("copies untrimmed slices", func(t *testing.T) {
+		timeline := []any{
+			map[string]any{"idx": 1},
+			map[string]any{"idx": 2},
+		}
+		breakoutHistory := []map[string]any{
+			{"idx": 1},
+			{"idx": 2},
+		}
+		input := map[string]any{
+			"timeline":        timeline,
+			"breakoutHistory": breakoutHistory,
+		}
+
+		got := stripHeavyState(input)
+
+		gotTimeline := got["timeline"].([]any)
+		gotTimeline[0] = map[string]any{"idx": "changed"}
+		if first := timeline[0].(map[string]any)["idx"]; first != 1 {
+			t.Fatalf("expected original timeline backing array to stay unchanged, got %v", first)
+		}
+
+		gotBreakoutHistory := got["breakoutHistory"].([]map[string]any)
+		gotBreakoutHistory[0] = map[string]any{"idx": "changed"}
+		if first := breakoutHistory[0]["idx"]; first != 1 {
+			t.Fatalf("expected original breakoutHistory backing array to stay unchanged, got %v", first)
+		}
+	})
 }


### PR DESCRIPTION
## 目的

瘦身 dashboard SSE 的 `live-sessions` summary payload，解决线上 EventSource 大流量中 `live-sessions` 占比过高的问题。

Closes #212

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] L0 - 文档/注释/测试数据，不影响运行
- [x] L1 - 后端监控摘要 payload 瘦身，不改变交易执行语义
- [ ] L2 - 涉及执行链路、状态机、配置默认值、生产部署
- [ ] L3 - 可能直接影响 live 下单/资金安全

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

Codex assisted with this PR.

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] dispatchMode 默认值无变更
- [x] mainnet 无硬编码变更
- [x] DB migration 无变更
- [x] 配置字段无变更

## 修改内容
- `stripHeavyState()` 继续剥离 `sourceStates` / `signalBarStates`。
- 新增剥离 `lastStrategyEvaluationSourceStates` / `lastStrategyEvaluationSignalBarStates`，避免 sourceStates 副本随 `live-sessions` 高频 SSE 推送。
- `timeline` 在 summary 中只保留最近 50 条。
- `breakoutHistory` 在 summary 中只保留最近 12 条。
- 补充单元测试，覆盖重字段剥离、尾部裁剪、原始 state 不被修改。

## 验证方式与测试证据
- [x] `/opt/homebrew/bin/go test ./internal/service ./internal/http`
- [x] `/opt/homebrew/bin/go build ./cmd/platform-api`
- [x] `/usr/bin/git diff --check`
