### PR TITLE
[codex] fix live account sync stale timestamp

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,12 +58,14 @@ jobs:
               go.mod|go.sum)
                 backend_changed=true
                 ctl_changed=true
+                docker_changed=true
                 ;;
               cmd/bktrader-ctl/*|internal/ctlclient/*|internal/http/registry.go|scripts/check-ctl-coverage/*|scripts/gen-ctl-command/*|docs/bktrader-ctl-reference.md|.github/workflows/release.yml)
                 ctl_changed=true
                 ;;
               cmd/*|internal/*|db/*)
                 backend_changed=true
+                docker_changed=true
                 ;;
               web/console/*)
                 frontend_changed=true
@@ -72,7 +74,10 @@ jobs:
                 docker_changed=true
                 ;;
               .github/workflows/ci.yml)
+                backend_changed=true
                 ctl_changed=true
+                frontend_changed=true
+                docker_changed=true
                 ;;
             esac
           done <<EOF

--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -910,9 +910,10 @@ func (p *Platform) persistLiveAccountSyncFailure(account domain.Account, attempt
 func (p *Platform) persistLiveAccountSyncSuccess(account domain.Account, binding map[string]any, previousSuccessAt time.Time) (domain.Account, error) {
 	account.Metadata = cloneMetadata(account.Metadata)
 	snapshot := cloneMetadata(mapValue(account.Metadata["liveSyncSnapshot"]))
-	syncedAt := parseOptionalRFC3339(stringValue(account.Metadata["lastLiveSyncAt"]))
-	if syncedAt.IsZero() {
-		syncedAt = parseOptionalRFC3339(stringValue(snapshot["syncedAt"]))
+	syncedAt := parseOptionalRFC3339(stringValue(snapshot["syncedAt"]))
+	lastLiveSyncAt := parseOptionalRFC3339(stringValue(account.Metadata["lastLiveSyncAt"]))
+	if syncedAt.IsZero() || (!lastLiveSyncAt.IsZero() && lastLiveSyncAt.After(syncedAt)) {
+		syncedAt = lastLiveSyncAt
 	}
 	if syncedAt.IsZero() {
 		syncedAt = time.Now().UTC()

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -8017,6 +8017,68 @@ func TestSyncLiveAccountNormalizesAdapterSuccessHealthState(t *testing.T) {
 	}
 }
 
+func TestSyncLiveAccountPersistsNewSnapshotTimeOverStaleLastLiveSyncAt(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	platform.runtimePolicy.LiveAccountSyncFreshnessSecs = 60
+	oldSyncedAt := time.Date(2026, 4, 14, 7, 19, 29, 0, time.UTC)
+	newSyncedAt := time.Date(2026, 4, 27, 5, 32, 56, 0, time.UTC)
+	platform.registerLiveAdapter(testLiveAccountSyncAdapter{
+		key: "test-sync-new-snapshot-time",
+		syncSnapshotFunc: func(p *Platform, account domain.Account, binding map[string]any) (domain.Account, error) {
+			account.Metadata = cloneMetadata(account.Metadata)
+			account.Metadata["liveSyncSnapshot"] = map[string]any{
+				"source":          "test-sync-new-snapshot-time",
+				"adapterKey":      normalizeLiveAdapterKey(stringValue(binding["adapterKey"])),
+				"syncedAt":        newSyncedAt.Format(time.RFC3339),
+				"bindingMode":     stringValue(binding["connectionMode"]),
+				"executionMode":   stringValue(binding["executionMode"]),
+				"syncStatus":      "SYNCED",
+				"accountExchange": account.Exchange,
+			}
+			return account, nil
+		},
+	})
+
+	account, err := platform.store.GetAccount("live-main")
+	if err != nil {
+		t.Fatalf("get account failed: %v", err)
+	}
+	account.Metadata = cloneMetadata(account.Metadata)
+	account.Metadata["lastLiveSyncAt"] = oldSyncedAt.Format(time.RFC3339)
+	account.Metadata["healthSummary"] = map[string]any{
+		"accountSync": map[string]any{
+			"lastSuccessAt": oldSyncedAt.Format(time.RFC3339),
+		},
+	}
+	account.Metadata["liveBinding"] = map[string]any{
+		"adapterKey":     "test-sync-new-snapshot-time",
+		"connectionMode": "mock",
+		"executionMode":  "mock",
+	}
+	if _, err := platform.store.UpdateAccount(account); err != nil {
+		t.Fatalf("update account failed: %v", err)
+	}
+
+	synced, err := platform.SyncLiveAccount("live-main")
+	if err != nil {
+		t.Fatalf("expected adapter sync success, got %v", err)
+	}
+	if got := stringValue(synced.Metadata["lastLiveSyncAt"]); got != newSyncedAt.Format(time.RFC3339) {
+		t.Fatalf("expected new snapshot time to replace stale lastLiveSyncAt, got %s", got)
+	}
+	snapshot := mapValue(synced.Metadata["liveSyncSnapshot"])
+	if got := stringValue(snapshot["syncedAt"]); got != newSyncedAt.Format(time.RFC3339) {
+		t.Fatalf("expected liveSyncSnapshot.syncedAt to stay fresh, got %s", got)
+	}
+	accountSync := mapValue(mapValue(synced.Metadata["healthSummary"])["accountSync"])
+	if got := stringValue(accountSync["lastSuccessAt"]); got != newSyncedAt.Format(time.RFC3339) {
+		t.Fatalf("expected accountSync.lastSuccessAt to use fresh snapshot time, got %s", got)
+	}
+	if platform.shouldRefreshLiveAccountSync(synced, newSyncedAt.Add(10*time.Second)) {
+		t.Fatal("expected fresh snapshot time to suppress immediate refresh")
+	}
+}
+
 func TestSyncLiveAccountDoesNotDoubleCountPersistedAdapterSuccessHealth(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
 	platform.runtimePolicy.LiveAccountSyncFreshnessSecs = 60


### PR DESCRIPTION
## 目的
修复 live account sync 成功后仍持续触发 `live-account-sync-stale` 的误报。

Root cause: `persistLiveAccountSyncSuccess` 先读取旧的 `lastLiveSyncAt`，导致 adapter 已写入的新 `liveSyncSnapshot.syncedAt` 被旧时间覆盖，生产上手动 `account sync` 成功后仍停留在 `2026-04-14T07:19:29Z`。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [x] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) - 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？- 无
- [x] DB migration 是否具备向下兼容幂等性？- 不涉及 DB migration
- [x] 配置字段有没有无意被混改？- 无配置字段变更

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

验证已通过：

```bash
go test ./internal/service -run 'TestSyncLiveAccount(PersistsNewSnapshotTimeOverStaleLastLiveSyncAt|NormalizesAdapterSuccessHealthState|DoesNotDoubleCountPersistedAdapterSuccessHealth|ReturnsFallbackSnapshotWithoutReportingAdapterFailure)'
go test ./...
go build ./cmd/platform-api
go build ./cmd/db-migrate
```

部署后验证：

```bash
bktrader-ctl --json account sync account-1776074625359537175
bktrader-ctl --json status
```

预期 `lastLiveSyncAt` / `liveSyncSnapshot.syncedAt` / `accountSync.lastSuccessAt` 刷新到当前同步时间，`live-account-sync-stale-account-1776074625359537175` 消失。
