### PR TITLE
[codex] Fix live recovery route conflict

### DIFF
--- a/internal/http/accounts.go
+++ b/internal/http/accounts.go
@@ -79,6 +79,10 @@ func registerAccountRoutes(mux *http.ServeMux, platform *service.Platform) {
 	mux.HandleFunc("/api/v1/live/accounts/", func(w http.ResponseWriter, r *http.Request) {
 		path := strings.TrimPrefix(r.URL.Path, "/api/v1/live/accounts/")
 		parts := strings.Split(strings.Trim(path, "/"), "/")
+		if len(parts) >= 2 && parts[1] == "recovery" {
+			handleLiveAccountRecoveryRoute(w, r, platform, parts)
+			return
+		}
 		if len(parts) != 2 {
 			writeError(w, http.StatusNotFound, "live account route not found")
 			return

--- a/internal/http/live_recovery.go
+++ b/internal/http/live_recovery.go
@@ -9,83 +9,79 @@ import (
 	"github.com/wuyaocheng/bktrader/internal/service"
 )
 
-func registerLiveRecoveryRoutes(mux *http.ServeMux, platform *service.Platform) {
-	mux.HandleFunc("/api/v1/live/accounts/", func(w http.ResponseWriter, r *http.Request) {
-		// 路由匹配：/api/v1/live/accounts/:id/recovery/:action
-		path := strings.TrimPrefix(r.URL.Path, "/api/v1/live/accounts/")
-		parts := strings.Split(strings.Trim(path, "/"), "/")
-		if len(parts) < 3 || parts[0] == "" || parts[1] != "recovery" || parts[2] == "" {
-			writeError(w, http.StatusNotFound, "unsupported live recovery route")
+func handleLiveAccountRecoveryRoute(w http.ResponseWriter, r *http.Request, platform *service.Platform, parts []string) {
+	// 路由匹配：/api/v1/live/accounts/:id/recovery/:action
+	if len(parts) < 3 || parts[0] == "" || parts[1] != "recovery" || parts[2] == "" {
+		writeError(w, http.StatusNotFound, "unsupported live recovery route")
+		return
+	}
+
+	accountID := parts[0]
+	subAction := parts[2]
+
+	switch subAction {
+	case "diagnose":
+		if r.Method != http.MethodPost && r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
 			return
 		}
-
-		accountID := parts[0]
-		subAction := parts[2]
-
-		switch subAction {
-		case "diagnose":
-			if r.Method != http.MethodPost && r.Method != http.MethodGet {
-				w.WriteHeader(http.StatusMethodNotAllowed)
+		var options service.LiveRecoveryDiagnoseOptions
+		if r.Method == http.MethodPost {
+			if err := decodeJSON(r, &options); err != nil {
+				writeError(w, http.StatusBadRequest, err.Error())
 				return
 			}
-			var options service.LiveRecoveryDiagnoseOptions
-			if r.Method == http.MethodPost {
-				if err := decodeJSON(r, &options); err != nil {
-					writeError(w, http.StatusBadRequest, err.Error())
+		} else {
+			query := r.URL.Query()
+			options.Symbol = query.Get("symbol")
+			options.SessionID = query.Get("sessionId")
+			if lookbackRaw := strings.TrimSpace(query.Get("lookbackHours")); lookbackRaw != "" {
+				lookback, err := strconv.Atoi(lookbackRaw)
+				if err != nil || lookback <= 0 {
+					writeError(w, http.StatusBadRequest, "invalid lookbackHours")
 					return
 				}
-			} else {
-				query := r.URL.Query()
-				options.Symbol = query.Get("symbol")
-				options.SessionID = query.Get("sessionId")
-				if lookbackRaw := strings.TrimSpace(query.Get("lookbackHours")); lookbackRaw != "" {
-					lookback, err := strconv.Atoi(lookbackRaw)
-					if err != nil || lookback <= 0 {
-						writeError(w, http.StatusBadRequest, "invalid lookbackHours")
-						return
-					}
-					options.LookbackHours = lookback
-				}
+				options.LookbackHours = lookback
 			}
-			options.AccountID = accountID
-
-			result, err := platform.DiagnoseLiveRecovery(r.Context(), options)
-			if err != nil {
-				writeError(w, http.StatusInternalServerError, err.Error())
-				return
-			}
-			writeJSON(w, http.StatusOK, result)
-
-		case "execute":
-			if r.Method != http.MethodPost {
-				w.WriteHeader(http.StatusMethodNotAllowed)
-				return
-			}
-			var req struct {
-				Action  string         `json:"action"`
-				Payload map[string]any `json:"payload"`
-			}
-			if err := decodeJSON(r, &req); err != nil {
-				writeError(w, http.StatusBadRequest, err.Error())
-				return
-			}
-			if strings.TrimSpace(req.Action) == "" {
-				writeError(w, http.StatusBadRequest, "action is required")
-				return
-			}
-			if req.Payload == nil {
-				req.Payload = map[string]any{}
-			}
-
-			result, err := platform.ExecuteLiveRecoveryAction(r.Context(), accountID, req.Action, req.Payload)
-			if err != nil {
-				writeError(w, http.StatusBadRequest, err.Error())
-				return
-			}
-			writeJSON(w, http.StatusOK, result)
-
-		default:
-			writeError(w, http.StatusNotFound, fmt.Sprintf("unsupported recovery sub-action: %s", subAction))
 		}
-	})
+		options.AccountID = accountID
+
+		result, err := platform.DiagnoseLiveRecovery(r.Context(), options)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		writeJSON(w, http.StatusOK, result)
+
+	case "execute":
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		var req struct {
+			Action  string         `json:"action"`
+			Payload map[string]any `json:"payload"`
+		}
+		if err := decodeJSON(r, &req); err != nil {
+			writeError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		if strings.TrimSpace(req.Action) == "" {
+			writeError(w, http.StatusBadRequest, "action is required")
+			return
+		}
+		if req.Payload == nil {
+			req.Payload = map[string]any{}
+		}
+
+		result, err := platform.ExecuteLiveRecoveryAction(r.Context(), accountID, req.Action, req.Payload)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		writeJSON(w, http.StatusOK, result)
+
+	default:
+		writeError(w, http.StatusNotFound, fmt.Sprintf("unsupported recovery sub-action: %s", subAction))
+	}
 }

--- a/internal/http/live_recovery_test.go
+++ b/internal/http/live_recovery_test.go
@@ -6,15 +6,21 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/wuyaocheng/bktrader/internal/config"
 	"github.com/wuyaocheng/bktrader/internal/service"
 	"github.com/wuyaocheng/bktrader/internal/store/memory"
 )
+
+func TestNewRouterWithLiveRecoveryDoesNotPanic(t *testing.T) {
+	platform := service.NewPlatform(memory.NewStore())
+	_ = NewRouter(config.Config{AppName: "test", Environment: "test"}, platform)
+}
 
 func TestLiveRecoveryRoutes(t *testing.T) {
 	s := memory.NewStore()
 	platform := service.NewPlatform(s)
 	mux := http.NewServeMux()
-	registerLiveRecoveryRoutes(mux, platform)
+	registerAccountRoutes(mux, platform)
 
 	// 1. 不完整 recovery URL 不 panic
 	t.Run("incomplete URL no panic", func(t *testing.T) {

--- a/internal/http/router.go
+++ b/internal/http/router.go
@@ -57,7 +57,6 @@ func NewRouter(cfg config.Config, platform *service.Platform) http.Handler {
 	registerStrategyRoutes(mux, platform)
 	registerAccountRoutes(mux, platform)
 	registerLiveRoutes(mux, platform, cfg)
-	registerLiveRecoveryRoutes(mux, platform)
 	registerOrderRoutes(mux, platform)
 	registerBacktestRoutes(mux, platform)
 	registerChartRoutes(mux, platform)


### PR DESCRIPTION
## 目的
修复生产 `platform-api` 启动 panic，恢复前端/API 可用性。

Root cause：PR #225 新增 `registerLiveRecoveryRoutes` 时再次注册了 `/api/v1/live/accounts/`，而该 pattern 已在 `accounts.go` 注册；Go `http.ServeMux` 启动时直接 panic，导致 `bktrader-platform-api` 容器反复重启。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [x] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值无变化
- [x] 不存在直接调用 `mainnet` 凭证或路由地址的硬编码
- [x] 不涉及 DB migration
- [x] 配置字段没有无意被混改

## 修改点
- 移除第二次 `/api/v1/live/accounts/` route registration。
- 将 recovery 子路径挂到既有 live accounts handler 下分发。
- 补 `NewRouter` smoke test，确保 live recovery route 注册不会 panic。

## 验证方式与测试证据
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

本地验证：

```bash
go test ./internal/http ./internal/app
go test ./...
go build ./cmd/platform-api
go build ./cmd/platform-worker
```
