### PR TITLE
prioritize active account sync candidates

### DIFF
--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -162,6 +162,8 @@ type liveAccountSyncCandidate struct {
 	SecondsUntilStale int64
 	AttemptAgeSeconds int64
 	ReconcilePending  bool
+	NeverSynced       bool
+	NeverAttempted    bool
 }
 
 const (
@@ -2612,6 +2614,8 @@ func (p *Platform) syncActiveLiveAccounts(eventTime time.Time) error {
 			"seconds_until_stale", candidate.SecondsUntilStale,
 			"attempt_age_seconds", candidate.AttemptAgeSeconds,
 			"reconcile_pending", candidate.ReconcilePending,
+			"never_synced", candidate.NeverSynced,
+			"never_attempted", candidate.NeverAttempted,
 		)
 		if _, syncErr := p.requestLiveAccountSync(candidate.Account.ID, "sync-active-live-accounts"); syncErr != nil {
 			syncErrs = append(syncErrs, fmt.Errorf("live account %s sync failed: %w", candidate.Account.ID, syncErr))
@@ -2627,8 +2631,8 @@ func (p *Platform) liveAccountSyncCandidate(account domain.Account, eventTime ti
 	lastAttemptAt := parseOptionalRFC3339(stringValue(accountSync["lastAttemptAt"]))
 	ageSeconds := int64(0)
 	secondsUntilStale := int64(0)
+	neverSynced := lastSuccessAt.IsZero()
 	if lastSuccessAt.IsZero() {
-		ageSeconds = math.MaxInt32
 		secondsUntilStale = 0
 	} else {
 		age := eventTime.Sub(lastSuccessAt)
@@ -2638,7 +2642,8 @@ func (p *Platform) liveAccountSyncCandidate(account domain.Account, eventTime ti
 			secondsUntilStale = 0
 		}
 	}
-	attemptAgeSeconds := int64(math.MaxInt32)
+	neverAttempted := lastAttemptAt.IsZero()
+	attemptAgeSeconds := int64(0)
 	if !lastAttemptAt.IsZero() {
 		attemptAgeSeconds = int64(eventTime.Sub(lastAttemptAt).Seconds())
 		if attemptAgeSeconds < 0 {
@@ -2663,7 +2668,9 @@ func (p *Platform) liveAccountSyncCandidate(account domain.Account, eventTime ti
 	if openOrderCount > 0 {
 		score += 250000
 	}
-	if secondsUntilStale == 0 {
+	if neverSynced {
+		score += 1000
+	} else if secondsUntilStale == 0 {
 		score += 100000
 	} else if threshold > 0 {
 		score += int64((threshold.Seconds() - float64(secondsUntilStale)) * 100)
@@ -2684,6 +2691,8 @@ func (p *Platform) liveAccountSyncCandidate(account domain.Account, eventTime ti
 		SecondsUntilStale: secondsUntilStale,
 		AttemptAgeSeconds: attemptAgeSeconds,
 		ReconcilePending:  reconcilePending,
+		NeverSynced:       neverSynced,
+		NeverAttempted:    neverAttempted,
 	}
 }
 

--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -153,6 +153,17 @@ type liveAccountSyncObservation struct {
 	Err            error
 }
 
+type liveAccountSyncCandidate struct {
+	Account           domain.Account
+	Score             int64
+	PositionCount     int
+	OpenOrderCount    int
+	AgeSeconds        int64
+	SecondsUntilStale int64
+	AttemptAgeSeconds int64
+	ReconcilePending  bool
+}
+
 const (
 	liveAccountSyncMaxConcurrent        = 2
 	defaultLiveAccountSyncGateTimeout   = 15 * time.Second
@@ -2565,6 +2576,7 @@ func (p *Platform) syncActiveLiveAccounts(eventTime time.Time) error {
 		return err
 	}
 	seen := make(map[string]struct{})
+	candidates := make([]liveAccountSyncCandidate, 0)
 	var syncErrs []error
 	for _, session := range sessions {
 		if !strings.EqualFold(session.Status, "RUNNING") {
@@ -2581,11 +2593,120 @@ func (p *Platform) syncActiveLiveAccounts(eventTime time.Time) error {
 		if !p.shouldRefreshLiveAccountSync(account, eventTime) {
 			continue
 		}
-		if _, syncErr := p.requestLiveAccountSync(account.ID, "sync-active-live-accounts"); syncErr != nil {
-			syncErrs = append(syncErrs, fmt.Errorf("live account %s sync failed: %w", account.ID, syncErr))
+		candidates = append(candidates, p.liveAccountSyncCandidate(account, eventTime))
+	}
+	sort.SliceStable(candidates, func(i, j int) bool {
+		return liveAccountSyncCandidateLess(candidates[i], candidates[j])
+	})
+	for index, candidate := range candidates {
+		p.logger("service.live",
+			"account_id", candidate.Account.ID,
+			"trigger", "sync-active-live-accounts",
+		).Info("live account sync candidate selected",
+			"rank", index+1,
+			"candidate_count", len(candidates),
+			"score", candidate.Score,
+			"position_count", candidate.PositionCount,
+			"open_order_count", candidate.OpenOrderCount,
+			"age_seconds", candidate.AgeSeconds,
+			"seconds_until_stale", candidate.SecondsUntilStale,
+			"attempt_age_seconds", candidate.AttemptAgeSeconds,
+			"reconcile_pending", candidate.ReconcilePending,
+		)
+		if _, syncErr := p.requestLiveAccountSync(candidate.Account.ID, "sync-active-live-accounts"); syncErr != nil {
+			syncErrs = append(syncErrs, fmt.Errorf("live account %s sync failed: %w", candidate.Account.ID, syncErr))
 		}
 	}
 	return errors.Join(syncErrs...)
+}
+
+func (p *Platform) liveAccountSyncCandidate(account domain.Account, eventTime time.Time) liveAccountSyncCandidate {
+	threshold := time.Duration(p.runtimePolicy.LiveAccountSyncFreshnessSecs) * time.Second
+	lastSuccessAt := liveAccountSyncLastSuccessAt(account)
+	accountSync := mapValue(mapValue(account.Metadata["healthSummary"])["accountSync"])
+	lastAttemptAt := parseOptionalRFC3339(stringValue(accountSync["lastAttemptAt"]))
+	ageSeconds := int64(0)
+	secondsUntilStale := int64(0)
+	if lastSuccessAt.IsZero() {
+		ageSeconds = math.MaxInt32
+		secondsUntilStale = 0
+	} else {
+		age := eventTime.Sub(lastSuccessAt)
+		ageSeconds = int64(age.Seconds())
+		secondsUntilStale = int64((threshold - age).Seconds())
+		if secondsUntilStale < 0 {
+			secondsUntilStale = 0
+		}
+	}
+	attemptAgeSeconds := int64(math.MaxInt32)
+	if !lastAttemptAt.IsZero() {
+		attemptAgeSeconds = int64(eventTime.Sub(lastAttemptAt).Seconds())
+		if attemptAgeSeconds < 0 {
+			attemptAgeSeconds = 0
+		}
+	}
+	snapshot := mapValue(account.Metadata["liveSyncSnapshot"])
+	positionCount := firstPositiveIntValue(snapshot["positionCount"], accountSync["positionCount"])
+	openOrderCount := firstPositiveIntValue(snapshot["openOrderCount"], accountSync["openOrderCount"])
+	reconcilePending := liveAccountPositionReconcilePending(account)
+
+	score := ageSeconds
+	if score > 100000 {
+		score = 100000
+	}
+	if reconcilePending {
+		score += 1000000
+	}
+	if positionCount > 0 {
+		score += 500000
+	}
+	if openOrderCount > 0 {
+		score += 250000
+	}
+	if secondsUntilStale == 0 {
+		score += 100000
+	} else if threshold > 0 {
+		score += int64((threshold.Seconds() - float64(secondsUntilStale)) * 100)
+	}
+	if attemptAgeSeconds > 0 {
+		starvation := attemptAgeSeconds
+		if starvation > 10000 {
+			starvation = 10000
+		}
+		score += starvation
+	}
+	return liveAccountSyncCandidate{
+		Account:           account,
+		Score:             score,
+		PositionCount:     positionCount,
+		OpenOrderCount:    openOrderCount,
+		AgeSeconds:        ageSeconds,
+		SecondsUntilStale: secondsUntilStale,
+		AttemptAgeSeconds: attemptAgeSeconds,
+		ReconcilePending:  reconcilePending,
+	}
+}
+
+func liveAccountSyncCandidateLess(a, b liveAccountSyncCandidate) bool {
+	if a.Score != b.Score {
+		return a.Score > b.Score
+	}
+	if a.SecondsUntilStale != b.SecondsUntilStale {
+		return a.SecondsUntilStale < b.SecondsUntilStale
+	}
+	if a.AttemptAgeSeconds != b.AttemptAgeSeconds {
+		return a.AttemptAgeSeconds > b.AttemptAgeSeconds
+	}
+	return a.Account.ID < b.Account.ID
+}
+
+func firstPositiveIntValue(values ...any) int {
+	for _, value := range values {
+		if parsed := maxIntValue(value, 0); parsed > 0 {
+			return parsed
+		}
+	}
+	return 0
 }
 
 func (p *Platform) shouldRefreshLiveAccountSync(account domain.Account, eventTime time.Time) bool {

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -7573,6 +7573,136 @@ func TestShouldRefreshLiveAccountSyncUsesEarlyRefreshWindow(t *testing.T) {
 	}
 }
 
+func TestLiveAccountSyncCandidatePrioritizesPositionDeadlineAndStarvation(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	platform.runtimePolicy.LiveAccountSyncFreshnessSecs = 120
+	now := time.Date(2026, 4, 27, 8, 0, 0, 0, time.UTC)
+	accountWithState := func(id string, lastSuccessAt, lastAttemptAt time.Time, positionCount int) domain.Account {
+		accountSync := map[string]any{
+			"lastSuccessAt": lastSuccessAt.Format(time.RFC3339),
+			"lastAttemptAt": lastAttemptAt.Format(time.RFC3339),
+		}
+		if positionCount > 0 {
+			accountSync["positionCount"] = positionCount
+		}
+		return domain.Account{
+			ID: id,
+			Metadata: map[string]any{
+				"lastLiveSyncAt": lastSuccessAt.Format(time.RFC3339),
+				"healthSummary": map[string]any{
+					"accountSync": accountSync,
+				},
+			},
+		}
+	}
+
+	noPosition := platform.liveAccountSyncCandidate(accountWithState("no-position", now.Add(-119*time.Second), now.Add(-119*time.Second), 0), now)
+	withPosition := platform.liveAccountSyncCandidate(accountWithState("with-position", now.Add(-100*time.Second), now.Add(-100*time.Second), 1), now)
+	if !liveAccountSyncCandidateLess(withPosition, noPosition) {
+		t.Fatal("expected account with position to outrank account that is only closer to stale")
+	}
+
+	closerToStale := platform.liveAccountSyncCandidate(accountWithState("closer", now.Add(-119*time.Second), now.Add(-119*time.Second), 0), now)
+	fartherFromStale := platform.liveAccountSyncCandidate(accountWithState("farther", now.Add(-100*time.Second), now.Add(-100*time.Second), 0), now)
+	if !liveAccountSyncCandidateLess(closerToStale, fartherFromStale) {
+		t.Fatal("expected account closer to stale deadline to outrank lower urgency account")
+	}
+
+	starved := platform.liveAccountSyncCandidate(accountWithState("starved", now.Add(-100*time.Second), now.Add(-1000*time.Second), 0), now)
+	recentAttempt := platform.liveAccountSyncCandidate(accountWithState("recent", now.Add(-100*time.Second), now.Add(-100*time.Second), 0), now)
+	if !liveAccountSyncCandidateLess(starved, recentAttempt) {
+		t.Fatal("expected account with older attempt to outrank equally urgent recent attempt")
+	}
+}
+
+func TestSyncActiveLiveAccountsUsesCandidatePriorityOrder(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	platform.runtimePolicy.LiveAccountSyncFreshnessSecs = 120
+	now := time.Date(2026, 4, 27, 8, 0, 0, 0, time.UTC)
+	var syncOrder []string
+
+	platform.registerLiveAdapter(testLiveAccountSyncAdapter{
+		key: "test-sync-priority-order",
+		syncSnapshotFunc: func(p *Platform, account domain.Account, binding map[string]any) (domain.Account, error) {
+			syncOrder = append(syncOrder, account.ID)
+			account.Metadata = cloneMetadata(account.Metadata)
+			account.Metadata["lastLiveSyncAt"] = now.Format(time.RFC3339)
+			return p.store.UpdateAccount(account)
+		},
+	})
+
+	first, err := platform.BindLiveAccount("live-main", map[string]any{
+		"adapterKey":     "test-sync-priority-order",
+		"connectionMode": "mock",
+		"executionMode":  "mock",
+	})
+	if err != nil {
+		t.Fatalf("bind first live account failed: %v", err)
+	}
+	first.Metadata = cloneMetadata(first.Metadata)
+	first.Metadata["lastLiveSyncAt"] = now.Add(-119 * time.Second).Format(time.RFC3339)
+	first.Metadata["healthSummary"] = map[string]any{
+		"accountSync": map[string]any{
+			"lastSuccessAt": now.Add(-119 * time.Second).Format(time.RFC3339),
+			"lastAttemptAt": now.Add(-119 * time.Second).Format(time.RFC3339),
+		},
+	}
+	if _, err := platform.store.UpdateAccount(first); err != nil {
+		t.Fatalf("update first account failed: %v", err)
+	}
+
+	second, err := platform.CreateAccount("Second Live", "LIVE", "BINANCE")
+	if err != nil {
+		t.Fatalf("create second live account failed: %v", err)
+	}
+	second, err = platform.BindLiveAccount(second.ID, map[string]any{
+		"adapterKey":     "test-sync-priority-order",
+		"connectionMode": "mock",
+		"executionMode":  "mock",
+	})
+	if err != nil {
+		t.Fatalf("bind second live account failed: %v", err)
+	}
+	second.Metadata = cloneMetadata(second.Metadata)
+	second.Metadata["lastLiveSyncAt"] = now.Add(-100 * time.Second).Format(time.RFC3339)
+	second.Metadata["liveSyncSnapshot"] = map[string]any{"positionCount": 1}
+	second.Metadata["healthSummary"] = map[string]any{
+		"accountSync": map[string]any{
+			"lastSuccessAt": now.Add(-100 * time.Second).Format(time.RFC3339),
+			"lastAttemptAt": now.Add(-100 * time.Second).Format(time.RFC3339),
+			"positionCount": 1,
+		},
+	}
+	if _, err := platform.store.UpdateAccount(second); err != nil {
+		t.Fatalf("update second account failed: %v", err)
+	}
+
+	firstSession, err := platform.CreateLiveSession("", first.ID, "strategy-bk-1d", map[string]any{"symbol": "BTCUSDT"})
+	if err != nil {
+		t.Fatalf("create first live session failed: %v", err)
+	}
+	if _, err := platform.store.UpdateLiveSessionStatus(firstSession.ID, "RUNNING"); err != nil {
+		t.Fatalf("run first live session failed: %v", err)
+	}
+	secondSession, err := platform.CreateLiveSession("", second.ID, "strategy-bk-1d", map[string]any{"symbol": "ETHUSDT"})
+	if err != nil {
+		t.Fatalf("create second live session failed: %v", err)
+	}
+	if _, err := platform.store.UpdateLiveSessionStatus(secondSession.ID, "RUNNING"); err != nil {
+		t.Fatalf("run second live session failed: %v", err)
+	}
+
+	if err := platform.syncActiveLiveAccounts(now); err != nil {
+		t.Fatalf("sync active live accounts failed: %v", err)
+	}
+	if len(syncOrder) != 2 {
+		t.Fatalf("expected two account syncs, got %v", syncOrder)
+	}
+	if syncOrder[0] != second.ID {
+		t.Fatalf("expected account with position to sync first, got order %v", syncOrder)
+	}
+}
+
 func TestLiveAccountSyncMinimumIntervalScalesWithFreshness(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
 	platform.runtimePolicy.LiveAccountSyncFreshnessSecs = 60

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -7613,6 +7613,24 @@ func TestLiveAccountSyncCandidatePrioritizesPositionDeadlineAndStarvation(t *tes
 	if !liveAccountSyncCandidateLess(starved, recentAttempt) {
 		t.Fatal("expected account with older attempt to outrank equally urgent recent attempt")
 	}
+
+	neverAttempted := platform.liveAccountSyncCandidate(domain.Account{
+		ID:        "never",
+		CreatedAt: now.Add(-5 * time.Second),
+		Metadata:  map[string]any{},
+	}, now)
+	if !neverAttempted.NeverAttempted || !neverAttempted.NeverSynced {
+		t.Fatalf("expected never-attempted account to be modeled explicitly, got %+v", neverAttempted)
+	}
+	if neverAttempted.AttemptAgeSeconds != 0 {
+		t.Fatalf("expected never-attempted account to avoid starvation age bonus, got %d", neverAttempted.AttemptAgeSeconds)
+	}
+	if liveAccountSyncCandidateLess(neverAttempted, withPosition) {
+		t.Fatal("did not expect never-attempted empty account to outrank account with position")
+	}
+	if liveAccountSyncCandidateLess(neverAttempted, closerToStale) {
+		t.Fatal("did not expect never-attempted empty account to outrank account closer to stale deadline")
+	}
 }
 
 func TestSyncActiveLiveAccountsUsesCandidatePriorityOrder(t *testing.T) {


### PR DESCRIPTION
## 目的
实现 issue #244 的 PR6：account sync 调度进阶，在 active live account sync dispatcher 中加入候选优先级、deadline 和 starvation 防护。

本 PR 只改变 `sync-active-live-accounts` 的候选执行顺序，不改变 direct/manual sync、不改变 Binance REST request scheduler、不改变 order submit/cancel/dispatch 行为。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [x] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## Root cause
PR4 已实现 account sync 最小间隔、提前刷新和全局并发 gate；PR5 已提供 queue/wait/duration/failure 观测。但 active sync dispatcher 仍按 live session/account 遍历顺序执行候选，无法表达：

- 有仓位/挂单账户应该优先同步
- 快接近 stale deadline 的账户应该优先同步
- 长时间没有尝试的账户不能被持续排在后面

## 修改点
- `syncActiveLiveAccounts` 改为先收集候选，再排序执行。
- 新增 `liveAccountSyncCandidate` 打分：
  - reconcile pending 最高优先级
  - 有持仓账户优先
  - 有挂单账户优先
  - 越接近 stale deadline 分数越高
  - lastAttempt 越久，starvation 分数越高
- 增加候选选择日志：
  - `rank`
  - `candidate_count`
  - `score`
  - `position_count`
  - `open_order_count`
  - `age_seconds`
  - `seconds_until_stale`
  - `attempt_age_seconds`
  - `reconcile_pending`

## 行为变化
- 多个 active account 同时需要 sync 时，不再只按 session 遍历顺序执行。
- 有仓位/挂单、接近 stale、长时间未尝试的账户会更靠前。
- direct/manual sync、authoritative reconcile、startup recovery 等触发路径不受此排序影响。
- 不改变 account sync 是否触发的阈值，只改变 eligible candidates 的执行顺序。

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) - 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？- 无
- [x] DB migration 是否具备向下兼容幂等性？- 不涉及 migration
- [x] 配置字段有没有无意被混改？- 无新增 runtimePolicy 字段

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

本地验证：

```text
/opt/homebrew/bin/go test ./internal/service -run 'TestLiveAccountSyncCandidatePrioritizesPositionDeadlineAndStarvation|TestSyncActiveLiveAccountsUsesCandidatePriorityOrder|TestSyncActiveLiveAccountsThrottlesFailedRetriesUntilFreshnessWindow|TestShouldRefreshLiveAccountSyncUsesEarlyRefreshWindow'
/opt/homebrew/bin/go test ./...
/opt/homebrew/bin/go build ./cmd/platform-api
/opt/homebrew/bin/go build ./cmd/db-migrate
```

新增测试覆盖：

- 有仓位账户优先于仅接近 stale 的账户
- 无仓位时更接近 stale deadline 的账户优先
- 同等 urgency 下更久未尝试的账户优先，防 starvation
- `syncActiveLiveAccounts` 实际按 candidate priority 执行，而不是按 session 创建顺序

## 后续 PR
- PR2：Binance REST exchange request scheduler，按 order/account/reconcile/history/public 拆队列、优先级、deadline 和 queue wait 指标。

Part of #244.
