### PR TITLE
ci: narrow CD service routing

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -61,6 +61,22 @@ jobs:
             add_service notification-worker
           }
 
+          add_worker_services() {
+            add_service live-runner
+            add_service signal-runtime-runner
+            add_service notification-worker
+          }
+
+          add_live_services() {
+            add_service platform-api
+            add_service live-runner
+          }
+
+          add_signal_runtime_services() {
+            add_service platform-api
+            add_service signal-runtime-runner
+          }
+
           validate_deploy_services() {
             for service in $1; do
               case "$service" in
@@ -129,27 +145,34 @@ jobs:
             esac
 
             case "$file" in
-              cmd/platform-api/*|internal/http/*)
+              cmd/platform-api/*|internal/http/*|internal/service/state_util*|internal/service/logs.go|internal/service/dashboard_broker*|internal/service/backtest*|internal/service/chart*|internal/service/paper*|internal/service/pnl*|internal/service/strategy_replay*)
                 add_service platform-api
                 ;;
             esac
 
             case "$file" in
-              internal/service/telegram*|internal/service/alerts.go|internal/http/signals.go|internal/domain/*|internal/store/*|db/*)
+              cmd/platform-worker/*)
+                add_worker_services
+                ;;
+            esac
+
+            case "$file" in
+              internal/service/telegram*|internal/service/alerts.go|internal/service/notifications*)
+                add_service platform-api
                 add_service notification-worker
                 ;;
             esac
 
             case "$file" in
-              cmd/platform-worker/*|internal/service/live*|internal/service/order*|internal/service/execution_strategy.go|internal/service/precision_tolerance.go|internal/service/strategy_registry.go|internal/service/signal_source_registry.go|internal/service/live_account_flow.go|internal/service/live_launch*|internal/service/live_trade*)
+              internal/service/live*|internal/service/order*|internal/service/execution_strategy.go|internal/service/precision_tolerance.go|internal/service/strategy_registry.go|internal/service/live_account_flow.go|internal/service/live_launch*|internal/service/live_trade*|internal/service/telemetry*)
                 live_runner_changed=true
-                add_service live-runner
+                add_live_services
                 ;;
             esac
 
             case "$file" in
-              internal/service/signal_runtime*|internal/service/runtime_lease*)
-                add_service signal-runtime-runner
+              internal/service/live_market_data.go|internal/service/signal_runtime*|internal/service/runtime_lease*)
+                add_signal_runtime_services
                 ;;
             esac
 
@@ -163,13 +186,22 @@ jobs:
 
             case "$file" in
               internal/service/runtime_event_bus*)
+                add_service live-runner
+                add_service signal-runtime-runner
+                ;;
+            esac
+
+            case "$file" in
+              internal/service/platform.go|internal/service/strategy.go|internal/service/signal_source_registry.go)
                 add_all_backend_services
                 ;;
             esac
 
             case "$file" in
-              internal/service/platform.go|internal/service/telemetry*|internal/service/health*|internal/service/safety_checks*|internal/service/state_util*|internal/service/logs.go|internal/service/notifications*|internal/service/paper*|internal/service/pnl*|internal/service/strategy.go|internal/service/strategy_replay*|internal/service/strategy_zero_initial*|internal/service/backtest*|internal/service/chart*|internal/service/dashboard_broker*)
-                add_all_backend_services
+              internal/service/health*|internal/service/safety_checks*)
+                add_service platform-api
+                add_service live-runner
+                add_service signal-runtime-runner
                 ;;
             esac
           done <<EOF

--- a/docs/cd-service-routing.md
+++ b/docs/cd-service-routing.md
@@ -1,0 +1,58 @@
+# CD 服务路由说明
+
+本文记录 `main` 分支合并后 `.github/workflows/cd.yml` 如何根据变更文件选择 Docker Compose 服务，目标是避免后端改动后粗暴重启所有业务进程。
+
+## 服务角色
+
+- `platform-api`: HTTP API、dashboard SSE、查询/控制入口。
+- `live-runner`: live session 恢复、实盘同步、runtime event 消费、最终交易执行。
+- `signal-runtime-runner`: 行情预热、signal runtime scanner、WebSocket 行情与 runtime event 发布。
+- `notification-worker`: Telegram 通知投递、交易事件播报、持仓报告。
+
+四个服务共用同一个 Docker image，因此后端代码变化都会先构建并推送镜像；是否重启某个服务由 `DEPLOY_SERVICES` 决定。
+
+## 路由原则
+
+1. 共享基础设施变化才全量重启。
+2. API 查询、摘要、dashboard 相关变化只重启 `platform-api`。
+3. live 执行相关变化重启 `platform-api` 和 `live-runner`。
+4. signal runtime 相关变化重启 `platform-api` 和 `signal-runtime-runner`。
+5. Telegram/通知相关变化只额外重启 `notification-worker`。
+6. 未明确归类但属于后端的文件仍走全量 fallback，避免漏部署。
+
+## 主要映射
+
+| 文件范围 | 部署服务 |
+| --- | --- |
+| `Dockerfile`, `.dockerignore`, `deployments/docker-compose.prod.yml`, `scripts/deploy.sh` | 全部后端服务 |
+| `internal/app/**`, `internal/config/**`, `internal/store/**`, `internal/domain/**`, `db/**` | 全部后端服务 |
+| `cmd/platform-api/**`, `internal/http/**` | `platform-api` |
+| `cmd/platform-worker/**` | `live-runner`, `signal-runtime-runner`, `notification-worker` |
+| `internal/service/state_util*`, `logs.go`, `dashboard_broker*`, `backtest*`, `chart*`, `paper*`, `pnl*`, `strategy_replay*` | `platform-api` |
+| `internal/service/live*`, `order*`, `execution_strategy.go`, `precision_tolerance.go`, `strategy_registry.go`, `live_account_flow.go`, `live_launch*`, `live_trade*`, `telemetry*` | `platform-api`, `live-runner` |
+| `internal/service/live_market_data.go`, `signal_runtime*`, `runtime_lease*` | `platform-api`, `signal-runtime-runner` |
+| `internal/service/runtime_event_consumer*` | `live-runner`, `signal-runtime-runner` |
+| `internal/service/runtime_event_bus*` | `live-runner`, `signal-runtime-runner` |
+| `internal/service/telegram*`, `alerts.go`, `notifications*` | `platform-api`, `notification-worker` |
+| `internal/service/platform.go`, `strategy.go`, `signal_source_registry.go` | 全部后端服务 |
+| `internal/service/health*`, `safety_checks*` | `platform-api`, `live-runner`, `signal-runtime-runner` |
+
+## 示例
+
+`internal/service/state_util.go` 只影响 live/signal runtime session 的摘要裁剪逻辑，实际入口是 API/dashboard，因此只部署：
+
+```text
+platform-api
+```
+
+`internal/service/live.go` 同时影响 HTTP live 控制入口和 live runner 后台恢复/同步，因此部署：
+
+```text
+platform-api live-runner
+```
+
+`internal/service/telegram.go` 影响通知查询和 Telegram dispatcher，因此部署：
+
+```text
+platform-api notification-worker
+```


### PR DESCRIPTION
## Summary
- Narrow CD service routing so backend changes restart only the affected compose services.
- Add a service routing document that records the mapping and examples.
- Keep full backend fallback for shared infrastructure and unknown backend files.

## Validation
- `git diff --check`
- Simulated routing locally:
  - `internal/service/state_util.go` -> `platform-api`
  - `internal/service/live.go` -> `platform-api live-runner`
  - `internal/service/signal_runtime_ws.go` -> `platform-api signal-runtime-runner`
  - `internal/service/telegram.go` -> `platform-api notification-worker`
  - `db/migrations/001.sql` -> all backend services
  - unknown backend service file -> all backend services

## Codex
Implemented by Codex.
