### PR TITLE
[codex] Add signal runtime runner role (#203)

### DIFF
--- a/cmd/platform-worker/main.go
+++ b/cmd/platform-worker/main.go
@@ -36,7 +36,7 @@ func main() {
 	}
 
 	switch role {
-	case "live-runner", "notification-worker":
+	case "live-runner", "signal-runtime-runner", "notification-worker":
 	default:
 		_, _ = fmt.Fprintf(os.Stderr, "platform-worker 不支持 BKTRADER_ROLE=%s\n", role)
 		os.Exit(1)

--- a/docs/runtime-runner-issue-199-workplan.md
+++ b/docs/runtime-runner-issue-199-workplan.md
@@ -173,8 +173,8 @@ Issue: [#203](https://github.com/folgercn/bktrader/issues/203)
 状态：
 
 - 🟡 **进行中（2026-04-26）**：分支 `codex/issue-203-signal-runtime-runner`，复用 worktree `/Users/fujun/node/bktrader-issue-202`。
-- ✅ 已完成：新增 `BKTRADER_ROLE=signal-runtime-runner` 校验、`platform-worker` role 支持、runtime option 映射、signal runtime scanner、`desiredStatus` / `actualStatus` 轻量状态标记。
-- ✅ 已覆盖测试：role option mapping、`signal-runtime-runner` 不启动 live recovery/sync/consumer、`live-runner` 不启动 WS scanner/market warmup、config validation、`RuntimeActionsEnabled=false`、scanner 只启动 desired running session。
+- ✅ 已完成：新增 `BKTRADER_ROLE=signal-runtime-runner` 校验、`platform-worker` role 支持、runtime option 映射、signal runtime scanner、`desiredStatus` / `actualStatus` 轻量状态标记、ERROR 会话自动重启熔断。
+- ✅ 已覆盖测试：role option mapping、`signal-runtime-runner` 不启动 live recovery/sync/consumer、`live-runner` 不启动 WS scanner/market warmup、config validation、`RuntimeActionsEnabled=false`、scanner 只启动 desired running session、scanner 不重启 ERROR 会话、start cancel 清理 desired/actual。
 - 🟡 待 review：本 PR 不改 deployments / compose；Step 5 lease 前仍要求单实例部署 `signal-runtime-runner`。
 
 目标：

--- a/docs/runtime-runner-issue-199-workplan.md
+++ b/docs/runtime-runner-issue-199-workplan.md
@@ -88,10 +88,10 @@ Issue: [#201](https://github.com/folgercn/bktrader/issues/201)
 
 状态：
 
-- 🟡 **进行中（2026-04-26）**：已新开分支 `codex/issue-201-runtime-event-bus`。
+- ✅ **PR 已合并（2026-04-26）**：[#221 Add runtime event bus publisher (#201)](https://github.com/folgercn/bktrader/pull/221)。
 - ✅ 已完成：runtime event envelope、stable `id` / `fingerprint`、in-memory fake publisher、NATS JetStream publisher、`BKT_RUNTIME_EVENTS` stream/subject 配置（`LimitsPolicy` 广播/日志流语义）、WebSocket 路径 side-publish、publish 失败日志/状态记录、tick event 每 symbol 每秒节流。
 - ✅ 已覆盖测试：envelope 字段完整、signal bar fingerprint 不含 receive/create time、duplicate idempotency、stream/subject 配置、publish 失败不阻塞并记录状态。
-- 🟡 待 review：本 PR 不改 deployments；`RUNTIME_EVENT_BUS` 默认 `nats`，NATS 不可用时自动降级为 noop，显式设置 `disabled` 可关闭 side-publish。
+- ✅ 已 review：本 PR 不改 deployments；`RUNTIME_EVENT_BUS` 默认 `nats`，NATS 不可用时自动降级为 noop，显式设置 `disabled` 可关闭 side-publish。
 
 目标：
 
@@ -131,10 +131,10 @@ Issue: [#202](https://github.com/folgercn/bktrader/issues/202)
 
 状态：
 
-- 🟡 **进行中（2026-04-26）**：已新开 worktree `/Users/fujun/node/bktrader-issue-202`，分支 `codex/issue-202-live-runner-jetstream-consumer`。
+- ✅ **PR 已合并（2026-04-26）**：[#222 Consume runtime events for live evaluation (#202)](https://github.com/folgercn/bktrader/pull/222)。
 - ✅ 已完成：`SignalRuntimeEventConsumer` handler、NATS pull durable consumer `live-evaluation`、success ack / failure nak、stale event drop、live-runner / monolith 启动 consumer、consumer 启用后关闭 WS direct live evaluation、复用现有 live evaluation fanout。
 - ✅ 已覆盖测试：consumer config、event 触发 live evaluation happy path、duplicate delivery 幂等、WS direct + consumer 双入口防护、stale event ack/drop、failure 不 ack。
-- 🟡 待 review：本 PR 不改 dispatch/reconcile/recovery gate，不新增独立 `signal-runtime-runner`，不改 deployments。
+- ✅ 已 review：本 PR 不改 dispatch/reconcile/recovery gate，不新增独立 `signal-runtime-runner`，不改 deployments。
 
 目标：
 
@@ -169,6 +169,13 @@ Issue: [#202](https://github.com/folgercn/bktrader/issues/202)
 ### Step 4: #203 新增独立 signal-runtime-runner 进程
 
 Issue: [#203](https://github.com/folgercn/bktrader/issues/203)
+
+状态：
+
+- 🟡 **进行中（2026-04-26）**：分支 `codex/issue-203-signal-runtime-runner`，复用 worktree `/Users/fujun/node/bktrader-issue-202`。
+- ✅ 已完成：新增 `BKTRADER_ROLE=signal-runtime-runner` 校验、`platform-worker` role 支持、runtime option 映射、signal runtime scanner、`desiredStatus` / `actualStatus` 轻量状态标记。
+- ✅ 已覆盖测试：role option mapping、`signal-runtime-runner` 不启动 live recovery/sync/consumer、`live-runner` 不启动 WS scanner/market warmup、config validation、`RuntimeActionsEnabled=false`、scanner 只启动 desired running session。
+- 🟡 待 review：本 PR 不改 deployments / compose；Step 5 lease 前仍要求单实例部署 `signal-runtime-runner`。
 
 目标：
 

--- a/internal/app/server.go
+++ b/internal/app/server.go
@@ -29,6 +29,7 @@ type RuntimeOptions struct {
 	StartLiveSync             bool
 	StartDashboard            bool
 	StartRuntimeEventConsumer bool
+	StartSignalRuntimeScanner bool
 }
 
 func RuntimeOptionsForRole(role string) RuntimeOptions {
@@ -37,10 +38,14 @@ func RuntimeOptionsForRole(role string) RuntimeOptions {
 		return RuntimeOptions{StartDashboard: true}
 	case "live-runner":
 		return RuntimeOptions{
-			WarmLiveMarketData:        true,
 			RecoverLiveTrading:        true,
 			StartLiveSync:             true,
 			StartRuntimeEventConsumer: true,
+		}
+	case "signal-runtime-runner":
+		return RuntimeOptions{
+			WarmLiveMarketData:        true,
+			StartSignalRuntimeScanner: true,
 		}
 	case "notification-worker":
 		return RuntimeOptions{StartTelegram: true}
@@ -52,6 +57,7 @@ func RuntimeOptionsForRole(role string) RuntimeOptions {
 			StartLiveSync:             true,
 			StartDashboard:            true,
 			StartRuntimeEventConsumer: true,
+			StartSignalRuntimeScanner: true,
 		}
 	}
 }
@@ -78,6 +84,7 @@ func NewServerWithRuntimeOptions(cfg config.Config, runtime RuntimeOptions) (*ht
 		"live_sync", runtime.StartLiveSync,
 		"dashboard", runtime.StartDashboard,
 		"runtime_event_consumer", runtime.StartRuntimeEventConsumer,
+		"signal_runtime_scanner", runtime.StartSignalRuntimeScanner,
 	)
 
 	return &http.Server{
@@ -166,6 +173,9 @@ func StartRuntimeComponents(ctx context.Context, platform *service.Platform, cfg
 			return
 		}
 		platform.SetRuntimeEventConsumerEnabled(true)
+	}
+	if runtime.StartSignalRuntimeScanner {
+		platform.StartSignalRuntimeScanner(ctx)
 	}
 }
 

--- a/internal/app/server_test.go
+++ b/internal/app/server_test.go
@@ -1,0 +1,42 @@
+package app
+
+import "testing"
+
+func TestRuntimeOptionsForSignalRuntimeRunner(t *testing.T) {
+	options := RuntimeOptionsForRole("signal-runtime-runner")
+	if !options.WarmLiveMarketData {
+		t.Fatal("expected signal-runtime-runner to warm market data")
+	}
+	if !options.StartSignalRuntimeScanner {
+		t.Fatal("expected signal-runtime-runner to start signal runtime scanner")
+	}
+	if options.RecoverLiveTrading || options.StartLiveSync || options.StartRuntimeEventConsumer || options.StartTelegram || options.StartDashboard {
+		t.Fatalf("expected signal-runtime-runner to avoid live/telegram/dashboard components, got %+v", options)
+	}
+}
+
+func TestRuntimeOptionsForLiveRunnerDoesNotStartSignalRuntimeScanner(t *testing.T) {
+	options := RuntimeOptionsForRole("live-runner")
+	if options.WarmLiveMarketData {
+		t.Fatal("expected live-runner to leave market data warmup to signal-runtime-runner")
+	}
+	if options.StartSignalRuntimeScanner {
+		t.Fatal("expected live-runner not to start signal runtime scanner")
+	}
+	if !options.RecoverLiveTrading || !options.StartLiveSync || !options.StartRuntimeEventConsumer {
+		t.Fatalf("expected live-runner to keep live recovery/sync/event consumer, got %+v", options)
+	}
+}
+
+func TestRuntimeOptionsForMonolithStartAllRuntimeComponents(t *testing.T) {
+	options := RuntimeOptionsForRole("monolith")
+	if !options.WarmLiveMarketData ||
+		!options.StartTelegram ||
+		!options.RecoverLiveTrading ||
+		!options.StartLiveSync ||
+		!options.StartDashboard ||
+		!options.StartRuntimeEventConsumer ||
+		!options.StartSignalRuntimeScanner {
+		t.Fatalf("expected monolith to start all runtime components, got %+v", options)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,7 +18,7 @@ type Config struct {
 	LogRetentionDays               int    // 日志保留天数
 	LogMaxSizeMB                   int    // 单个日志文件滚动前的最大体积（MB）
 	HTTPAddr                       string // HTTP 监听地址
-	ProcessRole                    string // 进程角色：monolith / api / live-runner / notification-worker
+	ProcessRole                    string // 进程角色：monolith / api / live-runner / signal-runtime-runner / notification-worker
 	StoreBackend                   string // 存储后端类型（memory / postgres）
 	AutoMigrate                    bool   // 是否在启动时自动执行数据库迁移
 	PostgresDSN                    string // PostgreSQL 连接字符串
@@ -180,9 +180,9 @@ func (c Config) Validate() error {
 		return fmt.Errorf("HTTP_ADDR 不能为空")
 	}
 	switch strings.ToLower(strings.TrimSpace(c.ProcessRole)) {
-	case "", "monolith", "api", "live-runner", "notification-worker":
+	case "", "monolith", "api", "live-runner", "signal-runtime-runner", "notification-worker":
 	default:
-		return fmt.Errorf("不支持的 BKTRADER_ROLE: %s（可选: monolith, api, live-runner, notification-worker）", c.ProcessRole)
+		return fmt.Errorf("不支持的 BKTRADER_ROLE: %s（可选: monolith, api, live-runner, signal-runtime-runner, notification-worker）", c.ProcessRole)
 	}
 	if c.StoreBackend == "postgres" && c.PostgresDSN == "" {
 		return fmt.Errorf("STORE_BACKEND=postgres 时 POSTGRES_DSN 不能为空")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -82,6 +82,16 @@ func TestLoadReadsLogPersistenceEnv(t *testing.T) {
 	}
 }
 
+func TestConfigValidateAcceptsSignalRuntimeRunnerRole(t *testing.T) {
+	cfg := Config{HTTPAddr: ":8080", StoreBackend: "memory", ProcessRole: "signal-runtime-runner"}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("expected signal-runtime-runner role to validate, got %v", err)
+	}
+	if cfg.RuntimeActionsEnabled() {
+		t.Fatal("expected signal-runtime-runner to reject live runtime mutations")
+	}
+}
+
 func TestBoolFromEnvRecognizesTruthyAndFalsyValues(t *testing.T) {
 	t.Setenv("BOOL_TRUE", "yes")
 	if !boolFromEnv("BOOL_TRUE", false) {

--- a/internal/service/signal_runtime_scanner.go
+++ b/internal/service/signal_runtime_scanner.go
@@ -1,0 +1,71 @@
+package service
+
+import (
+	"context"
+	"time"
+
+	"github.com/wuyaocheng/bktrader/internal/domain"
+)
+
+const signalRuntimeScannerInterval = 5 * time.Second
+
+type signalRuntimeSessionStarter func(string) (domain.SignalRuntimeSession, error)
+
+func (p *Platform) StartSignalRuntimeScanner(ctx context.Context) {
+	logger := p.logger("service.signal_runtime_scanner")
+	logger.Info("signal runtime scanner started")
+	go func() {
+		defer logger.Info("signal runtime scanner stopped")
+		p.scanSignalRuntimeSessions(ctx, p.StartSignalRuntimeSession)
+		ticker := time.NewTicker(signalRuntimeScannerInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				p.scanSignalRuntimeSessions(ctx, p.StartSignalRuntimeSession)
+			}
+		}
+	}()
+}
+
+func (p *Platform) scanSignalRuntimeSessions(ctx context.Context, starter signalRuntimeSessionStarter) {
+	if err := ctx.Err(); err != nil {
+		return
+	}
+	sessions := p.ListSignalRuntimeSessions()
+	for _, session := range sessions {
+		if err := ctx.Err(); err != nil {
+			return
+		}
+		if !signalRuntimeSessionDesiredRunning(session) {
+			continue
+		}
+		if p.signalRuntimeSessionRunningOrStarting(session.ID) {
+			continue
+		}
+		if _, err := starter(session.ID); err != nil {
+			p.logger("service.signal_runtime_scanner",
+				"session_id", session.ID,
+				"account_id", session.AccountID,
+				"strategy_id", session.StrategyID,
+			).Warn("signal runtime scanner failed to start session", "error", err)
+		}
+	}
+}
+
+func signalRuntimeSessionDesiredRunning(session domain.SignalRuntimeSession) bool {
+	desired := stringValue(session.State["desiredStatus"])
+	if desired != "" {
+		return desired == "RUNNING"
+	}
+	return session.Status == "RUNNING"
+}
+
+func (p *Platform) signalRuntimeSessionRunningOrStarting(sessionID string) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	_, exists := p.signalRun[sessionID]
+	return exists
+}

--- a/internal/service/signal_runtime_scanner.go
+++ b/internal/service/signal_runtime_scanner.go
@@ -56,6 +56,9 @@ func (p *Platform) scanSignalRuntimeSessions(ctx context.Context, starter signal
 }
 
 func signalRuntimeSessionDesiredRunning(session domain.SignalRuntimeSession) bool {
+	if session.Status == "ERROR" || stringValue(session.State["actualStatus"]) == "ERROR" {
+		return false
+	}
 	desired := stringValue(session.State["desiredStatus"])
 	if desired != "" {
 		return desired == "RUNNING"

--- a/internal/service/signal_runtime_scanner_test.go
+++ b/internal/service/signal_runtime_scanner_test.go
@@ -71,6 +71,64 @@ func TestScanSignalRuntimeSessionsSkipsLocalRunningSession(t *testing.T) {
 	}
 }
 
+func TestScanSignalRuntimeSessionsSkipsErroredDesiredRunningSession(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	now := time.Date(2026, 4, 26, 18, 0, 0, 0, time.UTC)
+	session := mustCreateScannerRuntimeSession(t, platform, domain.SignalRuntimeSession{
+		ID:         "runtime-error",
+		AccountID:  "account-1",
+		StrategyID: "strategy-1",
+		Status:     "ERROR",
+		State: map[string]any{
+			"desiredStatus": "RUNNING",
+			"actualStatus":  "ERROR",
+		},
+		CreatedAt: now,
+		UpdatedAt: now,
+	})
+
+	started := 0
+	platform.scanSignalRuntimeSessions(context.Background(), func(sessionID string) (domain.SignalRuntimeSession, error) {
+		started++
+		return session, nil
+	})
+	if started != 0 {
+		t.Fatalf("expected scanner to leave errored desired-running session stopped for manual restart, got %d starts", started)
+	}
+}
+
+func TestPersistSignalRuntimeStoppedAfterStartCancelClearsDesiredAndActual(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	now := time.Date(2026, 4, 26, 18, 0, 0, 0, time.UTC)
+	session := mustCreateScannerRuntimeSession(t, platform, domain.SignalRuntimeSession{
+		ID:         "runtime-cancelled",
+		AccountID:  "account-1",
+		StrategyID: "strategy-1",
+		Status:     "RUNNING",
+		State: map[string]any{
+			"desiredStatus": "RUNNING",
+			"actualStatus":  "STARTING",
+		},
+		CreatedAt: now,
+		UpdatedAt: now,
+	})
+
+	platform.persistSignalRuntimeStoppedAfterStartCancel(session)
+	updated, err := platform.GetSignalRuntimeSession(session.ID)
+	if err != nil {
+		t.Fatalf("get runtime session failed: %v", err)
+	}
+	if updated.Status != "STOPPED" {
+		t.Fatalf("expected status STOPPED after start cancel, got %s", updated.Status)
+	}
+	if got := stringValue(updated.State["desiredStatus"]); got != "STOPPED" {
+		t.Fatalf("expected desiredStatus STOPPED after start cancel, got %s", got)
+	}
+	if got := stringValue(updated.State["actualStatus"]); got != "STOPPED" {
+		t.Fatalf("expected actualStatus STOPPED after start cancel, got %s", got)
+	}
+}
+
 func mustCreateScannerRuntimeSession(t *testing.T, platform *Platform, session domain.SignalRuntimeSession) domain.SignalRuntimeSession {
 	t.Helper()
 	created, err := platform.store.CreateSignalRuntimeSession(session)

--- a/internal/service/signal_runtime_scanner_test.go
+++ b/internal/service/signal_runtime_scanner_test.go
@@ -1,0 +1,82 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/wuyaocheng/bktrader/internal/domain"
+	"github.com/wuyaocheng/bktrader/internal/store/memory"
+)
+
+func TestScanSignalRuntimeSessionsStartsDesiredRunningSessions(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	now := time.Date(2026, 4, 26, 18, 0, 0, 0, time.UTC)
+	desired := mustCreateScannerRuntimeSession(t, platform, domain.SignalRuntimeSession{
+		ID:         "runtime-desired",
+		AccountID:  "account-1",
+		StrategyID: "strategy-1",
+		Status:     "STOPPED",
+		State: map[string]any{
+			"desiredStatus": "RUNNING",
+		},
+		CreatedAt: now,
+		UpdatedAt: now,
+	})
+	mustCreateScannerRuntimeSession(t, platform, domain.SignalRuntimeSession{
+		ID:         "runtime-stopped",
+		AccountID:  "account-1",
+		StrategyID: "strategy-2",
+		Status:     "RUNNING",
+		State: map[string]any{
+			"desiredStatus": "STOPPED",
+		},
+		CreatedAt: now,
+		UpdatedAt: now,
+	})
+
+	started := make([]string, 0)
+	platform.scanSignalRuntimeSessions(context.Background(), func(sessionID string) (domain.SignalRuntimeSession, error) {
+		started = append(started, sessionID)
+		return desired, nil
+	})
+	if len(started) != 1 || started[0] != desired.ID {
+		t.Fatalf("expected only desired running session to start, got %#v", started)
+	}
+}
+
+func TestScanSignalRuntimeSessionsSkipsLocalRunningSession(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	now := time.Date(2026, 4, 26, 18, 0, 0, 0, time.UTC)
+	session := mustCreateScannerRuntimeSession(t, platform, domain.SignalRuntimeSession{
+		ID:         "runtime-running",
+		AccountID:  "account-1",
+		StrategyID: "strategy-1",
+		Status:     "RUNNING",
+		State:      map[string]any{},
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	})
+	platform.mu.Lock()
+	platform.signalRun[session.ID] = &signalRuntimeRun{starting: true}
+	platform.mu.Unlock()
+
+	started := 0
+	platform.scanSignalRuntimeSessions(context.Background(), func(sessionID string) (domain.SignalRuntimeSession, error) {
+		started++
+		return session, nil
+	})
+	if started != 0 {
+		t.Fatalf("expected scanner to skip locally running session, got %d starts", started)
+	}
+}
+
+func mustCreateScannerRuntimeSession(t *testing.T, platform *Platform, session domain.SignalRuntimeSession) domain.SignalRuntimeSession {
+	t.Helper()
+	created, err := platform.store.CreateSignalRuntimeSession(session)
+	if err != nil {
+		t.Fatalf("create runtime session failed: %v", err)
+	}
+	platform.cacheSignalRuntimeSession(created)
+	return created
+}

--- a/internal/service/signal_runtime_sessions.go
+++ b/internal/service/signal_runtime_sessions.go
@@ -541,6 +541,8 @@ func (p *Platform) persistSignalRuntimeStoppedAfterStartCancel(session domain.Si
 	now := time.Now().UTC()
 	state := cloneMetadata(session.State)
 	state["health"] = "stopped"
+	state["desiredStatus"] = "STOPPED"
+	state["actualStatus"] = "STOPPED"
 	state["stoppedAt"] = now.Format(time.RFC3339)
 	state["lastHeartbeatAt"] = now.Format(time.RFC3339)
 	state["lastEventAt"] = now.Format(time.RFC3339)

--- a/internal/service/signal_runtime_sessions.go
+++ b/internal/service/signal_runtime_sessions.go
@@ -266,6 +266,8 @@ func (p *Platform) StartSignalRuntimeSession(sessionID string) (domain.SignalRun
 	}
 	state["sourceStates"] = sourceStates
 	state["signalBarStates"] = deriveSignalBarStates(sourceStates)
+	state["desiredStatus"] = "RUNNING"
+	state["actualStatus"] = "STARTING"
 	session.RuntimeAdapter = adapterKey
 	session.Transport = inferSignalRuntimeTransport(subscriptions)
 	session.SubscriptionCnt = len(subscriptions)
@@ -344,6 +346,8 @@ func (p *Platform) StopSignalRuntimeSessionWithForce(sessionID string, force boo
 	now := time.Now().UTC()
 	state := cloneMetadata(session.State)
 	state["health"] = "stopped"
+	state["desiredStatus"] = "STOPPED"
+	state["actualStatus"] = "STOPPED"
 	state["stoppedAt"] = now.Format(time.RFC3339)
 	state["lastHeartbeatAt"] = now.Format(time.RFC3339)
 	state["lastEventAt"] = now.Format(time.RFC3339)

--- a/internal/service/signal_runtime_ws.go
+++ b/internal/service/signal_runtime_ws.go
@@ -432,6 +432,7 @@ func (p *Platform) setSessionTerminalError(sessionID string, err error) {
 		session.Status = "ERROR"
 		state := cloneMetadata(session.State)
 		state["health"] = "error"
+		state["actualStatus"] = "ERROR"
 		state["lastEventAt"] = time.Now().UTC().Format(time.RFC3339)
 		state["lastEventSummary"] = map[string]any{
 			"type":    "runtime_error",
@@ -458,6 +459,7 @@ func (p *Platform) setSessionStopped(sessionID string) {
 		session.Status = "STOPPED"
 		state := cloneMetadata(session.State)
 		state["health"] = "stopped"
+		state["actualStatus"] = "STOPPED"
 		state["stoppedAt"] = time.Now().UTC().Format(time.RFC3339)
 		state["lastEventAt"] = time.Now().UTC().Format(time.RFC3339)
 		state["lastEventSummary"] = map[string]any{
@@ -583,6 +585,7 @@ func (p *Platform) runExchangeWebsocketLoop(
 		session.Status = "RUNNING"
 		state := cloneMetadata(session.State)
 		state["health"] = "healthy"
+		state["actualStatus"] = "RUNNING"
 		state["connectedAt"] = now.Format(time.RFC3339)
 		state["wsURL"] = wsURL
 		state["lastHeartbeatAt"] = now.Format(time.RFC3339)


### PR DESCRIPTION
## 目的
实现 #203 的代码侧最小闭环：新增 `BKTRADER_ROLE=signal-runtime-runner`，将行情 WebSocket / signal runtime scanner 从 live-runner 角色中拆出来。

Closes #203

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [x] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
- [x] `dispatchMode` 默认值有否变化？无变化。
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？无。
- [x] DB migration 是否具备向下兼容幂等性？本 PR 无 DB migration。
- [x] 配置字段有没有无意被混改？新增允许的 `BKTRADER_ROLE=signal-runtime-runner`；未改默认 role。

## 验证方式与测试证据
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

本地验证：
- `go test ./internal/app ./internal/config ./internal/service -run 'TestRuntimeOptionsFor|TestConfigValidateAcceptsSignalRuntimeRunnerRole|TestScanSignalRuntimeSessions'`
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
- `/Users/fujun/node/bktrader/.venv-graphify/bin/python -c "from graphify.watch import _rebuild_code; from pathlib import Path; _rebuild_code(Path('.'))"`

Root cause / 行为变化：
- 新增 `signal-runtime-runner` role，`platform-worker` 允许该 role 启动。
- `signal-runtime-runner` 只启 market warmup + signal runtime scanner，不启 live recovery、live sync、runtime event consumer、Telegram、dashboard。
- `live-runner` 不再启 market warmup / signal runtime scanner，保留 live recovery、live sync、runtime event consumer。
- monolith 保持全功能回退。
- `StartSignalRuntimeSession` / `StopSignalRuntimeSession` 写入轻量 `desiredStatus`，WS 连接状态写 `actualStatus`。

## 不做
- 不改 deployments / compose / CD。
- 不启动 live recovery / live sync / dispatch 于 signal-runtime-runner。
- 不引入多副本 lease；Step 5 前仍按单实例 signal-runtime-runner 部署。