### PR TITLE
feat: 将 signal-runtime-runner 拆分为独立 Docker 服务以实现资源隔离

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -148,8 +148,22 @@ jobs:
             esac
 
             case "$file" in
-              internal/service/signal_runtime*|internal/service/runtime_event_bus*|internal/service/runtime_event_consumer*|internal/service/runtime_lease*)
+              internal/service/signal_runtime*|internal/service/runtime_lease*)
                 add_service signal-runtime-runner
+                ;;
+            esac
+
+            case "$file" in
+              internal/service/runtime_event_consumer*)
+                live_runner_changed=true
+                add_service live-runner
+                add_service signal-runtime-runner
+                ;;
+            esac
+
+            case "$file" in
+              internal/service/runtime_event_bus*)
+                add_all_backend_services
                 ;;
             esac
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -57,16 +57,17 @@ jobs:
           add_all_backend_services() {
             add_service platform-api
             add_service live-runner
+            add_service signal-runtime-runner
             add_service notification-worker
           }
 
           validate_deploy_services() {
             for service in $1; do
               case "$service" in
-                platform-api|live-runner|notification-worker) ;;
+                platform-api|live-runner|signal-runtime-runner|notification-worker) ;;
                 *)
                   echo "Unsupported deploy_services entry: $service" >&2
-                  echo "Allowed services: platform-api live-runner notification-worker" >&2
+                  echo "Allowed services: platform-api live-runner signal-runtime-runner notification-worker" >&2
                   exit 2
                   ;;
               esac
@@ -80,7 +81,7 @@ jobs:
               validate_deploy_services "$INPUT_DEPLOY_SERVICES"
               deploy_services="$INPUT_DEPLOY_SERVICES"
             else
-              deploy_services="platform-api notification-worker live-runner"
+              deploy_services="platform-api notification-worker signal-runtime-runner live-runner"
             fi
             echo "deploy_services=$deploy_services" >> "$GITHUB_OUTPUT"
             case " $deploy_services " in
@@ -140,14 +141,20 @@ jobs:
             esac
 
             case "$file" in
-              cmd/platform-worker/*|internal/service/live*|internal/service/signal_runtime*|internal/service/order*|internal/service/execution_strategy.go|internal/service/precision_tolerance.go|internal/service/strategy_registry.go|internal/service/signal_source_registry.go|internal/service/signal_runtime_registry.go|internal/service/live_account_flow.go|internal/service/live_launch*|internal/service/live_trade*|internal/service/telemetry.go)
+              cmd/platform-worker/*|internal/service/live*|internal/service/order*|internal/service/execution_strategy.go|internal/service/precision_tolerance.go|internal/service/strategy_registry.go|internal/service/signal_source_registry.go|internal/service/live_account_flow.go|internal/service/live_launch*|internal/service/live_trade*)
                 live_runner_changed=true
                 add_service live-runner
                 ;;
             esac
 
             case "$file" in
-              internal/service/*)
+              internal/service/signal_runtime*|internal/service/runtime_event_bus*|internal/service/runtime_event_consumer*|internal/service/runtime_lease*)
+                add_service signal-runtime-runner
+                ;;
+            esac
+
+            case "$file" in
+              internal/service/platform.go|internal/service/telemetry*|internal/service/health*|internal/service/safety_checks*|internal/service/state_util*|internal/service/logs.go|internal/service/notifications*|internal/service/paper*|internal/service/pnl*|internal/service/strategy.go|internal/service/strategy_replay*|internal/service/strategy_zero_initial*|internal/service/backtest*|internal/service/chart*|internal/service/dashboard_broker*)
                 add_all_backend_services
                 ;;
             esac

--- a/deployments/docker-compose.dev.yml
+++ b/deployments/docker-compose.dev.yml
@@ -1,6 +1,56 @@
 version: "3.9"
 
+x-app-image: &app-image
+    image: ${IMAGE_REPO:-ghcr.io/folgercn/bktrader-app}:${IMAGE_TAG:-latest}
+    mem_limit: ${APP_MEM_LIMIT:-512m}
+    memswap_limit: ${APP_MEMSWAP_LIMIT:-1g}
+    restart: "no"
+    env_file:
+      - ${APP_ENV_FILE:-../configs/app.env}
+    environment:
+      LOG_DIR: ${LOG_DIR:-/app/logs}
+    volumes:
+      - ../logs:/app/logs
+    depends_on:
+      - postgres
+      - redis
+      - nats
+
 services:
+  platform-api:
+    <<: *app-image
+    container_name: bktrader-platform-api
+    command: ["platform-api"]
+    environment:
+      BKTRADER_ROLE: api
+      AUTO_MIGRATE: ${API_AUTO_MIGRATE:-true}
+    ports:
+      - "8080:8080"
+
+  live-runner:
+    <<: *app-image
+    container_name: bktrader-live-runner
+    command: ["platform-worker"]
+    environment:
+      BKTRADER_ROLE: live-runner
+      AUTO_MIGRATE: "false"
+
+  signal-runtime-runner:
+    <<: *app-image
+    container_name: bktrader-signal-runtime-runner
+    command: ["platform-worker"]
+    environment:
+      BKTRADER_ROLE: signal-runtime-runner
+      AUTO_MIGRATE: "false"
+
+  notification-worker:
+    <<: *app-image
+    container_name: bktrader-notification-worker
+    command: ["platform-worker"]
+    environment:
+      BKTRADER_ROLE: notification-worker
+      AUTO_MIGRATE: "false"
+
   postgres:
     image: postgres:16
     environment:
@@ -24,4 +74,3 @@ services:
 
 volumes:
   postgres_data:
-

--- a/deployments/docker-compose.prod.yml
+++ b/deployments/docker-compose.prod.yml
@@ -43,6 +43,19 @@ services:
       LOG_RETENTION_DAYS: ${LOG_RETENTION_DAYS:-7}
       LOG_MAX_SIZE_MB: ${LOG_MAX_SIZE_MB:-100}
 
+  signal-runtime-runner:
+    <<: *app-image
+    container_name: bktrader-signal-runtime-runner
+    command: ["platform-worker"]
+    mem_limit: ${SIGNAL_RUNTIME_MEM_LIMIT:-1024m}
+    memswap_limit: ${SIGNAL_RUNTIME_MEMSWAP_LIMIT:-1536m}
+    environment:
+      BKTRADER_ROLE: signal-runtime-runner
+      AUTO_MIGRATE: "false"
+      LOG_DIR: ${LOG_DIR:-/app/logs}
+      LOG_RETENTION_DAYS: ${LOG_RETENTION_DAYS:-7}
+      LOG_MAX_SIZE_MB: ${LOG_MAX_SIZE_MB:-100}
+
   notification-worker:
     <<: *app-image
     container_name: bktrader-notification-worker

--- a/docs/cicd-maintenance.md
+++ b/docs/cicd-maintenance.md
@@ -109,7 +109,7 @@ gofmt -w .
 
 - 普通 push 会根据 diff 自动计算 `DEPLOY_SERVICES`，只重启需要更新的 compose 服务。
 - API / 配置 / 查询 / store / db 等改动默认部署 `platform-api`。
-- Dockerfile / compose / deploy script / app / config / store / domain / db 等共享层改动默认部署三类后端服务。
+- Dockerfile / compose / deploy script / app / config / store / domain / db 等共享层改动默认部署四类后端服务。
 - Telegram / alerts / notifications 相关改动默认部署 `notification-worker`。
 - `live-runner` 相关改动默认部署 `live-runner`，会自动重启交易运行时。
 - 如需手动指定部署范围，可使用 `workflow_dispatch` 填写 `deploy_services`，例如 `platform-api` 或 `live-runner`。

--- a/docs/cicd-maintenance.md
+++ b/docs/cicd-maintenance.md
@@ -6,7 +6,7 @@
 
 项目目前包含两个主要的 GitHub Actions 工作流：
 - **CI (`ci.yml`)**: 自动执行后端 (Go) 格式检查、编译、前端 (Vite) 构建以及 Docker 镜像构建验证。
-- **CD (`cd.yml`)**: 自动构建并推送后端 Docker 镜像，在自托管 (Self-hosted) 的 Macmini 节点上执行后端部署脚本，并构建前端静态文件后同步到远端 Nginx 目录。生产 compose 将后端镜像拆成 `platform-api`、`live-runner`、`notification-worker` 三类进程。
+- **CD (`cd.yml`)**: 自动构建并推送后端 Docker 镜像，在自托管 (Self-hosted) 的 Macmini 节点上执行后端部署脚本，并构建前端静态文件后同步到远端 Nginx 目录。生产 compose 将后端镜像拆成 `platform-api`、`live-runner`、`signal-runtime-runner`、`notification-worker` 四类进程。
 - **AI PR Review (`ai-review.yml`)**: 在自托管 Macmini runner 上调用已登录的 Codex CLI，按文件审查 PR diff，并把通过校验的结果写成 PR 行级评论。
 
 ---
@@ -100,9 +100,10 @@ gofmt -w .
 **当前后端进程角色**：
 
 - `platform-api`: 对外 HTTP API、控制台查询、配置与只读监控入口，监听 `8080`。
-- `live-runner`: 实盘 session 恢复、signal runtime、live sync / reconcile，不暴露 HTTP 端口。
+- `live-runner`: 实盘 session 恢复、live sync / reconcile / 策略评估，不暴露 HTTP 端口。
+- `signal-runtime-runner`: 行情数据管线（预热 + WebSocket 建连 + NATS 发布），不暴露 HTTP 端口。
 - `notification-worker`: Telegram 通知投递，不暴露 HTTP 端口。
-- `platform-api` 不设置 `BKTRADER_ROLE` 时仍为旧的 `monolith` 行为，便于本地开发和紧急回退；`platform-worker` 只接受 `live-runner` / `notification-worker`，避免生产误配出重复后台 worker。
+- `platform-api` 不设置 `BKTRADER_ROLE` 时仍为旧的 `monolith` 行为，便于本地开发和紧急回退；`platform-worker` 只接受 `live-runner` / `signal-runtime-runner` / `notification-worker`，避免生产误配出重复后台 worker。
 
 **后端选择性部署约定**：
 

--- a/docs/部署与网络架构.md
+++ b/docs/部署与网络架构.md
@@ -14,9 +14,9 @@
 2. **后端更新上线 (Macmini 自托管服务器完成)**：
    - GitHub Action 控制你的 Macmini 开始工作。
    - Macmini 使用本地的 `deploy.sh` 脚本和 `docker-compose.prod.yml`，把网上的最新镜像拉回本地。
-   - 借助 Docker Compose 启动拆分后的后台容器：`platform-api` 对外监听 **`8080`**，`live-runner` 负责实盘恢复 / 对账 / session runtime，`notification-worker` 负责 Telegram 告警投递。
-   - `platform-api` 使用 `BKTRADER_ROLE=api`，不启动 live 后台 worker；`live-runner` 使用 `BKTRADER_ROLE=live-runner`，不暴露 HTTP 端口。
-   - CD 会按 diff 计算 `DEPLOY_SERVICES`，后端改动默认只重启对应服务；`live-runner` 相关改动会自动重启交易运行时。
+   - 借助 Docker Compose 启动拆分后的后台容器：`platform-api` 对外监听 **`8080`**，`live-runner` 负责实盘恢复 / 对账 / 策略评估，`signal-runtime-runner` 负责行情数据管线（预热 + WebSocket + NATS 发布），`notification-worker` 负责 Telegram 告警投递。
+   - `platform-api` 使用 `BKTRADER_ROLE=api`，不启动后台 worker；`live-runner` 使用 `BKTRADER_ROLE=live-runner`，不暴露 HTTP 端口；`signal-runtime-runner` 使用 `BKTRADER_ROLE=signal-runtime-runner`，不暴露 HTTP 端口。
+   - CD 会按 diff 计算 `DEPLOY_SERVICES`，后端改动默认只重启对应服务；`live-runner` 相关改动会自动重启交易运行时，`signal-runtime-runner` 相关改动仅重启信号管线。
 
 3. **前端资源发布 (Macmini → IDC远端机)**：
    - 同上步骤，Macmini 本地从源码里进行 `npm run build` 编译项目。

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -52,12 +52,12 @@ deploy_args=()
 if [[ -n "$DEPLOY_SERVICES" ]]; then
   for service in $DEPLOY_SERVICES; do
     case "$service" in
-      platform-api|live-runner|notification-worker)
+      platform-api|live-runner|signal-runtime-runner|notification-worker)
         deploy_args+=("$service")
         ;;
       *)
         echo "Unsupported DEPLOY_SERVICES entry: $service" >&2
-        echo "Allowed services: platform-api live-runner notification-worker" >&2
+        echo "Allowed services: platform-api live-runner signal-runtime-runner notification-worker" >&2
         exit 2
         ;;
     esac


### PR DESCRIPTION
## 目的
将 `signal-runtime-runner` 从 `live-runner` 中拆解为独立的 Docker 服务。此举旨在实现信号产生逻辑与交易执行逻辑的物理隔离，提高系统稳定性和部署效率，并允许对信号处理层进行独立扩容。

## 本次改动风险定级
- [x] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**

## AI Agent 参与声明
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了 (Antigravity 辅助分析并确认)

## 风险点 checklist
- [ ] `dispatchMode` 默认值有否变化？ 否
- [ ] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？ 否
- [ ] DB migration 是否具备向下兼容幂等性？ N/A (本次未涉及 DB Schema 变动，仅调整了部署角色)
- [ ] 配置字段有没有无意被混改？ 否

## 验证方式与测试证据
- 修改了 `internal/app/server.go` 中的角色映射逻辑，并同步更新了 `docker-compose.dev.yml` 与 `docker-compose.prod.yml`。
- 本地启动验证：使用 `BKTRADER_ROLE=signal-runtime-runner` 启动 `platform-worker`，确认其仅加载行情预热与信号扫描组件。
- CD 流程验证：更新了 `.github/workflows/cd.yml` 的 diff 计算逻辑，确保特定文件变动能触发对应服务的重提部署。
- 文档同步：更新了 `docs/部署与网络架构.md` 以匹配最新的多容器拓扑。