### PR TITLE
add account sync observability

### DIFF
--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -137,6 +137,22 @@ type liveAccountSyncState struct {
 	completedAt time.Time
 }
 
+type liveAccountSyncGateObservation struct {
+	QueueDepth int64
+	Running    int64
+	WaitMS     int64
+	TimeoutMS  int64
+}
+
+type liveAccountSyncObservation struct {
+	Trigger        string
+	Gate           liveAccountSyncGateObservation
+	StartedAt      time.Time
+	CompletedAt    time.Time
+	SyncDurationMS int64
+	Err            error
+}
+
 const (
 	liveAccountSyncMaxConcurrent        = 2
 	defaultLiveAccountSyncGateTimeout   = 15 * time.Second
@@ -305,9 +321,8 @@ func (p *Platform) requestLiveAccountSync(accountID, trigger string) (domain.Acc
 	state.done = done
 	state.mu.Unlock()
 
-	gateWaitStartedAt := time.Now()
-	releaseSyncSlot, acquiredSlot := p.acquireLiveAccountSyncSlot()
-	gateWaitMS := time.Since(gateWaitStartedAt).Milliseconds()
+	syncRequestStartedAt := time.Now().UTC()
+	releaseSyncSlot, gateObservation, acquiredSlot := p.acquireLiveAccountSyncSlot()
 	if !acquiredSlot {
 		err := fmt.Errorf("%s: account=%s", liveAccountSyncGateTimeoutErrorText, accountID)
 		state.mu.Lock()
@@ -317,11 +332,20 @@ func (p *Platform) requestLiveAccountSync(accountID, trigger string) (domain.Acc
 		state.done = nil
 		close(done)
 		state.mu.Unlock()
+		p.persistLiveAccountSyncSchedulerFailure(accountID, syncRequestStartedAt, liveAccountSyncObservation{
+			Trigger:     normalizedTrigger,
+			Gate:        gateObservation,
+			StartedAt:   syncRequestStartedAt,
+			CompletedAt: time.Now().UTC(),
+			Err:         err,
+		})
 		logger.Warn("live account sync request rejected by global gate timeout",
 			"coalesced", false,
 			"waited_for_inflight", false,
 			"reused_recent_result", false,
-			"global_gate_wait_ms", gateWaitMS,
+			"sync_queue_length", gateObservation.QueueDepth,
+			"global_running", gateObservation.Running,
+			"global_gate_wait_ms", gateObservation.WaitMS,
 			"global_gate_timeout_ms", p.liveAccountSyncGateTimeout().Milliseconds(),
 			"max_concurrent", liveAccountSyncMaxConcurrent,
 		)
@@ -346,14 +370,31 @@ func (p *Platform) requestLiveAccountSync(accountID, trigger string) (domain.Acc
 		"coalesced", false,
 		"waited_for_inflight", false,
 		"reused_recent_result", false,
-		"global_gate_wait_ms", gateWaitMS,
+		"sync_queue_length", gateObservation.QueueDepth,
+		"global_running", gateObservation.Running,
+		"global_gate_wait_ms", gateObservation.WaitMS,
 		"max_concurrent", liveAccountSyncMaxConcurrent,
 	)
+	syncStartedAt := time.Now().UTC()
 	result, err := p.syncLiveAccountWithoutGate(accountID)
+	completedAt := time.Now().UTC()
+	syncDurationMS := completedAt.Sub(syncStartedAt).Milliseconds()
+	if observed, observeErr := p.persistLiveAccountSyncObservation(accountID, liveAccountSyncObservation{
+		Trigger:        normalizedTrigger,
+		Gate:           gateObservation,
+		StartedAt:      syncStartedAt,
+		CompletedAt:    completedAt,
+		SyncDurationMS: syncDurationMS,
+		Err:            err,
+	}); observeErr == nil && observed.ID != "" {
+		result = observed
+	} else if observeErr != nil {
+		logger.Warn("persist live account sync observation failed", "error", observeErr)
+	}
 	state.mu.Lock()
 	state.result = result
 	state.err = err
-	state.completedAt = time.Now().UTC()
+	state.completedAt = completedAt
 	state.running = false
 	state.done = nil
 	close(done)
@@ -364,24 +405,43 @@ func (p *Platform) requestLiveAccountSync(accountID, trigger string) (domain.Acc
 		"reused_recent_result", false,
 		"result_error", err != nil,
 		"completed_at", state.completedAt.Format(time.RFC3339),
-		"global_gate_wait_ms", gateWaitMS,
+		"sync_duration_ms", syncDurationMS,
+		"sync_duration_bucket", liveAccountSyncDurationBucket(syncDurationMS),
+		"sync_queue_length", gateObservation.QueueDepth,
+		"global_running", gateObservation.Running,
+		"global_gate_wait_ms", gateObservation.WaitMS,
+		"global_gate_wait_bucket", liveAccountSyncDurationBucket(gateObservation.WaitMS),
 	)
 	return result, err
 }
 
-func (p *Platform) acquireLiveAccountSyncSlot() (func(), bool) {
+func (p *Platform) acquireLiveAccountSyncSlot() (func(), liveAccountSyncGateObservation, bool) {
 	if p == nil || p.liveAccountSyncGate == nil {
-		return func() {}, true
+		return func() {}, liveAccountSyncGateObservation{}, true
+	}
+	waitStartedAt := time.Now()
+	waiting := p.liveAccountSyncWaiting.Add(1)
+	observe := liveAccountSyncGateObservation{
+		QueueDepth: maxInt64Value(waiting-1, 0),
+		Running:    p.liveAccountSyncRunning.Load(),
+		TimeoutMS:  p.liveAccountSyncGateTimeout().Milliseconds(),
 	}
 	timer := time.NewTimer(p.liveAccountSyncGateTimeout())
 	defer timer.Stop()
 	select {
 	case p.liveAccountSyncGate <- struct{}{}:
+		p.liveAccountSyncWaiting.Add(-1)
+		observe.WaitMS = time.Since(waitStartedAt).Milliseconds()
+		observe.Running = p.liveAccountSyncRunning.Add(1)
 		return func() {
 			<-p.liveAccountSyncGate
-		}, true
+			p.liveAccountSyncRunning.Add(-1)
+		}, observe, true
 	case <-timer.C:
-		return func() {}, false
+		p.liveAccountSyncWaiting.Add(-1)
+		observe.WaitMS = time.Since(waitStartedAt).Milliseconds()
+		observe.Running = p.liveAccountSyncRunning.Load()
+		return func() {}, observe, false
 	}
 }
 
@@ -390,6 +450,31 @@ func (p *Platform) liveAccountSyncGateTimeout() time.Duration {
 		return defaultLiveAccountSyncGateTimeout
 	}
 	return p.liveAccountSyncGateTTL
+}
+
+func (p *Platform) persistLiveAccountSyncSchedulerFailure(accountID string, attemptedAt time.Time, observation liveAccountSyncObservation) {
+	if observation.Err == nil {
+		return
+	}
+	account, err := p.store.GetAccount(accountID)
+	if err != nil {
+		p.logger("service.live", "account_id", accountID).Warn("load live account for sync scheduler failure failed", "error", err)
+		return
+	}
+	updateAccountSyncFailureHealth(&account, attemptedAt, observation.Err)
+	applyLiveAccountSyncObservation(&account, observation)
+	if _, err := p.store.UpdateAccount(account); err != nil {
+		p.logger("service.live", "account_id", accountID).Warn("persist live account sync scheduler failure failed", "error", err)
+	}
+}
+
+func (p *Platform) persistLiveAccountSyncObservation(accountID string, observation liveAccountSyncObservation) (domain.Account, error) {
+	account, err := p.store.GetAccount(accountID)
+	if err != nil {
+		return domain.Account{}, err
+	}
+	applyLiveAccountSyncObservation(&account, observation)
+	return p.store.UpdateAccount(account)
 }
 
 func (p *Platform) liveAccountSyncEntry(accountID string) *liveAccountSyncState {
@@ -435,6 +520,66 @@ func (p *Platform) liveAccountSyncRefreshInterval() time.Duration {
 		return threshold
 	}
 	return interval
+}
+
+func applyLiveAccountSyncObservation(account *domain.Account, observation liveAccountSyncObservation) {
+	if account == nil {
+		return
+	}
+	account.Metadata = cloneMetadata(account.Metadata)
+	section := ensureHealthSection(account.Metadata, "accountSync")
+	if !observation.CompletedAt.IsZero() {
+		section["lastObservedAt"] = observation.CompletedAt.UTC().Format(time.RFC3339)
+	}
+	if strings.TrimSpace(observation.Trigger) != "" {
+		section["lastTrigger"] = strings.TrimSpace(observation.Trigger)
+	}
+	if observation.SyncDurationMS > 0 {
+		section["lastSyncDurationMs"] = observation.SyncDurationMS
+		section["lastSyncDurationBucket"] = liveAccountSyncDurationBucket(observation.SyncDurationMS)
+	}
+	section["lastGateWaitMs"] = observation.Gate.WaitMS
+	section["lastGateWaitBucket"] = liveAccountSyncDurationBucket(observation.Gate.WaitMS)
+	section["lastQueueLength"] = observation.Gate.QueueDepth
+	section["lastGlobalRunning"] = observation.Gate.Running
+	section["globalMaxConcurrent"] = liveAccountSyncMaxConcurrent
+	section["lastResultError"] = observation.Err != nil
+	if observation.Err != nil {
+		section["lastObservedError"] = observation.Err.Error()
+	} else {
+		delete(section, "lastObservedError")
+	}
+	syncCount := parseFloatValue(mapValue(section["today"])["syncCount"])
+	errorCount := parseFloatValue(mapValue(section["today"])["errorCount"])
+	if total := syncCount + errorCount; total > 0 {
+		section["todayFailureRate"] = errorCount / total
+	}
+}
+
+func liveAccountSyncDurationBucket(ms int64) string {
+	switch {
+	case ms <= 0:
+		return "0ms"
+	case ms < 100:
+		return "lt_100ms"
+	case ms < 500:
+		return "lt_500ms"
+	case ms < 1000:
+		return "lt_1s"
+	case ms < 5000:
+		return "lt_5s"
+	case ms < 15000:
+		return "lt_15s"
+	default:
+		return "gte_15s"
+	}
+}
+
+func maxInt64Value(value, fallback int64) int64 {
+	if value > fallback {
+		return value
+	}
+	return fallback
 }
 
 func (p *Platform) liveAccountSyncAllowsRecentReuse(trigger string) bool {

--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -379,7 +379,7 @@ func (p *Platform) requestLiveAccountSync(accountID, trigger string) (domain.Acc
 	result, err := p.syncLiveAccountWithoutGate(accountID)
 	completedAt := time.Now().UTC()
 	syncDurationMS := completedAt.Sub(syncStartedAt).Milliseconds()
-	if observed, observeErr := p.persistLiveAccountSyncObservation(accountID, liveAccountSyncObservation{
+	if observed, observeErr := p.persistLiveAccountSyncObservation(result, liveAccountSyncObservation{
 		Trigger:        normalizedTrigger,
 		Gate:           gateObservation,
 		StartedAt:      syncStartedAt,
@@ -468,10 +468,9 @@ func (p *Platform) persistLiveAccountSyncSchedulerFailure(accountID string, atte
 	}
 }
 
-func (p *Platform) persistLiveAccountSyncObservation(accountID string, observation liveAccountSyncObservation) (domain.Account, error) {
-	account, err := p.store.GetAccount(accountID)
-	if err != nil {
-		return domain.Account{}, err
+func (p *Platform) persistLiveAccountSyncObservation(account domain.Account, observation liveAccountSyncObservation) (domain.Account, error) {
+	if strings.TrimSpace(account.ID) == "" {
+		return domain.Account{}, fmt.Errorf("live account sync observation requires account result")
 	}
 	applyLiveAccountSyncObservation(&account, observation)
 	return p.store.UpdateAccount(account)

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -7446,6 +7446,18 @@ func TestSyncLiveAccountRecordsAdapterResolutionFailuresInHealthSummary(t *testi
 	if !strings.Contains(stringValue(accountSync["lastError"]), "live adapter not registered") {
 		t.Fatalf("expected recorded adapter resolution failure, got %s", stringValue(accountSync["lastError"]))
 	}
+	if got := stringValue(accountSync["lastTrigger"]); got != "direct" {
+		t.Fatalf("expected sync observation trigger direct, got %s", got)
+	}
+	if got := boolValue(accountSync["lastResultError"]); !got {
+		t.Fatal("expected sync observation to record result error")
+	}
+	if got := parseFloatValue(accountSync["todayFailureRate"]); got != 1 {
+		t.Fatalf("expected failure rate 1 after one failed sync, got %v", got)
+	}
+	if got := stringValue(accountSync["lastGateWaitBucket"]); got == "" {
+		t.Fatal("expected gate wait bucket to be recorded")
+	}
 }
 
 func TestSyncActiveLiveAccountsReturnsPerAccountSyncErrors(t *testing.T) {
@@ -7796,11 +7808,22 @@ func TestSyncLiveAccountGlobalConcurrencyGateTimeoutReturnsError(t *testing.T) {
 	}
 
 	<-platform.liveAccountSyncGate
-	if _, err := platform.requestLiveAccountSync(account.ID, "direct"); err != nil {
+	synced, err := platform.requestLiveAccountSync(account.ID, "direct")
+	if err != nil {
 		t.Fatalf("expected sync to work after gate slot is available, got %v", err)
 	}
 	if got := syncCalls.Load(); got != 1 {
 		t.Fatalf("expected adapter to run after gate slot is available, got %d calls", got)
+	}
+	accountSync := mapValue(mapValue(synced.Metadata["healthSummary"])["accountSync"])
+	if got := stringValue(accountSync["lastTrigger"]); got != "direct" {
+		t.Fatalf("expected sync observation trigger direct, got %s", got)
+	}
+	if got := boolValue(accountSync["lastResultError"]); got {
+		t.Fatal("expected successful sync observation to clear result error")
+	}
+	if got := maxIntValue(accountSync["globalMaxConcurrent"], 0); got != liveAccountSyncMaxConcurrent {
+		t.Fatalf("expected global max concurrent observation %d, got %d", liveAccountSyncMaxConcurrent, got)
 	}
 }
 

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -7827,6 +7827,66 @@ func TestSyncLiveAccountGlobalConcurrencyGateTimeoutReturnsError(t *testing.T) {
 	}
 }
 
+func TestSyncLiveAccountObservationPreservesAdapterResultMetadata(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	platform.registerLiveAdapter(testLiveAccountSyncAdapter{
+		key: "test-sync-observation-preserves-result",
+		syncSnapshotFunc: func(p *Platform, account domain.Account, binding map[string]any) (domain.Account, error) {
+			account.Metadata = cloneMetadata(account.Metadata)
+			account.Metadata["adapterResultMarker"] = "preserved"
+			account.Metadata["liveSyncSnapshot"] = map[string]any{
+				"source":     "test-sync-observation-preserves-result",
+				"adapterKey": "test-sync-observation-preserves-result",
+				"syncedAt":   time.Now().UTC().Format(time.RFC3339),
+			}
+			health := cloneMetadata(mapValue(account.Metadata["healthSummary"]))
+			accountSync := cloneMetadata(mapValue(health["accountSync"]))
+			accountSync["adapterHealthMarker"] = "preserved"
+			health["accountSync"] = accountSync
+			account.Metadata["healthSummary"] = health
+			return account, nil
+		},
+	})
+	account, err := platform.BindLiveAccount("live-main", map[string]any{
+		"adapterKey":     "test-sync-observation-preserves-result",
+		"connectionMode": "mock",
+		"executionMode":  "mock",
+	})
+	if err != nil {
+		t.Fatalf("bind live account failed: %v", err)
+	}
+
+	synced, err := platform.requestLiveAccountSync(account.ID, "direct")
+	if err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+	if got := stringValue(synced.Metadata["adapterResultMarker"]); got != "preserved" {
+		t.Fatalf("expected returned account to preserve adapter result metadata, got %s", got)
+	}
+	accountSync := mapValue(mapValue(synced.Metadata["healthSummary"])["accountSync"])
+	if got := stringValue(accountSync["adapterHealthMarker"]); got != "preserved" {
+		t.Fatalf("expected returned account to preserve adapter health metadata, got %s", got)
+	}
+	if got := stringValue(accountSync["lastTrigger"]); got != "direct" {
+		t.Fatalf("expected observation trigger to be applied on returned account, got %s", got)
+	}
+
+	stored, err := platform.store.GetAccount(account.ID)
+	if err != nil {
+		t.Fatalf("reload account failed: %v", err)
+	}
+	if got := stringValue(stored.Metadata["adapterResultMarker"]); got != "preserved" {
+		t.Fatalf("expected stored account to preserve adapter result metadata, got %s", got)
+	}
+	storedAccountSync := mapValue(mapValue(stored.Metadata["healthSummary"])["accountSync"])
+	if got := stringValue(storedAccountSync["adapterHealthMarker"]); got != "preserved" {
+		t.Fatalf("expected stored account to preserve adapter health metadata, got %s", got)
+	}
+	if got := stringValue(storedAccountSync["lastTrigger"]); got != "direct" {
+		t.Fatalf("expected stored observation trigger direct, got %s", got)
+	}
+}
+
 func TestSyncLiveAccountAuthoritativeReconcileBypassesRecentReuseWindow(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
 	platform.runtimePolicy.LiveAccountSyncFreshnessSecs = 60

--- a/internal/service/platform.go
+++ b/internal/service/platform.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/wuyaocheng/bktrader/internal/config"
@@ -44,6 +45,8 @@ type Platform struct {
 	liveAccountSyncState   sync.Map // accountID -> *liveAccountSyncState
 	liveAccountSyncGate    chan struct{}
 	liveAccountSyncGateTTL time.Duration
+	liveAccountSyncWaiting atomic.Int64
+	liveAccountSyncRunning atomic.Int64
 	liveControlOpState     sync.Map // accountID|strategyID -> *liveControlOperationState
 	liveDispatchMu         sync.Map // liveSessionID -> *sync.Mutex; process-local guard, not distributed idempotency.
 	runtimeSourceGateState sync.Map // runtimeSessionID -> last blocked source gate signature


### PR DESCRIPTION
## 目的
实现 issue #244 的 PR5：account sync 调度可观测增强。

本 PR 只增加日志和 healthSummary 观测字段，不改变 PR4 的调度行为，也不包含 PR6 的 priority/deadline/starvation 调度逻辑。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [x] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## Root cause
PR4 已加入 account sync 最小间隔、提前刷新和全局并发 gate。上线后还需要回答：

- 是否仍然有 sync 在 gate 前排队？
- gate wait 是否接近 timeout？
- 单账户 sync 耗时是否异常？
- 哪个 trigger/account 的失败率高？

因此 PR5 增加可观测字段，为后续 PR6 的 priority/deadline/starvation 设计提供数据依据。

## 修改点
- 为 account sync 全局 gate 增加 process-local waiting/running 计数。
- 日志新增：
  - `sync_queue_length`
  - `global_running`
  - `global_gate_wait_ms`
  - `global_gate_wait_bucket`
  - `sync_duration_ms`
  - `sync_duration_bucket`
- `healthSummary.accountSync` 新增最近一次观测：
  - `lastObservedAt`
  - `lastTrigger`
  - `lastGateWaitMs`
  - `lastGateWaitBucket`
  - `lastQueueLength`
  - `lastGlobalRunning`
  - `globalMaxConcurrent`
  - `lastSyncDurationMs`
  - `lastSyncDurationBucket`
  - `lastResultError`
  - `lastObservedError`
  - `todayFailureRate`
- gate timeout 这类 scheduler-level failure 也会写入 account sync health，避免只在日志里可见。

## 行为变化
- 不改变 account sync 是否触发、并发上限、最小间隔、提前刷新窗口。
- 不改变 order submit/cancel、dispatchMode、testnet/mainnet、安全默认值。
- 只增加内存观测计数、日志字段和 account health metadata 字段。

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) - 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？- 无
- [x] DB migration 是否具备向下兼容幂等性？- 不涉及 migration
- [x] 配置字段有没有无意被混改？- 无新增 runtimePolicy 字段

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

本地验证：

```text
/opt/homebrew/bin/go test ./internal/service -run 'TestSyncLiveAccountRecordsAdapterResolutionFailuresInHealthSummary|TestSyncLiveAccountGlobalConcurrencyGateTimeoutReturnsError|TestSyncLiveAccountGlobalConcurrencyGateLimitsParallelAccounts'
/opt/homebrew/bin/go test ./...
/opt/homebrew/bin/go build ./cmd/platform-api
/opt/homebrew/bin/go build ./cmd/db-migrate
```

新增/覆盖测试：

- adapter resolve failure 会记录 trigger、result error、failure rate、gate wait bucket
- global gate timeout 不进入 adapter，释放 slot 后可恢复同步
- 成功同步后会记录 trigger、result success、global max concurrent

## 后续 PR
- PR6：基于 PR5 数据再做 per-account priority、deadline、starvation 防护。

Part of #244.
