### PR TITLE
[codex] Add router smoke test and recovery 404

### DIFF
--- a/internal/http/live_recovery.go
+++ b/internal/http/live_recovery.go
@@ -48,6 +48,10 @@ func handleLiveAccountRecoveryRoute(w http.ResponseWriter, r *http.Request, plat
 
 		result, err := platform.DiagnoseLiveRecovery(r.Context(), options)
 		if err != nil {
+			if strings.Contains(err.Error(), "account not found:") {
+				writeError(w, http.StatusNotFound, err.Error())
+				return
+			}
 			writeError(w, http.StatusInternalServerError, err.Error())
 			return
 		}

--- a/internal/http/live_recovery_test.go
+++ b/internal/http/live_recovery_test.go
@@ -11,9 +11,31 @@ import (
 	"github.com/wuyaocheng/bktrader/internal/store/memory"
 )
 
-func TestNewRouterWithLiveRecoveryDoesNotPanic(t *testing.T) {
+func TestNewRouterRegistersCoreRoutesWithoutPanic(t *testing.T) {
 	platform := service.NewPlatform(memory.NewStore())
-	_ = NewRouter(config.Config{AppName: "test", Environment: "test"}, platform)
+	router := NewRouter(config.Config{AppName: "test", Environment: "test"}, platform)
+
+	tests := []struct {
+		name       string
+		method     string
+		path       string
+		wantStatus int
+	}{
+		{name: "healthz", method: http.MethodGet, path: "/healthz", wantStatus: http.StatusOK},
+		{name: "overview", method: http.MethodGet, path: "/api/v1/overview", wantStatus: http.StatusOK},
+		{name: "live account positions", method: http.MethodGet, path: "/api/v1/live/accounts/live-main/positions", wantStatus: http.StatusOK},
+		{name: "live recovery diagnose missing account", method: http.MethodGet, path: "/api/v1/live/accounts/missing-account/recovery/diagnose?symbol=BTCUSDT", wantStatus: http.StatusNotFound},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.path, nil)
+			rr := httptest.NewRecorder()
+			router.ServeHTTP(rr, req)
+			if rr.Code != tc.wantStatus {
+				t.Fatalf("expected status %d, got %d: %s", tc.wantStatus, rr.Code, rr.Body.String())
+			}
+		})
+	}
 }
 
 func TestLiveRecoveryRoutes(t *testing.T) {
@@ -32,14 +54,13 @@ func TestLiveRecoveryRoutes(t *testing.T) {
 		}
 	})
 
-	// 2. GET diagnose 正常 (虽然因为没数据会报 500/error，但路由应该通)
+	// 2. GET diagnose 正常处理缺失 account，不应冒泡为 500
 	t.Run("GET diagnose route", func(t *testing.T) {
 		req := httptest.NewRequest("GET", "/api/v1/live/accounts/acc1/recovery/diagnose?symbol=BTCUSDT", nil)
 		rr := httptest.NewRecorder()
 		mux.ServeHTTP(rr, req)
-		// 应该因为找不到 account 而报错 500 (目前的逻辑)
-		if rr.Code != http.StatusInternalServerError {
-			t.Errorf("expected 500 (account not found), got %d", rr.Code)
+		if rr.Code != http.StatusNotFound {
+			t.Errorf("expected 404 (account not found), got %d", rr.Code)
 		}
 	})
 


### PR DESCRIPTION
## 目的
PR #230 后续小补丁：补一个 `NewRouter()` smoke 覆盖，确保核心路由注册不会因为重复 pattern panic；同时把 live recovery diagnose 的 account 不存在错误从 500 映射为 404。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [x] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) - 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？- 无
- [x] DB migration 是否具备向下兼容幂等性？- 不涉及
- [x] 配置字段有没有无意被混改？- 无

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

本地已验证：
- `go test ./internal/http ./internal/app`
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/platform-worker`
- `go build ./cmd/db-migrate`