### PR TITLE
Fix Binance REST limiter priority queues

### DIFF
--- a/internal/service/live_registry.go
+++ b/internal/service/live_registry.go
@@ -811,9 +811,14 @@ type binanceRESTLimiter struct {
 }
 
 type binanceRESTGate struct {
-	tokens chan struct{}
-	mu     sync.Mutex
-	block  time.Time
+	requests chan binanceRESTAcquireRequest
+	mu       sync.Mutex
+	block    time.Time
+}
+
+type binanceRESTAcquireRequest struct {
+	category binanceRESTRequestCategory
+	ready    chan struct{}
 }
 
 func newBinanceRESTLimiter() *binanceRESTLimiter {
@@ -832,35 +837,98 @@ func (l *binanceRESTLimiter) gate(key string) *binanceRESTGate {
 }
 
 func newBinanceRESTGate(requestsPerSecond, burst int) *binanceRESTGate {
-	gate := &binanceRESTGate{tokens: make(chan struct{}, burst)}
-	for i := 0; i < burst; i++ {
-		gate.tokens <- struct{}{}
-	}
+	gate := &binanceRESTGate{requests: make(chan binanceRESTAcquireRequest)}
 	interval := time.Second
 	if requestsPerSecond > 0 {
 		interval = time.Second / time.Duration(requestsPerSecond)
 	}
-	go func() {
-		ticker := time.NewTicker(interval)
-		defer ticker.Stop()
-		for range ticker.C {
-			select {
-			case gate.tokens <- struct{}{}:
-			default:
-			}
-		}
-	}()
+	go gate.run(maxInt(burst, 1), interval)
 	return gate
 }
 
-func (g *binanceRESTGate) acquire() error {
+func (g *binanceRESTGate) run(burst int, interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	tokens := burst
+	queues := make(map[binanceRESTRequestCategory][]chan struct{})
+	drain := func() {
+		g.mu.Lock()
+		blockedUntil := g.block
+		g.mu.Unlock()
+		if time.Now().UTC().Before(blockedUntil) {
+			return
+		}
+		for tokens > 0 {
+			category, ok := nextBinanceRESTQueueCategory(queues)
+			if !ok {
+				return
+			}
+			queue := queues[category]
+			ready := queue[0]
+			if len(queue) == 1 {
+				delete(queues, category)
+			} else {
+				queues[category] = queue[1:]
+			}
+			tokens--
+			close(ready)
+		}
+	}
+	for {
+		select {
+		case request := <-g.requests:
+			category := normalizeBinanceRESTRequestCategory(request.category)
+			queues[category] = append(queues[category], request.ready)
+			drain()
+		case <-ticker.C:
+			if tokens < burst {
+				tokens++
+			}
+			drain()
+		}
+	}
+}
+
+func nextBinanceRESTQueueCategory(queues map[binanceRESTRequestCategory][]chan struct{}) (binanceRESTRequestCategory, bool) {
+	for _, category := range binanceRESTCategoryPriorityOrder {
+		if len(queues[category]) > 0 {
+			return category, true
+		}
+	}
+	return "", false
+}
+
+var binanceRESTCategoryPriorityOrder = []binanceRESTRequestCategory{
+	binanceRESTCategoryTradeCritical,
+	binanceRESTCategoryAccountSync,
+	binanceRESTCategoryReconcile,
+	binanceRESTCategoryHistoryRead,
+	binanceRESTCategoryMetadataRead,
+	binanceRESTCategoryMarketData,
+}
+
+func normalizeBinanceRESTRequestCategory(category binanceRESTRequestCategory) binanceRESTRequestCategory {
+	for _, known := range binanceRESTCategoryPriorityOrder {
+		if category == known {
+			return category
+		}
+	}
+	return binanceRESTCategoryMarketData
+}
+
+func (g *binanceRESTGate) acquire(category binanceRESTRequestCategory) error {
 	g.mu.Lock()
 	blockedUntil := g.block
 	g.mu.Unlock()
 	if time.Now().UTC().Before(blockedUntil) {
 		return fmt.Errorf("binance rest temporarily rate-limited until %s", blockedUntil.Format(time.RFC3339))
 	}
-	<-g.tokens
+	ready := make(chan struct{})
+	g.requests <- binanceRESTAcquireRequest{
+		category: category,
+		ready:    ready,
+	}
+	<-ready
 	g.mu.Lock()
 	blockedUntil = g.block
 	g.mu.Unlock()
@@ -1245,7 +1313,7 @@ func doBinancePublicGET(baseURL, path string, params map[string]string, category
 
 func doBinanceSignedRequest(method string, creds binanceRESTCredentials, path string, params map[string]string, category binanceRESTRequestCategory) ([]byte, error) {
 	gate := binanceRESTLimiterState.gate(binanceRESTLimiterKey(creds.BaseURL))
-	if err := gate.acquire(); err != nil {
+	if err := gate.acquire(category); err != nil {
 		return nil, err
 	}
 	params = cloneStringMap(params)
@@ -1267,20 +1335,14 @@ func doBinanceSignedRequest(method string, creds binanceRESTCredentials, path st
 }
 
 func doBinanceRESTRequest(method, baseURL, path, query string, headers map[string]string, body io.Reader, category binanceRESTRequestCategory) ([]byte, http.Header, error) {
-	// Categories are tracked now so later PRs can add per-class scheduling without
-	// changing call sites again; this pass only unifies enforcement under one gate.
-	_ = category
 	gate := binanceRESTLimiterState.gate(binanceRESTLimiterKey(baseURL))
-	if err := gate.acquire(); err != nil {
+	if err := gate.acquire(category); err != nil {
 		return nil, nil, err
 	}
 	return doBinanceRESTRequestAfterAcquire(method, baseURL, path, query, headers, body, category, gate)
 }
 
 func doBinanceRESTRequestAfterAcquire(method, baseURL, path, query string, headers map[string]string, body io.Reader, category binanceRESTRequestCategory, gate *binanceRESTGate) ([]byte, http.Header, error) {
-	// Categories are tracked now so later PRs can add per-class scheduling without
-	// changing call sites again; this pass only unifies enforcement under one gate.
-	_ = category
 	requestURL := strings.TrimRight(baseURL, "/") + path
 	if (method == http.MethodGet || method == http.MethodDelete) && query != "" {
 		requestURL += "?" + query

--- a/internal/service/live_registry_test.go
+++ b/internal/service/live_registry_test.go
@@ -187,3 +187,78 @@ func TestDoBinanceSignedRequestRefreshesTimestampAfterLimiterWait(t *testing.T) 
 		t.Fatalf("expected signature to match refreshed timestamp, got %s want %s", secondSignature, expected)
 	}
 }
+
+func TestBinanceRESTGatePrioritizesTradeCriticalOverQueuedAccountSync(t *testing.T) {
+	gate := newBinanceRESTGate(20, 1)
+	if err := gate.acquire(binanceRESTCategoryAccountSync); err != nil {
+		t.Fatalf("initial acquire failed: %v", err)
+	}
+
+	completed := make(chan binanceRESTRequestCategory, 2)
+	go func() {
+		if err := gate.acquire(binanceRESTCategoryAccountSync); err != nil {
+			t.Errorf("account-sync acquire failed: %v", err)
+			return
+		}
+		completed <- binanceRESTCategoryAccountSync
+	}()
+	time.Sleep(10 * time.Millisecond)
+	go func() {
+		if err := gate.acquire(binanceRESTCategoryTradeCritical); err != nil {
+			t.Errorf("trade-critical acquire failed: %v", err)
+			return
+		}
+		completed <- binanceRESTCategoryTradeCritical
+	}()
+
+	select {
+	case got := <-completed:
+		if got != binanceRESTCategoryTradeCritical {
+			t.Fatalf("expected trade-critical to bypass queued account-sync request, got %s", got)
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("timed out waiting for prioritized acquire")
+	}
+	select {
+	case got := <-completed:
+		if got != binanceRESTCategoryAccountSync {
+			t.Fatalf("expected account-sync to acquire next, got %s", got)
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("timed out waiting for account-sync acquire")
+	}
+}
+
+func TestBinanceRESTGateDoesNotConsumeTokensDuringBackoff(t *testing.T) {
+	gate := newBinanceRESTGate(20, 1)
+	if err := gate.acquire(binanceRESTCategoryTradeCritical); err != nil {
+		t.Fatalf("initial acquire failed: %v", err)
+	}
+
+	completed := make(chan error, 1)
+	go func() {
+		completed <- gate.acquire(binanceRESTCategoryTradeCritical)
+	}()
+	time.Sleep(10 * time.Millisecond)
+	gate.markBackoff(80 * time.Millisecond)
+
+	select {
+	case err := <-completed:
+		t.Fatalf("expected queued request to wait during backoff without consuming token, got err=%v", err)
+	case <-time.After(60 * time.Millisecond):
+	}
+	select {
+	case err := <-completed:
+		if err != nil {
+			t.Fatalf("expected queued request to acquire after backoff without consuming token early, got %v", err)
+		}
+	case <-time.After(160 * time.Millisecond):
+		t.Fatal("timed out waiting for queued request after backoff")
+	}
+}
+
+func TestBinanceRESTGateUnknownCategoryDefaultsToLowestPriority(t *testing.T) {
+	if got := normalizeBinanceRESTRequestCategory(binanceRESTRequestCategory("new-background-class")); got != binanceRESTCategoryMarketData {
+		t.Fatalf("expected unknown category to default to lowest priority, got %s", got)
+	}
+}


### PR DESCRIPTION
## 目的
修复 issue #244 的 PR2 范围：Binance REST limiter 已有 request category，但之前所有请求共用 FIFO token channel，`trade-critical` 请求可能排在 `account-sync` / history / market-data 后面等待。此 PR 只让同一 baseURL gate 在发放 token 时按类别优先级释放等待请求，降低下单、撤单、订单同步被账户同步/历史读取排队拖住的风险。

Root cause:
- `binanceRESTRequestCategory` 已经在调用点传递，但 `doBinanceRESTRequest()` 里只是占位，没有进入实际调度。
- 单一 token channel 无法区分交易关键请求和后台同步/历史读取请求，生产 REST 堆积时会放大 signed request 排队时间和同步抖动风险。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [x] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 修改点
- 将 `binanceRESTGate` 从单一 token channel 改为 per-category wait queue + shared token scheduler。
- token 发放优先级：`trade-critical` -> `account-sync` -> `reconcile` -> `history-read` -> `metadata-read` -> `market-data`。
- 继续共享同一 baseURL 的 429 backoff；没有改 retry/backoff 语义。
- `doBinanceSignedRequest()` / public REST helper 只把现有 category 传入 gate acquire。
- 增加回归测试证明：当 `account-sync` 已经排队时，后来的 `trade-critical` 会优先拿到下一枚 token。

## 行为变化
- 交易关键 signed REST（下单、订单查询、撤单）不再被已排队的账户同步/历史读取/行情 metadata 请求 FIFO 阻塞。
- 不改变 Binance signed timestamp 刷新逻辑（PR #245 已处理）。
- 不改变账户同步 stale 告警逻辑。
- 不改变 live dispatch / reconcile / execution 判断语义。
- 不改变 `dispatchMode`、testnet/mainnet、安全默认值。

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) - 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？- 无
- [x] DB migration 是否具备向下兼容幂等性？- 不涉及 DB migration
- [x] 配置字段有没有无意被混改？- 无配置字段变更

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

本地验证：
```bash
/opt/homebrew/bin/go test ./internal/service -run 'TestDoBinanceSignedRequest|TestBinanceRESTGate|TestBinancePublicRequests'
/opt/homebrew/bin/go test ./internal/service
/opt/homebrew/bin/go test ./...
/opt/homebrew/bin/go build ./cmd/platform-api
/opt/homebrew/bin/go build ./cmd/db-migrate
```

## 后续不在本 PR 覆盖
- PR3：账户同步 stale 告警去抖。
- PR4：账户同步调度策略优化。

Closes part of #244.
