### PR TITLE
fix account sync stale alert hysteresis

### DIFF
--- a/internal/service/alerts.go
+++ b/internal/service/alerts.go
@@ -13,6 +13,15 @@ import (
 const (
 	liveExitDispatchFailureLogDedupeTTL        = 6 * time.Hour
 	liveExitDispatchFailureLogDedupeMaxEntries = 512
+	liveAccountSyncStaleAlertGrace             = 30 * time.Second
+)
+
+type liveAccountSyncStaleness string
+
+const (
+	liveAccountSyncFresh     liveAccountSyncStaleness = "fresh"
+	liveAccountSyncSoftStale liveAccountSyncStaleness = "soft-stale"
+	liveAccountSyncHardStale liveAccountSyncStaleness = "hard-stale"
 )
 
 var liveExitDispatchFailureLogDedupe = struct {
@@ -225,7 +234,7 @@ func (p *Platform) ListAlerts() ([]domain.PlatformAlert, error) {
 				EventTime:   parseOptionalRFC3339(stringValue(account.Metadata["lastLiveSyncAt"])),
 			})
 		}
-		if stale, ageSeconds := p.liveAccountSyncStale(account, time.Now().UTC()); stale {
+		if stale, ageSeconds := p.liveAccountSyncStaleForAlert(account, time.Now().UTC()); stale {
 			level := "warning"
 			if openPositionCount > 0 || len(runningLiveSessionsForAccount) > 0 {
 				level = "critical"
@@ -786,23 +795,48 @@ func (p *Platform) liveSessionEvaluationQuiet(mode, status string, sessionState 
 }
 
 func (p *Platform) liveAccountSyncStale(account domain.Account, referenceTime time.Time) (bool, int) {
+	staleness, ageSeconds := p.liveAccountSyncStaleness(account, referenceTime)
+	return staleness != liveAccountSyncFresh, ageSeconds
+}
+
+func (p *Platform) liveAccountSyncStaleForAlert(account domain.Account, referenceTime time.Time) (bool, int) {
+	staleness, ageSeconds := p.liveAccountSyncStaleness(account, referenceTime)
+	return staleness == liveAccountSyncHardStale, ageSeconds
+}
+
+func (p *Platform) liveAccountSyncStaleness(account domain.Account, referenceTime time.Time) (liveAccountSyncStaleness, int) {
 	threshold := time.Duration(p.runtimePolicy.LiveAccountSyncFreshnessSecs) * time.Second
 	if threshold <= 0 {
-		return false, 0
+		return liveAccountSyncFresh, 0
 	}
-	lastSuccessAt := parseOptionalRFC3339(firstNonEmpty(
-		stringValue(mapValue(mapValue(account.Metadata["healthSummary"])["accountSync"])["lastSuccessAt"]),
-		stringValue(account.Metadata["lastLiveSyncAt"]),
-	))
+	lastSuccessAt := liveAccountSyncLastSuccessAt(account)
 	if lastSuccessAt.IsZero() {
 		age := 0
 		if !account.CreatedAt.IsZero() {
 			age = int(referenceTime.Sub(account.CreatedAt).Seconds())
 		}
-		return true, age
+		return liveAccountSyncHardStale, age
 	}
-	age := int(referenceTime.Sub(lastSuccessAt).Seconds())
-	return referenceTime.Sub(lastSuccessAt) > threshold, age
+	elapsed := referenceTime.Sub(lastSuccessAt)
+	age := int(elapsed.Seconds())
+	if elapsed <= threshold {
+		return liveAccountSyncFresh, age
+	}
+	accountSync := mapValue(mapValue(account.Metadata["healthSummary"])["accountSync"])
+	if lastAttemptAt := parseOptionalRFC3339(stringValue(accountSync["lastAttemptAt"])); lastAttemptAt.After(lastSuccessAt) && referenceTime.Sub(lastAttemptAt) <= liveAccountSyncStaleAlertGrace {
+		return liveAccountSyncSoftStale, age
+	}
+	if elapsed <= threshold+liveAccountSyncStaleAlertGrace {
+		return liveAccountSyncSoftStale, age
+	}
+	return liveAccountSyncHardStale, age
+}
+
+func liveAccountSyncLastSuccessAt(account domain.Account) time.Time {
+	return parseOptionalRFC3339(firstNonEmpty(
+		stringValue(mapValue(mapValue(account.Metadata["healthSummary"])["accountSync"])["lastSuccessAt"]),
+		stringValue(account.Metadata["lastLiveSyncAt"]),
+	))
 }
 
 func summarizeSourceGate(sourceGate map[string]any) string {

--- a/internal/service/health_state_test.go
+++ b/internal/service/health_state_test.go
@@ -201,6 +201,67 @@ func TestLiveAccountSyncStaleAndRefreshThreshold(t *testing.T) {
 	}
 }
 
+func TestLiveAccountSyncStaleAlertGraceSuppressesThresholdFlap(t *testing.T) {
+	platform := &Platform{
+		runtimePolicy: RuntimePolicy{
+			LiveAccountSyncFreshnessSecs: 60,
+		},
+	}
+	now := time.Now().UTC()
+	account := domain.Account{
+		ID: "live-1",
+		Metadata: map[string]any{
+			"healthSummary": map[string]any{
+				"accountSync": map[string]any{
+					"lastSuccessAt": now.Add(-61 * time.Second).Format(time.RFC3339),
+				},
+			},
+			"lastLiveSyncAt": now.Add(-61 * time.Second).Format(time.RFC3339),
+		},
+	}
+
+	stale, ageSeconds := platform.liveAccountSyncStale(account, now)
+	if !stale {
+		t.Fatal("expected health stale state once freshness threshold is exceeded")
+	}
+	if staleness, _ := platform.liveAccountSyncStaleness(account, now); staleness != liveAccountSyncSoftStale {
+		t.Fatalf("expected soft stale inside alert grace, got %s", staleness)
+	}
+	alertStale, alertAgeSeconds := platform.liveAccountSyncStaleForAlert(account, now)
+	if alertStale {
+		t.Fatalf("expected alert grace to suppress threshold flap, age=%d", alertAgeSeconds)
+	}
+	if alertAgeSeconds != ageSeconds {
+		t.Fatalf("expected alert age to preserve stale age, got %d want %d", alertAgeSeconds, ageSeconds)
+	}
+
+	account.Metadata["healthSummary"] = map[string]any{
+		"accountSync": map[string]any{
+			"lastSuccessAt": now.Add(-91 * time.Second).Format(time.RFC3339),
+			"lastAttemptAt": now.Add(-5 * time.Second).Format(time.RFC3339),
+		},
+	}
+	account.Metadata["lastLiveSyncAt"] = now.Add(-91 * time.Second).Format(time.RFC3339)
+	alertStale, alertAgeSeconds = platform.liveAccountSyncStaleForAlert(account, now)
+	if alertStale {
+		t.Fatalf("expected recent sync attempt to suppress hard stale alert, age=%d", alertAgeSeconds)
+	}
+
+	account.Metadata["healthSummary"] = map[string]any{
+		"accountSync": map[string]any{
+			"lastSuccessAt": now.Add(-91 * time.Second).Format(time.RFC3339),
+			"lastAttemptAt": now.Add(-45 * time.Second).Format(time.RFC3339),
+		},
+	}
+	alertStale, alertAgeSeconds = platform.liveAccountSyncStaleForAlert(account, now)
+	if !alertStale {
+		t.Fatalf("expected alert after grace elapses, age=%d", alertAgeSeconds)
+	}
+	if staleness, _ := platform.liveAccountSyncStaleness(account, now); staleness != liveAccountSyncHardStale {
+		t.Fatalf("expected hard stale after alert grace elapses, got %s", staleness)
+	}
+}
+
 func TestUpdateRuntimePolicyAllowsDisablingHealthThresholds(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
 

--- a/internal/service/health_state_test.go
+++ b/internal/service/health_state_test.go
@@ -262,6 +262,32 @@ func TestLiveAccountSyncStaleAlertGraceSuppressesThresholdFlap(t *testing.T) {
 	}
 }
 
+func TestLiveAccountSyncNeverSucceededIsHardStale(t *testing.T) {
+	platform := &Platform{
+		runtimePolicy: RuntimePolicy{
+			LiveAccountSyncFreshnessSecs: 60,
+		},
+	}
+	now := time.Now().UTC()
+	account := domain.Account{
+		ID:        "live-1",
+		CreatedAt: now.Add(-5 * time.Second),
+		Metadata:  map[string]any{},
+	}
+
+	staleness, ageSeconds := platform.liveAccountSyncStaleness(account, now)
+	if staleness != liveAccountSyncHardStale {
+		t.Fatalf("expected never-synced account to be hard stale, got %s", staleness)
+	}
+	if ageSeconds < 5 {
+		t.Fatalf("expected age to use account creation time, got %d", ageSeconds)
+	}
+	alertStale, _ := platform.liveAccountSyncStaleForAlert(account, now)
+	if !alertStale {
+		t.Fatal("expected never-synced account to alert immediately")
+	}
+}
+
 func TestUpdateRuntimePolicyAllowsDisablingHealthThresholds(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
 


### PR DESCRIPTION
## 目的
修复生产 `账户同步过期 -> 已恢复` 在 120 秒 freshness 阈值附近反复误报的问题。

本 PR 是 issue #244 的 PR3，只做 account sync stale 告警去抖与分级，不包含 PR4 的 account sync 并发/最小间隔/提前刷新，也不包含 PR2 的 REST scheduler。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [x] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## Root cause
生产日志显示 PR1 部署后 Binance `-1021` 已停止，但 Telegram 仍在 `liveAccountSyncFreshnessSeconds=120` 附近采样到 stale：

- account sync 实际持续成功，`result_error=false`
- Telegram 在同步完成前后看到 `active=1 sent=1`
- 下一轮同步成功后又立刻 `recovered=1`

根因是 account sync freshness 阈值和告警触发阈值贴得太近，没有 soft/hard stale 分级和 hysteresis。

## 修改点
- 增加 account sync staleness 单一判定入口：`fresh` / `soft-stale` / `hard-stale`。
- `HealthSnapshot` 仍通过 `liveAccountSyncStale` 表达超过 freshness 的 stale 状态。
- `ListAlerts` 改为只对 `hard-stale` 发 `账户同步过期` 告警。
- hard-stale 前增加 30 秒 alert grace。
- 若 `lastAttemptAt` 晚于 `lastSuccessAt` 且仍在 grace 内，视为 sync 已在近期尝试，暂不发 hard stale 告警。

## 行为变化
- `age=120/124/130s` 这类边界抖动不会再触发 Telegram CRITICAL。
- 若长时间没有成功同步并超过 `freshness + grace`，仍会触发原有稳定 ID 的 stale 告警。
- 若账户从未成功同步，仍按 hard stale 报警，不隐藏真实初始化失败。
- 不改变 account sync 调度节奏、不改变 Binance REST 调度、不改变交易执行语义。

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) - 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？- 无
- [x] DB migration 是否具备向下兼容幂等性？- 不涉及 migration
- [x] 配置字段有没有无意被混改？- 无新增配置字段

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

本地验证：

```text
/opt/homebrew/bin/go test ./internal/service -run 'TestLiveAccountSyncStale'
/opt/homebrew/bin/go test ./...
/opt/homebrew/bin/go build ./cmd/platform-api
/opt/homebrew/bin/go build ./cmd/db-migrate
```

新增测试覆盖：

- freshness 刚超过阈值时为 `soft-stale`，health stale 仍成立，但 alert 被 suppress
- 超过 `freshness + grace` 后进入 `hard-stale`，alert 触发
- 有近期 `lastAttemptAt` 时暂不触发 hard stale

## 后续 PR
- PR4：account sync 最小间隔、最多并发 N、提前刷新窗口、trigger coalesce 优先级。
- PR2：Binance REST exchange request scheduler、队列隔离、priority/deadline/queue wait 指标。

Closes no issue; part of #244.
