### PR TITLE
[codex] fix live dispatch idempotency and reconcile cleanup

### DIFF
--- a/db/migrations/024_order_close_verification_account_symbol_indexes.sql
+++ b/db/migrations/024_order_close_verification_account_symbol_indexes.sql
@@ -1,3 +1,7 @@
 -- Support authoritative flat-position self-heal checks without scanning close verifications.
+UPDATE order_close_verifications
+SET symbol = UPPER(BTRIM(symbol))
+WHERE symbol <> UPPER(BTRIM(symbol));
+
 CREATE INDEX IF NOT EXISTS idx_order_close_verif_account_symbol_event_time
-    ON order_close_verifications (account_id, symbol, event_time DESC, recorded_at DESC);
+    ON order_close_verifications (account_id, symbol, event_time DESC, recorded_at DESC, id DESC);

--- a/db/migrations/024_order_close_verification_account_symbol_indexes.sql
+++ b/db/migrations/024_order_close_verification_account_symbol_indexes.sql
@@ -1,0 +1,3 @@
+-- Support authoritative flat-position self-heal checks without scanning close verifications.
+CREATE INDEX IF NOT EXISTS idx_order_close_verif_account_symbol_event_time
+    ON order_close_verifications (account_id, symbol, event_time DESC, recorded_at DESC);

--- a/internal/domain/order_close_verification.go
+++ b/internal/domain/order_close_verification.go
@@ -24,5 +24,7 @@ type OrderCloseVerificationQuery struct {
 	LiveSessionID string
 	OrderID       string
 	OrderIDs      []string
+	AccountID     string
+	Symbol        string
 	Limit         int
 }

--- a/internal/domain/order_close_verification.go
+++ b/internal/domain/order_close_verification.go
@@ -25,6 +25,7 @@ type OrderCloseVerificationQuery struct {
 	OrderID       string
 	OrderIDs      []string
 	AccountID     string
+	StrategyID    string
 	Symbol        string
 	Limit         int
 }

--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -2463,12 +2463,20 @@ func (p *Platform) clearVerifiedClosedExchangeMissingPosition(account domain.Acc
 	if !guard.authoritative || guard.pendingSettlement || guard.workingOrders || guard.exchangeOpenOrders {
 		return false, nil, nil
 	}
-	verification, found, err := p.latestOrderCloseVerificationForPosition(account.ID, symbol)
+	strategyID, err := p.resolveStrategyIDFromVersionID(position.StrategyVersionID)
+	if err != nil || strings.TrimSpace(strategyID) == "" {
+		return false, nil, nil
+	}
+	verification, found, err := p.latestOrderCloseVerificationForPosition(account.ID, symbol, strategyID)
 	if err != nil {
 		return false, nil, err
 	}
 	if !found || !verification.VerifiedClosed || tradingQuantityPositive(verification.RemainingPositionQty) {
 		return false, nil, nil
+	}
+	matches, err := p.closeVerificationMatchesPosition(account.ID, symbol, strategyID, position, verification)
+	if err != nil || !matches {
+		return false, nil, err
 	}
 	dbSnapshot := buildRecoveredLivePositionStateSnapshot(position)
 	if err := p.store.DeletePosition(position.ID); err != nil {
@@ -2482,8 +2490,10 @@ func (p *Platform) clearVerifiedClosedExchangeMissingPosition(account domain.Acc
 		"exchangePosition": map[string]any{},
 		"closeVerification": map[string]any{
 			"id":                   verification.ID,
+			"liveSessionId":        verification.LiveSessionID,
 			"orderId":              verification.OrderID,
 			"decisionEventId":      verification.DecisionEventID,
+			"strategyId":           verification.StrategyID,
 			"verifiedClosed":       verification.VerifiedClosed,
 			"remainingPositionQty": verification.RemainingPositionQty,
 			"verificationSource":   verification.VerificationSource,
@@ -2492,11 +2502,71 @@ func (p *Platform) clearVerifiedClosedExchangeMissingPosition(account domain.Acc
 	}, nil
 }
 
-func (p *Platform) latestOrderCloseVerificationForPosition(accountID string, symbol string) (domain.OrderCloseVerification, bool, error) {
+func (p *Platform) closeVerificationMatchesPosition(accountID string, symbol string, strategyID string, position domain.Position, verification domain.OrderCloseVerification) (bool, error) {
+	if !strings.EqualFold(strings.TrimSpace(verification.AccountID), strings.TrimSpace(accountID)) {
+		return false, nil
+	}
+	if NormalizeSymbol(verification.Symbol) != NormalizeSymbol(symbol) {
+		return false, nil
+	}
+	if !strings.EqualFold(strings.TrimSpace(verification.StrategyID), strings.TrimSpace(strategyID)) {
+		return false, nil
+	}
+	if strings.TrimSpace(verification.OrderID) == "" {
+		return false, nil
+	}
+	order, err := p.store.GetOrderByID(verification.OrderID)
+	if err != nil {
+		if strings.Contains(strings.ToLower(err.Error()), "order not found") {
+			return false, nil
+		}
+		return false, err
+	}
+	if !strings.EqualFold(strings.TrimSpace(order.AccountID), strings.TrimSpace(accountID)) || NormalizeSymbol(order.Symbol) != NormalizeSymbol(symbol) {
+		return false, nil
+	}
+	if position.StrategyVersionID != "" && order.StrategyVersionID != "" && !strings.EqualFold(strings.TrimSpace(position.StrategyVersionID), strings.TrimSpace(order.StrategyVersionID)) {
+		return false, nil
+	}
+	expectedSide := "SELL"
+	if strings.EqualFold(strings.TrimSpace(position.Side), "SHORT") {
+		expectedSide = "BUY"
+	}
+	if !strings.EqualFold(strings.TrimSpace(order.Side), expectedSide) {
+		return false, nil
+	}
+	if !strings.EqualFold(strings.TrimSpace(order.Status), "FILLED") {
+		return false, nil
+	}
+	if !order.EffectiveReduceOnly() && !order.EffectiveClosePosition() {
+		return false, nil
+	}
+	if !liveOrderRepresentsSystemExit(order) {
+		return false, nil
+	}
+	filledQuantity := firstPositive(parseFloatValue(order.Metadata["filledQuantity"]), order.Quantity)
+	if tradingQuantityBelow(filledQuantity, position.Quantity) {
+		return false, nil
+	}
+	if verification.LiveSessionID != "" {
+		if orderLiveSessionID := stringValue(order.Metadata["liveSessionId"]); orderLiveSessionID != "" && orderLiveSessionID != verification.LiveSessionID {
+			return false, nil
+		}
+	}
+	if verification.DecisionEventID != "" {
+		if orderDecisionEventID := stringValue(order.Metadata["decisionEventId"]); orderDecisionEventID != "" && orderDecisionEventID != verification.DecisionEventID {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func (p *Platform) latestOrderCloseVerificationForPosition(accountID string, symbol string, strategyID string) (domain.OrderCloseVerification, bool, error) {
 	items, err := p.store.QueryOrderCloseVerifications(domain.OrderCloseVerificationQuery{
-		AccountID: strings.TrimSpace(accountID),
-		Symbol:    NormalizeSymbol(symbol),
-		Limit:     1,
+		AccountID:  strings.TrimSpace(accountID),
+		StrategyID: strings.TrimSpace(strategyID),
+		Symbol:     NormalizeSymbol(symbol),
+		Limit:      1,
 	})
 	if err != nil {
 		return domain.OrderCloseVerification{}, false, err

--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -2395,12 +2395,19 @@ func (p *Platform) reconcileLiveAccountPositions(account domain.Account, exchang
 		if position.Quantity <= 0 {
 			continue
 		}
-		if cleared, gate, clearErr := p.clearStaleLivePositionAfterTerminalExit(account, position, livePositionFlatCleanupGuard{
+		cleanupGuard := livePositionFlatCleanupGuard{
 			authoritative:      authoritative,
 			pendingSettlement:  symbolInSet(pendingSettlementSymbols, symbol),
 			workingOrders:      symbolInSet(workingOrderSymbols, symbol),
 			exchangeOpenOrders: symbolInSet(openOrderSymbols, symbol),
-		}); clearErr != nil {
+		}
+		if cleared, gate, clearErr := p.clearVerifiedClosedExchangeMissingPosition(account, position, symbol, cleanupGuard); clearErr != nil {
+			return nil, clearErr
+		} else if cleared {
+			recordGate(symbol, gate)
+			continue
+		}
+		if cleared, gate, clearErr := p.clearStaleLivePositionAfterTerminalExit(account, position, cleanupGuard); clearErr != nil {
 			return nil, clearErr
 		} else if cleared {
 			recordGate(symbol, gate)
@@ -2446,6 +2453,58 @@ type livePositionFlatCleanupGuard struct {
 	pendingSettlement  bool
 	workingOrders      bool
 	exchangeOpenOrders bool
+}
+
+func (p *Platform) clearVerifiedClosedExchangeMissingPosition(account domain.Account, position domain.Position, symbol string, guard livePositionFlatCleanupGuard) (bool, map[string]any, error) {
+	symbol = NormalizeSymbol(symbol)
+	if symbol == "" || position.ID == "" || position.Quantity <= 0 {
+		return false, nil, nil
+	}
+	if !guard.authoritative || guard.pendingSettlement || guard.workingOrders || guard.exchangeOpenOrders {
+		return false, nil, nil
+	}
+	verification, found, err := p.latestOrderCloseVerificationForPosition(account.ID, symbol)
+	if err != nil {
+		return false, nil, err
+	}
+	if !found || !verification.VerifiedClosed || tradingQuantityPositive(verification.RemainingPositionQty) {
+		return false, nil, nil
+	}
+	dbSnapshot := buildRecoveredLivePositionStateSnapshot(position)
+	if err := p.store.DeletePosition(position.ID); err != nil {
+		return false, nil, err
+	}
+	return true, map[string]any{
+		"status":           livePositionReconcileGateStatusVerified,
+		"scenario":         "verified-closed-db-position-cleared",
+		"blocking":         false,
+		"dbPosition":       dbSnapshot,
+		"exchangePosition": map[string]any{},
+		"closeVerification": map[string]any{
+			"id":                   verification.ID,
+			"orderId":              verification.OrderID,
+			"decisionEventId":      verification.DecisionEventID,
+			"verifiedClosed":       verification.VerifiedClosed,
+			"remainingPositionQty": verification.RemainingPositionQty,
+			"verificationSource":   verification.VerificationSource,
+			"eventTime":            verification.EventTime.UTC().Format(time.RFC3339),
+		},
+	}, nil
+}
+
+func (p *Platform) latestOrderCloseVerificationForPosition(accountID string, symbol string) (domain.OrderCloseVerification, bool, error) {
+	items, err := p.store.QueryOrderCloseVerifications(domain.OrderCloseVerificationQuery{
+		AccountID: strings.TrimSpace(accountID),
+		Symbol:    NormalizeSymbol(symbol),
+		Limit:     1,
+	})
+	if err != nil {
+		return domain.OrderCloseVerification{}, false, err
+	}
+	if len(items) == 0 {
+		return domain.OrderCloseVerification{}, false, nil
+	}
+	return items[0], true, nil
 }
 
 func (p *Platform) clearStaleLivePositionAfterTerminalExit(account domain.Account, position domain.Position, guard livePositionFlatCleanupGuard) (bool, map[string]any, error) {
@@ -3249,6 +3308,7 @@ func liveSessionNonRegressiveFactKeys() []string {
 		"lastStrategyDecisionEventId",
 		"lastStrategyDecisionEventFingerprint",
 		"lastStrategyDecisionEventIntentSignature",
+		"lastDispatchedDecisionEventId",
 	}
 }
 

--- a/internal/service/live_execution.go
+++ b/internal/service/live_execution.go
@@ -981,9 +981,7 @@ func (p *Platform) dispatchLiveSessionIntent(session domain.LiveSession) (domain
 	}
 	if decisionEventID := stringValue(proposalMap["decisionEventId"]); decisionEventID != "" {
 		state["lastStrategyDecisionEventId"] = decisionEventID
-		if shouldAdvanceLivePlanForOrderStatus(created.Status) {
-			state["lastDispatchedDecisionEventId"] = decisionEventID
-		}
+		state["lastDispatchedDecisionEventId"] = decisionEventID
 	}
 	state["lastDispatchedOrderId"] = created.ID
 	state["lastDispatchedOrderStatus"] = created.Status

--- a/internal/service/live_execution.go
+++ b/internal/service/live_execution.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/wuyaocheng/bktrader/internal/domain"
@@ -914,6 +915,11 @@ func (p *Platform) recordLiveDispatchPreflightRejection(session domain.LiveSessi
 }
 
 func (p *Platform) dispatchLiveSessionIntent(session domain.LiveSession) (domain.Order, error) {
+	releaseDispatch := p.lockLiveSessionDispatch(session.ID)
+	defer releaseDispatch()
+	if latestSession, latestErr := p.store.GetLiveSession(session.ID); latestErr == nil {
+		session = latestSession
+	}
 	if !strings.EqualFold(session.Status, "RUNNING") && !strings.EqualFold(session.Status, "READY") {
 		return domain.Order{}, fmt.Errorf("live session %s is not dispatchable in status %s", session.ID, session.Status)
 	}
@@ -946,6 +952,9 @@ func (p *Platform) dispatchLiveSessionIntent(session domain.LiveSession) (domain
 	if err := validateLiveSignalBarEntryTradeLimit(session, proposalMap); err != nil {
 		return domain.Order{}, err
 	}
+	if err := validateLiveDispatchIdempotency(session.State, proposalMap); err != nil {
+		return domain.Order{}, err
+	}
 	dispatchStartedAt := time.Now().UTC()
 	proposalMap, err = p.ensureStrategyDecisionEventForExecutionProposal(session, version.ID, proposalMap, dispatchStartedAt, "dispatch-preflight")
 	if err != nil {
@@ -972,6 +981,9 @@ func (p *Platform) dispatchLiveSessionIntent(session domain.LiveSession) (domain
 	}
 	if decisionEventID := stringValue(proposalMap["decisionEventId"]); decisionEventID != "" {
 		state["lastStrategyDecisionEventId"] = decisionEventID
+		if shouldAdvanceLivePlanForOrderStatus(created.Status) {
+			state["lastDispatchedDecisionEventId"] = decisionEventID
+		}
 	}
 	state["lastDispatchedOrderId"] = created.ID
 	state["lastDispatchedOrderStatus"] = created.Status
@@ -1052,6 +1064,44 @@ func (p *Platform) dispatchLiveSessionIntent(session domain.LiveSession) (domain
 		"quantity", created.Quantity,
 	)
 	return created, nil
+}
+
+func (p *Platform) lockLiveSessionDispatch(sessionID string) func() {
+	sessionID = strings.TrimSpace(sessionID)
+	if sessionID == "" {
+		return func() {}
+	}
+	actual, _ := p.liveDispatchMu.LoadOrStore(sessionID, &sync.Mutex{})
+	mu, _ := actual.(*sync.Mutex)
+	if mu == nil {
+		return func() {}
+	}
+	mu.Lock()
+	return mu.Unlock
+}
+
+func validateLiveDispatchIdempotency(state map[string]any, proposalMap map[string]any) error {
+	if state == nil || len(proposalMap) == 0 {
+		return nil
+	}
+	decisionEventID := firstNonEmpty(
+		stringValue(proposalMap["decisionEventId"]),
+		stringValue(mapValue(proposalMap["metadata"])["decisionEventId"]),
+	)
+	if strings.TrimSpace(decisionEventID) == "" {
+		return nil
+	}
+	if decisionEventID == stringValue(state["lastDispatchedDecisionEventId"]) {
+		return fmt.Errorf("live execution proposal already dispatched for decision event %s", decisionEventID)
+	}
+	dispatchedIntent := mapValue(state["lastDispatchedIntent"])
+	if decisionEventID == firstNonEmpty(
+		stringValue(dispatchedIntent["decisionEventId"]),
+		stringValue(mapValue(dispatchedIntent["metadata"])["decisionEventId"]),
+	) {
+		return fmt.Errorf("live execution proposal already dispatched for decision event %s", decisionEventID)
+	}
+	return nil
 }
 
 func buildLiveOrderFromExecutionProposal(session domain.LiveSession, strategyVersionID string, proposal ExecutionProposal, proposalMap map[string]any) domain.Order {
@@ -1430,7 +1480,7 @@ func shouldBackfillTerminalFilledLiveOrder(order domain.Order, state map[string]
 	if strings.TrimSpace(stringValue(order.Metadata["lastFilledAt"])) == "" {
 		return true
 	}
-	return isLiveSessionBlockedByPositionReconcileGate(state)
+	return false
 }
 
 func shouldSyncLiveAccountAfterTerminalFilledOrder(order domain.Order, state map[string]any, eventTime time.Time) bool {

--- a/internal/service/live_reconcile_test.go
+++ b/internal/service/live_reconcile_test.go
@@ -851,6 +851,153 @@ func TestReconcileLiveAccountRefreshClearsStaleRecoveryCache(t *testing.T) {
 	}
 }
 
+func TestRefreshLiveAccountPositionReconcileGateClearsVerifiedClosedExchangeMissingPosition(t *testing.T) {
+	store := memory.NewStore()
+	platform := NewPlatform(store)
+	eventTime := time.Date(2026, 4, 26, 3, 36, 23, 0, time.UTC)
+
+	account, err := store.GetAccount("live-main")
+	if err != nil {
+		t.Fatalf("get account failed: %v", err)
+	}
+	account.Metadata = cloneMetadata(account.Metadata)
+	account.Metadata["liveSyncSnapshot"] = map[string]any{
+		"source":        "binance-rest-account-v3",
+		"executionMode": "rest",
+		"syncStatus":    "SYNCED",
+		"positions":     []map[string]any{},
+		"openOrders":    []map[string]any{},
+	}
+	if _, err := store.UpdateAccount(account); err != nil {
+		t.Fatalf("update account failed: %v", err)
+	}
+	if _, err := store.SavePosition(domain.Position{
+		AccountID:         "live-main",
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "SHORT",
+		Quantity:          0.0013,
+		EntryPrice:        0,
+		MarkPrice:         77313.3,
+	}); err != nil {
+		t.Fatalf("save ghost position failed: %v", err)
+	}
+	if _, err := store.CreateOrderCloseVerification(domain.OrderCloseVerification{
+		LiveSessionID:        "live-session-1",
+		OrderID:              "order-close-1",
+		AccountID:            "live-main",
+		StrategyID:           "strategy-bk-1d",
+		Symbol:               "BTCUSDT",
+		VerifiedClosed:       true,
+		RemainingPositionQty: 0,
+		VerificationSource:   "ws-sync",
+		EventTime:            eventTime,
+	}); err != nil {
+		t.Fatalf("create close verification failed: %v", err)
+	}
+
+	account, err = store.GetAccount("live-main")
+	if err != nil {
+		t.Fatalf("reload account failed: %v", err)
+	}
+	updated, err := platform.refreshLiveAccountPositionReconcileGate(account)
+	if err != nil {
+		t.Fatalf("refresh reconcile gate failed: %v", err)
+	}
+	if _, found, err := store.FindPosition("live-main", "BTCUSDT"); err != nil {
+		t.Fatalf("find position failed: %v", err)
+	} else if found {
+		t.Fatal("expected verified closed exchange-missing position to be cleared")
+	}
+	gate := mapValue(mapValue(mapValue(updated.Metadata["livePositionReconcileGate"])["symbols"])["BTCUSDT"])
+	if got := stringValue(gate["status"]); got != livePositionReconcileGateStatusVerified {
+		t.Fatalf("expected verified gate after clearing ghost position, got %#v", gate)
+	}
+	if got := stringValue(gate["scenario"]); got != "verified-closed-db-position-cleared" {
+		t.Fatalf("expected verified-closed cleanup scenario, got %#v", gate)
+	}
+}
+
+func TestRefreshLiveAccountPositionReconcileGateKeepsExchangeMissingPositionWhenLatestCloseVerificationIsResidual(t *testing.T) {
+	store := memory.NewStore()
+	platform := NewPlatform(store)
+	eventTime := time.Date(2026, 4, 26, 3, 36, 23, 0, time.UTC)
+
+	account, err := store.GetAccount("live-main")
+	if err != nil {
+		t.Fatalf("get account failed: %v", err)
+	}
+	account.Metadata = cloneMetadata(account.Metadata)
+	account.Metadata["liveSyncSnapshot"] = map[string]any{
+		"source":        "binance-rest-account-v3",
+		"executionMode": "rest",
+		"syncStatus":    "SYNCED",
+		"positions":     []map[string]any{},
+		"openOrders":    []map[string]any{},
+	}
+	if _, err := store.UpdateAccount(account); err != nil {
+		t.Fatalf("update account failed: %v", err)
+	}
+	if _, err := store.SavePosition(domain.Position{
+		AccountID:         "live-main",
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "SHORT",
+		Quantity:          0.0013,
+		EntryPrice:        77401.3,
+		MarkPrice:         77313.3,
+	}); err != nil {
+		t.Fatalf("save stale position failed: %v", err)
+	}
+	if _, err := store.CreateOrderCloseVerification(domain.OrderCloseVerification{
+		LiveSessionID:        "live-session-1",
+		OrderID:              "order-close-old",
+		AccountID:            "live-main",
+		StrategyID:           "strategy-bk-1d",
+		Symbol:               "BTCUSDT",
+		VerifiedClosed:       true,
+		RemainingPositionQty: 0,
+		VerificationSource:   "ws-sync",
+		EventTime:            eventTime,
+	}); err != nil {
+		t.Fatalf("create old close verification failed: %v", err)
+	}
+	if _, err := store.CreateOrderCloseVerification(domain.OrderCloseVerification{
+		LiveSessionID:        "live-session-1",
+		OrderID:              "order-close-new",
+		AccountID:            "live-main",
+		StrategyID:           "strategy-bk-1d",
+		Symbol:               "BTCUSDT",
+		VerifiedClosed:       false,
+		RemainingPositionQty: 0.0013,
+		VerificationSource:   "reconcile",
+		EventTime:            eventTime.Add(time.Second),
+	}); err != nil {
+		t.Fatalf("create residual close verification failed: %v", err)
+	}
+
+	account, err = store.GetAccount("live-main")
+	if err != nil {
+		t.Fatalf("reload account failed: %v", err)
+	}
+	updated, err := platform.refreshLiveAccountPositionReconcileGate(account)
+	if err != nil {
+		t.Fatalf("refresh reconcile gate failed: %v", err)
+	}
+	if _, found, err := store.FindPosition("live-main", "BTCUSDT"); err != nil {
+		t.Fatalf("find position failed: %v", err)
+	} else if !found {
+		t.Fatal("expected residual close verification to keep stale position for manual review")
+	}
+	gate := mapValue(mapValue(mapValue(updated.Metadata["livePositionReconcileGate"])["symbols"])["BTCUSDT"])
+	if got := stringValue(gate["scenario"]); got != "db-position-exchange-missing" {
+		t.Fatalf("expected stale exchange-missing gate to remain, got %#v", gate)
+	}
+	if !boolValue(gate["blocking"]) {
+		t.Fatalf("expected stale gate to remain blocking, got %#v", gate)
+	}
+}
+
 func configureTestLiveRESTReconcileHistoryAdapter(
 	t *testing.T,
 	platform *Platform,

--- a/internal/service/live_reconcile_test.go
+++ b/internal/service/live_reconcile_test.go
@@ -882,9 +882,43 @@ func TestRefreshLiveAccountPositionReconcileGateClearsVerifiedClosedExchangeMiss
 	}); err != nil {
 		t.Fatalf("save ghost position failed: %v", err)
 	}
+	closeOrder, err := store.CreateOrder(domain.Order{
+		ID:                "order-close-1",
+		AccountID:         "live-main",
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "BUY",
+		Type:              "MARKET",
+		Status:            "FILLED",
+		Quantity:          0.0013,
+		Price:             77313.3,
+		ReduceOnly:        true,
+		Metadata: map[string]any{
+			"source":             "live-session-intent",
+			"liveSessionId":      "live-session-1",
+			"decisionEventId":    "decision-close-1",
+			"filledQuantity":     0.0013,
+			"lastExchangeStatus": "FILLED",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create close order failed: %v", err)
+	}
+	closeOrder.Status = "FILLED"
+	closeOrder.Metadata = map[string]any{
+		"source":             "live-session-intent",
+		"liveSessionId":      "live-session-1",
+		"decisionEventId":    "decision-close-1",
+		"filledQuantity":     0.0013,
+		"lastExchangeStatus": "FILLED",
+	}
+	if _, err := store.UpdateOrder(closeOrder); err != nil {
+		t.Fatalf("update close order failed: %v", err)
+	}
 	if _, err := store.CreateOrderCloseVerification(domain.OrderCloseVerification{
 		LiveSessionID:        "live-session-1",
-		OrderID:              "order-close-1",
+		OrderID:              closeOrder.ID,
+		DecisionEventID:      "decision-close-1",
 		AccountID:            "live-main",
 		StrategyID:           "strategy-bk-1d",
 		Symbol:               "BTCUSDT",
@@ -915,6 +949,71 @@ func TestRefreshLiveAccountPositionReconcileGateClearsVerifiedClosedExchangeMiss
 	}
 	if got := stringValue(gate["scenario"]); got != "verified-closed-db-position-cleared" {
 		t.Fatalf("expected verified-closed cleanup scenario, got %#v", gate)
+	}
+}
+
+func TestRefreshLiveAccountPositionReconcileGateRejectsVerifiedCloseForDifferentStrategy(t *testing.T) {
+	store := memory.NewStore()
+	platform := NewPlatform(store)
+	eventTime := time.Date(2026, 4, 26, 3, 36, 23, 0, time.UTC)
+
+	account, err := store.GetAccount("live-main")
+	if err != nil {
+		t.Fatalf("get account failed: %v", err)
+	}
+	account.Metadata = cloneMetadata(account.Metadata)
+	account.Metadata["liveSyncSnapshot"] = map[string]any{
+		"source":        "binance-rest-account-v3",
+		"executionMode": "rest",
+		"syncStatus":    "SYNCED",
+		"positions":     []map[string]any{},
+		"openOrders":    []map[string]any{},
+	}
+	if _, err := store.UpdateAccount(account); err != nil {
+		t.Fatalf("update account failed: %v", err)
+	}
+	if _, err := store.SavePosition(domain.Position{
+		AccountID:         "live-main",
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "SHORT",
+		Quantity:          0.0013,
+		EntryPrice:        0,
+		MarkPrice:         77313.3,
+	}); err != nil {
+		t.Fatalf("save ghost position failed: %v", err)
+	}
+	if _, err := store.CreateOrderCloseVerification(domain.OrderCloseVerification{
+		LiveSessionID:        "live-session-other",
+		OrderID:              "order-close-other-strategy",
+		DecisionEventID:      "decision-other",
+		AccountID:            "live-main",
+		StrategyID:           "strategy-other",
+		Symbol:               "BTCUSDT",
+		VerifiedClosed:       true,
+		RemainingPositionQty: 0,
+		VerificationSource:   "ws-sync",
+		EventTime:            eventTime,
+	}); err != nil {
+		t.Fatalf("create other strategy close verification failed: %v", err)
+	}
+
+	account, err = store.GetAccount("live-main")
+	if err != nil {
+		t.Fatalf("reload account failed: %v", err)
+	}
+	updated, err := platform.refreshLiveAccountPositionReconcileGate(account)
+	if err != nil {
+		t.Fatalf("refresh reconcile gate failed: %v", err)
+	}
+	if _, found, err := store.FindPosition("live-main", "BTCUSDT"); err != nil {
+		t.Fatalf("find position failed: %v", err)
+	} else if !found {
+		t.Fatal("expected mismatched strategy close verification to leave stale position for manual review")
+	}
+	gate := mapValue(mapValue(mapValue(updated.Metadata["livePositionReconcileGate"])["symbols"])["BTCUSDT"])
+	if got := stringValue(gate["scenario"]); got != "db-position-exchange-missing" {
+		t.Fatalf("expected stale exchange-missing gate to remain, got %#v", gate)
 	}
 }
 

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -2366,6 +2366,90 @@ func TestDispatchLiveSessionIntentRejectsNonDispatchableProposal(t *testing.T) {
 	}
 }
 
+func TestDispatchLiveSessionIntentReloadsLatestStateBeforeDispatch(t *testing.T) {
+	platform, session, _, _, _ := prepareLiveDecisionTelemetryFixture(t)
+	platform.registerLiveAdapter(testLiveAccountSyncAdapter{key: "test-dispatch-reload"})
+
+	account, err := platform.store.GetAccount("live-main")
+	if err != nil {
+		t.Fatalf("get account failed: %v", err)
+	}
+	account.Status = "READY"
+	account.Metadata = cloneMetadata(account.Metadata)
+	account.Metadata["liveBinding"] = map[string]any{
+		"adapterKey":     "test-dispatch-reload",
+		"connectionMode": "mock",
+		"executionMode":  "mock",
+	}
+	if _, err := platform.store.UpdateAccount(account); err != nil {
+		t.Fatalf("update account failed: %v", err)
+	}
+
+	staleSession := session
+	staleState := cloneMetadata(session.State)
+	staleProposal := executionProposalToMap(ExecutionProposal{
+		Action:            "entry",
+		Role:              "entry",
+		Reason:            "SL-Reentry",
+		Side:              "SELL",
+		Symbol:            "BTCUSDT",
+		Type:              "MARKET",
+		Quantity:          0.001,
+		PriceHint:         75600.0,
+		SignalKind:        "sl-reentry",
+		DecisionState:     "entry-ready",
+		SignalBarStateKey: "bar-1",
+		ExecutionStrategy: "book-aware-v1",
+		Status:            "dispatchable",
+		Metadata: map[string]any{
+			"executionDecision": "direct-dispatch",
+			"executionMode":     "live",
+			"skipRuntimeCheck":  true,
+		},
+	})
+	staleProposal = setExecutionProposalDecisionEventID(staleProposal, "strategy-decision-event-stale-dispatch")
+	staleState["lastExecutionProposal"] = staleProposal
+	staleState["lastStrategyIntent"] = staleProposal
+	staleSession.State = staleState
+
+	latestState := cloneMetadata(session.State)
+	delete(latestState, "lastExecutionProposal")
+	delete(latestState, "lastStrategyIntent")
+	if _, err := platform.store.UpdateLiveSessionState(session.ID, latestState); err != nil {
+		t.Fatalf("update latest session state failed: %v", err)
+	}
+
+	order, err := platform.dispatchLiveSessionIntent(staleSession)
+	if err == nil || !strings.Contains(err.Error(), "has no execution proposal") {
+		t.Fatalf("expected stale dispatch snapshot to reload latest empty proposal, got order=%+v err=%v", order, err)
+	}
+	orders, err := platform.ListOrders()
+	if err != nil {
+		t.Fatalf("list orders failed: %v", err)
+	}
+	if len(orders) != 0 {
+		t.Fatalf("expected stale snapshot not to create orders, got %#v", orders)
+	}
+}
+
+func TestValidateLiveDispatchIdempotencyRejectsPreviouslyDispatchedDecisionEvent(t *testing.T) {
+	state := map[string]any{
+		"lastDispatchedDecisionEventId": "strategy-decision-event-1",
+	}
+	proposal := map[string]any{
+		"decisionEventId": "strategy-decision-event-1",
+		"role":            "entry",
+		"symbol":          "BTCUSDT",
+	}
+	if err := validateLiveDispatchIdempotency(state, proposal); err == nil {
+		t.Fatal("expected duplicate decision event dispatch to be rejected")
+	}
+	proposal["decisionEventId"] = "strategy-decision-event-2"
+	if err := validateLiveDispatchIdempotency(state, proposal); err != nil {
+		t.Fatalf("expected a different decision event to pass idempotency check, got %v", err)
+	}
+}
+
 func TestDispatchLiveSessionIntentRejectsEntryWhenSubmissionSlippageTooWide(t *testing.T) {
 	platform, session, runtimeSessionID, _, _ := prepareLiveDecisionTelemetryFixture(t)
 	eventTime := time.Now().UTC()
@@ -3669,12 +3753,13 @@ func TestUpdateLiveSessionStatePreservingNonRegressiveFactsKeepsLatestCountedBar
 		t.Fatalf("create live session failed: %v", err)
 	}
 	session, err = platform.store.UpdateLiveSessionState(session.ID, map[string]any{
-		"symbol":                    "BTCUSDT",
-		"signalTimeframe":           "30m",
-		"max_trades_per_bar":        2,
-		"lastSignalBarStateKey":     "BTCUSDT|30m|2026-04-22T03:00:00Z",
-		"sessionReentryCount":       2.0,
-		"lastCountedReentryOrderId": "order-2",
+		"symbol":                        "BTCUSDT",
+		"signalTimeframe":               "30m",
+		"max_trades_per_bar":            2,
+		"lastSignalBarStateKey":         "BTCUSDT|30m|2026-04-22T03:00:00Z",
+		"sessionReentryCount":           2.0,
+		"lastCountedReentryOrderId":     "order-2",
+		"lastDispatchedDecisionEventId": "strategy-decision-event-counted",
 	})
 	if err != nil {
 		t.Fatalf("seed live session state failed: %v", err)
@@ -3684,6 +3769,7 @@ func TestUpdateLiveSessionStatePreservingNonRegressiveFactsKeepsLatestCountedBar
 	delete(staleEvaluationState, "lastSignalBarStateKey")
 	delete(staleEvaluationState, "sessionReentryCount")
 	delete(staleEvaluationState, "lastCountedReentryOrderId")
+	delete(staleEvaluationState, "lastDispatchedDecisionEventId")
 	staleEvaluationState["lastStrategyEvaluationStatus"] = "intent-ready"
 
 	updated, err := platform.updateLiveSessionStatePreservingNonRegressiveFacts(session.ID, staleEvaluationState)
@@ -3698,6 +3784,9 @@ func TestUpdateLiveSessionStatePreservingNonRegressiveFactsKeepsLatestCountedBar
 	}
 	if got := stringValue(updated.State["lastCountedReentryOrderId"]); got != "order-2" {
 		t.Fatalf("expected last counted reentry order id to survive stale evaluation write, got %q", got)
+	}
+	if got := stringValue(updated.State["lastDispatchedDecisionEventId"]); got != "strategy-decision-event-counted" {
+		t.Fatalf("expected last dispatched decision event id to survive stale evaluation write, got %q", got)
 	}
 	proposal := map[string]any{
 		"role":   "entry",
@@ -3720,6 +3809,7 @@ func TestLiveSessionNonRegressiveFactKeysIncludeSignalBarTradeLimitFacts(t *test
 		"lastStrategyDecisionEventId",
 		"lastStrategyDecisionEventFingerprint",
 		"lastStrategyDecisionEventIntentSignature",
+		"lastDispatchedDecisionEventId",
 	} {
 		found := false
 		for _, key := range keys {
@@ -7602,6 +7692,26 @@ func TestSyncLatestLiveSessionOrderDoesNotRepeatTerminalAccountSync(t *testing.T
 	}
 	if got := stringValue(session.State["lastTerminalAccountSyncedOrderId"]); got != order.ID {
 		t.Fatalf("expected terminal account sync marker for order %s, got %s", order.ID, got)
+	}
+}
+
+func TestShouldBackfillTerminalFilledLiveOrderSkipsCompleteFillWhenGateBlocked(t *testing.T) {
+	order := domain.Order{
+		ID:       "order-terminal-complete",
+		Status:   "FILLED",
+		Quantity: 0.01,
+		Metadata: map[string]any{
+			"filledQuantity": 0.01,
+			"lastFilledAt":   time.Date(2026, 4, 26, 3, 36, 23, 0, time.UTC).Format(time.RFC3339),
+		},
+	}
+	state := map[string]any{
+		"positionReconcileGateStatus":   livePositionReconcileGateStatusStale,
+		"positionReconcileGateBlocking": true,
+		"positionReconcileGateScenario": "db-position-exchange-missing",
+	}
+	if shouldBackfillTerminalFilledLiveOrder(order, state) {
+		t.Fatal("expected complete terminal fill not to be repeatedly backfilled while reconcile gate is blocked")
 	}
 }
 

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -2450,6 +2450,96 @@ func TestValidateLiveDispatchIdempotencyRejectsPreviouslyDispatchedDecisionEvent
 	}
 }
 
+func TestDispatchLiveSessionIntentRecordsDecisionIDForRejectedDispatch(t *testing.T) {
+	platform, session, runtimeSessionID, _, _ := prepareLiveDecisionTelemetryFixture(t)
+	platform.registerLiveAdapter(testLiveAccountSyncAdapter{
+		key: "test-rejected-dispatch-idempotency",
+		submitOrderFunc: func(domain.Account, domain.Order, map[string]any) (LiveOrderSubmission, error) {
+			return LiveOrderSubmission{}, errors.New("exchange rejected order")
+		},
+	})
+
+	account, err := platform.store.GetAccount("live-main")
+	if err != nil {
+		t.Fatalf("get account failed: %v", err)
+	}
+	account.Status = "READY"
+	account.Metadata = cloneMetadata(account.Metadata)
+	account.Metadata["liveBinding"] = map[string]any{
+		"adapterKey":     "test-rejected-dispatch-idempotency",
+		"connectionMode": "mock",
+		"executionMode":  "mock",
+	}
+	if _, err := platform.store.UpdateAccount(account); err != nil {
+		t.Fatalf("update account failed: %v", err)
+	}
+	freshRuntimeAt := time.Now().UTC()
+	if err := platform.updateSignalRuntimeSessionState(runtimeSessionID, func(runtimeSession *domain.SignalRuntimeSession) {
+		state := cloneMetadata(runtimeSession.State)
+		state["lastEventAt"] = freshRuntimeAt.Format(time.RFC3339)
+		state["lastHeartbeatAt"] = freshRuntimeAt.Format(time.RFC3339)
+		sourceStates := cloneMetadata(mapValue(state["sourceStates"]))
+		for key, item := range sourceStates {
+			sourceState := cloneMetadata(mapValue(item))
+			sourceState["lastEventAt"] = freshRuntimeAt.Format(time.RFC3339)
+			sourceStates[key] = sourceState
+		}
+		state["sourceStates"] = sourceStates
+		runtimeSession.State = state
+		runtimeSession.UpdatedAt = freshRuntimeAt
+	}); err != nil {
+		t.Fatalf("refresh runtime state failed: %v", err)
+	}
+
+	decisionEventID := "strategy-decision-event-rejected-dispatch"
+	state := cloneMetadata(session.State)
+	proposal := executionProposalToMap(ExecutionProposal{
+		Action:            "entry",
+		Role:              "entry",
+		Reason:            "SL-Reentry",
+		Side:              "SELL",
+		Symbol:            "BTCUSDT",
+		Type:              "MARKET",
+		Quantity:          0.001,
+		PriceHint:         75600.0,
+		SignalKind:        "sl-reentry",
+		DecisionState:     "entry-ready",
+		SignalBarStateKey: "bar-1",
+		ExecutionStrategy: "book-aware-v1",
+		Status:            "dispatchable",
+		Metadata: map[string]any{
+			"executionDecision": "direct-dispatch",
+			"executionMode":     "live",
+			"skipRuntimeCheck":  true,
+		},
+	})
+	proposal = setExecutionProposalDecisionEventID(proposal, decisionEventID)
+	state["lastExecutionProposal"] = proposal
+	state["lastStrategyIntent"] = proposal
+	session, err = platform.store.UpdateLiveSessionState(session.ID, state)
+	if err != nil {
+		t.Fatalf("update session state failed: %v", err)
+	}
+
+	order, err := platform.dispatchLiveSessionIntent(session)
+	if err == nil {
+		t.Fatal("expected dispatch to return exchange rejection")
+	}
+	if order.ID == "" || !strings.EqualFold(order.Status, "REJECTED") {
+		t.Fatalf("expected rejected order to be persisted, got order=%+v err=%v", order, err)
+	}
+	updated, err := platform.store.GetLiveSession(session.ID)
+	if err != nil {
+		t.Fatalf("reload live session failed: %v", err)
+	}
+	if got := stringValue(updated.State["lastDispatchedDecisionEventId"]); got != decisionEventID {
+		t.Fatalf("expected rejected dispatch to persist decision id %s, got %s", decisionEventID, got)
+	}
+	if err := validateLiveDispatchIdempotency(updated.State, proposal); err == nil {
+		t.Fatal("expected persisted rejected dispatch decision id to block a duplicate dispatch")
+	}
+}
+
 func TestDispatchLiveSessionIntentRejectsEntryWhenSubmissionSlippageTooWide(t *testing.T) {
 	platform, session, runtimeSessionID, _, _ := prepareLiveDecisionTelemetryFixture(t)
 	eventTime := time.Now().UTC()

--- a/internal/service/platform.go
+++ b/internal/service/platform.go
@@ -41,6 +41,7 @@ type Platform struct {
 	liveMarketData         map[string]liveMarketSnapshot
 	liveAccountOpMu        sync.Map // accountID -> *sync.Mutex
 	liveAccountSyncState   sync.Map // accountID -> *liveAccountSyncState
+	liveDispatchMu         sync.Map // liveSessionID -> *sync.Mutex
 	runtimeSourceGateState sync.Map // runtimeSessionID -> last blocked source gate signature
 	runtimeEventPublisher  RuntimeEventPublisher
 	runtimeEventConsumerOn bool

--- a/internal/service/platform.go
+++ b/internal/service/platform.go
@@ -41,7 +41,7 @@ type Platform struct {
 	liveMarketData         map[string]liveMarketSnapshot
 	liveAccountOpMu        sync.Map // accountID -> *sync.Mutex
 	liveAccountSyncState   sync.Map // accountID -> *liveAccountSyncState
-	liveDispatchMu         sync.Map // liveSessionID -> *sync.Mutex
+	liveDispatchMu         sync.Map // liveSessionID -> *sync.Mutex; process-local guard, not distributed idempotency.
 	runtimeSourceGateState sync.Map // runtimeSessionID -> last blocked source gate signature
 	runtimeEventPublisher  RuntimeEventPublisher
 	runtimeEventConsumerOn bool

--- a/internal/store/memory/order_close_verification_test.go
+++ b/internal/store/memory/order_close_verification_test.go
@@ -1,0 +1,76 @@
+package memory
+
+import (
+	"testing"
+	"time"
+
+	"github.com/wuyaocheng/bktrader/internal/domain"
+)
+
+func TestQueryOrderCloseVerificationsFiltersAndSortsLatest(t *testing.T) {
+	store := NewStore()
+	eventTime := time.Date(2026, 4, 26, 3, 36, 23, 0, time.UTC)
+
+	items := []domain.OrderCloseVerification{
+		{
+			ID:                   "verification-old-closed",
+			LiveSessionID:        "live-session-1",
+			OrderID:              "order-old",
+			AccountID:            "live-main",
+			StrategyID:           "strategy-bk-1d",
+			Symbol:               "btcusdt",
+			VerifiedClosed:       true,
+			RemainingPositionQty: 0,
+			VerificationSource:   "ws-sync",
+			EventTime:            eventTime,
+			RecordedAt:           eventTime,
+		},
+		{
+			ID:                   "verification-new-residual",
+			LiveSessionID:        "live-session-1",
+			OrderID:              "order-new",
+			AccountID:            "live-main",
+			StrategyID:           "strategy-bk-1d",
+			Symbol:               "BTCUSDT",
+			VerifiedClosed:       false,
+			RemainingPositionQty: 0.0013,
+			VerificationSource:   "reconcile",
+			EventTime:            eventTime.Add(time.Second),
+			RecordedAt:           eventTime.Add(time.Second),
+		},
+		{
+			ID:                   "verification-other-strategy",
+			LiveSessionID:        "live-session-other",
+			OrderID:              "order-other",
+			AccountID:            "live-main",
+			StrategyID:           "strategy-other",
+			Symbol:               "BTCUSDT",
+			VerifiedClosed:       true,
+			RemainingPositionQty: 0,
+			VerificationSource:   "ws-sync",
+			EventTime:            eventTime.Add(2 * time.Second),
+			RecordedAt:           eventTime.Add(2 * time.Second),
+		},
+	}
+	for _, item := range items {
+		if _, err := store.CreateOrderCloseVerification(item); err != nil {
+			t.Fatalf("CreateOrderCloseVerification failed: %v", err)
+		}
+	}
+
+	got, err := store.QueryOrderCloseVerifications(domain.OrderCloseVerificationQuery{
+		AccountID:  "live-main",
+		StrategyID: "strategy-bk-1d",
+		Symbol:     "btcusdt",
+		Limit:      1,
+	})
+	if err != nil {
+		t.Fatalf("QueryOrderCloseVerifications failed: %v", err)
+	}
+	if len(got) != 1 || got[0].ID != "verification-new-residual" {
+		t.Fatalf("expected latest same-strategy residual verification, got %#v", got)
+	}
+	if got[0].Symbol != "BTCUSDT" {
+		t.Fatalf("expected stored symbol to be normalized, got %s", got[0].Symbol)
+	}
+}

--- a/internal/store/memory/store.go
+++ b/internal/store/memory/store.go
@@ -1224,6 +1224,7 @@ func (s *Store) CreateOrderCloseVerification(item domain.OrderCloseVerification)
 	if item.RecordedAt.IsZero() {
 		item.RecordedAt = time.Now().UTC()
 	}
+	item.Symbol = strings.ToUpper(strings.TrimSpace(item.Symbol))
 	item = cloneJSONValue(item)
 	s.closeVerifications = append(s.closeVerifications, item)
 	return cloneJSONValue(item), nil
@@ -1247,6 +1248,9 @@ func (s *Store) QueryOrderCloseVerifications(query domain.OrderCloseVerification
 			continue
 		}
 		if strings.TrimSpace(query.AccountID) != "" && item.AccountID != strings.TrimSpace(query.AccountID) {
+			continue
+		}
+		if strings.TrimSpace(query.StrategyID) != "" && item.StrategyID != strings.TrimSpace(query.StrategyID) {
 			continue
 		}
 		querySymbol := strings.ToUpper(strings.TrimSpace(query.Symbol))

--- a/internal/store/memory/store.go
+++ b/internal/store/memory/store.go
@@ -1246,6 +1246,13 @@ func (s *Store) QueryOrderCloseVerifications(query domain.OrderCloseVerification
 		if strings.TrimSpace(query.OrderID) != "" && item.OrderID != strings.TrimSpace(query.OrderID) {
 			continue
 		}
+		if strings.TrimSpace(query.AccountID) != "" && item.AccountID != strings.TrimSpace(query.AccountID) {
+			continue
+		}
+		querySymbol := strings.ToUpper(strings.TrimSpace(query.Symbol))
+		if querySymbol != "" && strings.ToUpper(strings.TrimSpace(item.Symbol)) != querySymbol {
+			continue
+		}
 		if len(query.OrderIDs) > 0 {
 			if _, ok := orderIDMap[item.OrderID]; !ok {
 				continue

--- a/internal/store/postgres/order_close_verification_test.go
+++ b/internal/store/postgres/order_close_verification_test.go
@@ -1,0 +1,90 @@
+package postgres
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/wuyaocheng/bktrader/internal/domain"
+)
+
+func TestQueryOrderCloseVerificationsFiltersAndSortsLatest(t *testing.T) {
+	dsn := os.Getenv("BKTRADER_TEST_POSTGRES_DSN")
+	if dsn == "" {
+		t.Skip("BKTRADER_TEST_POSTGRES_DSN is not set")
+	}
+	if err := Migrate(dsn); err != nil {
+		t.Fatalf("Migrate failed: %v", err)
+	}
+	store, err := New(dsn)
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	defer store.Close()
+
+	eventTime := time.Date(2026, 4, 26, 3, 36, 23, 0, time.UTC)
+	suffix := time.Now().UTC().Format("20060102150405.000000000")
+	accountID := "live-main-close-verif-" + suffix
+	items := []domain.OrderCloseVerification{
+		{
+			ID:                   "verification-old-closed-" + suffix,
+			LiveSessionID:        "live-session-1-" + suffix,
+			OrderID:              "order-old-" + suffix,
+			AccountID:            accountID,
+			StrategyID:           "strategy-bk-1d",
+			Symbol:               "btcusdt",
+			VerifiedClosed:       true,
+			RemainingPositionQty: 0,
+			VerificationSource:   "ws-sync",
+			EventTime:            eventTime,
+			RecordedAt:           eventTime,
+		},
+		{
+			ID:                   "verification-new-residual-" + suffix,
+			LiveSessionID:        "live-session-1-" + suffix,
+			OrderID:              "order-new-" + suffix,
+			AccountID:            accountID,
+			StrategyID:           "strategy-bk-1d",
+			Symbol:               "BTCUSDT",
+			VerifiedClosed:       false,
+			RemainingPositionQty: 0.0013,
+			VerificationSource:   "reconcile",
+			EventTime:            eventTime.Add(time.Second),
+			RecordedAt:           eventTime.Add(time.Second),
+		},
+		{
+			ID:                   "verification-other-strategy-" + suffix,
+			LiveSessionID:        "live-session-other-" + suffix,
+			OrderID:              "order-other-" + suffix,
+			AccountID:            accountID,
+			StrategyID:           "strategy-other",
+			Symbol:               "BTCUSDT",
+			VerifiedClosed:       true,
+			RemainingPositionQty: 0,
+			VerificationSource:   "ws-sync",
+			EventTime:            eventTime.Add(2 * time.Second),
+			RecordedAt:           eventTime.Add(2 * time.Second),
+		},
+	}
+	for _, item := range items {
+		if _, err := store.CreateOrderCloseVerification(item); err != nil {
+			t.Fatalf("CreateOrderCloseVerification failed: %v", err)
+		}
+	}
+
+	got, err := store.QueryOrderCloseVerifications(domain.OrderCloseVerificationQuery{
+		AccountID:  accountID,
+		StrategyID: "strategy-bk-1d",
+		Symbol:     "btcusdt",
+		Limit:      1,
+	})
+	if err != nil {
+		t.Fatalf("QueryOrderCloseVerifications failed: %v", err)
+	}
+	if len(got) != 1 || got[0].ID != "verification-new-residual-"+suffix {
+		t.Fatalf("expected latest same-strategy residual verification, got %#v", got)
+	}
+	if got[0].Symbol != "BTCUSDT" {
+		t.Fatalf("expected stored symbol to be normalized, got %s", got[0].Symbol)
+	}
+}

--- a/internal/store/postgres/store.go
+++ b/internal/store/postgres/store.go
@@ -2206,6 +2206,14 @@ func (s *Store) QueryOrderCloseVerifications(query domain.OrderCloseVerification
 		args = append(args, strings.TrimSpace(query.OrderID))
 		builder.WriteString(fmt.Sprintf(" and order_id = $%d", len(args)))
 	}
+	if strings.TrimSpace(query.AccountID) != "" {
+		args = append(args, strings.TrimSpace(query.AccountID))
+		builder.WriteString(fmt.Sprintf(" and account_id = $%d", len(args)))
+	}
+	if strings.TrimSpace(query.Symbol) != "" {
+		args = append(args, strings.ToUpper(strings.TrimSpace(query.Symbol)))
+		builder.WriteString(fmt.Sprintf(" and upper(symbol) = upper($%d)", len(args)))
+	}
 	if len(query.OrderIDs) > 0 {
 		placeholders := make([]string, 0, len(query.OrderIDs))
 		for _, id := range query.OrderIDs {
@@ -2220,7 +2228,7 @@ func (s *Store) QueryOrderCloseVerifications(query domain.OrderCloseVerification
 		}
 	}
 
-	builder.WriteString(" order by recorded_at desc")
+	builder.WriteString(" order by event_time desc, recorded_at desc, id desc")
 
 	if query.Limit > 0 {
 		args = append(args, query.Limit)

--- a/internal/store/postgres/store.go
+++ b/internal/store/postgres/store.go
@@ -2162,6 +2162,7 @@ func (s *Store) CreateOrderCloseVerification(item domain.OrderCloseVerification)
 	if item.ID == "" {
 		item.ID = fmt.Sprintf("order-close-verification-%d", time.Now().UTC().UnixNano())
 	}
+	item.Symbol = strings.ToUpper(strings.TrimSpace(item.Symbol))
 	if item.EventTime.IsZero() {
 		item.EventTime = time.Now().UTC()
 	}
@@ -2210,9 +2211,13 @@ func (s *Store) QueryOrderCloseVerifications(query domain.OrderCloseVerification
 		args = append(args, strings.TrimSpace(query.AccountID))
 		builder.WriteString(fmt.Sprintf(" and account_id = $%d", len(args)))
 	}
+	if strings.TrimSpace(query.StrategyID) != "" {
+		args = append(args, strings.TrimSpace(query.StrategyID))
+		builder.WriteString(fmt.Sprintf(" and strategy_id = $%d", len(args)))
+	}
 	if strings.TrimSpace(query.Symbol) != "" {
 		args = append(args, strings.ToUpper(strings.TrimSpace(query.Symbol)))
-		builder.WriteString(fmt.Sprintf(" and upper(symbol) = upper($%d)", len(args)))
+		builder.WriteString(fmt.Sprintf(" and symbol = $%d", len(args)))
 	}
 	if len(query.OrderIDs) > 0 {
 		placeholders := make([]string, 0, len(query.OrderIDs))


### PR DESCRIPTION
## 目的
修复线上 live session 中同一个 strategy decision event 可能被重复 dispatch 的问题，并收敛 close order 已确认全平后仍被 reconcile gate 反复 backfill 的行为。

Root cause:
- live dispatch 使用旧 session state 做 proposal 判断，缺少同一 session 的 dispatch 串行化和 decision event 幂等键。
- terminal FILLED close order 在 filled qty 已完整且已有 lastFilledAt 后，仍会因为 position reconcile gate blocked 被反复 backfill。
- exchange 已 flat 且 close verification 已确认全平时，DB 残留 position 缺少基于已验证 close 事实的安全自愈路径。

## 与 PR #225 的关系
PR #225 已合入 Live Recovery Workbench，并覆盖了一个相关症状：当 exchange flat 且存在 terminal exit order 时，可以清理 DB stale position。

本 PR 已 rebase 到包含 #225 的最新 main，并保留 #225 的 terminal-exit fallback；本 PR 额外补上：
- dispatch 级 idempotency，防止同一个 decision event 重复下单。
- terminal FILLED order 不再因为 reconcile gate blocked 反复 backfill。
- 基于 `order_close_verifications` 的更强事实源清理 ghost position，优先于 #225 的 terminal-exit fallback。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [x] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [ ] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main)
- [ ] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？
- [x] DB migration 是否具备向下兼容幂等性？
- [ ] 配置字段有没有无意被混改？

说明：本 PR 不修改 dispatchMode 默认值，不新增 mainnet 硬编码，不改配置字段语义。新增 migration 使用 `CREATE INDEX IF NOT EXISTS`。

## 修改点
- 为 live session dispatch 增加 session 级 mutex，dispatch 前重读最新 session state。
- 记录并校验 `lastDispatchedDecisionEventId`，防止同一个 decision event 重复下单。
- 已完整 FILLED 的 terminal live order 不再因为 reconcile gate blocked 反复 backfill。
- exchange authoritative flat 且最新 close verification 已确认全平时，清理 DB ghost position，并记录 verified gate 状态。
- 保留 #225 的 terminal-exit stale position cleanup 作为无 close verification 时的 fallback。
- 为 close verification 增加 account/symbol 查询过滤和索引，避免热路径扫描。

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

本地已通过：
- `go test ./internal/service -run 'TestDispatchLiveSessionIntentReloadsLatestStateBeforeDispatch|TestValidateLiveDispatchIdempotencyRejectsPreviouslyDispatchedDecisionEvent|TestShouldBackfillTerminalFilledLiveOrderSkipsCompleteFillWhenGateBlocked|TestRefreshLiveAccountPositionReconcileGateClearsVerifiedClosedExchangeMissingPosition|TestRefreshLiveAccountPositionReconcileGateKeepsExchangeMissingPositionWhenLatestCloseVerificationIsResidual|TestReconcileLiveAccountClearsStaleDBPositionAfterTerminalExit'`
- `go test ./internal/store/...`
- `go test ./internal/service`
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
- `go build ./cmd/platform-worker`
- pre-push harness / graphify rebuild passed during push

## Notes
工作区中仍有未提交的本地文档/research 文件，未纳入本 PR。
