### PR TITLE
feat: auto release CLI on main changes

### DIFF
--- a/.github/workflows/cli-auto-release.yml
+++ b/.github/workflows/cli-auto-release.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   release:
-    name: Build and release bktrader-ctl
+    name: Tag bktrader-ctl release
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -50,42 +50,3 @@ jobs:
             git tag "$tag" "$GITHUB_SHA"
             git push origin "$tag"
           fi
-
-      - name: Build Matrix
-        env:
-          RELEASE_TAG: ${{ steps.tag.outputs.tag }}
-        run: |
-          mkdir -p dist
-          platforms=(
-            "darwin/arm64"
-          )
-
-          for platform in "${platforms[@]}"; do
-            platform_split=(${platform//\// })
-            GOOS=${platform_split[0]}
-            GOARCH=${platform_split[1]}
-
-            output_name="bktrader-ctl-$GOOS-$GOARCH"
-
-            echo "Building $output_name..."
-            env GOOS=$GOOS GOARCH=$GOARCH go build \
-              -ldflags "-X main.Version=${RELEASE_TAG} -X main.Commit=${GITHUB_SHA} -X main.BuildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-              -o "dist/$output_name" ./cmd/bktrader-ctl
-          done
-
-          # ubuntu-latest intentionally provides sha256sum for release checksums.
-          cd dist && sha256sum * > checksums.txt && cd ..
-
-      - name: Create Release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ steps.tag.outputs.tag }}
-          name: bktrader-ctl ${{ steps.tag.outputs.tag }}
-          files: dist/*
-          make_latest: true
-          body: |
-            Automated bktrader-ctl release from main.
-
-            Commit: ${{ github.sha }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cli-auto-release.yml
+++ b/.github/workflows/cli-auto-release.yml
@@ -1,0 +1,91 @@
+name: Auto Release CLI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'cmd/bktrader-ctl/**'
+      - 'internal/ctlclient/**'
+      - 'internal/http/registry.go'
+      - 'scripts/check-ctl-coverage/**'
+      - 'scripts/gen-ctl-command/**'
+      - 'go.mod'
+      - 'go.sum'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Build and release bktrader-ctl
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run CLI tests
+        run: go test ./cmd/bktrader-ctl ./internal/ctlclient ./scripts/check-ctl-coverage
+
+      - name: Check CLI coverage
+        run: go run scripts/check-ctl-coverage/main.go
+
+      - name: Create release tag
+        id: tag
+        run: |
+          short_sha="${GITHUB_SHA::7}"
+          commit_ts="$(git show -s --format=%ct "$GITHUB_SHA")"
+          tag="ctl-v$(date -u -d "@$commit_ts" +%Y%m%d%H%M%S)-$short_sha"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          if git ls-remote --exit-code --tags origin "refs/tags/$tag" >/dev/null 2>&1; then
+            echo "Tag $tag already exists."
+          else
+            git tag "$tag" "$GITHUB_SHA"
+            git push origin "$tag"
+          fi
+
+      - name: Build Matrix
+        env:
+          RELEASE_TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          mkdir -p dist
+          platforms=(
+            "darwin/arm64"
+          )
+
+          for platform in "${platforms[@]}"; do
+            platform_split=(${platform//\// })
+            GOOS=${platform_split[0]}
+            GOARCH=${platform_split[1]}
+
+            output_name="bktrader-ctl-$GOOS-$GOARCH"
+
+            echo "Building $output_name..."
+            env GOOS=$GOOS GOARCH=$GOARCH go build \
+              -ldflags "-X main.Version=${RELEASE_TAG} -X main.Commit=${GITHUB_SHA} -X main.BuildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+              -o "dist/$output_name" ./cmd/bktrader-ctl
+          done
+
+          # ubuntu-latest intentionally provides sha256sum for release checksums.
+          cd dist && sha256sum * > checksums.txt && cd ..
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.tag.outputs.tag }}
+          name: bktrader-ctl ${{ steps.tag.outputs.tag }}
+          files: dist/*
+          make_latest: true
+          body: |
+            Automated bktrader-ctl release from main.
+
+            Commit: ${{ github.sha }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - 'v*'
+      - 'ctl-v*'
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ jobs:
   build:
     name: Build and Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -46,5 +48,6 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: dist/*
+          make_latest: ${{ startsWith(github.ref_name, 'v') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Add an automatic CLI release workflow for `main` pushes that touch bktrader-ctl code, ctlclient, CLI coverage/generator code, or Go dependencies.
- The workflow verifies CLI tests and coverage before creating a deterministic `ctl-v<commit-time>-<sha>` tag and uploading the built `bktrader-ctl` binary to GitHub Releases.
- Keep the existing manual tag release path and allow `ctl-v*` tags there as well.

## Expected behavior
- CLI changes merged into `main` automatically produce a GitHub Release binary.
- No manual `git tag` step is required for routine CLI updates.
- Existing manual `v*` releases still work.

## Verification
- YAML parsed locally with Ruby.
- `go test ./cmd/bktrader-ctl ./internal/ctlclient ./scripts/check-ctl-coverage`
- `go run scripts/check-ctl-coverage/main.go`
- `go build ./cmd/bktrader-ctl`
- `git diff --check`

## Codex
Assisted by Codex.
