### PR TITLE
[codex] fix postgres fill null trade id scan

### DIFF
--- a/internal/store/postgres/store.go
+++ b/internal/store/postgres/store.go
@@ -856,13 +856,14 @@ func (s *Store) CreateFill(fill domain.Fill) (domain.Fill, error) {
 			returning id, order_id, exchange_trade_id, exchange_trade_time, dedup_fallback_fingerprint, price, quantity, fee, created_at
 		`, fill.ID, fill.OrderID, nullIfEmpty(fill.ExchangeTradeID), fill.ExchangeTradeTime, fill.DedupFingerprint, fill.Price, fill.Quantity, fill.Fee, fill.CreatedAt)
 		var (
+			exchangeTradeID     sql.NullString
 			exchangeTradeTime   sql.NullTime
 			fallbackFingerprint sql.NullString
 		)
 		err := row.Scan(
 			&fill.ID,
 			&fill.OrderID,
-			&fill.ExchangeTradeID,
+			&exchangeTradeID,
 			&exchangeTradeTime,
 			&fallbackFingerprint,
 			&fill.Price,
@@ -870,6 +871,7 @@ func (s *Store) CreateFill(fill domain.Fill) (domain.Fill, error) {
 			&fill.Fee,
 			&fill.CreatedAt,
 		)
+		fill.ExchangeTradeID = exchangeTradeID.String
 		fill.DedupFingerprint = fallbackFingerprint.String
 		if exchangeTradeTime.Valid {
 			parsed := exchangeTradeTime.Time.UTC()
@@ -891,13 +893,14 @@ func (s *Store) CreateFill(fill domain.Fill) (domain.Fill, error) {
 		returning id, order_id, exchange_trade_id, exchange_trade_time, dedup_fallback_fingerprint, price, quantity, fee, created_at
 	`, fill.ID, fill.OrderID, fill.ExchangeTradeID, fill.ExchangeTradeTime, nil, fill.Price, fill.Quantity, fill.Fee, fill.CreatedAt)
 	var (
+		exchangeTradeID     sql.NullString
 		exchangeTradeTime   sql.NullTime
 		fallbackFingerprint sql.NullString
 	)
 	err := row.Scan(
 		&fill.ID,
 		&fill.OrderID,
-		&fill.ExchangeTradeID,
+		&exchangeTradeID,
 		&exchangeTradeTime,
 		&fallbackFingerprint,
 		&fill.Price,
@@ -905,6 +908,7 @@ func (s *Store) CreateFill(fill domain.Fill) (domain.Fill, error) {
 		&fill.Fee,
 		&fill.CreatedAt,
 	)
+	fill.ExchangeTradeID = exchangeTradeID.String
 	fill.DedupFingerprint = fallbackFingerprint.String
 	if exchangeTradeTime.Valid {
 		parsed := exchangeTradeTime.Time.UTC()


### PR DESCRIPTION
## 目的
修复 PR #217 部署后 live-runner 恢复 pending settlement 时暴露的 Postgres NULL scan 问题。

生产现象：`liveSettlementPendingOrderSymbols()` 已进入 submission-result synthetic fill 恢复路径，并为 pending immediate FILLED 订单创建了 fallback fill；但 `CreateFill()` 的 `RETURNING exchange_trade_id` 在 fallback fill 场景下为 NULL，代码直接 scan 到 `string`，导致：

```text
sql: Scan error on column index 2, name "exchange_trade_id": converting NULL to string is unsupported
```

本次改动把 `CreateFill()` 两个 returning 分支里的 `exchange_trade_id` 都改为 `sql.NullString` 扫描，与 `ListFills()` / `QueryFills()` 现有 nullable 读取语义保持一致。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [x] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) - 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？- 无
- [x] DB migration 是否具备向下兼容幂等性？- 无 migration
- [x] 配置字段有没有无意被混改？- 无配置改动

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

验证已跑：

```bash
go test ./...
go build ./cmd/platform-api
go build ./cmd/db-migrate
```
