### PR TITLE
[codex] Handle unknown-order cancel race

### DIFF
--- a/internal/service/live_execution.go
+++ b/internal/service/live_execution.go
@@ -1405,13 +1405,21 @@ func (p *Platform) syncLatestLiveSessionOrder(session domain.LiveSession, eventT
 					state["lastDispatchedOrderStatus"] = syncedOrder.Status
 					state["lastSyncedAt"] = eventTime.UTC().Format(time.RFC3339)
 					recordExecutionSyncResultHealth(state, eventTime, syncedOrder.Status, nil)
-					state["lastExecutionDispatch"] = executionDispatchSummary(mapValue(order.Metadata["executionProposal"]), syncedOrder, false)
+					dispatchOrder := syncedOrder
+					if strings.EqualFold(syncedOrder.Status, "CANCELLED") {
+						recordLiveExecutionTimeoutMetadata(state, eventTime, order)
+						dispatchOrder = withExecutionSubmissionFallback(syncedOrder, order)
+					}
+					state["lastExecutionDispatch"] = executionDispatchSummary(mapValue(order.Metadata["executionProposal"]), dispatchOrder, false)
 					updateExecutionEventStats(state, mapValue(order.Metadata["executionProposal"]), mapValue(state["lastExecutionDispatch"]))
 					appendTimelineEvent(state, "order", eventTime, "live-order-cancel-fallback-synced", map[string]any{
 						"orderId":     order.ID,
 						"cancelError": cancelErr.Error(),
 						"status":      syncedOrder.Status,
 					})
+					if strings.EqualFold(syncedOrder.Status, "CANCELLED") {
+						appendTimelineEvent(state, "order", eventTime, "live-order-cancelled-timeout", executionTimeoutTimelineMetadata(order, dispatchOrder))
+					}
 					if strings.EqualFold(syncedOrder.Status, "FILLED") {
 						if _, accountSyncErr := p.requestLiveAccountSync(session.AccountID, "live-filled-order-sync"); accountSyncErr != nil && !errors.Is(accountSyncErr, ErrLiveAccountOperationInProgress) {
 							p.logger("service.live_execution", "session_id", session.ID, "account_id", session.AccountID).Warn("live account sync failed after cancel fallback order sync", "error", accountSyncErr)
@@ -1460,18 +1468,10 @@ func (p *Platform) syncLatestLiveSessionOrder(session domain.LiveSession, eventT
 		state["lastDispatchedOrderStatus"] = cancelledOrder.Status
 		state["lastSyncedAt"] = eventTime.UTC().Format(time.RFC3339)
 		recordExecutionSyncResultHealth(state, eventTime, cancelledOrder.Status, nil)
-		state["lastExecutionTimeoutAt"] = eventTime.UTC().Format(time.RFC3339)
-		state["lastExecutionTimeoutReason"] = "resting-order-expired"
+		recordLiveExecutionTimeoutMetadata(state, eventTime, order)
 		timeoutOrder := withExecutionSubmissionFallback(cancelledOrder, order)
 		state["lastExecutionDispatch"] = executionDispatchSummary(mapValue(order.Metadata["executionProposal"]), timeoutOrder, false)
 		updateExecutionEventStats(state, mapValue(order.Metadata["executionProposal"]), mapValue(state["lastExecutionDispatch"]))
-		timeoutSignature := buildLiveIntentSignature(mapValue(order.Metadata["executionProposal"]))
-		if timeoutSignature == "" {
-			timeoutSignature = buildLiveIntentSignature(mapValue(order.Metadata["intent"]))
-		}
-		if timeoutSignature != "" {
-			state["lastExecutionTimeoutIntentSignature"] = timeoutSignature
-		}
 		appendTimelineEvent(state, "order", eventTime, "live-order-cancelled-timeout", executionTimeoutTimelineMetadata(order, timeoutOrder))
 		return p.store.UpdateLiveSessionState(session.ID, state)
 	}
@@ -1567,6 +1567,21 @@ func shouldCancelLiveOrderForExecutionTimeout(order domain.Order, eventTime time
 		return false
 	}
 	return !eventTime.UTC().Before(expiresAt.UTC())
+}
+
+func recordLiveExecutionTimeoutMetadata(state map[string]any, eventTime time.Time, order domain.Order) {
+	if state == nil {
+		return
+	}
+	state["lastExecutionTimeoutAt"] = eventTime.UTC().Format(time.RFC3339)
+	state["lastExecutionTimeoutReason"] = "resting-order-expired"
+	timeoutSignature := buildLiveIntentSignature(mapValue(order.Metadata["executionProposal"]))
+	if timeoutSignature == "" {
+		timeoutSignature = buildLiveIntentSignature(mapValue(order.Metadata["intent"]))
+	}
+	if timeoutSignature != "" {
+		state["lastExecutionTimeoutIntentSignature"] = timeoutSignature
+	}
 }
 
 func shouldSyncLiveOrderAfterCancelError(err error) bool {

--- a/internal/service/live_execution.go
+++ b/internal/service/live_execution.go
@@ -1392,8 +1392,55 @@ func (p *Platform) syncLatestLiveSessionOrder(session domain.LiveSession, eventT
 		state["lastSyncAttemptAt"] = eventTime.UTC().Format(time.RFC3339)
 		recordExecutionSyncAttemptHealth(state, eventTime)
 		if cancelErr != nil {
+			syncAfterCancelError := shouldSyncLiveOrderAfterCancelError(cancelErr)
+			var fallbackSyncErr error
+			if syncAfterCancelError {
+				syncedOrder, syncErr := p.SyncLiveOrder(order.ID)
+				if syncErr == nil {
+					delete(state, "lastSyncError")
+					delete(state, "lastCancelFallbackSyncError")
+					maybeIncrementLiveSessionReentryCount(state, mapValue(order.Metadata["executionProposal"]), syncedOrder.ID, syncedOrder.Status)
+					state["lastSyncedOrderId"] = syncedOrder.ID
+					state["lastSyncedOrderStatus"] = syncedOrder.Status
+					state["lastDispatchedOrderStatus"] = syncedOrder.Status
+					state["lastSyncedAt"] = eventTime.UTC().Format(time.RFC3339)
+					recordExecutionSyncResultHealth(state, eventTime, syncedOrder.Status, nil)
+					state["lastExecutionDispatch"] = executionDispatchSummary(mapValue(order.Metadata["executionProposal"]), syncedOrder, false)
+					updateExecutionEventStats(state, mapValue(order.Metadata["executionProposal"]), mapValue(state["lastExecutionDispatch"]))
+					appendTimelineEvent(state, "order", eventTime, "live-order-cancel-fallback-synced", map[string]any{
+						"orderId":     order.ID,
+						"cancelError": cancelErr.Error(),
+						"status":      syncedOrder.Status,
+					})
+					if strings.EqualFold(syncedOrder.Status, "FILLED") {
+						if _, accountSyncErr := p.requestLiveAccountSync(session.AccountID, "live-filled-order-sync"); accountSyncErr != nil && !errors.Is(accountSyncErr, ErrLiveAccountOperationInProgress) {
+							p.logger("service.live_execution", "session_id", session.ID, "account_id", session.AccountID).Warn("live account sync failed after cancel fallback order sync", "error", accountSyncErr)
+						}
+					}
+					updated, updateErr := p.store.UpdateLiveSessionState(session.ID, state)
+					if updateErr != nil {
+						return domain.LiveSession{}, updateErr
+					}
+					if strings.EqualFold(syncedOrder.Status, "FILLED") {
+						if refreshed, refreshErr := p.refreshLiveSessionPositionContext(updated, eventTime, "live-order-cancel-fallback-sync"); refreshErr == nil {
+							return refreshed, nil
+						}
+					}
+					return updated, nil
+				}
+				fallbackSyncErr = syncErr
+				state["lastCancelFallbackSyncError"] = syncErr.Error()
+				recordExecutionSyncResultHealth(state, eventTime, order.Status, syncErr)
+				appendTimelineEvent(state, "order", eventTime, "live-order-cancel-fallback-sync-error", map[string]any{
+					"orderId":     order.ID,
+					"cancelError": cancelErr.Error(),
+					"syncError":   syncErr.Error(),
+				})
+			}
 			state["lastSyncError"] = cancelErr.Error()
-			recordExecutionSyncResultHealth(state, eventTime, order.Status, cancelErr)
+			if !syncAfterCancelError {
+				recordExecutionSyncResultHealth(state, eventTime, order.Status, cancelErr)
+			}
 			appendTimelineEvent(state, "order", eventTime, "live-order-cancel-error", map[string]any{
 				"orderId": order.ID,
 				"error":   cancelErr.Error(),
@@ -1401,6 +1448,9 @@ func (p *Platform) syncLatestLiveSessionOrder(session domain.LiveSession, eventT
 			updated, updateErr := p.store.UpdateLiveSessionState(session.ID, state)
 			if updateErr != nil {
 				return domain.LiveSession{}, updateErr
+			}
+			if fallbackSyncErr != nil {
+				return updated, fallbackSyncErr
 			}
 			return updated, cancelErr
 		}
@@ -1517,6 +1567,17 @@ func shouldCancelLiveOrderForExecutionTimeout(order domain.Order, eventTime time
 		return false
 	}
 	return !eventTime.UTC().Before(expiresAt.UTC())
+}
+
+func shouldSyncLiveOrderAfterCancelError(err error) bool {
+	if err == nil {
+		return false
+	}
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "unknown order sent") ||
+		strings.Contains(message, `"code":-2011`) ||
+		strings.Contains(message, `"code": -2011`) ||
+		strings.Contains(message, "code=-2011")
 }
 
 func shouldAdvanceLivePlanForOrderStatus(status string) bool {

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -3886,6 +3886,112 @@ func TestSyncLatestLiveSessionOrderSyncsAfterUnknownOrderCancelRace(t *testing.T
 	}
 }
 
+func TestSyncLatestLiveSessionOrderMarksTimeoutAfterUnknownOrderCancelRaceCancelled(t *testing.T) {
+	platform, session, _, _, _ := prepareLiveDecisionTelemetryFixture(t)
+	var syncCount int64
+	platform.registerLiveAdapter(testLiveAccountSyncAdapter{
+		key: "test-cancel-unknown-sync-cancelled",
+		cancelOrderFunc: func(domain.Account, domain.Order, map[string]any) (LiveOrderSync, error) {
+			return LiveOrderSync{}, fmt.Errorf(`binance request failed: 400 Bad Request {"code":-2011,"msg":"Unknown order sent."}`)
+		},
+		syncOrderFunc: func(domain.Account, domain.Order, map[string]any) (LiveOrderSync, error) {
+			atomic.AddInt64(&syncCount, 1)
+			return LiveOrderSync{
+				Status:   "CANCELLED",
+				SyncedAt: "2026-04-27T13:09:46Z",
+				Metadata: map[string]any{
+					"updateTime": "2026-04-27T13:09:46Z",
+				},
+				Terminal: true,
+			}, nil
+		},
+	})
+
+	account, err := platform.store.GetAccount("live-main")
+	if err != nil {
+		t.Fatalf("get account failed: %v", err)
+	}
+	account.Status = "READY"
+	account.Metadata = cloneMetadata(account.Metadata)
+	account.Metadata["liveBinding"] = map[string]any{
+		"adapterKey":     "test-cancel-unknown-sync-cancelled",
+		"connectionMode": "mock",
+		"executionMode":  "mock",
+	}
+	if _, err := platform.store.UpdateAccount(account); err != nil {
+		t.Fatalf("update account failed: %v", err)
+	}
+
+	eventTime := time.Date(2026, 4, 27, 13, 9, 46, 0, time.UTC)
+	intent := map[string]any{
+		"action":            "entry",
+		"side":              "BUY",
+		"symbol":            "BTCUSDT",
+		"signalKind":        "initial-entry",
+		"signalBarStateKey": "state-1",
+	}
+	signature := buildLiveIntentSignature(intent)
+	proposal := cloneMetadata(intent)
+	proposal["role"] = "entry"
+	proposal["reason"] = "Initial"
+	proposal["type"] = "LIMIT"
+	proposal["quantity"] = 0.002
+	order, err := platform.store.CreateOrder(domain.Order{
+		AccountID:         session.AccountID,
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "BUY",
+		Type:              "LIMIT",
+		Status:            "PARTIALLY_FILLED",
+		Quantity:          0.002,
+		Price:             69000.0,
+		Metadata: map[string]any{
+			"source":             "live-session-intent",
+			"liveSessionId":      session.ID,
+			"executionExpiresAt": eventTime.Format(time.RFC3339),
+			"executionProposal":  proposal,
+		},
+	})
+	if err != nil {
+		t.Fatalf("create live order failed: %v", err)
+	}
+	state := cloneMetadata(session.State)
+	state["dispatchMode"] = "auto-dispatch"
+	state["dispatchCooldownSeconds"] = 300
+	state["lastDispatchedAt"] = eventTime.Format(time.RFC3339)
+	state["lastDispatchedIntentSignature"] = signature
+	state["lastDispatchedOrderId"] = order.ID
+	state["lastDispatchedOrderStatus"] = "PARTIALLY_FILLED"
+	state["lastSyncedOrderStatus"] = "PARTIALLY_FILLED"
+	session, err = platform.store.UpdateLiveSessionState(session.ID, state)
+	if err != nil {
+		t.Fatalf("update live session state failed: %v", err)
+	}
+
+	updated, err := platform.syncLatestLiveSessionOrder(session, eventTime)
+	if err != nil {
+		t.Fatalf("expected unknown-order cancel race to fall back to cancelled order sync, got %v", err)
+	}
+	if got := atomic.LoadInt64(&syncCount); got != 1 {
+		t.Fatalf("expected one fallback order sync, got %d", got)
+	}
+	if got := stringValue(updated.State["lastSyncedOrderStatus"]); got != "CANCELLED" {
+		t.Fatalf("expected synced CANCELLED status, got %s", got)
+	}
+	if got := stringValue(updated.State["lastExecutionTimeoutReason"]); got != "resting-order-expired" {
+		t.Fatalf("expected timeout reason to be recorded, got %q", got)
+	}
+	if got := stringValue(updated.State["lastExecutionTimeoutIntentSignature"]); got != signature {
+		t.Fatalf("expected timeout signature %q, got %q", signature, got)
+	}
+	if got := stringValue(updated.State["lastExecutionTimeoutAt"]); got != eventTime.Format(time.RFC3339) {
+		t.Fatalf("expected timeout timestamp %s, got %q", eventTime.Format(time.RFC3339), got)
+	}
+	if !shouldAutoDispatchLiveIntent(updated, intent, eventTime) {
+		t.Fatal("expected cancel-race timeout to allow immediate retry for the same intent")
+	}
+}
+
 func TestSyncLatestLiveSessionOrderReturnsFallbackSyncErrorAfterUnknownOrderCancel(t *testing.T) {
 	platform, session, _, _, _ := prepareLiveDecisionTelemetryFixture(t)
 	var syncCount int64

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -3775,6 +3775,195 @@ func TestShouldCancelLiveOrderForExecutionTimeout(t *testing.T) {
 	}
 }
 
+func TestSyncLatestLiveSessionOrderSyncsAfterUnknownOrderCancelRace(t *testing.T) {
+	platform, session, _, _, _ := prepareLiveDecisionTelemetryFixture(t)
+	var cancelCount int64
+	var syncCount int64
+	platform.registerLiveAdapter(testLiveAccountSyncAdapter{
+		key: "test-cancel-unknown-sync",
+		cancelOrderFunc: func(domain.Account, domain.Order, map[string]any) (LiveOrderSync, error) {
+			atomic.AddInt64(&cancelCount, 1)
+			return LiveOrderSync{}, fmt.Errorf(`binance request failed: 400 Bad Request {"code":-2011,"msg":"Unknown order sent."}`)
+		},
+		syncOrderFunc: func(_ domain.Account, order domain.Order, _ map[string]any) (LiveOrderSync, error) {
+			atomic.AddInt64(&syncCount, 1)
+			return LiveOrderSync{
+				Status:   "FILLED",
+				SyncedAt: "2026-04-27T13:09:46Z",
+				Fills: []LiveFillReport{{
+					Quantity: order.Quantity,
+					Price:    69000.0,
+					Metadata: map[string]any{"tradeTime": "2026-04-27T13:09:46Z"},
+				}},
+				Metadata: map[string]any{
+					"executedQty": order.Quantity,
+					"avgPrice":    69000.0,
+					"updateTime":  "2026-04-27T13:09:46Z",
+				},
+				Terminal: true,
+			}, nil
+		},
+	})
+
+	account, err := platform.store.GetAccount("live-main")
+	if err != nil {
+		t.Fatalf("get account failed: %v", err)
+	}
+	account.Status = "READY"
+	account.Metadata = cloneMetadata(account.Metadata)
+	account.Metadata["liveBinding"] = map[string]any{
+		"adapterKey":     "test-cancel-unknown-sync",
+		"connectionMode": "mock",
+		"executionMode":  "mock",
+	}
+	if _, err := platform.store.UpdateAccount(account); err != nil {
+		t.Fatalf("update account failed: %v", err)
+	}
+
+	eventTime := time.Date(2026, 4, 27, 13, 9, 46, 0, time.UTC)
+	proposal := map[string]any{
+		"role":     "entry",
+		"reason":   "Initial",
+		"side":     "BUY",
+		"symbol":   "BTCUSDT",
+		"type":     "LIMIT",
+		"quantity": 0.002,
+	}
+	order, err := platform.store.CreateOrder(domain.Order{
+		AccountID:         session.AccountID,
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "BUY",
+		Type:              "LIMIT",
+		Status:            "PARTIALLY_FILLED",
+		Quantity:          0.002,
+		Price:             69000.0,
+		Metadata: map[string]any{
+			"source":             "live-session-intent",
+			"liveSessionId":      session.ID,
+			"executionExpiresAt": eventTime.Format(time.RFC3339),
+			"executionProposal":  proposal,
+		},
+	})
+	if err != nil {
+		t.Fatalf("create live order failed: %v", err)
+	}
+	state := cloneMetadata(session.State)
+	state["lastDispatchedOrderId"] = order.ID
+	state["lastDispatchedOrderStatus"] = "PARTIALLY_FILLED"
+	state["lastSyncedOrderStatus"] = "PARTIALLY_FILLED"
+	state["lastSyncError"] = "previous stale sync error"
+	session, err = platform.store.UpdateLiveSessionState(session.ID, state)
+	if err != nil {
+		t.Fatalf("update live session state failed: %v", err)
+	}
+
+	updated, err := platform.syncLatestLiveSessionOrder(session, eventTime)
+	if err != nil {
+		t.Fatalf("expected unknown-order cancel race to fall back to order sync, got %v", err)
+	}
+	if got := atomic.LoadInt64(&cancelCount); got != 1 {
+		t.Fatalf("expected one cancel attempt, got %d", got)
+	}
+	if got := atomic.LoadInt64(&syncCount); got != 1 {
+		t.Fatalf("expected one fallback order sync, got %d", got)
+	}
+	if got := stringValue(updated.State["lastSyncError"]); got != "" {
+		t.Fatalf("expected fallback sync to clear lastSyncError, got %q", got)
+	}
+	if got := stringValue(updated.State["lastSyncedOrderStatus"]); got != "FILLED" {
+		t.Fatalf("expected synced FILLED status, got %s", got)
+	}
+	syncedOrder, err := platform.GetOrder(order.ID)
+	if err != nil {
+		t.Fatalf("get synced order failed: %v", err)
+	}
+	if got := syncedOrder.Status; got != "FILLED" {
+		t.Fatalf("expected persisted order status FILLED, got %s", got)
+	}
+	if got := parseFloatValue(syncedOrder.Metadata["filledQuantity"]); got != 0.002 {
+		t.Fatalf("expected filled quantity 0.002, got %v", got)
+	}
+}
+
+func TestSyncLatestLiveSessionOrderReturnsFallbackSyncErrorAfterUnknownOrderCancel(t *testing.T) {
+	platform, session, _, _, _ := prepareLiveDecisionTelemetryFixture(t)
+	var syncCount int64
+	platform.registerLiveAdapter(testLiveAccountSyncAdapter{
+		key: "test-cancel-unknown-sync-failure",
+		cancelOrderFunc: func(domain.Account, domain.Order, map[string]any) (LiveOrderSync, error) {
+			return LiveOrderSync{}, fmt.Errorf(`binance request failed: 400 Bad Request {"code":-2011,"msg":"Unknown order sent."}`)
+		},
+		syncOrderFunc: func(domain.Account, domain.Order, map[string]any) (LiveOrderSync, error) {
+			atomic.AddInt64(&syncCount, 1)
+			return LiveOrderSync{}, fmt.Errorf("fallback order sync failed")
+		},
+	})
+
+	account, err := platform.store.GetAccount("live-main")
+	if err != nil {
+		t.Fatalf("get account failed: %v", err)
+	}
+	account.Status = "READY"
+	account.Metadata = cloneMetadata(account.Metadata)
+	account.Metadata["liveBinding"] = map[string]any{
+		"adapterKey":     "test-cancel-unknown-sync-failure",
+		"connectionMode": "mock",
+		"executionMode":  "mock",
+	}
+	if _, err := platform.store.UpdateAccount(account); err != nil {
+		t.Fatalf("update account failed: %v", err)
+	}
+
+	eventTime := time.Date(2026, 4, 27, 13, 9, 46, 0, time.UTC)
+	order, err := platform.store.CreateOrder(domain.Order{
+		AccountID:         session.AccountID,
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "BUY",
+		Type:              "LIMIT",
+		Status:            "PARTIALLY_FILLED",
+		Quantity:          0.002,
+		Price:             69000.0,
+		Metadata: map[string]any{
+			"source":             "live-session-intent",
+			"liveSessionId":      session.ID,
+			"executionExpiresAt": eventTime.Format(time.RFC3339),
+			"executionProposal": map[string]any{
+				"role":     "entry",
+				"reason":   "Initial",
+				"side":     "BUY",
+				"symbol":   "BTCUSDT",
+				"type":     "LIMIT",
+				"quantity": 0.002,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("create live order failed: %v", err)
+	}
+	state := cloneMetadata(session.State)
+	state["lastDispatchedOrderId"] = order.ID
+	session, err = platform.store.UpdateLiveSessionState(session.ID, state)
+	if err != nil {
+		t.Fatalf("update live session state failed: %v", err)
+	}
+
+	updated, err := platform.syncLatestLiveSessionOrder(session, eventTime)
+	if err == nil || !strings.Contains(err.Error(), "fallback order sync failed") {
+		t.Fatalf("expected fallback sync failure to be returned, got %v", err)
+	}
+	if got := atomic.LoadInt64(&syncCount); got != 1 {
+		t.Fatalf("expected fallback order sync attempt, got %d", got)
+	}
+	if got := stringValue(updated.State["lastCancelFallbackSyncError"]); got != "fallback order sync failed" {
+		t.Fatalf("expected fallback sync error in state, got %q", got)
+	}
+	if got := stringValue(updated.State["lastSyncedOrderStatus"]); got == "FILLED" {
+		t.Fatal("expected failed fallback sync not to mark order filled")
+	}
+}
+
 func TestMaybeIncrementLiveSessionReentryCountOnlyCountsFilledReentries(t *testing.T) {
 	state := map[string]any{
 		"sessionReentryCount": 0.0,


### PR DESCRIPTION
## 目的
修复 live 策略执行中 resting order 超时撤单与交易所最终成交同时发生时的竞态。

Root cause: 本地在 `executionExpiresAt` 到期后进入 `CancelLiveOrder()`，如果 Binance 此时已经把订单成交/终态化，撤单会返回 `-2011 Unknown order sent`。原逻辑直接把这个 cancel error 作为最终失败返回，没有继续用 REST `SyncLiveOrder()` 拉取交易所事实，导致 `lastSyncError`、`lastSyncedOrderStatus` 和 position context 滞后。

本 PR 在该特定撤单错误后补一次订单同步：
- fallback sync 成功时，按同步到的真实订单状态更新 session/order，并在 `FILLED` 时继续触发账户同步与 position context refresh。
- fallback sync 失败时，真实返回 sync error，并记录 `lastCancelFallbackSyncError`，不把失败伪装成成功。
- 其他撤单错误保持原失败路径。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [x] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) — 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？— 无
- [x] DB migration 是否具备向下兼容幂等性？— 不涉及 migration
- [x] 配置字段有没有无意被混改？— 无配置字段变更

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

本地验证：
- `go test ./internal/service -run 'TestSyncLatestLiveSessionOrderSyncsAfterUnknownOrderCancelRace|TestSyncLatestLiveSessionOrderReturnsFallbackSyncErrorAfterUnknownOrderCancel|TestShouldCancelLiveOrderForExecutionTimeout'`
- `go test ./internal/service`
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
- `git diff --check`
- `/usr/local/bin/python3.12 -c "from graphify.watch import _rebuild_code; from pathlib import Path; _rebuild_code(Path('.'))"`

Agent: Codex assisted with implementation, tests, validation, graphify rebuild, branch push, and draft PR creation.

Note: PR #262 was opened from the wrong base branch and closed as superseded. This PR is based on `main` and contains only the scoped live cancel-race fix.