### PR TITLE
fix: align docker builder with go mod

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22-alpine AS backend-builder
+FROM golang:1.23-alpine AS backend-builder
 ARG TARGETOS
 ARG TARGETARCH
 WORKDIR /app


### PR DESCRIPTION
## Summary
- Align the Docker backend builder image with `go.mod` (`go 1.23.0`).
- Keeps backend/CD Docker builds from failing at `go mod download` with Go 1.22.

## Verification
- `go test ./...`
- Local `docker build --target backend-builder .` could not run because the local Colima/Docker daemon is not running.

## Codex
Assisted by Codex.
