### PR TITLE
[codex] Add live session detail lazy loading

### DIFF
--- a/internal/http/live.go
+++ b/internal/http/live.go
@@ -271,16 +271,18 @@ func registerLiveRoutes(mux *http.ServeMux, platform *service.Platform, cfg conf
 					writeError(w, http.StatusNotFound, err.Error())
 					return
 				}
-				fields := parseLiveSessionDetailFields(r.URL.Query().Get("fields"))
-				if len(fields) > 0 {
-					filtered := make(map[string]any, len(fields))
-					for _, field := range fields {
-						if value, ok := item.State[field]; ok {
-							filtered[field] = value
-						}
-					}
-					item.State = filtered
+				fields, fieldErr := parseLiveSessionDetailFields(r.URL.Query().Get("fields"))
+				if fieldErr != "" {
+					writeError(w, http.StatusBadRequest, fieldErr)
+					return
 				}
+				filtered := make(map[string]any, len(fields))
+				for _, field := range fields {
+					if value, ok := item.State[field]; ok {
+						filtered[field] = value
+					}
+				}
+				item.State = filtered
 				writeJSON(w, http.StatusOK, item)
 				return
 			}
@@ -721,7 +723,19 @@ func registerLiveRoutes(mux *http.ServeMux, platform *service.Platform, cfg conf
 	})
 }
 
-func parseLiveSessionDetailFields(raw string) []string {
+var allowedLiveSessionDetailFields = map[string]struct{}{
+	"timeline":                              {},
+	"breakoutHistory":                       {},
+	"lastStrategyEvaluationSignalBarStates": {},
+	"lastStrategyEvaluationSourceStates":    {},
+	"signalRuntimePlan":                     {},
+	"lastStrategyDecision":                  {},
+	"lastDispatchedIntent":                  {},
+	"lastExecutionDispatch":                 {},
+	"lastExecutionTelemetry":                {},
+}
+
+func parseLiveSessionDetailFields(raw string) ([]string, string) {
 	seen := make(map[string]struct{})
 	fields := make([]string, 0)
 	for _, item := range strings.Split(raw, ",") {
@@ -729,11 +743,17 @@ func parseLiveSessionDetailFields(raw string) []string {
 		if field == "" {
 			continue
 		}
+		if _, ok := allowedLiveSessionDetailFields[field]; !ok {
+			return nil, "unsupported live session detail field: " + field
+		}
 		if _, ok := seen[field]; ok {
 			continue
 		}
 		seen[field] = struct{}{}
 		fields = append(fields, field)
 	}
-	return fields
+	if len(fields) == 0 {
+		return nil, "live session detail fields are required"
+	}
+	return fields, ""
 }

--- a/internal/http/live.go
+++ b/internal/http/live.go
@@ -265,6 +265,25 @@ func registerLiveRoutes(mux *http.ServeMux, platform *service.Platform, cfg conf
 		path := strings.TrimPrefix(r.URL.Path, "/api/v1/live/sessions/")
 		parts := strings.Split(strings.Trim(path, "/"), "/")
 		if r.Method == http.MethodGet {
+			if len(parts) == 2 && parts[0] != "" && parts[1] == "detail" {
+				item, err := platform.GetLiveSession(parts[0])
+				if err != nil {
+					writeError(w, http.StatusNotFound, err.Error())
+					return
+				}
+				fields := parseLiveSessionDetailFields(r.URL.Query().Get("fields"))
+				if len(fields) > 0 {
+					filtered := make(map[string]any, len(fields))
+					for _, field := range fields {
+						if value, ok := item.State[field]; ok {
+							filtered[field] = value
+						}
+					}
+					item.State = filtered
+				}
+				writeJSON(w, http.StatusOK, item)
+				return
+			}
 			if len(parts) == 2 && parts[0] != "" && parts[1] == "trade-pairs" {
 				limit, err := parseOptionalPositiveInt(r.URL.Query().Get("limit"))
 				if err != nil {
@@ -700,4 +719,21 @@ func registerLiveRoutes(mux *http.ServeMux, platform *service.Platform, cfg conf
 			writeError(w, http.StatusNotFound, "unsupported live session action")
 		}
 	})
+}
+
+func parseLiveSessionDetailFields(raw string) []string {
+	seen := make(map[string]struct{})
+	fields := make([]string, 0)
+	for _, item := range strings.Split(raw, ",") {
+		field := strings.TrimSpace(item)
+		if field == "" {
+			continue
+		}
+		if _, ok := seen[field]; ok {
+			continue
+		}
+		seen[field] = struct{}{}
+		fields = append(fields, field)
+	}
+	return fields
 }

--- a/internal/http/session_safety_test.go
+++ b/internal/http/session_safety_test.go
@@ -109,6 +109,20 @@ func TestLiveSessionDetailRouteFiltersStateFields(t *testing.T) {
 	if len(detail.State) != 2 {
 		t.Fatalf("expected only 2 requested fields, got %#v", detail.State)
 	}
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/live/sessions/live-session-main/detail", nil)
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 when fields are missing, got %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/live/sessions/live-session-main/detail?fields=sourceStates", nil)
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for unsupported detail field, got %d body=%s", rec.Code, rec.Body.String())
+	}
 }
 
 func TestLiveAccountStopRouteStopsRunningFlow(t *testing.T) {

--- a/internal/http/session_safety_test.go
+++ b/internal/http/session_safety_test.go
@@ -68,6 +68,49 @@ func TestLiveSessionRuntimeActionsDisabledForAPIRole(t *testing.T) {
 	}
 }
 
+func TestLiveSessionDetailRouteFiltersStateFields(t *testing.T) {
+	store := memory.NewStore()
+	platform := service.NewPlatform(store)
+	if _, err := store.UpdateLiveSessionState("live-session-main", map[string]any{
+		"timeline":                             []any{map[string]any{"title": "first"}},
+		"breakoutHistory":                      []any{map[string]any{"side": "BUY"}},
+		"lastStrategyEvaluationSourceStates":   map[string]any{"heavy": true},
+		"lastStrategyEvaluationSignalBarState": "keep-out",
+	}); err != nil {
+		t.Fatalf("update live session state failed: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	registerLiveRoutes(mux, platform, config.Config{ProcessRole: "monolith"})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/live/sessions/live-session-main/detail?fields=timeline,breakoutHistory,timeline", nil)
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 for detail route, got %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	var detail domain.LiveSession
+	if err := json.NewDecoder(rec.Body).Decode(&detail); err != nil {
+		t.Fatalf("decode live session detail failed: %v", err)
+	}
+	if detail.ID != "live-session-main" {
+		t.Fatalf("expected live-session-main, got %s", detail.ID)
+	}
+	if _, ok := detail.State["timeline"]; !ok {
+		t.Fatalf("expected timeline in filtered state, got %#v", detail.State)
+	}
+	if _, ok := detail.State["breakoutHistory"]; !ok {
+		t.Fatalf("expected breakoutHistory in filtered state, got %#v", detail.State)
+	}
+	if _, ok := detail.State["lastStrategyEvaluationSourceStates"]; ok {
+		t.Fatalf("did not expect unrequested source states, got %#v", detail.State)
+	}
+	if len(detail.State) != 2 {
+		t.Fatalf("expected only 2 requested fields, got %#v", detail.State)
+	}
+}
+
 func TestLiveAccountStopRouteStopsRunningFlow(t *testing.T) {
 	store := memory.NewStore()
 	platform := service.NewPlatform(store)

--- a/web/console/src/hooks/useDashboardRealtime.ts
+++ b/web/console/src/hooks/useDashboardRealtime.ts
@@ -8,6 +8,7 @@ import {
   PlatformNotification, PlatformHealthSnapshot
 } from '../types/domain';
 import { useDashboardStream } from './useDashboardStream';
+import { mergeLiveSessionSnapshot } from '../utils/liveSessionDetail';
 
 const DEFAULT_REALTIME_POLL_MS = 5000;
 const MIN_REALTIME_POLL_MS = 1000;
@@ -65,7 +66,7 @@ export function useDashboardRealtime() {
     const normalizedAlerts = Array.isArray(alertData) ? alertData : [];
     const normalizedNotifications = Array.isArray(notificationData) ? notificationData : [];
 
-    setLiveSessions(normalizedLiveSessions);
+    setLiveSessions((current) => mergeLiveSessionSnapshot(current, normalizedLiveSessions));
     setPositions(normalizedPositions);
     setOrders(normalizedOrders);
     setFills(normalizedFills);

--- a/web/console/src/hooks/useDashboardStream.ts
+++ b/web/console/src/hooks/useDashboardStream.ts
@@ -2,6 +2,7 @@ import { useEffect, useState, useRef } from 'react';
 import { fetchJSON } from '../utils/api';
 import { useTradingStore } from '../store/useTradingStore';
 import { useUIStore } from '../store/useUIStore';
+import { mergeLiveSessionSnapshot } from '../utils/liveSessionDetail';
 
 export function useDashboardStream(enabled: boolean) {
   const setError = useUIStore(s => s.setError);
@@ -118,7 +119,10 @@ export function useDashboardStream(enabled: boolean) {
         }
       };
 
-      es.addEventListener('live-sessions', handleEvent('live-sessions', setLiveSessions));
+      es.addEventListener('live-sessions', handleEvent('live-sessions', (data) => {
+        const snapshot = Array.isArray(data) ? data : [];
+        setLiveSessions((current) => mergeLiveSessionSnapshot(current, snapshot));
+      }));
       es.addEventListener('positions', handleEvent('positions', setPositions));
       es.addEventListener('orders', handleEvent('orders', setOrders));
       es.addEventListener('fills', handleEvent('fills', setFills));

--- a/web/console/src/pages/LogStage.tsx
+++ b/web/console/src/pages/LogStage.tsx
@@ -1,8 +1,10 @@
-import React, { useMemo, useState, useEffect } from 'react';
+import React, { useMemo, useState, useEffect, useRef } from 'react';
 import { useTradingStore } from '../store/useTradingStore';
 import { useUIStore } from '../store/useUIStore';
 import { formatFullLogTime, shrink } from '../utils/format';
 import { getList } from '../utils/derivation';
+import { fetchJSON } from '../utils/api';
+import { hasLiveSessionDetailFields, mergeLiveSessionDetail } from '../utils/liveSessionDetail';
 import { 
   Terminal, 
   AlertCircle, 
@@ -30,9 +32,11 @@ import {
   SelectValue 
 } from '../components/ui/select';
 import { Separator } from '../components/ui/separator';
+import type { LiveSession } from '../types/domain';
 
 type LogSource = "alert" | "notification" | "timeline" | "system";
 type LogLevel = "critical" | "warning" | "info" | "debug";
+const LOG_LIVE_SESSION_DETAIL_FIELDS = ["timeline"];
 
 interface ConsoleLogEvent {
   id: string;
@@ -53,8 +57,55 @@ export function LogStage() {
   const alerts = useTradingStore(s => s.alerts);
   const notifications = useTradingStore(s => s.notifications);
   const liveSessions = useTradingStore(s => s.liveSessions);
+  const setLiveSessions = useTradingStore(s => s.setLiveSessions);
   const signalRuntimeSessions = useTradingStore(s => s.signalRuntimeSessions);
   const systemLogs = useUIStore(s => s.systemLogs);
+  const detailRequestsRef = useRef<Set<string>>(new Set());
+  const [timelineDetailStatus, setTimelineDetailStatus] = useState<"idle" | "loading" | "loaded" | "error">("idle");
+
+  useEffect(() => {
+    if (logType !== "all" && logType !== "timeline") {
+      setTimelineDetailStatus("idle");
+      return;
+    }
+    const missing = liveSessions.filter(
+      (session) =>
+        !hasLiveSessionDetailFields(session, LOG_LIVE_SESSION_DETAIL_FIELDS) &&
+        !detailRequestsRef.current.has(session.id)
+    );
+    if (missing.length === 0) {
+      setTimelineDetailStatus(liveSessions.length > 0 ? "loaded" : "idle");
+      return;
+    }
+
+    let active = true;
+    setTimelineDetailStatus("loading");
+    for (const session of missing) {
+      detailRequestsRef.current.add(session.id);
+      fetchJSON<LiveSession>(
+        `/api/v1/live/sessions/${encodeURIComponent(session.id)}/detail?fields=${LOG_LIVE_SESSION_DETAIL_FIELDS.map(encodeURIComponent).join(",")}`
+      )
+        .then((detail) => {
+          if (!active) {
+            return;
+          }
+          setLiveSessions((current) => mergeLiveSessionDetail(current, detail, LOG_LIVE_SESSION_DETAIL_FIELDS));
+          setTimelineDetailStatus("loaded");
+        })
+        .catch((error) => {
+          detailRequestsRef.current.delete(session.id);
+          if (!active) {
+            return;
+          }
+          console.warn("Failed to load live session timeline detail", error);
+          setTimelineDetailStatus("error");
+        });
+    }
+
+    return () => {
+      active = false;
+    };
+  }, [liveSessions, logType, setLiveSessions]);
 
   const processedEvents = useMemo(() => {
     const events: ConsoleLogEvent[] = [];
@@ -214,6 +265,11 @@ export function LogStage() {
             {autoRefresh ? <Pause size={12} /> : <Play size={12} />}
             {autoRefresh ? '自动刷新' : '已暂停'}
           </Button>
+          {(logType === "all" || logType === "timeline") && timelineDetailStatus !== "idle" ? (
+            <Badge variant={timelineDetailStatus === "error" ? "destructive" : "neutral"} className="h-8 px-3 text-[10px] font-black uppercase">
+              {timelineDetailStatus === "loading" ? "Timeline Loading" : timelineDetailStatus === "error" ? "Timeline Error" : "Timeline Ready"}
+            </Badge>
+          ) : null}
           
           <Button
              variant="bento-ghost"

--- a/web/console/src/pages/MonitorStage.tsx
+++ b/web/console/src/pages/MonitorStage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useUIStore } from '../store/useUIStore';
 import { useTradingStore } from '../store/useTradingStore';
 import { SignalMonitorChart } from '../components/charts/SignalMonitorChart';
@@ -30,6 +30,7 @@ import {
   technicalStatusLabel
 } from '../utils/derivation';
 import { fetchJSON } from '../utils/api';
+import { hasLiveSessionDetailFields, mergeLiveSessionDetail } from '../utils/liveSessionDetail';
 import { Card, CardHeader, CardTitle, CardContent } from '../components/ui/card';
 import { Badge } from '../components/ui/badge';
 import { Table, TableHeader, TableBody, TableHead, TableRow, TableCell } from '../components/ui/table';
@@ -43,11 +44,16 @@ import { Input } from '../components/ui/input';
 import { Label } from '../components/ui/label';
 
 import { cn } from '../lib/utils';
-import type { ChartCandle, SignalBarCandle } from '../types/domain';
+import type { ChartCandle, LiveSession, SignalBarCandle } from '../types/domain';
 
 const MONITOR_HISTORY_CANDLE_LIMIT = 240;
 const MONITOR_CANDLE_EDGE_THRESHOLD = 24;
 const MONITOR_CANDLE_CACHE_LIMIT = 1500;
+const MONITOR_LIVE_SESSION_DETAIL_FIELDS = [
+  "timeline",
+  "breakoutHistory",
+  "lastStrategyEvaluationSignalBarStates",
+];
 
 function resolveMonitorFallbackResolution(timeframe: string) {
   const normalized = String(timeframe ?? "").trim().toLowerCase();
@@ -135,6 +141,7 @@ type MonitorStageProps = {
 
 export function MonitorStage({ syncLiveOrder, dockTab, onDockTabChange, dockContent }: MonitorStageProps) {
   const liveSessions = useTradingStore(s => s.liveSessions);
+  const setLiveSessions = useTradingStore(s => s.setLiveSessions);
   const orders = useTradingStore(s => s.orders);
   const fills = useTradingStore(s => s.fills);
   const positions = useTradingStore(s => s.positions);
@@ -155,6 +162,7 @@ export function MonitorStage({ syncLiveOrder, dockTab, onDockTabChange, dockCont
   const setTimelineConfig = useUIStore(s => s.setTimelineConfig);
   const fallbackRequestKeyRef = useRef<string>("");
   const candleExpansionRequestKeyRef = useRef<string>("");
+  const [liveSessionDetailStatus, setLiveSessionDetailStatus] = useState<"idle" | "loading" | "loaded" | "error">("idle");
 
 
   // 1. 高亮会话选择逻辑
@@ -217,6 +225,42 @@ export function MonitorStage({ syncLiveOrder, dockTab, onDockTabChange, dockCont
   const monitorExecutionSummary = highlightedLiveSession?.execution ?? derivePaperSessionExecutionSummary(null, orders, fills, positions);
   const monitorRuntimeState = highlightedLiveSession?.session ? highlightedLiveRuntimeState : {};
   const monitorSessionState = getRecord(monitorSession?.state);
+
+  useEffect(() => {
+    if (!monitorSession?.id) {
+      setLiveSessionDetailStatus("idle");
+      return;
+    }
+    if (hasLiveSessionDetailFields(monitorSession, MONITOR_LIVE_SESSION_DETAIL_FIELDS)) {
+      setLiveSessionDetailStatus("loaded");
+      return;
+    }
+
+    let active = true;
+    setLiveSessionDetailStatus("loading");
+    fetchJSON<LiveSession>(
+      `/api/v1/live/sessions/${encodeURIComponent(monitorSession.id)}/detail?fields=${MONITOR_LIVE_SESSION_DETAIL_FIELDS.map(encodeURIComponent).join(",")}`
+    )
+      .then((detail) => {
+        if (!active) {
+          return;
+        }
+        setLiveSessions((current) => mergeLiveSessionDetail(current, detail, MONITOR_LIVE_SESSION_DETAIL_FIELDS));
+        setLiveSessionDetailStatus("loaded");
+      })
+      .catch((error) => {
+        if (!active) {
+          return;
+        }
+        console.warn("Failed to load live session detail", error);
+        setLiveSessionDetailStatus("error");
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [monitorSession, setLiveSessions]);
+
   const sessionSymbol = String(monitorSession?.state?.symbol ?? "").trim().toUpperCase();
   const monitorSignalContext = getRecord(monitorSessionState.lastStrategyEvaluationContext);
   const monitorDecisionMeta = getRecord(getRecord(monitorSession?.state?.lastStrategyDecision).metadata);
@@ -819,7 +863,11 @@ export function MonitorStage({ syncLiveOrder, dockTab, onDockTabChange, dockCont
                     </PopoverContent>
                   </Popover>
                   <div className="rounded-lg border border-[var(--bk-border)] bg-[var(--bk-surface)] px-2 py-1 font-mono text-[9px] font-black uppercase shadow-sm text-[var(--bk-text-muted)]">
-                    AUTO_SCROLL_MONITOR
+                    {liveSessionDetailStatus === "loading"
+                      ? "DETAIL_LOADING"
+                      : liveSessionDetailStatus === "error"
+                        ? "DETAIL_ERROR"
+                        : "AUTO_SCROLL_MONITOR"}
                   </div>
                 </div>
              </div>

--- a/web/console/src/utils/liveSessionDetail.ts
+++ b/web/console/src/utils/liveSessionDetail.ts
@@ -28,6 +28,27 @@ function withDetailFields(session: LiveSession, fields: string[]): LiveSession {
   };
 }
 
+function mergeStateList(existing: unknown, snapshot: unknown): unknown {
+  if (!Array.isArray(existing) || !Array.isArray(snapshot)) {
+    return snapshot ?? existing;
+  }
+  const byKey = new Map<string, unknown>();
+  for (const item of existing) {
+    byKey.set(JSON.stringify(item), item);
+  }
+  for (const item of snapshot) {
+    byKey.set(JSON.stringify(item), item);
+  }
+  return Array.from(byKey.values());
+}
+
+function mergeDetailField(field: string, existingValue: unknown, snapshotValue: unknown): unknown {
+  if (field === "timeline" || field === "breakoutHistory") {
+    return mergeStateList(existingValue, snapshotValue);
+  }
+  return snapshotValue === undefined ? existingValue : snapshotValue;
+}
+
 export function mergeLiveSessionSnapshot(current: LiveSession[], snapshot: LiveSession[]): LiveSession[] {
   const currentById = new Map(current.map((item) => [item.id, item] as const));
   return snapshot.map((item) => {
@@ -43,7 +64,7 @@ export function mergeLiveSessionSnapshot(current: LiveSession[], snapshot: LiveS
     const existingState = existing.state ?? {};
     for (const field of loadedFields) {
       if (field in existingState) {
-        state[field] = existingState[field];
+        state[field] = mergeDetailField(field, existingState[field], state[field]);
       }
     }
     return withDetailFields(

--- a/web/console/src/utils/liveSessionDetail.ts
+++ b/web/console/src/utils/liveSessionDetail.ts
@@ -1,0 +1,91 @@
+import type { LiveSession } from '../types/domain';
+
+const DETAIL_FIELDS_META_KEY = "__detailFields";
+
+function detailFieldSet(session: LiveSession | undefined): Set<string> {
+  const fields = session?.metadata?.[DETAIL_FIELDS_META_KEY];
+  return new Set(Array.isArray(fields) ? fields.map((item) => String(item)) : []);
+}
+
+export function hasLiveSessionDetailFields(session: LiveSession | null | undefined, fields: string[]) {
+  const loaded = detailFieldSet(session ?? undefined);
+  return fields.every((field) => loaded.has(field));
+}
+
+function withDetailFields(session: LiveSession, fields: string[]): LiveSession {
+  const merged = detailFieldSet(session);
+  for (const field of fields) {
+    if (field) {
+      merged.add(field);
+    }
+  }
+  return {
+    ...session,
+    metadata: {
+      ...(session.metadata ?? {}),
+      [DETAIL_FIELDS_META_KEY]: Array.from(merged).sort(),
+    },
+  };
+}
+
+export function mergeLiveSessionSnapshot(current: LiveSession[], snapshot: LiveSession[]): LiveSession[] {
+  const currentById = new Map(current.map((item) => [item.id, item] as const));
+  return snapshot.map((item) => {
+    const existing = currentById.get(item.id);
+    if (!existing) {
+      return item;
+    }
+    const loadedFields = detailFieldSet(existing);
+    if (loadedFields.size === 0) {
+      return item;
+    }
+    const state = { ...(item.state ?? {}) };
+    const existingState = existing.state ?? {};
+    for (const field of loadedFields) {
+      if (field in existingState) {
+        state[field] = existingState[field];
+      }
+    }
+    return withDetailFields(
+      {
+        ...item,
+        state,
+        metadata: {
+          ...(item.metadata ?? {}),
+          ...(existing.metadata ?? {}),
+        },
+      },
+      Array.from(loadedFields)
+    );
+  });
+}
+
+export function mergeLiveSessionDetail(
+  current: LiveSession[],
+  detail: LiveSession,
+  fields: string[]
+): LiveSession[] {
+  let found = false;
+  const next = current.map((item) => {
+    if (item.id !== detail.id) {
+      return item;
+    }
+    found = true;
+    return withDetailFields(
+      {
+        ...item,
+        ...detail,
+        state: {
+          ...(item.state ?? {}),
+          ...(detail.state ?? {}),
+        },
+        metadata: {
+          ...(item.metadata ?? {}),
+          ...(detail.metadata ?? {}),
+        },
+      },
+      fields
+    );
+  });
+  return found ? next : [withDetailFields(detail, fields), ...next];
+}


### PR DESCRIPTION
## 目的

把 dashboard 高频 `live-sessions` summary 和重字段详情分层：主屏继续使用轻量 summary，Timeline/监控详情按需拉 live session detail 字段，避免重 state 再随 SSE 高频推送。

Closes #213

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] L0 - 文档/注释/测试数据，不影响运行
- [x] L1 - 后端只读详情接口 + 前端按需加载，不改变交易执行语义
- [ ] L2 - 涉及执行链路、状态机、配置默认值、生产部署
- [ ] L3 - 可能直接影响 live 下单/资金安全

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

Codex assisted with this PR.

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] dispatchMode 默认值无变更
- [x] mainnet 无硬编码变更
- [x] DB migration 无变更
- [x] 配置字段无变更

## 修改内容
- 新增 `GET /api/v1/live/sessions/{id}/detail` 只读详情接口。
- 支持 `fields=timeline,breakoutHistory,...`，只返回请求的 state 字段。
- 前端新增 live session detail merge 工具，记录已按需加载字段。
- SSE / polling 收到 summary 时，保留已按需加载的 detail 字段，避免 summary 覆盖完整 timeline。
- MonitorStage 选中 session 后按需拉 `timeline`、`breakoutHistory`、`lastStrategyEvaluationSignalBarStates`。
- LogStage 进入全部/时间线视图时按需拉 live session `timeline`。

## 验证方式与测试证据
- [x] `/opt/homebrew/bin/go test ./internal/http ./internal/service`
- [x] `/opt/homebrew/bin/go build ./cmd/platform-api`
- [x] `cd web/console && /Users/fujun/.nvm/versions/node/v22.18.0/bin/npm run build`
- [x] `/usr/bin/git diff --check`
