### PR TITLE
[codex] Persist signal runtime sessions (#200)

### DIFF
--- a/db/migrations/024_signal_runtime_sessions.sql
+++ b/db/migrations/024_signal_runtime_sessions.sql
@@ -1,0 +1,19 @@
+create table if not exists signal_runtime_sessions (
+    id text primary key,
+    account_id text not null references accounts(id),
+    strategy_id text not null references strategies(id),
+    status text not null,
+    runtime_adapter text not null default '',
+    transport text not null default '',
+    subscription_count integer not null default 0,
+    state jsonb not null default '{}'::jsonb,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    constraint signal_runtime_sessions_status_nonempty check (length(trim(status)) > 0)
+);
+
+create unique index if not exists signal_runtime_sessions_account_strategy_uidx
+    on signal_runtime_sessions (account_id, strategy_id);
+
+create index if not exists signal_runtime_sessions_updated_at_idx
+    on signal_runtime_sessions (updated_at desc);

--- a/docs/runtime-runner-issue-199-workplan.md
+++ b/docs/runtime-runner-issue-199-workplan.md
@@ -46,6 +46,13 @@
 
 Issue: [#200](https://github.com/folgercn/bktrader/issues/200)
 
+状态：
+
+- ✅ **PR 已提交（2026-04-26）**：[#220 Persist signal runtime sessions (#200)](https://github.com/folgercn/bktrader/pull/220)
+- ✅ 已完成：`signal_runtime_sessions` migration、store CRUD、memory/postgres 实现、service cache miss → store restore、`syncLiveSessionRuntime` 复用旧 runtime ID。
+- ✅ 已按 review 修正：Create 语义改为真 upsert（同一 account+strategy 保留 runtime identity 但刷新 status/adapter/transport/subscription/state）、Start 使用运行占位避免并发双启动、Delete 改为 DB 删除成功后再取消本地 runner、not-found 改为 typed error。
+- 🟡 待 review/merge：#220 合并后才能开始 #201。
+
 目标：
 
 - 将 `SignalRuntimeSession` identity / state / subscription plan 从 `Platform.signalSessions` 内存 map 中持久化到 store。
@@ -70,7 +77,7 @@ Issue: [#200](https://github.com/folgercn/bktrader/issues/200)
 最低测试：
 
 - memory store runtime session CRUD。
-- postgres store runtime session CRUD。
+- postgres store runtime session CRUD / upsert 语义测试。
 - `syncLiveSessionRuntime` 在内存缓存为空但 store 存在时复用旧 ID。
 - stop/delete 状态持久化正确。
 
@@ -246,4 +253,3 @@ Review / merge 必须串行。后续 step 只能基于已合并的前序 step。
 - 是否影响 final submit payload。
 - 是否影响 reconcile / recovery gate。
 - 是否有 failure path 测试。
-

--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -3379,8 +3379,8 @@ func (p *Platform) syncLiveSessionRuntime(session domain.LiveSession) (domain.Li
 		if getErr == nil {
 			state["signalRuntimeStatus"] = runtimeSession.Status
 		} else {
-			// 如果在内存中找不到该 signalRuntimeSession（例如系统发生重启后内存缓存被清空），
-			// 则立刻抹除这个失效的 state ID，阻止崩溃向后传播，并在下方的必须条件分支中触发重新创建。
+			// Persisted runtime session identity is the source of truth. Only clear
+			// the linked ID after both hot cache and store lookup fail.
 			runtimeSessionID = ""
 			delete(state, "signalRuntimeSessionId")
 			delete(state, "signalRuntimeStatus")

--- a/internal/service/platform.go
+++ b/internal/service/platform.go
@@ -28,7 +28,7 @@ type Platform struct {
 	store                  store.Repository              // 存储层接口（内存 / PostgreSQL）
 	mu                     sync.Mutex                    // 保护 run map 的并发访问
 	run                    map[string]context.CancelFunc // 运行中的 paper session -> cancel 函数
-	signalRun              map[string]context.CancelFunc // 运行中的 signal runtime session -> cancel 函数
+	signalRun              map[string]*signalRuntimeRun  // 运行中的 signal runtime session -> run handle
 	paperPlans             map[string][]paperPlannedOrder
 	livePlans              map[string][]paperPlannedOrder
 	strategyEngines        map[string]StrategyEngine
@@ -92,7 +92,7 @@ func NewPlatform(store store.Repository) *Platform {
 	platform := &Platform{
 		store:               store,
 		run:                 make(map[string]context.CancelFunc),
-		signalRun:           make(map[string]context.CancelFunc),
+		signalRun:           make(map[string]*signalRuntimeRun),
 		paperPlans:          make(map[string][]paperPlannedOrder),
 		livePlans:           make(map[string][]paperPlannedOrder),
 		strategyEngines:     make(map[string]StrategyEngine),

--- a/internal/service/signal_runtime_sessions.go
+++ b/internal/service/signal_runtime_sessions.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 	"strconv"
@@ -9,12 +10,53 @@ import (
 	"time"
 
 	"github.com/wuyaocheng/bktrader/internal/domain"
+	"github.com/wuyaocheng/bktrader/internal/store"
 )
 
+type signalRuntimeRun struct {
+	ctx      context.Context
+	cancel   context.CancelFunc
+	starting bool
+}
+
 func (p *Platform) ListSignalRuntimeSessions() []domain.SignalRuntimeSession {
+	items, err := p.store.ListSignalRuntimeSessions()
+	if err == nil {
+		p.mu.Lock()
+		seen := make(map[string]struct{}, len(items)+len(p.signalSessions))
+		for _, session := range items {
+			p.signalSessions[session.ID] = session
+			seen[session.ID] = struct{}{}
+		}
+		for _, session := range p.signalSessions {
+			if _, ok := seen[session.ID]; ok {
+				continue
+			}
+			items = append(items, session)
+		}
+		p.mu.Unlock()
+		slices.SortFunc(items, func(a, b domain.SignalRuntimeSession) int {
+			if a.UpdatedAt.Equal(b.UpdatedAt) {
+				switch {
+				case a.ID < b.ID:
+					return -1
+				case a.ID > b.ID:
+					return 1
+				default:
+					return 0
+				}
+			}
+			if a.UpdatedAt.Before(b.UpdatedAt) {
+				return 1
+			}
+			return -1
+		})
+		return items
+	}
+	p.logger("service.signal_runtime").Warn("list persisted signal runtime sessions failed", "error", err)
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	items := make([]domain.SignalRuntimeSession, 0, len(p.signalSessions))
+	items = make([]domain.SignalRuntimeSession, 0, len(p.signalSessions))
 	for _, session := range p.signalSessions {
 		items = append(items, session)
 	}
@@ -50,11 +92,16 @@ func (p *Platform) ListSignalRuntimeSessionsSummary() []domain.SignalRuntimeSess
 
 func (p *Platform) GetSignalRuntimeSession(sessionID string) (domain.SignalRuntimeSession, error) {
 	p.mu.Lock()
-	defer p.mu.Unlock()
 	session, ok := p.signalSessions[sessionID]
-	if !ok {
-		return domain.SignalRuntimeSession{}, fmt.Errorf("signal runtime session not found: %s", sessionID)
+	p.mu.Unlock()
+	if ok {
+		return session, nil
 	}
+	session, err := p.store.GetSignalRuntimeSession(sessionID)
+	if err != nil {
+		return domain.SignalRuntimeSession{}, err
+	}
+	p.cacheSignalRuntimeSession(session)
 	return session, nil
 }
 
@@ -95,18 +142,21 @@ func (p *Platform) CreateSignalRuntimeSession(accountID, strategyID string) (dom
 		CreatedAt: now,
 		UpdatedAt: now,
 	}
-	p.mu.Lock()
-	p.signalSessions[session.ID] = session
-	p.mu.Unlock()
+	persisted, err := p.store.CreateSignalRuntimeSession(session)
+	if err != nil {
+		logger.Warn("persist signal runtime session failed", "error", err)
+		return domain.SignalRuntimeSession{}, err
+	}
+	p.cacheSignalRuntimeSession(persisted)
 	p.logger("service.signal_runtime",
-		"session_id", session.ID,
-		"account_id", session.AccountID,
-		"strategy_id", session.StrategyID,
+		"session_id", persisted.ID,
+		"account_id", persisted.AccountID,
+		"strategy_id", persisted.StrategyID,
 	).Info("signal runtime session created",
-		"subscription_count", len(subscriptions),
-		"runtime_adapter", adapterKey,
+		"subscription_count", persisted.SubscriptionCnt,
+		"runtime_adapter", persisted.RuntimeAdapter,
 	)
-	return session, nil
+	return persisted, nil
 }
 
 // syncSignalRuntimeSessionPlan rebuilds the stored runtime plan/subscription
@@ -130,11 +180,9 @@ func (p *Platform) syncSignalRuntimeSessionPlan(sessionID string) (domain.Signal
 	}
 	now := time.Now().UTC()
 
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	current, ok := p.signalSessions[sessionID]
-	if !ok {
-		return domain.SignalRuntimeSession{}, fmt.Errorf("signal runtime session not found: %s", sessionID)
+	current, err := p.GetSignalRuntimeSession(sessionID)
+	if err != nil {
+		return domain.SignalRuntimeSession{}, err
 	}
 	state := cloneMetadata(current.State)
 	state["plan"] = plan
@@ -153,28 +201,54 @@ func (p *Platform) syncSignalRuntimeSessionPlan(sessionID string) (domain.Signal
 	current.SubscriptionCnt = len(subscriptions)
 	current.State = state
 	current.UpdatedAt = now
-	p.signalSessions[sessionID] = current
-	return current, nil
+	updated, updateErr := p.store.UpdateSignalRuntimeSession(current)
+	if updateErr != nil {
+		if isSignalRuntimeSessionNotFoundError(updateErr) {
+			p.cacheSignalRuntimeSession(current)
+			return current, nil
+		}
+		return domain.SignalRuntimeSession{}, updateErr
+	}
+	p.cacheSignalRuntimeSession(updated)
+	return updated, nil
 }
 
 func (p *Platform) StartSignalRuntimeSession(sessionID string) (domain.SignalRuntimeSession, error) {
 	logger := p.logger("service.signal_runtime", "session_id", sessionID)
 	p.mu.Lock()
-	session, ok := p.signalSessions[sessionID]
-	if !ok {
+	if run, exists := p.signalRun[sessionID]; exists {
+		session, ok := p.signalSessions[sessionID]
 		p.mu.Unlock()
-		logger.Warn("signal runtime session not found")
-		return domain.SignalRuntimeSession{}, fmt.Errorf("signal runtime session not found: %s", sessionID)
-	}
-	if _, exists := p.signalRun[sessionID]; exists {
-		p.mu.Unlock()
-		logger.Debug("signal runtime session already running")
+		if !ok {
+			var err error
+			session, err = p.GetSignalRuntimeSession(sessionID)
+			if err != nil {
+				return domain.SignalRuntimeSession{}, err
+			}
+		}
+		logger.Debug("signal runtime session already running", "starting", run.starting)
 		return session, nil
 	}
+	ctx, cancel := context.WithCancel(context.Background())
+	run := &signalRuntimeRun{ctx: ctx, cancel: cancel, starting: true}
+	p.signalRun[sessionID] = run
 	p.mu.Unlock()
+	session, err := p.GetSignalRuntimeSession(sessionID)
+	if err != nil {
+		p.clearSignalRuntimeRun(sessionID, run)
+		cancel()
+		logger.Warn("signal runtime session not found")
+		return domain.SignalRuntimeSession{}, err
+	}
 	plan, err := p.BuildSignalRuntimePlan(session.AccountID, session.StrategyID)
 	if err != nil {
+		p.clearSignalRuntimeRun(sessionID, run)
+		cancel()
 		logger.Warn("build signal runtime plan failed", "error", err)
+		return domain.SignalRuntimeSession{}, err
+	}
+	if err := ctx.Err(); err != nil {
+		p.clearSignalRuntimeRun(sessionID, run)
 		return domain.SignalRuntimeSession{}, err
 	}
 	subscriptions := metadataList(plan["subscriptions"])
@@ -182,18 +256,6 @@ func (p *Platform) StartSignalRuntimeSession(sessionID string) (domain.SignalRun
 	if len(subscriptions) > 0 {
 		adapterKey = stringValue(subscriptions[0]["adapterKey"])
 	}
-	p.mu.Lock()
-	session, ok = p.signalSessions[sessionID]
-	if !ok {
-		p.mu.Unlock()
-		return domain.SignalRuntimeSession{}, fmt.Errorf("signal runtime session not found: %s", sessionID)
-	}
-	if _, exists := p.signalRun[sessionID]; exists {
-		p.mu.Unlock()
-		return session, nil
-	}
-	ctx, cancel := context.WithCancel(context.Background())
-	p.signalRun[sessionID] = cancel
 	now := time.Now().UTC()
 	state := cloneMetadata(session.State)
 	state["plan"] = plan
@@ -220,6 +282,30 @@ func (p *Platform) StartSignalRuntimeSession(sessionID string) (domain.SignalRun
 	session.Status = "RUNNING"
 	session.State = state
 	session.UpdatedAt = now
+	updatedSession, updateErr := p.store.UpdateSignalRuntimeSession(session)
+	if updateErr != nil {
+		if !isSignalRuntimeSessionNotFoundError(updateErr) {
+			p.clearSignalRuntimeRun(sessionID, run)
+			cancel()
+			logger.Warn("persist signal runtime session start failed", "error", updateErr)
+			return domain.SignalRuntimeSession{}, updateErr
+		}
+		logger.Warn("persist signal runtime session start missed store row; using cache-only session", "error", updateErr)
+	} else {
+		session = updatedSession
+	}
+	if err := ctx.Err(); err != nil {
+		p.persistSignalRuntimeStoppedAfterStartCancel(session)
+		p.clearSignalRuntimeRun(sessionID, run)
+		return domain.SignalRuntimeSession{}, err
+	}
+	p.mu.Lock()
+	if current := p.signalRun[sessionID]; current != run {
+		p.mu.Unlock()
+		cancel()
+		return domain.SignalRuntimeSession{}, fmt.Errorf("signal runtime session start superseded: %s", sessionID)
+	}
+	run.starting = false
 	p.signalSessions[session.ID] = session
 	p.mu.Unlock()
 	go p.runSignalRuntimeWithRecovery(ctx, sessionID)
@@ -252,16 +338,9 @@ func (p *Platform) StopSignalRuntimeSessionWithForce(sessionID string, force boo
 		}
 	}
 	p.mu.Lock()
-	session, ok := p.signalSessions[sessionID]
-	if !ok {
-		p.mu.Unlock()
-		logger.Warn("signal runtime session not found")
-		return domain.SignalRuntimeSession{}, fmt.Errorf("signal runtime session not found: %s", sessionID)
-	}
-	cancel, running := p.signalRun[sessionID]
-	if running {
-		delete(p.signalRun, sessionID)
-	}
+	run, running := p.signalRun[sessionID]
+	p.mu.Unlock()
+	session := existing
 	now := time.Now().UTC()
 	state := cloneMetadata(session.State)
 	state["health"] = "stopped"
@@ -275,10 +354,24 @@ func (p *Platform) StopSignalRuntimeSessionWithForce(sessionID string, force boo
 	session.Status = "STOPPED"
 	session.State = state
 	session.UpdatedAt = now
+	updatedSession, updateErr := p.store.UpdateSignalRuntimeSession(session)
+	if updateErr != nil {
+		if !isSignalRuntimeSessionNotFoundError(updateErr) {
+			logger.Warn("persist signal runtime session stop failed", "error", updateErr)
+			return domain.SignalRuntimeSession{}, updateErr
+		}
+		logger.Warn("persist signal runtime session stop missed store row; using cache-only session", "error", updateErr)
+	} else {
+		session = updatedSession
+	}
+	p.mu.Lock()
+	if running {
+		delete(p.signalRun, sessionID)
+	}
 	p.signalSessions[session.ID] = session
 	p.mu.Unlock()
 	if running {
-		cancel()
+		run.cancel()
 	}
 	p.logger("service.signal_runtime",
 		"session_id", session.ID,
@@ -385,30 +478,80 @@ func (p *Platform) DeleteSignalRuntimeSessionWithForce(sessionID string, force b
 			return err
 		}
 	}
+	if err := p.store.DeleteSignalRuntimeSession(sessionID); err != nil && !isSignalRuntimeSessionNotFoundError(err) {
+		return err
+	}
 	p.mu.Lock()
-	defer p.mu.Unlock()
-	cancel, running := p.signalRun[sessionID]
+	run, running := p.signalRun[sessionID]
 	if running {
 		delete(p.signalRun, sessionID)
-		cancel()
-	}
-	if _, exists := p.signalSessions[sessionID]; !exists {
-		return fmt.Errorf("signal runtime session not found: %s", sessionID)
 	}
 	delete(p.signalSessions, sessionID)
+	p.mu.Unlock()
+	if running {
+		run.cancel()
+	}
 	return nil
 }
 
 func (p *Platform) updateSignalRuntimeSessionState(sessionID string, updater func(session *domain.SignalRuntimeSession)) error {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	session, ok := p.signalSessions[sessionID]
-	if !ok {
-		return fmt.Errorf("signal runtime session not found: %s", sessionID)
+	session, err := p.GetSignalRuntimeSession(sessionID)
+	if err != nil {
+		return err
 	}
 	updater(&session)
-	p.signalSessions[sessionID] = session
+	session.UpdatedAt = time.Now().UTC()
+	updated, updateErr := p.store.UpdateSignalRuntimeSession(session)
+	if updateErr != nil {
+		if isSignalRuntimeSessionNotFoundError(updateErr) {
+			p.cacheSignalRuntimeSession(session)
+			return nil
+		}
+		return updateErr
+	}
+	p.cacheSignalRuntimeSession(updated)
 	return nil
+}
+
+func (p *Platform) cacheSignalRuntimeSession(session domain.SignalRuntimeSession) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.signalSessions[session.ID] = session
+}
+
+func isSignalRuntimeSessionNotFoundError(err error) bool {
+	return errors.Is(err, store.ErrSignalRuntimeSessionNotFound)
+}
+
+func (p *Platform) clearSignalRuntimeRun(sessionID string, run *signalRuntimeRun) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if current := p.signalRun[sessionID]; current == run {
+		delete(p.signalRun, sessionID)
+		return true
+	}
+	return false
+}
+
+func (p *Platform) persistSignalRuntimeStoppedAfterStartCancel(session domain.SignalRuntimeSession) {
+	now := time.Now().UTC()
+	state := cloneMetadata(session.State)
+	state["health"] = "stopped"
+	state["stoppedAt"] = now.Format(time.RFC3339)
+	state["lastHeartbeatAt"] = now.Format(time.RFC3339)
+	state["lastEventAt"] = now.Format(time.RFC3339)
+	state["lastEventSummary"] = map[string]any{
+		"type":    "runtime_start_cancelled",
+		"message": "signal runtime start cancelled before runner was launched",
+	}
+	session.Status = "STOPPED"
+	session.State = state
+	session.UpdatedAt = now
+	if updated, err := p.store.UpdateSignalRuntimeSession(session); err == nil {
+		p.cacheSignalRuntimeSession(updated)
+		return
+	}
+	p.cacheSignalRuntimeSession(session)
 }
 
 func (p *Platform) removeSignalRuntimeRunner(sessionID string) {

--- a/internal/service/signal_runtime_sessions_persistence_test.go
+++ b/internal/service/signal_runtime_sessions_persistence_test.go
@@ -1,0 +1,165 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/wuyaocheng/bktrader/internal/domain"
+	"github.com/wuyaocheng/bktrader/internal/store/memory"
+)
+
+func TestGetSignalRuntimeSessionRestoresCacheFromStore(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	runtimeSession, err := platform.CreateSignalRuntimeSession("live-main", "strategy-bk-1d")
+	if err != nil {
+		t.Fatalf("CreateSignalRuntimeSession failed: %v", err)
+	}
+	platform.mu.Lock()
+	platform.signalSessions = map[string]domain.SignalRuntimeSession{}
+	platform.mu.Unlock()
+
+	restored, err := platform.GetSignalRuntimeSession(runtimeSession.ID)
+	if err != nil {
+		t.Fatalf("GetSignalRuntimeSession failed: %v", err)
+	}
+	if restored.ID != runtimeSession.ID {
+		t.Fatalf("expected restored runtime id %q, got %q", runtimeSession.ID, restored.ID)
+	}
+	platform.mu.Lock()
+	_, cached := platform.signalSessions[runtimeSession.ID]
+	platform.mu.Unlock()
+	if !cached {
+		t.Fatal("expected persisted runtime session to be cached after get")
+	}
+}
+
+func TestSyncLiveSessionRuntimeReusesPersistedRuntimeAfterCacheMiss(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	if _, err := platform.BindStrategySignalSource("strategy-bk-1d", map[string]any{
+		"sourceKey": "binance-kline",
+		"role":      "signal",
+		"symbol":    "BTCUSDT",
+		"options":   map[string]any{"timeframe": "30m"},
+	}); err != nil {
+		t.Fatalf("bind strategy signal source failed: %v", err)
+	}
+	runtimeSession, err := platform.CreateSignalRuntimeSession("live-main", "strategy-bk-1d")
+	if err != nil {
+		t.Fatalf("CreateSignalRuntimeSession failed: %v", err)
+	}
+	liveSession, err := platform.store.GetLiveSession("live-session-main")
+	if err != nil {
+		t.Fatalf("GetLiveSession failed: %v", err)
+	}
+	state := cloneMetadata(liveSession.State)
+	state["signalRuntimeSessionId"] = runtimeSession.ID
+	liveSession, err = platform.store.UpdateLiveSessionState(liveSession.ID, state)
+	if err != nil {
+		t.Fatalf("UpdateLiveSessionState failed: %v", err)
+	}
+
+	platform.mu.Lock()
+	platform.signalSessions = map[string]domain.SignalRuntimeSession{}
+	platform.mu.Unlock()
+
+	updated, err := platform.syncLiveSessionRuntime(liveSession)
+	if err != nil {
+		t.Fatalf("syncLiveSessionRuntime failed: %v", err)
+	}
+	if got := stringValue(updated.State["signalRuntimeSessionId"]); got != runtimeSession.ID {
+		t.Fatalf("expected persisted runtime id %q to be reused, got %q", runtimeSession.ID, got)
+	}
+	if got := stringValue(updated.State["signalRuntimeStatus"]); got != runtimeSession.Status {
+		t.Fatalf("expected restored runtime status %q, got %q", runtimeSession.Status, got)
+	}
+}
+
+func TestStartSignalRuntimeSessionSingleFlightsConcurrentStarts(t *testing.T) {
+	store := &blockingSignalRuntimeStore{
+		Store:   memory.NewStore(),
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	platform := NewPlatform(store)
+	runtimeSession, err := platform.CreateSignalRuntimeSession("live-main", "strategy-bk-1d")
+	if err != nil {
+		t.Fatalf("CreateSignalRuntimeSession failed: %v", err)
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := platform.StartSignalRuntimeSession(runtimeSession.ID)
+		errCh <- err
+	}()
+	<-store.entered
+
+	if _, err := platform.StartSignalRuntimeSession(runtimeSession.ID); err != nil {
+		t.Fatalf("second StartSignalRuntimeSession should return existing in-flight runtime: %v", err)
+	}
+	close(store.release)
+	if err := <-errCh; err != nil {
+		t.Fatalf("first StartSignalRuntimeSession failed: %v", err)
+	}
+	if got := store.runningUpdates.Load(); got != 1 {
+		t.Fatalf("expected one persisted RUNNING transition, got %d", got)
+	}
+	_, _ = platform.StopSignalRuntimeSessionWithForce(runtimeSession.ID, true)
+}
+
+func TestDeleteSignalRuntimeSessionKeepsRunnerWhenStoreDeleteFails(t *testing.T) {
+	store := &deleteFailSignalRuntimeStore{Store: memory.NewStore()}
+	platform := NewPlatform(store)
+	runtimeSession, err := platform.CreateSignalRuntimeSession("live-main", "strategy-bk-1d")
+	if err != nil {
+		t.Fatalf("CreateSignalRuntimeSession failed: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	run := &signalRuntimeRun{ctx: ctx, cancel: cancel}
+	platform.mu.Lock()
+	platform.signalRun[runtimeSession.ID] = run
+	platform.signalSessions[runtimeSession.ID] = runtimeSession
+	platform.mu.Unlock()
+
+	if err := platform.DeleteSignalRuntimeSessionWithForce(runtimeSession.ID, true); err == nil {
+		t.Fatal("expected delete failure")
+	}
+	platform.mu.Lock()
+	_, stillRunning := platform.signalRun[runtimeSession.ID]
+	_, stillCached := platform.signalSessions[runtimeSession.ID]
+	platform.mu.Unlock()
+	if !stillRunning || !stillCached {
+		t.Fatal("expected local runner/cache to remain when store delete fails")
+	}
+	if ctx.Err() != nil {
+		t.Fatalf("expected runner context to remain active, got %v", ctx.Err())
+	}
+}
+
+type blockingSignalRuntimeStore struct {
+	*memory.Store
+	entered        chan struct{}
+	release        chan struct{}
+	enteredOnce    sync.Once
+	runningUpdates atomic.Int32
+}
+
+func (s *blockingSignalRuntimeStore) UpdateSignalRuntimeSession(session domain.SignalRuntimeSession) (domain.SignalRuntimeSession, error) {
+	if session.Status == "RUNNING" {
+		s.runningUpdates.Add(1)
+		s.enteredOnce.Do(func() { close(s.entered) })
+		<-s.release
+	}
+	return s.Store.UpdateSignalRuntimeSession(session)
+}
+
+type deleteFailSignalRuntimeStore struct {
+	*memory.Store
+}
+
+func (s *deleteFailSignalRuntimeStore) DeleteSignalRuntimeSession(string) error {
+	return errors.New("delete failed")
+}

--- a/internal/store/memory/signal_runtime_sessions_test.go
+++ b/internal/store/memory/signal_runtime_sessions_test.go
@@ -1,0 +1,115 @@
+package memory
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/wuyaocheng/bktrader/internal/domain"
+)
+
+func TestSignalRuntimeSessionCRUD(t *testing.T) {
+	store := NewStore()
+	now := time.Now().UTC()
+	session := domain.SignalRuntimeSession{
+		ID:              "signal-runtime-test",
+		AccountID:       "live-main",
+		StrategyID:      "strategy-bk-1d",
+		Status:          "READY",
+		RuntimeAdapter:  "binance-futures",
+		Transport:       "websocket",
+		SubscriptionCnt: 1,
+		State:           map[string]any{"health": "idle"},
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+
+	created, err := store.CreateSignalRuntimeSession(session)
+	if err != nil {
+		t.Fatalf("CreateSignalRuntimeSession failed: %v", err)
+	}
+	if created.ID != session.ID {
+		t.Fatalf("expected created id %q, got %q", session.ID, created.ID)
+	}
+
+	created.Status = "RUNNING"
+	created.State["health"] = "healthy"
+	updated, err := store.UpdateSignalRuntimeSession(created)
+	if err != nil {
+		t.Fatalf("UpdateSignalRuntimeSession failed: %v", err)
+	}
+	if updated.Status != "RUNNING" || updated.State["health"] != "healthy" {
+		t.Fatalf("expected updated runtime session, got %#v", updated)
+	}
+
+	items, err := store.ListSignalRuntimeSessions()
+	if err != nil {
+		t.Fatalf("ListSignalRuntimeSessions failed: %v", err)
+	}
+	if len(items) != 1 || items[0].ID != session.ID {
+		t.Fatalf("expected one listed session %q, got %#v", session.ID, items)
+	}
+
+	if err := store.DeleteSignalRuntimeSession(session.ID); err != nil {
+		t.Fatalf("DeleteSignalRuntimeSession failed: %v", err)
+	}
+	if _, err := store.GetSignalRuntimeSession(session.ID); err == nil {
+		t.Fatal("expected deleted runtime session to be missing")
+	}
+}
+
+func TestCreateSignalRuntimeSessionUpsertsAccountStrategyIdentity(t *testing.T) {
+	store := NewStore()
+	first := domain.SignalRuntimeSession{
+		ID:         "signal-runtime-first",
+		AccountID:  "live-main",
+		StrategyID: "strategy-bk-1d",
+		Status:     "READY",
+		State:      map[string]any{"health": "idle", "plan": map[string]any{"version": "old"}},
+		CreatedAt:  time.Now().UTC(),
+		UpdatedAt:  time.Now().UTC(),
+	}
+	second := first
+	second.ID = "signal-runtime-second"
+	second.Status = "RUNNING"
+	second.RuntimeAdapter = "binance-market-ws"
+	second.Transport = "websocket"
+	second.SubscriptionCnt = 2
+	second.State = map[string]any{"health": "healthy", "plan": map[string]any{"version": "new"}}
+	second.UpdatedAt = first.UpdatedAt.Add(time.Minute)
+
+	created, err := store.CreateSignalRuntimeSession(first)
+	if err != nil {
+		t.Fatalf("CreateSignalRuntimeSession first failed: %v", err)
+	}
+	reused, err := store.CreateSignalRuntimeSession(second)
+	if err != nil {
+		t.Fatalf("CreateSignalRuntimeSession second failed: %v", err)
+	}
+	if reused.ID != created.ID {
+		t.Fatalf("expected duplicate account+strategy to reuse %q, got %q", created.ID, reused.ID)
+	}
+	if reused.Status != "RUNNING" || reused.RuntimeAdapter != "binance-market-ws" || reused.SubscriptionCnt != 2 {
+		t.Fatalf("expected duplicate account+strategy to update runtime fields, got %#v", reused)
+	}
+	plan := reused.State["plan"].(map[string]any)
+	if plan["version"] != "new" {
+		t.Fatalf("expected duplicate account+strategy to update plan state, got %#v", reused.State)
+	}
+}
+
+func TestCreateSignalRuntimeSessionRejectsInvalidStateJSON(t *testing.T) {
+	store := NewStore()
+	_, err := store.CreateSignalRuntimeSession(domain.SignalRuntimeSession{
+		ID:         "signal-runtime-invalid",
+		AccountID:  "live-main",
+		StrategyID: "strategy-bk-1d",
+		Status:     "READY",
+		State:      map[string]any{"bad": math.NaN()},
+		CreatedAt:  time.Now().UTC(),
+		UpdatedAt:  time.Now().UTC(),
+	})
+	if err == nil {
+		t.Fatal("expected NaN state to fail JSON persistence")
+	}
+}

--- a/internal/store/memory/store.go
+++ b/internal/store/memory/store.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/wuyaocheng/bktrader/internal/domain"
+	storepkg "github.com/wuyaocheng/bktrader/internal/store"
 )
 
 type Store struct {
@@ -23,6 +24,7 @@ type Store struct {
 	backtests          map[string]domain.BacktestRun
 	paperSessions      map[string]domain.PaperSession
 	liveSessions       map[string]domain.LiveSession
+	signalRuntime      map[string]domain.SignalRuntimeSession
 	equitySnapshots    map[string][]domain.AccountEquitySnapshot
 	decisionEvents     []domain.StrategyDecisionEvent
 	executionEvents    []domain.OrderExecutionEvent
@@ -51,6 +53,7 @@ func NewStore() *Store {
 		backtests:          make(map[string]domain.BacktestRun),
 		paperSessions:      make(map[string]domain.PaperSession),
 		liveSessions:       make(map[string]domain.LiveSession),
+		signalRuntime:      make(map[string]domain.SignalRuntimeSession),
 		equitySnapshots:    make(map[string][]domain.AccountEquitySnapshot),
 		liveSnapshots:      make([]domain.PositionAccountSnapshot, 0),
 		marketBars:         make(map[string]domain.MarketBar),
@@ -954,6 +957,91 @@ func (s *Store) UpdateLiveSessionState(sessionID string, state map[string]any) (
 	item.State = state
 	s.liveSessions[sessionID] = item
 	return item, nil
+}
+
+func (s *Store) ListSignalRuntimeSessions() ([]domain.SignalRuntimeSession, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	items := make([]domain.SignalRuntimeSession, 0, len(s.signalRuntime))
+	for _, item := range s.signalRuntime {
+		items = append(items, cloneJSONValue(item))
+	}
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].UpdatedAt.Equal(items[j].UpdatedAt) {
+			return items[i].ID < items[j].ID
+		}
+		return items[i].UpdatedAt.After(items[j].UpdatedAt)
+	})
+	return items, nil
+}
+
+func (s *Store) GetSignalRuntimeSession(sessionID string) (domain.SignalRuntimeSession, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	item, ok := s.signalRuntime[sessionID]
+	if !ok {
+		return domain.SignalRuntimeSession{}, fmt.Errorf("%w: %s", storepkg.ErrSignalRuntimeSessionNotFound, sessionID)
+	}
+	return cloneJSONValue(item), nil
+}
+
+func (s *Store) CreateSignalRuntimeSession(session domain.SignalRuntimeSession) (domain.SignalRuntimeSession, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if strings.TrimSpace(session.Status) == "" {
+		return domain.SignalRuntimeSession{}, fmt.Errorf("signal runtime session status is required")
+	}
+	for _, existing := range s.signalRuntime {
+		if existing.AccountID == session.AccountID && existing.StrategyID == session.StrategyID {
+			session.ID = existing.ID
+			session.CreatedAt = existing.CreatedAt
+			if session.UpdatedAt.IsZero() {
+				session.UpdatedAt = time.Now().UTC()
+			}
+			session = cloneJSONValue(session)
+			s.signalRuntime[session.ID] = session
+			return cloneJSONValue(session), nil
+		}
+	}
+	if _, err := json.Marshal(session.State); err != nil {
+		return domain.SignalRuntimeSession{}, fmt.Errorf("failed to marshal signal runtime session state: %w", err)
+	}
+	if session.CreatedAt.IsZero() {
+		session.CreatedAt = time.Now().UTC()
+	}
+	if session.UpdatedAt.IsZero() {
+		session.UpdatedAt = session.CreatedAt
+	}
+	session = cloneJSONValue(session)
+	s.signalRuntime[session.ID] = session
+	return cloneJSONValue(session), nil
+}
+
+func (s *Store) UpdateSignalRuntimeSession(session domain.SignalRuntimeSession) (domain.SignalRuntimeSession, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if strings.TrimSpace(session.Status) == "" {
+		return domain.SignalRuntimeSession{}, fmt.Errorf("signal runtime session status is required")
+	}
+	if _, ok := s.signalRuntime[session.ID]; !ok {
+		return domain.SignalRuntimeSession{}, fmt.Errorf("%w: %s", storepkg.ErrSignalRuntimeSessionNotFound, session.ID)
+	}
+	if _, err := json.Marshal(session.State); err != nil {
+		return domain.SignalRuntimeSession{}, fmt.Errorf("failed to marshal signal runtime session state: %w", err)
+	}
+	session = cloneJSONValue(session)
+	s.signalRuntime[session.ID] = session
+	return cloneJSONValue(session), nil
+}
+
+func (s *Store) DeleteSignalRuntimeSession(sessionID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.signalRuntime[sessionID]; !ok {
+		return fmt.Errorf("%w: %s", storepkg.ErrSignalRuntimeSessionNotFound, sessionID)
+	}
+	delete(s.signalRuntime, sessionID)
+	return nil
 }
 
 func (s *Store) ListAccountEquitySnapshots(query domain.AccountEquitySnapshotQuery) ([]domain.AccountEquitySnapshot, error) {

--- a/internal/store/postgres/signal_runtime_sessions_test.go
+++ b/internal/store/postgres/signal_runtime_sessions_test.go
@@ -1,0 +1,79 @@
+package postgres
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/wuyaocheng/bktrader/internal/domain"
+)
+
+func TestSignalRuntimeSessionCreateUpsertsPlanState(t *testing.T) {
+	dsn := os.Getenv("BKTRADER_TEST_POSTGRES_DSN")
+	if dsn == "" {
+		t.Skip("BKTRADER_TEST_POSTGRES_DSN is not set")
+	}
+	if err := Migrate(dsn); err != nil {
+		t.Fatalf("Migrate failed: %v", err)
+	}
+	store, err := New(dsn)
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	defer store.Close()
+
+	account, err := store.CreateAccount("Runtime Upsert Test", "LIVE", "binance-futures")
+	if err != nil {
+		t.Fatalf("CreateAccount failed: %v", err)
+	}
+	strategy, err := store.CreateStrategy("runtime-upsert-test", "runtime upsert test", map[string]any{
+		"strategyEngine": "bk-default",
+	})
+	if err != nil {
+		t.Fatalf("CreateStrategy failed: %v", err)
+	}
+	strategyID := strategy["id"].(string)
+	now := time.Now().UTC()
+
+	first, err := store.CreateSignalRuntimeSession(domain.SignalRuntimeSession{
+		ID:              "signal-runtime-pg-first-" + now.Format("20060102150405.000000000"),
+		AccountID:       account.ID,
+		StrategyID:      strategyID,
+		Status:          "READY",
+		RuntimeAdapter:  "old-adapter",
+		Transport:       "websocket",
+		SubscriptionCnt: 1,
+		State:           map[string]any{"plan": map[string]any{"version": "old"}},
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	})
+	if err != nil {
+		t.Fatalf("CreateSignalRuntimeSession first failed: %v", err)
+	}
+
+	second, err := store.CreateSignalRuntimeSession(domain.SignalRuntimeSession{
+		ID:              "signal-runtime-pg-second-" + now.Format("20060102150405.000000000"),
+		AccountID:       account.ID,
+		StrategyID:      strategyID,
+		Status:          "RUNNING",
+		RuntimeAdapter:  "new-adapter",
+		Transport:       "websocket",
+		SubscriptionCnt: 2,
+		State:           map[string]any{"plan": map[string]any{"version": "new"}},
+		CreatedAt:       now.Add(time.Second),
+		UpdatedAt:       now.Add(time.Second),
+	})
+	if err != nil {
+		t.Fatalf("CreateSignalRuntimeSession second failed: %v", err)
+	}
+	if second.ID != first.ID {
+		t.Fatalf("expected upsert to preserve runtime identity %q, got %q", first.ID, second.ID)
+	}
+	if second.Status != "RUNNING" || second.RuntimeAdapter != "new-adapter" || second.SubscriptionCnt != 2 {
+		t.Fatalf("expected upserted runtime fields, got %#v", second)
+	}
+	plan := second.State["plan"].(map[string]any)
+	if plan["version"] != "new" {
+		t.Fatalf("expected upserted plan state, got %#v", second.State)
+	}
+}

--- a/internal/store/postgres/store.go
+++ b/internal/store/postgres/store.go
@@ -13,6 +13,7 @@ import (
 	_ "github.com/lib/pq"
 
 	"github.com/wuyaocheng/bktrader/internal/domain"
+	storepkg "github.com/wuyaocheng/bktrader/internal/store"
 )
 
 type Store struct {
@@ -1321,6 +1322,124 @@ func (s *Store) UpdateLiveSessionState(sessionID string, state map[string]any) (
 	return s.GetLiveSession(sessionID)
 }
 
+func (s *Store) ListSignalRuntimeSessions() ([]domain.SignalRuntimeSession, error) {
+	rows, err := s.db.Query(`
+		select id, account_id, strategy_id, status, runtime_adapter, transport, subscription_count, state, created_at, updated_at
+		from signal_runtime_sessions
+		order by updated_at desc, id asc
+	`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	items := []domain.SignalRuntimeSession{}
+	for rows.Next() {
+		item, err := scanSignalRuntimeSession(rows)
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, item)
+	}
+	return items, rows.Err()
+}
+
+func (s *Store) GetSignalRuntimeSession(sessionID string) (domain.SignalRuntimeSession, error) {
+	row := s.db.QueryRow(`
+		select id, account_id, strategy_id, status, runtime_adapter, transport, subscription_count, state, created_at, updated_at
+		from signal_runtime_sessions
+		where id = $1
+	`, sessionID)
+	item, err := scanSignalRuntimeSession(row)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return domain.SignalRuntimeSession{}, fmt.Errorf("%w: %s", storepkg.ErrSignalRuntimeSessionNotFound, sessionID)
+		}
+		return domain.SignalRuntimeSession{}, err
+	}
+	return item, nil
+}
+
+func (s *Store) CreateSignalRuntimeSession(item domain.SignalRuntimeSession) (domain.SignalRuntimeSession, error) {
+	if strings.TrimSpace(item.Status) == "" {
+		return domain.SignalRuntimeSession{}, fmt.Errorf("signal runtime session status is required")
+	}
+	if item.CreatedAt.IsZero() {
+		item.CreatedAt = time.Now().UTC()
+	}
+	if item.UpdatedAt.IsZero() {
+		item.UpdatedAt = item.CreatedAt
+	}
+	stateRaw, err := json.Marshal(item.State)
+	if err != nil {
+		return domain.SignalRuntimeSession{}, fmt.Errorf("failed to marshal signal runtime session state: %w", err)
+	}
+	row := s.db.QueryRow(`
+		insert into signal_runtime_sessions (
+			id, account_id, strategy_id, status, runtime_adapter, transport, subscription_count, state, created_at, updated_at
+		)
+		values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+		on conflict (account_id, strategy_id) do update set
+			status = excluded.status,
+			runtime_adapter = excluded.runtime_adapter,
+			transport = excluded.transport,
+			subscription_count = excluded.subscription_count,
+			state = excluded.state,
+			updated_at = excluded.updated_at
+		returning id, account_id, strategy_id, status, runtime_adapter, transport, subscription_count, state, created_at, updated_at
+	`, item.ID, item.AccountID, item.StrategyID, item.Status, item.RuntimeAdapter, item.Transport, item.SubscriptionCnt, stateRaw, item.CreatedAt, item.UpdatedAt)
+	return scanSignalRuntimeSession(row)
+}
+
+func (s *Store) UpdateSignalRuntimeSession(item domain.SignalRuntimeSession) (domain.SignalRuntimeSession, error) {
+	if strings.TrimSpace(item.Status) == "" {
+		return domain.SignalRuntimeSession{}, fmt.Errorf("signal runtime session status is required")
+	}
+	if item.UpdatedAt.IsZero() {
+		item.UpdatedAt = time.Now().UTC()
+	}
+	stateRaw, err := json.Marshal(item.State)
+	if err != nil {
+		return domain.SignalRuntimeSession{}, fmt.Errorf("failed to marshal signal runtime session state: %w", err)
+	}
+	row := s.db.QueryRow(`
+		update signal_runtime_sessions
+		set account_id = $2,
+			strategy_id = $3,
+			status = $4,
+			runtime_adapter = $5,
+			transport = $6,
+			subscription_count = $7,
+			state = $8,
+			updated_at = $9
+		where id = $1
+		returning id, account_id, strategy_id, status, runtime_adapter, transport, subscription_count, state, created_at, updated_at
+	`, item.ID, item.AccountID, item.StrategyID, item.Status, item.RuntimeAdapter, item.Transport, item.SubscriptionCnt, stateRaw, item.UpdatedAt)
+	updated, err := scanSignalRuntimeSession(row)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return domain.SignalRuntimeSession{}, fmt.Errorf("%w: %s", storepkg.ErrSignalRuntimeSessionNotFound, item.ID)
+		}
+		return domain.SignalRuntimeSession{}, err
+	}
+	return updated, nil
+}
+
+func (s *Store) DeleteSignalRuntimeSession(sessionID string) error {
+	result, err := s.db.Exec(`delete from signal_runtime_sessions where id = $1`, sessionID)
+	if err != nil {
+		return err
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rows == 0 {
+		return fmt.Errorf("%w: %s", storepkg.ErrSignalRuntimeSessionNotFound, sessionID)
+	}
+	return nil
+}
+
 func (s *Store) ListAccountEquitySnapshots(query domain.AccountEquitySnapshotQuery) ([]domain.AccountEquitySnapshot, error) {
 	args := []any{query.AccountID}
 	filters := []string{"account_id = $1"}
@@ -2245,6 +2364,32 @@ func nullIfEmpty(v string) any {
 		return nil
 	}
 	return v
+}
+
+type signalRuntimeScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanSignalRuntimeSession(scanner signalRuntimeScanner) (domain.SignalRuntimeSession, error) {
+	var item domain.SignalRuntimeSession
+	var stateRaw []byte
+	err := scanner.Scan(
+		&item.ID,
+		&item.AccountID,
+		&item.StrategyID,
+		&item.Status,
+		&item.RuntimeAdapter,
+		&item.Transport,
+		&item.SubscriptionCnt,
+		&stateRaw,
+		&item.CreatedAt,
+		&item.UpdatedAt,
+	)
+	if err != nil {
+		return domain.SignalRuntimeSession{}, err
+	}
+	item.State = unmarshalJSONMap(stateRaw)
+	return item, nil
 }
 
 func marshalJSONValue(value any) []byte {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -3,10 +3,13 @@
 package store
 
 import (
+	"errors"
 	"time"
 
 	"github.com/wuyaocheng/bktrader/internal/domain"
 )
+
+var ErrSignalRuntimeSessionNotFound = errors.New("signal runtime session not found")
 
 // Repository 定义平台的数据持久化接口。
 // 支持可插拔的后端实现（memory/postgres），通过 STORE_BACKEND 配置切换。
@@ -114,6 +117,19 @@ type Repository interface {
 	UpdateLiveSessionStatus(sessionID, status string) (domain.LiveSession, error)
 	// UpdateLiveSessionState 更新实盘策略会话运行时状态。
 	UpdateLiveSessionState(sessionID string, state map[string]any) (domain.LiveSession, error)
+
+	// --- Signal runtime 会话 ---
+
+	// ListSignalRuntimeSessions 获取所有 signal runtime 会话。
+	ListSignalRuntimeSessions() ([]domain.SignalRuntimeSession, error)
+	// GetSignalRuntimeSession 根据 ID 获取单个 signal runtime 会话。
+	GetSignalRuntimeSession(sessionID string) (domain.SignalRuntimeSession, error)
+	// CreateSignalRuntimeSession 创建 signal runtime 会话；同一 account+strategy 已存在时返回现有会话。
+	CreateSignalRuntimeSession(session domain.SignalRuntimeSession) (domain.SignalRuntimeSession, error)
+	// UpdateSignalRuntimeSession 更新 signal runtime 会话。
+	UpdateSignalRuntimeSession(session domain.SignalRuntimeSession) (domain.SignalRuntimeSession, error)
+	// DeleteSignalRuntimeSession 删除 signal runtime 会话。
+	DeleteSignalRuntimeSession(sessionID string) error
 
 	// --- 净值快照 ---
 


### PR DESCRIPTION
## 目的
Closes #200. Part of parent #199.

Persist signal runtime session identity/state/subscription plan so `Platform.signalSessions` becomes a hot cache instead of the only source of truth. This prevents live sessions from losing a previously linked `signalRuntimeSessionId` after process restart or cache miss.

Root cause: signal runtime sessions only lived in memory, and `syncLiveSessionRuntime` cleared the linked runtime id when the cache missed.

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [x] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) — 无变化，仍保持 `manual-review` 默认。
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？— 无。
- [x] DB migration 是否具备向下兼容幂等性？— 使用 `create table/index if not exists`。
- [x] 配置字段有没有无意被混改？— 无配置字段改动。

## 修改点
- 新增 `signal_runtime_sessions` migration，持久化 runtime identity/status/adapter/transport/subscription count/state。
- 扩展 `store.Repository`，实现 memory/postgres runtime session CRUD。
- 改造 signal runtime session create/list/get/start/stop/delete/state update：store 成功后更新内存缓存；cache miss 可从 store restore。
- 改造 `syncLiveSessionRuntime` 的 cache miss 语义：只有 hot cache 和 store 都找不到时才清除 linked runtime id。
- 更新 `docs/runtime-runner-issue-199-workplan.md`，标记 #200 / PR #220 当前完成与待 review/merge 状态。

## Review 修复
- Create 改为真 upsert：同一 account+strategy 保留 runtime identity，但刷新 status/runtime adapter/transport/subscription count/state/updated_at，避免旧 plan 被继续使用。
- Start 改为 mutex 下运行占位 single-flight，避免并发 start 双写 RUNNING 状态；失败时清理占位。
- Delete 改为 store 删除成功后再取消本地 runner，避免 DB 失败时出现本地误判未运行的窗口。
- not-found 判断改为 typed error：`store.ErrSignalRuntimeSessionNotFound`。
- 补 Postgres upsert 语义测试、并发 start 单飞测试、delete 失败不取消 runner 测试。

## 行为变化
- 新进程内存为空但 DB 仍有 runtime session 时，live session 会复用旧 `signalRuntimeSessionId`。
- `Platform.signalSessions` 现在是 hot cache；DB/store 是 signal runtime session identity/state 的持久层。
- 不引入 NATS/JetStream，不新增 runner，不改变 live evaluation callback、dispatch、reconcile/recovery gate 或 final submit payload。

## 验证方式与测试证据
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

已运行：
- `git diff --check -- ...`
- `go test ./internal/store/... ./internal/service -count=1`
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
