### PR TITLE
fix: dispatch CLI release workflow after auto tag

### DIFF
--- a/.github/workflows/cli-auto-release.yml
+++ b/.github/workflows/cli-auto-release.yml
@@ -13,6 +13,7 @@ on:
       - 'go.sum'
 
 permissions:
+  actions: write
   contents: write
 
 jobs:
@@ -50,3 +51,14 @@ jobs:
             git tag "$tag" "$GITHUB_SHA"
             git push origin "$tag"
           fi
+
+      - name: Dispatch release workflow
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            echo "Release $RELEASE_TAG already exists; skipping dispatch."
+            exit 0
+          fi
+          gh workflow run release.yml --ref "$RELEASE_TAG" -f release_tag="$RELEASE_TAG"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,11 @@
 name: Release CLI
 
 on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Release tag to build, for example ctl-v20260427123000-abcdef0.'
+        required: true
   push:
     tags:
       - 'v*'
@@ -12,9 +17,13 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    env:
+      RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_TAG }}
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -37,7 +46,7 @@ jobs:
             
             echo "Building $output_name..."
             env GOOS=$GOOS GOARCH=$GOARCH go build \
-              -ldflags "-X main.Version=${GITHUB_REF_NAME} -X main.Commit=${GITHUB_SHA} -X main.BuildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+              -ldflags "-X main.Version=${RELEASE_TAG} -X main.Commit=${GITHUB_SHA} -X main.BuildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
               -o "dist/$output_name" ./cmd/bktrader-ctl
           done
 
@@ -47,7 +56,8 @@ jobs:
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ env.RELEASE_TAG }}
           files: dist/*
-          make_latest: ${{ startsWith(github.ref_name, 'v') }}
+          make_latest: ${{ startsWith(env.RELEASE_TAG, 'v') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Keep `cli-auto-release.yml` as the automatic tag creator only.
- Explicitly dispatch `release.yml` after creating the `ctl-v*` tag, because tag pushes made with `GITHUB_TOKEN` do not reliably trigger a second workflow run.
- Add `workflow_dispatch` support to `release.yml` so the existing build/checksum/release logic remains the single publishing path.
- Keep `ctl-v*` releases from taking GitHub Latest; only formal `v*` releases become latest.

## Verification
- YAML parsed locally with Ruby.
- `go test ./cmd/bktrader-ctl ./internal/ctlclient ./scripts/check-ctl-coverage`
- `go run scripts/check-ctl-coverage/main.go`
- `go build ./cmd/bktrader-ctl`
- `git diff --check`

## Codex
Assisted by Codex.
