### PR TITLE
[codex] follow issue 234 live runtime lifecycle

### DIFF
--- a/docs/AGENT_PATHS.md
+++ b/docs/AGENT_PATHS.md
@@ -10,6 +10,13 @@
 - **NPX**: `/Users/fujun/.nvm/versions/node/v22.18.0/bin/npx`
 - **Go**: `/opt/homebrew/bin/go`
 - **Python 3**: `/usr/bin/python3`
+- **Graphify Python**: `/usr/local/bin/python3.12`
+  - 用于重建知识图谱：
+    ```bash
+    /usr/local/bin/python3.12 -c "from graphify.watch import _rebuild_code; from pathlib import Path; _rebuild_code(Path('.'))"
+    ```
+  - 不要默认使用 `python3` / `python` 执行 graphify：当前 shell 下它们可能解析到 `/Users/wuyaocheng/miniconda3/bin/python3` 或 `/Users/wuyaocheng/miniconda3/bin/python`，这些环境没有安装 `graphify.watch`。
+  - 若不确定可用解释器，优先执行本地 harness 探测脚本：`bash .agents/local-harness/scripts/find_graphify_python.sh`。
 
 ## 2. 协作与版本控制 (CLI Tools)
 
@@ -24,4 +31,4 @@
 source ~/.zshrc && <your_command>
 ```
 ---
-*上次更新时间: 2026-04-23 (Antigravity 路径修正)*
+*上次更新时间: 2026-04-27 (Graphify Python 路径补充)*

--- a/internal/http/accounts.go
+++ b/internal/http/accounts.go
@@ -157,6 +157,10 @@ func registerAccountRoutes(mux *http.ServeMux, platform *service.Platform) {
 			}
 			item, err := platform.LaunchLiveFlow(accountID, payload)
 			if err != nil {
+				if errors.Is(err, service.ErrLiveControlOperationInProgress) {
+					writeError(w, http.StatusConflict, err.Error())
+					return
+				}
 				writeError(w, http.StatusBadRequest, err.Error())
 				return
 			}
@@ -164,6 +168,10 @@ func registerAccountRoutes(mux *http.ServeMux, platform *service.Platform) {
 		case "stop":
 			item, err := platform.StopLiveFlowWithForce(accountID, queryFlagEnabled(r, "force"))
 			if err != nil {
+				if errors.Is(err, service.ErrLiveControlOperationInProgress) {
+					writeError(w, http.StatusConflict, err.Error())
+					return
+				}
 				if errors.Is(err, service.ErrActivePositionsOrOrders) {
 					writeError(w, http.StatusBadRequest, err.Error())
 					return

--- a/internal/http/live.go
+++ b/internal/http/live.go
@@ -547,6 +547,10 @@ func registerLiveRoutes(mux *http.ServeMux, platform *service.Platform, cfg conf
 				return
 			}
 			if err := platform.DeleteLiveSessionWithForce(parts[0], queryFlagEnabled(r, "force")); err != nil {
+				if errors.Is(err, service.ErrLiveControlOperationInProgress) {
+					writeError(w, http.StatusConflict, err.Error())
+					return
+				}
 				if errors.Is(err, service.ErrActivePositionsOrOrders) {
 					writeError(w, http.StatusBadRequest, err.Error())
 					return
@@ -676,6 +680,10 @@ func registerLiveRoutes(mux *http.ServeMux, platform *service.Platform, cfg conf
 			}
 			item, err := platform.StartLiveSession(sessionID)
 			if err != nil {
+				if errors.Is(err, service.ErrLiveControlOperationInProgress) {
+					writeError(w, http.StatusConflict, err.Error())
+					return
+				}
 				writeError(w, http.StatusInternalServerError, err.Error())
 				return
 			}
@@ -687,6 +695,10 @@ func registerLiveRoutes(mux *http.ServeMux, platform *service.Platform, cfg conf
 			}
 			item, err := platform.StopLiveSessionWithForce(sessionID, queryFlagEnabled(r, "force"))
 			if err != nil {
+				if errors.Is(err, service.ErrLiveControlOperationInProgress) {
+					writeError(w, http.StatusConflict, err.Error())
+					return
+				}
 				if errors.Is(err, service.ErrActivePositionsOrOrders) {
 					writeError(w, http.StatusBadRequest, err.Error())
 					return

--- a/internal/http/session_safety_test.go
+++ b/internal/http/session_safety_test.go
@@ -103,6 +103,31 @@ func TestLiveSessionDeleteRouteReturnsConflictDuringSamePairOperation(t *testing
 	}
 }
 
+func TestLiveSessionStartRouteDoesNotReportMissingControlKeyAsConflict(t *testing.T) {
+	store := memory.NewStore()
+	session, err := store.GetLiveSession("live-session-main")
+	if err != nil {
+		t.Fatalf("get live session failed: %v", err)
+	}
+	session.StrategyID = ""
+	if _, err := store.UpdateLiveSession(session); err != nil {
+		t.Fatalf("corrupt live session strategy id failed: %v", err)
+	}
+	platform := service.NewPlatform(store)
+	mux := http.NewServeMux()
+	registerLiveRoutes(mux, platform, config.Config{ProcessRole: "monolith"})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/live/sessions/live-session-main/start", nil)
+	mux.ServeHTTP(rec, req)
+	if rec.Code == http.StatusConflict {
+		t.Fatalf("missing live control key must not be reported as 409 conflict, body=%s", rec.Body.String())
+	}
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500 for corrupted live session control key, got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
 func TestLiveSessionDetailRouteFiltersStateFields(t *testing.T) {
 	store := memory.NewStore()
 	platform := service.NewPlatform(store)

--- a/internal/http/session_safety_test.go
+++ b/internal/http/session_safety_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync"
 	"testing"
 
 	"github.com/wuyaocheng/bktrader/internal/config"
@@ -68,6 +70,39 @@ func TestLiveSessionRuntimeActionsDisabledForAPIRole(t *testing.T) {
 	}
 }
 
+func TestLiveSessionDeleteRouteReturnsConflictDuringSamePairOperation(t *testing.T) {
+	store := &blockingLiveSessionStatusStore{
+		Store:       memory.NewStore(),
+		blockStatus: "STOPPED",
+		entered:     make(chan struct{}),
+		release:     make(chan struct{}),
+	}
+	platform := service.NewPlatform(store)
+	mux := http.NewServeMux()
+	registerLiveRoutes(mux, platform, config.Config{ProcessRole: "monolith"})
+
+	stopDone := make(chan *httptest.ResponseRecorder, 1)
+	go func() {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/live/sessions/live-session-main/stop", nil)
+		mux.ServeHTTP(rec, req)
+		stopDone <- rec
+	}()
+	<-store.entered
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/live/sessions/live-session-main?force=true", nil)
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusConflict {
+		close(store.release)
+		t.Fatalf("expected 409 for concurrent delete, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	close(store.release)
+	if stopRec := <-stopDone; stopRec.Code != http.StatusOK {
+		t.Fatalf("expected original stop to complete with 200, got %d body=%s", stopRec.Code, stopRec.Body.String())
+	}
+}
+
 func TestLiveSessionDetailRouteFiltersStateFields(t *testing.T) {
 	store := memory.NewStore()
 	platform := service.NewPlatform(store)
@@ -123,6 +158,22 @@ func TestLiveSessionDetailRouteFiltersStateFields(t *testing.T) {
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400 for unsupported detail field, got %d body=%s", rec.Code, rec.Body.String())
 	}
+}
+
+type blockingLiveSessionStatusStore struct {
+	*memory.Store
+	blockStatus string
+	entered     chan struct{}
+	release     chan struct{}
+	once        sync.Once
+}
+
+func (s *blockingLiveSessionStatusStore) UpdateLiveSessionStatus(sessionID, status string) (domain.LiveSession, error) {
+	if strings.EqualFold(status, s.blockStatus) {
+		s.once.Do(func() { close(s.entered) })
+		<-s.release
+	}
+	return s.Store.UpdateLiveSessionStatus(sessionID, status)
 }
 
 func TestLiveAccountStopRouteStopsRunningFlow(t *testing.T) {

--- a/internal/http/signals.go
+++ b/internal/http/signals.go
@@ -291,6 +291,10 @@ func registerSignalRoutes(mux *http.ServeMux, platform *service.Platform, cfg co
 				writeJSON(w, http.StatusOK, item)
 			case http.MethodDelete:
 				if err := platform.DeleteSignalRuntimeSessionWithForce(parts[0], queryFlagEnabled(r, "force")); err != nil {
+					if errors.Is(err, service.ErrLiveControlOperationInProgress) {
+						writeError(w, http.StatusConflict, err.Error())
+						return
+					}
 					if errors.Is(err, service.ErrActivePositionsOrOrders) {
 						writeError(w, http.StatusBadRequest, err.Error())
 						return
@@ -322,6 +326,10 @@ func registerSignalRoutes(mux *http.ServeMux, platform *service.Platform, cfg co
 			}
 			item, err := platform.StartSignalRuntimeSession(sessionID)
 			if err != nil {
+				if errors.Is(err, service.ErrLiveControlOperationInProgress) {
+					writeError(w, http.StatusConflict, err.Error())
+					return
+				}
 				if errors.Is(err, service.ErrRuntimeLeaseNotAcquired) {
 					writeError(w, http.StatusConflict, "signal runtime session is already owned by another runner")
 					return
@@ -337,6 +345,10 @@ func registerSignalRoutes(mux *http.ServeMux, platform *service.Platform, cfg co
 			}
 			item, err := platform.StopSignalRuntimeSessionWithForce(sessionID, queryFlagEnabled(r, "force"))
 			if err != nil {
+				if errors.Is(err, service.ErrLiveControlOperationInProgress) {
+					writeError(w, http.StatusConflict, err.Error())
+					return
+				}
 				writeError(w, http.StatusBadRequest, err.Error())
 				return
 			}

--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -88,6 +88,7 @@ const (
 )
 
 var ErrLiveAccountOperationInProgress = errors.New("live account operation already in progress")
+var ErrLiveControlOperationInProgress = errors.New("live control operation already in progress")
 
 type liveAccountOperationKind string
 
@@ -95,6 +96,36 @@ const (
 	liveAccountOperationSync      liveAccountOperationKind = "sync"
 	liveAccountOperationReconcile liveAccountOperationKind = "reconcile"
 )
+
+type liveControlOperationKind string
+
+const (
+	liveControlOperationLaunch              liveControlOperationKind = "launch"
+	liveControlOperationStart               liveControlOperationKind = "start"
+	liveControlOperationStop                liveControlOperationKind = "stop"
+	liveControlOperationDelete              liveControlOperationKind = "delete"
+	liveControlOperationAccountStop         liveControlOperationKind = "account-stop"
+	liveControlOperationStartupRecovery     liveControlOperationKind = "startup-recovery"
+	liveControlOperationSignalRuntimeStart  liveControlOperationKind = "signal-runtime-start"
+	liveControlOperationSignalRuntimeStop   liveControlOperationKind = "signal-runtime-stop"
+	liveControlOperationSignalRuntimeDelete liveControlOperationKind = "signal-runtime-delete"
+	liveControlOperationScannerStop         liveControlOperationKind = "scanner-stop"
+)
+
+type liveControlOperationInfo struct {
+	Operation        liveControlOperationKind
+	AccountID        string
+	StrategyID       string
+	LiveSessionID    string
+	RuntimeSessionID string
+	StartedAt        time.Time
+}
+
+type liveControlOperationState struct {
+	lock    sync.Mutex
+	metaMu  sync.Mutex
+	current liveControlOperationInfo
+}
 
 type liveAccountSyncState struct {
 	mu          sync.Mutex
@@ -129,17 +160,38 @@ func (p *Platform) DeleteLiveSession(sessionID string) error {
 }
 
 func (p *Platform) DeleteLiveSessionWithForce(sessionID string, force bool) error {
-	p.logger("service.live", "session_id", sessionID).Info("deleting live session")
+	logger := p.logger("service.live", "session_id", sessionID)
+	logger.Info("deleting live session")
 	session, err := p.store.GetLiveSession(sessionID)
 	if err != nil {
 		return err
 	}
+	requested := liveControlOperationInfo{
+		Operation:     liveControlOperationDelete,
+		AccountID:     session.AccountID,
+		StrategyID:    session.StrategyID,
+		LiveSessionID: session.ID,
+	}
+	release, acquired, current := p.tryStartLiveControlOperation(requested)
+	if !acquired {
+		return liveControlOperationInProgressError(requested, current)
+	}
+	defer release()
+	return p.deleteLiveSessionWithForceLocked(session, force)
+}
+
+func (p *Platform) deleteLiveSessionWithForceLocked(session domain.LiveSession, force bool) error {
+	logger := p.logger("service.live", "session_id", session.ID)
 	if !force {
 		if err := p.ensureNoActivePositionsOrOrders(session.AccountID, session.StrategyID); err != nil {
 			return err
 		}
 	}
-	return p.store.DeleteLiveSession(sessionID)
+	if _, err := p.stopLinkedLiveSignalRuntime(session); err != nil {
+		logger.Warn("stop linked signal runtime before live session delete failed", "error", err)
+		return err
+	}
+	return p.store.DeleteLiveSession(session.ID)
 }
 
 func (p *Platform) UpdateLiveSession(sessionID, alias, accountID, strategyID string, overrides map[string]any) (domain.LiveSession, error) {
@@ -475,6 +527,112 @@ func (p *Platform) tryStartLiveAccountOperation(accountID string, kind liveAccou
 		return func() {}, false
 	}
 	return mu.Unlock, true
+}
+
+func (p *Platform) tryStartLiveControlOperation(info liveControlOperationInfo) (func(), bool, liveControlOperationInfo) {
+	info.AccountID = strings.TrimSpace(info.AccountID)
+	info.StrategyID = strings.TrimSpace(info.StrategyID)
+	if info.AccountID == "" || info.StrategyID == "" {
+		return func() {}, false, liveControlOperationInfo{}
+	}
+	if info.StartedAt.IsZero() {
+		info.StartedAt = time.Now().UTC()
+	}
+	key := liveControlOperationKey(info.AccountID, info.StrategyID)
+	actual, _ := p.liveControlOpState.LoadOrStore(key, &liveControlOperationState{})
+	state, _ := actual.(*liveControlOperationState)
+	if state == nil || !state.lock.TryLock() {
+		return func() {}, false, p.currentLiveControlOperation(key)
+	}
+	state.metaMu.Lock()
+	state.current = info
+	state.metaMu.Unlock()
+	release := func() {
+		state.metaMu.Lock()
+		state.current = liveControlOperationInfo{}
+		state.metaMu.Unlock()
+		state.lock.Unlock()
+	}
+	return release, true, liveControlOperationInfo{}
+}
+
+func (p *Platform) tryStartLiveControlOperations(infos []liveControlOperationInfo) (func(), bool, liveControlOperationInfo) {
+	if len(infos) == 0 {
+		return func() {}, true, liveControlOperationInfo{}
+	}
+	byKey := make(map[string]liveControlOperationInfo, len(infos))
+	for _, info := range infos {
+		info.AccountID = strings.TrimSpace(info.AccountID)
+		info.StrategyID = strings.TrimSpace(info.StrategyID)
+		if info.AccountID == "" || info.StrategyID == "" {
+			continue
+		}
+		if info.StartedAt.IsZero() {
+			info.StartedAt = time.Now().UTC()
+		}
+		byKey[liveControlOperationKey(info.AccountID, info.StrategyID)] = info
+	}
+	keys := make([]string, 0, len(byKey))
+	for key := range byKey {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	releases := make([]func(), 0, len(keys))
+	for _, key := range keys {
+		release, acquired, current := p.tryStartLiveControlOperation(byKey[key])
+		if acquired {
+			releases = append(releases, release)
+			continue
+		}
+		for i := len(releases) - 1; i >= 0; i-- {
+			releases[i]()
+		}
+		return func() {}, false, current
+	}
+	return func() {
+		for i := len(releases) - 1; i >= 0; i-- {
+			releases[i]()
+		}
+	}, true, liveControlOperationInfo{}
+}
+
+func liveControlOperationKey(accountID, strategyID string) string {
+	return strings.TrimSpace(accountID) + ":" + strings.TrimSpace(strategyID)
+}
+
+func (p *Platform) currentLiveControlOperation(key string) liveControlOperationInfo {
+	actual, ok := p.liveControlOpState.Load(key)
+	if !ok {
+		return liveControlOperationInfo{}
+	}
+	state, _ := actual.(*liveControlOperationState)
+	if state == nil {
+		return liveControlOperationInfo{}
+	}
+	state.metaMu.Lock()
+	defer state.metaMu.Unlock()
+	return state.current
+}
+
+func liveControlOperationInProgressError(requested, current liveControlOperationInfo) error {
+	operation := string(current.Operation)
+	if operation == "" {
+		operation = "unknown"
+	}
+	startedAt := ""
+	if !current.StartedAt.IsZero() {
+		startedAt = current.StartedAt.UTC().Format(time.RFC3339)
+	}
+	return fmt.Errorf("%w: requested=%s current=%s account=%s strategy=%s startedAt=%s liveSession=%s runtimeSession=%s",
+		ErrLiveControlOperationInProgress,
+		requested.Operation,
+		operation,
+		firstNonEmpty(current.AccountID, requested.AccountID),
+		firstNonEmpty(current.StrategyID, requested.StrategyID),
+		startedAt,
+		current.LiveSessionID,
+		current.RuntimeSessionID,
+	)
 }
 
 func liveAccountPositionReconcilePending(account domain.Account) bool {
@@ -1236,13 +1394,43 @@ func (p *Platform) RecoverLiveTradingOnStartup(ctx context.Context) {
 		if !strings.EqualFold(session.Status, "RUNNING") {
 			continue
 		}
+		requested := liveControlOperationInfo{
+			Operation:     liveControlOperationStartupRecovery,
+			AccountID:     session.AccountID,
+			StrategyID:    session.StrategyID,
+			LiveSessionID: session.ID,
+		}
+		release, acquired, current := p.tryStartLiveControlOperation(requested)
+		if !acquired {
+			p.logger("service.live", "session_id", session.ID).Warn("skip live session recovery because control operation is already in progress", "error", liveControlOperationInProgressError(requested, current))
+			continue
+		}
+		if p.liveSessionLinkedRuntimeDesiredStopped(session) {
+			state := cloneMetadata(session.State)
+			delete(state, "lastRecoveryError")
+			state["lastRecoveryAttemptAt"] = time.Now().UTC().Format(time.RFC3339)
+			state["lastRecoveryStatus"] = "skipped-runtime-desired-stopped"
+			_, _ = p.store.UpdateLiveSessionState(session.ID, state)
+			p.logger("service.live", "session_id", session.ID).Warn("skip live session recovery because linked signal runtime desiredStatus is STOPPED")
+			release()
+			continue
+		}
 		recovered, recoverErr := p.recoverRunningLiveSession(session)
 		if recoverErr != nil {
 			p.logger("service.live", "session_id", session.ID).Warn("recover running live session failed", "error", recoverErr)
 			state := cloneMetadata(session.State)
+			if errors.Is(recoverErr, ErrRuntimeLeaseNotAcquired) {
+				delete(state, "lastRecoveryError")
+				state["lastRecoveryAttemptAt"] = time.Now().UTC().Format(time.RFC3339)
+				state["lastRecoveryStatus"] = "lease-not-acquired"
+				_, _ = p.store.UpdateLiveSessionState(session.ID, state)
+				release()
+				continue
+			}
 			state["lastRecoveryError"] = recoverErr.Error()
 			state["lastRecoveryAttemptAt"] = time.Now().UTC().Format(time.RFC3339)
 			_, _ = p.store.UpdateLiveSessionState(session.ID, state)
+			release()
 			continue
 		}
 		recoveredSessions++
@@ -1255,6 +1443,7 @@ func (p *Platform) RecoverLiveTradingOnStartup(ctx context.Context) {
 			state["lastRecoveryStatus"] = "recovered"
 		}
 		_, _ = p.store.UpdateLiveSessionState(recovered.ID, state)
+		release()
 	}
 	logger.Info("live trading recovery completed",
 		"synced_account_count", syncedAccounts,
@@ -1543,6 +1732,16 @@ func (p *Platform) LaunchLiveFlow(accountID string, options LiveLaunchOptions) (
 	if strategyID == "" {
 		return LiveLaunchResult{}, fmt.Errorf("strategyId is required")
 	}
+	requested := liveControlOperationInfo{
+		Operation:  liveControlOperationLaunch,
+		AccountID:  account.ID,
+		StrategyID: strategyID,
+	}
+	release, acquired, current := p.tryStartLiveControlOperation(requested)
+	if !acquired {
+		return LiveLaunchResult{}, liveControlOperationInProgressError(requested, current)
+	}
+	defer release()
 	if !options.MirrorStrategySignals {
 		options.MirrorStrategySignals = true
 	}
@@ -1631,7 +1830,7 @@ func (p *Platform) LaunchLiveFlow(accountID string, options LiveLaunchOptions) (
 	result.RuntimeSession = runtimeSession
 	result.RuntimeSessionCreated = runtimeCreated
 	if options.StartRuntime && !strings.EqualFold(runtimeSession.Status, "RUNNING") {
-		runtimeSession, err = p.StartSignalRuntimeSession(runtimeSession.ID)
+		runtimeSession, err = p.startSignalRuntimeSession(context.Background(), runtimeSession.ID)
 		if err != nil {
 			return LiveLaunchResult{}, err
 		}
@@ -1646,7 +1845,7 @@ func (p *Platform) LaunchLiveFlow(accountID string, options LiveLaunchOptions) (
 	result.LiveSession = liveSession
 	result.LiveSessionCreated = liveCreated
 	if options.StartSession && !strings.EqualFold(liveSession.Status, "RUNNING") {
-		liveSession, err = p.StartLiveSession(liveSession.ID)
+		liveSession, err = p.startLiveSessionLocked(liveSession)
 		if err != nil {
 			return LiveLaunchResult{}, err
 		}
@@ -1936,11 +2135,28 @@ func (p *Platform) ensureLaunchLiveSession(accountID, strategyID string, overrid
 }
 
 func (p *Platform) StartLiveSession(sessionID string) (domain.LiveSession, error) {
-	logger := p.logger("service.live", "session_id", sessionID)
 	session, err := p.store.GetLiveSession(sessionID)
 	if err != nil {
-		logger.Warn("load live session failed", "error", err)
 		return domain.LiveSession{}, err
+	}
+	requested := liveControlOperationInfo{
+		Operation:     liveControlOperationStart,
+		AccountID:     session.AccountID,
+		StrategyID:    session.StrategyID,
+		LiveSessionID: session.ID,
+	}
+	release, acquired, current := p.tryStartLiveControlOperation(requested)
+	if !acquired {
+		return domain.LiveSession{}, liveControlOperationInProgressError(requested, current)
+	}
+	defer release()
+	return p.startLiveSessionLocked(session)
+}
+
+func (p *Platform) startLiveSessionLocked(session domain.LiveSession) (domain.LiveSession, error) {
+	logger := p.logger("service.live", "session_id", session.ID)
+	if strings.EqualFold(session.Status, "DELETED") {
+		return domain.LiveSession{}, fmt.Errorf("live session %s is deleted", session.ID)
 	}
 	account, err := p.store.GetAccount(session.AccountID)
 	if err != nil {
@@ -2048,7 +2264,7 @@ func (p *Platform) StartLiveSession(sessionID string) (domain.LiveSession, error
 		logger.Warn("ensure live signal runtime failed", "error", err)
 		return domain.LiveSession{}, err
 	}
-	session, err = p.store.UpdateLiveSessionStatus(sessionID, "RUNNING")
+	session, err = p.store.UpdateLiveSessionStatus(session.ID, "RUNNING")
 	if err != nil {
 		logger.Error("mark live session running failed", "error", err)
 		return domain.LiveSession{}, err
@@ -2947,13 +3163,33 @@ func (p *Platform) StopLiveSessionWithForce(sessionID string, force bool) (domai
 		logger.Error("load live session before stop failed", "error", err)
 		return domain.LiveSession{}, err
 	}
+	requested := liveControlOperationInfo{
+		Operation:     liveControlOperationStop,
+		AccountID:     existing.AccountID,
+		StrategyID:    existing.StrategyID,
+		LiveSessionID: existing.ID,
+	}
+	release, acquired, current := p.tryStartLiveControlOperation(requested)
+	if !acquired {
+		return domain.LiveSession{}, liveControlOperationInProgressError(requested, current)
+	}
+	defer release()
+	return p.stopLiveSessionWithForceLocked(existing, force)
+}
+
+func (p *Platform) stopLiveSessionWithForceLocked(existing domain.LiveSession, force bool) (domain.LiveSession, error) {
+	logger := p.logger("service.live", "session_id", existing.ID)
 	if !force {
 		if err := p.ensureNoActivePositionsOrOrders(existing.AccountID, existing.StrategyID); err != nil {
 			logger.Warn("stop live session blocked by active positions or orders", "error", err)
 			return domain.LiveSession{}, err
 		}
 	}
-	session, err := p.store.UpdateLiveSessionStatus(sessionID, "STOPPED")
+	if _, err := p.stopLinkedLiveSignalRuntime(existing); err != nil {
+		logger.Warn("stop linked signal runtime failed", "error", err)
+		return domain.LiveSession{}, err
+	}
+	session, err := p.store.UpdateLiveSessionStatus(existing.ID, "STOPPED")
 	if err != nil {
 		logger.Error("stop live session failed", "error", err)
 		return domain.LiveSession{}, err
@@ -2961,7 +3197,6 @@ func (p *Platform) StopLiveSessionWithForce(sessionID string, force bool) (domai
 	p.mu.Lock()
 	delete(p.livePlans, session.ID)
 	p.mu.Unlock()
-	_, _ = p.stopLinkedLiveSignalRuntime(session)
 	p.logger("service.live",
 		"session_id", session.ID,
 		"account_id", session.AccountID,
@@ -3658,7 +3893,7 @@ func (p *Platform) ensureLiveSessionSignalRuntimeStarted(session domain.LiveSess
 	if runtimeSessionID == "" {
 		return domain.LiveSession{}, fmt.Errorf("live session %s has no linked signal runtime session", session.ID)
 	}
-	runtimeSession, err := p.StartSignalRuntimeSession(runtimeSessionID)
+	runtimeSession, err := p.startSignalRuntimeSession(context.Background(), runtimeSessionID)
 	if err != nil {
 		return domain.LiveSession{}, err
 	}
@@ -3701,18 +3936,42 @@ func (p *Platform) awaitLiveSignalRuntimeReadiness(session domain.LiveSession, r
 }
 
 func (p *Platform) stopLinkedLiveSignalRuntime(session domain.LiveSession) (domain.SignalRuntimeSession, error) {
-	runtimeSessionID := stringValue(session.State["signalRuntimeSessionId"])
+	runtimeSessionID := firstNonEmpty(
+		stringValue(session.State["signalRuntimeSessionId"]),
+		stringValue(session.State["lastSignalRuntimeSessionId"]),
+	)
 	if runtimeSessionID == "" {
-		return domain.SignalRuntimeSession{}, fmt.Errorf("live session %s has no linked signal runtime session", session.ID)
+		return domain.SignalRuntimeSession{}, nil
 	}
-	runtimeSession, err := p.StopSignalRuntimeSession(runtimeSessionID)
+	runtimeSession, err := p.GetSignalRuntimeSession(runtimeSessionID)
+	if err != nil {
+		return domain.SignalRuntimeSession{}, err
+	}
+	runtimeSession, err = p.stopSignalRuntimeSessionWithForceLocked(runtimeSession, true)
 	if err != nil {
 		return domain.SignalRuntimeSession{}, err
 	}
 	state := cloneMetadata(session.State)
 	state["signalRuntimeStatus"] = runtimeSession.Status
-	_, _ = p.store.UpdateLiveSessionState(session.ID, state)
+	if _, err := p.store.UpdateLiveSessionState(session.ID, state); err != nil {
+		return domain.SignalRuntimeSession{}, err
+	}
 	return runtimeSession, nil
+}
+
+func (p *Platform) liveSessionLinkedRuntimeDesiredStopped(session domain.LiveSession) bool {
+	runtimeSessionID := strings.TrimSpace(firstNonEmpty(
+		stringValue(session.State["signalRuntimeSessionId"]),
+		stringValue(session.State["lastSignalRuntimeSessionId"]),
+	))
+	if runtimeSessionID == "" {
+		return false
+	}
+	runtimeSession, err := p.GetSignalRuntimeSession(runtimeSessionID)
+	if err != nil {
+		return false
+	}
+	return strings.EqualFold(stringValue(runtimeSession.State["desiredStatus"]), "STOPPED")
 }
 
 func (p *Platform) ensureLiveExecutionPlan(session domain.LiveSession) (domain.LiveSession, []paperPlannedOrder, error) {

--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -533,6 +533,10 @@ func (p *Platform) tryStartLiveAccountOperation(accountID string, kind liveAccou
 	return mu.Unlock, true
 }
 
+// Live control operations are intentionally process-local only. They prevent
+// in-process start/stop/delete/launch interleaving for one account+strategy,
+// but distributed deployments must still rely on runtime leases and persisted
+// session state for cross-process convergence.
 func normalizeLiveControlOperationInfo(info liveControlOperationInfo) (liveControlOperationInfo, error) {
 	info.AccountID = strings.TrimSpace(info.AccountID)
 	info.StrategyID = strings.TrimSpace(info.StrategyID)

--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -89,6 +89,7 @@ const (
 
 var ErrLiveAccountOperationInProgress = errors.New("live account operation already in progress")
 var ErrLiveControlOperationInProgress = errors.New("live control operation already in progress")
+var ErrLiveControlOperationKeyMissing = errors.New("live control operation key missing")
 
 type liveAccountOperationKind string
 
@@ -172,7 +173,10 @@ func (p *Platform) DeleteLiveSessionWithForce(sessionID string, force bool) erro
 		StrategyID:    session.StrategyID,
 		LiveSessionID: session.ID,
 	}
-	release, acquired, current := p.tryStartLiveControlOperation(requested)
+	release, acquired, current, lockErr := p.tryStartLiveControlOperation(requested)
+	if lockErr != nil {
+		return lockErr
+	}
 	if !acquired {
 		return liveControlOperationInProgressError(requested, current)
 	}
@@ -529,20 +533,28 @@ func (p *Platform) tryStartLiveAccountOperation(accountID string, kind liveAccou
 	return mu.Unlock, true
 }
 
-func (p *Platform) tryStartLiveControlOperation(info liveControlOperationInfo) (func(), bool, liveControlOperationInfo) {
+func normalizeLiveControlOperationInfo(info liveControlOperationInfo) (liveControlOperationInfo, error) {
 	info.AccountID = strings.TrimSpace(info.AccountID)
 	info.StrategyID = strings.TrimSpace(info.StrategyID)
 	if info.AccountID == "" || info.StrategyID == "" {
-		return func() {}, false, liveControlOperationInfo{}
+		return info, liveControlOperationKeyMissingError(info)
 	}
 	if info.StartedAt.IsZero() {
 		info.StartedAt = time.Now().UTC()
+	}
+	return info, nil
+}
+
+func (p *Platform) tryStartLiveControlOperation(info liveControlOperationInfo) (func(), bool, liveControlOperationInfo, error) {
+	info, err := normalizeLiveControlOperationInfo(info)
+	if err != nil {
+		return func() {}, false, liveControlOperationInfo{}, err
 	}
 	key := liveControlOperationKey(info.AccountID, info.StrategyID)
 	actual, _ := p.liveControlOpState.LoadOrStore(key, &liveControlOperationState{})
 	state, _ := actual.(*liveControlOperationState)
 	if state == nil || !state.lock.TryLock() {
-		return func() {}, false, p.currentLiveControlOperation(key)
+		return func() {}, false, p.currentLiveControlOperation(key), nil
 	}
 	state.metaMu.Lock()
 	state.current = info
@@ -553,24 +565,20 @@ func (p *Platform) tryStartLiveControlOperation(info liveControlOperationInfo) (
 		state.metaMu.Unlock()
 		state.lock.Unlock()
 	}
-	return release, true, liveControlOperationInfo{}
+	return release, true, liveControlOperationInfo{}, nil
 }
 
-func (p *Platform) tryStartLiveControlOperations(infos []liveControlOperationInfo) (func(), bool, liveControlOperationInfo) {
+func (p *Platform) tryStartLiveControlOperations(infos []liveControlOperationInfo) (func(), bool, liveControlOperationInfo, error) {
 	if len(infos) == 0 {
-		return func() {}, true, liveControlOperationInfo{}
+		return func() {}, true, liveControlOperationInfo{}, nil
 	}
 	byKey := make(map[string]liveControlOperationInfo, len(infos))
 	for _, info := range infos {
-		info.AccountID = strings.TrimSpace(info.AccountID)
-		info.StrategyID = strings.TrimSpace(info.StrategyID)
-		if info.AccountID == "" || info.StrategyID == "" {
-			continue
+		normalized, err := normalizeLiveControlOperationInfo(info)
+		if err != nil {
+			return func() {}, false, liveControlOperationInfo{}, err
 		}
-		if info.StartedAt.IsZero() {
-			info.StartedAt = time.Now().UTC()
-		}
-		byKey[liveControlOperationKey(info.AccountID, info.StrategyID)] = info
+		byKey[liveControlOperationKey(normalized.AccountID, normalized.StrategyID)] = normalized
 	}
 	keys := make([]string, 0, len(byKey))
 	for key := range byKey {
@@ -579,7 +587,13 @@ func (p *Platform) tryStartLiveControlOperations(infos []liveControlOperationInf
 	sort.Strings(keys)
 	releases := make([]func(), 0, len(keys))
 	for _, key := range keys {
-		release, acquired, current := p.tryStartLiveControlOperation(byKey[key])
+		release, acquired, current, err := p.tryStartLiveControlOperation(byKey[key])
+		if err != nil {
+			for i := len(releases) - 1; i >= 0; i-- {
+				releases[i]()
+			}
+			return func() {}, false, liveControlOperationInfo{}, err
+		}
 		if acquired {
 			releases = append(releases, release)
 			continue
@@ -587,13 +601,13 @@ func (p *Platform) tryStartLiveControlOperations(infos []liveControlOperationInf
 		for i := len(releases) - 1; i >= 0; i-- {
 			releases[i]()
 		}
-		return func() {}, false, current
+		return func() {}, false, current, nil
 	}
 	return func() {
 		for i := len(releases) - 1; i >= 0; i-- {
 			releases[i]()
 		}
-	}, true, liveControlOperationInfo{}
+	}, true, liveControlOperationInfo{}, nil
 }
 
 func liveControlOperationKey(accountID, strategyID string) string {
@@ -632,6 +646,17 @@ func liveControlOperationInProgressError(requested, current liveControlOperation
 		startedAt,
 		current.LiveSessionID,
 		current.RuntimeSessionID,
+	)
+}
+
+func liveControlOperationKeyMissingError(info liveControlOperationInfo) error {
+	return fmt.Errorf("%w: operation=%s account=%s strategy=%s liveSession=%s runtimeSession=%s",
+		ErrLiveControlOperationKeyMissing,
+		info.Operation,
+		info.AccountID,
+		info.StrategyID,
+		info.LiveSessionID,
+		info.RuntimeSessionID,
 	)
 }
 
@@ -1400,7 +1425,11 @@ func (p *Platform) RecoverLiveTradingOnStartup(ctx context.Context) {
 			StrategyID:    session.StrategyID,
 			LiveSessionID: session.ID,
 		}
-		release, acquired, current := p.tryStartLiveControlOperation(requested)
+		release, acquired, current, lockErr := p.tryStartLiveControlOperation(requested)
+		if lockErr != nil {
+			p.logger("service.live", "session_id", session.ID).Warn("skip live session recovery because control operation key is invalid", "error", lockErr)
+			continue
+		}
 		if !acquired {
 			p.logger("service.live", "session_id", session.ID).Warn("skip live session recovery because control operation is already in progress", "error", liveControlOperationInProgressError(requested, current))
 			continue
@@ -1737,7 +1766,10 @@ func (p *Platform) LaunchLiveFlow(accountID string, options LiveLaunchOptions) (
 		AccountID:  account.ID,
 		StrategyID: strategyID,
 	}
-	release, acquired, current := p.tryStartLiveControlOperation(requested)
+	release, acquired, current, lockErr := p.tryStartLiveControlOperation(requested)
+	if lockErr != nil {
+		return LiveLaunchResult{}, lockErr
+	}
 	if !acquired {
 		return LiveLaunchResult{}, liveControlOperationInProgressError(requested, current)
 	}
@@ -2145,7 +2177,10 @@ func (p *Platform) StartLiveSession(sessionID string) (domain.LiveSession, error
 		StrategyID:    session.StrategyID,
 		LiveSessionID: session.ID,
 	}
-	release, acquired, current := p.tryStartLiveControlOperation(requested)
+	release, acquired, current, lockErr := p.tryStartLiveControlOperation(requested)
+	if lockErr != nil {
+		return domain.LiveSession{}, lockErr
+	}
 	if !acquired {
 		return domain.LiveSession{}, liveControlOperationInProgressError(requested, current)
 	}
@@ -3169,7 +3204,10 @@ func (p *Platform) StopLiveSessionWithForce(sessionID string, force bool) (domai
 		StrategyID:    existing.StrategyID,
 		LiveSessionID: existing.ID,
 	}
-	release, acquired, current := p.tryStartLiveControlOperation(requested)
+	release, acquired, current, lockErr := p.tryStartLiveControlOperation(requested)
+	if lockErr != nil {
+		return domain.LiveSession{}, lockErr
+	}
 	if !acquired {
 		return domain.LiveSession{}, liveControlOperationInProgressError(requested, current)
 	}

--- a/internal/service/live_account_flow.go
+++ b/internal/service/live_account_flow.go
@@ -75,7 +75,10 @@ func (p *Platform) StopLiveFlowWithForce(accountID string, force bool) (StopLive
 			StrategyID: strategyID,
 		})
 	}
-	release, acquired, current := p.tryStartLiveControlOperations(lockRequests)
+	release, acquired, current, lockErr := p.tryStartLiveControlOperations(lockRequests)
+	if lockErr != nil {
+		return StopLiveFlowResult{}, lockErr
+	}
 	if !acquired {
 		return StopLiveFlowResult{}, liveControlOperationInProgressError(liveControlOperationInfo{
 			Operation: liveControlOperationAccountStop,

--- a/internal/service/live_account_flow.go
+++ b/internal/service/live_account_flow.go
@@ -2,7 +2,10 @@ package service
 
 import (
 	"fmt"
+	"sort"
 	"strings"
+
+	"github.com/wuyaocheng/bktrader/internal/domain"
 )
 
 type StopLiveFlowResult struct {
@@ -26,8 +29,8 @@ func (p *Platform) StopLiveFlowWithForce(accountID string, force bool) (StopLive
 	}
 	runtimeSessions := p.ListSignalRuntimeSessions()
 
-	runningLiveSessions := make([]string, 0)
-	runningRuntimeSessions := make([]string, 0)
+	runningLiveSessions := make([]domain.LiveSession, 0)
+	runningRuntimeSessions := make([]domain.SignalRuntimeSession, 0)
 	strategyIDs := make(map[string]struct{})
 	seenRuntimeIDs := make(map[string]struct{})
 
@@ -36,7 +39,7 @@ func (p *Platform) StopLiveFlowWithForce(accountID string, force bool) (StopLive
 			continue
 		}
 		if strings.EqualFold(strings.TrimSpace(session.Status), "RUNNING") {
-			runningLiveSessions = append(runningLiveSessions, session.ID)
+			runningLiveSessions = append(runningLiveSessions, session)
 		}
 		if strategyID := strings.TrimSpace(session.StrategyID); strategyID != "" {
 			strategyIDs[strategyID] = struct{}{}
@@ -56,11 +59,33 @@ func (p *Platform) StopLiveFlowWithForce(accountID string, force bool) (StopLive
 			continue
 		}
 		seenRuntimeIDs[session.ID] = struct{}{}
-		runningRuntimeSessions = append(runningRuntimeSessions, session.ID)
+		runningRuntimeSessions = append(runningRuntimeSessions, session)
 	}
 
+	strategyList := make([]string, 0, len(strategyIDs))
+	for strategyID := range strategyIDs {
+		strategyList = append(strategyList, strategyID)
+	}
+	sort.Strings(strategyList)
+	lockRequests := make([]liveControlOperationInfo, 0, len(strategyList))
+	for _, strategyID := range strategyList {
+		lockRequests = append(lockRequests, liveControlOperationInfo{
+			Operation:  liveControlOperationAccountStop,
+			AccountID:  accountID,
+			StrategyID: strategyID,
+		})
+	}
+	release, acquired, current := p.tryStartLiveControlOperations(lockRequests)
+	if !acquired {
+		return StopLiveFlowResult{}, liveControlOperationInProgressError(liveControlOperationInfo{
+			Operation: liveControlOperationAccountStop,
+			AccountID: accountID,
+		}, current)
+	}
+	defer release()
+
 	if !force {
-		for strategyID := range strategyIDs {
+		for _, strategyID := range strategyList {
 			if err := p.ensureNoActivePositionsOrOrders(accountID, strategyID); err != nil {
 				return StopLiveFlowResult{}, err
 			}
@@ -72,17 +97,17 @@ func (p *Platform) StopLiveFlowWithForce(accountID string, force bool) (StopLive
 		StoppedLiveSessionIDs:    make([]string, 0, len(runningLiveSessions)),
 		StoppedRuntimeSessionIDs: make([]string, 0, len(runningRuntimeSessions)),
 	}
-	for _, sessionID := range runningLiveSessions {
-		if _, err := p.StopLiveSessionWithForce(sessionID, true); err != nil {
+	for _, session := range runningLiveSessions {
+		if _, err := p.stopLiveSessionWithForceLocked(session, true); err != nil {
 			return StopLiveFlowResult{}, err
 		}
-		result.StoppedLiveSessionIDs = append(result.StoppedLiveSessionIDs, sessionID)
+		result.StoppedLiveSessionIDs = append(result.StoppedLiveSessionIDs, session.ID)
 	}
-	for _, sessionID := range runningRuntimeSessions {
-		if _, err := p.StopSignalRuntimeSessionWithForce(sessionID, true); err != nil {
+	for _, session := range runningRuntimeSessions {
+		if _, err := p.stopSignalRuntimeSessionWithForceLocked(session, true); err != nil {
 			return StopLiveFlowResult{}, err
 		}
-		result.StoppedRuntimeSessionIDs = append(result.StoppedRuntimeSessionIDs, sessionID)
+		result.StoppedRuntimeSessionIDs = append(result.StoppedRuntimeSessionIDs, session.ID)
 	}
 	return result, nil
 }

--- a/internal/service/live_account_flow.go
+++ b/internal/service/live_account_flow.go
@@ -14,6 +14,11 @@ type StopLiveFlowResult struct {
 	StoppedRuntimeSessionIDs []string `json:"stoppedRuntimeSessionIds"`
 }
 
+// StopLiveFlowWithForce is a process-local account stop helper. It closes the
+// live/runtime sessions visible to this process and coordinates them with the
+// account+strategy control lock, but it is not a distributed global stop
+// barrier; multi-writer deployments still rely on runtime leases and persisted
+// session state convergence outside this call.
 func (p *Platform) StopLiveFlowWithForce(accountID string, force bool) (StopLiveFlowResult, error) {
 	accountID = strings.TrimSpace(accountID)
 	if accountID == "" {

--- a/internal/service/platform.go
+++ b/internal/service/platform.go
@@ -42,6 +42,7 @@ type Platform struct {
 	liveMarketData         map[string]liveMarketSnapshot
 	liveAccountOpMu        sync.Map // accountID -> *sync.Mutex
 	liveAccountSyncState   sync.Map // accountID -> *liveAccountSyncState
+	liveControlOpState     sync.Map // accountID|strategyID -> *liveControlOperationState
 	liveDispatchMu         sync.Map // liveSessionID -> *sync.Mutex; process-local guard, not distributed idempotency.
 	runtimeSourceGateState sync.Map // runtimeSessionID -> last blocked source gate signature
 	runtimeEventPublisher  RuntimeEventPublisher

--- a/internal/service/safety_checks_test.go
+++ b/internal/service/safety_checks_test.go
@@ -1,9 +1,11 @@
 package service
 
 import (
+	"context"
 	"errors"
 	"math"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -100,8 +102,245 @@ func TestDeleteLiveSessionWithForceRequiresForceWhenExposureExists(t *testing.T)
 	if err := platform.DeleteLiveSessionWithForce("live-session-main", true); err != nil {
 		t.Fatalf("force delete live session failed: %v", err)
 	}
-	if _, err := platform.store.GetLiveSession("live-session-main"); err == nil {
-		t.Fatal("expected live session to be deleted after force delete")
+	deleted, err := platform.store.GetLiveSession("live-session-main")
+	if err != nil {
+		t.Fatalf("expected soft-deleted live session to remain loadable, got %v", err)
+	}
+	if deleted.Status != "DELETED" {
+		t.Fatalf("expected live session status DELETED after force delete, got %s", deleted.Status)
+	}
+	if got := stringValue(deleted.State["deletedAt"]); got == "" {
+		t.Fatal("expected soft-deleted live session to record deletedAt")
+	}
+	items, err := platform.ListLiveSessions()
+	if err != nil {
+		t.Fatalf("list live sessions failed: %v", err)
+	}
+	for _, item := range items {
+		if item.ID == deleted.ID {
+			t.Fatalf("expected deleted live session %s to be hidden from default list", deleted.ID)
+		}
+	}
+}
+
+func TestStopLiveSessionWithForceStopsLinkedRuntimeWhenLiveAlreadyStopped(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	session, err := platform.store.UpdateLiveSessionStatus("live-session-main", "STOPPED")
+	if err != nil {
+		t.Fatalf("set live session stopped failed: %v", err)
+	}
+	runtime := mustCreateLinkedLiveRuntime(t, platform, session, "RUNNING", "RUNNING")
+
+	stopped, err := platform.StopLiveSessionWithForce(session.ID, false)
+	if err != nil {
+		t.Fatalf("stop already-stopped live session failed: %v", err)
+	}
+	if stopped.Status != "STOPPED" {
+		t.Fatalf("expected live session to remain STOPPED, got %s", stopped.Status)
+	}
+	updatedRuntime, err := platform.GetSignalRuntimeSession(runtime.ID)
+	if err != nil {
+		t.Fatalf("reload runtime failed: %v", err)
+	}
+	if updatedRuntime.Status != "STOPPED" {
+		t.Fatalf("expected linked runtime STOPPED, got %s", updatedRuntime.Status)
+	}
+	if got := stringValue(updatedRuntime.State["desiredStatus"]); got != "STOPPED" {
+		t.Fatalf("expected linked runtime desiredStatus STOPPED, got %s", got)
+	}
+	updatedSession, err := platform.store.GetLiveSession(session.ID)
+	if err != nil {
+		t.Fatalf("reload live session failed: %v", err)
+	}
+	if got := stringValue(updatedSession.State["signalRuntimeStatus"]); got != "STOPPED" {
+		t.Fatalf("expected live session signalRuntimeStatus STOPPED, got %s", got)
+	}
+}
+
+func TestDeleteLiveSessionWithForceStopsLinkedRuntimeBeforeDelete(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	session, err := platform.store.GetLiveSession("live-session-main")
+	if err != nil {
+		t.Fatalf("get live session failed: %v", err)
+	}
+	runtime := mustCreateLinkedLiveRuntime(t, platform, session, "RUNNING", "RUNNING")
+
+	if err := platform.DeleteLiveSessionWithForce(session.ID, false); err != nil {
+		t.Fatalf("delete live session failed: %v", err)
+	}
+	deleted, err := platform.store.GetLiveSession(session.ID)
+	if err != nil {
+		t.Fatalf("expected soft-deleted live session to remain loadable, got %v", err)
+	}
+	if deleted.Status != "DELETED" {
+		t.Fatalf("expected live session status DELETED, got %s", deleted.Status)
+	}
+	if got := stringValue(deleted.State["deletedAt"]); got == "" {
+		t.Fatal("expected deletedAt to be set")
+	}
+	updatedRuntime, err := platform.GetSignalRuntimeSession(runtime.ID)
+	if err != nil {
+		t.Fatalf("reload runtime failed: %v", err)
+	}
+	if updatedRuntime.Status != "STOPPED" {
+		t.Fatalf("expected linked runtime STOPPED before live delete, got %s", updatedRuntime.Status)
+	}
+	if got := stringValue(updatedRuntime.State["desiredStatus"]); got != "STOPPED" {
+		t.Fatalf("expected linked runtime desiredStatus STOPPED, got %s", got)
+	}
+}
+
+func TestDeleteLiveSessionWithForceKeepsSessionWhenLinkedRuntimeStopFails(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	session, err := platform.store.GetLiveSession("live-session-main")
+	if err != nil {
+		t.Fatalf("get live session failed: %v", err)
+	}
+	state := cloneMetadata(session.State)
+	state["signalRuntimeSessionId"] = "signal-runtime-missing"
+	if _, err := platform.store.UpdateLiveSessionState(session.ID, state); err != nil {
+		t.Fatalf("seed linked runtime id failed: %v", err)
+	}
+
+	if err := platform.DeleteLiveSessionWithForce(session.ID, true); err == nil {
+		t.Fatal("expected delete to fail when linked runtime stop fails")
+	}
+	if _, err := platform.store.GetLiveSession(session.ID); err != nil {
+		t.Fatalf("expected live session to remain after failed linked runtime stop, got %v", err)
+	}
+}
+
+func TestRecoverLiveTradingOnStartupSkipsLinkedRuntimeDesiredStopped(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	session, err := platform.store.UpdateLiveSessionStatus("live-session-main", "RUNNING")
+	if err != nil {
+		t.Fatalf("set live session running failed: %v", err)
+	}
+	runtime := mustCreateLinkedLiveRuntime(t, platform, session, "STOPPED", "STOPPED")
+
+	platform.RecoverLiveTradingOnStartup(context.Background())
+
+	updatedRuntime, err := platform.GetSignalRuntimeSession(runtime.ID)
+	if err != nil {
+		t.Fatalf("reload runtime failed: %v", err)
+	}
+	if updatedRuntime.Status != "STOPPED" {
+		t.Fatalf("expected runtime to stay STOPPED, got %s", updatedRuntime.Status)
+	}
+	if got := stringValue(updatedRuntime.State["desiredStatus"]); got != "STOPPED" {
+		t.Fatalf("expected desiredStatus STOPPED, got %s", got)
+	}
+	updatedSession, err := platform.store.GetLiveSession(session.ID)
+	if err != nil {
+		t.Fatalf("reload live session failed: %v", err)
+	}
+	if got := stringValue(updatedSession.State["lastRecoveryError"]); got != "" {
+		t.Fatalf("expected no lastRecoveryError for skipped desired-stopped runtime, got %s", got)
+	}
+	if got := stringValue(updatedSession.State["lastRecoveryStatus"]); got != "skipped-runtime-desired-stopped" {
+		t.Fatalf("expected skipped recovery status, got %s", got)
+	}
+}
+
+func TestRecoverLiveTradingOnStartupTreatsRuntimeLeaseRaceAsTransient(t *testing.T) {
+	store := memory.NewStore()
+	platform := NewPlatform(store)
+	platform.setRuntimeLeaseOwnerIDForTest("runner-local")
+	session, err := platform.store.UpdateLiveSessionStatus("live-session-main", "RUNNING")
+	if err != nil {
+		t.Fatalf("set live session running failed: %v", err)
+	}
+	runtime := mustCreateLinkedLiveRuntime(t, platform, session, "STOPPED", "RUNNING")
+	state := cloneMetadata(session.State)
+	state["signalRuntimeSessionId"] = runtime.ID
+	state["lastRecoveryError"] = "old critical error"
+	if _, err := platform.store.UpdateLiveSessionState(session.ID, state); err != nil {
+		t.Fatalf("seed live recovery state failed: %v", err)
+	}
+	if _, ok, err := store.AcquireRuntimeLease(domain.RuntimeLeaseAcquireRequest{
+		ResourceType: domain.RuntimeLeaseResourceSignalRuntimeSession,
+		ResourceID:   runtime.ID,
+		OwnerID:      "runner-other",
+		TTL:          time.Minute,
+	}); err != nil || !ok {
+		t.Fatalf("pre-acquire runtime lease failed: ok=%v err=%v", ok, err)
+	}
+
+	platform.RecoverLiveTradingOnStartup(context.Background())
+
+	updatedSession, err := platform.store.GetLiveSession(session.ID)
+	if err != nil {
+		t.Fatalf("reload live session failed: %v", err)
+	}
+	if got := stringValue(updatedSession.State["lastRecoveryError"]); got != "" {
+		t.Fatalf("expected transient lease race to clear lastRecoveryError, got %s", got)
+	}
+	if got := stringValue(updatedSession.State["lastRecoveryStatus"]); got != "lease-not-acquired" {
+		t.Fatalf("expected lease-not-acquired recovery status, got %s", got)
+	}
+	updatedRuntime, err := platform.GetSignalRuntimeSession(runtime.ID)
+	if err != nil {
+		t.Fatalf("reload runtime failed: %v", err)
+	}
+	if updatedRuntime.Status != "STOPPED" {
+		t.Fatalf("expected runtime to remain STOPPED after lease race, got %s", updatedRuntime.Status)
+	}
+}
+
+func TestLiveSessionControlRejectsConcurrentSameAccountStrategyOperations(t *testing.T) {
+	store := &blockingLiveSessionStatusStore{
+		Store:       memory.NewStore(),
+		blockStatus: "STOPPED",
+		entered:     make(chan struct{}),
+		release:     make(chan struct{}),
+	}
+	platform := NewPlatform(store)
+
+	stopDone := make(chan error, 1)
+	go func() {
+		_, err := platform.StopLiveSessionWithForce("live-session-main", false)
+		stopDone <- err
+	}()
+	<-store.entered
+
+	if err := platform.DeleteLiveSessionWithForce("live-session-main", true); !errors.Is(err, ErrLiveControlOperationInProgress) {
+		close(store.release)
+		t.Fatalf("expected concurrent delete to return control operation error, got %v", err)
+	}
+	close(store.release)
+	if err := <-stopDone; err != nil {
+		t.Fatalf("stop operation should complete after release: %v", err)
+	}
+}
+
+func TestSignalRuntimeStartReturnsConflictDuringLiveControlOperation(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	session, err := platform.store.GetLiveSession("live-session-main")
+	if err != nil {
+		t.Fatalf("get live session failed: %v", err)
+	}
+	runtime := mustCreateLinkedLiveRuntime(t, platform, session, "STOPPED", "RUNNING")
+	if _, err := platform.StartSignalRuntimeSession(runtime.ID); err != nil {
+		t.Fatalf("start runtime failed: %v", err)
+	}
+
+	requested := liveControlOperationInfo{
+		Operation:     liveControlOperationStop,
+		AccountID:     session.AccountID,
+		StrategyID:    session.StrategyID,
+		LiveSessionID: session.ID,
+	}
+	release, acquired, current := platform.tryStartLiveControlOperation(requested)
+	if !acquired {
+		t.Fatalf("acquire live control operation failed: %v", liveControlOperationInProgressError(requested, current))
+	}
+	_, err = platform.StartSignalRuntimeSession(runtime.ID)
+	release()
+	if !errors.Is(err, ErrLiveControlOperationInProgress) {
+		t.Fatalf("expected runtime start to return live control conflict, got %v", err)
+	}
+	if _, stopErr := platform.StopSignalRuntimeSessionWithForce(runtime.ID, true); stopErr != nil {
+		t.Fatalf("cleanup runtime failed: %v", stopErr)
 	}
 }
 
@@ -205,6 +444,57 @@ func TestStopLiveFlowWithForceSucceedsWhenLiveStopAlreadyStoppedLinkedRuntime(t 
 	if updatedRuntime.Status != "STOPPED" {
 		t.Fatalf("expected runtime STOPPED, got %s", updatedRuntime.Status)
 	}
+}
+
+func mustCreateLinkedLiveRuntime(t *testing.T, platform *Platform, session domain.LiveSession, status, desiredStatus string) domain.SignalRuntimeSession {
+	t.Helper()
+	if _, err := platform.BindStrategySignalSource(session.StrategyID, map[string]any{
+		"sourceKey": "binance-kline",
+		"role":      "signal",
+		"symbol":    "BTCUSDT",
+		"options":   map[string]any{"timeframe": "1d"},
+	}); err != nil {
+		t.Fatalf("bind strategy signal failed: %v", err)
+	}
+	runtime, err := platform.CreateSignalRuntimeSession(session.AccountID, session.StrategyID)
+	if err != nil {
+		t.Fatalf("create runtime failed: %v", err)
+	}
+	now := time.Now().UTC()
+	runtime.Status = status
+	runtime.State = cloneMetadata(runtime.State)
+	runtime.State["desiredStatus"] = desiredStatus
+	runtime.State["actualStatus"] = status
+	runtime.State["health"] = strings.ToLower(status)
+	runtime.UpdatedAt = now
+	updatedRuntime, err := platform.store.UpdateSignalRuntimeSession(runtime)
+	if err != nil {
+		t.Fatalf("update runtime failed: %v", err)
+	}
+	platform.cacheSignalRuntimeSession(updatedRuntime)
+	state := cloneMetadata(session.State)
+	state["signalRuntimeSessionId"] = updatedRuntime.ID
+	state["signalRuntimeStatus"] = updatedRuntime.Status
+	if _, err := platform.store.UpdateLiveSessionState(session.ID, state); err != nil {
+		t.Fatalf("link runtime into live session failed: %v", err)
+	}
+	return updatedRuntime
+}
+
+type blockingLiveSessionStatusStore struct {
+	*memory.Store
+	blockStatus string
+	entered     chan struct{}
+	release     chan struct{}
+	once        sync.Once
+}
+
+func (s *blockingLiveSessionStatusStore) UpdateLiveSessionStatus(sessionID, status string) (domain.LiveSession, error) {
+	if strings.EqualFold(status, s.blockStatus) {
+		s.once.Do(func() { close(s.entered) })
+		<-s.release
+	}
+	return s.Store.UpdateLiveSessionStatus(sessionID, status)
 }
 
 func TestClosePositionCreatesReduceOnlyMarketOrder(t *testing.T) {

--- a/internal/service/safety_checks_test.go
+++ b/internal/service/safety_checks_test.go
@@ -330,7 +330,10 @@ func TestSignalRuntimeStartReturnsConflictDuringLiveControlOperation(t *testing.
 		StrategyID:    session.StrategyID,
 		LiveSessionID: session.ID,
 	}
-	release, acquired, current := platform.tryStartLiveControlOperation(requested)
+	release, acquired, current, lockErr := platform.tryStartLiveControlOperation(requested)
+	if lockErr != nil {
+		t.Fatalf("acquire live control operation failed: %v", lockErr)
+	}
 	if !acquired {
 		t.Fatalf("acquire live control operation failed: %v", liveControlOperationInProgressError(requested, current))
 	}
@@ -342,6 +345,67 @@ func TestSignalRuntimeStartReturnsConflictDuringLiveControlOperation(t *testing.
 	if _, stopErr := platform.StopSignalRuntimeSessionWithForce(runtime.ID, true); stopErr != nil {
 		t.Fatalf("cleanup runtime failed: %v", stopErr)
 	}
+}
+
+func TestLiveControlOperationMissingKeyIsNotConflict(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	_, acquired, _, err := platform.tryStartLiveControlOperation(liveControlOperationInfo{
+		Operation: liveControlOperationStart,
+		AccountID: "live-main",
+	})
+	if acquired {
+		t.Fatal("expected missing strategy key to prevent lock acquisition")
+	}
+	if !errors.Is(err, ErrLiveControlOperationKeyMissing) {
+		t.Fatalf("expected missing key error, got %v", err)
+	}
+	if errors.Is(err, ErrLiveControlOperationInProgress) {
+		t.Fatalf("missing key must not be reported as control conflict: %v", err)
+	}
+}
+
+func TestStopLiveFlowWithForceReleasesBatchLocksWhenLaterLockFails(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	const accountID = "live-main"
+	const firstStrategyID = "strategy-bk-1d"
+	const secondStrategyID = "zz-review-strategy"
+	if _, err := platform.store.CreateLiveSession(accountID, secondStrategyID); err != nil {
+		t.Fatalf("create second live session failed: %v", err)
+	}
+
+	secondRelease, acquired, current, lockErr := platform.tryStartLiveControlOperation(liveControlOperationInfo{
+		Operation:  liveControlOperationStart,
+		AccountID:  accountID,
+		StrategyID: secondStrategyID,
+	})
+	if lockErr != nil {
+		t.Fatalf("pre-acquire second strategy lock failed: %v", lockErr)
+	}
+	if !acquired {
+		t.Fatalf("pre-acquire second strategy lock conflict: %v", liveControlOperationInProgressError(liveControlOperationInfo{
+			Operation:  liveControlOperationStart,
+			AccountID:  accountID,
+			StrategyID: secondStrategyID,
+		}, current))
+	}
+	defer secondRelease()
+
+	if _, err := platform.StopLiveFlowWithForce(accountID, true); !errors.Is(err, ErrLiveControlOperationInProgress) {
+		t.Fatalf("expected account stop to hit later strategy lock conflict, got %v", err)
+	}
+
+	firstRelease, acquired, current, lockErr := platform.tryStartLiveControlOperation(liveControlOperationInfo{
+		Operation:  liveControlOperationStart,
+		AccountID:  accountID,
+		StrategyID: firstStrategyID,
+	})
+	if lockErr != nil {
+		t.Fatalf("acquire first strategy lock after failed batch failed: %v", lockErr)
+	}
+	if !acquired {
+		t.Fatalf("expected failed batch to release first strategy lock, still blocked by %v", current)
+	}
+	firstRelease()
 }
 
 func TestSignalRuntimeSessionForceActionsRespectSafetyLock(t *testing.T) {

--- a/internal/service/signal_runtime_scanner.go
+++ b/internal/service/signal_runtime_scanner.go
@@ -94,7 +94,16 @@ func (p *Platform) stopSignalRuntimeLinkedToStoppedLiveSession(runtimeSession do
 		LiveSessionID:    liveSession.ID,
 		RuntimeSessionID: runtimeSession.ID,
 	}
-	release, acquired, current := p.tryStartLiveControlOperation(requested)
+	release, acquired, current, lockErr := p.tryStartLiveControlOperation(requested)
+	if lockErr != nil {
+		p.logger("service.signal_runtime_scanner",
+			"session_id", runtimeSession.ID,
+			"live_session_id", liveSession.ID,
+			"account_id", runtimeSession.AccountID,
+			"strategy_id", runtimeSession.StrategyID,
+		).Warn("skip stopped-live runtime cleanup because control operation key is invalid", "error", lockErr)
+		return true
+	}
 	if !acquired {
 		p.logger("service.signal_runtime_scanner",
 			"session_id", runtimeSession.ID,

--- a/internal/service/signal_runtime_scanner.go
+++ b/internal/service/signal_runtime_scanner.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"errors"
+	"strings"
 	"time"
 
 	"github.com/wuyaocheng/bktrader/internal/domain"
@@ -43,6 +44,9 @@ func (p *Platform) scanSignalRuntimeSessions(ctx context.Context, starter signal
 		if !signalRuntimeSessionDesiredRunning(session) {
 			continue
 		}
+		if p.stopSignalRuntimeLinkedToStoppedLiveSession(session) {
+			continue
+		}
 		if p.signalRuntimeSessionRunningOrStarting(session.ID) {
 			continue
 		}
@@ -76,4 +80,78 @@ func (p *Platform) signalRuntimeSessionRunningOrStarting(sessionID string) bool 
 	defer p.mu.Unlock()
 	_, exists := p.signalRun[sessionID]
 	return exists
+}
+
+func (p *Platform) stopSignalRuntimeLinkedToStoppedLiveSession(runtimeSession domain.SignalRuntimeSession) bool {
+	liveSession, found := p.findStoppedLiveSessionLinkedToRuntime(runtimeSession.ID)
+	if !found {
+		return false
+	}
+	requested := liveControlOperationInfo{
+		Operation:        liveControlOperationScannerStop,
+		AccountID:        runtimeSession.AccountID,
+		StrategyID:       runtimeSession.StrategyID,
+		LiveSessionID:    liveSession.ID,
+		RuntimeSessionID: runtimeSession.ID,
+	}
+	release, acquired, current := p.tryStartLiveControlOperation(requested)
+	if !acquired {
+		p.logger("service.signal_runtime_scanner",
+			"session_id", runtimeSession.ID,
+			"live_session_id", liveSession.ID,
+			"account_id", runtimeSession.AccountID,
+			"strategy_id", runtimeSession.StrategyID,
+		).Warn("skip stopped-live runtime cleanup because control operation is already in progress", "error", liveControlOperationInProgressError(requested, current))
+		return true
+	}
+	defer release()
+	if _, err := p.stopLinkedLiveSignalRuntime(liveSession); err != nil {
+		p.logger("service.signal_runtime_scanner",
+			"session_id", runtimeSession.ID,
+			"live_session_id", liveSession.ID,
+			"account_id", runtimeSession.AccountID,
+			"strategy_id", runtimeSession.StrategyID,
+		).Warn("failed to stop signal runtime linked to stopped live session", "error", err)
+		return true
+	}
+	p.logger("service.signal_runtime_scanner",
+		"session_id", runtimeSession.ID,
+		"live_session_id", liveSession.ID,
+		"account_id", runtimeSession.AccountID,
+		"strategy_id", runtimeSession.StrategyID,
+	).Warn("stopped signal runtime linked to stopped live session")
+	return true
+}
+
+func (p *Platform) findStoppedLiveSessionLinkedToRuntime(runtimeSessionID string) (domain.LiveSession, bool) {
+	runtimeSessionID = strings.TrimSpace(runtimeSessionID)
+	if runtimeSessionID == "" {
+		return domain.LiveSession{}, false
+	}
+	sessions, err := p.ListLiveSessions()
+	if err != nil {
+		return domain.LiveSession{}, false
+	}
+	var stopped domain.LiveSession
+	for _, session := range sessions {
+		if !liveSessionReferencesRuntime(session, runtimeSessionID) {
+			continue
+		}
+		if strings.EqualFold(session.Status, "RUNNING") {
+			return domain.LiveSession{}, false
+		}
+		if strings.EqualFold(session.Status, "STOPPED") && stopped.ID == "" {
+			stopped = session
+		}
+	}
+	return stopped, stopped.ID != ""
+}
+
+func liveSessionReferencesRuntime(session domain.LiveSession, runtimeSessionID string) bool {
+	runtimeSessionID = strings.TrimSpace(runtimeSessionID)
+	if runtimeSessionID == "" {
+		return false
+	}
+	return strings.TrimSpace(stringValue(session.State["signalRuntimeSessionId"])) == runtimeSessionID ||
+		strings.TrimSpace(stringValue(session.State["lastSignalRuntimeSessionId"])) == runtimeSessionID
 }

--- a/internal/service/signal_runtime_scanner_test.go
+++ b/internal/service/signal_runtime_scanner_test.go
@@ -136,6 +136,59 @@ func TestScanSignalRuntimeSessionsSkipsSessionOwnedByActiveLease(t *testing.T) {
 	}
 }
 
+func TestScanSignalRuntimeSessionsStopsDesiredRunningRuntimeLinkedToStoppedLiveSession(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	now := time.Date(2026, 4, 26, 18, 0, 0, 0, time.UTC)
+	runtime := mustCreateScannerRuntimeSession(t, platform, domain.SignalRuntimeSession{
+		ID:         "runtime-linked-stopped-live",
+		AccountID:  "live-main",
+		StrategyID: "strategy-bk-1d",
+		Status:     "RUNNING",
+		State: map[string]any{
+			"desiredStatus": "RUNNING",
+			"actualStatus":  "RUNNING",
+			"health":        "healthy",
+		},
+		CreatedAt: now,
+		UpdatedAt: now,
+	})
+	liveSession, err := platform.store.UpdateLiveSessionStatus("live-session-main", "STOPPED")
+	if err != nil {
+		t.Fatalf("set live session stopped failed: %v", err)
+	}
+	liveState := cloneMetadata(liveSession.State)
+	liveState["signalRuntimeSessionId"] = runtime.ID
+	if _, err := platform.store.UpdateLiveSessionState(liveSession.ID, liveState); err != nil {
+		t.Fatalf("link live session to runtime failed: %v", err)
+	}
+
+	started := 0
+	platform.scanSignalRuntimeSessions(context.Background(), func(_ context.Context, sessionID string) (domain.SignalRuntimeSession, error) {
+		started++
+		return runtime, nil
+	})
+	if started != 0 {
+		t.Fatalf("expected scanner not to start runtime linked to stopped live session, got %d starts", started)
+	}
+	updatedRuntime, err := platform.GetSignalRuntimeSession(runtime.ID)
+	if err != nil {
+		t.Fatalf("reload runtime failed: %v", err)
+	}
+	if updatedRuntime.Status != "STOPPED" {
+		t.Fatalf("expected runtime STOPPED, got %s", updatedRuntime.Status)
+	}
+	if got := stringValue(updatedRuntime.State["desiredStatus"]); got != "STOPPED" {
+		t.Fatalf("expected desiredStatus STOPPED, got %s", got)
+	}
+	updatedLiveSession, err := platform.store.GetLiveSession(liveSession.ID)
+	if err != nil {
+		t.Fatalf("reload live session failed: %v", err)
+	}
+	if got := stringValue(updatedLiveSession.State["signalRuntimeStatus"]); got != "STOPPED" {
+		t.Fatalf("expected live signalRuntimeStatus STOPPED, got %s", got)
+	}
+}
+
 func TestPersistSignalRuntimeStoppedAfterStartCancelClearsDesiredAndActual(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
 	now := time.Date(2026, 4, 26, 18, 0, 0, 0, time.UTC)

--- a/internal/service/signal_runtime_sessions.go
+++ b/internal/service/signal_runtime_sessions.go
@@ -235,7 +235,12 @@ func (p *Platform) StartSignalRuntimeSession(sessionID string) (domain.SignalRun
 			StrategyID:       session.StrategyID,
 			RuntimeSessionID: session.ID,
 		}
-		current := p.currentLiveControlOperation(liveControlOperationKey(session.AccountID, session.StrategyID))
+		var lockErr error
+		requested, lockErr = normalizeLiveControlOperationInfo(requested)
+		if lockErr != nil {
+			return domain.SignalRuntimeSession{}, lockErr
+		}
+		current := p.currentLiveControlOperation(liveControlOperationKey(requested.AccountID, requested.StrategyID))
 		if current.Operation != "" &&
 			(current.Operation != liveControlOperationSignalRuntimeStart || current.RuntimeSessionID != session.ID) {
 			return domain.SignalRuntimeSession{}, liveControlOperationInProgressError(requested, current)
@@ -248,7 +253,10 @@ func (p *Platform) StartSignalRuntimeSession(sessionID string) (domain.SignalRun
 		StrategyID:       session.StrategyID,
 		RuntimeSessionID: session.ID,
 	}
-	release, acquired, current := p.tryStartLiveControlOperation(requested)
+	release, acquired, current, lockErr := p.tryStartLiveControlOperation(requested)
+	if lockErr != nil {
+		return domain.SignalRuntimeSession{}, lockErr
+	}
 	if !acquired {
 		return domain.SignalRuntimeSession{}, liveControlOperationInProgressError(requested, current)
 	}
@@ -399,7 +407,10 @@ func (p *Platform) StopSignalRuntimeSessionWithForce(sessionID string, force boo
 		StrategyID:       existing.StrategyID,
 		RuntimeSessionID: existing.ID,
 	}
-	release, acquired, current := p.tryStartLiveControlOperation(requested)
+	release, acquired, current, lockErr := p.tryStartLiveControlOperation(requested)
+	if lockErr != nil {
+		return domain.SignalRuntimeSession{}, lockErr
+	}
 	if !acquired {
 		return domain.SignalRuntimeSession{}, liveControlOperationInProgressError(requested, current)
 	}
@@ -560,7 +571,10 @@ func (p *Platform) DeleteSignalRuntimeSessionWithForce(sessionID string, force b
 		StrategyID:       existing.StrategyID,
 		RuntimeSessionID: existing.ID,
 	}
-	release, acquired, current := p.tryStartLiveControlOperation(requested)
+	release, acquired, current, lockErr := p.tryStartLiveControlOperation(requested)
+	if lockErr != nil {
+		return lockErr
+	}
 	if !acquired {
 		return liveControlOperationInProgressError(requested, current)
 	}

--- a/internal/service/signal_runtime_sessions.go
+++ b/internal/service/signal_runtime_sessions.go
@@ -224,6 +224,35 @@ func (p *Platform) syncSignalRuntimeSessionPlan(sessionID string) (domain.Signal
 }
 
 func (p *Platform) StartSignalRuntimeSession(sessionID string) (domain.SignalRuntimeSession, error) {
+	session, err := p.GetSignalRuntimeSession(sessionID)
+	if err != nil {
+		return domain.SignalRuntimeSession{}, err
+	}
+	if p.signalRuntimeSessionRunningOrStarting(sessionID) {
+		requested := liveControlOperationInfo{
+			Operation:        liveControlOperationSignalRuntimeStart,
+			AccountID:        session.AccountID,
+			StrategyID:       session.StrategyID,
+			RuntimeSessionID: session.ID,
+		}
+		current := p.currentLiveControlOperation(liveControlOperationKey(session.AccountID, session.StrategyID))
+		if current.Operation != "" &&
+			(current.Operation != liveControlOperationSignalRuntimeStart || current.RuntimeSessionID != session.ID) {
+			return domain.SignalRuntimeSession{}, liveControlOperationInProgressError(requested, current)
+		}
+		return p.startSignalRuntimeSession(context.Background(), sessionID)
+	}
+	requested := liveControlOperationInfo{
+		Operation:        liveControlOperationSignalRuntimeStart,
+		AccountID:        session.AccountID,
+		StrategyID:       session.StrategyID,
+		RuntimeSessionID: session.ID,
+	}
+	release, acquired, current := p.tryStartLiveControlOperation(requested)
+	if !acquired {
+		return domain.SignalRuntimeSession{}, liveControlOperationInProgressError(requested, current)
+	}
+	defer release()
 	return p.startSignalRuntimeSession(context.Background(), sessionID)
 }
 
@@ -364,6 +393,22 @@ func (p *Platform) StopSignalRuntimeSessionWithForce(sessionID string, force boo
 		logger.Warn("signal runtime session not found")
 		return domain.SignalRuntimeSession{}, err
 	}
+	requested := liveControlOperationInfo{
+		Operation:        liveControlOperationSignalRuntimeStop,
+		AccountID:        existing.AccountID,
+		StrategyID:       existing.StrategyID,
+		RuntimeSessionID: existing.ID,
+	}
+	release, acquired, current := p.tryStartLiveControlOperation(requested)
+	if !acquired {
+		return domain.SignalRuntimeSession{}, liveControlOperationInProgressError(requested, current)
+	}
+	defer release()
+	return p.stopSignalRuntimeSessionWithForceLocked(existing, force)
+}
+
+func (p *Platform) stopSignalRuntimeSessionWithForceLocked(existing domain.SignalRuntimeSession, force bool) (domain.SignalRuntimeSession, error) {
+	logger := p.logger("service.signal_runtime", "session_id", existing.ID)
 	if !force {
 		if err := p.ensureNoActivePositionsOrOrders(existing.AccountID, existing.StrategyID); err != nil {
 			logger.Warn("stop signal runtime session blocked by active positions or orders", "error", err)
@@ -371,7 +416,7 @@ func (p *Platform) StopSignalRuntimeSessionWithForce(sessionID string, force boo
 		}
 	}
 	p.mu.Lock()
-	run, running := p.signalRun[sessionID]
+	run, running := p.signalRun[existing.ID]
 	p.mu.Unlock()
 	session := existing
 	now := time.Now().UTC()
@@ -401,7 +446,7 @@ func (p *Platform) StopSignalRuntimeSessionWithForce(sessionID string, force boo
 	}
 	p.mu.Lock()
 	if running {
-		delete(p.signalRun, sessionID)
+		delete(p.signalRun, existing.ID)
 	}
 	p.signalSessions[session.ID] = session
 	p.mu.Unlock()
@@ -509,20 +554,35 @@ func (p *Platform) DeleteSignalRuntimeSessionWithForce(sessionID string, force b
 	if err != nil {
 		return err
 	}
+	requested := liveControlOperationInfo{
+		Operation:        liveControlOperationSignalRuntimeDelete,
+		AccountID:        existing.AccountID,
+		StrategyID:       existing.StrategyID,
+		RuntimeSessionID: existing.ID,
+	}
+	release, acquired, current := p.tryStartLiveControlOperation(requested)
+	if !acquired {
+		return liveControlOperationInProgressError(requested, current)
+	}
+	defer release()
+	return p.deleteSignalRuntimeSessionWithForceLocked(existing, force)
+}
+
+func (p *Platform) deleteSignalRuntimeSessionWithForceLocked(existing domain.SignalRuntimeSession, force bool) error {
 	if !force {
 		if err := p.ensureNoActivePositionsOrOrders(existing.AccountID, existing.StrategyID); err != nil {
 			return err
 		}
 	}
-	if err := p.store.DeleteSignalRuntimeSession(sessionID); err != nil && !isSignalRuntimeSessionNotFoundError(err) {
+	if err := p.store.DeleteSignalRuntimeSession(existing.ID); err != nil && !isSignalRuntimeSessionNotFoundError(err) {
 		return err
 	}
 	p.mu.Lock()
-	run, running := p.signalRun[sessionID]
+	run, running := p.signalRun[existing.ID]
 	if running {
-		delete(p.signalRun, sessionID)
+		delete(p.signalRun, existing.ID)
 	}
-	delete(p.signalSessions, sessionID)
+	delete(p.signalSessions, existing.ID)
 	p.mu.Unlock()
 	if running {
 		run.cancelRunner()

--- a/internal/store/memory/live_sessions_test.go
+++ b/internal/store/memory/live_sessions_test.go
@@ -31,3 +31,30 @@ func TestDeleteLiveSessionSoftDeletesAndListHidesDeleted(t *testing.T) {
 		}
 	}
 }
+
+func TestListLiveSessionsKeepsNonDeletedSessionWithLegacyDeletedAtState(t *testing.T) {
+	store := NewStore()
+	session, err := store.GetLiveSession("live-session-main")
+	if err != nil {
+		t.Fatalf("GetLiveSession failed: %v", err)
+	}
+	session.Status = "READY"
+	session.State = map[string]any{
+		"deletedAt":    "legacy-non-soft-delete-marker",
+		"dispatchMode": "manual-review",
+	}
+	if _, err := store.UpdateLiveSession(session); err != nil {
+		t.Fatalf("UpdateLiveSession failed: %v", err)
+	}
+
+	items, err := store.ListLiveSessions()
+	if err != nil {
+		t.Fatalf("ListLiveSessions failed: %v", err)
+	}
+	for _, item := range items {
+		if item.ID == session.ID {
+			return
+		}
+	}
+	t.Fatalf("expected non-DELETED live session %s with legacy deletedAt state to remain listed", session.ID)
+}

--- a/internal/store/memory/live_sessions_test.go
+++ b/internal/store/memory/live_sessions_test.go
@@ -1,0 +1,33 @@
+package memory
+
+import "testing"
+
+func TestDeleteLiveSessionSoftDeletesAndListHidesDeleted(t *testing.T) {
+	store := NewStore()
+	session, err := store.GetLiveSession("live-session-main")
+	if err != nil {
+		t.Fatalf("GetLiveSession failed: %v", err)
+	}
+	if err := store.DeleteLiveSession(session.ID); err != nil {
+		t.Fatalf("DeleteLiveSession failed: %v", err)
+	}
+	deleted, err := store.GetLiveSession(session.ID)
+	if err != nil {
+		t.Fatalf("soft-deleted session should remain loadable: %v", err)
+	}
+	if deleted.Status != "DELETED" {
+		t.Fatalf("expected status DELETED, got %s", deleted.Status)
+	}
+	if raw, ok := deleted.State["deletedAt"]; !ok || raw == "" {
+		t.Fatalf("expected deletedAt in state, got %#v", deleted.State)
+	}
+	items, err := store.ListLiveSessions()
+	if err != nil {
+		t.Fatalf("ListLiveSessions failed: %v", err)
+	}
+	for _, item := range items {
+		if item.ID == session.ID {
+			t.Fatalf("expected deleted live session %s to be hidden from list", session.ID)
+		}
+	}
+}

--- a/internal/store/memory/store.go
+++ b/internal/store/memory/store.go
@@ -1576,17 +1576,7 @@ func cloneJSONValue[T any](value T) T {
 }
 
 func liveSessionDeleted(session domain.LiveSession) bool {
-	if strings.EqualFold(strings.TrimSpace(session.Status), "DELETED") {
-		return true
-	}
-	if session.State == nil {
-		return false
-	}
-	deletedAt, ok := session.State["deletedAt"]
-	if !ok || deletedAt == nil {
-		return false
-	}
-	return strings.TrimSpace(fmt.Sprint(deletedAt)) != ""
+	return strings.EqualFold(strings.TrimSpace(session.Status), "DELETED")
 }
 
 func accountStatusForMode(mode string) string {

--- a/internal/store/memory/store.go
+++ b/internal/store/memory/store.go
@@ -881,6 +881,9 @@ func (s *Store) ListLiveSessions() ([]domain.LiveSession, error) {
 	defer s.mu.RUnlock()
 	items := make([]domain.LiveSession, 0, len(s.liveSessions))
 	for _, item := range s.liveSessions {
+		if liveSessionDeleted(item) {
+			continue
+		}
 		items = append(items, item)
 	}
 	sort.Slice(items, func(i, j int) bool { return items[i].CreatedAt.Before(items[j].CreatedAt) })
@@ -930,10 +933,15 @@ func (s *Store) UpdateLiveSession(session domain.LiveSession) (domain.LiveSessio
 func (s *Store) DeleteLiveSession(sessionID string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if _, ok := s.liveSessions[sessionID]; !ok {
+	item, ok := s.liveSessions[sessionID]
+	if !ok {
 		return fmt.Errorf("live session not found: %s", sessionID)
 	}
-	delete(s.liveSessions, sessionID)
+	item.Status = "DELETED"
+	state := cloneJSONValue(item.State)
+	state["deletedAt"] = time.Now().UTC().Format(time.RFC3339)
+	item.State = state
+	s.liveSessions[sessionID] = item
 	return nil
 }
 
@@ -1565,6 +1573,20 @@ func cloneJSONValue[T any](value T) T {
 		return value
 	}
 	return cloned
+}
+
+func liveSessionDeleted(session domain.LiveSession) bool {
+	if strings.EqualFold(strings.TrimSpace(session.Status), "DELETED") {
+		return true
+	}
+	if session.State == nil {
+		return false
+	}
+	deletedAt, ok := session.State["deletedAt"]
+	if !ok || deletedAt == nil {
+		return false
+	}
+	return strings.TrimSpace(fmt.Sprint(deletedAt)) != ""
 }
 
 func accountStatusForMode(mode string) string {

--- a/internal/store/postgres/live_sessions_test.go
+++ b/internal/store/postgres/live_sessions_test.go
@@ -57,3 +57,52 @@ func TestDeleteLiveSessionSoftDeletesAndListHidesDeleted(t *testing.T) {
 		}
 	}
 }
+
+func TestListLiveSessionsKeepsNonDeletedSessionWithLegacyDeletedAtState(t *testing.T) {
+	dsn := os.Getenv("BKTRADER_TEST_POSTGRES_DSN")
+	if dsn == "" {
+		t.Skip("BKTRADER_TEST_POSTGRES_DSN is not set")
+	}
+	if err := Migrate(dsn); err != nil {
+		t.Fatalf("Migrate failed: %v", err)
+	}
+	store, err := New(dsn)
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	defer store.Close()
+
+	account, err := store.CreateAccount("Live Legacy DeletedAt Test", "LIVE", "binance-futures")
+	if err != nil {
+		t.Fatalf("CreateAccount failed: %v", err)
+	}
+	strategy, err := store.CreateStrategy("live-legacy-deleted-at-test", "live legacy deletedAt test", map[string]any{
+		"strategyEngine": "bk-default",
+	})
+	if err != nil {
+		t.Fatalf("CreateStrategy failed: %v", err)
+	}
+	session, err := store.CreateLiveSession(account.ID, strategy["id"].(string))
+	if err != nil {
+		t.Fatalf("CreateLiveSession failed: %v", err)
+	}
+	session.Status = "READY"
+	session.State = map[string]any{
+		"deletedAt":    "legacy-non-soft-delete-marker",
+		"dispatchMode": "manual-review",
+	}
+	if _, err := store.UpdateLiveSession(session); err != nil {
+		t.Fatalf("UpdateLiveSession failed: %v", err)
+	}
+
+	items, err := store.ListLiveSessions()
+	if err != nil {
+		t.Fatalf("ListLiveSessions failed: %v", err)
+	}
+	for _, item := range items {
+		if item.ID == session.ID {
+			return
+		}
+	}
+	t.Fatalf("expected non-DELETED live session %s with legacy deletedAt state to remain listed", session.ID)
+}

--- a/internal/store/postgres/live_sessions_test.go
+++ b/internal/store/postgres/live_sessions_test.go
@@ -1,0 +1,59 @@
+package postgres
+
+import (
+	"os"
+	"testing"
+)
+
+func TestDeleteLiveSessionSoftDeletesAndListHidesDeleted(t *testing.T) {
+	dsn := os.Getenv("BKTRADER_TEST_POSTGRES_DSN")
+	if dsn == "" {
+		t.Skip("BKTRADER_TEST_POSTGRES_DSN is not set")
+	}
+	if err := Migrate(dsn); err != nil {
+		t.Fatalf("Migrate failed: %v", err)
+	}
+	store, err := New(dsn)
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	defer store.Close()
+
+	account, err := store.CreateAccount("Live Soft Delete Test", "LIVE", "binance-futures")
+	if err != nil {
+		t.Fatalf("CreateAccount failed: %v", err)
+	}
+	strategy, err := store.CreateStrategy("live-soft-delete-test", "live soft delete test", map[string]any{
+		"strategyEngine": "bk-default",
+	})
+	if err != nil {
+		t.Fatalf("CreateStrategy failed: %v", err)
+	}
+	session, err := store.CreateLiveSession(account.ID, strategy["id"].(string))
+	if err != nil {
+		t.Fatalf("CreateLiveSession failed: %v", err)
+	}
+
+	if err := store.DeleteLiveSession(session.ID); err != nil {
+		t.Fatalf("DeleteLiveSession failed: %v", err)
+	}
+	deleted, err := store.GetLiveSession(session.ID)
+	if err != nil {
+		t.Fatalf("soft-deleted session should remain loadable: %v", err)
+	}
+	if deleted.Status != "DELETED" {
+		t.Fatalf("expected status DELETED, got %s", deleted.Status)
+	}
+	if raw, ok := deleted.State["deletedAt"]; !ok || raw == "" {
+		t.Fatalf("expected deletedAt in state, got %#v", deleted.State)
+	}
+	items, err := store.ListLiveSessions()
+	if err != nil {
+		t.Fatalf("ListLiveSessions failed: %v", err)
+	}
+	for _, item := range items {
+		if item.ID == session.ID {
+			t.Fatalf("expected deleted live session %s to be hidden from list", session.ID)
+		}
+	}
+}

--- a/internal/store/postgres/store.go
+++ b/internal/store/postgres/store.go
@@ -1196,9 +1196,12 @@ func (s *Store) UpdatePaperSessionState(sessionID string, state map[string]any) 
 
 func (s *Store) ListLiveSessions() ([]domain.LiveSession, error) {
 	rows, err := s.db.Query(`
-		select id, alias, account_id, strategy_id, status, state, created_at
-		from live_sessions order by created_at asc
-	`)
+			select id, alias, account_id, strategy_id, status, state, created_at
+			from live_sessions
+			where upper(status) <> 'DELETED'
+				and not (state ? 'deletedAt')
+			order by created_at asc
+		`)
 	if err != nil {
 		return nil, err
 	}
@@ -1288,7 +1291,13 @@ func (s *Store) UpdateLiveSession(item domain.LiveSession) (domain.LiveSession, 
 }
 
 func (s *Store) DeleteLiveSession(sessionID string) error {
-	result, err := s.db.Exec(`delete from live_sessions where id = $1`, sessionID)
+	deletedAt := time.Now().UTC().Format(time.RFC3339)
+	result, err := s.db.Exec(`
+		update live_sessions
+		set status = 'DELETED',
+			state = coalesce(state, '{}'::jsonb) || jsonb_build_object('deletedAt', $2)
+		where id = $1
+	`, sessionID, deletedAt)
 	if err != nil {
 		return err
 	}

--- a/internal/store/postgres/store.go
+++ b/internal/store/postgres/store.go
@@ -1199,7 +1199,6 @@ func (s *Store) ListLiveSessions() ([]domain.LiveSession, error) {
 			select id, alias, account_id, strategy_id, status, state, created_at
 			from live_sessions
 			where upper(status) <> 'DELETED'
-				and not (state ? 'deletedAt')
 			order by created_at asc
 		`)
 	if err != nil {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -111,7 +111,7 @@ type Repository interface {
 	CreateLiveSession(accountID, strategyID string) (domain.LiveSession, error)
 	// UpdateLiveSession 更新指定实盘策略会话的账户、策略或状态载荷。
 	UpdateLiveSession(session domain.LiveSession) (domain.LiveSession, error)
-	// DeleteLiveSession 删除指定实盘策略会话。
+	// DeleteLiveSession marks a live session as deleted; default list queries hide deleted sessions.
 	DeleteLiveSession(sessionID string) error
 	// UpdateLiveSessionStatus 更新实盘策略会话状态。
 	UpdateLiveSessionStatus(sessionID, status string) (domain.LiveSession, error)

--- a/web/console/src/pages/AccountStage.tsx
+++ b/web/console/src/pages/AccountStage.tsx
@@ -197,7 +197,14 @@ export function AccountStage({
     onConfirm: () => Promise<void> | void;
   }>({ open: false, title: "", description: "", onConfirm: () => {} });
 
-  const confirmActionPending = liveSessionDeleteAction !== null || liveFlowAction !== null;
+  const liveControlActionPending =
+    liveSessionAction !== null ||
+    liveSessionDeleteAction !== null ||
+    liveFlowAction !== null ||
+    liveSessionLaunchAction ||
+    signalRuntimeAction !== null ||
+    launchingTemplate !== null;
+  const confirmActionPending = liveControlActionPending || liveBindAction;
 
   const activeLiveSession = liveSessions.find(s => s.accountId === quickLiveAccountId);
   const activeTemplateKey = String(
@@ -544,6 +551,7 @@ export function AccountStage({
                 const liveNextAction = deriveLiveNextAction(livePreflight);
                 const liveAlerts = deriveLiveAlerts(account, activeRuntimeState, activeRuntimeSourceSummary, activeRuntimeReadiness, activeSignalAction, runtimePolicy);
                 const accountDetailOpen = expandedAccountId === account.id;
+                const accountControlPending = liveControlActionPending || liveBindAction;
                 const handleStopLiveFlow = () => {
                   if (!hasOpenExposure) {
                     openConfirm(
@@ -642,10 +650,12 @@ export function AccountStage({
                           <Button 
                             variant={isLiveFlowRunning ? "bento-danger" : "bento"}
                             className="h-11 w-full rounded-xl text-xs font-black shadow-md transition-transform active:scale-95"
-                            disabled={liveFlowAction !== null || liveBindAction || signalRuntimeAction !== null}
+                            disabled={accountControlPending}
                             onClick={() => isLiveFlowRunning ? handleStopLiveFlow() : launchLiveFlow(account)}
                           >
-                             {isLiveFlowRunning ? (
+                             {liveFlowAction === account.id ? (
+                               <div className="flex items-center gap-2"><RotateCw size={14} className="animate-spin" /> 处理中...</div>
+                             ) : isLiveFlowRunning ? (
                                <div className="flex items-center gap-2"><Square size={14} fill="currentColor" /> 停止实盘流程</div>
                              ) : (
                                <div className="flex items-center gap-2"><Play size={14} fill="currentColor" /> 启动实盘流程</div>
@@ -791,7 +801,7 @@ export function AccountStage({
                         <Button 
                           variant="bento-outline"
                           className="h-8 w-full rounded-lg bg-[var(--bk-surface)] text-[10px] font-black transition-all hover:border-transparent hover:bg-[var(--bk-surface-inverse)] hover:text-[var(--bk-text-contrast)]"
-                          disabled={launchingTemplate !== null}
+                          disabled={liveControlActionPending}
                           onClick={() => {
                             const isSwitching = activeLiveSession && activeTemplateKey !== tpl.key;
                             setConfirmConfig({
@@ -1064,7 +1074,26 @@ export function AccountStage({
              <div className="space-y-3">
                {validLiveSessions.length > 0 ? (
                  validLiveSessions.map((session) => {
-                   const isRunning = session.status === "RUNNING";
+                   const sessionState = getRecord(session.state);
+                   const isRunning = String(session.status).toUpperCase() === "RUNNING";
+                   const linkedRuntimeSessionId = String(
+                     sessionState.signalRuntimeSessionId ?? sessionState.lastSignalRuntimeSessionId ?? ""
+                   ).trim();
+                   const linkedRuntimeSession = linkedRuntimeSessionId
+                     ? signalRuntimeSessions.find((item) => item.id === linkedRuntimeSessionId) ?? null
+                     : null;
+                   const linkedRuntimeState = getRecord(linkedRuntimeSession?.state);
+                   const linkedRuntimeStatus = String(
+                     linkedRuntimeSession?.status ?? sessionState.signalRuntimeStatus ?? ""
+                   ).trim().toUpperCase();
+                   const linkedRuntimeDesiredStatus = String(
+                     linkedRuntimeState.desiredStatus ?? sessionState.signalRuntimeDesiredStatus ?? ""
+                   ).trim().toUpperCase();
+                   const linkedRuntimeStillActive =
+                     !isRunning &&
+                     (linkedRuntimeStatus === "RUNNING" ||
+                       linkedRuntimeStatus === "STARTING" ||
+                       linkedRuntimeDesiredStatus === "RUNNING");
                    return (
                      <div key={session.id} className="group flex items-center justify-between rounded-[20px] border border-[var(--bk-border)] bg-[var(--bk-surface-strong)] p-4 transition-all hover:bg-[var(--bk-surface)]">
                         <div className="space-y-1">
@@ -1076,14 +1105,20 @@ export function AccountStage({
                                 {session.status}
                               </Badge>
                            </div>
-                           <p className="text-[10px] font-mono text-[var(--bk-text-muted)]">{String(getRecord(session.state).symbol || "--")} · {session.strategyId}</p>
+                           <p className="text-[10px] font-mono text-[var(--bk-text-muted)]">{String(sessionState.symbol || "--")} · {session.strategyId}</p>
+                           {linkedRuntimeStillActive && (
+                             <p className="flex items-center gap-1.5 text-[10px] font-bold text-[var(--bk-status-warning)]">
+                               <AlertTriangle size={12} />
+                               Live 已停止，但关联 runtime 仍处于 {linkedRuntimeStatus || linkedRuntimeDesiredStatus}，请先停止 runtime 或等待修复。
+                             </p>
+                           )}
                         </div>
                         <div className="flex items-center gap-1">
                            <Button 
                               variant="bento-ghost" 
                               size="icon" 
                               className={`h-8 w-8 ${isRunning ? 'text-[var(--bk-status-danger)]' : 'text-[var(--bk-status-success)]'}`}
-                              disabled={liveSessionAction !== null}
+                              disabled={liveControlActionPending}
                               onClick={() => runLiveSessionAction(session.id, isRunning ? "stop" : "start")}
                             >
                               {isRunning ? <Square size={14} /> : <Play size={14} fill="currentColor" />}
@@ -1100,8 +1135,8 @@ export function AccountStage({
                               variant="bento-ghost" 
                               size="icon" 
                               className="h-8 w-8 text-[var(--bk-status-danger)] opacity-0 group-hover:opacity-100 transition-opacity"
-                              disabled={liveSessionDeleteAction !== null}
-                              onClick={() => openConfirm("删除会话？", "确定要彻底删除该实盘会话吗？删除后相关监控快照将无法恢复。", () => deleteLiveSession(session.id))}
+                              disabled={liveControlActionPending}
+                              onClick={() => openConfirm("删除会话？", "系统会将该实盘会话标记为删除并从默认列表隐藏；订单、成交与审计记录会继续保留。", () => deleteLiveSession(session.id))}
                             >
                              <Trash2 size={14} />
                            </Button>

--- a/web/console/src/pages/AccountStage.tsx
+++ b/web/console/src/pages/AccountStage.tsx
@@ -197,14 +197,14 @@ export function AccountStage({
     onConfirm: () => Promise<void> | void;
   }>({ open: false, title: "", description: "", onConfirm: () => {} });
 
-  const liveControlActionPending =
+  const confirmActionPending =
     liveSessionAction !== null ||
     liveSessionDeleteAction !== null ||
     liveFlowAction !== null ||
     liveSessionLaunchAction ||
     signalRuntimeAction !== null ||
-    launchingTemplate !== null;
-  const confirmActionPending = liveControlActionPending || liveBindAction;
+    launchingTemplate !== null ||
+    liveBindAction;
 
   const activeLiveSession = liveSessions.find(s => s.accountId === quickLiveAccountId);
   const activeTemplateKey = String(
@@ -213,6 +213,25 @@ export function AccountStage({
 
   const openConfirm = (title: string, description: string, onConfirm: () => Promise<void> | void) => {
     setConfirmConfig({ open: true, title, description, onConfirm });
+  };
+
+  const liveSessionActionTargets = (sessionId: string) =>
+    liveSessionAction === sessionId || liveSessionAction?.startsWith(`${sessionId}:`) || liveSessionDeleteAction === sessionId;
+
+  const signalRuntimeActionTargets = (runtimeId: string) =>
+    signalRuntimeAction === runtimeId || signalRuntimeAction?.startsWith(`${runtimeId}:`);
+
+  const liveControlActionPendingForAccount = (accountId: string) => {
+    if (!accountId) return false;
+    const sessionPending = validLiveSessions.some(
+      (item) => item.accountId === accountId && liveSessionActionTargets(item.id)
+    );
+    const runtimePending =
+      signalRuntimeSessions.some((item) => item.accountId === accountId && signalRuntimeActionTargets(item.id)) ||
+      (signalRuntimeAction === "create" && signalRuntimeForm.accountId === accountId);
+    const launchPending =
+      (liveSessionLaunchAction || launchingTemplate !== null || liveBindAction) && quickLiveAccountId === accountId;
+    return liveFlowAction === accountId || sessionPending || runtimePending || launchPending;
   };
 
   const activeOrderStatuses = useMemo(() => new Set(["NEW", "PARTIALLY_FILLED", "ACCEPTED"]), []);
@@ -228,6 +247,9 @@ export function AccountStage({
     () => liveSessions.filter((item) => strategyIds.has(item.strategyId)),
     [liveSessions, strategyIds]
   );
+  const quickLiveControlActionPending = quickLiveAccountId
+    ? liveControlActionPendingForAccount(quickLiveAccountId)
+    : liveSessionLaunchAction || launchingTemplate !== null;
 
   const primaryLiveSession = highlightedLiveSession?.session ?? null;
   const primaryLiveSessionIntent = getRecord(primaryLiveSession?.state?.lastStrategyIntent);
@@ -551,7 +573,7 @@ export function AccountStage({
                 const liveNextAction = deriveLiveNextAction(livePreflight);
                 const liveAlerts = deriveLiveAlerts(account, activeRuntimeState, activeRuntimeSourceSummary, activeRuntimeReadiness, activeSignalAction, runtimePolicy);
                 const accountDetailOpen = expandedAccountId === account.id;
-                const accountControlPending = liveControlActionPending || liveBindAction;
+                const accountControlPending = liveControlActionPendingForAccount(account.id);
                 const handleStopLiveFlow = () => {
                   if (!hasOpenExposure) {
                     openConfirm(
@@ -801,7 +823,7 @@ export function AccountStage({
                         <Button 
                           variant="bento-outline"
                           className="h-8 w-full rounded-lg bg-[var(--bk-surface)] text-[10px] font-black transition-all hover:border-transparent hover:bg-[var(--bk-surface-inverse)] hover:text-[var(--bk-text-contrast)]"
-                          disabled={liveControlActionPending}
+                          disabled={quickLiveControlActionPending}
                           onClick={() => {
                             const isSwitching = activeLiveSession && activeTemplateKey !== tpl.key;
                             setConfirmConfig({
@@ -1094,6 +1116,11 @@ export function AccountStage({
                      (linkedRuntimeStatus === "RUNNING" ||
                        linkedRuntimeStatus === "STARTING" ||
                        linkedRuntimeDesiredStatus === "RUNNING");
+                   const sessionControlPending =
+                     liveFlowAction === session.accountId ||
+                     liveSessionActionTargets(session.id) ||
+                     (linkedRuntimeSession ? signalRuntimeActionTargets(linkedRuntimeSession.id) : false) ||
+                     ((liveSessionLaunchAction || launchingTemplate !== null) && quickLiveAccountId === session.accountId);
                    return (
                      <div key={session.id} className="group flex items-center justify-between rounded-[20px] border border-[var(--bk-border)] bg-[var(--bk-surface-strong)] p-4 transition-all hover:bg-[var(--bk-surface)]">
                         <div className="space-y-1">
@@ -1118,7 +1145,7 @@ export function AccountStage({
                               variant="bento-ghost" 
                               size="icon" 
                               className={`h-8 w-8 ${isRunning ? 'text-[var(--bk-status-danger)]' : 'text-[var(--bk-status-success)]'}`}
-                              disabled={liveControlActionPending}
+                              disabled={sessionControlPending}
                               onClick={() => runLiveSessionAction(session.id, isRunning ? "stop" : "start")}
                             >
                               {isRunning ? <Square size={14} /> : <Play size={14} fill="currentColor" />}
@@ -1135,7 +1162,7 @@ export function AccountStage({
                               variant="bento-ghost" 
                               size="icon" 
                               className="h-8 w-8 text-[var(--bk-status-danger)] opacity-0 group-hover:opacity-100 transition-opacity"
-                              disabled={liveControlActionPending}
+                              disabled={sessionControlPending}
                               onClick={() => openConfirm("删除会话？", "系统会将该实盘会话标记为删除并从默认列表隐藏；订单、成交与审计记录会继续保留。", () => deleteLiveSession(session.id))}
                             >
                              <Trash2 size={14} />


### PR DESCRIPTION
## 目的
Fixes #234.

修复 live session stop/delete 与 signal runtime 生命周期不一致的问题：停止或删除 live session 时同步停止关联 runtime；启动恢复不再恢复 desired-stopped runtime；runtime lease 竞争不再写成长时间 critical recovery error；默认列表隐藏软删除 live session；同 account+strategy 的 live/runtime 控制操作返回 409 冲突；前端补操作中禁用与状态提示。

Root cause: live session 的生命周期状态和 signal runtime 的 `desiredStatus`/实际运行态此前缺少统一收敛入口，scanner/recovery 可能把已停止或已删除 live session 的 runtime 重新拉起；控制操作也缺少 account+strategy 级别互斥，导致 start/stop/delete/launch 可并发交错。

额外补充：本机 `python3` 会解析到不含 `graphify.watch` 的 miniconda 环境，本 PR 将可用的 `/usr/local/bin/python3.12` Graphify Python 路径写入 `docs/AGENT_PATHS.md`。

## 已知边界 / Residual Risk

- `StopLiveFlowWithForce` 当前解决的是单进程内 account+strategy 控制操作交错和 lifecycle convergence，不提供多实例部署下的 distributed global stop barrier。多 active writers 场景仍需要依赖 runtime lease、持久化 session state 收敛；如果后续要做到严格 account-level 原子 cutover，应单独引入 persisted account/account+strategy control lease 或 store 层条件更新/版本检查。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [x] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) — 未变化，仍保持既有 manual-review 语义。
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？— 无。
- [x] DB migration 是否具备向下兼容幂等性？— 无 DB migration；soft delete 复用现有 `status/state` 字段。
- [x] 配置字段有没有无意被混改？— 未改运行时默认强约束参数；仅增加 lifecycle 状态收敛与本地路径文档。

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

已执行：
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
- `cd web/console && ./node_modules/.bin/tsc --noEmit src/pages/AccountStage.tsx --jsx react-jsx --esModuleInterop --target esnext --module esnext --moduleResolution Bundler --allowSyntheticDefaultImports`
- `cd web/console && npm run build`（通过，有既有 Vite chunk-size warning）
- `git diff --check`
- `/usr/local/bin/python3.12 - <<'PY'`
  `from graphify.watch import _rebuild_code`
  `print('graphify.watch ok')`
  `PY`
- pre-push harness：backend/frontend scope checks 通过；docs-only follow-up push safety sensors 通过。

新增/更新的关键回归覆盖：
- live stop/delete 会停止 linked signal runtime；runtime stop 失败时 delete 不会伪成功。
- startup recovery 跳过 desired-stopped linked runtime。
- runtime lease race 按 transient 处理并清理旧 recovery error。
- 同 account+strategy live/runtime 控制并发返回 `ErrLiveControlOperationInProgress` / HTTP 409。
- scanner 会停止 desired-running 但只关联 STOPPED live session 的 runtime。
- memory/postgres live session soft delete 后默认 list 隐藏。

