### PR TITLE
tune live account sync scheduler

### DIFF
--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -137,6 +137,8 @@ type liveAccountSyncState struct {
 	completedAt time.Time
 }
 
+const liveAccountSyncMaxConcurrent = 2
+
 func (p *Platform) ListLiveSessions() ([]domain.LiveSession, error) {
 	return p.store.ListLiveSessions()
 }
@@ -299,6 +301,11 @@ func (p *Platform) requestLiveAccountSync(accountID, trigger string) (domain.Acc
 	state.done = done
 	state.mu.Unlock()
 
+	gateWaitStartedAt := time.Now()
+	releaseSyncSlot := p.acquireLiveAccountSyncSlot()
+	defer releaseSyncSlot()
+	gateWaitMS := time.Since(gateWaitStartedAt).Milliseconds()
+
 	release, acquired := p.tryStartLiveAccountOperation(accountID, liveAccountOperationSync)
 	if !acquired {
 		err := fmt.Errorf("%w: sync account=%s", ErrLiveAccountOperationInProgress, accountID)
@@ -316,6 +323,8 @@ func (p *Platform) requestLiveAccountSync(accountID, trigger string) (domain.Acc
 		"coalesced", false,
 		"waited_for_inflight", false,
 		"reused_recent_result", false,
+		"global_gate_wait_ms", gateWaitMS,
+		"max_concurrent", liveAccountSyncMaxConcurrent,
 	)
 	result, err := p.syncLiveAccountWithoutGate(accountID)
 	state.mu.Lock()
@@ -332,8 +341,19 @@ func (p *Platform) requestLiveAccountSync(accountID, trigger string) (domain.Acc
 		"reused_recent_result", false,
 		"result_error", err != nil,
 		"completed_at", state.completedAt.Format(time.RFC3339),
+		"global_gate_wait_ms", gateWaitMS,
 	)
 	return result, err
+}
+
+func (p *Platform) acquireLiveAccountSyncSlot() func() {
+	if p == nil || p.liveAccountSyncGate == nil {
+		return func() {}
+	}
+	p.liveAccountSyncGate <- struct{}{}
+	return func() {
+		<-p.liveAccountSyncGate
+	}
 }
 
 func (p *Platform) liveAccountSyncEntry(accountID string) *liveAccountSyncState {
@@ -347,6 +367,10 @@ func (p *Platform) liveAccountSyncEntry(accountID string) *liveAccountSyncState 
 }
 
 func (p *Platform) liveAccountSyncReuseWindow() time.Duration {
+	return p.liveAccountSyncMinimumInterval()
+}
+
+func (p *Platform) liveAccountSyncMinimumInterval() time.Duration {
 	threshold := time.Duration(p.runtimePolicy.LiveAccountSyncFreshnessSecs) * time.Second
 	switch {
 	case threshold <= 0:
@@ -354,15 +378,27 @@ func (p *Platform) liveAccountSyncReuseWindow() time.Duration {
 	case threshold < 4*time.Second:
 		return threshold
 	default:
-		window := threshold / 4
-		if window > 5*time.Second {
-			window = 5 * time.Second
+		window := threshold / 12
+		if window > 10*time.Second {
+			window = 10 * time.Second
 		}
 		if window < time.Second {
 			window = time.Second
 		}
 		return window
 	}
+}
+
+func (p *Platform) liveAccountSyncRefreshInterval() time.Duration {
+	threshold := time.Duration(p.runtimePolicy.LiveAccountSyncFreshnessSecs) * time.Second
+	if threshold <= 0 {
+		return 0
+	}
+	interval := threshold * 4 / 5
+	if interval < time.Second {
+		return threshold
+	}
+	return interval
 }
 
 func (p *Platform) liveAccountSyncAllowsRecentReuse(trigger string) bool {
@@ -2380,15 +2416,27 @@ func (p *Platform) shouldRefreshLiveAccountSync(account domain.Account, eventTim
 	if threshold <= 0 {
 		return false
 	}
-	lastSyncActivityAt := parseOptionalRFC3339(stringValue(account.Metadata["lastLiveSyncAt"]))
+	lastSuccessfulSyncAt := liveAccountSyncLastSuccessAt(account)
 	accountSync := mapValue(mapValue(account.Metadata["healthSummary"])["accountSync"])
-	if attemptedAt := parseOptionalRFC3339(stringValue(accountSync["lastAttemptAt"])); attemptedAt.After(lastSyncActivityAt) {
-		lastSyncActivityAt = attemptedAt
-	}
-	if lastSyncActivityAt.IsZero() {
+	lastAttemptAt := parseOptionalRFC3339(stringValue(accountSync["lastAttemptAt"]))
+	if lastAttemptAt.After(lastSuccessfulSyncAt) {
+		if eventTime.Sub(lastAttemptAt) < threshold {
+			return false
+		}
 		return true
 	}
-	return eventTime.Sub(lastSyncActivityAt) >= threshold
+	if lastSuccessfulSyncAt.IsZero() {
+		return true
+	}
+	minimumInterval := p.liveAccountSyncMinimumInterval()
+	if !lastAttemptAt.IsZero() && eventTime.Sub(lastAttemptAt) < minimumInterval {
+		return false
+	}
+	refreshInterval := p.liveAccountSyncRefreshInterval()
+	if refreshInterval <= 0 {
+		return false
+	}
+	return eventTime.Sub(lastSuccessfulSyncAt) >= refreshInterval
 }
 
 func (p *Platform) recoverRunningLiveSession(session domain.LiveSession) (domain.LiveSession, error) {

--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -137,7 +137,11 @@ type liveAccountSyncState struct {
 	completedAt time.Time
 }
 
-const liveAccountSyncMaxConcurrent = 2
+const (
+	liveAccountSyncMaxConcurrent        = 2
+	defaultLiveAccountSyncGateTimeout   = 15 * time.Second
+	liveAccountSyncGateTimeoutErrorText = "live account sync global gate timeout"
+)
 
 func (p *Platform) ListLiveSessions() ([]domain.LiveSession, error) {
 	return p.store.ListLiveSessions()
@@ -302,9 +306,28 @@ func (p *Platform) requestLiveAccountSync(accountID, trigger string) (domain.Acc
 	state.mu.Unlock()
 
 	gateWaitStartedAt := time.Now()
-	releaseSyncSlot := p.acquireLiveAccountSyncSlot()
-	defer releaseSyncSlot()
+	releaseSyncSlot, acquiredSlot := p.acquireLiveAccountSyncSlot()
 	gateWaitMS := time.Since(gateWaitStartedAt).Milliseconds()
+	if !acquiredSlot {
+		err := fmt.Errorf("%s: account=%s", liveAccountSyncGateTimeoutErrorText, accountID)
+		state.mu.Lock()
+		state.result = domain.Account{}
+		state.err = err
+		state.running = false
+		state.done = nil
+		close(done)
+		state.mu.Unlock()
+		logger.Warn("live account sync request rejected by global gate timeout",
+			"coalesced", false,
+			"waited_for_inflight", false,
+			"reused_recent_result", false,
+			"global_gate_wait_ms", gateWaitMS,
+			"global_gate_timeout_ms", p.liveAccountSyncGateTimeout().Milliseconds(),
+			"max_concurrent", liveAccountSyncMaxConcurrent,
+		)
+		return domain.Account{}, err
+	}
+	defer releaseSyncSlot()
 
 	release, acquired := p.tryStartLiveAccountOperation(accountID, liveAccountOperationSync)
 	if !acquired {
@@ -346,14 +369,27 @@ func (p *Platform) requestLiveAccountSync(accountID, trigger string) (domain.Acc
 	return result, err
 }
 
-func (p *Platform) acquireLiveAccountSyncSlot() func() {
+func (p *Platform) acquireLiveAccountSyncSlot() (func(), bool) {
 	if p == nil || p.liveAccountSyncGate == nil {
-		return func() {}
+		return func() {}, true
 	}
-	p.liveAccountSyncGate <- struct{}{}
-	return func() {
-		<-p.liveAccountSyncGate
+	timer := time.NewTimer(p.liveAccountSyncGateTimeout())
+	defer timer.Stop()
+	select {
+	case p.liveAccountSyncGate <- struct{}{}:
+		return func() {
+			<-p.liveAccountSyncGate
+		}, true
+	case <-timer.C:
+		return func() {}, false
 	}
+}
+
+func (p *Platform) liveAccountSyncGateTimeout() time.Duration {
+	if p == nil || p.liveAccountSyncGateTTL <= 0 {
+		return defaultLiveAccountSyncGateTimeout
+	}
+	return p.liveAccountSyncGateTTL
 }
 
 func (p *Platform) liveAccountSyncEntry(accountID string) *liveAccountSyncState {

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -7761,6 +7761,49 @@ func TestSyncLiveAccountGlobalConcurrencyGateLimitsParallelAccounts(t *testing.T
 	}
 }
 
+func TestSyncLiveAccountGlobalConcurrencyGateTimeoutReturnsError(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	platform.liveAccountSyncGate = make(chan struct{}, 1)
+	platform.liveAccountSyncGateTTL = 20 * time.Millisecond
+	var syncCalls atomic.Int32
+
+	platform.registerLiveAdapter(testLiveAccountSyncAdapter{
+		key: "test-sync-global-gate-timeout",
+		syncSnapshotFunc: func(p *Platform, account domain.Account, binding map[string]any) (domain.Account, error) {
+			syncCalls.Add(1)
+			return account, nil
+		},
+	})
+	account, err := platform.BindLiveAccount("live-main", map[string]any{
+		"adapterKey":     "test-sync-global-gate-timeout",
+		"connectionMode": "mock",
+		"executionMode":  "mock",
+	})
+	if err != nil {
+		t.Fatalf("bind live account failed: %v", err)
+	}
+
+	platform.liveAccountSyncGate <- struct{}{}
+	_, err = platform.requestLiveAccountSync(account.ID, "direct")
+	if err == nil {
+		t.Fatal("expected global gate timeout")
+	}
+	if !strings.Contains(err.Error(), liveAccountSyncGateTimeoutErrorText) {
+		t.Fatalf("expected global gate timeout error, got %v", err)
+	}
+	if got := syncCalls.Load(); got != 0 {
+		t.Fatalf("expected adapter not to run when global gate times out, got %d calls", got)
+	}
+
+	<-platform.liveAccountSyncGate
+	if _, err := platform.requestLiveAccountSync(account.ID, "direct"); err != nil {
+		t.Fatalf("expected sync to work after gate slot is available, got %v", err)
+	}
+	if got := syncCalls.Load(); got != 1 {
+		t.Fatalf("expected adapter to run after gate slot is available, got %d calls", got)
+	}
+}
+
 func TestSyncLiveAccountAuthoritativeReconcileBypassesRecentReuseWindow(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
 	platform.runtimePolicy.LiveAccountSyncFreshnessSecs = 60

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -7536,6 +7536,44 @@ func TestSyncActiveLiveAccountsThrottlesFailedRetriesUntilFreshnessWindow(t *tes
 	}
 }
 
+func TestShouldRefreshLiveAccountSyncUsesEarlyRefreshWindow(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	platform.runtimePolicy.LiveAccountSyncFreshnessSecs = 60
+	lastSyncedAt := time.Date(2026, 4, 27, 8, 0, 0, 0, time.UTC)
+	account := domain.Account{
+		ID: "live-main",
+		Metadata: map[string]any{
+			"lastLiveSyncAt": lastSyncedAt.Format(time.RFC3339),
+			"healthSummary": map[string]any{
+				"accountSync": map[string]any{
+					"lastSuccessAt": lastSyncedAt.Format(time.RFC3339),
+					"lastAttemptAt": lastSyncedAt.Format(time.RFC3339),
+				},
+			},
+		},
+	}
+
+	if platform.shouldRefreshLiveAccountSync(account, lastSyncedAt.Add(47*time.Second)) {
+		t.Fatal("did not expect refresh before early refresh window")
+	}
+	if !platform.shouldRefreshLiveAccountSync(account, lastSyncedAt.Add(48*time.Second)) {
+		t.Fatal("expected refresh at 80 percent of freshness threshold")
+	}
+}
+
+func TestLiveAccountSyncMinimumIntervalScalesWithFreshness(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	platform.runtimePolicy.LiveAccountSyncFreshnessSecs = 60
+	if got := platform.liveAccountSyncMinimumInterval(); got != 5*time.Second {
+		t.Fatalf("expected 60s freshness to produce 5s minimum interval, got %s", got)
+	}
+
+	platform.runtimePolicy.LiveAccountSyncFreshnessSecs = 120
+	if got := platform.liveAccountSyncMinimumInterval(); got != 10*time.Second {
+		t.Fatalf("expected 120s freshness to cap minimum interval at 10s, got %s", got)
+	}
+}
+
 func TestSyncLiveAccountCoalescesConcurrentAdapterSyncForSameAccount(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
 	blockSync := make(chan struct{})
@@ -7646,6 +7684,80 @@ func TestSyncLiveAccountReusesRecentResultWithinReuseWindow(t *testing.T) {
 	}
 	if got := syncCalls.Load(); got != 1 {
 		t.Fatalf("expected recent follow-up sync to reuse prior result, got %d adapter calls", got)
+	}
+}
+
+func TestSyncLiveAccountGlobalConcurrencyGateLimitsParallelAccounts(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	platform.liveAccountSyncGate = make(chan struct{}, 1)
+	blockSync := make(chan struct{})
+	enteredSync := make(chan string, 2)
+	var syncCalls atomic.Int32
+
+	platform.registerLiveAdapter(testLiveAccountSyncAdapter{
+		key: "test-sync-global-gate",
+		syncSnapshotFunc: func(p *Platform, account domain.Account, binding map[string]any) (domain.Account, error) {
+			syncCalls.Add(1)
+			enteredSync <- account.ID
+			<-blockSync
+			account.Metadata = cloneMetadata(account.Metadata)
+			now := time.Now().UTC().Format(time.RFC3339)
+			account.Metadata["lastLiveSyncAt"] = now
+			return p.store.UpdateAccount(account)
+		},
+	})
+
+	first, err := platform.BindLiveAccount("live-main", map[string]any{
+		"adapterKey":     "test-sync-global-gate",
+		"connectionMode": "mock",
+		"executionMode":  "mock",
+	})
+	if err != nil {
+		t.Fatalf("bind first live account failed: %v", err)
+	}
+	second, err := platform.CreateAccount("Second Live", "LIVE", "BINANCE")
+	if err != nil {
+		t.Fatalf("create second live account failed: %v", err)
+	}
+	second, err = platform.BindLiveAccount(second.ID, map[string]any{
+		"adapterKey":     "test-sync-global-gate",
+		"connectionMode": "mock",
+		"executionMode":  "mock",
+	})
+	if err != nil {
+		t.Fatalf("bind second live account failed: %v", err)
+	}
+
+	firstDone := make(chan error, 1)
+	secondDone := make(chan error, 1)
+	go func() {
+		_, err := platform.requestLiveAccountSync(first.ID, "direct")
+		firstDone <- err
+	}()
+	select {
+	case <-enteredSync:
+	case <-time.After(time.Second):
+		t.Fatal("first sync did not enter adapter")
+	}
+	go func() {
+		_, err := platform.requestLiveAccountSync(second.ID, "direct")
+		secondDone <- err
+	}()
+	select {
+	case accountID := <-enteredSync:
+		t.Fatalf("expected second sync to wait for global gate, entered adapter for %s", accountID)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(blockSync)
+	if err := <-firstDone; err != nil {
+		t.Fatalf("first sync failed: %v", err)
+	}
+	if err := <-secondDone; err != nil {
+		t.Fatalf("second sync failed: %v", err)
+	}
+	if got := syncCalls.Load(); got != 2 {
+		t.Fatalf("expected both syncs to eventually run, got %d", got)
 	}
 }
 

--- a/internal/service/platform.go
+++ b/internal/service/platform.go
@@ -43,6 +43,7 @@ type Platform struct {
 	liveAccountOpMu        sync.Map // accountID -> *sync.Mutex
 	liveAccountSyncState   sync.Map // accountID -> *liveAccountSyncState
 	liveAccountSyncGate    chan struct{}
+	liveAccountSyncGateTTL time.Duration
 	liveControlOpState     sync.Map // accountID|strategyID -> *liveControlOperationState
 	liveDispatchMu         sync.Map // liveSessionID -> *sync.Mutex; process-local guard, not distributed idempotency.
 	runtimeSourceGateState sync.Map // runtimeSessionID -> last blocked source gate signature
@@ -99,22 +100,23 @@ type RuntimePolicy struct {
 // NewPlatform 创建并初始化平台服务实例。
 func NewPlatform(store store.Repository) *Platform {
 	platform := &Platform{
-		store:                 store,
-		run:                   make(map[string]context.CancelFunc),
-		signalRun:             make(map[string]*signalRuntimeRun),
-		paperPlans:            make(map[string][]paperPlannedOrder),
-		livePlans:             make(map[string][]paperPlannedOrder),
-		strategyEngines:       make(map[string]StrategyEngine),
-		liveAdapters:          make(map[string]LiveExecutionAdapter),
-		signalSources:         make(map[string]SignalSourceProvider),
-		signalAdapters:        make(map[string]SignalRuntimeAdapter),
-		executionStrategies:   make(map[string]ExecutionStrategy),
-		signalSessions:        make(map[string]domain.SignalRuntimeSession),
-		runtimeEventPublisher: NoopRuntimeEventPublisher{},
-		runtimeLeaseOwnerID:   defaultRuntimeLeaseOwnerID(),
-		liveMarketData:        make(map[string]liveMarketSnapshot),
-		liveAccountSyncGate:   make(chan struct{}, liveAccountSyncMaxConcurrent),
-		logBroker:             logging.NewBroker(),
+		store:                  store,
+		run:                    make(map[string]context.CancelFunc),
+		signalRun:              make(map[string]*signalRuntimeRun),
+		paperPlans:             make(map[string][]paperPlannedOrder),
+		livePlans:              make(map[string][]paperPlannedOrder),
+		strategyEngines:        make(map[string]StrategyEngine),
+		liveAdapters:           make(map[string]LiveExecutionAdapter),
+		signalSources:          make(map[string]SignalSourceProvider),
+		signalAdapters:         make(map[string]SignalRuntimeAdapter),
+		executionStrategies:    make(map[string]ExecutionStrategy),
+		signalSessions:         make(map[string]domain.SignalRuntimeSession),
+		runtimeEventPublisher:  NoopRuntimeEventPublisher{},
+		runtimeLeaseOwnerID:    defaultRuntimeLeaseOwnerID(),
+		liveMarketData:         make(map[string]liveMarketSnapshot),
+		liveAccountSyncGate:    make(chan struct{}, liveAccountSyncMaxConcurrent),
+		liveAccountSyncGateTTL: defaultLiveAccountSyncGateTimeout,
+		logBroker:              logging.NewBroker(),
 		telegramConfig: domain.TelegramConfig{
 			SendLevels:                    []string{"critical", "warning"},
 			TradeEventsEnabled:            true,

--- a/internal/service/platform.go
+++ b/internal/service/platform.go
@@ -42,6 +42,7 @@ type Platform struct {
 	liveMarketData         map[string]liveMarketSnapshot
 	liveAccountOpMu        sync.Map // accountID -> *sync.Mutex
 	liveAccountSyncState   sync.Map // accountID -> *liveAccountSyncState
+	liveAccountSyncGate    chan struct{}
 	liveControlOpState     sync.Map // accountID|strategyID -> *liveControlOperationState
 	liveDispatchMu         sync.Map // liveSessionID -> *sync.Mutex; process-local guard, not distributed idempotency.
 	runtimeSourceGateState sync.Map // runtimeSessionID -> last blocked source gate signature
@@ -112,6 +113,7 @@ func NewPlatform(store store.Repository) *Platform {
 		runtimeEventPublisher: NoopRuntimeEventPublisher{},
 		runtimeLeaseOwnerID:   defaultRuntimeLeaseOwnerID(),
 		liveMarketData:        make(map[string]liveMarketSnapshot),
+		liveAccountSyncGate:   make(chan struct{}, liveAccountSyncMaxConcurrent),
 		logBroker:             logging.NewBroker(),
 		telegramConfig: domain.TelegramConfig{
 			SendLevels:                    []string{"critical", "warning"},


### PR DESCRIPTION
## 目的
实现 issue #244 的 PR4：account sync 调度节奏控制，降低账户同步在 freshness 边界才触发导致的 stale 抖动，并限制并发同步对交易所 REST 的压力。

本 PR 只调整 account sync coordinator，不包含 PR2 的 Binance REST exchange request scheduler、REST 分类队列或优先级调度。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [x] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## Root cause
PR3 已经把 stale 告警分成 soft/hard，避免 Telegram 在 120 秒边界误报。但 account sync 调度仍然是在 freshness 阈值附近才启动同步，容易出现：

```text
freshness 刚过期 -> Telegram/health 采样到 stale -> sync 才开始 -> 很快 recovered
```

同时，同步请求虽然已有同账号 in-flight 合并和近期结果复用，但缺少全局并发上限和明确的提前刷新窗口。

## 修改点
- 增加全局 account sync gate，默认最多 `2` 个 account sync 同时执行。
- 记录 `global_gate_wait_ms` 和 `max_concurrent`，便于后续观察同步排队。
- 将 account sync recent result reuse window 收敛为最小同步间隔：
  - `freshness / 12`
  - 最小 `1s`
  - 最大 `10s`
  - `120s` freshness 下为 `10s`
- 增加提前刷新窗口：成功同步后到 `freshness * 80%` 即可由 active live account dispatcher 触发刷新。
- 失败后的重试仍按完整 freshness threshold 退避，不因为提前刷新而高频打失败请求。
- 保留现有同账号 in-flight coalesce 语义。

## 行为变化
- 正常 `120s` freshness 下，active account sync 会在约 `96s` 进入刷新窗口，而不是等到 stale 后才触发。
- 多账户同时需要同步时，全局最多 2 个并发，避免恢复/启动阶段同时打爆 REST。
- 失败路径不会因为提前刷新变成高频重试；仍等完整 freshness 后再重试。
- 不改变 order submit/cancel、dispatchMode、testnet/mainnet、安全默认值。

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) - 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？- 无
- [x] DB migration 是否具备向下兼容幂等性？- 不涉及 migration
- [x] 配置字段有没有无意被混改？- 无新增 runtimePolicy 字段

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

本地验证：

```text
/opt/homebrew/bin/go test ./internal/service -run 'TestSyncActiveLiveAccountsThrottlesFailedRetriesUntilFreshnessWindow|TestShouldRefreshLiveAccountSyncUsesEarlyRefreshWindow|TestLiveAccountSyncMinimumIntervalScalesWithFreshness|TestSyncLiveAccountGlobalConcurrencyGateLimitsParallelAccounts|TestSyncLiveAccountCoalescesConcurrentAdapterSyncForSameAccount'
/opt/homebrew/bin/go test ./...
/opt/homebrew/bin/go build ./cmd/platform-api
/opt/homebrew/bin/go build ./cmd/db-migrate
```

新增/覆盖测试：

- active account sync 失败后仍按完整 freshness retry backoff
- 成功同步后在 80% freshness 时提前刷新
- minimum interval 随 freshness 缩放，120s 时封顶 10s
- 全局并发 gate 会阻止第二个 account sync 进入 adapter，直到第一个释放
- 同账号 in-flight coalesce 继续有效

## 后续 PR
- PR2：Binance REST exchange request scheduler，按 order/account/reconcile/history/public 拆队列、优先级、deadline 和 queue wait 指标。

Part of #244.
