### PR TITLE
[codex] fix live recovery diagnosis feedback

### DIFF
--- a/internal/service/live_recovery_workbench.go
+++ b/internal/service/live_recovery_workbench.go
@@ -48,15 +48,26 @@ type LiveRecoveryActionCandidate struct {
 	Payload     map[string]any `json:"payload,omitempty"` // 执行动作所需的参数
 }
 
+// LiveRecoveryDiagnosticError records the failing diagnostic stage without
+// hiding partial DB/exchange evidence that was already collected.
+type LiveRecoveryDiagnosticError struct {
+	Stage     string `json:"stage"`
+	Message   string `json:"message"`
+	Retryable bool   `json:"retryable"`
+}
+
 // LiveRecoveryDiagnoseResult 诊断结果
 type LiveRecoveryDiagnoseResult struct {
 	AccountID     string                        `json:"accountId"`
 	Symbol        string                        `json:"symbol"`
+	Status        string                        `json:"status"`  // "ok", "warning", "error"
+	Summary       string                        `json:"summary"` // operator-facing summary
 	ExchangeFact  LiveRecoveryFact              `json:"exchangeFact"`
 	DBFact        LiveRecoveryFact              `json:"dbFact"`
 	Mismatches    []LiveRecoveryMismatch        `json:"mismatches"`
 	Actions       []LiveRecoveryActionCandidate `json:"actions"`
 	Authoritative bool                          `json:"authoritative"`
+	Error         *LiveRecoveryDiagnosticError  `json:"error,omitempty"`
 	RuntimeRole   string                        `json:"runtimeRole"` // BKTRADER_ROLE
 	DiagnosedAt   time.Time                     `json:"diagnosedAt"`
 }
@@ -77,6 +88,8 @@ func (p *Platform) DiagnoseLiveRecovery(ctx context.Context, options LiveRecover
 	result := LiveRecoveryDiagnoseResult{
 		AccountID:   account.ID,
 		Symbol:      symbol,
+		Status:      "ok",
+		Summary:     "诊断完成，未发现状态不一致。",
 		RuntimeRole: p.processRole,
 		DiagnosedAt: time.Now().UTC(),
 	}
@@ -84,22 +97,48 @@ func (p *Platform) DiagnoseLiveRecovery(ctx context.Context, options LiveRecover
 	// 1. 获取本地数据库事实
 	dbFact, err := p.fetchDBFact(account.ID, symbol, lookback)
 	if err != nil {
-		return result, fmt.Errorf("fetch db fact failed: %w", err)
+		result.Status = "error"
+		result.Summary = "本地数据库事实获取失败，无法完成恢复诊断。"
+		result.Error = &LiveRecoveryDiagnosticError{
+			Stage:     "fetch-db-fact",
+			Message:   err.Error(),
+			Retryable: true,
+		}
+		result.Authoritative = false
+		return result, nil
 	}
 	result.DBFact = dbFact
 
 	// 2. 获取交易所权威事实
 	exchangeFact, err := p.fetchExchangeFact(account, symbol, lookback)
 	if err != nil {
-		// 如果获取交易所事实失败，标记权威性为 false
+		// 如果获取交易所事实失败，返回一份非权威诊断报告，保留已采集到的 DB fact。
 		result.Authoritative = false
-		return result, fmt.Errorf("fetch exchange fact failed: %w", err)
+		result.Status = "error"
+		result.Summary = "交易所 REST 权威事实获取失败，诊断结果不可用于破坏性修复。"
+		result.Error = &LiveRecoveryDiagnosticError{
+			Stage:     "fetch-exchange-fact",
+			Message:   err.Error(),
+			Retryable: true,
+		}
+		result.ExchangeFact = exchangeFact
+		result.Mismatches = []LiveRecoveryMismatch{{
+			Scenario: "non-authoritative",
+			Level:    "critical",
+			Message:  fmt.Sprintf("未能获取交易所权威事实：%s。", err.Error()),
+		}}
+		result.Actions = blockLiveRecoveryActions(p.generateRecoveryActions(account, symbol, result.DBFact, result.ExchangeFact, result.Mismatches), "non-authoritative-diagnosis")
+		return result, nil
 	}
 	result.ExchangeFact = exchangeFact
 	result.Authoritative = true // 成功获取 REST 事实即视为权威
 
 	// 3. 评估差异与分类
 	result.Mismatches = p.classifyRecoveryMismatches(result.DBFact, result.ExchangeFact)
+	if len(result.Mismatches) > 0 {
+		result.Status = "warning"
+		result.Summary = fmt.Sprintf("诊断完成，发现 %d 个状态差异。", len(result.Mismatches))
+	}
 
 	// 4. 生成可选修复动作
 	result.Actions = p.generateRecoveryActions(account, symbol, result.DBFact, result.ExchangeFact, result.Mismatches)
@@ -198,10 +237,8 @@ func (p *Platform) fetchExchangeFact(account domain.Account, symbol string, look
 		}
 		snapshot := mapValue(synced.Metadata["liveSyncSnapshot"])
 		exchangePositions := metadataList(snapshot["positions"])
-		foundSymbol := false
 		for _, item := range exchangePositions {
 			if NormalizeSymbol(stringValue(item["symbol"])) == symbol {
-				foundSymbol = true
 				positionAmt := parseFloatValue(item["positionAmt"])
 				if positionAmt != 0 {
 					side := "LONG"
@@ -218,10 +255,6 @@ func (p *Platform) fetchExchangeFact(account domain.Account, symbol string, look
 				}
 				break
 			}
-		}
-		if !foundSymbol && symbol != "" {
-			// 如果指定了 symbol 但在快照中完全没找到该 symbol (即使是 0 仓位也应该有记录)，视作异常
-			return fact, fmt.Errorf("symbol %s not found in exchange account snapshot", symbol)
 		}
 	}
 	if fact.Position == nil {
@@ -430,6 +463,14 @@ func (p *Platform) generateRecoveryActions(account domain.Account, symbol string
 	return actions
 }
 
+func blockLiveRecoveryActions(actions []LiveRecoveryActionCandidate, reason string) []LiveRecoveryActionCandidate {
+	for i := range actions {
+		actions[i].Allowed = false
+		actions[i].BlockedBy = reason
+	}
+	return actions
+}
+
 // ExecuteLiveRecoveryAction 执行特定的修复动作（安全版）
 func (p *Platform) ExecuteLiveRecoveryAction(ctx context.Context, accountID, action string, payload map[string]any) (map[string]any, error) {
 	account, err := p.store.GetAccount(accountID)
@@ -446,6 +487,9 @@ func (p *Platform) ExecuteLiveRecoveryAction(ctx context.Context, accountID, act
 	})
 	if err != nil {
 		return nil, fmt.Errorf("pre-check diagnose failed: %w", err)
+	}
+	if !diag.Authoritative || strings.EqualFold(diag.Status, "error") {
+		return nil, fmt.Errorf("action %s blocked: non-authoritative diagnosis", action)
 	}
 
 	allowed := false

--- a/internal/service/live_recovery_workbench_test.go
+++ b/internal/service/live_recovery_workbench_test.go
@@ -1,7 +1,14 @@
 package service
 
 import (
+	"context"
+	"errors"
+	"strings"
 	"testing"
+	"time"
+
+	"github.com/wuyaocheng/bktrader/internal/domain"
+	"github.com/wuyaocheng/bktrader/internal/store/memory"
 )
 
 func TestClassifyRecoveryMismatches(t *testing.T) {
@@ -66,5 +73,143 @@ func TestScenarioClassification(t *testing.T) {
 		t.Errorf("expected 1 mismatch, got %d", len(mismatches4))
 	} else if mismatches4[0].Scenario != "side-conflict" {
 		t.Errorf("expected scenario side-conflict, got %s", mismatches4[0].Scenario)
+	}
+}
+
+func TestDiagnoseLiveRecoveryTreatsMissingSnapshotSymbolAsFlat(t *testing.T) {
+	store := memory.NewStore()
+	platform := NewPlatform(store)
+	adapterKey := "test-recovery-flat-snapshot"
+	platform.registerLiveAdapter(testLiveAccountReconcileAdapter{
+		key: adapterKey,
+		syncSnapshotFunc: func(p *Platform, account domain.Account, binding map[string]any) (domain.Account, error) {
+			previousSuccessAt := parseOptionalRFC3339(stringValue(account.Metadata["lastLiveSyncAt"]))
+			account.Metadata = cloneMetadata(account.Metadata)
+			account.Metadata["liveSyncSnapshot"] = map[string]any{
+				"source":          "binance-rest-account-v3",
+				"adapterKey":      adapterKey,
+				"syncedAt":        time.Now().UTC().Format(time.RFC3339),
+				"bindingMode":     "api-key-ref",
+				"executionMode":   "rest",
+				"syncStatus":      "SYNCED",
+				"accountExchange": account.Exchange,
+				"positions":       []map[string]any{},
+				"openOrders":      []map[string]any{},
+			}
+			return p.persistLiveAccountSyncSuccess(account, binding, previousSuccessAt)
+		},
+	})
+
+	account, err := store.CreateAccount("live-main", "LIVE", "binance-futures")
+	if err != nil {
+		t.Fatalf("create account failed: %v", err)
+	}
+	account.Metadata = map[string]any{
+		"liveBinding": map[string]any{
+			"adapterKey":     adapterKey,
+			"connectionMode": "api-key-ref",
+			"executionMode":  "rest",
+		},
+	}
+	if _, err := store.UpdateAccount(account); err != nil {
+		t.Fatalf("update account failed: %v", err)
+	}
+	if _, err := store.SavePosition(domain.Position{
+		AccountID:  account.ID,
+		Symbol:     "BTCUSDT",
+		Side:       "LONG",
+		Quantity:   0.1,
+		EntryPrice: 68000,
+		UpdatedAt:  time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("save position failed: %v", err)
+	}
+
+	diag, err := platform.DiagnoseLiveRecovery(context.Background(), LiveRecoveryDiagnoseOptions{
+		AccountID: account.ID,
+		Symbol:    "BTCUSDT",
+	})
+	if err != nil {
+		t.Fatalf("diagnose failed: %v", err)
+	}
+	if !diag.Authoritative {
+		t.Fatal("expected authoritative diagnosis")
+	}
+	if got := parseFloatValue(diag.ExchangeFact.Position["quantity"]); got != 0 {
+		t.Fatalf("expected missing exchange symbol to be treated as flat, got quantity %v", got)
+	}
+	if len(diag.Mismatches) == 0 || diag.Mismatches[0].Scenario != "exchange-flat-db-position-present" {
+		t.Fatalf("expected stale DB position mismatch, got %#v", diag.Mismatches)
+	}
+	if diag.Status != "warning" {
+		t.Fatalf("expected warning status, got %s", diag.Status)
+	}
+}
+
+func TestDiagnoseLiveRecoveryReturnsNonAuthoritativeReportOnExchangeFailure(t *testing.T) {
+	store := memory.NewStore()
+	platform := NewPlatform(store)
+	adapterKey := "test-recovery-exchange-failure"
+	platform.registerLiveAdapter(testLiveAccountReconcileAdapter{
+		key: adapterKey,
+		syncSnapshotFunc: func(*Platform, domain.Account, map[string]any) (domain.Account, error) {
+			return domain.Account{}, errors.New("binance account sync failed: test outage")
+		},
+	})
+
+	account, err := store.CreateAccount("live-main", "LIVE", "binance-futures")
+	if err != nil {
+		t.Fatalf("create account failed: %v", err)
+	}
+	account.Metadata = map[string]any{
+		"liveBinding": map[string]any{
+			"adapterKey":     adapterKey,
+			"connectionMode": "api-key-ref",
+			"executionMode":  "rest",
+		},
+	}
+	if _, err := store.UpdateAccount(account); err != nil {
+		t.Fatalf("update account failed: %v", err)
+	}
+
+	diag, err := platform.DiagnoseLiveRecovery(context.Background(), LiveRecoveryDiagnoseOptions{
+		AccountID: account.ID,
+		Symbol:    "BTCUSDT",
+	})
+	if err != nil {
+		t.Fatalf("diagnose should return a report instead of error: %v", err)
+	}
+	if diag.Authoritative {
+		t.Fatal("expected non-authoritative diagnosis")
+	}
+	if diag.Status != "error" {
+		t.Fatalf("expected error status, got %s", diag.Status)
+	}
+	if diag.Error == nil || diag.Error.Stage != "fetch-exchange-fact" {
+		t.Fatalf("expected fetch-exchange-fact diagnostic error, got %#v", diag.Error)
+	}
+	if len(diag.Mismatches) == 0 || diag.Mismatches[0].Scenario != "non-authoritative" {
+		t.Fatalf("expected non-authoritative mismatch, got %#v", diag.Mismatches)
+	}
+	if len(diag.Actions) == 0 {
+		t.Fatal("expected diagnostic actions to explain blocked recovery options")
+	}
+	for _, action := range diag.Actions {
+		if action.Allowed {
+			t.Fatalf("expected non-authoritative action %s to be blocked", action.Action)
+		}
+		if action.BlockedBy != "non-authoritative-diagnosis" {
+			t.Fatalf("expected non-authoritative block reason, got %s for %s", action.BlockedBy, action.Action)
+		}
+	}
+
+	_, err = platform.ExecuteLiveRecoveryAction(context.Background(), account.ID, "reconcile", map[string]any{
+		"symbol": "BTCUSDT",
+	})
+	if err == nil {
+		t.Fatal("expected execute action to reject non-authoritative diagnosis")
+	}
+	if !strings.Contains(err.Error(), "non-authoritative diagnosis") {
+		t.Fatalf("expected non-authoritative execution error, got %v", err)
 	}
 }

--- a/web/console/src/pages/RecoveryStage.tsx
+++ b/web/console/src/pages/RecoveryStage.tsx
@@ -1,8 +1,9 @@
 import React, { useState, useMemo, useEffect } from 'react';
-import { 
-  ShieldAlert, 
-  Search, 
-  CheckCircle2, 
+import {
+  ShieldAlert,
+  Search,
+  CheckCircle2,
+  AlertCircle,
   Zap,
   Info,
   ArrowLeft,
@@ -11,6 +12,7 @@ import {
   Database,
   RefreshCw
 } from 'lucide-react';
+import { toast } from 'sonner';
 import { useTradingStore } from '../store/useTradingStore';
 import { useUIStore } from '../store/useUIStore';
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "../components/ui/card";
@@ -58,11 +60,18 @@ interface RecoveryAction {
 interface DiagnosisResult {
   accountId: string;
   symbol: string;
+  status?: 'ok' | 'warning' | 'error';
+  summary?: string;
   exchangeFact: any;
   dbFact: any;
   mismatches: RecoveryMismatch[];
   actions: RecoveryAction[];
   authoritative: boolean;
+  error?: {
+    stage: string;
+    message: string;
+    retryable: boolean;
+  };
   runtimeRole: string;
   diagnosedAt: string;
 }
@@ -92,6 +101,7 @@ export function RecoveryStage() {
     if (!selectedAccountId) return [];
     return sessions.filter(s => s.accountId === selectedAccountId);
   }, [sessions, selectedAccountId]);
+  const diagnosisActionBlocked = !!diagnosis && (!diagnosis.authoritative || diagnosis.status === 'error');
 
   const handleDiagnose = async () => {
     if (!selectedAccountId) return;
@@ -113,8 +123,20 @@ export function RecoveryStage() {
       const result = await fetchJSON<DiagnosisResult>(url);
       setDiagnosis(result);
       setStep('diagnose');
+      if (result.status === 'error') {
+        toast.error(result.summary || "诊断完成，但未能获取权威事实", {
+          description: result.error?.message,
+        });
+      } else if (result.mismatches.length > 0) {
+        toast.info(result.summary || `诊断完成，发现 ${result.mismatches.length} 个状态差异`);
+      } else {
+        toast.success(result.summary || "诊断完成，未发现状态不一致");
+      }
     } catch (err: any) {
       console.error("Diagnosis failed:", err);
+      toast.error("状态诊断请求失败", {
+        description: err instanceof Error ? err.message : "请稍后重试",
+      });
     } finally {
       setIsDiagnosing(false);
     }
@@ -133,8 +155,14 @@ export function RecoveryStage() {
       });
       setVerificationResult(result);
       setStep('verify');
+      toast.success("修复动作已执行", {
+        description: `${action.label} 返回成功`,
+      });
     } catch (err: any) {
       console.error("Action execution failed:", err);
+      toast.error("修复动作执行失败", {
+        description: err instanceof Error ? err.message : "请重新诊断后再试",
+      });
     } finally {
       setExecutingActionId(null);
     }
@@ -303,6 +331,35 @@ export function RecoveryStage() {
               </Card>
             </div>
 
+            {(diagnosis.summary || diagnosis.error) && (
+              <Card tone="bento" className={cn(
+                "rounded-2xl border",
+                diagnosis.status === 'error' ? "border-[var(--bk-status-danger)]" : "border-[var(--bk-border)]"
+              )}>
+                <CardContent className="p-5 flex items-start gap-4">
+                  {diagnosis.status === 'error' ? (
+                    <AlertCircle className="w-5 h-5 text-[var(--bk-status-danger)] shrink-0 mt-0.5" />
+                  ) : (
+                    <Info className="w-5 h-5 text-[var(--bk-accent)] shrink-0 mt-0.5" />
+                  )}
+                  <div className="min-w-0 space-y-2">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <Badge variant={diagnosis.authoritative ? "outline" : "destructive"}>
+                        {diagnosis.authoritative ? "authoritative" : "non-authoritative"}
+                      </Badge>
+                      {diagnosis.error?.stage && (
+                        <Badge variant="metal" className="font-mono text-[9px]">{diagnosis.error.stage}</Badge>
+                      )}
+                    </div>
+                    <p className="text-sm font-bold text-[var(--bk-text-primary)]">{diagnosis.summary}</p>
+                    {diagnosis.error?.message && (
+                      <p className="font-mono text-xs text-[var(--bk-text-muted)] break-words">{diagnosis.error.message}</p>
+                    )}
+                  </div>
+                </CardContent>
+              </Card>
+            )}
+
             <Card tone="bento" className="rounded-[32px] border border-[var(--bk-border-strong)] overflow-hidden">
               <div className="bg-[var(--bk-surface-strong)] px-8 py-4 border-b border-[var(--bk-border)] flex items-center justify-between">
                 <h3 className="font-black flex items-center gap-2">
@@ -359,7 +416,7 @@ export function RecoveryStage() {
               <Button 
                 variant="bento-primary" 
                 onClick={() => setStep('action')}
-                disabled={diagnosis.actions.length === 0}
+                disabled={diagnosis.actions.length === 0 || diagnosisActionBlocked}
                 className="rounded-xl px-10 h-12 font-black"
               >
                 进入修复阶段
@@ -402,9 +459,9 @@ export function RecoveryStage() {
                                 <span className="text-[10px] font-black uppercase text-[var(--bk-text-muted)]">是否可用:</span>
                                 <span className={cn(
                                   "text-[10px] font-black uppercase",
-                                  action.allowed ? "text-[var(--bk-status-success)]" : "text-[var(--bk-status-danger)]"
+                                  action.allowed && !diagnosisActionBlocked ? "text-[var(--bk-status-success)]" : "text-[var(--bk-status-danger)]"
                                 )}>
-                                  {action.allowed ? "ALLOWED" : "BLOCKED"}
+                                  {action.allowed && !diagnosisActionBlocked ? "ALLOWED" : "BLOCKED"}
                                 </span>
                               </div>
                               {action.blockedBy && (
@@ -419,11 +476,11 @@ export function RecoveryStage() {
                           </div>
 
                           <Button 
-                            variant={!action.allowed ? "secondary" : (action.action.includes('clear') || action.action.includes('adopt') ? "bento-destructive" : "bento-primary")}
+                            variant={!action.allowed || diagnosisActionBlocked ? "secondary" : (action.action.includes('clear') || action.action.includes('adopt') ? "bento-destructive" : "bento-primary")}
                             size="lg"
                             className="rounded-2xl h-16 px-8 font-black shadow-lg shrink-0"
                             onClick={() => handleExecuteAction(action)}
-                            disabled={executingActionId !== null || !action.allowed}
+                            disabled={executingActionId !== null || diagnosisActionBlocked || !action.allowed}
                           >
                             {executingActionId === action.action ? (
                               <RefreshCw className="w-5 h-5 mr-2 animate-spin" />


### PR DESCRIPTION
## 目的
修复 Live Recovery Workbench 点击“开始状态诊断”时在 exchange flat 场景返回 500 的问题，并让诊断成功/失败都给操作员更明确的后台报告和前端提示。

Root cause: Binance REST 账户同步快照只保存非零仓位，BTCUSDT 平仓后不会出现在 `liveSyncSnapshot.positions` 中。原诊断逻辑把“指定 symbol 不存在于非零仓位列表”当成异常，导致本应展示 `exchange-flat-db-position-present` 的恢复诊断直接 500。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [x] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 改动内容
- `DiagnoseLiveRecovery` 增加 `status`、`summary`、结构化 `error.stage/message/retryable`。
- 交易所 REST 获取失败时返回 `authoritative=false` 的诊断报告，保留已采集 DB fact，并生成 `non-authoritative` mismatch，避免只给空泛 500。
- 指定 symbol 不在 exchange 非零仓位快照时按 exchange flat 处理，让 stale DB position 可以被正常分类。
- Recovery Workbench 前端在诊断成功、发现差异、非权威诊断、请求失败、修复动作成功/失败时弹出 toast。
- 诊断页显示 authoritative/non-authoritative、失败 stage 和后台详细 message。

## 行为变化
- exchange flat + DB stale position 不再导致诊断 500，而是返回可操作的诊断报告。
- 非权威诊断不会允许破坏性修复，仍通过 mismatch/action blocked 状态提醒操作员。
- 没有修改 dispatchMode 默认值、实盘下单提交边界、reconcile 执行语义或部署配置。

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) - 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？- 无
- [x] DB migration 是否具备向下兼容幂等性？- 无 DB migration
- [x] 配置字段有没有无意被混改？- 无配置字段变更

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

已通过：
- `go test ./internal/service -run 'TestDiagnoseLiveRecoveryTreatsMissingSnapshotSymbolAsFlat|TestDiagnoseLiveRecoveryReturnsNonAuthoritativeReportOnExchangeFailure|TestClassifyRecoveryMismatches|TestScenarioClassification'`
- `go test ./internal/http -run TestLiveRecoveryRoutes`
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
- `cd web/console && ./node_modules/.bin/tsc --noEmit src/pages/RecoveryStage.tsx --jsx react-jsx --esModuleInterop --target esnext --module esnext --moduleResolution Bundler --allowSyntheticDefaultImports`
- `cd web/console && npm run build`
- `git diff --check`

## 生产排查记录
- 生产日志确认 2026-04-26 15:26、15:30 多次 `/api/v1/live/accounts/account-1776074625359537175/recovery/diagnose?sessionId=live-session-1776937952228871971&symbol=BTCUSDT` 返回 500。
- 未修改生产服务器，只读查看日志。