### PR TITLE
[codex] Adjust SL reentry schedule sizing

### DIFF
--- a/internal/service/execution_strategy.go
+++ b/internal/service/execution_strategy.go
@@ -480,6 +480,9 @@ func resolveReentryScheduleQuantity(session domain.LiveSession, account domain.A
 	if index < 0 {
 		index = 0
 	}
+	if reasonTag == "sl-reentry" && index == 0 && len(schedule) > 1 {
+		index = 1
+	}
 	if index >= len(schedule) {
 		index = len(schedule) - 1
 	}

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -1710,6 +1710,68 @@ func TestBookAwareExecutionStrategyUsesReentrySizeScheduleForLiveEntry(t *testin
 	}
 }
 
+func TestBookAwareExecutionStrategyStartsSLReentryAtSecondScheduleSlot(t *testing.T) {
+	strategy := bookAwareExecutionStrategy{}
+	account := domain.Account{
+		Metadata: map[string]any{
+			"liveSyncSnapshot": map[string]any{
+				"availableBalance": 1000.0,
+			},
+		},
+	}
+	execution := StrategyExecutionContext{
+		Parameters: map[string]any{
+			"executionMaxSpreadBps": 8.0,
+			"reentry_size_schedule": []float64{0.20, 0.10},
+		},
+	}
+	intent := SignalIntent{
+		Action:        "entry",
+		Role:          "entry",
+		Reason:        "SL-Reentry",
+		Side:          "BUY",
+		Symbol:        "BTCUSDT",
+		SignalKind:    "sl-reentry",
+		DecisionState: "entry-ready",
+		PriceHint:     25000,
+		PriceSource:   "trade_tick.price",
+		Metadata: map[string]any{
+			"bestBid":                       24999.5,
+			"bestAsk":                       25000.0,
+			"spreadBps":                     0.1,
+			"signalBarStateKey":             "state-schedule",
+			liveSignalBarTradeLimitKeyField: "BTCUSDT|30m|2026-04-22T06:30:00Z",
+		},
+	}
+
+	proposal, err := strategy.BuildProposal(ExecutionPlanningContext{
+		Session: domain.LiveSession{
+			State: map[string]any{
+				"positionSizingMode":    "reentry_size_schedule",
+				"defaultOrderQuantity":  0.002,
+				"lastSignalBarStateKey": "BTCUSDT|30m|2026-04-22T06:00:00Z",
+				"sessionReentryCount":   1.0,
+				"max_trades_per_bar":    2,
+			},
+		},
+		Account:   account,
+		Execution: execution,
+		Intent:    intent,
+	})
+	if err != nil {
+		t.Fatalf("unexpected proposal error: %v", err)
+	}
+	if proposal.Quantity != 0.004 {
+		t.Fatalf("expected SL-Reentry to use 10%% schedule slot after stop, got %v", proposal.Quantity)
+	}
+	if got := parseFloatValue(proposal.Metadata["sizingReentryScheduleIndex"]); got != 1 {
+		t.Fatalf("expected SL-Reentry schedule index 1, got %v", got)
+	}
+	if got := parseFloatValue(proposal.Metadata["sizingReentryFraction"]); got != 0.10 {
+		t.Fatalf("expected SL-Reentry fraction 0.10, got %v", got)
+	}
+}
+
 func TestBookAwareExecutionStrategyUsesPositionQuantityForScheduledReentryExits(t *testing.T) {
 	strategy := bookAwareExecutionStrategy{}
 	for _, tc := range []struct {


### PR DESCRIPTION
## 目的
修正 `SL-Reentry` 的实盘 sizing 语义：止损后的同向重入不再因为跨到新 signal bar 就回到 `reentry_size_schedule` 第一档 20%，而是在存在第二档时从 10% 档起步。

Root cause: live sizing 的 schedule index 只按当前 signal bar 的 `sessionReentryCount` 推导。跨 bar 后 index 会重置为 0，导致 `SL-Reentry` 又按第一档 20% 下单。当前 baseline 语义下 `Initial` 只是打开 reentry window，第一笔真实仓位由 `Zero-Initial-Reentry` 承担；止损后的 `SL-Reentry` 应避免再次使用第一档满 size。

Codex 参与：本 PR 由 Codex 按用户确认实现，改动已通读并本地验证。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [x] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) — 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？— 无
- [x] DB migration 是否具备向下兼容幂等性？— 无 DB migration
- [x] 配置字段有没有无意被混改？— 仅消费既有 `reentry_size_schedule`

## 验证方式与测试证据
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

本地验证：
- `go test ./internal/service -run 'TestBookAwareExecutionStrategyUsesReentrySizeScheduleForLiveEntry|TestBookAwareExecutionStrategyStartsSLReentryAtSecondScheduleSlot|TestEffectiveReentryCountForSizing|TestValidateLiveSignalBarEntryTradeLimit|TestShouldAutoDispatchLiveIntentBlocksEntryAfterMaxTradesPerSignalBar|TestDispatchLiveSessionIntentRejectsEntryAfterMaxTradesPerSignalBar|TestDispatchLiveSessionIntentRejectsThirdEntryAfterInterveningExitOnSameSignalBar'`
- `go test ./internal/service`
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
- pre-push harness: graphify rebuild, high-risk defaults check, env safety check, backend checks all passed