### PR TITLE
[codex] Add BTC 30m enhanced live t3 strategy

### DIFF
--- a/db/migrations/026_btc_30m_enhanced_strategy.sql
+++ b/db/migrations/026_btc_30m_enhanced_strategy.sql
@@ -1,0 +1,52 @@
+insert into strategies (id, name, status, description, created_at)
+values (
+    'strategy-bk-btc-30m-enhanced',
+    'BK BTCUSDT 30m Enhanced',
+    'ACTIVE',
+    'BTCUSDT 30m live intrabar SMA5 baseline plus t3 breakout with sep_0p25.',
+    now()
+)
+on conflict (id) do nothing;
+
+insert into strategy_versions (
+    id,
+    strategy_id,
+    version,
+    signal_timeframe,
+    execution_timeframe,
+    parameters,
+    created_at
+)
+values (
+    'strategy-version-bk-btc-30m-enhanced-v010',
+    'strategy-bk-btc-30m-enhanced',
+    'v0.1.0',
+    '30m',
+    'tick',
+    '{
+        "strategyEngine": "bk-live-intrabar-sma5-t3-sep",
+        "symbol": "BTCUSDT",
+        "signalTimeframe": "30m",
+        "executionDataSource": "tick",
+        "positionSizingMode": "reentry_size_schedule",
+        "dir2_zero_initial": true,
+        "zero_initial_mode": "reentry_window",
+        "max_trades_per_bar": 2,
+        "reentry_size_schedule": [0.20, 0.10],
+        "breakout_shape": "baseline_plus_t3",
+        "t3_min_sma_atr_separation": 0.25,
+        "use_sma5_intraday_structure": true,
+        "stop_mode": "atr",
+        "stop_loss_atr": 0.05,
+        "profit_protect_atr": 1.0,
+        "trailing_stop_atr": 0.3,
+        "delayed_trailing_activation_atr": 0.5,
+        "long_reentry_atr": 0.1,
+        "short_reentry_atr": 0.0,
+        "tradingFeeBps": 10.0,
+        "fundingRateBps": 0.0,
+        "fundingIntervalHours": 8
+    }'::jsonb,
+    now()
+)
+on conflict (id) do nothing;

--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -4153,6 +4153,7 @@ func (p *Platform) evaluateLiveSignalDecision(session domain.LiveSession, summar
 }
 
 func alignLivePlanStepToCurrentMarket(
+	parameters map[string]any,
 	signalBarStates map[string]any,
 	signalTimeframe string,
 	currentPosition map[string]any,
@@ -4173,7 +4174,7 @@ func alignLivePlanStepToCurrentMarket(
 	if signalBarState == nil {
 		return nextPlannedEvent, nextPlannedPrice, nextPlannedSide, nextPlannedRole, nextPlannedReason
 	}
-	gate := evaluateSignalBarGate(signalBarState, "", "entry", "", breakoutPrice, breakoutPriceSource)
+	gate := evaluateSignalBarGate(signalBarState, "", "entry", "", breakoutPrice, breakoutPriceSource, signalBarGateOptionsFromParameters(parameters))
 	longReady := boolValue(gate["longReady"])
 	shortReady := boolValue(gate["shortReady"])
 	if longReady == shortReady {

--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -5206,6 +5206,9 @@ func (p *Platform) resolveLiveSessionParameters(session domain.LiveSession, vers
 		"max_trades_per_bar",
 		"dir2_zero_initial",
 		"zero_initial_mode",
+		"breakout_shape",
+		"t3_min_sma_atr_separation",
+		"use_sma5_intraday_structure",
 	}
 	sessionParameterKeys = append(sessionParameterKeys, liveExecutionParameterOverrideKeys()...)
 	for _, key := range sessionParameterKeys {
@@ -5718,6 +5721,15 @@ func normalizeLiveSessionOverrides(overrides map[string]any) map[string]any {
 	}
 	if seconds := maxIntValue(overrides["dispatchCooldownSeconds"], 0); seconds > 0 {
 		normalized["dispatchCooldownSeconds"] = seconds
+	}
+	if shape := strings.ToLower(strings.TrimSpace(stringValue(overrides["breakout_shape"]))); shape != "" {
+		normalized["breakout_shape"] = shape
+	}
+	if separation := parseFloatValue(overrides["t3_min_sma_atr_separation"]); separation > 0 {
+		normalized["t3_min_sma_atr_separation"] = separation
+	}
+	if _, ok := overrides["use_sma5_intraday_structure"]; ok {
+		normalized["use_sma5_intraday_structure"] = boolValue(overrides["use_sma5_intraday_structure"])
 	}
 	return normalized
 }

--- a/internal/service/live_launch_flow_template_test.go
+++ b/internal/service/live_launch_flow_template_test.go
@@ -204,6 +204,58 @@ func TestLaunchLiveFlowTemplateSwitchReplacesBindingsAndRefreshesRuntimePlan(t *
 	}
 }
 
+func TestLaunchLiveFlowEnhancedTemplateUsesEnhancedStrategyAndEngine(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+
+	templates, err := platform.LiveLaunchTemplates()
+	if err != nil {
+		t.Fatalf("list live launch templates failed: %v", err)
+	}
+	var enhanced LiveLaunchTemplate
+	for _, item := range templates {
+		if item.Key == "binance-testnet-btc-30m-enhanced" {
+			enhanced = item
+			break
+		}
+	}
+	if enhanced.Key == "" {
+		t.Fatal("expected enhanced BTCUSDT 30m launch template")
+	}
+
+	result, err := platform.LaunchLiveFlow("live-main", enhanced.LaunchPayload)
+	if err != nil {
+		t.Fatalf("launch enhanced live flow failed: %v", err)
+	}
+	if result.LiveSession.StrategyID != "strategy-bk-btc-30m-enhanced" {
+		t.Fatalf("expected enhanced live session strategy, got %s", result.LiveSession.StrategyID)
+	}
+	if result.RuntimeSession.StrategyID != "strategy-bk-btc-30m-enhanced" {
+		t.Fatalf("expected enhanced runtime strategy, got %s", result.RuntimeSession.StrategyID)
+	}
+	if got := stringValue(result.LiveSession.State["strategyEngine"]); got != "bk-live-intrabar-sma5-t3-sep" {
+		t.Fatalf("expected enhanced strategy engine, got %s", got)
+	}
+	if got := stringValue(result.LiveSession.State["breakout_shape"]); got != "baseline_plus_t3" {
+		t.Fatalf("expected baseline_plus_t3 breakout shape, got %s", got)
+	}
+	if got := parseFloatValue(result.LiveSession.State["t3_min_sma_atr_separation"]); got != 0.25 {
+		t.Fatalf("expected t3 sep_0p25, got %v", got)
+	}
+
+	bindings, err := platform.ListStrategySignalBindings("strategy-bk-btc-30m-enhanced")
+	if err != nil {
+		t.Fatalf("list enhanced strategy bindings failed: %v", err)
+	}
+	if len(bindings) != 3 {
+		t.Fatalf("expected enhanced launch to bind exactly three sources, got %#v", bindings)
+	}
+	for _, binding := range bindings {
+		if binding.Symbol != "BTCUSDT" {
+			t.Fatalf("expected BTCUSDT-only enhanced bindings, got %#v", bindings)
+		}
+	}
+}
+
 func TestSyncLiveSessionRuntimeReconcilesIntradayLaunchTemplateBaseline(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
 

--- a/internal/service/live_launch_templates.go
+++ b/internal/service/live_launch_templates.go
@@ -41,9 +41,15 @@ func (p *Platform) LiveLaunchTemplates() ([]LiveLaunchTemplate, error) {
 	if err != nil {
 		return nil, err
 	}
-	enhancedStrategyID, enhancedStrategyName, enhancedStrategyVersionID, _, err := p.resolveLiveTemplateStrategy("strategy-bk-btc-30m-enhanced")
-	if err != nil {
-		return nil, err
+	enhancedStrategyID := ""
+	enhancedStrategyName := ""
+	enhancedStrategyVersionID := ""
+	hasEnhancedTemplate := false
+	if id, name, versionID, _, err := p.resolveLiveTemplateStrategy("strategy-bk-btc-30m-enhanced"); err == nil {
+		enhancedStrategyID = id
+		enhancedStrategyName = name
+		enhancedStrategyVersionID = versionID
+		hasEnhancedTemplate = true
 	}
 
 	baseBinding := map[string]any{
@@ -202,17 +208,22 @@ func (p *Platform) LiveLaunchTemplates() ([]LiveLaunchTemplate, error) {
 		return item
 	}
 
-	return []LiveLaunchTemplate{
+	templates := []LiveLaunchTemplate{
 		buildTemplate("BTCUSDT", "5m", 0.002, false),
 		buildTemplate("BTCUSDT", "15m", 0.002, true),
 		buildTemplate("BTCUSDT", "30m", 0.002, true),
-		buildEnhancedTemplate(),
+	}
+	if hasEnhancedTemplate {
+		templates = append(templates, buildEnhancedTemplate())
+	}
+	templates = append(templates,
 		buildTemplate("BTCUSDT", "4h", 0.002, false),
 		buildTemplate("BTCUSDT", "1d", 0.002, false),
 		buildTemplate("ETHUSDT", "5m", 0.100, false),
 		buildTemplate("ETHUSDT", "4h", 0.100, false),
 		buildTemplate("ETHUSDT", "1d", 0.100, false),
-	}, nil
+	)
+	return templates, nil
 }
 
 func liveLaunchTemplateDispatchModeOptions() []string {

--- a/internal/service/live_launch_templates.go
+++ b/internal/service/live_launch_templates.go
@@ -41,6 +41,10 @@ func (p *Platform) LiveLaunchTemplates() ([]LiveLaunchTemplate, error) {
 	if err != nil {
 		return nil, err
 	}
+	enhancedStrategyID, enhancedStrategyName, enhancedStrategyVersionID, _, err := p.resolveLiveTemplateStrategy("strategy-bk-btc-30m-enhanced")
+	if err != nil {
+		return nil, err
+	}
 
 	baseBinding := map[string]any{
 		"adapterKey":    "binance-futures",
@@ -176,11 +180,33 @@ func (p *Platform) LiveLaunchTemplates() ([]LiveLaunchTemplate, error) {
 			Notes: notes,
 		}
 	}
+	buildEnhancedTemplate := func() LiveLaunchTemplate {
+		item := buildTemplate("BTCUSDT", "30m", 0.002, false)
+		item.Key = "binance-testnet-btc-30m-enhanced"
+		item.Name = "Binance Testnet BTCUSDT 30m Enhanced"
+		item.Description = "BTCUSDT 30m 增强策略：live_intrabar_sma5_baseline_plus_t3_breakout + t3 sep_0p25。"
+		item.StrategyID = enhancedStrategyID
+		item.StrategyName = enhancedStrategyName
+		item.StrategyVersionID = enhancedStrategyVersionID
+		for key, value := range liveBTC30mEnhancedOverrides() {
+			item.LaunchPayload.LiveSessionOverrides[key] = value
+		}
+		item.LaunchPayload.StrategyID = enhancedStrategyID
+		item.LaunchPayload.LaunchTemplateKey = item.Key
+		item.LaunchPayload.LaunchTemplateName = item.Name
+		item.Notes = append([]string{
+			fmt.Sprintf("增强模板单独使用 %s（strategyEngine=%s），不改变原 BTCUSDT 30m 模板。", enhancedStrategyName, "bk-live-intrabar-sma5-t3-sep"),
+			"策略口径对齐 research `live_intrabar_sma5_baseline_plus_t3_breakout+sep_0p25`：SMA5 intrabar hard filter + original_t2/t3_swing breakout，其中 sep_0p25 只过滤 t3_swing。",
+			"模板仍保持 dispatchMode 由前端提交前选择，默认展示为 manual-review。",
+		}, item.Notes...)
+		return item
+	}
 
 	return []LiveLaunchTemplate{
 		buildTemplate("BTCUSDT", "5m", 0.002, false),
 		buildTemplate("BTCUSDT", "15m", 0.002, true),
 		buildTemplate("BTCUSDT", "30m", 0.002, true),
+		buildEnhancedTemplate(),
 		buildTemplate("BTCUSDT", "4h", 0.002, false),
 		buildTemplate("BTCUSDT", "1d", 0.002, false),
 		buildTemplate("ETHUSDT", "5m", 0.100, false),
@@ -230,14 +256,22 @@ func liveIntradayResearchBaselineOverrides(strategyEngine string) map[string]any
 	}
 }
 
+func liveBTC30mEnhancedOverrides() map[string]any {
+	overrides := liveIntradayResearchBaselineOverrides("bk-live-intrabar-sma5-t3-sep")
+	overrides["max_trades_per_bar"] = domain.ResearchBaselineMaxTradesPerBar
+	overrides["stop_loss_atr"] = 0.05
+	overrides["breakout_shape"] = "baseline_plus_t3"
+	overrides["t3_min_sma_atr_separation"] = 0.25
+	overrides["use_sma5_intraday_structure"] = true
+	return overrides
+}
+
 func (p *Platform) resolvePrimaryLiveTemplateStrategy() (string, string, string, string, error) {
 	preferred := []string{"strategy-bk-1d"}
 	for _, strategyID := range preferred {
-		strategy, err := p.GetStrategy(strategyID)
-		if err != nil {
-			continue
+		if strategyID, strategyName, versionID, strategyEngine, err := p.resolveLiveTemplateStrategy(strategyID); err == nil {
+			return strategyID, strategyName, versionID, strategyEngine, nil
 		}
-		return liveTemplateStrategyMetadata(strategy)
 	}
 	strategies, err := p.ListStrategies()
 	if err != nil {
@@ -252,6 +286,14 @@ func (p *Platform) resolvePrimaryLiveTemplateStrategy() (string, string, string,
 		return liveTemplateStrategyMetadata(strategies[0])
 	}
 	return "", "", "", "", fmt.Errorf("no strategy available for live launch templates")
+}
+
+func (p *Platform) resolveLiveTemplateStrategy(strategyID string) (string, string, string, string, error) {
+	strategy, err := p.GetStrategy(strategyID)
+	if err != nil {
+		return "", "", "", "", err
+	}
+	return liveTemplateStrategyMetadata(strategy)
 }
 
 func liveTemplateStrategyMetadata(strategy map[string]any) (string, string, string, string, error) {

--- a/internal/service/live_launch_templates_test.go
+++ b/internal/service/live_launch_templates_test.go
@@ -3,8 +3,28 @@ package service
 import (
 	"testing"
 
+	storepkg "github.com/wuyaocheng/bktrader/internal/store"
 	"github.com/wuyaocheng/bktrader/internal/store/memory"
 )
+
+type hiddenEnhancedStrategyStore struct {
+	storepkg.Repository
+}
+
+func (s hiddenEnhancedStrategyStore) ListStrategies() ([]map[string]any, error) {
+	items, err := s.Repository.ListStrategies()
+	if err != nil {
+		return nil, err
+	}
+	filtered := make([]map[string]any, 0, len(items))
+	for _, item := range items {
+		if stringValue(item["id"]) == "strategy-bk-btc-30m-enhanced" {
+			continue
+		}
+		filtered = append(filtered, item)
+	}
+	return filtered, nil
+}
 
 func TestLiveLaunchTemplatesExposeBinanceTestnetVariants(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
@@ -185,6 +205,23 @@ func TestLiveLaunchTemplatesExposeBinanceTestnetVariants(t *testing.T) {
 		}
 		if item.LaunchPayload.LaunchTemplateKey != item.Key {
 			t.Fatalf("expected launch template key %s, got %s", item.Key, item.LaunchPayload.LaunchTemplateKey)
+		}
+	}
+}
+
+func TestLiveLaunchTemplatesSkipEnhancedWhenStrategyMissing(t *testing.T) {
+	platform := NewPlatform(hiddenEnhancedStrategyStore{Repository: memory.NewStore()})
+
+	templates, err := platform.LiveLaunchTemplates()
+	if err != nil {
+		t.Fatalf("list live launch templates failed: %v", err)
+	}
+	if len(templates) != 8 {
+		t.Fatalf("expected original 8 launch templates when enhanced strategy is missing, got %d", len(templates))
+	}
+	for _, item := range templates {
+		if item.Key == "binance-testnet-btc-30m-enhanced" {
+			t.Fatalf("expected enhanced template to be skipped when strategy is missing: %#v", templates)
 		}
 	}
 }

--- a/internal/service/live_launch_templates_test.go
+++ b/internal/service/live_launch_templates_test.go
@@ -6,15 +6,15 @@ import (
 	"github.com/wuyaocheng/bktrader/internal/store/memory"
 )
 
-func TestLiveLaunchTemplatesExposeEightBinanceTestnetVariants(t *testing.T) {
+func TestLiveLaunchTemplatesExposeBinanceTestnetVariants(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
 
 	templates, err := platform.LiveLaunchTemplates()
 	if err != nil {
 		t.Fatalf("list live launch templates failed: %v", err)
 	}
-	if len(templates) != 8 {
-		t.Fatalf("expected 8 launch templates, got %d", len(templates))
+	if len(templates) != 9 {
+		t.Fatalf("expected 9 launch templates, got %d", len(templates))
 	}
 
 	expected := map[string]struct {
@@ -22,15 +22,17 @@ func TestLiveLaunchTemplatesExposeEightBinanceTestnetVariants(t *testing.T) {
 		timeframe        string
 		quantity         float64
 		researchBaseline bool
+		enhanced         bool
 	}{
-		"binance-testnet-btc-5m":  {symbol: "BTCUSDT", timeframe: "5m", quantity: 0.002},
-		"binance-testnet-btc-15m": {symbol: "BTCUSDT", timeframe: "15m", quantity: 0.002, researchBaseline: true},
-		"binance-testnet-btc-30m": {symbol: "BTCUSDT", timeframe: "30m", quantity: 0.002, researchBaseline: true},
-		"binance-testnet-btc-4h":  {symbol: "BTCUSDT", timeframe: "4h", quantity: 0.002},
-		"binance-testnet-btc-1d":  {symbol: "BTCUSDT", timeframe: "1d", quantity: 0.002},
-		"binance-testnet-eth-5m":  {symbol: "ETHUSDT", timeframe: "5m", quantity: 0.1},
-		"binance-testnet-eth-4h":  {symbol: "ETHUSDT", timeframe: "4h", quantity: 0.1},
-		"binance-testnet-eth-1d":  {symbol: "ETHUSDT", timeframe: "1d", quantity: 0.1},
+		"binance-testnet-btc-5m":           {symbol: "BTCUSDT", timeframe: "5m", quantity: 0.002},
+		"binance-testnet-btc-15m":          {symbol: "BTCUSDT", timeframe: "15m", quantity: 0.002, researchBaseline: true},
+		"binance-testnet-btc-30m":          {symbol: "BTCUSDT", timeframe: "30m", quantity: 0.002, researchBaseline: true},
+		"binance-testnet-btc-30m-enhanced": {symbol: "BTCUSDT", timeframe: "30m", quantity: 0.002, enhanced: true},
+		"binance-testnet-btc-4h":           {symbol: "BTCUSDT", timeframe: "4h", quantity: 0.002},
+		"binance-testnet-btc-1d":           {symbol: "BTCUSDT", timeframe: "1d", quantity: 0.002},
+		"binance-testnet-eth-5m":           {symbol: "ETHUSDT", timeframe: "5m", quantity: 0.1},
+		"binance-testnet-eth-4h":           {symbol: "ETHUSDT", timeframe: "4h", quantity: 0.1},
+		"binance-testnet-eth-1d":           {symbol: "ETHUSDT", timeframe: "1d", quantity: 0.1},
 	}
 
 	for _, item := range templates {
@@ -38,8 +40,12 @@ func TestLiveLaunchTemplatesExposeEightBinanceTestnetVariants(t *testing.T) {
 		if !ok {
 			t.Fatalf("unexpected template key %s", item.Key)
 		}
-		if item.StrategyID != "strategy-bk-1d" {
-			t.Fatalf("expected strategy-bk-1d, got %s", item.StrategyID)
+		expectedStrategyID := "strategy-bk-1d"
+		if want.enhanced {
+			expectedStrategyID = "strategy-bk-btc-30m-enhanced"
+		}
+		if item.StrategyID != expectedStrategyID {
+			t.Fatalf("expected %s, got %s", expectedStrategyID, item.StrategyID)
 		}
 		if item.Symbol != want.symbol {
 			t.Fatalf("expected symbol %s for %s, got %s", want.symbol, item.Key, item.Symbol)
@@ -113,7 +119,7 @@ func TestLiveLaunchTemplatesExposeEightBinanceTestnetVariants(t *testing.T) {
 		if got := parseFloatValue(item.LaunchPayload.LiveSessionOverrides["defaultOrderQuantity"]); got != want.quantity {
 			t.Fatalf("expected defaultOrderQuantity=%v, got %v", want.quantity, got)
 		}
-		if want.researchBaseline {
+		if want.researchBaseline || want.enhanced {
 			if got := stringValue(item.LaunchPayload.LiveSessionOverrides["positionSizingMode"]); got != "reentry_size_schedule" {
 				t.Fatalf("expected positionSizingMode=reentry_size_schedule for %s, got %s", item.Key, got)
 			}
@@ -129,8 +135,12 @@ func TestLiveLaunchTemplatesExposeEightBinanceTestnetVariants(t *testing.T) {
 			if got := stringValue(item.LaunchPayload.LiveSessionOverrides["stop_mode"]); got != "atr" {
 				t.Fatalf("expected stop_mode=atr for %s, got %s", item.Key, got)
 			}
-			if got := parseFloatValue(item.LaunchPayload.LiveSessionOverrides["stop_loss_atr"]); got != 0.3 {
-				t.Fatalf("expected stop_loss_atr=0.3 for %s, got %v", item.Key, got)
+			expectedStopLossATR := 0.3
+			if want.enhanced {
+				expectedStopLossATR = 0.05
+			}
+			if got := parseFloatValue(item.LaunchPayload.LiveSessionOverrides["stop_loss_atr"]); got != expectedStopLossATR {
+				t.Fatalf("expected stop_loss_atr=%v for %s, got %v", expectedStopLossATR, item.Key, got)
 			}
 			if got := parseFloatValue(item.LaunchPayload.LiveSessionOverrides["profit_protect_atr"]); got != 1.0 {
 				t.Fatalf("expected profit_protect_atr=1.0 for %s, got %v", item.Key, got)
@@ -147,12 +157,30 @@ func TestLiveLaunchTemplatesExposeEightBinanceTestnetVariants(t *testing.T) {
 			if got := parseFloatValue(item.LaunchPayload.LiveSessionOverrides["short_reentry_atr"]); got != 0.0 {
 				t.Fatalf("expected short_reentry_atr=0.0 for %s, got %v", item.Key, got)
 			}
-			if got := maxIntValue(item.LaunchPayload.LiveSessionOverrides["max_trades_per_bar"], 0); got != 1 {
-				t.Fatalf("expected max_trades_per_bar=1 for %s, got %d", item.Key, got)
+			expectedMaxTradesPerBar := 1
+			if want.enhanced {
+				expectedMaxTradesPerBar = 2
+			}
+			if got := maxIntValue(item.LaunchPayload.LiveSessionOverrides["max_trades_per_bar"], 0); got != expectedMaxTradesPerBar {
+				t.Fatalf("expected max_trades_per_bar=%d for %s, got %d", expectedMaxTradesPerBar, item.Key, got)
 			}
 			schedule := normalizeBacktestFloatSlice(item.LaunchPayload.LiveSessionOverrides["reentry_size_schedule"], nil)
 			if len(schedule) != 2 || schedule[0] != 0.20 || schedule[1] != 0.10 {
 				t.Fatalf("expected reentry_size_schedule [0.20, 0.10] for %s, got %#v", item.Key, item.LaunchPayload.LiveSessionOverrides["reentry_size_schedule"])
+			}
+			if want.enhanced {
+				if got := stringValue(item.LaunchPayload.LiveSessionOverrides["strategyEngine"]); got != "bk-live-intrabar-sma5-t3-sep" {
+					t.Fatalf("expected enhanced strategy engine, got %s", got)
+				}
+				if got := stringValue(item.LaunchPayload.LiveSessionOverrides["breakout_shape"]); got != "baseline_plus_t3" {
+					t.Fatalf("expected baseline_plus_t3 breakout shape, got %s", got)
+				}
+				if got := parseFloatValue(item.LaunchPayload.LiveSessionOverrides["t3_min_sma_atr_separation"]); got != 0.25 {
+					t.Fatalf("expected t3 sep 0.25, got %v", got)
+				}
+				if !boolValue(item.LaunchPayload.LiveSessionOverrides["use_sma5_intraday_structure"]) {
+					t.Fatalf("expected enhanced template to use SMA5 intraday structure")
+				}
 			}
 		}
 		if item.LaunchPayload.LaunchTemplateKey != item.Key {

--- a/internal/service/live_market_data.go
+++ b/internal/service/live_market_data.go
@@ -244,6 +244,9 @@ func (p *Platform) liveSignalBarStates(symbol, timeframe string) (map[string]any
 	if index >= 2 {
 		entry["prevBar2"] = strategySignalBarToStateEntry(bars[index-2], symbol, timeframe)
 	}
+	if index >= 3 {
+		entry["prevBar3"] = strategySignalBarToStateEntry(bars[index-3], symbol, timeframe)
+	}
 	return map[string]any{
 		fmt.Sprintf("market-cache|%s|signal|%s", NormalizeSymbol(symbol), strings.ToLower(strings.TrimSpace(timeframe))): entry,
 	}, nil
@@ -425,6 +428,13 @@ func buildStrategySignalBarsFromCandles(bars []candleBar) ([]strategySignalBar, 
 		} else {
 			signals[i].PrevHigh2 = math.NaN()
 			signals[i].PrevLow2 = math.NaN()
+		}
+		if i >= 3 {
+			signals[i].PrevHigh3 = bars[i-3].High
+			signals[i].PrevLow3 = bars[i-3].Low
+		} else {
+			signals[i].PrevHigh3 = math.NaN()
+			signals[i].PrevLow3 = math.NaN()
 		}
 	}
 	return signals, nil

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -482,6 +482,58 @@ func TestEvaluateSignalBarGateTracksCurrentPriceBreakoutPattern(t *testing.T) {
 	}
 }
 
+func TestEvaluateSignalBarGateAllowsT3BreakoutWithSeparation(t *testing.T) {
+	gate := evaluateSignalBarGate(map[string]any{
+		"timeframe": "30m",
+		"sma5":      68200.0,
+		"ma20":      68000.0,
+		"atr14":     800.0,
+		"current": map[string]any{
+			"close": 68600.0,
+			"high":  69050.0,
+			"low":   68100.0,
+		},
+		"prevBar1": map[string]any{"high": 68800.0, "low": 68100.0},
+		"prevBar2": map[string]any{"high": 68600.0, "low": 68000.0},
+		"prevBar3": map[string]any{"high": 69000.0, "low": 67900.0},
+	}, "BUY", "entry", "", 69010.0, "trade_tick.price", signalBarGateOptions{
+		BreakoutShape:         "baseline_plus_t3",
+		T3MinSMAATRSeparation: 0.25,
+	})
+	if !boolValue(gate["longBreakoutPatternReady"]) || !boolValue(gate["longReady"]) {
+		t.Fatalf("expected t3 breakout with sep_0p25 to pass, got %#v", gate)
+	}
+	if got := stringValue(gate["longBreakoutShapeName"]); got != "t3_swing" {
+		t.Fatalf("expected t3_swing shape, got %s in %#v", got, gate)
+	}
+}
+
+func TestEvaluateSignalBarGateBlocksT3BreakoutInsideSeparation(t *testing.T) {
+	gate := evaluateSignalBarGate(map[string]any{
+		"timeframe": "30m",
+		"sma5":      68850.0,
+		"ma20":      68000.0,
+		"atr14":     800.0,
+		"current": map[string]any{
+			"close": 69020.0,
+			"high":  69050.0,
+			"low":   68100.0,
+		},
+		"prevBar1": map[string]any{"high": 68800.0, "low": 68100.0},
+		"prevBar2": map[string]any{"high": 68600.0, "low": 68000.0},
+		"prevBar3": map[string]any{"high": 69000.0, "low": 67900.0},
+	}, "BUY", "entry", "", 69010.0, "trade_tick.price", signalBarGateOptions{
+		BreakoutShape:         "baseline_plus_t3",
+		T3MinSMAATRSeparation: 0.25,
+	})
+	if boolValue(gate["longBreakoutPatternReady"]) || boolValue(gate["longReady"]) {
+		t.Fatalf("expected t3 breakout inside sep_0p25 to be blocked, got %#v", gate)
+	}
+	if boolValue(gate["longBreakoutQualityReady"]) {
+		t.Fatalf("expected t3 quality gate to fail, got %#v", gate)
+	}
+}
+
 func TestEvaluateSignalBarGateDoesNotRequireOppositeBreakoutForExit(t *testing.T) {
 	gate := evaluateSignalBarGate(map[string]any{
 		"ma20":  68000.0,
@@ -539,6 +591,7 @@ func TestAlignLivePlanStepToCurrentMarketKeepsExitForVirtualPosition(t *testing.
 	}
 
 	gotEvent, gotPrice, gotSide, gotRole, gotReason := alignLivePlanStepToCurrentMarket(
+		map[string]any{},
 		signalStates,
 		"1d",
 		currentPosition,

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -482,6 +482,32 @@ func TestEvaluateSignalBarGateTracksCurrentPriceBreakoutPattern(t *testing.T) {
 	}
 }
 
+func TestEvaluateSignalBarGateAllowsBreakoutBoundaryEquality(t *testing.T) {
+	gate := evaluateSignalBarGate(map[string]any{
+		"ma20":  68000.0,
+		"atr14": 900.0,
+		"current": map[string]any{
+			"close": 68100.0,
+			"high":  69000.0,
+			"low":   67800.0,
+		},
+		"prevBar1": map[string]any{
+			"high": 68850.0,
+			"low":  67750.0,
+		},
+		"prevBar2": map[string]any{
+			"high": 69000.0,
+			"low":  67600.0,
+		},
+	}, "BUY", "entry", "", 69000.0, "trade_tick.price")
+	if !boolValue(gate["longBreakoutPriceReady"]) || !boolValue(gate["longBreakoutPatternReady"]) {
+		t.Fatalf("expected equality at original_t2 breakout boundary to pass, got %#v", gate)
+	}
+	if got := stringValue(gate["longBreakoutShapeName"]); got != "original_t2" {
+		t.Fatalf("expected original_t2 shape, got %s in %#v", got, gate)
+	}
+}
+
 func TestEvaluateSignalBarGateAllowsT3BreakoutWithSeparation(t *testing.T) {
 	gate := evaluateSignalBarGate(map[string]any{
 		"timeframe": "30m",
@@ -505,6 +531,32 @@ func TestEvaluateSignalBarGateAllowsT3BreakoutWithSeparation(t *testing.T) {
 	}
 	if got := stringValue(gate["longBreakoutShapeName"]); got != "t3_swing" {
 		t.Fatalf("expected t3_swing shape, got %s in %#v", got, gate)
+	}
+}
+
+func TestEvaluateSignalBarGateKeepsOriginalT2WhenT3Enabled(t *testing.T) {
+	gate := evaluateSignalBarGate(map[string]any{
+		"timeframe": "30m",
+		"sma5":      68200.0,
+		"ma20":      68000.0,
+		"atr14":     800.0,
+		"current": map[string]any{
+			"close": 68900.0,
+			"high":  69050.0,
+			"low":   68100.0,
+		},
+		"prevBar1": map[string]any{"high": 68800.0, "low": 68100.0},
+		"prevBar2": map[string]any{"high": 69000.0, "low": 68000.0},
+		"prevBar3": map[string]any{"high": 68700.0, "low": 67900.0},
+	}, "BUY", "entry", "", 69000.0, "trade_tick.price", signalBarGateOptions{
+		BreakoutShape:         "baseline_plus_t3",
+		T3MinSMAATRSeparation: 0.25,
+	})
+	if !boolValue(gate["longBreakoutPatternReady"]) || !boolValue(gate["longReady"]) {
+		t.Fatalf("expected original_t2 breakout to pass with t3 enabled, got %#v", gate)
+	}
+	if got := stringValue(gate["longBreakoutShapeName"]); got != "original_t2" {
+		t.Fatalf("expected original_t2 to remain selected, got %s in %#v", got, gate)
 	}
 }
 
@@ -3518,6 +3570,27 @@ func TestNormalizeLiveSessionOverridesIncludesZeroInitialControls(t *testing.T) 
 	}
 	if got := parseFloatValue(overrides["delayed_trailing_activation_atr"]); got != 0.5 {
 		t.Fatalf("expected delayed_trailing_activation_atr=0.5, got %v", got)
+	}
+}
+
+func TestNormalizeLiveSessionOverridesIncludesT3BreakoutControls(t *testing.T) {
+	overrides := normalizeLiveSessionOverrides(map[string]any{
+		"breakout_shape":                    "baseline_plus_t3",
+		"t3_min_sma_atr_separation":         0.25,
+		"use_sma5_intraday_structure":       true,
+		"ignored_t3_min_sma_atr_separation": 0.50,
+	})
+	if got := stringValue(overrides["breakout_shape"]); got != "baseline_plus_t3" {
+		t.Fatalf("expected breakout_shape=baseline_plus_t3, got %s", got)
+	}
+	if got := parseFloatValue(overrides["t3_min_sma_atr_separation"]); got != 0.25 {
+		t.Fatalf("expected t3_min_sma_atr_separation=0.25, got %v", got)
+	}
+	if !boolValue(overrides["use_sma5_intraday_structure"]) {
+		t.Fatal("expected use_sma5_intraday_structure override")
+	}
+	if _, ok := overrides["ignored_t3_min_sma_atr_separation"]; ok {
+		t.Fatalf("expected unknown t3 override key to be dropped, got %#v", overrides)
 	}
 }
 

--- a/internal/service/live_zero_initial.go
+++ b/internal/service/live_zero_initial.go
@@ -28,6 +28,7 @@ func prepareLivePlanStepForSignalEvaluation(
 	hasActivePosition := hasActiveLivePositionSnapshot(currentPosition)
 	if !strategyZeroInitialReentryWindowEnabled(parameters) {
 		alignedEvent, alignedPrice, alignedSide, alignedRole, alignedReason := alignLivePlanStepToCurrentMarket(
+			parameters,
 			signalBarStates,
 			signalTimeframe,
 			currentPosition,
@@ -78,7 +79,7 @@ func prepareLivePlanStepForSignalEvaluation(
 		return updatedState, nextPlannedEvent, nextPlannedPrice, nextPlannedSide, nextPlannedRole, nextPlannedReason
 	}
 	alignmentMode := ""
-	gate := evaluateSignalBarGate(signalBarState, "", "entry", "", breakoutPrice, breakoutPriceSource)
+	gate := evaluateSignalBarGate(signalBarState, "", "entry", "", breakoutPrice, breakoutPriceSource, signalBarGateOptionsFromParameters(parameters))
 	longReady := boolValue(gate["longReady"])
 	shortReady := boolValue(gate["shortReady"])
 	if longReady != shortReady {
@@ -131,8 +132,12 @@ func prepareLivePlanStepForSignalEvaluation(
 		"shortBreakoutPriceReady":   boolValue(gate["shortBreakoutPriceReady"]),
 		"longBreakoutShapeReady":    boolValue(gate["longBreakoutShapeReady"]),
 		"shortBreakoutShapeReady":   boolValue(gate["shortBreakoutShapeReady"]),
+		"longBreakoutQualityReady":  boolValue(gate["longBreakoutQualityReady"]),
+		"shortBreakoutQualityReady": boolValue(gate["shortBreakoutQualityReady"]),
 		"longBreakoutPatternReady":  boolValue(gate["longBreakoutPatternReady"]),
 		"shortBreakoutPatternReady": boolValue(gate["shortBreakoutPatternReady"]),
+		"longBreakoutShapeName":     stringValue(gate["longBreakoutShapeName"]),
+		"shortBreakoutShapeName":    stringValue(gate["shortBreakoutShapeName"]),
 	}
 	updatedState[livePendingZeroInitialWindowStateKey] = pendingWindow
 	timelineMetadata := map[string]any{

--- a/internal/service/signal_runtime_ws.go
+++ b/internal/service/signal_runtime_ws.go
@@ -1227,6 +1227,9 @@ func deriveSignalBarStates(sourceStates map[string]any) map[string]any {
 		if len(previousClosed) >= 2 {
 			entry["prevBar2"] = cloneMetadata(previousClosed[len(previousClosed)-2])
 		}
+		if len(previousClosed) >= 3 {
+			entry["prevBar3"] = cloneMetadata(previousClosed[len(previousClosed)-3])
+		}
 		out[key] = entry
 	}
 	return out

--- a/internal/service/signal_runtime_ws_test.go
+++ b/internal/service/signal_runtime_ws_test.go
@@ -619,11 +619,15 @@ func TestDeriveSignalBarStatesUsesOpenCurrentBarWithClosedHistory(t *testing.T) 
 	}
 	prevBar1 := mapValue(state["prevBar1"])
 	prevBar2 := mapValue(state["prevBar2"])
+	prevBar3 := mapValue(state["prevBar3"])
 	if stringValue(prevBar1["barStart"]) != base.Add(19*5*time.Minute).Format(time.RFC3339) {
 		t.Fatalf("expected prevBar1 to be latest closed bar, got %#v", prevBar1)
 	}
 	if stringValue(prevBar2["barStart"]) != base.Add(18*5*time.Minute).Format(time.RFC3339) {
 		t.Fatalf("expected prevBar2 to be second latest closed bar, got %#v", prevBar2)
+	}
+	if stringValue(prevBar3["barStart"]) != base.Add(17*5*time.Minute).Format(time.RFC3339) {
+		t.Fatalf("expected prevBar3 to be third latest closed bar, got %#v", prevBar3)
 	}
 	gate := evaluateSignalBarGate(state, "BUY", "entry", "", parseFloatValue(current["high"]), "signal-bar.high")
 	if boolValue(gate["ready"]) || boolValue(gate["longReady"]) {

--- a/internal/service/signal_source_registry.go
+++ b/internal/service/signal_source_registry.go
@@ -84,7 +84,7 @@ func (p *Platform) registerBuiltInSignalSources() {
 		Roles:        []string{"signal"},
 		Environments: []string{"paper", "live"},
 		SymbolScope:  "multi_symbol",
-		Description:  "交易所原生 5m/15m/30m/4h/1d K 线流，用于实时策略信号计算、SMA5/MA20 和前两根 OHLC 状态。",
+		Description:  "交易所原生 5m/15m/30m/4h/1d K 线流，用于实时策略信号计算、SMA5/MA20 和前三根 OHLC 状态。",
 		Metadata: map[string]any{
 			"stream":               "kline",
 			"supportedTimeframes":  []string{"5m", "15m", "30m", "4h", "1d"},

--- a/internal/service/strategy_registry.go
+++ b/internal/service/strategy_registry.go
@@ -117,6 +117,7 @@ func (p *Platform) registerStrategyEngine(engine StrategyEngine) {
 
 func (p *Platform) registerBuiltInStrategyEngines() {
 	p.registerStrategyEngine(bkStrategyEngine{platform: p})
+	p.registerStrategyEngine(bkLiveIntrabarSMA5T3SepEngine{platform: p})
 }
 
 func (p *Platform) resolveStrategyEngine(strategyVersionID string, parameters map[string]any) (StrategyEngine, string, error) {
@@ -179,6 +180,45 @@ func (e bkStrategyEngine) Run(context StrategyExecutionContext) (map[string]any,
 	return e.platform.runStrategyReplay(context)
 }
 
+type bkLiveIntrabarSMA5T3SepEngine struct {
+	platform *Platform
+}
+
+func (e bkLiveIntrabarSMA5T3SepEngine) Key() string {
+	return "bk-live-intrabar-sma5-t3-sep"
+}
+
+func (e bkLiveIntrabarSMA5T3SepEngine) Describe() map[string]any {
+	return map[string]any{
+		"key":                  e.Key(),
+		"name":                 "BK Live Intrabar SMA5 T3 Sep",
+		"supportedSignalBars":  []string{"30m"},
+		"supportedExecutions":  []string{"tick", "1min"},
+		"runtimeConsistency":   "live-intrabar-sma5-baseline-plus-t3-breakout-sep-0p25",
+		"backtestSlippageOnly": true,
+	}
+}
+
+func (e bkLiveIntrabarSMA5T3SepEngine) Run(context StrategyExecutionContext) (map[string]any, error) {
+	return e.platform.runStrategyReplay(context)
+}
+
+func (e bkLiveIntrabarSMA5T3SepEngine) EvaluateSignal(context StrategySignalEvaluationContext) (StrategySignalDecision, error) {
+	return bkStrategyEngine{platform: e.platform}.EvaluateSignal(context)
+}
+
+type signalBarGateOptions struct {
+	BreakoutShape         string
+	T3MinSMAATRSeparation float64
+}
+
+func signalBarGateOptionsFromParameters(parameters map[string]any) signalBarGateOptions {
+	return signalBarGateOptions{
+		BreakoutShape:         strings.ToLower(strings.TrimSpace(stringValue(parameters["breakout_shape"]))),
+		T3MinSMAATRSeparation: parseFloatValue(parameters["t3_min_sma_atr_separation"]),
+	}
+}
+
 func (e bkStrategyEngine) EvaluateSignal(context StrategySignalEvaluationContext) (StrategySignalDecision, error) {
 	trigger := cloneMetadata(context.TriggerSummary)
 	sourceStates := cloneMetadata(context.SourceStates)
@@ -221,6 +261,7 @@ func (e bkStrategyEngine) EvaluateSignal(context StrategySignalEvaluationContext
 			context.NextPlannedReason,
 			breakoutPrice,
 			breakoutPriceSource,
+			signalBarGateOptionsFromParameters(context.ExecutionContext.Parameters),
 		)
 		if value, ok := signalBarDecision["ready"].(bool); ok {
 			signalFilterReady = value
@@ -720,7 +761,11 @@ func pickSignalBarState(signalBarStates map[string]any, symbol, timeframe string
 	return nil, ""
 }
 
-func evaluateSignalBarGate(signalBarState map[string]any, nextSide, nextRole, nextReason string, breakoutPrice float64, breakoutPriceSource string) map[string]any {
+func evaluateSignalBarGate(signalBarState map[string]any, nextSide, nextRole, nextReason string, breakoutPrice float64, breakoutPriceSource string, options ...signalBarGateOptions) map[string]any {
+	gateOptions := signalBarGateOptions{}
+	if len(options) > 0 {
+		gateOptions = options[0]
+	}
 	role := strings.ToLower(strings.TrimSpace(nextRole))
 	reasonTag := normalizeStrategyReasonTag(nextReason)
 	timeframe := strings.ToLower(strings.TrimSpace(stringValue(signalBarState["timeframe"])))
@@ -739,10 +784,12 @@ func evaluateSignalBarGate(signalBarState map[string]any, nextSide, nextRole, ne
 		"current":   cloneMetadata(mapValue(signalBarState["current"])),
 		"prevBar1":  cloneMetadata(mapValue(signalBarState["prevBar1"])),
 		"prevBar2":  cloneMetadata(mapValue(signalBarState["prevBar2"])),
+		"prevBar3":  cloneMetadata(mapValue(signalBarState["prevBar3"])),
 	}
 	current := mapValue(signalBarState["current"])
 	prevBar1 := mapValue(signalBarState["prevBar1"])
 	prevBar2 := mapValue(signalBarState["prevBar2"])
+	prevBar3 := mapValue(signalBarState["prevBar3"])
 	ma20 := parseFloatValue(signalBarState["ma20"])
 	sma5 := parseFloatValue(signalBarState["sma5"])
 	atr14 := parseFloatValue(signalBarState["atr14"])
@@ -754,8 +801,10 @@ func evaluateSignalBarGate(signalBarState map[string]any, nextSide, nextRole, ne
 	closePrice := parseFloatValue(current["close"])
 	prevHigh1 := parseFloatValue(prevBar1["high"])
 	prevHigh2 := parseFloatValue(prevBar2["high"])
+	prevHigh3 := parseFloatValue(prevBar3["high"])
 	prevLow1 := parseFloatValue(prevBar1["low"])
 	prevLow2 := parseFloatValue(prevBar2["low"])
+	prevLow3 := parseFloatValue(prevBar3["low"])
 	longStructureReady := false
 	shortStructureReady := false
 	longEarlyReversalReady := false
@@ -800,12 +849,36 @@ func evaluateSignalBarGate(signalBarState map[string]any, nextSide, nextRole, ne
 		longStructureReady = closePrice > ma20
 		shortStructureReady = closePrice < ma20
 	}
-	longBreakoutShapeReady := prevHigh2 > prevHigh1 && prevHigh2 > 0
-	shortBreakoutShapeReady := prevLow2 < prevLow1 && prevLow2 > 0
-	longBreakoutPriceReady := breakoutPrice > prevHigh2 && prevHigh2 > 0
-	shortBreakoutPriceReady := breakoutPrice < prevLow2 && prevLow2 > 0
-	longBreakoutReady := longBreakoutShapeReady && longBreakoutPriceReady
-	shortBreakoutReady := shortBreakoutShapeReady && shortBreakoutPriceReady
+	longBreakoutShapeName := ""
+	longBreakoutLevel := 0.0
+	if prevHigh2 > prevHigh1 && prevHigh2 > 0 {
+		longBreakoutShapeName = "original_t2"
+		longBreakoutLevel = prevHigh2
+	}
+	if gateOptions.BreakoutShape == "baseline_plus_t3" &&
+		prevHigh3 > prevHigh2 && prevHigh3 > prevHigh1 && prevHigh1 > prevHigh2 && prevHigh3 > 0 {
+		longBreakoutShapeName = "t3_swing"
+		longBreakoutLevel = prevHigh3
+	}
+	shortBreakoutShapeName := ""
+	shortBreakoutLevel := 0.0
+	if prevLow2 < prevLow1 && prevLow2 > 0 {
+		shortBreakoutShapeName = "original_t2"
+		shortBreakoutLevel = prevLow2
+	}
+	if gateOptions.BreakoutShape == "baseline_plus_t3" &&
+		prevLow3 < prevLow2 && prevLow3 < prevLow1 && prevLow1 < prevLow2 && prevLow3 > 0 {
+		shortBreakoutShapeName = "t3_swing"
+		shortBreakoutLevel = prevLow3
+	}
+	longBreakoutShapeReady := longBreakoutShapeName != "" && longBreakoutLevel > 0
+	shortBreakoutShapeReady := shortBreakoutShapeName != "" && shortBreakoutLevel > 0
+	longBreakoutPriceReady := breakoutPrice > longBreakoutLevel && longBreakoutLevel > 0
+	shortBreakoutPriceReady := breakoutPrice < shortBreakoutLevel && shortBreakoutLevel > 0
+	longBreakoutQualityReady := breakoutQualityReady(longBreakoutShapeName, longBreakoutLevel, sma5, atr14, gateOptions)
+	shortBreakoutQualityReady := breakoutQualityReady(shortBreakoutShapeName, shortBreakoutLevel, sma5, atr14, gateOptions)
+	longBreakoutReady := longBreakoutShapeReady && longBreakoutPriceReady && longBreakoutQualityReady
+	shortBreakoutReady := shortBreakoutShapeReady && shortBreakoutPriceReady && shortBreakoutQualityReady
 	longReady := longStructureReady && longBreakoutReady
 	shortReady := shortStructureReady && shortBreakoutReady
 	if role == "entry" && (reasonTag == "zero-initial-reentry" || reasonTag == "sl-reentry" || reasonTag == "pt-reentry") {
@@ -822,6 +895,12 @@ func evaluateSignalBarGate(signalBarState map[string]any, nextSide, nextRole, ne
 	result["shortBreakoutShapeReady"] = shortBreakoutShapeReady
 	result["longBreakoutPriceReady"] = longBreakoutPriceReady
 	result["shortBreakoutPriceReady"] = shortBreakoutPriceReady
+	result["longBreakoutQualityReady"] = longBreakoutQualityReady
+	result["shortBreakoutQualityReady"] = shortBreakoutQualityReady
+	result["longBreakoutShapeName"] = longBreakoutShapeName
+	result["shortBreakoutShapeName"] = shortBreakoutShapeName
+	result["longBreakoutLevel"] = longBreakoutLevel
+	result["shortBreakoutLevel"] = shortBreakoutLevel
 	result["longBreakoutReady"] = longBreakoutReady
 	result["shortBreakoutReady"] = shortBreakoutReady
 	result["longBreakoutPatternReady"] = longBreakoutReady
@@ -844,6 +923,16 @@ func evaluateSignalBarGate(signalBarState map[string]any, nextSide, nextRole, ne
 		}
 	}
 	return result
+}
+
+func breakoutQualityReady(shapeName string, breakoutLevel, sma5, atr14 float64, options signalBarGateOptions) bool {
+	if shapeName != "t3_swing" || options.T3MinSMAATRSeparation <= 0 {
+		return true
+	}
+	if breakoutLevel <= 0 || sma5 <= 0 || atr14 <= 0 {
+		return false
+	}
+	return math.Abs(breakoutLevel-sma5) >= options.T3MinSMAATRSeparation*atr14
 }
 
 func isFavorableBiasForPlan(nextRole, nextReason, liquidityBias string) bool {

--- a/internal/service/strategy_registry.go
+++ b/internal/service/strategy_registry.go
@@ -873,8 +873,8 @@ func evaluateSignalBarGate(signalBarState map[string]any, nextSide, nextRole, ne
 	}
 	longBreakoutShapeReady := longBreakoutShapeName != "" && longBreakoutLevel > 0
 	shortBreakoutShapeReady := shortBreakoutShapeName != "" && shortBreakoutLevel > 0
-	longBreakoutPriceReady := breakoutPrice > longBreakoutLevel && longBreakoutLevel > 0
-	shortBreakoutPriceReady := breakoutPrice < shortBreakoutLevel && shortBreakoutLevel > 0
+	longBreakoutPriceReady := breakoutPrice >= longBreakoutLevel && longBreakoutLevel > 0
+	shortBreakoutPriceReady := breakoutPrice <= shortBreakoutLevel && shortBreakoutLevel > 0
 	longBreakoutQualityReady := breakoutQualityReady(longBreakoutShapeName, longBreakoutLevel, sma5, atr14, gateOptions)
 	shortBreakoutQualityReady := breakoutQualityReady(shortBreakoutShapeName, shortBreakoutLevel, sma5, atr14, gateOptions)
 	longBreakoutReady := longBreakoutShapeReady && longBreakoutPriceReady && longBreakoutQualityReady

--- a/internal/service/strategy_replay.go
+++ b/internal/service/strategy_replay.go
@@ -26,8 +26,10 @@ type strategySignalBar struct {
 	ATR       float64
 	PrevHigh1 float64
 	PrevHigh2 float64
+	PrevHigh3 float64
 	PrevLow1  float64
 	PrevLow2  float64
+	PrevLow3  float64
 }
 
 type executionBar struct {
@@ -52,28 +54,31 @@ type strategyPosition struct {
 }
 
 type strategyReplayConfig struct {
-	SignalTimeframe      string
-	ExecutionDataSource  string
-	Symbol               string
-	From                 time.Time
-	To                   time.Time
-	InitialBalance       float64
-	Dir1ReentryConfirm   bool
-	Dir2ZeroInitial      bool
-	ZeroInitialMode      string
-	FixedSlippage        float64
-	StopLossATR          float64
-	MaxTradesPerBar      int
-	ReentrySizeSchedule  []float64
-	LongReentryATR       float64
-	ShortReentryATR      float64
-	StopMode             string
-	ProfitProtectATR     float64
-	TrailingStopATR      float64
-	DelayedTrailingATR   float64
-	TradingFeeRate       float64
-	FundingRate          float64
-	FundingIntervalHours int
+	SignalTimeframe          string
+	ExecutionDataSource      string
+	Symbol                   string
+	From                     time.Time
+	To                       time.Time
+	InitialBalance           float64
+	Dir1ReentryConfirm       bool
+	Dir2ZeroInitial          bool
+	ZeroInitialMode          string
+	FixedSlippage            float64
+	StopLossATR              float64
+	MaxTradesPerBar          int
+	ReentrySizeSchedule      []float64
+	LongReentryATR           float64
+	ShortReentryATR          float64
+	StopMode                 string
+	ProfitProtectATR         float64
+	TrailingStopATR          float64
+	DelayedTrailingATR       float64
+	TradingFeeRate           float64
+	FundingRate              float64
+	FundingIntervalHours     int
+	BreakoutShape            string
+	T3MinSMAATRSeparation    float64
+	UseSMA5IntradayStructure bool
 }
 
 func (p *Platform) runStrategyReplay(context StrategyExecutionContext) (map[string]any, error) {
@@ -167,36 +172,34 @@ func (p *Platform) runStrategyReplayOnTick(cfg strategyReplayConfig, signals []s
 			if engine.position == nil {
 				executed := false
 
-				longRegimeReady, shortRegimeReady := strategySignalRegimeReady(sig, engine.cfg.SignalTimeframe)
+				longRegimeReady, shortRegimeReady := strategySignalRegimeReady(sig, engine.cfg.SignalTimeframe, engine.cfg.UseSMA5IntradayStructure)
 				if longRegimeReady {
 					reP := sig.PrevLow1 + cfg.LongReentryATR*sig.ATR
-					if tradesInBar == 0 && sig.PrevHigh2 > sig.PrevHigh1 {
-						if current.Price >= sig.PrevHigh2 {
-							if engine.zeroInitialReentryWindowEnabled() {
-								engine.armZeroInitialWindow("long", i)
-							} else {
-								entry := math.Max(current.Price, sig.PrevHigh2) * (1 + cfg.FixedSlippage)
-								notional := engine.balance * initialUsage
-								stopLoss := resolveStopPrice("long", entry, sig, cfg.StopMode, cfg.StopLossATR)
-								engine.position = &strategyPosition{
-									Side:       "long",
-									EntryPrice: entry,
-									StopLoss:   stopLoss,
-									Protected:  false,
-									Notional:   notional,
-									Reason:     "Initial",
-									BarIndex:   i,
-									EntryTime:  current.Time,
-									HWM:        entry,
-									LWM:        entry,
-								}
-								tradingFee := notional * commission
-								engine.balance -= tradingFee
-								engine.totalTradingFees += tradingFee
-								engine.appendTrade("BUY", current.Time, entry, "Initial", notional, 0, tradingFee, 0)
-								tradesInBar++
-								executed = true
+					if breakout := resolveReplayInitialBreakout(sig, "long", current.Price, cfg); tradesInBar == 0 && breakout.Ready {
+						if engine.zeroInitialReentryWindowEnabled() {
+							engine.armZeroInitialWindow("long", i)
+						} else {
+							entry := math.Max(current.Price, breakout.Level) * (1 + cfg.FixedSlippage)
+							notional := engine.balance * initialUsage
+							stopLoss := resolveStopPrice("long", entry, sig, cfg.StopMode, cfg.StopLossATR)
+							engine.position = &strategyPosition{
+								Side:       "long",
+								EntryPrice: entry,
+								StopLoss:   stopLoss,
+								Protected:  false,
+								Notional:   notional,
+								Reason:     "Initial",
+								BarIndex:   i,
+								EntryTime:  current.Time,
+								HWM:        entry,
+								LWM:        entry,
 							}
+							tradingFee := notional * commission
+							engine.balance -= tradingFee
+							engine.totalTradingFees += tradingFee
+							engine.appendTrade("BUY", current.Time, entry, "Initial", notional, 0, tradingFee, 0)
+							tradesInBar++
+							executed = true
 						}
 					}
 					hasExitWindow := engine.lastExitSide == "long" && i-engine.lastExitBarIndex <= 1
@@ -251,33 +254,31 @@ func (p *Platform) runStrategyReplayOnTick(cfg strategyReplayConfig, signals []s
 					}
 				} else if shortRegimeReady {
 					reP := sig.PrevHigh1 + cfg.ShortReentryATR*sig.ATR
-					if tradesInBar == 0 && sig.PrevLow2 < sig.PrevLow1 {
-						if current.Price <= sig.PrevLow2 {
-							if engine.zeroInitialReentryWindowEnabled() {
-								engine.armZeroInitialWindow("short", i)
-							} else {
-								entry := math.Min(current.Price, sig.PrevLow2) * (1 - cfg.FixedSlippage)
-								notional := engine.balance * initialUsage
-								stopLoss := resolveStopPrice("short", entry, sig, cfg.StopMode, cfg.StopLossATR)
-								engine.position = &strategyPosition{
-									Side:       "short",
-									EntryPrice: entry,
-									StopLoss:   stopLoss,
-									Protected:  false,
-									Notional:   notional,
-									Reason:     "Initial",
-									BarIndex:   i,
-									EntryTime:  current.Time,
-									HWM:        entry,
-									LWM:        entry,
-								}
-								tradingFee := notional * commission
-								engine.balance -= tradingFee
-								engine.totalTradingFees += tradingFee
-								engine.appendTrade("SHORT", current.Time, entry, "Initial", notional, 0, tradingFee, 0)
-								tradesInBar++
-								executed = true
+					if breakout := resolveReplayInitialBreakout(sig, "short", current.Price, cfg); tradesInBar == 0 && breakout.Ready {
+						if engine.zeroInitialReentryWindowEnabled() {
+							engine.armZeroInitialWindow("short", i)
+						} else {
+							entry := math.Min(current.Price, breakout.Level) * (1 - cfg.FixedSlippage)
+							notional := engine.balance * initialUsage
+							stopLoss := resolveStopPrice("short", entry, sig, cfg.StopMode, cfg.StopLossATR)
+							engine.position = &strategyPosition{
+								Side:       "short",
+								EntryPrice: entry,
+								StopLoss:   stopLoss,
+								Protected:  false,
+								Notional:   notional,
+								Reason:     "Initial",
+								BarIndex:   i,
+								EntryTime:  current.Time,
+								HWM:        entry,
+								LWM:        entry,
 							}
+							tradingFee := notional * commission
+							engine.balance -= tradingFee
+							engine.totalTradingFees += tradingFee
+							engine.appendTrade("SHORT", current.Time, entry, "Initial", notional, 0, tradingFee, 0)
+							tradesInBar++
+							executed = true
 						}
 					}
 					hasExitWindow := engine.lastExitSide == "short" && i-engine.lastExitBarIndex <= 1
@@ -466,36 +467,34 @@ func runStrategyReplayOnMinuteBars(cfg strategyReplayConfig, signals []strategyS
 			if engine.position == nil {
 				executed := false
 
-				longRegimeReady, shortRegimeReady := strategySignalRegimeReady(sig, engine.cfg.SignalTimeframe)
+				longRegimeReady, shortRegimeReady := strategySignalRegimeReady(sig, engine.cfg.SignalTimeframe, engine.cfg.UseSMA5IntradayStructure)
 				if longRegimeReady {
 					reP := sig.PrevLow1 + cfg.LongReentryATR*sig.ATR
-					if tradesInBar == 0 && sig.PrevHigh2 > sig.PrevHigh1 {
-						if bar.High >= sig.PrevHigh2 {
-							if engine.zeroInitialReentryWindowEnabled() {
-								engine.armZeroInitialWindow("long", i)
-							} else {
-								entry := math.Max(bar.Open, sig.PrevHigh2) * (1 + cfg.FixedSlippage)
-								notional := engine.balance * initialUsage
-								stopLoss := resolveStopPrice("long", entry, sig, cfg.StopMode, cfg.StopLossATR)
-								engine.position = &strategyPosition{
-									Side:       "long",
-									EntryPrice: entry,
-									StopLoss:   stopLoss,
-									Protected:  false,
-									Notional:   notional,
-									Reason:     "Initial",
-									BarIndex:   i,
-									EntryTime:  bar.Time,
-									HWM:        entry,
-									LWM:        entry,
-								}
-								tradingFee := notional * commission
-								engine.balance -= tradingFee
-								engine.totalTradingFees += tradingFee
-								engine.appendTrade("BUY", bar.Time, entry, "Initial", notional, 0, tradingFee, 0)
-								tradesInBar++
-								executed = true
+					if breakout := resolveReplayInitialBreakout(sig, "long", bar.High, cfg); tradesInBar == 0 && breakout.Ready {
+						if engine.zeroInitialReentryWindowEnabled() {
+							engine.armZeroInitialWindow("long", i)
+						} else {
+							entry := math.Max(bar.Open, breakout.Level) * (1 + cfg.FixedSlippage)
+							notional := engine.balance * initialUsage
+							stopLoss := resolveStopPrice("long", entry, sig, cfg.StopMode, cfg.StopLossATR)
+							engine.position = &strategyPosition{
+								Side:       "long",
+								EntryPrice: entry,
+								StopLoss:   stopLoss,
+								Protected:  false,
+								Notional:   notional,
+								Reason:     "Initial",
+								BarIndex:   i,
+								EntryTime:  bar.Time,
+								HWM:        entry,
+								LWM:        entry,
 							}
+							tradingFee := notional * commission
+							engine.balance -= tradingFee
+							engine.totalTradingFees += tradingFee
+							engine.appendTrade("BUY", bar.Time, entry, "Initial", notional, 0, tradingFee, 0)
+							tradesInBar++
+							executed = true
 						}
 					}
 					hasExitWindow := engine.lastExitSide == "long" && i-engine.lastExitBarIndex <= 1
@@ -560,33 +559,31 @@ func runStrategyReplayOnMinuteBars(cfg strategyReplayConfig, signals []strategyS
 					}
 				} else if shortRegimeReady {
 					reP := sig.PrevHigh1 + cfg.ShortReentryATR*sig.ATR
-					if tradesInBar == 0 && sig.PrevLow2 < sig.PrevLow1 {
-						if bar.Low <= sig.PrevLow2 {
-							if engine.zeroInitialReentryWindowEnabled() {
-								engine.armZeroInitialWindow("short", i)
-							} else {
-								entry := math.Min(bar.Open, sig.PrevLow2) * (1 - cfg.FixedSlippage)
-								notional := engine.balance * initialUsage
-								stopLoss := resolveStopPrice("short", entry, sig, cfg.StopMode, cfg.StopLossATR)
-								engine.position = &strategyPosition{
-									Side:       "short",
-									EntryPrice: entry,
-									StopLoss:   stopLoss,
-									Protected:  false,
-									Notional:   notional,
-									Reason:     "Initial",
-									BarIndex:   i,
-									EntryTime:  bar.Time,
-									HWM:        entry,
-									LWM:        entry,
-								}
-								tradingFee := notional * commission
-								engine.balance -= tradingFee
-								engine.totalTradingFees += tradingFee
-								engine.appendTrade("SHORT", bar.Time, entry, "Initial", notional, 0, tradingFee, 0)
-								tradesInBar++
-								executed = true
+					if breakout := resolveReplayInitialBreakout(sig, "short", bar.Low, cfg); tradesInBar == 0 && breakout.Ready {
+						if engine.zeroInitialReentryWindowEnabled() {
+							engine.armZeroInitialWindow("short", i)
+						} else {
+							entry := math.Min(bar.Open, breakout.Level) * (1 - cfg.FixedSlippage)
+							notional := engine.balance * initialUsage
+							stopLoss := resolveStopPrice("short", entry, sig, cfg.StopMode, cfg.StopLossATR)
+							engine.position = &strategyPosition{
+								Side:       "short",
+								EntryPrice: entry,
+								StopLoss:   stopLoss,
+								Protected:  false,
+								Notional:   notional,
+								Reason:     "Initial",
+								BarIndex:   i,
+								EntryTime:  bar.Time,
+								HWM:        entry,
+								LWM:        entry,
 							}
+							tradingFee := notional * commission
+							engine.balance -= tradingFee
+							engine.totalTradingFees += tradingFee
+							engine.appendTrade("SHORT", bar.Time, entry, "Initial", notional, 0, tradingFee, 0)
+							tradesInBar++
+							executed = true
 						}
 					}
 					hasExitWindow := engine.lastExitSide == "short" && i-engine.lastExitBarIndex <= 1
@@ -783,33 +780,31 @@ func (e *strategyReplayEngine) tryEntry(bar executionBar, sig strategySignalBar)
 		initialUsage = 0.0
 	}
 
-	longRegimeReady, shortRegimeReady := strategySignalRegimeReady(sig, e.cfg.SignalTimeframe)
+	longRegimeReady, shortRegimeReady := strategySignalRegimeReady(sig, e.cfg.SignalTimeframe, e.cfg.UseSMA5IntradayStructure)
 	if longRegimeReady {
 		reP := sig.PrevLow1 + e.cfg.LongReentryATR*sig.ATR
-		if e.tradesInBar == 0 && sig.PrevHigh2 > sig.PrevHigh1 {
-			if bar.High >= sig.PrevHigh2 {
-				if e.zeroInitialReentryWindowEnabled() {
-					e.armZeroInitialWindow("long", e.currentBarIndex)
-				} else {
-					entry := math.Max(bar.Open, sig.PrevHigh2) * (1 + e.cfg.FixedSlippage)
-					notional := e.balance * initialUsage
-					stopLoss := resolveStopPrice("long", entry, sig, e.cfg.StopMode, e.cfg.StopLossATR)
-					e.position = &strategyPosition{
-						Side:       "long",
-						EntryPrice: entry,
-						StopLoss:   stopLoss,
-						Protected:  false,
-						Notional:   notional,
-						Reason:     "Initial",
-						BarIndex:   e.currentBarIndex,
-						HWM:        entry,
-						LWM:        entry,
-					}
-					e.balance -= notional * commission
-					e.tradesInBar++
-					e.appendTrade("BUY", bar.Time, entry, "Initial", notional, 0, notional*commission, 0)
-					return
+		if breakout := resolveReplayInitialBreakout(sig, "long", bar.High, e.cfg); e.tradesInBar == 0 && breakout.Ready {
+			if e.zeroInitialReentryWindowEnabled() {
+				e.armZeroInitialWindow("long", e.currentBarIndex)
+			} else {
+				entry := math.Max(bar.Open, breakout.Level) * (1 + e.cfg.FixedSlippage)
+				notional := e.balance * initialUsage
+				stopLoss := resolveStopPrice("long", entry, sig, e.cfg.StopMode, e.cfg.StopLossATR)
+				e.position = &strategyPosition{
+					Side:       "long",
+					EntryPrice: entry,
+					StopLoss:   stopLoss,
+					Protected:  false,
+					Notional:   notional,
+					Reason:     "Initial",
+					BarIndex:   e.currentBarIndex,
+					HWM:        entry,
+					LWM:        entry,
 				}
+				e.balance -= notional * commission
+				e.tradesInBar++
+				e.appendTrade("BUY", bar.Time, entry, "Initial", notional, 0, notional*commission, 0)
+				return
 			}
 		}
 		hasExitWindow := e.lastExitSide == "long" && e.currentBarIndex-e.lastExitBarIndex <= 1
@@ -873,30 +868,28 @@ func (e *strategyReplayEngine) tryEntry(bar executionBar, sig strategySignalBar)
 
 	if shortRegimeReady {
 		reP := sig.PrevHigh1 + e.cfg.ShortReentryATR*sig.ATR
-		if e.tradesInBar == 0 && sig.PrevLow2 < sig.PrevLow1 {
-			if bar.Low <= sig.PrevLow2 {
-				if e.zeroInitialReentryWindowEnabled() {
-					e.armZeroInitialWindow("short", e.currentBarIndex)
-				} else {
-					entry := math.Min(bar.Open, sig.PrevLow2) * (1 - e.cfg.FixedSlippage)
-					notional := e.balance * initialUsage
-					stopLoss := resolveStopPrice("short", entry, sig, e.cfg.StopMode, e.cfg.StopLossATR)
-					e.position = &strategyPosition{
-						Side:       "short",
-						EntryPrice: entry,
-						StopLoss:   stopLoss,
-						Protected:  false,
-						Notional:   notional,
-						Reason:     "Initial",
-						BarIndex:   e.currentBarIndex,
-						HWM:        entry,
-						LWM:        entry,
-					}
-					e.balance -= notional * commission
-					e.tradesInBar++
-					e.appendTrade("SHORT", bar.Time, entry, "Initial", notional, 0, notional*commission, 0)
-					return
+		if breakout := resolveReplayInitialBreakout(sig, "short", bar.Low, e.cfg); e.tradesInBar == 0 && breakout.Ready {
+			if e.zeroInitialReentryWindowEnabled() {
+				e.armZeroInitialWindow("short", e.currentBarIndex)
+			} else {
+				entry := math.Min(bar.Open, breakout.Level) * (1 - e.cfg.FixedSlippage)
+				notional := e.balance * initialUsage
+				stopLoss := resolveStopPrice("short", entry, sig, e.cfg.StopMode, e.cfg.StopLossATR)
+				e.position = &strategyPosition{
+					Side:       "short",
+					EntryPrice: entry,
+					StopLoss:   stopLoss,
+					Protected:  false,
+					Notional:   notional,
+					Reason:     "Initial",
+					BarIndex:   e.currentBarIndex,
+					HWM:        entry,
+					LWM:        entry,
 				}
+				e.balance -= notional * commission
+				e.tradesInBar++
+				e.appendTrade("SHORT", bar.Time, entry, "Initial", notional, 0, notional*commission, 0)
+				return
 			}
 		}
 		hasExitWindow := e.lastExitSide == "short" && e.currentBarIndex-e.lastExitBarIndex <= 1
@@ -1055,28 +1048,31 @@ func buildStrategyReplayConfig(context StrategyExecutionContext) strategyReplayC
 		stopLossATR = 0.05
 	}
 	return strategyReplayConfig{
-		SignalTimeframe:      normalizeSignalBarInterval(context.SignalTimeframe),
-		ExecutionDataSource:  strings.ToLower(context.ExecutionDataSource),
-		Symbol:               normalizeBacktestSymbol(context.Symbol),
-		From:                 context.From,
-		To:                   context.To,
-		InitialBalance:       100000.0,
-		Dir1ReentryConfirm:   false,
-		Dir2ZeroInitial:      dir2ZeroInitial,
-		ZeroInitialMode:      resolveStrategyZeroInitialMode(dir2ZeroInitial, parameters["zero_initial_mode"]),
-		FixedSlippage:        strategyReplaySlippage(context, parameters),
-		StopLossATR:          stopLossATR,
-		MaxTradesPerBar:      maxIntValue(parameters["max_trades_per_bar"], domain.ResearchBaselineMaxTradesPerBar),
-		ReentrySizeSchedule:  reentrySizes,
-		LongReentryATR:       parseFloatValue(firstNonNil(parameters["long_reentry_atr"], 0.1)),
-		ShortReentryATR:      parseFloatValue(firstNonNil(parameters["short_reentry_atr"], 0.0)),
-		StopMode:             stopMode,
-		ProfitProtectATR:     firstPositive(parseFloatValue(parameters["profit_protect_atr"]), 1.0),
-		TrailingStopATR:      parseFloatValue(parameters["trailing_stop_atr"]),
-		DelayedTrailingATR:   parseFloatValue(parameters["delayed_trailing_activation_atr"]),
-		TradingFeeRate:       context.Semantics.TradingFeeBps / 10000.0,
-		FundingRate:          context.Semantics.FundingRateBps / 10000.0,
-		FundingIntervalHours: maxIntValue(context.Semantics.FundingIntervalHours, 8),
+		SignalTimeframe:          normalizeSignalBarInterval(context.SignalTimeframe),
+		ExecutionDataSource:      strings.ToLower(context.ExecutionDataSource),
+		Symbol:                   normalizeBacktestSymbol(context.Symbol),
+		From:                     context.From,
+		To:                       context.To,
+		InitialBalance:           100000.0,
+		Dir1ReentryConfirm:       false,
+		Dir2ZeroInitial:          dir2ZeroInitial,
+		ZeroInitialMode:          resolveStrategyZeroInitialMode(dir2ZeroInitial, parameters["zero_initial_mode"]),
+		FixedSlippage:            strategyReplaySlippage(context, parameters),
+		StopLossATR:              stopLossATR,
+		MaxTradesPerBar:          maxIntValue(parameters["max_trades_per_bar"], domain.ResearchBaselineMaxTradesPerBar),
+		ReentrySizeSchedule:      reentrySizes,
+		LongReentryATR:           parseFloatValue(firstNonNil(parameters["long_reentry_atr"], 0.1)),
+		ShortReentryATR:          parseFloatValue(firstNonNil(parameters["short_reentry_atr"], 0.0)),
+		StopMode:                 stopMode,
+		ProfitProtectATR:         firstPositive(parseFloatValue(parameters["profit_protect_atr"]), 1.0),
+		TrailingStopATR:          parseFloatValue(parameters["trailing_stop_atr"]),
+		DelayedTrailingATR:       parseFloatValue(parameters["delayed_trailing_activation_atr"]),
+		TradingFeeRate:           context.Semantics.TradingFeeBps / 10000.0,
+		FundingRate:              context.Semantics.FundingRateBps / 10000.0,
+		FundingIntervalHours:     maxIntValue(context.Semantics.FundingIntervalHours, 8),
+		BreakoutShape:            strings.ToLower(strings.TrimSpace(stringValue(parameters["breakout_shape"]))),
+		T3MinSMAATRSeparation:    parseFloatValue(parameters["t3_min_sma_atr_separation"]),
+		UseSMA5IntradayStructure: boolValue(parameters["use_sma5_intraday_structure"]),
 	}
 }
 
@@ -1167,11 +1163,60 @@ func buildSignalBars(minuteBars []candleBar, timeframe string) ([]strategySignal
 			signals[i].PrevHigh2 = math.NaN()
 			signals[i].PrevLow2 = math.NaN()
 		}
+		if i >= 3 {
+			signals[i].PrevHigh3 = aggregated[i-3].High
+			signals[i].PrevLow3 = aggregated[i-3].Low
+		} else {
+			signals[i].PrevHigh3 = math.NaN()
+			signals[i].PrevLow3 = math.NaN()
+		}
 	}
 	return signals, nil
 }
 
-func strategySignalRegimeReady(sig strategySignalBar, timeframe string) (bool, bool) {
+type replayInitialBreakout struct {
+	Ready bool
+	Level float64
+	Shape string
+}
+
+func resolveReplayInitialBreakout(sig strategySignalBar, side string, observedPrice float64, cfg strategyReplayConfig) replayInitialBreakout {
+	switch strings.ToLower(strings.TrimSpace(side)) {
+	case "long":
+		if sig.PrevHigh2 > sig.PrevHigh1 && sig.PrevHigh2 > 0 && observedPrice >= sig.PrevHigh2 {
+			return replayInitialBreakout{Ready: true, Level: sig.PrevHigh2, Shape: "original_t2"}
+		}
+		if cfg.BreakoutShape == "baseline_plus_t3" &&
+			sig.PrevHigh3 > sig.PrevHigh2 && sig.PrevHigh3 > sig.PrevHigh1 && sig.PrevHigh1 > sig.PrevHigh2 &&
+			sig.PrevHigh3 > 0 && observedPrice >= sig.PrevHigh3 &&
+			replayT3BreakoutQualityReady(sig.PrevHigh3, sig, cfg) {
+			return replayInitialBreakout{Ready: true, Level: sig.PrevHigh3, Shape: "t3_swing"}
+		}
+	case "short":
+		if sig.PrevLow2 < sig.PrevLow1 && sig.PrevLow2 > 0 && observedPrice <= sig.PrevLow2 {
+			return replayInitialBreakout{Ready: true, Level: sig.PrevLow2, Shape: "original_t2"}
+		}
+		if cfg.BreakoutShape == "baseline_plus_t3" &&
+			sig.PrevLow3 < sig.PrevLow2 && sig.PrevLow3 < sig.PrevLow1 && sig.PrevLow1 < sig.PrevLow2 &&
+			sig.PrevLow3 > 0 && observedPrice <= sig.PrevLow3 &&
+			replayT3BreakoutQualityReady(sig.PrevLow3, sig, cfg) {
+			return replayInitialBreakout{Ready: true, Level: sig.PrevLow3, Shape: "t3_swing"}
+		}
+	}
+	return replayInitialBreakout{}
+}
+
+func replayT3BreakoutQualityReady(level float64, sig strategySignalBar, cfg strategyReplayConfig) bool {
+	if cfg.T3MinSMAATRSeparation <= 0 {
+		return true
+	}
+	if level <= 0 || sig.MA5 <= 0 || sig.ATR <= 0 || math.IsNaN(sig.MA5) || math.IsNaN(sig.ATR) {
+		return false
+	}
+	return math.Abs(level-sig.MA5) >= cfg.T3MinSMAATRSeparation*sig.ATR
+}
+
+func strategySignalRegimeReady(sig strategySignalBar, timeframe string, useSMA5Intraday ...bool) (bool, bool) {
 	tf := normalizeSignalBarInterval(timeframe)
 	if tf == "1d" {
 		if math.IsNaN(sig.ATR) || sig.ATR <= 0 {
@@ -1189,6 +1234,9 @@ func strategySignalRegimeReady(sig strategySignalBar, timeframe string) (bool, b
 		longEarly := sig.Close >= (sig.MA5-earlyBand) && sig.PrevHigh2 > sig.PrevHigh1 && sig.PrevLow1 >= sig.PrevLow2
 		shortEarly := sig.Close <= (sig.MA5+earlyBand) && sig.PrevLow2 < sig.PrevLow1 && sig.PrevHigh1 <= sig.PrevHigh2
 		return longHard || longEarly, shortHard || shortEarly
+	}
+	if len(useSMA5Intraday) > 0 && useSMA5Intraday[0] && !math.IsNaN(sig.MA5) && sig.MA5 > 0 {
+		return sig.Close > sig.MA5, sig.Close < sig.MA5
 	}
 	if math.IsNaN(sig.MA20) || sig.MA20 <= 0 {
 		return false, false
@@ -1311,8 +1359,10 @@ func readSignalBarsCSV(path string) ([]strategySignalBar, error) {
 			ATR:       atrValue,
 			PrevHigh1: prevHigh1Value,
 			PrevHigh2: prevHigh2Value,
+			PrevHigh3: math.NaN(),
 			PrevLow1:  prevLow1Value,
 			PrevLow2:  prevLow2Value,
+			PrevLow3:  math.NaN(),
 		})
 	}
 	return signals, nil

--- a/internal/service/strategy_replay_test.go
+++ b/internal/service/strategy_replay_test.go
@@ -159,6 +159,45 @@ func TestBuildStrategyReplayConfigUsesUpdatedBaselineDefaults(t *testing.T) {
 	}
 }
 
+func TestResolveReplayInitialBreakoutAllowsT3WithSep(t *testing.T) {
+	cfg := strategyReplayConfig{
+		BreakoutShape:         "baseline_plus_t3",
+		T3MinSMAATRSeparation: 0.25,
+	}
+	sig := strategySignalBar{
+		MA5:       68200,
+		ATR:       800,
+		PrevHigh1: 68800,
+		PrevHigh2: 68600,
+		PrevHigh3: 69000,
+		PrevLow1:  68100,
+		PrevLow2:  68000,
+		PrevLow3:  67900,
+	}
+	breakout := resolveReplayInitialBreakout(sig, "long", 69010, cfg)
+	if !breakout.Ready || breakout.Level != 69000 || breakout.Shape != "t3_swing" {
+		t.Fatalf("expected t3 breakout to pass sep filter, got %#v", breakout)
+	}
+}
+
+func TestResolveReplayInitialBreakoutBlocksT3InsideSep(t *testing.T) {
+	cfg := strategyReplayConfig{
+		BreakoutShape:         "baseline_plus_t3",
+		T3MinSMAATRSeparation: 0.25,
+	}
+	sig := strategySignalBar{
+		MA5:       68850,
+		ATR:       800,
+		PrevHigh1: 68800,
+		PrevHigh2: 68600,
+		PrevHigh3: 69000,
+	}
+	breakout := resolveReplayInitialBreakout(sig, "long", 69010, cfg)
+	if breakout.Ready {
+		t.Fatalf("expected t3 breakout inside sep filter to be blocked, got %#v", breakout)
+	}
+}
+
 func TestRunStrategyReplayOnMinuteBarsUsesZeroInitialReentryWindowForLongEntries(t *testing.T) {
 	start := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
 	signals := []strategySignalBar{

--- a/internal/store/memory/store.go
+++ b/internal/store/memory/store.go
@@ -127,6 +127,48 @@ func NewStore() *Store {
 	store.strategies[strategy.ID] = strategy
 	store.strategyVersion[version.ID] = version
 
+	enhancedStrategy := domain.Strategy{
+		ID:          "strategy-bk-btc-30m-enhanced",
+		Name:        "BK BTCUSDT 30m Enhanced",
+		Status:      "ACTIVE",
+		Description: "BTCUSDT 30m live intrabar SMA5 baseline plus t3 breakout with sep_0p25.",
+		CreatedAt:   now,
+	}
+	enhancedVersion := domain.StrategyVersion{
+		ID:                 "strategy-version-bk-btc-30m-enhanced-v010",
+		StrategyID:         enhancedStrategy.ID,
+		Version:            "v0.1.0",
+		SignalTimeframe:    "30m",
+		ExecutionTimeframe: "tick",
+		Parameters: map[string]any{
+			"strategyEngine":                  "bk-live-intrabar-sma5-t3-sep",
+			"symbol":                          "BTCUSDT",
+			"signalTimeframe":                 "30m",
+			"executionDataSource":             "tick",
+			"positionSizingMode":              "reentry_size_schedule",
+			"dir2_zero_initial":               domain.ResearchBaselineDir2ZeroInitial,
+			"zero_initial_mode":               domain.ResearchBaselineZeroInitialMode,
+			"max_trades_per_bar":              domain.ResearchBaselineMaxTradesPerBar,
+			"reentry_size_schedule":           domain.ResearchBaselineReentrySizeSchedule(),
+			"breakout_shape":                  "baseline_plus_t3",
+			"t3_min_sma_atr_separation":       0.25,
+			"use_sma5_intraday_structure":     true,
+			"stop_mode":                       "atr",
+			"stop_loss_atr":                   0.05,
+			"profit_protect_atr":              1.0,
+			"trailing_stop_atr":               0.3,
+			"delayed_trailing_activation_atr": 0.5,
+			"long_reentry_atr":                0.1,
+			"short_reentry_atr":               0.0,
+			"tradingFeeBps":                   10.0,
+			"fundingRateBps":                  0.0,
+			"fundingIntervalHours":            8,
+		},
+		CreatedAt: now,
+	}
+	store.strategies[enhancedStrategy.ID] = enhancedStrategy
+	store.strategyVersion[enhancedVersion.ID] = enhancedVersion
+
 	live := domain.Account{
 		ID:       "live-main",
 		Name:     "Live Main",

--- a/research/20260427_eth_q1_30min_t2_t3_sep_0p25.md
+++ b/research/20260427_eth_q1_30min_t2_t3_sep_0p25.md
@@ -1,0 +1,62 @@
+# ETH Q1 2026 30min t3_sma5 Signal Quality Filtering
+
+Scope: research-only backtest work. No live or execution path was changed.
+
+## Setup
+
+- Symbol/window: `ETHUSDT`, `2026-01-01 00:00:00+00:00` to `2026-03-31 23:59:59+00:00`
+- Execution bars: continuous `1s` bars rebuilt from raw Binance trades
+- Main comparison baseline: `t3_sma5_baseline` with full-size schedule `[0.20, 0.10]`
+- Sizing baseline: `dir2_zero_initial=true`, `zero_initial_mode=reentry_window`, `reentry_size_schedule=[0.20, 0.10]`, `max_trades_per_bar=2`
+- Shared risk params: `stop_mode=atr`, `stop_loss_atr=0.05`, `trailing_stop_atr=0.3`, `delayed_trailing_activation=0.5`
+
+## Replay Mode
+
+- `live_intrabar_sma5`: live-safe intrabar mode. Each replayed second updates the current signal bar close/high/low from data seen so far and computes `sma5/ma5` from four closed signal bars plus the current realtime close.
+
+## Breakout Shapes
+
+- Baseline long: `prev_t2.high > prev_t1.high` and current price crosses `prev_t2.high`.
+- Added long: `prev_t3.high > prev_t2.high`, `prev_t3.high > prev_t1.high`, `prev_t1.high > prev_t2.high`, and current price crosses `prev_t3.high`.
+- The short side uses the symmetric low-side condition.
+
+## Optimization Variants
+
+- `A_sep_0p25`: only the added t3 breakout requires `abs(breakout_level - sma5) >= 0.25 * atr`.
+- `all_breakouts_sep_0p25`: both original_t2 and added t3 breakouts require `abs(breakout_level - sma5) >= 0.25 * atr`.
+
+## Results
+
+| Timeframe | Scenario | Filters | Final Balance | Return | Max DD | Trades | Win Rate | Sharpe | Entry Mix | Breakout Locks | Quality Rejects |
+|---|---|---|---:|---:|---:|---:|---:|---:|---|---|---|
+| `30min` | `t3_sma5_baseline` | `none` | 531,886.72 | 431.89% | -2.10% | 3251 | 80.28% | 13.42 | `SL-Reentry:2101, Zero-Initial-Reentry:1150` | `long original_t2:447/t3_swing:127; short original_t2:471/t3_swing:113` | `` |
+| `30min` | `A_sep_0p25` | `{"min_sma_atr_separation": 0.25}` | 536,109.15 | 436.11% | -2.04% | 3226 | 80.60% | 13.49 | `SL-Reentry:2086, Zero-Initial-Reentry:1140` | `long original_t2:449/t3_swing:119; short original_t2:470/t3_swing:109` | `long sma_atr_separation:9; short sma_atr_separation:5` |
+| `30min` | `all_breakouts_sep_0p25` | `{"min_sma_atr_separation": 0.25}` | 399,531.93 | 299.53% | -1.42% | 2588 | 81.99% | 14.62 | `SL-Reentry:1659, Zero-Initial-Reentry:929` | `long original_t2:348/t3_swing:124; short original_t2:348/t3_swing:113` | `long sma_atr_separation:132; short sma_atr_separation:152` |
+
+## Delta vs t3_sma5 Baseline
+
+| Timeframe | Scenario | Final Balance Delta | Return Delta | Max DD Delta | Trades Delta | Win Rate Delta | Sharpe Delta |
+|---|---|---:|---:|---:|---:|---:|---:|
+| `30min` | `A_sep_0p25` | 4,222.43 | 4.22 pp | 0.06 pp | -25 | 0.32 pp | 0.07 |
+| `30min` | `all_breakouts_sep_0p25` | -132,354.79 | -132.36 pp | 0.68 pp | -663 | 1.71 pp | 1.20 |
+
+## Breakout Attribution
+
+| Timeframe | Scenario | Shape | Trades | Win Rate | Avg PnL | Median PnL | PnL Std | Worst PnL | Net PnL | Shape PnL DD | Profit Factor |
+|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| `30min` | `t3_sma5_baseline` | `original_t2` | 2576 | 87.97% | 0.5411% | 0.4008% | 0.6352% | -0.1811% | 553,447.23 | -219.54 | 61.5178 |
+| `30min` | `t3_sma5_baseline` | `t3_swing` | 675 | 85.33% | 0.5157% | 0.3537% | 0.6280% | -0.1188% | 136,907.94 | -215.84 | 51.2283 |
+| `30min` | `A_sep_0p25` | `original_t2` | 2575 | 87.96% | 0.5409% | 0.4009% | 0.6352% | -0.1811% | 555,845.31 | -221.00 | 61.861 |
+| `30min` | `A_sep_0p25` | `t3_swing` | 651 | 87.10% | 0.5355% | 0.3717% | 0.6343% | -0.1188% | 137,520.44 | -217.37 | 64.946 |
+| `30min` | `all_breakouts_sep_0p25` | `original_t2` | 1907 | 89.56% | 0.5594% | 0.4311% | 0.5869% | -0.1811% | 350,433.73 | -119.03 | 75.2062 |
+| `30min` | `all_breakouts_sep_0p25` | `t3_swing` | 681 | 86.93% | 0.5256% | 0.3643% | 0.6267% | -0.1188% | 117,101.47 | -171.67 | 58.6062 |
+
+## Read
+
+`A_sep_0p25` is the prior t3-only separation filter. `all_breakouts_sep_0p25` applies the same `0.25 * atr` SMA5 separation gate to both the original_t2 breakout and the added t3_swing breakout.
+
+On this Q1 30min replay, extending the separation gate to original_t2 is defensive: it cuts 663 trades, improves MaxDD by 0.68 pp, win rate by 1.71 pp, and Sharpe by 1.20 versus `t3_sma5_baseline`, but gives up 132.36 pp of return.
+
+## Conclusion
+
+Keep `A_sep_0p25` as the return-oriented candidate. Treat `all_breakouts_sep_0p25` as a risk-constrained variant rather than a primary return upgrade, because filtering original_t2 removes too much profitable flow despite the cleaner Sharpe/MaxDD profile.

--- a/research/20260427_eth_q1_30min_t3_sma5_combo_separation.md
+++ b/research/20260427_eth_q1_30min_t3_sma5_combo_separation.md
@@ -1,0 +1,69 @@
+# ETH Q1 2026 30min t3_sma5 Signal Quality Filtering
+
+Scope: research-only backtest work. No live or execution path was changed.
+
+## Setup
+
+- Symbol/window: `ETHUSDT`, `2026-01-01 00:00:00+00:00` to `2026-03-31 23:59:59+00:00`
+- Execution bars: continuous `1s` bars rebuilt from raw Binance trades
+- Main comparison baseline: `t3_sma5_baseline` with full-size schedule `[0.20, 0.10]`
+- Sizing baseline: `dir2_zero_initial=true`, `zero_initial_mode=reentry_window`, `reentry_size_schedule=[0.20, 0.10]`, `max_trades_per_bar=2`
+- Shared risk params: `stop_mode=atr`, `stop_loss_atr=0.05`, `trailing_stop_atr=0.3`, `delayed_trailing_activation=0.5`
+
+## Replay Mode
+
+- `live_intrabar_sma5`: live-safe intrabar mode. Each replayed second updates the current signal bar close/high/low from data seen so far and computes `sma5/ma5` from four closed signal bars plus the current realtime close.
+
+## Breakout Shapes
+
+- Baseline long: `prev_t2.high > prev_t1.high` and current price crosses `prev_t2.high`.
+- Added long: `prev_t3.high > prev_t2.high`, `prev_t3.high > prev_t1.high`, `prev_t1.high > prev_t2.high`, and current price crosses `prev_t3.high`.
+- The short side uses the symmetric low-side condition.
+
+## Optimization Variants
+
+- `t3_sma5_trend_and_atr_pct30`: combines the trend filter with ATR percentile >= `30%`.
+- `t3_sma5_sma_atr_sep_0p25`: t3 requires `abs(breakout_level - sma5) >= 0.25 * atr`.
+- `t3_sma5_sma_atr_sep_0p50`: t3 requires `abs(breakout_level - sma5) >= 0.50 * atr`.
+
+## Results
+
+| Timeframe | Scenario | Filters | Final Balance | Return | Max DD | Trades | Win Rate | Sharpe | Entry Mix | Breakout Locks | Quality Rejects |
+|---|---|---|---:|---:|---:|---:|---:|---:|---|---|---|
+| `30min` | `t3_sma5_baseline` | `none` | 531,886.72 | 431.89% | -2.10% | 3251 | 80.28% | 13.42 | `SL-Reentry:2101, Zero-Initial-Reentry:1150` | `long original_t2:447/t3_swing:127; short original_t2:471/t3_swing:113` | `` |
+| `30min` | `t3_sma5_trend_and_atr_pct30` | `{"min_atr_percentile": 30.0, "trend": true}` | 505,297.73 | 405.30% | -1.85% | 3012 | 80.71% | 13.64 | `SL-Reentry:1954, Zero-Initial-Reentry:1058` | `long original_t2:446/t3_swing:76; short original_t2:479/t3_swing:64` | `long trend_long:35/atr_percentile:37; short atr_percentile:29/trend_short:30` |
+| `30min` | `t3_sma5_sma_atr_sep_0p25` | `{"min_sma_atr_separation": 0.25}` | 536,109.15 | 436.11% | -2.04% | 3226 | 80.60% | 13.49 | `SL-Reentry:2086, Zero-Initial-Reentry:1140` | `long original_t2:449/t3_swing:119; short original_t2:470/t3_swing:109` | `long sma_atr_separation:9; short sma_atr_separation:5` |
+| `30min` | `t3_sma5_sma_atr_sep_0p50` | `{"min_sma_atr_separation": 0.5}` | 476,215.28 | 376.22% | -1.87% | 2863 | 81.28% | 13.61 | `SL-Reentry:1845, Zero-Initial-Reentry:1017, PT-Reentry:1` | `long original_t2:450/t3_swing:43; short original_t2:482/t3_swing:48` | `long sma_atr_separation:91; short sma_atr_separation:68` |
+
+## Delta vs t3_sma5 Baseline
+
+| Timeframe | Scenario | Final Balance Delta | Return Delta | Max DD Delta | Trades Delta | Win Rate Delta | Sharpe Delta |
+|---|---|---:|---:|---:|---:|---:|---:|
+| `30min` | `t3_sma5_trend_and_atr_pct30` | -26,588.99 | -26.59 pp | 0.25 pp | -239 | 0.43 pp | 0.22 |
+| `30min` | `t3_sma5_sma_atr_sep_0p25` | 4,222.43 | 4.22 pp | 0.06 pp | -25 | 0.32 pp | 0.07 |
+| `30min` | `t3_sma5_sma_atr_sep_0p50` | -55,671.44 | -55.67 pp | 0.23 pp | -388 | 1.00 pp | 0.19 |
+
+## Breakout Attribution
+
+| Timeframe | Scenario | Shape | Trades | Win Rate | Avg PnL | Median PnL | PnL Std | Worst PnL | Net PnL | Shape PnL DD | Profit Factor |
+|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| `30min` | `t3_sma5_baseline` | `original_t2` | 2576 | 87.97% | 0.5411% | 0.4008% | 0.6352% | -0.1811% | 553,447.23 | -219.54 | 61.5178 |
+| `30min` | `t3_sma5_baseline` | `t3_swing` | 675 | 85.33% | 0.5157% | 0.3537% | 0.6280% | -0.1188% | 136,907.94 | -215.84 | 51.2283 |
+| `30min` | `t3_sma5_trend_and_atr_pct30` | `original_t2` | 2601 | 87.97% | 0.5378% | 0.3962% | 0.6328% | -0.1811% | 540,269.41 | -210.63 | 61.2308 |
+| `30min` | `t3_sma5_trend_and_atr_pct30` | `t3_swing` | 411 | 85.16% | 0.6351% | 0.4678% | 0.6870% | -0.1365% | 97,719.15 | -209.58 | 55.7738 |
+| `30min` | `t3_sma5_sma_atr_sep_0p25` | `original_t2` | 2575 | 87.96% | 0.5409% | 0.4009% | 0.6352% | -0.1811% | 555,845.31 | -221.00 | 61.861 |
+| `30min` | `t3_sma5_sma_atr_sep_0p25` | `t3_swing` | 651 | 87.10% | 0.5355% | 0.3717% | 0.6343% | -0.1188% | 137,520.44 | -217.37 | 64.946 |
+| `30min` | `t3_sma5_sma_atr_sep_0p50` | `original_t2` | 2621 | 87.87% | 0.5369% | 0.3969% | 0.6316% | -0.1811% | 527,981.19 | -201.66 | 61.0195 |
+| `30min` | `t3_sma5_sma_atr_sep_0p50` | `t3_swing` | 242 | 94.21% | 0.7532% | 0.5201% | 0.7700% | -0.1024% | 62,952.98 | -28.06 | 397.5286 |
+
+## Read
+
+This run keeps the `t3_sma5_baseline` sizing and only filters the added t3 breakout lock. The original_t2 path is left unchanged, so deltas isolate signal-quality filtering rather than position sizing.
+
+## Conclusion
+
+- `t3_sma5_sma_atr_sep_0p25` is the best candidate in this run. It improves return by `+4.22 pp`, MaxDD by `0.06 pp`, Sharpe by `+0.07`, win rate by `+0.32 pp`, and reduces trades by `25`.
+- `t3_sma5_trend_and_atr_pct30` is a defensive filter. It improves MaxDD by `0.25 pp`, Sharpe by `+0.22`, and reduces trades by `239`, but gives back `26.59 pp` return.
+- `t3_sma5_sma_atr_sep_0p50` is too strict for a primary 30min setting. It improves MaxDD by `0.23 pp`, Sharpe by `+0.19`, and win rate by `+1.00 pp`, but gives back `55.67 pp` return.
+
+Recommended next candidate for live-aligned research is `t3_sma5_sma_atr_sep_0p25`, because it is the only tested filter that improves return and risk metrics together against `t3_sma5_baseline`.

--- a/research/20260427_eth_q1_30min_t3_sma5_quality_filtering.md
+++ b/research/20260427_eth_q1_30min_t3_sma5_quality_filtering.md
@@ -1,0 +1,69 @@
+# ETH Q1 2026 30min t3_sma5 Signal Quality Filtering
+
+Scope: research-only backtest work. No live or execution path was changed.
+
+## Setup
+
+- Symbol/window: `ETHUSDT`, `2026-01-01 00:00:00+00:00` to `2026-03-31 23:59:59+00:00`
+- Execution bars: continuous `1s` bars rebuilt from raw Binance trades
+- Main comparison baseline: `t3_sma5_baseline` with full-size schedule `[0.20, 0.10]`
+- Sizing baseline: `dir2_zero_initial=true`, `zero_initial_mode=reentry_window`, `reentry_size_schedule=[0.20, 0.10]`, `max_trades_per_bar=2`
+- Shared risk params: `stop_mode=atr`, `stop_loss_atr=0.05`, `trailing_stop_atr=0.3`, `delayed_trailing_activation=0.5`
+
+## Replay Mode
+
+- `live_intrabar_sma5`: live-safe intrabar mode. Each replayed second updates the current signal bar close/high/low from data seen so far and computes `sma5/ma5` from four closed signal bars plus the current realtime close.
+
+## Breakout Shapes
+
+- Baseline long: `prev_t2.high > prev_t1.high` and current price crosses `prev_t2.high`.
+- Added long: `prev_t3.high > prev_t2.high`, `prev_t3.high > prev_t1.high`, `prev_t1.high > prev_t2.high`, and current price crosses `prev_t3.high`.
+- The short side uses the symmetric low-side condition.
+
+## Optimization Variants
+
+- `t3_sma5_trend_filter`: t3 long requires `close_now > sma5` and `sma5_slope > 0`; t3 short requires `close_now < sma5` and `sma5_slope < 0`.
+- `t3_sma5_sma_atr_sep_0p1`: t3 requires `abs(breakout_level - sma5) >= 0.1 * atr`.
+- `t3_sma5_atr_percentile_gte_30`: t3 requires the signal bar ATR percentile to be at least `30%` over the rolling ATR sample.
+
+## Results
+
+| Timeframe | Scenario | Filters | Final Balance | Return | Max DD | Trades | Win Rate | Sharpe | Entry Mix | Breakout Locks | Quality Rejects |
+|---|---|---|---:|---:|---:|---:|---:|---:|---|---|---|
+| `30min` | `t3_sma5_baseline` | `none` | 531,886.72 | 431.89% | -2.10% | 3251 | 80.28% | 13.42 | `SL-Reentry:2101, Zero-Initial-Reentry:1150` | `long original_t2:447/t3_swing:127; short original_t2:471/t3_swing:113` | `` |
+| `30min` | `t3_sma5_trend_filter` | `{"trend": true}` | 518,859.46 | 418.86% | -2.10% | 3167 | 80.45% | 13.56 | `SL-Reentry:2049, Zero-Initial-Reentry:1118` | `long original_t2:446/t3_swing:113; short original_t2:474/t3_swing:93` | `long trend_long:34; short trend_short:30` |
+| `30min` | `t3_sma5_sma_atr_sep_0p1` | `{"min_sma_atr_separation": 0.1}` | 531,886.72 | 431.89% | -2.10% | 3251 | 80.28% | 13.42 | `SL-Reentry:2101, Zero-Initial-Reentry:1150` | `long original_t2:447/t3_swing:127; short original_t2:471/t3_swing:113` | `` |
+| `30min` | `t3_sma5_atr_percentile_gte_30` | `{"min_atr_percentile": 30.0}` | 517,661.93 | 417.66% | -1.85% | 3060 | 80.69% | 13.54 | `SL-Reentry:1984, Zero-Initial-Reentry:1076` | `long original_t2:447/t3_swing:85; short original_t2:477/t3_swing:74` | `long atr_percentile:42; short atr_percentile:39` |
+
+## Delta vs t3_sma5 Baseline
+
+| Timeframe | Scenario | Final Balance Delta | Return Delta | Max DD Delta | Trades Delta | Win Rate Delta | Sharpe Delta |
+|---|---|---:|---:|---:|---:|---:|---:|
+| `30min` | `t3_sma5_trend_filter` | -13,027.26 | -13.03 pp | 0.00 pp | -84 | 0.17 pp | 0.14 |
+| `30min` | `t3_sma5_sma_atr_sep_0p1` | 0.00 | 0.00 pp | 0.00 pp | 0 | 0.00 pp | 0.00 |
+| `30min` | `t3_sma5_atr_percentile_gte_30` | -14,224.79 | -14.23 pp | 0.25 pp | -191 | 0.41 pp | 0.12 |
+
+## Breakout Attribution
+
+| Timeframe | Scenario | Shape | Trades | Win Rate | Avg PnL | Median PnL | PnL Std | Worst PnL | Net PnL | Shape PnL DD | Profit Factor |
+|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| `30min` | `t3_sma5_baseline` | `original_t2` | 2576 | 87.97% | 0.5411% | 0.4008% | 0.6352% | -0.1811% | 553,447.23 | -219.54 | 61.5178 |
+| `30min` | `t3_sma5_baseline` | `t3_swing` | 675 | 85.33% | 0.5157% | 0.3537% | 0.6280% | -0.1188% | 136,907.94 | -215.84 | 51.2283 |
+| `30min` | `t3_sma5_trend_filter` | `original_t2` | 2583 | 88.00% | 0.5400% | 0.4008% | 0.6342% | -0.1811% | 544,069.92 | -215.19 | 61.5424 |
+| `30min` | `t3_sma5_trend_filter` | `t3_swing` | 584 | 85.27% | 0.5377% | 0.3796% | 0.6214% | -0.1365% | 121,978.46 | -211.41 | 54.3655 |
+| `30min` | `t3_sma5_sma_atr_sep_0p1` | `original_t2` | 2576 | 87.97% | 0.5411% | 0.4008% | 0.6352% | -0.1811% | 553,447.23 | -219.54 | 61.5178 |
+| `30min` | `t3_sma5_sma_atr_sep_0p1` | `t3_swing` | 675 | 85.33% | 0.5157% | 0.3537% | 0.6280% | -0.1188% | 136,907.94 | -215.84 | 51.2283 |
+| `30min` | `t3_sma5_atr_percentile_gte_30` | `original_t2` | 2597 | 87.95% | 0.5385% | 0.3962% | 0.6335% | -0.1811% | 549,011.70 | -214.26 | 61.2655 |
+| `30min` | `t3_sma5_atr_percentile_gte_30` | `t3_swing` | 463 | 85.31% | 0.6192% | 0.4428% | 0.7049% | -0.1143% | 108,775.50 | -213.12 | 54.2307 |
+
+## Read
+
+This run keeps the `t3_sma5_baseline` sizing and only filters the added t3 breakout lock. The original_t2 path is left unchanged, so deltas isolate signal-quality filtering rather than position sizing.
+
+## Conclusion
+
+- `t3_sma5_trend_filter` is the cleanest Sharpe improvement in this batch: Sharpe improves `+0.14`, trades drop `84`, and win rate improves `+0.17 pp`, while return gives back `13.03 pp`. MaxDD is unchanged.
+- `t3_sma5_atr_percentile_gte_30` is the best risk/trade-count filter: trades drop `191`, MaxDD improves `0.25 pp`, win rate improves `+0.41 pp`, and Sharpe improves `+0.12`, while return gives back `14.23 pp`.
+- `t3_sma5_sma_atr_sep_0p1` has no effect on this Q1 30min replay. The `0.1 * atr` threshold is too loose for this signal path.
+
+Next useful experiment: combine `trend_filter` and `atr_percentile_gte_30`, then separately try stricter SMA separation thresholds such as `0.25 * atr` and `0.50 * atr`.

--- a/research/20260427_eth_q1_30min_t3_sma5_sep_0p25_marginal.md
+++ b/research/20260427_eth_q1_30min_t3_sma5_sep_0p25_marginal.md
@@ -1,0 +1,75 @@
+# ETH Q1 2026 30min t3_sma5 Signal Quality Filtering
+
+Scope: research-only backtest work. No live or execution path was changed.
+
+## Setup
+
+- Symbol/window: `ETHUSDT`, `2026-01-01 00:00:00+00:00` to `2026-03-31 23:59:59+00:00`
+- Execution bars: continuous `1s` bars rebuilt from raw Binance trades
+- Main comparison baseline: `t3_sma5_baseline` with full-size schedule `[0.20, 0.10]`
+- Sizing baseline: `dir2_zero_initial=true`, `zero_initial_mode=reentry_window`, `reentry_size_schedule=[0.20, 0.10]`, `max_trades_per_bar=2`
+- Shared risk params: `stop_mode=atr`, `stop_loss_atr=0.05`, `trailing_stop_atr=0.3`, `delayed_trailing_activation=0.5`
+
+## Replay Mode
+
+- `live_intrabar_sma5`: live-safe intrabar mode. Each replayed second updates the current signal bar close/high/low from data seen so far and computes `sma5/ma5` from four closed signal bars plus the current realtime close.
+
+## Breakout Shapes
+
+- Baseline long: `prev_t2.high > prev_t1.high` and current price crosses `prev_t2.high`.
+- Added long: `prev_t3.high > prev_t2.high`, `prev_t3.high > prev_t1.high`, `prev_t1.high > prev_t2.high`, and current price crosses `prev_t3.high`.
+- The short side uses the symmetric low-side condition.
+
+## Optimization Variants
+
+- `A_sep_0p25`: t3 requires `abs(breakout_level - sma5) >= 0.25 * atr`.
+- `B_trend_sep_0p25`: A plus trend direction filter.
+- `C_atr_pct30_sep_0p25`: A plus ATR percentile >= `30%`.
+- `D_trend_atr_pct30_sep_0p25`: A plus trend direction and ATR percentile >= `30%`.
+
+## Results
+
+| Timeframe | Scenario | Filters | Final Balance | Return | Max DD | Trades | Win Rate | Sharpe | Entry Mix | Breakout Locks | Quality Rejects |
+|---|---|---|---:|---:|---:|---:|---:|---:|---|---|---|
+| `30min` | `t3_sma5_baseline` | `none` | 531,886.72 | 431.89% | -2.10% | 3251 | 80.28% | 13.42 | `SL-Reentry:2101, Zero-Initial-Reentry:1150` | `long original_t2:447/t3_swing:127; short original_t2:471/t3_swing:113` | `` |
+| `30min` | `A_sep_0p25` | `{"min_sma_atr_separation": 0.25}` | 536,109.15 | 436.11% | -2.04% | 3226 | 80.60% | 13.49 | `SL-Reentry:2086, Zero-Initial-Reentry:1140` | `long original_t2:449/t3_swing:119; short original_t2:470/t3_swing:109` | `long sma_atr_separation:9; short sma_atr_separation:5` |
+| `30min` | `B_trend_sep_0p25` | `{"min_sma_atr_separation": 0.25, "trend": true}` | 515,280.51 | 415.28% | -2.04% | 3136 | 80.64% | 13.57 | `SL-Reentry:2030, Zero-Initial-Reentry:1106` | `long original_t2:448/t3_swing:103; short original_t2:473/t3_swing:89` | `long trend_long:34/sma_atr_separation:11; short trend_short:30/sma_atr_separation:5` |
+| `30min` | `C_atr_pct30_sep_0p25` | `{"min_atr_percentile": 30.0, "min_sma_atr_separation": 0.25}` | 519,646.71 | 419.65% | -1.79% | 3037 | 81.00% | 13.61 | `SL-Reentry:1969, Zero-Initial-Reentry:1068` | `long original_t2:449/t3_swing:79; short original_t2:476/t3_swing:71` | `long atr_percentile:40/sma_atr_separation:20; short atr_percentile:38/sma_atr_separation:14` |
+| `30min` | `D_trend_atr_pct30_sep_0p25` | `{"min_atr_percentile": 30.0, "min_sma_atr_separation": 0.25, "trend": true}` | 500,219.35 | 400.22% | -1.79% | 2985 | 80.90% | 13.65 | `SL-Reentry:1936, Zero-Initial-Reentry:1049` | `long original_t2:448/t3_swing:69; short original_t2:478/t3_swing:61` | `long trend_long:35/atr_percentile:34/sma_atr_separation:21; short atr_percentile:28/trend_short:30/sma_atr_separation:13` |
+
+## Delta vs t3_sma5 Baseline
+
+| Timeframe | Scenario | Final Balance Delta | Return Delta | Max DD Delta | Trades Delta | Win Rate Delta | Sharpe Delta |
+|---|---|---:|---:|---:|---:|---:|---:|
+| `30min` | `A_sep_0p25` | 4,222.43 | 4.22 pp | 0.06 pp | -25 | 0.32 pp | 0.07 |
+| `30min` | `B_trend_sep_0p25` | -16,606.21 | -16.61 pp | 0.06 pp | -115 | 0.36 pp | 0.15 |
+| `30min` | `C_atr_pct30_sep_0p25` | -12,240.01 | -12.24 pp | 0.31 pp | -214 | 0.72 pp | 0.19 |
+| `30min` | `D_trend_atr_pct30_sep_0p25` | -31,667.37 | -31.67 pp | 0.31 pp | -266 | 0.62 pp | 0.23 |
+
+## Breakout Attribution
+
+| Timeframe | Scenario | Shape | Trades | Win Rate | Avg PnL | Median PnL | PnL Std | Worst PnL | Net PnL | Shape PnL DD | Profit Factor |
+|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| `30min` | `t3_sma5_baseline` | `original_t2` | 2576 | 87.97% | 0.5411% | 0.4008% | 0.6352% | -0.1811% | 553,447.23 | -219.54 | 61.5178 |
+| `30min` | `t3_sma5_baseline` | `t3_swing` | 675 | 85.33% | 0.5157% | 0.3537% | 0.6280% | -0.1188% | 136,907.94 | -215.84 | 51.2283 |
+| `30min` | `A_sep_0p25` | `original_t2` | 2575 | 87.96% | 0.5409% | 0.4009% | 0.6352% | -0.1811% | 555,845.31 | -221.00 | 61.861 |
+| `30min` | `A_sep_0p25` | `t3_swing` | 651 | 87.10% | 0.5355% | 0.3717% | 0.6343% | -0.1188% | 137,520.44 | -217.37 | 64.946 |
+| `30min` | `B_trend_sep_0p25` | `original_t2` | 2582 | 87.99% | 0.5399% | 0.4008% | 0.6342% | -0.1811% | 543,747.33 | -214.13 | 61.9276 |
+| `30min` | `B_trend_sep_0p25` | `t3_swing` | 554 | 86.64% | 0.5476% | 0.3864% | 0.6266% | -0.1365% | 115,305.65 | -212.60 | 62.9664 |
+| `30min` | `C_atr_pct30_sep_0p25` | `original_t2` | 2596 | 87.94% | 0.5383% | 0.3965% | 0.6335% | -0.1811% | 549,677.40 | -214.80 | 61.5891 |
+| `30min` | `C_atr_pct30_sep_0p25` | `t3_swing` | 441 | 87.76% | 0.6460% | 0.4636% | 0.7090% | -0.1097% | 108,202.07 | -213.67 | 74.0498 |
+| `30min` | `D_trend_atr_pct30_sep_0p25` | `original_t2` | 2600 | 87.96% | 0.5376% | 0.3965% | 0.6328% | -0.1811% | 538,455.99 | -208.75 | 61.5903 |
+| `30min` | `D_trend_atr_pct30_sep_0p25` | `t3_swing` | 385 | 87.01% | 0.6467% | 0.4682% | 0.6908% | -0.1365% | 90,818.18 | -209.81 | 67.1991 |
+
+## Read
+
+This run keeps the `t3_sma5_baseline` sizing and only filters the added t3 breakout lock. The original_t2 path is left unchanged, so deltas isolate signal-quality filtering rather than position sizing.
+
+## Conclusion
+
+- A (`sep_0p25`) is still the best primary candidate: return improves `+4.22 pp`, MaxDD improves `0.06 pp`, Sharpe improves `+0.07`, and trades drop `25`.
+- Adding trend on top of A is defensive but gives back too much return: B improves Sharpe more (`+0.15`) and cuts `115` trades, but return falls `16.61 pp` vs baseline and `20.83 pp` vs A.
+- Adding ATR percentile on top of A is the better defensive overlay: C improves MaxDD `0.31 pp`, Sharpe `+0.19`, win rate `+0.72 pp`, and cuts `214` trades, while giving back `12.24 pp` vs baseline and `16.46 pp` vs A.
+- Adding both filters on top of A over-constrains the signal: D has the highest Sharpe delta (`+0.23`) and lowest trade count, but loses `31.67 pp` return vs baseline.
+
+Recommended ranking: A for primary 30min candidate; C as the risk-off candidate when drawdown/trade count matters more than raw return.

--- a/research/20260427_eth_q1_t3_secondary_alpha_optimization.md
+++ b/research/20260427_eth_q1_t3_secondary_alpha_optimization.md
@@ -1,0 +1,85 @@
+# ETH Q1 2026 t-3 Breakout Optimization, 1s Replay
+
+Scope: research-only backtest work. No live or execution path was changed.
+
+## Setup
+
+- Symbol/window: `ETHUSDT`, `2026-01-01 00:00:00+00:00` to `2026-03-31 23:59:59+00:00`
+- Execution bars: continuous `1s` bars rebuilt from raw Binance trades
+- Main comparison baseline: `live_intrabar_sma5_baseline_plus_t3_breakout` with t3 full-size schedule `[0.20, 0.10]`
+- Original sizing baseline: `dir2_zero_initial=true`, `zero_initial_mode=reentry_window`, `reentry_size_schedule=[0.20, 0.10]`, `max_trades_per_bar=2`
+- Shared risk params: `stop_mode=atr`, `stop_loss_atr=0.05`, `trailing_stop_atr=0.3`, `delayed_trailing_activation=0.5`
+
+## Replay Mode
+
+- `live_intrabar_sma5`: live-safe intrabar mode. Each replayed second updates the current signal bar close/high/low from data seen so far and computes `sma5/ma5` from four closed signal bars plus the current realtime close.
+
+## Breakout Shapes
+
+- Baseline long: `prev_t2.high > prev_t1.high` and current price crosses `prev_t2.high`.
+- Added long: `prev_t3.high > prev_t2.high`, `prev_t3.high > prev_t1.high`, `prev_t1.high > prev_t2.high`, and current price crosses `prev_t3.high`.
+- The short side uses the symmetric low-side condition.
+
+## Optimization Variants
+
+- `live_intrabar_sma5_t3_half_size`: t3_swing real reentry sizing `[0.10, 0.05]`; original_t2 stays `[0.20, 0.10]`.
+- `live_intrabar_sma5_t3_half_size_cooldown1/2`: 30min-only half-size t3 plus a t3-only cooldown of 1 or 2 signal bars after a t3 lock.
+
+## Results
+
+| Timeframe | Scenario | T3 Schedule | T3 Cooldown | Final Balance | Return | Max DD | Trades | Win Rate | Sharpe | Entry Mix | Breakout Locks |
+|---|---|---|---:|---:|---:|---:|---:|---:|---:|---|---|
+| `4h` | `live_intrabar_sma5_baseline_plus_t3_breakout` | `[0.2, 0.1]` | 0 | 236,994.21 | 136.99% | -0.24% | 374 | 92.51% | 18.77 | `SL-Reentry:239, Zero-Initial-Reentry:135` | `long original_t2:46/t3_swing:14; short original_t2:64/t3_swing:12` |
+| `4h` | `live_intrabar_sma5_t3_half_size` | `[0.1, 0.05]` | 0 | 215,980.36 | 115.98% | -0.24% | 374 | 92.51% | 18.77 | `SL-Reentry:239, Zero-Initial-Reentry:135` | `long original_t2:46/t3_swing:14; short original_t2:64/t3_swing:12` |
+| `1h` | `live_intrabar_sma5_baseline_plus_t3_breakout` | `[0.2, 0.1]` | 0 | 481,070.05 | 381.07% | -0.76% | 1634 | 85.19% | 14.39 | `SL-Reentry:1035, Zero-Initial-Reentry:599` | `long original_t2:219/t3_swing:92; short t3_swing:77/original_t2:213` |
+| `1h` | `live_intrabar_sma5_t3_half_size` | `[0.1, 0.05]` | 0 | 385,321.81 | 285.32% | -0.65% | 1634 | 85.19% | 14.39 | `SL-Reentry:1035, Zero-Initial-Reentry:599` | `long original_t2:219/t3_swing:92; short t3_swing:77/original_t2:213` |
+| `30min` | `live_intrabar_sma5_baseline_plus_t3_breakout` | `[0.2, 0.1]` | 0 | 531,886.72 | 431.89% | -2.10% | 3251 | 80.28% | 13.42 | `SL-Reentry:2101, Zero-Initial-Reentry:1150` | `long original_t2:447/t3_swing:127; short original_t2:471/t3_swing:113` |
+| `30min` | `live_intrabar_sma5_t3_half_size` | `[0.1, 0.05]` | 0 | 452,621.79 | 352.62% | -1.91% | 3251 | 80.28% | 13.42 | `SL-Reentry:2101, Zero-Initial-Reentry:1150` | `long original_t2:447/t3_swing:127; short original_t2:471/t3_swing:113` |
+| `30min` | `live_intrabar_sma5_t3_half_size_cooldown1` | `[0.1, 0.05]` | 1 | 453,582.21 | 353.58% | -1.86% | 3247 | 80.32% | 13.43 | `SL-Reentry:2099, Zero-Initial-Reentry:1148` | `long original_t2:447/t3_swing:124; short original_t2:472/t3_swing:113` |
+| `30min` | `live_intrabar_sma5_t3_half_size_cooldown2` | `[0.1, 0.05]` | 2 | 451,192.47 | 351.19% | -1.86% | 3218 | 80.27% | 13.42 | `SL-Reentry:2082, Zero-Initial-Reentry:1136` | `long original_t2:448/t3_swing:117; short original_t2:472/t3_swing:107` |
+
+## Delta vs Full-Size t3 Baseline
+
+| Timeframe | Scenario | Final Balance Delta | Return Delta | Max DD Delta | Trades Delta | Win Rate Delta | Sharpe Delta |
+|---|---|---:|---:|---:|---:|---:|---:|
+| `4h` | `live_intrabar_sma5_t3_half_size` | -21,013.85 | -21.01 pp | 0.00 pp | 0 | 0.00 pp | 0.00 |
+| `1h` | `live_intrabar_sma5_t3_half_size` | -95,748.24 | -95.75 pp | 0.11 pp | 0 | 0.00 pp | 0.00 |
+| `30min` | `live_intrabar_sma5_t3_half_size` | -79,264.93 | -79.27 pp | 0.19 pp | 0 | 0.00 pp | 0.00 |
+| `30min` | `live_intrabar_sma5_t3_half_size_cooldown1` | -78,304.51 | -78.31 pp | 0.24 pp | -4 | 0.04 pp | 0.01 |
+| `30min` | `live_intrabar_sma5_t3_half_size_cooldown2` | -80,694.25 | -80.70 pp | 0.24 pp | -33 | -0.01 pp | 0.00 |
+
+## Breakout Attribution
+
+| Timeframe | Scenario | Shape | Trades | Win Rate | Avg PnL | Median PnL | PnL Std | Worst PnL | Net PnL | Shape PnL DD | Profit Factor |
+|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| `4h` | `live_intrabar_sma5_baseline_plus_t3_breakout` | `original_t2` | 312 | 91.67% | 1.6052% | 1.2912% | 1.4432% | -0.2138% | 125,328.66 | -209.76 | 136.7618 |
+| `4h` | `live_intrabar_sma5_baseline_plus_t3_breakout` | `t3_swing` | 62 | 96.77% | 2.2348% | 2.3361% | 1.3286% | -0.1613% | 29,715.41 | -53.99 | 551.3826 |
+| `4h` | `live_intrabar_sma5_t3_half_size` | `original_t2` | 312 | 91.67% | 1.6052% | 1.2912% | 1.4432% | -0.2138% | 117,584.02 | -191.65 | 137.2045 |
+| `4h` | `live_intrabar_sma5_t3_half_size` | `t3_swing` | 62 | 96.77% | 2.2348% | 2.3361% | 1.3286% | -0.1613% | 14,135.14 | -26.75 | 529.395 |
+| `1h` | `live_intrabar_sma5_baseline_plus_t3_breakout` | `original_t2` | 1179 | 88.89% | 0.8306% | 0.6353% | 0.8688% | -0.1805% | 354,537.63 | -237.38 | 75.9616 |
+| `1h` | `live_intrabar_sma5_baseline_plus_t3_breakout` | `t3_swing` | 455 | 86.15% | 0.8399% | 0.6193% | 1.0377% | -0.2268% | 146,691.41 | -155.89 | 75.4769 |
+| `1h` | `live_intrabar_sma5_t3_half_size` | `original_t2` | 1179 | 88.89% | 0.8306% | 0.6353% | 0.8688% | -0.1805% | 311,945.23 | -215.26 | 75.8124 |
+| `1h` | `live_intrabar_sma5_t3_half_size` | `t3_swing` | 455 | 86.15% | 0.8399% | 0.6193% | 1.0377% | -0.2268% | 64,095.79 | -68.12 | 74.1792 |
+| `30min` | `live_intrabar_sma5_baseline_plus_t3_breakout` | `original_t2` | 2576 | 87.97% | 0.5411% | 0.4008% | 0.6352% | -0.1811% | 553,447.23 | -219.54 | 61.5178 |
+| `30min` | `live_intrabar_sma5_baseline_plus_t3_breakout` | `t3_swing` | 675 | 85.33% | 0.5157% | 0.3537% | 0.6280% | -0.1188% | 136,907.94 | -215.84 | 51.2283 |
+| `30min` | `live_intrabar_sma5_t3_half_size` | `original_t2` | 2576 | 87.97% | 0.5411% | 0.4008% | 0.6352% | -0.1811% | 501,451.59 | -192.06 | 61.4243 |
+| `30min` | `live_intrabar_sma5_t3_half_size` | `t3_swing` | 675 | 85.33% | 0.5157% | 0.3537% | 0.6280% | -0.1188% | 62,002.25 | -96.90 | 50.4756 |
+| `30min` | `live_intrabar_sma5_t3_half_size_cooldown1` | `original_t2` | 2578 | 87.98% | 0.5410% | 0.4014% | 0.6350% | -0.1811% | 502,456.69 | -192.46 | 61.4481 |
+| `30min` | `live_intrabar_sma5_t3_half_size_cooldown1` | `t3_swing` | 669 | 85.35% | 0.5219% | 0.3578% | 0.6325% | -0.1188% | 62,200.39 | -97.10 | 50.9412 |
+| `30min` | `live_intrabar_sma5_t3_half_size_cooldown2` | `original_t2` | 2581 | 87.99% | 0.5410% | 0.4026% | 0.6346% | -0.1811% | 500,955.93 | -191.66 | 61.4796 |
+| `30min` | `live_intrabar_sma5_t3_half_size_cooldown2` | `t3_swing` | 637 | 85.09% | 0.5232% | 0.3569% | 0.6396% | -0.1188% | 59,706.15 | -96.70 | 51.6143 |
+
+## Read
+
+The optimization keeps the `live_intrabar_sma5_baseline_plus_t3_breakout` signal logic as the comparison baseline and only changes t3_swing sizing/cooldown. Because `dir2_zero_initial=true`, the lock itself remains a proof gate; real sizing still starts from the reentry window.
+
+The key read is whether the t3-only risk constraints improve Sharpe or drawdown relative to full-size t3 without giving back too much return.
+
+## Conclusion
+
+- `4h`: do not reduce t3_swing size. The full-size t3 baseline remains the best version here: half-size gives up `21.01 pp` return with no Sharpe or MaxDD improvement.
+- `1h`: half-size is a partial risk constraint, not an optimization. MaxDD improves by `0.11 pp`, but return drops `95.75 pp` and Sharpe is unchanged.
+- `30min`: half-size plus cooldown1 is the best risk-constrained variant among the tested options, but it is still not better than full-size t3 overall. It improves MaxDD by `0.24 pp`, reduces trades by `4`, and adds only `0.01` Sharpe, while giving up `78.31 pp` return.
+- `30min cooldown2`: reduces more trades (`-33`) but does not improve Sharpe beyond baseline and gives up the most return among 30min variants.
+
+The attribution supports the PR comment's interpretation: t3_swing is real positive alpha, especially on `4h` where it has higher win rate, average PnL, median PnL, lower worst trade, and stronger profit factor than original_t2. The Sharpe pressure on shorter frames is not fixed by simply halving t3 size; the next useful constraint should be signal-quality filtering rather than just smaller sizing.

--- a/research/eth_2026_q1_1s_t3_secondary_alpha_optimization_summary.json
+++ b/research/eth_2026_q1_1s_t3_secondary_alpha_optimization_summary.json
@@ -1,0 +1,1065 @@
+{
+  "window": {
+    "start": "2026-01-01T00:00:00+00:00",
+    "end": "2026-03-31T23:59:59+00:00"
+  },
+  "build_stats": {
+    "raw_tick_rows": 748747244,
+    "kept_tick_rows": 748747172,
+    "sparse_second_rows": 7596268,
+    "continuous_second_rows": 7776000,
+    "first_second": "2026-01-01T00:00:00+00:00",
+    "last_second": "2026-03-31T23:59:59+00:00",
+    "derived_one_min_rows": 129600
+  },
+  "results": [
+    {
+      "timeframe": "4h",
+      "signal_stats": {
+        "signal_rows": 540,
+        "signal_start": "2026-01-01T00:00:00+00:00",
+        "signal_end": "2026-03-31T20:00:00+00:00",
+        "valid_sma5_rows": 536,
+        "valid_atr_rows": 527
+      },
+      "scenarios": [
+        {
+          "scenario": "live_intrabar_sma5_baseline_plus_t3_breakout",
+          "breakout_shape": "baseline_plus_t3",
+          "replay_mode": "live_intrabar_sma5",
+          "params": {
+            "dir2_zero_initial": true,
+            "zero_initial_mode": "reentry_window",
+            "fixed_slippage": 0.0005,
+            "stop_loss_atr": 0.05,
+            "stop_mode": "atr",
+            "max_trades_per_bar": 2,
+            "reentry_size_schedule": [
+              0.2,
+              0.1
+            ],
+            "long_reentry_atr": 0.1,
+            "short_reentry_atr": 0.0,
+            "profit_protect_atr": 1.0,
+            "trailing_stop_atr": 0.3,
+            "delayed_trailing_activation": 0.5,
+            "reentry_anchor_levels": "wick",
+            "reentry_trigger_mode": "reclaim",
+            "t3_reentry_size_schedule": [
+              0.2,
+              0.1
+            ],
+            "t3_cooldown_bars": 0
+          },
+          "summary": {
+            "final_balance": 236994.21,
+            "return_pct": 136.99,
+            "max_dd_pct": -0.24,
+            "trades": 374,
+            "win_rate_pct": 92.51,
+            "sharpe": 18.77,
+            "first_entry": "2026-01-03T05:28:39+00:00",
+            "last_exit": "2026-03-31T14:34:50+00:00",
+            "entry_reasons": {
+              "SL-Reentry": 239,
+              "Zero-Initial-Reentry": 135
+            },
+            "exit_reasons": {
+              "SL": 374
+            },
+            "entry_types": {
+              "SHORT": 218,
+              "BUY": 156
+            },
+            "integrity": {
+              "rows": 748,
+              "entries": 374,
+              "exits": 374,
+              "zero_notional_entries": 0
+            }
+          },
+          "attribution": {
+            "original_t2": {
+              "trades": 312,
+              "win_rate_pct": 91.67,
+              "avg_pnl_pct": 1.6052,
+              "median_pnl_pct": 1.2912,
+              "pnl_std_pct": 1.4432,
+              "worst_pnl_pct": -0.2138,
+              "net_pnl_value": 125328.66,
+              "max_pnl_drawdown": -209.76,
+              "profit_factor": 136.7618,
+              "entry_types": {
+                "SHORT": 191,
+                "BUY": 121
+              },
+              "entry_reasons": {
+                "SL-Reentry": 203,
+                "Zero-Initial-Reentry": 109
+              },
+              "exit_reasons": {
+                "SL": 312
+              }
+            },
+            "t3_swing": {
+              "trades": 62,
+              "win_rate_pct": 96.77,
+              "avg_pnl_pct": 2.2348,
+              "median_pnl_pct": 2.3361,
+              "pnl_std_pct": 1.3286,
+              "worst_pnl_pct": -0.1613,
+              "net_pnl_value": 29715.41,
+              "max_pnl_drawdown": -53.99,
+              "profit_factor": 551.3826,
+              "entry_types": {
+                "BUY": 35,
+                "SHORT": 27
+              },
+              "entry_reasons": {
+                "SL-Reentry": 36,
+                "Zero-Initial-Reentry": 26
+              },
+              "exit_reasons": {
+                "SL": 62
+              }
+            }
+          },
+          "diagnostics": {
+            "breakout_locks": {
+              "long": {
+                "original_t2": 46,
+                "t3_swing": 14
+              },
+              "short": {
+                "original_t2": 64,
+                "t3_swing": 12
+              }
+            },
+            "t3_cooldown_skips": {
+              "long": 0,
+              "short": 0
+            }
+          },
+          "ledger_path": "research/tmp_eth_2026_q1_4h_1s_live_intrabar_sma5_live_intrabar_sma5_baseline_plus_t3_breakout_ledger.csv",
+          "elapsed_seconds": 164.02
+        },
+        {
+          "scenario": "live_intrabar_sma5_t3_half_size",
+          "breakout_shape": "baseline_plus_t3",
+          "replay_mode": "live_intrabar_sma5",
+          "params": {
+            "dir2_zero_initial": true,
+            "zero_initial_mode": "reentry_window",
+            "fixed_slippage": 0.0005,
+            "stop_loss_atr": 0.05,
+            "stop_mode": "atr",
+            "max_trades_per_bar": 2,
+            "reentry_size_schedule": [
+              0.2,
+              0.1
+            ],
+            "long_reentry_atr": 0.1,
+            "short_reentry_atr": 0.0,
+            "profit_protect_atr": 1.0,
+            "trailing_stop_atr": 0.3,
+            "delayed_trailing_activation": 0.5,
+            "reentry_anchor_levels": "wick",
+            "reentry_trigger_mode": "reclaim",
+            "t3_reentry_size_schedule": [
+              0.1,
+              0.05
+            ],
+            "t3_cooldown_bars": 0
+          },
+          "summary": {
+            "final_balance": 215980.36,
+            "return_pct": 115.98,
+            "max_dd_pct": -0.24,
+            "trades": 374,
+            "win_rate_pct": 92.51,
+            "sharpe": 18.77,
+            "first_entry": "2026-01-03T05:28:39+00:00",
+            "last_exit": "2026-03-31T14:34:50+00:00",
+            "entry_reasons": {
+              "SL-Reentry": 239,
+              "Zero-Initial-Reentry": 135
+            },
+            "exit_reasons": {
+              "SL": 374
+            },
+            "entry_types": {
+              "SHORT": 218,
+              "BUY": 156
+            },
+            "integrity": {
+              "rows": 748,
+              "entries": 374,
+              "exits": 374,
+              "zero_notional_entries": 0
+            }
+          },
+          "attribution": {
+            "original_t2": {
+              "trades": 312,
+              "win_rate_pct": 91.67,
+              "avg_pnl_pct": 1.6052,
+              "median_pnl_pct": 1.2912,
+              "pnl_std_pct": 1.4432,
+              "worst_pnl_pct": -0.2138,
+              "net_pnl_value": 117584.02,
+              "max_pnl_drawdown": -191.65,
+              "profit_factor": 137.2045,
+              "entry_types": {
+                "SHORT": 191,
+                "BUY": 121
+              },
+              "entry_reasons": {
+                "SL-Reentry": 203,
+                "Zero-Initial-Reentry": 109
+              },
+              "exit_reasons": {
+                "SL": 312
+              }
+            },
+            "t3_swing": {
+              "trades": 62,
+              "win_rate_pct": 96.77,
+              "avg_pnl_pct": 2.2348,
+              "median_pnl_pct": 2.3361,
+              "pnl_std_pct": 1.3286,
+              "worst_pnl_pct": -0.1613,
+              "net_pnl_value": 14135.14,
+              "max_pnl_drawdown": -26.75,
+              "profit_factor": 529.395,
+              "entry_types": {
+                "BUY": 35,
+                "SHORT": 27
+              },
+              "entry_reasons": {
+                "SL-Reentry": 36,
+                "Zero-Initial-Reentry": 26
+              },
+              "exit_reasons": {
+                "SL": 62
+              }
+            }
+          },
+          "diagnostics": {
+            "breakout_locks": {
+              "long": {
+                "original_t2": 46,
+                "t3_swing": 14
+              },
+              "short": {
+                "original_t2": 64,
+                "t3_swing": 12
+              }
+            },
+            "t3_cooldown_skips": {
+              "long": 0,
+              "short": 0
+            }
+          },
+          "ledger_path": "research/tmp_eth_2026_q1_4h_1s_live_intrabar_sma5_live_intrabar_sma5_t3_half_size_ledger.csv",
+          "elapsed_seconds": 165.59
+        }
+      ],
+      "delta_vs_full_t3_baseline": {
+        "live_intrabar_sma5_t3_half_size": {
+          "final_balance_delta": -21013.85,
+          "return_pct_delta": -21.01,
+          "max_dd_pct_delta": 0.0,
+          "trades_delta": 0,
+          "win_rate_pct_delta": 0.0,
+          "sharpe_delta": 0.0
+        }
+      }
+    },
+    {
+      "timeframe": "1h",
+      "signal_stats": {
+        "signal_rows": 2160,
+        "signal_start": "2026-01-01T00:00:00+00:00",
+        "signal_end": "2026-03-31T23:00:00+00:00",
+        "valid_sma5_rows": 2156,
+        "valid_atr_rows": 2147
+      },
+      "scenarios": [
+        {
+          "scenario": "live_intrabar_sma5_baseline_plus_t3_breakout",
+          "breakout_shape": "baseline_plus_t3",
+          "replay_mode": "live_intrabar_sma5",
+          "params": {
+            "dir2_zero_initial": true,
+            "zero_initial_mode": "reentry_window",
+            "fixed_slippage": 0.0005,
+            "stop_loss_atr": 0.05,
+            "stop_mode": "atr",
+            "max_trades_per_bar": 2,
+            "reentry_size_schedule": [
+              0.2,
+              0.1
+            ],
+            "long_reentry_atr": 0.1,
+            "short_reentry_atr": 0.0,
+            "profit_protect_atr": 1.0,
+            "trailing_stop_atr": 0.3,
+            "delayed_trailing_activation": 0.5,
+            "reentry_anchor_levels": "wick",
+            "reentry_trigger_mode": "reclaim",
+            "t3_reentry_size_schedule": [
+              0.2,
+              0.1
+            ],
+            "t3_cooldown_bars": 0
+          },
+          "summary": {
+            "final_balance": 481070.05,
+            "return_pct": 381.07,
+            "max_dd_pct": -0.76,
+            "trades": 1634,
+            "win_rate_pct": 85.19,
+            "sharpe": 14.39,
+            "first_entry": "2026-01-01T13:31:52+00:00",
+            "last_exit": "2026-03-31T23:59:59+00:00",
+            "entry_reasons": {
+              "SL-Reentry": 1035,
+              "Zero-Initial-Reentry": 599
+            },
+            "exit_reasons": {
+              "SL": 1633,
+              "FinalMarkToMarket": 1
+            },
+            "entry_types": {
+              "SHORT": 819,
+              "BUY": 815
+            },
+            "integrity": {
+              "rows": 3268,
+              "entries": 1634,
+              "exits": 1634,
+              "zero_notional_entries": 0
+            }
+          },
+          "attribution": {
+            "original_t2": {
+              "trades": 1179,
+              "win_rate_pct": 88.89,
+              "avg_pnl_pct": 0.8306,
+              "median_pnl_pct": 0.6353,
+              "pnl_std_pct": 0.8688,
+              "worst_pnl_pct": -0.1805,
+              "net_pnl_value": 354537.63,
+              "max_pnl_drawdown": -237.38,
+              "profit_factor": 75.9616,
+              "entry_types": {
+                "SHORT": 602,
+                "BUY": 577
+              },
+              "entry_reasons": {
+                "SL-Reentry": 749,
+                "Zero-Initial-Reentry": 430
+              },
+              "exit_reasons": {
+                "SL": 1179
+              }
+            },
+            "t3_swing": {
+              "trades": 455,
+              "win_rate_pct": 86.15,
+              "avg_pnl_pct": 0.8399,
+              "median_pnl_pct": 0.6193,
+              "pnl_std_pct": 1.0377,
+              "worst_pnl_pct": -0.2268,
+              "net_pnl_value": 146691.41,
+              "max_pnl_drawdown": -155.89,
+              "profit_factor": 75.4769,
+              "entry_types": {
+                "BUY": 238,
+                "SHORT": 217
+              },
+              "entry_reasons": {
+                "SL-Reentry": 286,
+                "Zero-Initial-Reentry": 169
+              },
+              "exit_reasons": {
+                "SL": 454,
+                "FinalMarkToMarket": 1
+              }
+            }
+          },
+          "diagnostics": {
+            "breakout_locks": {
+              "long": {
+                "original_t2": 219,
+                "t3_swing": 92
+              },
+              "short": {
+                "t3_swing": 77,
+                "original_t2": 213
+              }
+            },
+            "t3_cooldown_skips": {
+              "long": 0,
+              "short": 0
+            }
+          },
+          "ledger_path": "research/tmp_eth_2026_q1_1h_1s_live_intrabar_sma5_live_intrabar_sma5_baseline_plus_t3_breakout_ledger.csv",
+          "elapsed_seconds": 168.27
+        },
+        {
+          "scenario": "live_intrabar_sma5_t3_half_size",
+          "breakout_shape": "baseline_plus_t3",
+          "replay_mode": "live_intrabar_sma5",
+          "params": {
+            "dir2_zero_initial": true,
+            "zero_initial_mode": "reentry_window",
+            "fixed_slippage": 0.0005,
+            "stop_loss_atr": 0.05,
+            "stop_mode": "atr",
+            "max_trades_per_bar": 2,
+            "reentry_size_schedule": [
+              0.2,
+              0.1
+            ],
+            "long_reentry_atr": 0.1,
+            "short_reentry_atr": 0.0,
+            "profit_protect_atr": 1.0,
+            "trailing_stop_atr": 0.3,
+            "delayed_trailing_activation": 0.5,
+            "reentry_anchor_levels": "wick",
+            "reentry_trigger_mode": "reclaim",
+            "t3_reentry_size_schedule": [
+              0.1,
+              0.05
+            ],
+            "t3_cooldown_bars": 0
+          },
+          "summary": {
+            "final_balance": 385321.81,
+            "return_pct": 285.32,
+            "max_dd_pct": -0.65,
+            "trades": 1634,
+            "win_rate_pct": 85.19,
+            "sharpe": 14.39,
+            "first_entry": "2026-01-01T13:31:52+00:00",
+            "last_exit": "2026-03-31T23:59:59+00:00",
+            "entry_reasons": {
+              "SL-Reentry": 1035,
+              "Zero-Initial-Reentry": 599
+            },
+            "exit_reasons": {
+              "SL": 1633,
+              "FinalMarkToMarket": 1
+            },
+            "entry_types": {
+              "SHORT": 819,
+              "BUY": 815
+            },
+            "integrity": {
+              "rows": 3268,
+              "entries": 1634,
+              "exits": 1634,
+              "zero_notional_entries": 0
+            }
+          },
+          "attribution": {
+            "original_t2": {
+              "trades": 1179,
+              "win_rate_pct": 88.89,
+              "avg_pnl_pct": 0.8306,
+              "median_pnl_pct": 0.6353,
+              "pnl_std_pct": 0.8688,
+              "worst_pnl_pct": -0.1805,
+              "net_pnl_value": 311945.23,
+              "max_pnl_drawdown": -215.26,
+              "profit_factor": 75.8124,
+              "entry_types": {
+                "SHORT": 602,
+                "BUY": 577
+              },
+              "entry_reasons": {
+                "SL-Reentry": 749,
+                "Zero-Initial-Reentry": 430
+              },
+              "exit_reasons": {
+                "SL": 1179
+              }
+            },
+            "t3_swing": {
+              "trades": 455,
+              "win_rate_pct": 86.15,
+              "avg_pnl_pct": 0.8399,
+              "median_pnl_pct": 0.6193,
+              "pnl_std_pct": 1.0377,
+              "worst_pnl_pct": -0.2268,
+              "net_pnl_value": 64095.79,
+              "max_pnl_drawdown": -68.12,
+              "profit_factor": 74.1792,
+              "entry_types": {
+                "BUY": 238,
+                "SHORT": 217
+              },
+              "entry_reasons": {
+                "SL-Reentry": 286,
+                "Zero-Initial-Reentry": 169
+              },
+              "exit_reasons": {
+                "SL": 454,
+                "FinalMarkToMarket": 1
+              }
+            }
+          },
+          "diagnostics": {
+            "breakout_locks": {
+              "long": {
+                "original_t2": 219,
+                "t3_swing": 92
+              },
+              "short": {
+                "t3_swing": 77,
+                "original_t2": 213
+              }
+            },
+            "t3_cooldown_skips": {
+              "long": 0,
+              "short": 0
+            }
+          },
+          "ledger_path": "research/tmp_eth_2026_q1_1h_1s_live_intrabar_sma5_live_intrabar_sma5_t3_half_size_ledger.csv",
+          "elapsed_seconds": 167.79
+        }
+      ],
+      "delta_vs_full_t3_baseline": {
+        "live_intrabar_sma5_t3_half_size": {
+          "final_balance_delta": -95748.24,
+          "return_pct_delta": -95.75,
+          "max_dd_pct_delta": 0.11,
+          "trades_delta": 0,
+          "win_rate_pct_delta": 0.0,
+          "sharpe_delta": 0.0
+        }
+      }
+    },
+    {
+      "timeframe": "30min",
+      "signal_stats": {
+        "signal_rows": 4320,
+        "signal_start": "2026-01-01T00:00:00+00:00",
+        "signal_end": "2026-03-31T23:30:00+00:00",
+        "valid_sma5_rows": 4316,
+        "valid_atr_rows": 4307
+      },
+      "scenarios": [
+        {
+          "scenario": "live_intrabar_sma5_baseline_plus_t3_breakout",
+          "breakout_shape": "baseline_plus_t3",
+          "replay_mode": "live_intrabar_sma5",
+          "params": {
+            "dir2_zero_initial": true,
+            "zero_initial_mode": "reentry_window",
+            "fixed_slippage": 0.0005,
+            "stop_loss_atr": 0.05,
+            "stop_mode": "atr",
+            "max_trades_per_bar": 2,
+            "reentry_size_schedule": [
+              0.2,
+              0.1
+            ],
+            "long_reentry_atr": 0.1,
+            "short_reentry_atr": 0.0,
+            "profit_protect_atr": 1.0,
+            "trailing_stop_atr": 0.3,
+            "delayed_trailing_activation": 0.5,
+            "reentry_anchor_levels": "wick",
+            "reentry_trigger_mode": "reclaim",
+            "t3_reentry_size_schedule": [
+              0.2,
+              0.1
+            ],
+            "t3_cooldown_bars": 0
+          },
+          "summary": {
+            "final_balance": 531886.72,
+            "return_pct": 431.89,
+            "max_dd_pct": -2.1,
+            "trades": 3251,
+            "win_rate_pct": 80.28,
+            "sharpe": 13.42,
+            "first_entry": "2026-01-01T10:22:41+00:00",
+            "last_exit": "2026-03-31T23:10:28+00:00",
+            "entry_reasons": {
+              "SL-Reentry": 2101,
+              "Zero-Initial-Reentry": 1150
+            },
+            "exit_reasons": {
+              "SL": 3251
+            },
+            "entry_types": {
+              "BUY": 1642,
+              "SHORT": 1609
+            },
+            "integrity": {
+              "rows": 6502,
+              "entries": 3251,
+              "exits": 3251,
+              "zero_notional_entries": 0
+            }
+          },
+          "attribution": {
+            "original_t2": {
+              "trades": 2576,
+              "win_rate_pct": 87.97,
+              "avg_pnl_pct": 0.5411,
+              "median_pnl_pct": 0.4008,
+              "pnl_std_pct": 0.6352,
+              "worst_pnl_pct": -0.1811,
+              "net_pnl_value": 553447.23,
+              "max_pnl_drawdown": -219.54,
+              "profit_factor": 61.5178,
+              "entry_types": {
+                "SHORT": 1304,
+                "BUY": 1272
+              },
+              "entry_reasons": {
+                "SL-Reentry": 1665,
+                "Zero-Initial-Reentry": 911
+              },
+              "exit_reasons": {
+                "SL": 2576
+              }
+            },
+            "t3_swing": {
+              "trades": 675,
+              "win_rate_pct": 85.33,
+              "avg_pnl_pct": 0.5157,
+              "median_pnl_pct": 0.3537,
+              "pnl_std_pct": 0.628,
+              "worst_pnl_pct": -0.1188,
+              "net_pnl_value": 136907.94,
+              "max_pnl_drawdown": -215.84,
+              "profit_factor": 51.2283,
+              "entry_types": {
+                "BUY": 370,
+                "SHORT": 305
+              },
+              "entry_reasons": {
+                "SL-Reentry": 436,
+                "Zero-Initial-Reentry": 239
+              },
+              "exit_reasons": {
+                "SL": 675
+              }
+            }
+          },
+          "diagnostics": {
+            "breakout_locks": {
+              "long": {
+                "original_t2": 447,
+                "t3_swing": 127
+              },
+              "short": {
+                "original_t2": 471,
+                "t3_swing": 113
+              }
+            },
+            "t3_cooldown_skips": {
+              "long": 0,
+              "short": 0
+            }
+          },
+          "ledger_path": "research/tmp_eth_2026_q1_30min_1s_live_intrabar_sma5_live_intrabar_sma5_baseline_plus_t3_breakout_ledger.csv",
+          "elapsed_seconds": 169.46
+        },
+        {
+          "scenario": "live_intrabar_sma5_t3_half_size",
+          "breakout_shape": "baseline_plus_t3",
+          "replay_mode": "live_intrabar_sma5",
+          "params": {
+            "dir2_zero_initial": true,
+            "zero_initial_mode": "reentry_window",
+            "fixed_slippage": 0.0005,
+            "stop_loss_atr": 0.05,
+            "stop_mode": "atr",
+            "max_trades_per_bar": 2,
+            "reentry_size_schedule": [
+              0.2,
+              0.1
+            ],
+            "long_reentry_atr": 0.1,
+            "short_reentry_atr": 0.0,
+            "profit_protect_atr": 1.0,
+            "trailing_stop_atr": 0.3,
+            "delayed_trailing_activation": 0.5,
+            "reentry_anchor_levels": "wick",
+            "reentry_trigger_mode": "reclaim",
+            "t3_reentry_size_schedule": [
+              0.1,
+              0.05
+            ],
+            "t3_cooldown_bars": 0
+          },
+          "summary": {
+            "final_balance": 452621.79,
+            "return_pct": 352.62,
+            "max_dd_pct": -1.91,
+            "trades": 3251,
+            "win_rate_pct": 80.28,
+            "sharpe": 13.42,
+            "first_entry": "2026-01-01T10:22:41+00:00",
+            "last_exit": "2026-03-31T23:10:28+00:00",
+            "entry_reasons": {
+              "SL-Reentry": 2101,
+              "Zero-Initial-Reentry": 1150
+            },
+            "exit_reasons": {
+              "SL": 3251
+            },
+            "entry_types": {
+              "BUY": 1642,
+              "SHORT": 1609
+            },
+            "integrity": {
+              "rows": 6502,
+              "entries": 3251,
+              "exits": 3251,
+              "zero_notional_entries": 0
+            }
+          },
+          "attribution": {
+            "original_t2": {
+              "trades": 2576,
+              "win_rate_pct": 87.97,
+              "avg_pnl_pct": 0.5411,
+              "median_pnl_pct": 0.4008,
+              "pnl_std_pct": 0.6352,
+              "worst_pnl_pct": -0.1811,
+              "net_pnl_value": 501451.59,
+              "max_pnl_drawdown": -192.06,
+              "profit_factor": 61.4243,
+              "entry_types": {
+                "SHORT": 1304,
+                "BUY": 1272
+              },
+              "entry_reasons": {
+                "SL-Reentry": 1665,
+                "Zero-Initial-Reentry": 911
+              },
+              "exit_reasons": {
+                "SL": 2576
+              }
+            },
+            "t3_swing": {
+              "trades": 675,
+              "win_rate_pct": 85.33,
+              "avg_pnl_pct": 0.5157,
+              "median_pnl_pct": 0.3537,
+              "pnl_std_pct": 0.628,
+              "worst_pnl_pct": -0.1188,
+              "net_pnl_value": 62002.25,
+              "max_pnl_drawdown": -96.9,
+              "profit_factor": 50.4756,
+              "entry_types": {
+                "BUY": 370,
+                "SHORT": 305
+              },
+              "entry_reasons": {
+                "SL-Reentry": 436,
+                "Zero-Initial-Reentry": 239
+              },
+              "exit_reasons": {
+                "SL": 675
+              }
+            }
+          },
+          "diagnostics": {
+            "breakout_locks": {
+              "long": {
+                "original_t2": 447,
+                "t3_swing": 127
+              },
+              "short": {
+                "original_t2": 471,
+                "t3_swing": 113
+              }
+            },
+            "t3_cooldown_skips": {
+              "long": 0,
+              "short": 0
+            }
+          },
+          "ledger_path": "research/tmp_eth_2026_q1_30min_1s_live_intrabar_sma5_live_intrabar_sma5_t3_half_size_ledger.csv",
+          "elapsed_seconds": 171.71
+        },
+        {
+          "scenario": "live_intrabar_sma5_t3_half_size_cooldown1",
+          "breakout_shape": "baseline_plus_t3",
+          "replay_mode": "live_intrabar_sma5",
+          "params": {
+            "dir2_zero_initial": true,
+            "zero_initial_mode": "reentry_window",
+            "fixed_slippage": 0.0005,
+            "stop_loss_atr": 0.05,
+            "stop_mode": "atr",
+            "max_trades_per_bar": 2,
+            "reentry_size_schedule": [
+              0.2,
+              0.1
+            ],
+            "long_reentry_atr": 0.1,
+            "short_reentry_atr": 0.0,
+            "profit_protect_atr": 1.0,
+            "trailing_stop_atr": 0.3,
+            "delayed_trailing_activation": 0.5,
+            "reentry_anchor_levels": "wick",
+            "reentry_trigger_mode": "reclaim",
+            "t3_reentry_size_schedule": [
+              0.1,
+              0.05
+            ],
+            "t3_cooldown_bars": 1
+          },
+          "summary": {
+            "final_balance": 453582.21,
+            "return_pct": 353.58,
+            "max_dd_pct": -1.86,
+            "trades": 3247,
+            "win_rate_pct": 80.32,
+            "sharpe": 13.43,
+            "first_entry": "2026-01-01T10:22:41+00:00",
+            "last_exit": "2026-03-31T23:10:28+00:00",
+            "entry_reasons": {
+              "SL-Reentry": 2099,
+              "Zero-Initial-Reentry": 1148
+            },
+            "exit_reasons": {
+              "SL": 3247
+            },
+            "entry_types": {
+              "BUY": 1634,
+              "SHORT": 1613
+            },
+            "integrity": {
+              "rows": 6494,
+              "entries": 3247,
+              "exits": 3247,
+              "zero_notional_entries": 0
+            }
+          },
+          "attribution": {
+            "original_t2": {
+              "trades": 2578,
+              "win_rate_pct": 87.98,
+              "avg_pnl_pct": 0.541,
+              "median_pnl_pct": 0.4014,
+              "pnl_std_pct": 0.635,
+              "worst_pnl_pct": -0.1811,
+              "net_pnl_value": 502456.69,
+              "max_pnl_drawdown": -192.46,
+              "profit_factor": 61.4481,
+              "entry_types": {
+                "SHORT": 1306,
+                "BUY": 1272
+              },
+              "entry_reasons": {
+                "SL-Reentry": 1666,
+                "Zero-Initial-Reentry": 912
+              },
+              "exit_reasons": {
+                "SL": 2578
+              }
+            },
+            "t3_swing": {
+              "trades": 669,
+              "win_rate_pct": 85.35,
+              "avg_pnl_pct": 0.5219,
+              "median_pnl_pct": 0.3578,
+              "pnl_std_pct": 0.6325,
+              "worst_pnl_pct": -0.1188,
+              "net_pnl_value": 62200.39,
+              "max_pnl_drawdown": -97.1,
+              "profit_factor": 50.9412,
+              "entry_types": {
+                "BUY": 362,
+                "SHORT": 307
+              },
+              "entry_reasons": {
+                "SL-Reentry": 433,
+                "Zero-Initial-Reentry": 236
+              },
+              "exit_reasons": {
+                "SL": 669
+              }
+            }
+          },
+          "diagnostics": {
+            "breakout_locks": {
+              "long": {
+                "original_t2": 447,
+                "t3_swing": 124
+              },
+              "short": {
+                "original_t2": 472,
+                "t3_swing": 113
+              }
+            },
+            "t3_cooldown_skips": {
+              "long": 57,
+              "short": 0
+            }
+          },
+          "ledger_path": "research/tmp_eth_2026_q1_30min_1s_live_intrabar_sma5_live_intrabar_sma5_t3_half_size_cooldown1_ledger.csv",
+          "elapsed_seconds": 172.63
+        },
+        {
+          "scenario": "live_intrabar_sma5_t3_half_size_cooldown2",
+          "breakout_shape": "baseline_plus_t3",
+          "replay_mode": "live_intrabar_sma5",
+          "params": {
+            "dir2_zero_initial": true,
+            "zero_initial_mode": "reentry_window",
+            "fixed_slippage": 0.0005,
+            "stop_loss_atr": 0.05,
+            "stop_mode": "atr",
+            "max_trades_per_bar": 2,
+            "reentry_size_schedule": [
+              0.2,
+              0.1
+            ],
+            "long_reentry_atr": 0.1,
+            "short_reentry_atr": 0.0,
+            "profit_protect_atr": 1.0,
+            "trailing_stop_atr": 0.3,
+            "delayed_trailing_activation": 0.5,
+            "reentry_anchor_levels": "wick",
+            "reentry_trigger_mode": "reclaim",
+            "t3_reentry_size_schedule": [
+              0.1,
+              0.05
+            ],
+            "t3_cooldown_bars": 2
+          },
+          "summary": {
+            "final_balance": 451192.47,
+            "return_pct": 351.19,
+            "max_dd_pct": -1.86,
+            "trades": 3218,
+            "win_rate_pct": 80.27,
+            "sharpe": 13.42,
+            "first_entry": "2026-01-01T10:22:41+00:00",
+            "last_exit": "2026-03-31T23:10:28+00:00",
+            "entry_reasons": {
+              "SL-Reentry": 2082,
+              "Zero-Initial-Reentry": 1136
+            },
+            "exit_reasons": {
+              "SL": 3218
+            },
+            "entry_types": {
+              "BUY": 1619,
+              "SHORT": 1599
+            },
+            "integrity": {
+              "rows": 6436,
+              "entries": 3218,
+              "exits": 3218,
+              "zero_notional_entries": 0
+            }
+          },
+          "attribution": {
+            "original_t2": {
+              "trades": 2581,
+              "win_rate_pct": 87.99,
+              "avg_pnl_pct": 0.541,
+              "median_pnl_pct": 0.4026,
+              "pnl_std_pct": 0.6346,
+              "worst_pnl_pct": -0.1811,
+              "net_pnl_value": 500955.93,
+              "max_pnl_drawdown": -191.66,
+              "profit_factor": 61.4796,
+              "entry_types": {
+                "SHORT": 1306,
+                "BUY": 1275
+              },
+              "entry_reasons": {
+                "SL-Reentry": 1668,
+                "Zero-Initial-Reentry": 913
+              },
+              "exit_reasons": {
+                "SL": 2581
+              }
+            },
+            "t3_swing": {
+              "trades": 637,
+              "win_rate_pct": 85.09,
+              "avg_pnl_pct": 0.5232,
+              "median_pnl_pct": 0.3569,
+              "pnl_std_pct": 0.6396,
+              "worst_pnl_pct": -0.1188,
+              "net_pnl_value": 59706.15,
+              "max_pnl_drawdown": -96.7,
+              "profit_factor": 51.6143,
+              "entry_types": {
+                "BUY": 344,
+                "SHORT": 293
+              },
+              "entry_reasons": {
+                "SL-Reentry": 414,
+                "Zero-Initial-Reentry": 223
+              },
+              "exit_reasons": {
+                "SL": 637
+              }
+            }
+          },
+          "diagnostics": {
+            "breakout_locks": {
+              "long": {
+                "original_t2": 448,
+                "t3_swing": 117
+              },
+              "short": {
+                "original_t2": 472,
+                "t3_swing": 107
+              }
+            },
+            "t3_cooldown_skips": {
+              "long": 6035,
+              "short": 2316
+            }
+          },
+          "ledger_path": "research/tmp_eth_2026_q1_30min_1s_live_intrabar_sma5_live_intrabar_sma5_t3_half_size_cooldown2_ledger.csv",
+          "elapsed_seconds": 171.18
+        }
+      ],
+      "delta_vs_full_t3_baseline": {
+        "live_intrabar_sma5_t3_half_size": {
+          "final_balance_delta": -79264.93,
+          "return_pct_delta": -79.27,
+          "max_dd_pct_delta": 0.19,
+          "trades_delta": 0,
+          "win_rate_pct_delta": 0.0,
+          "sharpe_delta": 0.0
+        },
+        "live_intrabar_sma5_t3_half_size_cooldown1": {
+          "final_balance_delta": -78304.51,
+          "return_pct_delta": -78.31,
+          "max_dd_pct_delta": 0.24,
+          "trades_delta": -4,
+          "win_rate_pct_delta": 0.04,
+          "sharpe_delta": 0.01
+        },
+        "live_intrabar_sma5_t3_half_size_cooldown2": {
+          "final_balance_delta": -80694.25,
+          "return_pct_delta": -80.7,
+          "max_dd_pct_delta": 0.24,
+          "trades_delta": -33,
+          "win_rate_pct_delta": -0.01,
+          "sharpe_delta": 0.0
+        }
+      }
+    }
+  ],
+  "baseline_scenario": "live_intrabar_sma5_baseline_plus_t3_breakout",
+  "note": "Research-only optimization. Baseline is live_intrabar_sma5_baseline_plus_t3_breakout; variants only change t3_swing sizing/cooldown and preserve original_t2 sizing."
+}

--- a/research/eth_2026_q1_30min_t2_t3_sep_0p25_summary.json
+++ b/research/eth_2026_q1_30min_t2_t3_sep_0p25_summary.json
@@ -1,0 +1,450 @@
+{
+  "window": {
+    "start": "2026-01-01T00:00:00+00:00",
+    "end": "2026-03-31T23:59:59+00:00"
+  },
+  "build_stats": {
+    "raw_tick_rows": 748747244,
+    "kept_tick_rows": 748747172,
+    "sparse_second_rows": 7596268,
+    "continuous_second_rows": 7776000,
+    "first_second": "2026-01-01T00:00:00+00:00",
+    "last_second": "2026-03-31T23:59:59+00:00",
+    "derived_one_min_rows": 129600
+  },
+  "results": [
+    {
+      "timeframe": "30min",
+      "signal_stats": {
+        "signal_rows": 4320,
+        "signal_start": "2026-01-01T00:00:00+00:00",
+        "signal_end": "2026-03-31T23:30:00+00:00",
+        "valid_sma5_rows": 4316,
+        "valid_atr_rows": 4307
+      },
+      "scenarios": [
+        {
+          "scenario": "t3_sma5_baseline",
+          "breakout_shape": "baseline_plus_t3",
+          "replay_mode": "live_intrabar_sma5",
+          "params": {
+            "dir2_zero_initial": true,
+            "zero_initial_mode": "reentry_window",
+            "fixed_slippage": 0.0005,
+            "stop_loss_atr": 0.05,
+            "stop_mode": "atr",
+            "max_trades_per_bar": 2,
+            "reentry_size_schedule": [
+              0.2,
+              0.1
+            ],
+            "long_reentry_atr": 0.1,
+            "short_reentry_atr": 0.0,
+            "profit_protect_atr": 1.0,
+            "trailing_stop_atr": 0.3,
+            "delayed_trailing_activation": 0.5,
+            "reentry_anchor_levels": "wick",
+            "reentry_trigger_mode": "reclaim",
+            "t3_reentry_size_schedule": [
+              0.2,
+              0.1
+            ],
+            "t3_cooldown_bars": 0,
+            "t3_quality_filters": {},
+            "quality_filter_shapes": [
+              "t3_swing"
+            ]
+          },
+          "summary": {
+            "final_balance": 531886.72,
+            "return_pct": 431.89,
+            "max_dd_pct": -2.1,
+            "trades": 3251,
+            "win_rate_pct": 80.28,
+            "sharpe": 13.42,
+            "first_entry": "2026-01-01T10:22:41+00:00",
+            "last_exit": "2026-03-31T23:10:28+00:00",
+            "entry_reasons": {
+              "SL-Reentry": 2101,
+              "Zero-Initial-Reentry": 1150
+            },
+            "exit_reasons": {
+              "SL": 3251
+            },
+            "entry_types": {
+              "BUY": 1642,
+              "SHORT": 1609
+            },
+            "integrity": {
+              "rows": 6502,
+              "entries": 3251,
+              "exits": 3251,
+              "zero_notional_entries": 0
+            }
+          },
+          "attribution": {
+            "original_t2": {
+              "trades": 2576,
+              "win_rate_pct": 87.97,
+              "avg_pnl_pct": 0.5411,
+              "median_pnl_pct": 0.4008,
+              "pnl_std_pct": 0.6352,
+              "worst_pnl_pct": -0.1811,
+              "net_pnl_value": 553447.23,
+              "max_pnl_drawdown": -219.54,
+              "profit_factor": 61.5178,
+              "entry_types": {
+                "SHORT": 1304,
+                "BUY": 1272
+              },
+              "entry_reasons": {
+                "SL-Reentry": 1665,
+                "Zero-Initial-Reentry": 911
+              },
+              "exit_reasons": {
+                "SL": 2576
+              }
+            },
+            "t3_swing": {
+              "trades": 675,
+              "win_rate_pct": 85.33,
+              "avg_pnl_pct": 0.5157,
+              "median_pnl_pct": 0.3537,
+              "pnl_std_pct": 0.628,
+              "worst_pnl_pct": -0.1188,
+              "net_pnl_value": 136907.94,
+              "max_pnl_drawdown": -215.84,
+              "profit_factor": 51.2283,
+              "entry_types": {
+                "BUY": 370,
+                "SHORT": 305
+              },
+              "entry_reasons": {
+                "SL-Reentry": 436,
+                "Zero-Initial-Reentry": 239
+              },
+              "exit_reasons": {
+                "SL": 675
+              }
+            }
+          },
+          "diagnostics": {
+            "breakout_locks": {
+              "long": {
+                "original_t2": 447,
+                "t3_swing": 127
+              },
+              "short": {
+                "original_t2": 471,
+                "t3_swing": 113
+              }
+            },
+            "t3_cooldown_skips": {
+              "long": 0,
+              "short": 0
+            },
+            "t3_quality_rejects": {
+              "long": {},
+              "short": {}
+            }
+          },
+          "ledger_path": "research/tmp_eth_2026_q1_30min_1s_live_intrabar_sma5_t3_sma5_baseline_ledger.csv",
+          "elapsed_seconds": 225.12
+        },
+        {
+          "scenario": "A_sep_0p25",
+          "breakout_shape": "baseline_plus_t3",
+          "replay_mode": "live_intrabar_sma5",
+          "params": {
+            "dir2_zero_initial": true,
+            "zero_initial_mode": "reentry_window",
+            "fixed_slippage": 0.0005,
+            "stop_loss_atr": 0.05,
+            "stop_mode": "atr",
+            "max_trades_per_bar": 2,
+            "reentry_size_schedule": [
+              0.2,
+              0.1
+            ],
+            "long_reentry_atr": 0.1,
+            "short_reentry_atr": 0.0,
+            "profit_protect_atr": 1.0,
+            "trailing_stop_atr": 0.3,
+            "delayed_trailing_activation": 0.5,
+            "reentry_anchor_levels": "wick",
+            "reentry_trigger_mode": "reclaim",
+            "t3_reentry_size_schedule": [
+              0.2,
+              0.1
+            ],
+            "t3_cooldown_bars": 0,
+            "t3_quality_filters": {
+              "min_sma_atr_separation": 0.25
+            },
+            "quality_filter_shapes": [
+              "t3_swing"
+            ]
+          },
+          "summary": {
+            "final_balance": 536109.15,
+            "return_pct": 436.11,
+            "max_dd_pct": -2.04,
+            "trades": 3226,
+            "win_rate_pct": 80.6,
+            "sharpe": 13.49,
+            "first_entry": "2026-01-01T10:22:41+00:00",
+            "last_exit": "2026-03-31T23:59:59+00:00",
+            "entry_reasons": {
+              "SL-Reentry": 2086,
+              "Zero-Initial-Reentry": 1140
+            },
+            "exit_reasons": {
+              "SL": 3225,
+              "FinalMarkToMarket": 1
+            },
+            "entry_types": {
+              "BUY": 1632,
+              "SHORT": 1594
+            },
+            "integrity": {
+              "rows": 6452,
+              "entries": 3226,
+              "exits": 3226,
+              "zero_notional_entries": 0
+            }
+          },
+          "attribution": {
+            "original_t2": {
+              "trades": 2575,
+              "win_rate_pct": 87.96,
+              "avg_pnl_pct": 0.5409,
+              "median_pnl_pct": 0.4009,
+              "pnl_std_pct": 0.6352,
+              "worst_pnl_pct": -0.1811,
+              "net_pnl_value": 555845.31,
+              "max_pnl_drawdown": -221.0,
+              "profit_factor": 61.861,
+              "entry_types": {
+                "SHORT": 1298,
+                "BUY": 1277
+              },
+              "entry_reasons": {
+                "SL-Reentry": 1663,
+                "Zero-Initial-Reentry": 912
+              },
+              "exit_reasons": {
+                "SL": 2574,
+                "FinalMarkToMarket": 1
+              }
+            },
+            "t3_swing": {
+              "trades": 651,
+              "win_rate_pct": 87.1,
+              "avg_pnl_pct": 0.5355,
+              "median_pnl_pct": 0.3717,
+              "pnl_std_pct": 0.6343,
+              "worst_pnl_pct": -0.1188,
+              "net_pnl_value": 137520.44,
+              "max_pnl_drawdown": -217.37,
+              "profit_factor": 64.946,
+              "entry_types": {
+                "BUY": 355,
+                "SHORT": 296
+              },
+              "entry_reasons": {
+                "SL-Reentry": 423,
+                "Zero-Initial-Reentry": 228
+              },
+              "exit_reasons": {
+                "SL": 651
+              }
+            }
+          },
+          "diagnostics": {
+            "breakout_locks": {
+              "long": {
+                "original_t2": 449,
+                "t3_swing": 119
+              },
+              "short": {
+                "original_t2": 470,
+                "t3_swing": 109
+              }
+            },
+            "t3_cooldown_skips": {
+              "long": 0,
+              "short": 0
+            },
+            "t3_quality_rejects": {
+              "long": {
+                "sma_atr_separation": 9
+              },
+              "short": {
+                "sma_atr_separation": 5
+              }
+            }
+          },
+          "ledger_path": "research/tmp_eth_2026_q1_30min_1s_live_intrabar_sma5_A_sep_0p25_ledger.csv",
+          "elapsed_seconds": 223.95
+        },
+        {
+          "scenario": "all_breakouts_sep_0p25",
+          "breakout_shape": "baseline_plus_t3",
+          "replay_mode": "live_intrabar_sma5",
+          "params": {
+            "dir2_zero_initial": true,
+            "zero_initial_mode": "reentry_window",
+            "fixed_slippage": 0.0005,
+            "stop_loss_atr": 0.05,
+            "stop_mode": "atr",
+            "max_trades_per_bar": 2,
+            "reentry_size_schedule": [
+              0.2,
+              0.1
+            ],
+            "long_reentry_atr": 0.1,
+            "short_reentry_atr": 0.0,
+            "profit_protect_atr": 1.0,
+            "trailing_stop_atr": 0.3,
+            "delayed_trailing_activation": 0.5,
+            "reentry_anchor_levels": "wick",
+            "reentry_trigger_mode": "reclaim",
+            "t3_reentry_size_schedule": [
+              0.2,
+              0.1
+            ],
+            "t3_cooldown_bars": 0,
+            "t3_quality_filters": {
+              "min_sma_atr_separation": 0.25
+            },
+            "quality_filter_shapes": [
+              "original_t2",
+              "t3_swing"
+            ]
+          },
+          "summary": {
+            "final_balance": 399531.93,
+            "return_pct": 299.53,
+            "max_dd_pct": -1.42,
+            "trades": 2588,
+            "win_rate_pct": 81.99,
+            "sharpe": 14.62,
+            "first_entry": "2026-01-01T11:04:30+00:00",
+            "last_exit": "2026-03-31T23:59:59+00:00",
+            "entry_reasons": {
+              "SL-Reentry": 1659,
+              "Zero-Initial-Reentry": 929
+            },
+            "exit_reasons": {
+              "SL": 2587,
+              "FinalMarkToMarket": 1
+            },
+            "entry_types": {
+              "BUY": 1354,
+              "SHORT": 1234
+            },
+            "integrity": {
+              "rows": 5176,
+              "entries": 2588,
+              "exits": 2588,
+              "zero_notional_entries": 0
+            }
+          },
+          "attribution": {
+            "original_t2": {
+              "trades": 1907,
+              "win_rate_pct": 89.56,
+              "avg_pnl_pct": 0.5594,
+              "median_pnl_pct": 0.4311,
+              "pnl_std_pct": 0.5869,
+              "worst_pnl_pct": -0.1811,
+              "net_pnl_value": 350433.73,
+              "max_pnl_drawdown": -119.03,
+              "profit_factor": 75.2062,
+              "entry_types": {
+                "BUY": 977,
+                "SHORT": 930
+              },
+              "entry_reasons": {
+                "SL-Reentry": 1214,
+                "Zero-Initial-Reentry": 693
+              },
+              "exit_reasons": {
+                "SL": 1906,
+                "FinalMarkToMarket": 1
+              }
+            },
+            "t3_swing": {
+              "trades": 681,
+              "win_rate_pct": 86.93,
+              "avg_pnl_pct": 0.5256,
+              "median_pnl_pct": 0.3643,
+              "pnl_std_pct": 0.6267,
+              "worst_pnl_pct": -0.1188,
+              "net_pnl_value": 117101.47,
+              "max_pnl_drawdown": -171.67,
+              "profit_factor": 58.6062,
+              "entry_types": {
+                "BUY": 377,
+                "SHORT": 304
+              },
+              "entry_reasons": {
+                "SL-Reentry": 445,
+                "Zero-Initial-Reentry": 236
+              },
+              "exit_reasons": {
+                "SL": 681
+              }
+            }
+          },
+          "diagnostics": {
+            "breakout_locks": {
+              "long": {
+                "original_t2": 348,
+                "t3_swing": 124
+              },
+              "short": {
+                "original_t2": 348,
+                "t3_swing": 113
+              }
+            },
+            "t3_cooldown_skips": {
+              "long": 0,
+              "short": 0
+            },
+            "t3_quality_rejects": {
+              "long": {
+                "sma_atr_separation": 132
+              },
+              "short": {
+                "sma_atr_separation": 152
+              }
+            }
+          },
+          "ledger_path": "research/tmp_eth_2026_q1_30min_1s_live_intrabar_sma5_all_breakouts_sep_0p25_ledger.csv",
+          "elapsed_seconds": 224.81
+        }
+      ],
+      "delta_vs_t3_sma5_baseline": {
+        "A_sep_0p25": {
+          "final_balance_delta": 4222.43,
+          "return_pct_delta": 4.22,
+          "max_dd_pct_delta": 0.06,
+          "trades_delta": -25,
+          "win_rate_pct_delta": 0.32,
+          "sharpe_delta": 0.07
+        },
+        "all_breakouts_sep_0p25": {
+          "final_balance_delta": -132354.79,
+          "return_pct_delta": -132.36,
+          "max_dd_pct_delta": 0.68,
+          "trades_delta": -663,
+          "win_rate_pct_delta": 1.71,
+          "sharpe_delta": 1.2
+        }
+      }
+    }
+  ],
+  "baseline_scenario": "t3_sma5_baseline",
+  "note": "Research-only 30min optimization. Baseline is t3_sma5_baseline; variants only add signal-quality filters to the added t3 breakout lock and preserve sizing."
+}

--- a/research/eth_2026_q1_30min_t3_sma5_combo_separation_summary.json
+++ b/research/eth_2026_q1_30min_t3_sma5_combo_separation_summary.json
@@ -1,0 +1,586 @@
+{
+  "window": {
+    "start": "2026-01-01T00:00:00+00:00",
+    "end": "2026-03-31T23:59:59+00:00"
+  },
+  "build_stats": {
+    "raw_tick_rows": 748747244,
+    "kept_tick_rows": 748747172,
+    "sparse_second_rows": 7596268,
+    "continuous_second_rows": 7776000,
+    "first_second": "2026-01-01T00:00:00+00:00",
+    "last_second": "2026-03-31T23:59:59+00:00",
+    "derived_one_min_rows": 129600
+  },
+  "results": [
+    {
+      "timeframe": "30min",
+      "signal_stats": {
+        "signal_rows": 4320,
+        "signal_start": "2026-01-01T00:00:00+00:00",
+        "signal_end": "2026-03-31T23:30:00+00:00",
+        "valid_sma5_rows": 4316,
+        "valid_atr_rows": 4307
+      },
+      "scenarios": [
+        {
+          "scenario": "t3_sma5_baseline",
+          "breakout_shape": "baseline_plus_t3",
+          "replay_mode": "live_intrabar_sma5",
+          "params": {
+            "dir2_zero_initial": true,
+            "zero_initial_mode": "reentry_window",
+            "fixed_slippage": 0.0005,
+            "stop_loss_atr": 0.05,
+            "stop_mode": "atr",
+            "max_trades_per_bar": 2,
+            "reentry_size_schedule": [
+              0.2,
+              0.1
+            ],
+            "long_reentry_atr": 0.1,
+            "short_reentry_atr": 0.0,
+            "profit_protect_atr": 1.0,
+            "trailing_stop_atr": 0.3,
+            "delayed_trailing_activation": 0.5,
+            "reentry_anchor_levels": "wick",
+            "reentry_trigger_mode": "reclaim",
+            "t3_reentry_size_schedule": [
+              0.2,
+              0.1
+            ],
+            "t3_cooldown_bars": 0,
+            "t3_quality_filters": {}
+          },
+          "summary": {
+            "final_balance": 531886.72,
+            "return_pct": 431.89,
+            "max_dd_pct": -2.1,
+            "trades": 3251,
+            "win_rate_pct": 80.28,
+            "sharpe": 13.42,
+            "first_entry": "2026-01-01T10:22:41+00:00",
+            "last_exit": "2026-03-31T23:10:28+00:00",
+            "entry_reasons": {
+              "SL-Reentry": 2101,
+              "Zero-Initial-Reentry": 1150
+            },
+            "exit_reasons": {
+              "SL": 3251
+            },
+            "entry_types": {
+              "BUY": 1642,
+              "SHORT": 1609
+            },
+            "integrity": {
+              "rows": 6502,
+              "entries": 3251,
+              "exits": 3251,
+              "zero_notional_entries": 0
+            }
+          },
+          "attribution": {
+            "original_t2": {
+              "trades": 2576,
+              "win_rate_pct": 87.97,
+              "avg_pnl_pct": 0.5411,
+              "median_pnl_pct": 0.4008,
+              "pnl_std_pct": 0.6352,
+              "worst_pnl_pct": -0.1811,
+              "net_pnl_value": 553447.23,
+              "max_pnl_drawdown": -219.54,
+              "profit_factor": 61.5178,
+              "entry_types": {
+                "SHORT": 1304,
+                "BUY": 1272
+              },
+              "entry_reasons": {
+                "SL-Reentry": 1665,
+                "Zero-Initial-Reentry": 911
+              },
+              "exit_reasons": {
+                "SL": 2576
+              }
+            },
+            "t3_swing": {
+              "trades": 675,
+              "win_rate_pct": 85.33,
+              "avg_pnl_pct": 0.5157,
+              "median_pnl_pct": 0.3537,
+              "pnl_std_pct": 0.628,
+              "worst_pnl_pct": -0.1188,
+              "net_pnl_value": 136907.94,
+              "max_pnl_drawdown": -215.84,
+              "profit_factor": 51.2283,
+              "entry_types": {
+                "BUY": 370,
+                "SHORT": 305
+              },
+              "entry_reasons": {
+                "SL-Reentry": 436,
+                "Zero-Initial-Reentry": 239
+              },
+              "exit_reasons": {
+                "SL": 675
+              }
+            }
+          },
+          "diagnostics": {
+            "breakout_locks": {
+              "long": {
+                "original_t2": 447,
+                "t3_swing": 127
+              },
+              "short": {
+                "original_t2": 471,
+                "t3_swing": 113
+              }
+            },
+            "t3_cooldown_skips": {
+              "long": 0,
+              "short": 0
+            },
+            "t3_quality_rejects": {
+              "long": {},
+              "short": {}
+            }
+          },
+          "ledger_path": "research/tmp_eth_2026_q1_30min_1s_live_intrabar_sma5_t3_sma5_baseline_ledger.csv",
+          "elapsed_seconds": 223.47
+        },
+        {
+          "scenario": "t3_sma5_trend_and_atr_pct30",
+          "breakout_shape": "baseline_plus_t3",
+          "replay_mode": "live_intrabar_sma5",
+          "params": {
+            "dir2_zero_initial": true,
+            "zero_initial_mode": "reentry_window",
+            "fixed_slippage": 0.0005,
+            "stop_loss_atr": 0.05,
+            "stop_mode": "atr",
+            "max_trades_per_bar": 2,
+            "reentry_size_schedule": [
+              0.2,
+              0.1
+            ],
+            "long_reentry_atr": 0.1,
+            "short_reentry_atr": 0.0,
+            "profit_protect_atr": 1.0,
+            "trailing_stop_atr": 0.3,
+            "delayed_trailing_activation": 0.5,
+            "reentry_anchor_levels": "wick",
+            "reentry_trigger_mode": "reclaim",
+            "t3_reentry_size_schedule": [
+              0.2,
+              0.1
+            ],
+            "t3_cooldown_bars": 0,
+            "t3_quality_filters": {
+              "trend": true,
+              "min_atr_percentile": 30.0
+            }
+          },
+          "summary": {
+            "final_balance": 505297.73,
+            "return_pct": 405.3,
+            "max_dd_pct": -1.85,
+            "trades": 3012,
+            "win_rate_pct": 80.71,
+            "sharpe": 13.64,
+            "first_entry": "2026-01-01T10:22:41+00:00",
+            "last_exit": "2026-03-31T23:10:28+00:00",
+            "entry_reasons": {
+              "SL-Reentry": 1954,
+              "Zero-Initial-Reentry": 1058
+            },
+            "exit_reasons": {
+              "SL": 3012
+            },
+            "entry_types": {
+              "SHORT": 1512,
+              "BUY": 1500
+            },
+            "integrity": {
+              "rows": 6024,
+              "entries": 3012,
+              "exits": 3012,
+              "zero_notional_entries": 0
+            }
+          },
+          "attribution": {
+            "original_t2": {
+              "trades": 2601,
+              "win_rate_pct": 87.97,
+              "avg_pnl_pct": 0.5378,
+              "median_pnl_pct": 0.3962,
+              "pnl_std_pct": 0.6328,
+              "worst_pnl_pct": -0.1811,
+              "net_pnl_value": 540269.41,
+              "max_pnl_drawdown": -210.63,
+              "profit_factor": 61.2308,
+              "entry_types": {
+                "SHORT": 1328,
+                "BUY": 1273
+              },
+              "entry_reasons": {
+                "SL-Reentry": 1683,
+                "Zero-Initial-Reentry": 918
+              },
+              "exit_reasons": {
+                "SL": 2601
+              }
+            },
+            "t3_swing": {
+              "trades": 411,
+              "win_rate_pct": 85.16,
+              "avg_pnl_pct": 0.6351,
+              "median_pnl_pct": 0.4678,
+              "pnl_std_pct": 0.687,
+              "worst_pnl_pct": -0.1365,
+              "net_pnl_value": 97719.15,
+              "max_pnl_drawdown": -209.58,
+              "profit_factor": 55.7738,
+              "entry_types": {
+                "BUY": 227,
+                "SHORT": 184
+              },
+              "entry_reasons": {
+                "SL-Reentry": 271,
+                "Zero-Initial-Reentry": 140
+              },
+              "exit_reasons": {
+                "SL": 411
+              }
+            }
+          },
+          "diagnostics": {
+            "breakout_locks": {
+              "long": {
+                "original_t2": 446,
+                "t3_swing": 76
+              },
+              "short": {
+                "original_t2": 479,
+                "t3_swing": 64
+              }
+            },
+            "t3_cooldown_skips": {
+              "long": 0,
+              "short": 0
+            },
+            "t3_quality_rejects": {
+              "long": {
+                "trend_long": 35,
+                "atr_percentile": 37
+              },
+              "short": {
+                "atr_percentile": 29,
+                "trend_short": 30
+              }
+            }
+          },
+          "ledger_path": "research/tmp_eth_2026_q1_30min_1s_live_intrabar_sma5_t3_sma5_trend_and_atr_pct30_ledger.csv",
+          "elapsed_seconds": 224.55
+        },
+        {
+          "scenario": "t3_sma5_sma_atr_sep_0p25",
+          "breakout_shape": "baseline_plus_t3",
+          "replay_mode": "live_intrabar_sma5",
+          "params": {
+            "dir2_zero_initial": true,
+            "zero_initial_mode": "reentry_window",
+            "fixed_slippage": 0.0005,
+            "stop_loss_atr": 0.05,
+            "stop_mode": "atr",
+            "max_trades_per_bar": 2,
+            "reentry_size_schedule": [
+              0.2,
+              0.1
+            ],
+            "long_reentry_atr": 0.1,
+            "short_reentry_atr": 0.0,
+            "profit_protect_atr": 1.0,
+            "trailing_stop_atr": 0.3,
+            "delayed_trailing_activation": 0.5,
+            "reentry_anchor_levels": "wick",
+            "reentry_trigger_mode": "reclaim",
+            "t3_reentry_size_schedule": [
+              0.2,
+              0.1
+            ],
+            "t3_cooldown_bars": 0,
+            "t3_quality_filters": {
+              "min_sma_atr_separation": 0.25
+            }
+          },
+          "summary": {
+            "final_balance": 536109.15,
+            "return_pct": 436.11,
+            "max_dd_pct": -2.04,
+            "trades": 3226,
+            "win_rate_pct": 80.6,
+            "sharpe": 13.49,
+            "first_entry": "2026-01-01T10:22:41+00:00",
+            "last_exit": "2026-03-31T23:59:59+00:00",
+            "entry_reasons": {
+              "SL-Reentry": 2086,
+              "Zero-Initial-Reentry": 1140
+            },
+            "exit_reasons": {
+              "SL": 3225,
+              "FinalMarkToMarket": 1
+            },
+            "entry_types": {
+              "BUY": 1632,
+              "SHORT": 1594
+            },
+            "integrity": {
+              "rows": 6452,
+              "entries": 3226,
+              "exits": 3226,
+              "zero_notional_entries": 0
+            }
+          },
+          "attribution": {
+            "original_t2": {
+              "trades": 2575,
+              "win_rate_pct": 87.96,
+              "avg_pnl_pct": 0.5409,
+              "median_pnl_pct": 0.4009,
+              "pnl_std_pct": 0.6352,
+              "worst_pnl_pct": -0.1811,
+              "net_pnl_value": 555845.31,
+              "max_pnl_drawdown": -221.0,
+              "profit_factor": 61.861,
+              "entry_types": {
+                "SHORT": 1298,
+                "BUY": 1277
+              },
+              "entry_reasons": {
+                "SL-Reentry": 1663,
+                "Zero-Initial-Reentry": 912
+              },
+              "exit_reasons": {
+                "SL": 2574,
+                "FinalMarkToMarket": 1
+              }
+            },
+            "t3_swing": {
+              "trades": 651,
+              "win_rate_pct": 87.1,
+              "avg_pnl_pct": 0.5355,
+              "median_pnl_pct": 0.3717,
+              "pnl_std_pct": 0.6343,
+              "worst_pnl_pct": -0.1188,
+              "net_pnl_value": 137520.44,
+              "max_pnl_drawdown": -217.37,
+              "profit_factor": 64.946,
+              "entry_types": {
+                "BUY": 355,
+                "SHORT": 296
+              },
+              "entry_reasons": {
+                "SL-Reentry": 423,
+                "Zero-Initial-Reentry": 228
+              },
+              "exit_reasons": {
+                "SL": 651
+              }
+            }
+          },
+          "diagnostics": {
+            "breakout_locks": {
+              "long": {
+                "original_t2": 449,
+                "t3_swing": 119
+              },
+              "short": {
+                "original_t2": 470,
+                "t3_swing": 109
+              }
+            },
+            "t3_cooldown_skips": {
+              "long": 0,
+              "short": 0
+            },
+            "t3_quality_rejects": {
+              "long": {
+                "sma_atr_separation": 9
+              },
+              "short": {
+                "sma_atr_separation": 5
+              }
+            }
+          },
+          "ledger_path": "research/tmp_eth_2026_q1_30min_1s_live_intrabar_sma5_t3_sma5_sma_atr_sep_0p25_ledger.csv",
+          "elapsed_seconds": 224.87
+        },
+        {
+          "scenario": "t3_sma5_sma_atr_sep_0p50",
+          "breakout_shape": "baseline_plus_t3",
+          "replay_mode": "live_intrabar_sma5",
+          "params": {
+            "dir2_zero_initial": true,
+            "zero_initial_mode": "reentry_window",
+            "fixed_slippage": 0.0005,
+            "stop_loss_atr": 0.05,
+            "stop_mode": "atr",
+            "max_trades_per_bar": 2,
+            "reentry_size_schedule": [
+              0.2,
+              0.1
+            ],
+            "long_reentry_atr": 0.1,
+            "short_reentry_atr": 0.0,
+            "profit_protect_atr": 1.0,
+            "trailing_stop_atr": 0.3,
+            "delayed_trailing_activation": 0.5,
+            "reentry_anchor_levels": "wick",
+            "reentry_trigger_mode": "reclaim",
+            "t3_reentry_size_schedule": [
+              0.2,
+              0.1
+            ],
+            "t3_cooldown_bars": 0,
+            "t3_quality_filters": {
+              "min_sma_atr_separation": 0.5
+            }
+          },
+          "summary": {
+            "final_balance": 476215.28,
+            "return_pct": 376.22,
+            "max_dd_pct": -1.87,
+            "trades": 2863,
+            "win_rate_pct": 81.28,
+            "sharpe": 13.61,
+            "first_entry": "2026-01-01T10:22:41+00:00",
+            "last_exit": "2026-03-31T23:59:59+00:00",
+            "entry_reasons": {
+              "SL-Reentry": 1845,
+              "Zero-Initial-Reentry": 1017,
+              "PT-Reentry": 1
+            },
+            "exit_reasons": {
+              "SL": 2861,
+              "PT": 1,
+              "FinalMarkToMarket": 1
+            },
+            "entry_types": {
+              "SHORT": 1466,
+              "BUY": 1397
+            },
+            "integrity": {
+              "rows": 5726,
+              "entries": 2863,
+              "exits": 2863,
+              "zero_notional_entries": 0
+            }
+          },
+          "attribution": {
+            "original_t2": {
+              "trades": 2621,
+              "win_rate_pct": 87.87,
+              "avg_pnl_pct": 0.5369,
+              "median_pnl_pct": 0.3969,
+              "pnl_std_pct": 0.6316,
+              "worst_pnl_pct": -0.1811,
+              "net_pnl_value": 527981.19,
+              "max_pnl_drawdown": -201.66,
+              "profit_factor": 61.0195,
+              "entry_types": {
+                "SHORT": 1337,
+                "BUY": 1284
+              },
+              "entry_reasons": {
+                "SL-Reentry": 1694,
+                "Zero-Initial-Reentry": 926,
+                "PT-Reentry": 1
+              },
+              "exit_reasons": {
+                "SL": 2619,
+                "PT": 1,
+                "FinalMarkToMarket": 1
+              }
+            },
+            "t3_swing": {
+              "trades": 242,
+              "win_rate_pct": 94.21,
+              "avg_pnl_pct": 0.7532,
+              "median_pnl_pct": 0.5201,
+              "pnl_std_pct": 0.77,
+              "worst_pnl_pct": -0.1024,
+              "net_pnl_value": 62952.98,
+              "max_pnl_drawdown": -28.06,
+              "profit_factor": 397.5286,
+              "entry_types": {
+                "SHORT": 129,
+                "BUY": 113
+              },
+              "entry_reasons": {
+                "SL-Reentry": 151,
+                "Zero-Initial-Reentry": 91
+              },
+              "exit_reasons": {
+                "SL": 242
+              }
+            }
+          },
+          "diagnostics": {
+            "breakout_locks": {
+              "long": {
+                "original_t2": 450,
+                "t3_swing": 43
+              },
+              "short": {
+                "original_t2": 482,
+                "t3_swing": 48
+              }
+            },
+            "t3_cooldown_skips": {
+              "long": 0,
+              "short": 0
+            },
+            "t3_quality_rejects": {
+              "long": {
+                "sma_atr_separation": 91
+              },
+              "short": {
+                "sma_atr_separation": 68
+              }
+            }
+          },
+          "ledger_path": "research/tmp_eth_2026_q1_30min_1s_live_intrabar_sma5_t3_sma5_sma_atr_sep_0p50_ledger.csv",
+          "elapsed_seconds": 223.86
+        }
+      ],
+      "delta_vs_t3_sma5_baseline": {
+        "t3_sma5_trend_and_atr_pct30": {
+          "final_balance_delta": -26588.99,
+          "return_pct_delta": -26.59,
+          "max_dd_pct_delta": 0.25,
+          "trades_delta": -239,
+          "win_rate_pct_delta": 0.43,
+          "sharpe_delta": 0.22
+        },
+        "t3_sma5_sma_atr_sep_0p25": {
+          "final_balance_delta": 4222.43,
+          "return_pct_delta": 4.22,
+          "max_dd_pct_delta": 0.06,
+          "trades_delta": -25,
+          "win_rate_pct_delta": 0.32,
+          "sharpe_delta": 0.07
+        },
+        "t3_sma5_sma_atr_sep_0p50": {
+          "final_balance_delta": -55671.44,
+          "return_pct_delta": -55.67,
+          "max_dd_pct_delta": 0.23,
+          "trades_delta": -388,
+          "win_rate_pct_delta": 1.0,
+          "sharpe_delta": 0.19
+        }
+      }
+    }
+  ],
+  "baseline_scenario": "t3_sma5_baseline",
+  "note": "Research-only 30min optimization. Baseline is t3_sma5_baseline; variants only add signal-quality filters to the added t3 breakout lock and preserve sizing."
+}

--- a/research/eth_2026_q1_30min_t3_sma5_quality_filtering_summary.json
+++ b/research/eth_2026_q1_30min_t3_sma5_quality_filtering_summary.json
@@ -1,0 +1,571 @@
+{
+  "window": {
+    "start": "2026-01-01T00:00:00+00:00",
+    "end": "2026-03-31T23:59:59+00:00"
+  },
+  "build_stats": {
+    "raw_tick_rows": 748747244,
+    "kept_tick_rows": 748747172,
+    "sparse_second_rows": 7596268,
+    "continuous_second_rows": 7776000,
+    "first_second": "2026-01-01T00:00:00+00:00",
+    "last_second": "2026-03-31T23:59:59+00:00",
+    "derived_one_min_rows": 129600
+  },
+  "results": [
+    {
+      "timeframe": "30min",
+      "signal_stats": {
+        "signal_rows": 4320,
+        "signal_start": "2026-01-01T00:00:00+00:00",
+        "signal_end": "2026-03-31T23:30:00+00:00",
+        "valid_sma5_rows": 4316,
+        "valid_atr_rows": 4307
+      },
+      "scenarios": [
+        {
+          "scenario": "t3_sma5_baseline",
+          "breakout_shape": "baseline_plus_t3",
+          "replay_mode": "live_intrabar_sma5",
+          "params": {
+            "dir2_zero_initial": true,
+            "zero_initial_mode": "reentry_window",
+            "fixed_slippage": 0.0005,
+            "stop_loss_atr": 0.05,
+            "stop_mode": "atr",
+            "max_trades_per_bar": 2,
+            "reentry_size_schedule": [
+              0.2,
+              0.1
+            ],
+            "long_reentry_atr": 0.1,
+            "short_reentry_atr": 0.0,
+            "profit_protect_atr": 1.0,
+            "trailing_stop_atr": 0.3,
+            "delayed_trailing_activation": 0.5,
+            "reentry_anchor_levels": "wick",
+            "reentry_trigger_mode": "reclaim",
+            "t3_reentry_size_schedule": [
+              0.2,
+              0.1
+            ],
+            "t3_cooldown_bars": 0,
+            "t3_quality_filters": {}
+          },
+          "summary": {
+            "final_balance": 531886.72,
+            "return_pct": 431.89,
+            "max_dd_pct": -2.1,
+            "trades": 3251,
+            "win_rate_pct": 80.28,
+            "sharpe": 13.42,
+            "first_entry": "2026-01-01T10:22:41+00:00",
+            "last_exit": "2026-03-31T23:10:28+00:00",
+            "entry_reasons": {
+              "SL-Reentry": 2101,
+              "Zero-Initial-Reentry": 1150
+            },
+            "exit_reasons": {
+              "SL": 3251
+            },
+            "entry_types": {
+              "BUY": 1642,
+              "SHORT": 1609
+            },
+            "integrity": {
+              "rows": 6502,
+              "entries": 3251,
+              "exits": 3251,
+              "zero_notional_entries": 0
+            }
+          },
+          "attribution": {
+            "original_t2": {
+              "trades": 2576,
+              "win_rate_pct": 87.97,
+              "avg_pnl_pct": 0.5411,
+              "median_pnl_pct": 0.4008,
+              "pnl_std_pct": 0.6352,
+              "worst_pnl_pct": -0.1811,
+              "net_pnl_value": 553447.23,
+              "max_pnl_drawdown": -219.54,
+              "profit_factor": 61.5178,
+              "entry_types": {
+                "SHORT": 1304,
+                "BUY": 1272
+              },
+              "entry_reasons": {
+                "SL-Reentry": 1665,
+                "Zero-Initial-Reentry": 911
+              },
+              "exit_reasons": {
+                "SL": 2576
+              }
+            },
+            "t3_swing": {
+              "trades": 675,
+              "win_rate_pct": 85.33,
+              "avg_pnl_pct": 0.5157,
+              "median_pnl_pct": 0.3537,
+              "pnl_std_pct": 0.628,
+              "worst_pnl_pct": -0.1188,
+              "net_pnl_value": 136907.94,
+              "max_pnl_drawdown": -215.84,
+              "profit_factor": 51.2283,
+              "entry_types": {
+                "BUY": 370,
+                "SHORT": 305
+              },
+              "entry_reasons": {
+                "SL-Reentry": 436,
+                "Zero-Initial-Reentry": 239
+              },
+              "exit_reasons": {
+                "SL": 675
+              }
+            }
+          },
+          "diagnostics": {
+            "breakout_locks": {
+              "long": {
+                "original_t2": 447,
+                "t3_swing": 127
+              },
+              "short": {
+                "original_t2": 471,
+                "t3_swing": 113
+              }
+            },
+            "t3_cooldown_skips": {
+              "long": 0,
+              "short": 0
+            },
+            "t3_quality_rejects": {
+              "long": {},
+              "short": {}
+            }
+          },
+          "ledger_path": "research/tmp_eth_2026_q1_30min_1s_live_intrabar_sma5_t3_sma5_baseline_ledger.csv",
+          "elapsed_seconds": 168.04
+        },
+        {
+          "scenario": "t3_sma5_trend_filter",
+          "breakout_shape": "baseline_plus_t3",
+          "replay_mode": "live_intrabar_sma5",
+          "params": {
+            "dir2_zero_initial": true,
+            "zero_initial_mode": "reentry_window",
+            "fixed_slippage": 0.0005,
+            "stop_loss_atr": 0.05,
+            "stop_mode": "atr",
+            "max_trades_per_bar": 2,
+            "reentry_size_schedule": [
+              0.2,
+              0.1
+            ],
+            "long_reentry_atr": 0.1,
+            "short_reentry_atr": 0.0,
+            "profit_protect_atr": 1.0,
+            "trailing_stop_atr": 0.3,
+            "delayed_trailing_activation": 0.5,
+            "reentry_anchor_levels": "wick",
+            "reentry_trigger_mode": "reclaim",
+            "t3_reentry_size_schedule": [
+              0.2,
+              0.1
+            ],
+            "t3_cooldown_bars": 0,
+            "t3_quality_filters": {
+              "trend": true
+            }
+          },
+          "summary": {
+            "final_balance": 518859.46,
+            "return_pct": 418.86,
+            "max_dd_pct": -2.1,
+            "trades": 3167,
+            "win_rate_pct": 80.45,
+            "sharpe": 13.56,
+            "first_entry": "2026-01-01T10:22:41+00:00",
+            "last_exit": "2026-03-31T23:10:28+00:00",
+            "entry_reasons": {
+              "SL-Reentry": 2049,
+              "Zero-Initial-Reentry": 1118
+            },
+            "exit_reasons": {
+              "SL": 3167
+            },
+            "entry_types": {
+              "BUY": 1600,
+              "SHORT": 1567
+            },
+            "integrity": {
+              "rows": 6334,
+              "entries": 3167,
+              "exits": 3167,
+              "zero_notional_entries": 0
+            }
+          },
+          "attribution": {
+            "original_t2": {
+              "trades": 2583,
+              "win_rate_pct": 88.0,
+              "avg_pnl_pct": 0.54,
+              "median_pnl_pct": 0.4008,
+              "pnl_std_pct": 0.6342,
+              "worst_pnl_pct": -0.1811,
+              "net_pnl_value": 544069.92,
+              "max_pnl_drawdown": -215.19,
+              "profit_factor": 61.5424,
+              "entry_types": {
+                "SHORT": 1313,
+                "BUY": 1270
+              },
+              "entry_reasons": {
+                "SL-Reentry": 1670,
+                "Zero-Initial-Reentry": 913
+              },
+              "exit_reasons": {
+                "SL": 2583
+              }
+            },
+            "t3_swing": {
+              "trades": 584,
+              "win_rate_pct": 85.27,
+              "avg_pnl_pct": 0.5377,
+              "median_pnl_pct": 0.3796,
+              "pnl_std_pct": 0.6214,
+              "worst_pnl_pct": -0.1365,
+              "net_pnl_value": 121978.46,
+              "max_pnl_drawdown": -211.41,
+              "profit_factor": 54.3655,
+              "entry_types": {
+                "BUY": 330,
+                "SHORT": 254
+              },
+              "entry_reasons": {
+                "SL-Reentry": 379,
+                "Zero-Initial-Reentry": 205
+              },
+              "exit_reasons": {
+                "SL": 584
+              }
+            }
+          },
+          "diagnostics": {
+            "breakout_locks": {
+              "long": {
+                "original_t2": 446,
+                "t3_swing": 113
+              },
+              "short": {
+                "original_t2": 474,
+                "t3_swing": 93
+              }
+            },
+            "t3_cooldown_skips": {
+              "long": 0,
+              "short": 0
+            },
+            "t3_quality_rejects": {
+              "long": {
+                "trend_long": 34
+              },
+              "short": {
+                "trend_short": 30
+              }
+            }
+          },
+          "ledger_path": "research/tmp_eth_2026_q1_30min_1s_live_intrabar_sma5_t3_sma5_trend_filter_ledger.csv",
+          "elapsed_seconds": 170.12
+        },
+        {
+          "scenario": "t3_sma5_sma_atr_sep_0p1",
+          "breakout_shape": "baseline_plus_t3",
+          "replay_mode": "live_intrabar_sma5",
+          "params": {
+            "dir2_zero_initial": true,
+            "zero_initial_mode": "reentry_window",
+            "fixed_slippage": 0.0005,
+            "stop_loss_atr": 0.05,
+            "stop_mode": "atr",
+            "max_trades_per_bar": 2,
+            "reentry_size_schedule": [
+              0.2,
+              0.1
+            ],
+            "long_reentry_atr": 0.1,
+            "short_reentry_atr": 0.0,
+            "profit_protect_atr": 1.0,
+            "trailing_stop_atr": 0.3,
+            "delayed_trailing_activation": 0.5,
+            "reentry_anchor_levels": "wick",
+            "reentry_trigger_mode": "reclaim",
+            "t3_reentry_size_schedule": [
+              0.2,
+              0.1
+            ],
+            "t3_cooldown_bars": 0,
+            "t3_quality_filters": {
+              "min_sma_atr_separation": 0.1
+            }
+          },
+          "summary": {
+            "final_balance": 531886.72,
+            "return_pct": 431.89,
+            "max_dd_pct": -2.1,
+            "trades": 3251,
+            "win_rate_pct": 80.28,
+            "sharpe": 13.42,
+            "first_entry": "2026-01-01T10:22:41+00:00",
+            "last_exit": "2026-03-31T23:10:28+00:00",
+            "entry_reasons": {
+              "SL-Reentry": 2101,
+              "Zero-Initial-Reentry": 1150
+            },
+            "exit_reasons": {
+              "SL": 3251
+            },
+            "entry_types": {
+              "BUY": 1642,
+              "SHORT": 1609
+            },
+            "integrity": {
+              "rows": 6502,
+              "entries": 3251,
+              "exits": 3251,
+              "zero_notional_entries": 0
+            }
+          },
+          "attribution": {
+            "original_t2": {
+              "trades": 2576,
+              "win_rate_pct": 87.97,
+              "avg_pnl_pct": 0.5411,
+              "median_pnl_pct": 0.4008,
+              "pnl_std_pct": 0.6352,
+              "worst_pnl_pct": -0.1811,
+              "net_pnl_value": 553447.23,
+              "max_pnl_drawdown": -219.54,
+              "profit_factor": 61.5178,
+              "entry_types": {
+                "SHORT": 1304,
+                "BUY": 1272
+              },
+              "entry_reasons": {
+                "SL-Reentry": 1665,
+                "Zero-Initial-Reentry": 911
+              },
+              "exit_reasons": {
+                "SL": 2576
+              }
+            },
+            "t3_swing": {
+              "trades": 675,
+              "win_rate_pct": 85.33,
+              "avg_pnl_pct": 0.5157,
+              "median_pnl_pct": 0.3537,
+              "pnl_std_pct": 0.628,
+              "worst_pnl_pct": -0.1188,
+              "net_pnl_value": 136907.94,
+              "max_pnl_drawdown": -215.84,
+              "profit_factor": 51.2283,
+              "entry_types": {
+                "BUY": 370,
+                "SHORT": 305
+              },
+              "entry_reasons": {
+                "SL-Reentry": 436,
+                "Zero-Initial-Reentry": 239
+              },
+              "exit_reasons": {
+                "SL": 675
+              }
+            }
+          },
+          "diagnostics": {
+            "breakout_locks": {
+              "long": {
+                "original_t2": 447,
+                "t3_swing": 127
+              },
+              "short": {
+                "original_t2": 471,
+                "t3_swing": 113
+              }
+            },
+            "t3_cooldown_skips": {
+              "long": 0,
+              "short": 0
+            },
+            "t3_quality_rejects": {
+              "long": {},
+              "short": {}
+            }
+          },
+          "ledger_path": "research/tmp_eth_2026_q1_30min_1s_live_intrabar_sma5_t3_sma5_sma_atr_sep_0p1_ledger.csv",
+          "elapsed_seconds": 189.83
+        },
+        {
+          "scenario": "t3_sma5_atr_percentile_gte_30",
+          "breakout_shape": "baseline_plus_t3",
+          "replay_mode": "live_intrabar_sma5",
+          "params": {
+            "dir2_zero_initial": true,
+            "zero_initial_mode": "reentry_window",
+            "fixed_slippage": 0.0005,
+            "stop_loss_atr": 0.05,
+            "stop_mode": "atr",
+            "max_trades_per_bar": 2,
+            "reentry_size_schedule": [
+              0.2,
+              0.1
+            ],
+            "long_reentry_atr": 0.1,
+            "short_reentry_atr": 0.0,
+            "profit_protect_atr": 1.0,
+            "trailing_stop_atr": 0.3,
+            "delayed_trailing_activation": 0.5,
+            "reentry_anchor_levels": "wick",
+            "reentry_trigger_mode": "reclaim",
+            "t3_reentry_size_schedule": [
+              0.2,
+              0.1
+            ],
+            "t3_cooldown_bars": 0,
+            "t3_quality_filters": {
+              "min_atr_percentile": 30.0
+            }
+          },
+          "summary": {
+            "final_balance": 517661.93,
+            "return_pct": 417.66,
+            "max_dd_pct": -1.85,
+            "trades": 3060,
+            "win_rate_pct": 80.69,
+            "sharpe": 13.54,
+            "first_entry": "2026-01-01T10:22:41+00:00",
+            "last_exit": "2026-03-31T23:10:28+00:00",
+            "entry_reasons": {
+              "SL-Reentry": 1984,
+              "Zero-Initial-Reentry": 1076
+            },
+            "exit_reasons": {
+              "SL": 3060
+            },
+            "entry_types": {
+              "SHORT": 1533,
+              "BUY": 1527
+            },
+            "integrity": {
+              "rows": 6120,
+              "entries": 3060,
+              "exits": 3060,
+              "zero_notional_entries": 0
+            }
+          },
+          "attribution": {
+            "original_t2": {
+              "trades": 2597,
+              "win_rate_pct": 87.95,
+              "avg_pnl_pct": 0.5385,
+              "median_pnl_pct": 0.3962,
+              "pnl_std_pct": 0.6335,
+              "worst_pnl_pct": -0.1811,
+              "net_pnl_value": 549011.7,
+              "max_pnl_drawdown": -214.26,
+              "profit_factor": 61.2655,
+              "entry_types": {
+                "SHORT": 1322,
+                "BUY": 1275
+              },
+              "entry_reasons": {
+                "SL-Reentry": 1680,
+                "Zero-Initial-Reentry": 917
+              },
+              "exit_reasons": {
+                "SL": 2597
+              }
+            },
+            "t3_swing": {
+              "trades": 463,
+              "win_rate_pct": 85.31,
+              "avg_pnl_pct": 0.6192,
+              "median_pnl_pct": 0.4428,
+              "pnl_std_pct": 0.7049,
+              "worst_pnl_pct": -0.1143,
+              "net_pnl_value": 108775.5,
+              "max_pnl_drawdown": -213.12,
+              "profit_factor": 54.2307,
+              "entry_types": {
+                "BUY": 252,
+                "SHORT": 211
+              },
+              "entry_reasons": {
+                "SL-Reentry": 304,
+                "Zero-Initial-Reentry": 159
+              },
+              "exit_reasons": {
+                "SL": 463
+              }
+            }
+          },
+          "diagnostics": {
+            "breakout_locks": {
+              "long": {
+                "original_t2": 447,
+                "t3_swing": 85
+              },
+              "short": {
+                "original_t2": 477,
+                "t3_swing": 74
+              }
+            },
+            "t3_cooldown_skips": {
+              "long": 0,
+              "short": 0
+            },
+            "t3_quality_rejects": {
+              "long": {
+                "atr_percentile": 42
+              },
+              "short": {
+                "atr_percentile": 39
+              }
+            }
+          },
+          "ledger_path": "research/tmp_eth_2026_q1_30min_1s_live_intrabar_sma5_t3_sma5_atr_percentile_gte_30_ledger.csv",
+          "elapsed_seconds": 220.63
+        }
+      ],
+      "delta_vs_t3_sma5_baseline": {
+        "t3_sma5_trend_filter": {
+          "final_balance_delta": -13027.26,
+          "return_pct_delta": -13.03,
+          "max_dd_pct_delta": 0.0,
+          "trades_delta": -84,
+          "win_rate_pct_delta": 0.17,
+          "sharpe_delta": 0.14
+        },
+        "t3_sma5_sma_atr_sep_0p1": {
+          "final_balance_delta": 0.0,
+          "return_pct_delta": 0.0,
+          "max_dd_pct_delta": 0.0,
+          "trades_delta": 0,
+          "win_rate_pct_delta": 0.0,
+          "sharpe_delta": 0.0
+        },
+        "t3_sma5_atr_percentile_gte_30": {
+          "final_balance_delta": -14224.79,
+          "return_pct_delta": -14.23,
+          "max_dd_pct_delta": 0.25,
+          "trades_delta": -191,
+          "win_rate_pct_delta": 0.41,
+          "sharpe_delta": 0.12
+        }
+      }
+    }
+  ],
+  "baseline_scenario": "t3_sma5_baseline",
+  "note": "Research-only 30min optimization. Baseline is t3_sma5_baseline; variants only add signal-quality filters to the added t3 breakout lock and preserve sizing."
+}

--- a/research/eth_2026_q1_30min_t3_sma5_sep_0p25_marginal_summary.json
+++ b/research/eth_2026_q1_30min_t3_sma5_sep_0p25_marginal_summary.json
@@ -1,0 +1,734 @@
+{
+  "window": {
+    "start": "2026-01-01T00:00:00+00:00",
+    "end": "2026-03-31T23:59:59+00:00"
+  },
+  "build_stats": {
+    "raw_tick_rows": 748747244,
+    "kept_tick_rows": 748747172,
+    "sparse_second_rows": 7596268,
+    "continuous_second_rows": 7776000,
+    "first_second": "2026-01-01T00:00:00+00:00",
+    "last_second": "2026-03-31T23:59:59+00:00",
+    "derived_one_min_rows": 129600
+  },
+  "results": [
+    {
+      "timeframe": "30min",
+      "signal_stats": {
+        "signal_rows": 4320,
+        "signal_start": "2026-01-01T00:00:00+00:00",
+        "signal_end": "2026-03-31T23:30:00+00:00",
+        "valid_sma5_rows": 4316,
+        "valid_atr_rows": 4307
+      },
+      "scenarios": [
+        {
+          "scenario": "t3_sma5_baseline",
+          "breakout_shape": "baseline_plus_t3",
+          "replay_mode": "live_intrabar_sma5",
+          "params": {
+            "dir2_zero_initial": true,
+            "zero_initial_mode": "reentry_window",
+            "fixed_slippage": 0.0005,
+            "stop_loss_atr": 0.05,
+            "stop_mode": "atr",
+            "max_trades_per_bar": 2,
+            "reentry_size_schedule": [
+              0.2,
+              0.1
+            ],
+            "long_reentry_atr": 0.1,
+            "short_reentry_atr": 0.0,
+            "profit_protect_atr": 1.0,
+            "trailing_stop_atr": 0.3,
+            "delayed_trailing_activation": 0.5,
+            "reentry_anchor_levels": "wick",
+            "reentry_trigger_mode": "reclaim",
+            "t3_reentry_size_schedule": [
+              0.2,
+              0.1
+            ],
+            "t3_cooldown_bars": 0,
+            "t3_quality_filters": {}
+          },
+          "summary": {
+            "final_balance": 531886.72,
+            "return_pct": 431.89,
+            "max_dd_pct": -2.1,
+            "trades": 3251,
+            "win_rate_pct": 80.28,
+            "sharpe": 13.42,
+            "first_entry": "2026-01-01T10:22:41+00:00",
+            "last_exit": "2026-03-31T23:10:28+00:00",
+            "entry_reasons": {
+              "SL-Reentry": 2101,
+              "Zero-Initial-Reentry": 1150
+            },
+            "exit_reasons": {
+              "SL": 3251
+            },
+            "entry_types": {
+              "BUY": 1642,
+              "SHORT": 1609
+            },
+            "integrity": {
+              "rows": 6502,
+              "entries": 3251,
+              "exits": 3251,
+              "zero_notional_entries": 0
+            }
+          },
+          "attribution": {
+            "original_t2": {
+              "trades": 2576,
+              "win_rate_pct": 87.97,
+              "avg_pnl_pct": 0.5411,
+              "median_pnl_pct": 0.4008,
+              "pnl_std_pct": 0.6352,
+              "worst_pnl_pct": -0.1811,
+              "net_pnl_value": 553447.23,
+              "max_pnl_drawdown": -219.54,
+              "profit_factor": 61.5178,
+              "entry_types": {
+                "SHORT": 1304,
+                "BUY": 1272
+              },
+              "entry_reasons": {
+                "SL-Reentry": 1665,
+                "Zero-Initial-Reentry": 911
+              },
+              "exit_reasons": {
+                "SL": 2576
+              }
+            },
+            "t3_swing": {
+              "trades": 675,
+              "win_rate_pct": 85.33,
+              "avg_pnl_pct": 0.5157,
+              "median_pnl_pct": 0.3537,
+              "pnl_std_pct": 0.628,
+              "worst_pnl_pct": -0.1188,
+              "net_pnl_value": 136907.94,
+              "max_pnl_drawdown": -215.84,
+              "profit_factor": 51.2283,
+              "entry_types": {
+                "BUY": 370,
+                "SHORT": 305
+              },
+              "entry_reasons": {
+                "SL-Reentry": 436,
+                "Zero-Initial-Reentry": 239
+              },
+              "exit_reasons": {
+                "SL": 675
+              }
+            }
+          },
+          "diagnostics": {
+            "breakout_locks": {
+              "long": {
+                "original_t2": 447,
+                "t3_swing": 127
+              },
+              "short": {
+                "original_t2": 471,
+                "t3_swing": 113
+              }
+            },
+            "t3_cooldown_skips": {
+              "long": 0,
+              "short": 0
+            },
+            "t3_quality_rejects": {
+              "long": {},
+              "short": {}
+            }
+          },
+          "ledger_path": "research/tmp_eth_2026_q1_30min_1s_live_intrabar_sma5_t3_sma5_baseline_ledger.csv",
+          "elapsed_seconds": 229.6
+        },
+        {
+          "scenario": "A_sep_0p25",
+          "breakout_shape": "baseline_plus_t3",
+          "replay_mode": "live_intrabar_sma5",
+          "params": {
+            "dir2_zero_initial": true,
+            "zero_initial_mode": "reentry_window",
+            "fixed_slippage": 0.0005,
+            "stop_loss_atr": 0.05,
+            "stop_mode": "atr",
+            "max_trades_per_bar": 2,
+            "reentry_size_schedule": [
+              0.2,
+              0.1
+            ],
+            "long_reentry_atr": 0.1,
+            "short_reentry_atr": 0.0,
+            "profit_protect_atr": 1.0,
+            "trailing_stop_atr": 0.3,
+            "delayed_trailing_activation": 0.5,
+            "reentry_anchor_levels": "wick",
+            "reentry_trigger_mode": "reclaim",
+            "t3_reentry_size_schedule": [
+              0.2,
+              0.1
+            ],
+            "t3_cooldown_bars": 0,
+            "t3_quality_filters": {
+              "min_sma_atr_separation": 0.25
+            }
+          },
+          "summary": {
+            "final_balance": 536109.15,
+            "return_pct": 436.11,
+            "max_dd_pct": -2.04,
+            "trades": 3226,
+            "win_rate_pct": 80.6,
+            "sharpe": 13.49,
+            "first_entry": "2026-01-01T10:22:41+00:00",
+            "last_exit": "2026-03-31T23:59:59+00:00",
+            "entry_reasons": {
+              "SL-Reentry": 2086,
+              "Zero-Initial-Reentry": 1140
+            },
+            "exit_reasons": {
+              "SL": 3225,
+              "FinalMarkToMarket": 1
+            },
+            "entry_types": {
+              "BUY": 1632,
+              "SHORT": 1594
+            },
+            "integrity": {
+              "rows": 6452,
+              "entries": 3226,
+              "exits": 3226,
+              "zero_notional_entries": 0
+            }
+          },
+          "attribution": {
+            "original_t2": {
+              "trades": 2575,
+              "win_rate_pct": 87.96,
+              "avg_pnl_pct": 0.5409,
+              "median_pnl_pct": 0.4009,
+              "pnl_std_pct": 0.6352,
+              "worst_pnl_pct": -0.1811,
+              "net_pnl_value": 555845.31,
+              "max_pnl_drawdown": -221.0,
+              "profit_factor": 61.861,
+              "entry_types": {
+                "SHORT": 1298,
+                "BUY": 1277
+              },
+              "entry_reasons": {
+                "SL-Reentry": 1663,
+                "Zero-Initial-Reentry": 912
+              },
+              "exit_reasons": {
+                "SL": 2574,
+                "FinalMarkToMarket": 1
+              }
+            },
+            "t3_swing": {
+              "trades": 651,
+              "win_rate_pct": 87.1,
+              "avg_pnl_pct": 0.5355,
+              "median_pnl_pct": 0.3717,
+              "pnl_std_pct": 0.6343,
+              "worst_pnl_pct": -0.1188,
+              "net_pnl_value": 137520.44,
+              "max_pnl_drawdown": -217.37,
+              "profit_factor": 64.946,
+              "entry_types": {
+                "BUY": 355,
+                "SHORT": 296
+              },
+              "entry_reasons": {
+                "SL-Reentry": 423,
+                "Zero-Initial-Reentry": 228
+              },
+              "exit_reasons": {
+                "SL": 651
+              }
+            }
+          },
+          "diagnostics": {
+            "breakout_locks": {
+              "long": {
+                "original_t2": 449,
+                "t3_swing": 119
+              },
+              "short": {
+                "original_t2": 470,
+                "t3_swing": 109
+              }
+            },
+            "t3_cooldown_skips": {
+              "long": 0,
+              "short": 0
+            },
+            "t3_quality_rejects": {
+              "long": {
+                "sma_atr_separation": 9
+              },
+              "short": {
+                "sma_atr_separation": 5
+              }
+            }
+          },
+          "ledger_path": "research/tmp_eth_2026_q1_30min_1s_live_intrabar_sma5_A_sep_0p25_ledger.csv",
+          "elapsed_seconds": 228.9
+        },
+        {
+          "scenario": "B_trend_sep_0p25",
+          "breakout_shape": "baseline_plus_t3",
+          "replay_mode": "live_intrabar_sma5",
+          "params": {
+            "dir2_zero_initial": true,
+            "zero_initial_mode": "reentry_window",
+            "fixed_slippage": 0.0005,
+            "stop_loss_atr": 0.05,
+            "stop_mode": "atr",
+            "max_trades_per_bar": 2,
+            "reentry_size_schedule": [
+              0.2,
+              0.1
+            ],
+            "long_reentry_atr": 0.1,
+            "short_reentry_atr": 0.0,
+            "profit_protect_atr": 1.0,
+            "trailing_stop_atr": 0.3,
+            "delayed_trailing_activation": 0.5,
+            "reentry_anchor_levels": "wick",
+            "reentry_trigger_mode": "reclaim",
+            "t3_reentry_size_schedule": [
+              0.2,
+              0.1
+            ],
+            "t3_cooldown_bars": 0,
+            "t3_quality_filters": {
+              "trend": true,
+              "min_sma_atr_separation": 0.25
+            }
+          },
+          "summary": {
+            "final_balance": 515280.51,
+            "return_pct": 415.28,
+            "max_dd_pct": -2.04,
+            "trades": 3136,
+            "win_rate_pct": 80.64,
+            "sharpe": 13.57,
+            "first_entry": "2026-01-01T10:22:41+00:00",
+            "last_exit": "2026-03-31T23:59:59+00:00",
+            "entry_reasons": {
+              "SL-Reentry": 2030,
+              "Zero-Initial-Reentry": 1106
+            },
+            "exit_reasons": {
+              "SL": 3135,
+              "FinalMarkToMarket": 1
+            },
+            "entry_types": {
+              "BUY": 1584,
+              "SHORT": 1552
+            },
+            "integrity": {
+              "rows": 6272,
+              "entries": 3136,
+              "exits": 3136,
+              "zero_notional_entries": 0
+            }
+          },
+          "attribution": {
+            "original_t2": {
+              "trades": 2582,
+              "win_rate_pct": 87.99,
+              "avg_pnl_pct": 0.5399,
+              "median_pnl_pct": 0.4008,
+              "pnl_std_pct": 0.6342,
+              "worst_pnl_pct": -0.1811,
+              "net_pnl_value": 543747.33,
+              "max_pnl_drawdown": -214.13,
+              "profit_factor": 61.9276,
+              "entry_types": {
+                "SHORT": 1307,
+                "BUY": 1275
+              },
+              "entry_reasons": {
+                "SL-Reentry": 1668,
+                "Zero-Initial-Reentry": 914
+              },
+              "exit_reasons": {
+                "SL": 2581,
+                "FinalMarkToMarket": 1
+              }
+            },
+            "t3_swing": {
+              "trades": 554,
+              "win_rate_pct": 86.64,
+              "avg_pnl_pct": 0.5476,
+              "median_pnl_pct": 0.3864,
+              "pnl_std_pct": 0.6266,
+              "worst_pnl_pct": -0.1365,
+              "net_pnl_value": 115305.65,
+              "max_pnl_drawdown": -212.6,
+              "profit_factor": 62.9664,
+              "entry_types": {
+                "BUY": 309,
+                "SHORT": 245
+              },
+              "entry_reasons": {
+                "SL-Reentry": 362,
+                "Zero-Initial-Reentry": 192
+              },
+              "exit_reasons": {
+                "SL": 554
+              }
+            }
+          },
+          "diagnostics": {
+            "breakout_locks": {
+              "long": {
+                "original_t2": 448,
+                "t3_swing": 103
+              },
+              "short": {
+                "original_t2": 473,
+                "t3_swing": 89
+              }
+            },
+            "t3_cooldown_skips": {
+              "long": 0,
+              "short": 0
+            },
+            "t3_quality_rejects": {
+              "long": {
+                "trend_long": 34,
+                "sma_atr_separation": 11
+              },
+              "short": {
+                "trend_short": 30,
+                "sma_atr_separation": 5
+              }
+            }
+          },
+          "ledger_path": "research/tmp_eth_2026_q1_30min_1s_live_intrabar_sma5_B_trend_sep_0p25_ledger.csv",
+          "elapsed_seconds": 229.78
+        },
+        {
+          "scenario": "C_atr_pct30_sep_0p25",
+          "breakout_shape": "baseline_plus_t3",
+          "replay_mode": "live_intrabar_sma5",
+          "params": {
+            "dir2_zero_initial": true,
+            "zero_initial_mode": "reentry_window",
+            "fixed_slippage": 0.0005,
+            "stop_loss_atr": 0.05,
+            "stop_mode": "atr",
+            "max_trades_per_bar": 2,
+            "reentry_size_schedule": [
+              0.2,
+              0.1
+            ],
+            "long_reentry_atr": 0.1,
+            "short_reentry_atr": 0.0,
+            "profit_protect_atr": 1.0,
+            "trailing_stop_atr": 0.3,
+            "delayed_trailing_activation": 0.5,
+            "reentry_anchor_levels": "wick",
+            "reentry_trigger_mode": "reclaim",
+            "t3_reentry_size_schedule": [
+              0.2,
+              0.1
+            ],
+            "t3_cooldown_bars": 0,
+            "t3_quality_filters": {
+              "min_atr_percentile": 30.0,
+              "min_sma_atr_separation": 0.25
+            }
+          },
+          "summary": {
+            "final_balance": 519646.71,
+            "return_pct": 419.65,
+            "max_dd_pct": -1.79,
+            "trades": 3037,
+            "win_rate_pct": 81.0,
+            "sharpe": 13.61,
+            "first_entry": "2026-01-01T10:22:41+00:00",
+            "last_exit": "2026-03-31T23:59:59+00:00",
+            "entry_reasons": {
+              "SL-Reentry": 1969,
+              "Zero-Initial-Reentry": 1068
+            },
+            "exit_reasons": {
+              "SL": 3036,
+              "FinalMarkToMarket": 1
+            },
+            "entry_types": {
+              "BUY": 1519,
+              "SHORT": 1518
+            },
+            "integrity": {
+              "rows": 6074,
+              "entries": 3037,
+              "exits": 3037,
+              "zero_notional_entries": 0
+            }
+          },
+          "attribution": {
+            "original_t2": {
+              "trades": 2596,
+              "win_rate_pct": 87.94,
+              "avg_pnl_pct": 0.5383,
+              "median_pnl_pct": 0.3965,
+              "pnl_std_pct": 0.6335,
+              "worst_pnl_pct": -0.1811,
+              "net_pnl_value": 549677.4,
+              "max_pnl_drawdown": -214.8,
+              "profit_factor": 61.5891,
+              "entry_types": {
+                "SHORT": 1316,
+                "BUY": 1280
+              },
+              "entry_reasons": {
+                "SL-Reentry": 1678,
+                "Zero-Initial-Reentry": 918
+              },
+              "exit_reasons": {
+                "SL": 2595,
+                "FinalMarkToMarket": 1
+              }
+            },
+            "t3_swing": {
+              "trades": 441,
+              "win_rate_pct": 87.76,
+              "avg_pnl_pct": 0.646,
+              "median_pnl_pct": 0.4636,
+              "pnl_std_pct": 0.709,
+              "worst_pnl_pct": -0.1097,
+              "net_pnl_value": 108202.07,
+              "max_pnl_drawdown": -213.67,
+              "profit_factor": 74.0498,
+              "entry_types": {
+                "BUY": 239,
+                "SHORT": 202
+              },
+              "entry_reasons": {
+                "SL-Reentry": 291,
+                "Zero-Initial-Reentry": 150
+              },
+              "exit_reasons": {
+                "SL": 441
+              }
+            }
+          },
+          "diagnostics": {
+            "breakout_locks": {
+              "long": {
+                "original_t2": 449,
+                "t3_swing": 79
+              },
+              "short": {
+                "original_t2": 476,
+                "t3_swing": 71
+              }
+            },
+            "t3_cooldown_skips": {
+              "long": 0,
+              "short": 0
+            },
+            "t3_quality_rejects": {
+              "long": {
+                "atr_percentile": 40,
+                "sma_atr_separation": 20
+              },
+              "short": {
+                "atr_percentile": 38,
+                "sma_atr_separation": 14
+              }
+            }
+          },
+          "ledger_path": "research/tmp_eth_2026_q1_30min_1s_live_intrabar_sma5_C_atr_pct30_sep_0p25_ledger.csv",
+          "elapsed_seconds": 228.85
+        },
+        {
+          "scenario": "D_trend_atr_pct30_sep_0p25",
+          "breakout_shape": "baseline_plus_t3",
+          "replay_mode": "live_intrabar_sma5",
+          "params": {
+            "dir2_zero_initial": true,
+            "zero_initial_mode": "reentry_window",
+            "fixed_slippage": 0.0005,
+            "stop_loss_atr": 0.05,
+            "stop_mode": "atr",
+            "max_trades_per_bar": 2,
+            "reentry_size_schedule": [
+              0.2,
+              0.1
+            ],
+            "long_reentry_atr": 0.1,
+            "short_reentry_atr": 0.0,
+            "profit_protect_atr": 1.0,
+            "trailing_stop_atr": 0.3,
+            "delayed_trailing_activation": 0.5,
+            "reentry_anchor_levels": "wick",
+            "reentry_trigger_mode": "reclaim",
+            "t3_reentry_size_schedule": [
+              0.2,
+              0.1
+            ],
+            "t3_cooldown_bars": 0,
+            "t3_quality_filters": {
+              "trend": true,
+              "min_atr_percentile": 30.0,
+              "min_sma_atr_separation": 0.25
+            }
+          },
+          "summary": {
+            "final_balance": 500219.35,
+            "return_pct": 400.22,
+            "max_dd_pct": -1.79,
+            "trades": 2985,
+            "win_rate_pct": 80.9,
+            "sharpe": 13.65,
+            "first_entry": "2026-01-01T10:22:41+00:00",
+            "last_exit": "2026-03-31T23:59:59+00:00",
+            "entry_reasons": {
+              "SL-Reentry": 1936,
+              "Zero-Initial-Reentry": 1049
+            },
+            "exit_reasons": {
+              "SL": 2984,
+              "FinalMarkToMarket": 1
+            },
+            "entry_types": {
+              "SHORT": 1497,
+              "BUY": 1488
+            },
+            "integrity": {
+              "rows": 5970,
+              "entries": 2985,
+              "exits": 2985,
+              "zero_notional_entries": 0
+            }
+          },
+          "attribution": {
+            "original_t2": {
+              "trades": 2600,
+              "win_rate_pct": 87.96,
+              "avg_pnl_pct": 0.5376,
+              "median_pnl_pct": 0.3965,
+              "pnl_std_pct": 0.6328,
+              "worst_pnl_pct": -0.1811,
+              "net_pnl_value": 538455.99,
+              "max_pnl_drawdown": -208.75,
+              "profit_factor": 61.5903,
+              "entry_types": {
+                "SHORT": 1322,
+                "BUY": 1278
+              },
+              "entry_reasons": {
+                "SL-Reentry": 1681,
+                "Zero-Initial-Reentry": 919
+              },
+              "exit_reasons": {
+                "SL": 2599,
+                "FinalMarkToMarket": 1
+              }
+            },
+            "t3_swing": {
+              "trades": 385,
+              "win_rate_pct": 87.01,
+              "avg_pnl_pct": 0.6467,
+              "median_pnl_pct": 0.4682,
+              "pnl_std_pct": 0.6908,
+              "worst_pnl_pct": -0.1365,
+              "net_pnl_value": 90818.18,
+              "max_pnl_drawdown": -209.81,
+              "profit_factor": 67.1991,
+              "entry_types": {
+                "BUY": 210,
+                "SHORT": 175
+              },
+              "entry_reasons": {
+                "SL-Reentry": 255,
+                "Zero-Initial-Reentry": 130
+              },
+              "exit_reasons": {
+                "SL": 385
+              }
+            }
+          },
+          "diagnostics": {
+            "breakout_locks": {
+              "long": {
+                "original_t2": 448,
+                "t3_swing": 69
+              },
+              "short": {
+                "original_t2": 478,
+                "t3_swing": 61
+              }
+            },
+            "t3_cooldown_skips": {
+              "long": 0,
+              "short": 0
+            },
+            "t3_quality_rejects": {
+              "long": {
+                "trend_long": 35,
+                "atr_percentile": 34,
+                "sma_atr_separation": 21
+              },
+              "short": {
+                "atr_percentile": 28,
+                "trend_short": 30,
+                "sma_atr_separation": 13
+              }
+            }
+          },
+          "ledger_path": "research/tmp_eth_2026_q1_30min_1s_live_intrabar_sma5_D_trend_atr_pct30_sep_0p25_ledger.csv",
+          "elapsed_seconds": 228.72
+        }
+      ],
+      "delta_vs_t3_sma5_baseline": {
+        "A_sep_0p25": {
+          "final_balance_delta": 4222.43,
+          "return_pct_delta": 4.22,
+          "max_dd_pct_delta": 0.06,
+          "trades_delta": -25,
+          "win_rate_pct_delta": 0.32,
+          "sharpe_delta": 0.07
+        },
+        "B_trend_sep_0p25": {
+          "final_balance_delta": -16606.21,
+          "return_pct_delta": -16.61,
+          "max_dd_pct_delta": 0.06,
+          "trades_delta": -115,
+          "win_rate_pct_delta": 0.36,
+          "sharpe_delta": 0.15
+        },
+        "C_atr_pct30_sep_0p25": {
+          "final_balance_delta": -12240.01,
+          "return_pct_delta": -12.24,
+          "max_dd_pct_delta": 0.31,
+          "trades_delta": -214,
+          "win_rate_pct_delta": 0.72,
+          "sharpe_delta": 0.19
+        },
+        "D_trend_atr_pct30_sep_0p25": {
+          "final_balance_delta": -31667.37,
+          "return_pct_delta": -31.67,
+          "max_dd_pct_delta": 0.31,
+          "trades_delta": -266,
+          "win_rate_pct_delta": 0.62,
+          "sharpe_delta": 0.23
+        }
+      }
+    }
+  ],
+  "baseline_scenario": "t3_sma5_baseline",
+  "note": "Research-only 30min optimization. Baseline is t3_sma5_baseline; variants only add signal-quality filters to the added t3 breakout lock and preserve sizing."
+}

--- a/research/eth_q1_breakout_t3_shape_compare.py
+++ b/research/eth_q1_breakout_t3_shape_compare.py
@@ -50,34 +50,40 @@ DEFAULT_TICK_FILES = [
 
 SCENARIOS = [
     {
-        "scenario": "live_intrabar_sma5_baseline_plus_t3_breakout",
+        "scenario": "t3_sma5_baseline",
         "breakout_shape": "baseline_plus_t3",
         "replay_mode": "live_intrabar_sma5",
         "t3_reentry_size_schedule": [0.20, 0.10],
         "t3_cooldown_bars": 0,
+        "timeframes": ["30min"],
+        "t3_quality_filters": {},
     },
     {
-        "scenario": "live_intrabar_sma5_t3_half_size",
+        "scenario": "t3_sma5_trend_filter",
         "breakout_shape": "baseline_plus_t3",
         "replay_mode": "live_intrabar_sma5",
-        "t3_reentry_size_schedule": [0.10, 0.05],
+        "t3_reentry_size_schedule": [0.20, 0.10],
         "t3_cooldown_bars": 0,
+        "timeframes": ["30min"],
+        "t3_quality_filters": {"trend": True},
     },
     {
-        "scenario": "live_intrabar_sma5_t3_half_size_cooldown1",
+        "scenario": "t3_sma5_sma_atr_sep_0p1",
         "breakout_shape": "baseline_plus_t3",
         "replay_mode": "live_intrabar_sma5",
-        "t3_reentry_size_schedule": [0.10, 0.05],
-        "t3_cooldown_bars": 1,
+        "t3_reentry_size_schedule": [0.20, 0.10],
+        "t3_cooldown_bars": 0,
         "timeframes": ["30min"],
+        "t3_quality_filters": {"min_sma_atr_separation": 0.10},
     },
     {
-        "scenario": "live_intrabar_sma5_t3_half_size_cooldown2",
+        "scenario": "t3_sma5_atr_percentile_gte_30",
         "breakout_shape": "baseline_plus_t3",
         "replay_mode": "live_intrabar_sma5",
-        "t3_reentry_size_schedule": [0.10, 0.05],
-        "t3_cooldown_bars": 2,
+        "t3_reentry_size_schedule": [0.20, 0.10],
+        "t3_cooldown_bars": 0,
         "timeframes": ["30min"],
+        "t3_quality_filters": {"min_atr_percentile": 30.0},
     },
 ]
 
@@ -206,13 +212,23 @@ def build_signal_frame(second_bars: pd.DataFrame, timeframe: str):
     ).max(axis=1)
     signal["sma5"] = signal["close"].rolling(5).mean()
     signal["ma5"] = signal["sma5"]
+    signal["prev_sma5_1"] = signal["sma5"].shift(1)
+    signal["sma5_slope"] = signal["sma5"] - signal["prev_sma5_1"]
     signal["atr"] = true_range.rolling(14).mean()
+    signal["atr_percentile"] = signal["atr"].rolling(240, min_periods=50).apply(_last_percentile, raw=True)
     for n in range(1, 5):
         signal[f"prev_close_{n}"] = signal["close"].shift(n)
     signal = apply_breakout_levels(signal, "wick")
     signal["prev_high_3"] = signal["high"].shift(3)
     signal["prev_low_3"] = signal["low"].shift(3)
     return one_min, signal
+
+
+def _last_percentile(values: np.ndarray) -> float:
+    clean = values[~np.isnan(values)]
+    if len(clean) == 0:
+        return np.nan
+    return float((clean <= clean[-1]).mean() * 100.0)
 
 
 def _positive(*values: float) -> bool:
@@ -285,6 +301,47 @@ def _allow_breakout_lock(shape_name: str, bar_index: int, last_t3_lock_bar_index
     return bar_index - last_t3_lock_bar_index > t3_cooldown_bars
 
 
+def _t3_quality_reject_reason(sig, side: str, current_price: float, breakout_level: float, filters: dict) -> str:
+    if not filters:
+        return ""
+
+    sma5 = sig.get("sma5", np.nan)
+    sma5_slope = sig.get("sma5_slope", np.nan)
+    atr = sig.get("atr", np.nan)
+
+    if filters.get("trend"):
+        if not _positive(sma5) or pd.isna(sma5_slope):
+            return "trend_missing"
+        if side == "long" and not (current_price > float(sma5) and float(sma5_slope) > 0):
+            return "trend_long"
+        if side == "short" and not (current_price < float(sma5) and float(sma5_slope) < 0):
+            return "trend_short"
+
+    min_sma_atr_separation = filters.get("min_sma_atr_separation")
+    if min_sma_atr_separation is not None:
+        if not _positive(sma5, atr):
+            return "sma_atr_separation_missing"
+        separation = abs(float(breakout_level) - float(sma5)) / float(atr)
+        if separation < float(min_sma_atr_separation):
+            return "sma_atr_separation"
+
+    min_atr_percentile = filters.get("min_atr_percentile")
+    if min_atr_percentile is not None:
+        atr_percentile = sig.get("atr_percentile", np.nan)
+        if pd.isna(atr_percentile) or float(atr_percentile) < float(min_atr_percentile):
+            return "atr_percentile"
+
+    max_breakout_extension_atr = filters.get("max_breakout_extension_atr")
+    if max_breakout_extension_atr is not None:
+        if not _positive(atr):
+            return "breakout_extension_missing"
+        extension = abs(float(current_price) - float(breakout_level)) / float(atr)
+        if extension > float(max_breakout_extension_atr):
+            return "breakout_extension"
+
+    return ""
+
+
 def _intrabar_signal(sig: dict, high_so_far: float, low_so_far: float, close_now: float) -> dict:
     sig["high"] = float(high_so_far)
     sig["low"] = float(low_so_far)
@@ -299,6 +356,9 @@ def _intrabar_signal(sig: dict, high_so_far: float, low_so_far: float, close_now
     if len(prev_closes) >= 4:
         sig["sma5"] = float(np.mean(prev_closes[:4] + [float(close_now)]))
         sig["ma5"] = sig["sma5"]
+        prev_sma5 = sig.get("prev_sma5_1", np.nan)
+        if pd.notna(prev_sma5):
+            sig["sma5_slope"] = sig["sma5"] - float(prev_sma5)
 
     prev_close_1 = sig.get("prev_close_1", np.nan)
     if pd.notna(prev_close_1):
@@ -327,6 +387,7 @@ def run_second_bar_replay(
     replay_mode: str,
     t3_reentry_size_schedule=None,
     t3_cooldown_bars: int = 0,
+    t3_quality_filters=None,
 ):
     if replay_mode not in {"same_bar_parity", "live_intrabar_sma5"}:
         raise ValueError(f"unknown replay mode: {replay_mode}")
@@ -337,6 +398,7 @@ def run_second_bar_replay(
     diagnostics = {
         "breakout_locks": {"long": {}, "short": {}},
         "t3_cooldown_skips": {"long": 0, "short": 0},
+        "t3_quality_rejects": {"long": {}, "short": {}},
     }
     second_index = df_seconds.index
     high_values = df_seconds["high"].to_numpy(dtype="float64", copy=False)
@@ -359,6 +421,7 @@ def run_second_bar_replay(
     if t3_reentry_size_schedule is not None:
         t3_reentry_size_schedule = [float(v) for v in t3_reentry_size_schedule]
     t3_cooldown_bars = int(t3_cooldown_bars)
+    t3_quality_filters = t3_quality_filters or {}
 
     last_exit_bar_index = -999
     reentry_timeout = 1
@@ -384,6 +447,7 @@ def run_second_bar_replay(
         trades_in_bar = 0
         current_pos = start_pos
         breakout_locked_this_bar = False
+        quality_reject_recorded_this_bar = {"long": set(), "short": set()}
         bar_high_so_far = -np.inf
         bar_low_so_far = np.inf
         sig = base_sig
@@ -417,7 +481,22 @@ def run_second_bar_replay(
                 if long_regime_ready:
                     triggered, breakout_level, shape_name = _long_breakout(sig, high_value, breakout_shape)
                     if trades_in_bar == 0 and triggered:
-                        if _allow_breakout_lock(shape_name, i, last_t3_lock_bar_index, t3_cooldown_bars):
+                        quality_reject_reason = ""
+                        if shape_name == "t3_swing":
+                            quality_reject_reason = _t3_quality_reject_reason(
+                                sig,
+                                "long",
+                                close_value,
+                                breakout_level,
+                                t3_quality_filters,
+                            )
+                        if quality_reject_reason:
+                            if quality_reject_reason not in quality_reject_recorded_this_bar["long"]:
+                                diagnostics["t3_quality_rejects"]["long"][quality_reject_reason] = (
+                                    diagnostics["t3_quality_rejects"]["long"].get(quality_reject_reason, 0) + 1
+                                )
+                                quality_reject_recorded_this_bar["long"].add(quality_reject_reason)
+                        elif _allow_breakout_lock(shape_name, i, last_t3_lock_bar_index, t3_cooldown_bars):
                             if shape_name == "t3_swing":
                                 last_t3_lock_bar_index = i
                             if not breakout_locked_this_bar:
@@ -497,7 +576,22 @@ def run_second_bar_replay(
                 elif short_regime_ready:
                     triggered, breakout_level, shape_name = _short_breakout(sig, low_value, breakout_shape)
                     if trades_in_bar == 0 and triggered:
-                        if _allow_breakout_lock(shape_name, i, last_t3_lock_bar_index, t3_cooldown_bars):
+                        quality_reject_reason = ""
+                        if shape_name == "t3_swing":
+                            quality_reject_reason = _t3_quality_reject_reason(
+                                sig,
+                                "short",
+                                close_value,
+                                breakout_level,
+                                t3_quality_filters,
+                            )
+                        if quality_reject_reason:
+                            if quality_reject_reason not in quality_reject_recorded_this_bar["short"]:
+                                diagnostics["t3_quality_rejects"]["short"][quality_reject_reason] = (
+                                    diagnostics["t3_quality_rejects"]["short"].get(quality_reject_reason, 0) + 1
+                                )
+                                quality_reject_recorded_this_bar["short"].add(quality_reject_reason)
+                        elif _allow_breakout_lock(shape_name, i, last_t3_lock_bar_index, t3_cooldown_bars):
                             if shape_name == "t3_swing":
                                 last_t3_lock_bar_index = i
                             if not breakout_locked_this_bar:
@@ -789,7 +883,7 @@ def _scenario_delta(base_summary: dict, variant_summary: dict) -> dict:
 
 def write_markdown(summary: dict, output_path: Path):
     lines = [
-        "# ETH Q1 2026 t-3 Breakout Optimization, 1s Replay",
+        "# ETH Q1 2026 30min t3_sma5 Signal Quality Filtering",
         "",
         "Scope: research-only backtest work. No live or execution path was changed.",
         "",
@@ -797,8 +891,8 @@ def write_markdown(summary: dict, output_path: Path):
         "",
         "- Symbol/window: `ETHUSDT`, `2026-01-01 00:00:00+00:00` to `2026-03-31 23:59:59+00:00`",
         "- Execution bars: continuous `1s` bars rebuilt from raw Binance trades",
-        "- Main comparison baseline: `live_intrabar_sma5_baseline_plus_t3_breakout` with t3 full-size schedule `[0.20, 0.10]`",
-        "- Original sizing baseline: `dir2_zero_initial=true`, `zero_initial_mode=reentry_window`, `reentry_size_schedule=[0.20, 0.10]`, `max_trades_per_bar=2`",
+        "- Main comparison baseline: `t3_sma5_baseline` with full-size schedule `[0.20, 0.10]`",
+        "- Sizing baseline: `dir2_zero_initial=true`, `zero_initial_mode=reentry_window`, `reentry_size_schedule=[0.20, 0.10]`, `max_trades_per_bar=2`",
         "- Shared risk params: `stop_mode=atr`, `stop_loss_atr=0.05`, `trailing_stop_atr=0.3`, `delayed_trailing_activation=0.5`",
         "",
         "## Replay Mode",
@@ -813,13 +907,14 @@ def write_markdown(summary: dict, output_path: Path):
         "",
         "## Optimization Variants",
         "",
-        "- `live_intrabar_sma5_t3_half_size`: t3_swing real reentry sizing `[0.10, 0.05]`; original_t2 stays `[0.20, 0.10]`.",
-        "- `live_intrabar_sma5_t3_half_size_cooldown1/2`: 30min-only half-size t3 plus a t3-only cooldown of 1 or 2 signal bars after a t3 lock.",
+        "- `t3_sma5_trend_filter`: t3 long requires `close_now > sma5` and `sma5_slope > 0`; t3 short requires `close_now < sma5` and `sma5_slope < 0`.",
+        "- `t3_sma5_sma_atr_sep_0p1`: t3 requires `abs(breakout_level - sma5) >= 0.1 * atr`.",
+        "- `t3_sma5_atr_percentile_gte_30`: t3 requires the signal bar ATR percentile to be at least `30%` over the rolling ATR sample.",
         "",
         "## Results",
         "",
-        "| Timeframe | Scenario | T3 Schedule | T3 Cooldown | Final Balance | Return | Max DD | Trades | Win Rate | Sharpe | Entry Mix | Breakout Locks |",
-        "|---|---|---|---:|---:|---:|---:|---:|---:|---:|---|---|",
+        "| Timeframe | Scenario | Filters | Final Balance | Return | Max DD | Trades | Win Rate | Sharpe | Entry Mix | Breakout Locks | Quality Rejects |",
+        "|---|---|---|---:|---:|---:|---:|---:|---:|---|---|---|",
     ]
     for result in summary["results"]:
         timeframe = result["timeframe"]
@@ -833,18 +928,24 @@ def write_markdown(summary: dict, output_path: Path):
                     lock_parts.append(f"{side} " + "/".join(f"{k}:{v}" for k, v in counts.items()))
             lock_text = "; ".join(lock_parts)
             params = scenario["params"]
-            t3_schedule = params.get("t3_reentry_size_schedule")
-            t3_schedule_text = str(t3_schedule) if t3_schedule else "baseline"
+            filters = params.get("t3_quality_filters") or {}
+            filter_text = json.dumps(filters, sort_keys=True) if filters else "none"
+            rejects = scenario["diagnostics"].get("t3_quality_rejects", {})
+            reject_parts = []
+            for side, counts in rejects.items():
+                if counts:
+                    reject_parts.append(f"{side} " + "/".join(f"{k}:{v}" for k, v in counts.items()))
+            reject_text = "; ".join(reject_parts)
             lines.append(
-                f"| `{timeframe}` | `{scenario['scenario']}` | `{t3_schedule_text}` | {params.get('t3_cooldown_bars', 0)} | {s['final_balance']:,.2f} | "
+                f"| `{timeframe}` | `{scenario['scenario']}` | `{filter_text}` | {s['final_balance']:,.2f} | "
                 f"{s['return_pct']:.2f}% | {s['max_dd_pct']:.2f}% | {s['trades']} | "
-                f"{s['win_rate_pct']:.2f}% | {s['sharpe']:.2f} | `{entry_mix}` | `{lock_text}` |"
+                f"{s['win_rate_pct']:.2f}% | {s['sharpe']:.2f} | `{entry_mix}` | `{lock_text}` | `{reject_text}` |"
             )
-    lines.extend(["", "## Delta vs Full-Size t3 Baseline", ""])
+    lines.extend(["", "## Delta vs t3_sma5 Baseline", ""])
     lines.append("| Timeframe | Scenario | Final Balance Delta | Return Delta | Max DD Delta | Trades Delta | Win Rate Delta | Sharpe Delta |")
     lines.append("|---|---|---:|---:|---:|---:|---:|---:|")
     for result in summary["results"]:
-        for scenario_name, d in result["delta_vs_full_t3_baseline"].items():
+        for scenario_name, d in result["delta_vs_t3_sma5_baseline"].items():
             lines.append(
                 f"| `{result['timeframe']}` | `{scenario_name}` | {d['final_balance_delta']:,.2f} | "
                 f"{d['return_pct_delta']:.2f} pp | {d['max_dd_pct_delta']:.2f} pp | "
@@ -867,18 +968,15 @@ def write_markdown(summary: dict, output_path: Path):
             "",
             "## Read",
             "",
-            "The optimization keeps the `live_intrabar_sma5_baseline_plus_t3_breakout` signal logic as the comparison baseline and only changes t3_swing sizing/cooldown. Because `dir2_zero_initial=true`, the lock itself remains a proof gate; real sizing still starts from the reentry window.",
-            "",
-            "The key read is whether the t3-only risk constraints improve Sharpe or drawdown relative to full-size t3 without giving back too much return.",
+            "This run keeps the `t3_sma5_baseline` sizing and only filters the added t3 breakout lock. The original_t2 path is left unchanged, so deltas isolate signal-quality filtering rather than position sizing.",
             "",
             "## Conclusion",
             "",
-            "- `4h`: do not reduce t3_swing size. The full-size t3 baseline remains the best version here: half-size gives up `21.01 pp` return with no Sharpe or MaxDD improvement.",
-            "- `1h`: half-size is a partial risk constraint, not an optimization. MaxDD improves by `0.11 pp`, but return drops `95.75 pp` and Sharpe is unchanged.",
-            "- `30min`: half-size plus cooldown1 is the best risk-constrained variant among the tested options, but it is still not better than full-size t3 overall. It improves MaxDD by `0.24 pp`, reduces trades by `4`, and adds only `0.01` Sharpe, while giving up `78.31 pp` return.",
-            "- `30min cooldown2`: reduces more trades (`-33`) but does not improve Sharpe beyond baseline and gives up the most return among 30min variants.",
+            "- `t3_sma5_trend_filter` is the cleanest Sharpe improvement in this batch: Sharpe improves `+0.14`, trades drop `84`, and win rate improves `+0.17 pp`, while return gives back `13.03 pp`. MaxDD is unchanged.",
+            "- `t3_sma5_atr_percentile_gte_30` is the best risk/trade-count filter: trades drop `191`, MaxDD improves `0.25 pp`, win rate improves `+0.41 pp`, and Sharpe improves `+0.12`, while return gives back `14.23 pp`.",
+            "- `t3_sma5_sma_atr_sep_0p1` has no effect on this Q1 30min replay. The `0.1 * atr` threshold is too loose for this signal path.",
             "",
-            "The attribution supports the PR comment's interpretation: t3_swing is real positive alpha, especially on `4h` where it has higher win rate, average PnL, median PnL, lower worst trade, and stronger profit factor than original_t2. The Sharpe pressure on shorter frames is not fixed by simply halving t3 size; the next useful constraint should be signal-quality filtering rather than just smaller sizing.",
+            "Next useful experiment: combine `trend_filter` and `atr_percentile_gte_30`, then separately try stricter SMA separation thresholds such as `0.25 * atr` and `0.50 * atr`.",
             "",
         ]
     )
@@ -886,20 +984,20 @@ def write_markdown(summary: dict, output_path: Path):
 
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="ETH Q1 2026 1s breakout-shape comparison")
+    parser = argparse.ArgumentParser(description="ETH Q1 2026 30min t3_sma5 signal-quality filtering")
     parser.add_argument("--tick-files", nargs="+", default=DEFAULT_TICK_FILES)
-    parser.add_argument("--timeframes", nargs="+", default=["4h", "1h", "30min"])
+    parser.add_argument("--timeframes", nargs="+", default=["30min"])
     parser.add_argument("--start", default="2026-01-01T00:00:00Z")
     parser.add_argument("--end", default="2026-03-31T23:59:59Z")
     parser.add_argument("--initial-balance", type=float, default=100000.0)
     parser.add_argument("--chunksize", type=int, default=2_000_000)
     parser.add_argument(
         "--summary-json",
-        default="research/eth_2026_q1_1s_t3_secondary_alpha_optimization_summary.json",
+        default="research/eth_2026_q1_30min_t3_sma5_quality_filtering_summary.json",
     )
     parser.add_argument(
         "--markdown",
-        default="research/20260427_eth_q1_t3_secondary_alpha_optimization.md",
+        default="research/20260427_eth_q1_30min_t3_sma5_quality_filtering.md",
     )
     return parser.parse_args()
 
@@ -943,6 +1041,7 @@ def main():
                 replay_mode=replay_mode,
                 t3_reentry_size_schedule=scenario_config["t3_reentry_size_schedule"],
                 t3_cooldown_bars=scenario_config["t3_cooldown_bars"],
+                t3_quality_filters=scenario_config.get("t3_quality_filters"),
             )
             elapsed = round(time.time() - started, 2)
             ledger_path = Path(
@@ -954,6 +1053,7 @@ def main():
                 **COMMON_REPLAY_KWARGS,
                 "t3_reentry_size_schedule": scenario_config["t3_reentry_size_schedule"],
                 "t3_cooldown_bars": scenario_config["t3_cooldown_bars"],
+                "t3_quality_filters": scenario_config.get("t3_quality_filters", {}),
             }
             scenario = {
                 "scenario": scenario_name,
@@ -973,12 +1073,12 @@ def main():
                 flush=True,
             )
             summaries_by_name[scenario_name] = summary
-        result["delta_vs_full_t3_baseline"] = {}
-        baseline_summary = summaries_by_name["live_intrabar_sma5_baseline_plus_t3_breakout"]
+        result["delta_vs_t3_sma5_baseline"] = {}
+        baseline_summary = summaries_by_name["t3_sma5_baseline"]
         for scenario_name, scenario_summary in summaries_by_name.items():
-            if scenario_name == "live_intrabar_sma5_baseline_plus_t3_breakout":
+            if scenario_name == "t3_sma5_baseline":
                 continue
-            result["delta_vs_full_t3_baseline"][scenario_name] = _scenario_delta(
+            result["delta_vs_t3_sma5_baseline"][scenario_name] = _scenario_delta(
                 baseline_summary,
                 scenario_summary,
             )
@@ -988,8 +1088,8 @@ def main():
         "window": {"start": start.isoformat(), "end": end.isoformat()},
         "build_stats": {**build_stats, "derived_one_min_rows": derived_one_min_rows},
         "results": all_results,
-        "baseline_scenario": "live_intrabar_sma5_baseline_plus_t3_breakout",
-        "note": "Research-only optimization. Baseline is live_intrabar_sma5_baseline_plus_t3_breakout; variants only change t3_swing sizing/cooldown and preserve original_t2 sizing.",
+        "baseline_scenario": "t3_sma5_baseline",
+        "note": "Research-only 30min optimization. Baseline is t3_sma5_baseline; variants only add signal-quality filters to the added t3 breakout lock and preserve sizing.",
     }
     summary_path = Path(args.summary_json)
     summary_path.write_text(json.dumps(summary, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")

--- a/research/eth_q1_breakout_t3_shape_compare.py
+++ b/research/eth_q1_breakout_t3_shape_compare.py
@@ -49,10 +49,36 @@ DEFAULT_TICK_FILES = [
 ]
 
 SCENARIOS = [
-    ("baseline", "same_bar_parity", "baseline_original_breakout"),
-    ("baseline_plus_t3", "same_bar_parity", "baseline_plus_t3_breakout"),
-    ("baseline", "live_intrabar_sma5", "live_intrabar_sma5_baseline_original_breakout"),
-    ("baseline_plus_t3", "live_intrabar_sma5", "live_intrabar_sma5_baseline_plus_t3_breakout"),
+    {
+        "scenario": "live_intrabar_sma5_baseline_plus_t3_breakout",
+        "breakout_shape": "baseline_plus_t3",
+        "replay_mode": "live_intrabar_sma5",
+        "t3_reentry_size_schedule": [0.20, 0.10],
+        "t3_cooldown_bars": 0,
+    },
+    {
+        "scenario": "live_intrabar_sma5_t3_half_size",
+        "breakout_shape": "baseline_plus_t3",
+        "replay_mode": "live_intrabar_sma5",
+        "t3_reentry_size_schedule": [0.10, 0.05],
+        "t3_cooldown_bars": 0,
+    },
+    {
+        "scenario": "live_intrabar_sma5_t3_half_size_cooldown1",
+        "breakout_shape": "baseline_plus_t3",
+        "replay_mode": "live_intrabar_sma5",
+        "t3_reentry_size_schedule": [0.10, 0.05],
+        "t3_cooldown_bars": 1,
+        "timeframes": ["30min"],
+    },
+    {
+        "scenario": "live_intrabar_sma5_t3_half_size_cooldown2",
+        "breakout_shape": "baseline_plus_t3",
+        "replay_mode": "live_intrabar_sma5",
+        "t3_reentry_size_schedule": [0.10, 0.05],
+        "t3_cooldown_bars": 2,
+        "timeframes": ["30min"],
+    },
 ]
 
 
@@ -217,7 +243,18 @@ def _short_breakout(sig: pd.Series, current_low: float, breakout_shape: str):
     return False, np.nan, ""
 
 
-def _open_position(balance, sig, side, entry_price, notional_share, reason, stop_mode, stop_loss_atr):
+def _open_position(
+    balance,
+    sig,
+    side,
+    entry_price,
+    notional_share,
+    reason,
+    stop_mode,
+    stop_loss_atr,
+    breakout_shape_name,
+    replay_mode,
+):
     notional_value = balance * notional_share
     position = {
         "side": side,
@@ -225,6 +262,8 @@ def _open_position(balance, sig, side, entry_price, notional_share, reason, stop
         "sl": _resolve_stop_price(side, entry_price, sig, stop_mode, stop_loss_atr),
         "protected": reason == "PT-Reentry",
         "notional": notional_value,
+        "breakout_shape_name": breakout_shape_name,
+        "replay_mode": replay_mode,
     }
     if side == "long":
         position["hwm"] = entry_price
@@ -232,6 +271,18 @@ def _open_position(balance, sig, side, entry_price, notional_share, reason, stop
         position["lwm"] = entry_price
     balance -= notional_value * 0.001
     return balance, position
+
+
+def _shape_schedule(shape_name: str, baseline_schedule: list[float], t3_schedule) -> list[float]:
+    if shape_name == "t3_swing" and t3_schedule:
+        return t3_schedule
+    return baseline_schedule
+
+
+def _allow_breakout_lock(shape_name: str, bar_index: int, last_t3_lock_bar_index: int, t3_cooldown_bars: int) -> bool:
+    if shape_name != "t3_swing" or t3_cooldown_bars <= 0:
+        return True
+    return bar_index - last_t3_lock_bar_index > t3_cooldown_bars
 
 
 def _intrabar_signal(sig: dict, high_so_far: float, low_so_far: float, close_now: float) -> dict:
@@ -274,6 +325,8 @@ def run_second_bar_replay(
     initial_balance: float,
     breakout_shape: str,
     replay_mode: str,
+    t3_reentry_size_schedule=None,
+    t3_cooldown_bars: int = 0,
 ):
     if replay_mode not in {"same_bar_parity", "live_intrabar_sma5"}:
         raise ValueError(f"unknown replay mode: {replay_mode}")
@@ -283,6 +336,7 @@ def run_second_bar_replay(
     trade_logs = []
     diagnostics = {
         "breakout_locks": {"long": {}, "short": {}},
+        "t3_cooldown_skips": {"long": 0, "short": 0},
     }
     second_index = df_seconds.index
     high_values = df_seconds["high"].to_numpy(dtype="float64", copy=False)
@@ -302,13 +356,19 @@ def run_second_bar_replay(
     reentry_trigger_mode = str(COMMON_REPLAY_KWARGS["reentry_trigger_mode"])
     reentry_anchor_levels = str(COMMON_REPLAY_KWARGS["reentry_anchor_levels"])
     reentry_size_schedule = [float(v) for v in COMMON_REPLAY_KWARGS["reentry_size_schedule"]]
+    if t3_reentry_size_schedule is not None:
+        t3_reentry_size_schedule = [float(v) for v in t3_reentry_size_schedule]
+    t3_cooldown_bars = int(t3_cooldown_bars)
 
     last_exit_bar_index = -999
     reentry_timeout = 1
     last_exit_reason = None
     last_exit_side = None
+    last_exit_breakout_shape = ""
     pending_zero_initial_side = None
+    pending_zero_initial_breakout_shape = ""
     pending_zero_initial_bar_index = -999
+    last_t3_lock_bar_index = -999
 
     for i in range(len(signal) - 1):
         start_t, end_t = signal.index[i], signal.index[i + 1]
@@ -336,8 +396,10 @@ def run_second_bar_replay(
 
         if i - last_exit_bar_index > reentry_timeout:
             last_exit_side = None
+            last_exit_breakout_shape = ""
         if i - pending_zero_initial_bar_index > reentry_timeout:
             pending_zero_initial_side = None
+            pending_zero_initial_breakout_shape = ""
 
         while current_pos < end_pos:
             bar_time = second_index[current_pos]
@@ -355,13 +417,19 @@ def run_second_bar_replay(
                 if long_regime_ready:
                     triggered, breakout_level, shape_name = _long_breakout(sig, high_value, breakout_shape)
                     if trades_in_bar == 0 and triggered:
-                        if not breakout_locked_this_bar:
-                            diagnostics["breakout_locks"]["long"][shape_name] = (
-                                diagnostics["breakout_locks"]["long"].get(shape_name, 0) + 1
-                            )
-                            breakout_locked_this_bar = True
-                        pending_zero_initial_side = "long"
-                        pending_zero_initial_bar_index = i
+                        if _allow_breakout_lock(shape_name, i, last_t3_lock_bar_index, t3_cooldown_bars):
+                            if shape_name == "t3_swing":
+                                last_t3_lock_bar_index = i
+                            if not breakout_locked_this_bar:
+                                diagnostics["breakout_locks"]["long"][shape_name] = (
+                                    diagnostics["breakout_locks"]["long"].get(shape_name, 0) + 1
+                                )
+                                breakout_locked_this_bar = True
+                            pending_zero_initial_side = "long"
+                            pending_zero_initial_breakout_shape = shape_name
+                            pending_zero_initial_bar_index = i
+                        else:
+                            diagnostics["t3_cooldown_skips"]["long"] += 1
 
                     has_exit_reentry_window = last_exit_side == "long" and (i - last_exit_bar_index <= reentry_timeout)
                     has_zero_initial_window = (
@@ -384,7 +452,15 @@ def run_second_bar_replay(
                             if has_exit_reentry_window:
                                 reason = "SL-Reentry" if last_exit_reason == "SL" else "PT-Reentry"
                             if trades_in_bar < max_trades_per_bar:
-                                notional_share = _get_reentry_window_real_order_size(trades_in_bar, reentry_size_schedule)
+                                entry_breakout_shape = pending_zero_initial_breakout_shape
+                                if has_exit_reentry_window:
+                                    entry_breakout_shape = last_exit_breakout_shape
+                                active_schedule = _shape_schedule(
+                                    entry_breakout_shape,
+                                    reentry_size_schedule,
+                                    t3_reentry_size_schedule,
+                                )
+                                notional_share = _get_reentry_window_real_order_size(trades_in_bar, active_schedule)
                                 entry_price = float(entry_p_raw) * (1 + slippage)
                                 balance, position = _open_position(
                                     balance,
@@ -395,6 +471,8 @@ def run_second_bar_replay(
                                     reason,
                                     stop_mode,
                                     stop_loss_atr,
+                                    entry_breakout_shape,
+                                    replay_mode,
                                 )
                                 trade_logs.append(
                                     {
@@ -404,24 +482,34 @@ def run_second_bar_replay(
                                         "reason": reason,
                                         "notional": position["notional"],
                                         "bal": balance,
+                                        "breakout_shape_name": position["breakout_shape_name"],
+                                        "replay_mode": replay_mode,
                                     }
                                 )
                                 trades_in_bar += 1
                             if has_exit_reentry_window:
                                 last_exit_side = None
+                                last_exit_breakout_shape = ""
                             if has_zero_initial_window:
                                 pending_zero_initial_side = None
+                                pending_zero_initial_breakout_shape = ""
 
                 elif short_regime_ready:
                     triggered, breakout_level, shape_name = _short_breakout(sig, low_value, breakout_shape)
                     if trades_in_bar == 0 and triggered:
-                        if not breakout_locked_this_bar:
-                            diagnostics["breakout_locks"]["short"][shape_name] = (
-                                diagnostics["breakout_locks"]["short"].get(shape_name, 0) + 1
-                            )
-                            breakout_locked_this_bar = True
-                        pending_zero_initial_side = "short"
-                        pending_zero_initial_bar_index = i
+                        if _allow_breakout_lock(shape_name, i, last_t3_lock_bar_index, t3_cooldown_bars):
+                            if shape_name == "t3_swing":
+                                last_t3_lock_bar_index = i
+                            if not breakout_locked_this_bar:
+                                diagnostics["breakout_locks"]["short"][shape_name] = (
+                                    diagnostics["breakout_locks"]["short"].get(shape_name, 0) + 1
+                                )
+                                breakout_locked_this_bar = True
+                            pending_zero_initial_side = "short"
+                            pending_zero_initial_breakout_shape = shape_name
+                            pending_zero_initial_bar_index = i
+                        else:
+                            diagnostics["t3_cooldown_skips"]["short"] += 1
 
                     has_exit_reentry_window = last_exit_side == "short" and (i - last_exit_bar_index <= reentry_timeout)
                     has_zero_initial_window = (
@@ -444,7 +532,15 @@ def run_second_bar_replay(
                             if has_exit_reentry_window:
                                 reason = "SL-Reentry" if last_exit_reason == "SL" else "PT-Reentry"
                             if trades_in_bar < max_trades_per_bar:
-                                notional_share = _get_reentry_window_real_order_size(trades_in_bar, reentry_size_schedule)
+                                entry_breakout_shape = pending_zero_initial_breakout_shape
+                                if has_exit_reentry_window:
+                                    entry_breakout_shape = last_exit_breakout_shape
+                                active_schedule = _shape_schedule(
+                                    entry_breakout_shape,
+                                    reentry_size_schedule,
+                                    t3_reentry_size_schedule,
+                                )
+                                notional_share = _get_reentry_window_real_order_size(trades_in_bar, active_schedule)
                                 entry_price = float(entry_p_raw) * (1 - slippage)
                                 balance, position = _open_position(
                                     balance,
@@ -455,6 +551,8 @@ def run_second_bar_replay(
                                     reason,
                                     stop_mode,
                                     stop_loss_atr,
+                                    entry_breakout_shape,
+                                    replay_mode,
                                 )
                                 trade_logs.append(
                                     {
@@ -464,13 +562,17 @@ def run_second_bar_replay(
                                         "reason": reason,
                                         "notional": position["notional"],
                                         "bal": balance,
+                                        "breakout_shape_name": position["breakout_shape_name"],
+                                        "replay_mode": replay_mode,
                                     }
                                 )
                                 trades_in_bar += 1
                             if has_exit_reentry_window:
                                 last_exit_side = None
+                                last_exit_breakout_shape = ""
                             if has_zero_initial_window:
                                 pending_zero_initial_side = None
+                                pending_zero_initial_breakout_shape = ""
 
             else:
                 exit_triggered = False
@@ -524,6 +626,7 @@ def run_second_bar_replay(
                             position["sl"] = min(position["sl"], trailing_sl)
 
                 if exit_triggered:
+                    exit_breakout_shape = position.get("breakout_shape_name", "")
                     side_mult = 1 if position["side"] == "long" else -1
                     exit_p = exit_p * (1 - slippage) if position["side"] == "long" else exit_p * (1 + slippage)
                     pnl = (
@@ -543,10 +646,13 @@ def run_second_bar_replay(
                             "reason": reason,
                             "notional": position["notional"],
                             "bal": balance,
+                            "breakout_shape_name": exit_breakout_shape,
+                            "replay_mode": replay_mode,
                         }
                     )
                     last_exit_reason = reason
                     last_exit_side = position["side"]
+                    last_exit_breakout_shape = exit_breakout_shape
                     last_exit_bar_index = i
                     position = None
 
@@ -574,6 +680,8 @@ def run_second_bar_replay(
                 "reason": "FinalMarkToMarket",
                 "notional": position["notional"],
                 "bal": balance,
+                "breakout_shape_name": position.get("breakout_shape_name", ""),
+                "replay_mode": replay_mode,
             }
         )
 
@@ -609,6 +717,65 @@ def summarize_run(ledger: pd.DataFrame, initial_balance: float) -> dict:
     }
 
 
+def summarize_breakout_attribution(ledger: pd.DataFrame) -> dict:
+    if ledger.empty or "breakout_shape_name" not in ledger.columns:
+        return {}
+
+    rows = []
+    open_entry = None
+    for _, row in ledger.iterrows():
+        if row["type"] in {"BUY", "SHORT"}:
+            open_entry = row
+            continue
+        if row["type"] != "EXIT" or open_entry is None:
+            continue
+        side_mult = 1.0 if open_entry["type"] == "BUY" else -1.0
+        entry_price = float(open_entry["price"])
+        exit_price = float(row["price"])
+        pnl_pct = side_mult * (exit_price - entry_price) / entry_price if entry_price > 0 else 0.0
+        pnl_value = pnl_pct * float(open_entry["notional"])
+        rows.append(
+            {
+                "breakout_shape_name": str(open_entry.get("breakout_shape_name", "")),
+                "entry_type": str(open_entry["type"]),
+                "entry_reason": str(open_entry["reason"]),
+                "exit_reason": str(row["reason"]),
+                "pnl_pct": pnl_pct,
+                "pnl_value": pnl_value,
+            }
+        )
+        open_entry = None
+
+    if not rows:
+        return {}
+
+    pairs = pd.DataFrame(rows)
+    attribution = {}
+    for shape_name, group in pairs.groupby("breakout_shape_name", dropna=False):
+        pnl_values = group["pnl_value"].astype("float64")
+        pnl_pct = group["pnl_pct"].astype("float64")
+        cumulative_pnl = pnl_values.cumsum()
+        shape_peak = cumulative_pnl.cummax()
+        max_pnl_drawdown = float((cumulative_pnl - shape_peak).min()) if not cumulative_pnl.empty else 0.0
+        gross_profit = float(pnl_values[pnl_values > 0].sum())
+        gross_loss = abs(float(pnl_values[pnl_values < 0].sum()))
+        attribution[str(shape_name) or "unknown"] = {
+            "trades": int(len(group)),
+            "win_rate_pct": round(float((pnl_values > 0).mean()) * 100, 2),
+            "avg_pnl_pct": round(float(pnl_pct.mean()) * 100, 4),
+            "median_pnl_pct": round(float(pnl_pct.median()) * 100, 4),
+            "pnl_std_pct": round(float(pnl_pct.std(ddof=0)) * 100, 4),
+            "worst_pnl_pct": round(float(pnl_pct.min()) * 100, 4),
+            "net_pnl_value": round(float(pnl_values.sum()), 2),
+            "max_pnl_drawdown": round(max_pnl_drawdown, 2),
+            "profit_factor": round(gross_profit / gross_loss, 4) if gross_loss > 0 else None,
+            "entry_types": {str(k): int(v) for k, v in group["entry_type"].value_counts().items()},
+            "entry_reasons": {str(k): int(v) for k, v in group["entry_reason"].value_counts().items()},
+            "exit_reasons": {str(k): int(v) for k, v in group["exit_reason"].value_counts().items()},
+        }
+    return attribution
+
+
 def _scenario_delta(base_summary: dict, variant_summary: dict) -> dict:
     return {
         "final_balance_delta": round(variant_summary["final_balance"] - base_summary["final_balance"], 2),
@@ -622,7 +789,7 @@ def _scenario_delta(base_summary: dict, variant_summary: dict) -> dict:
 
 def write_markdown(summary: dict, output_path: Path):
     lines = [
-        "# ETH Q1 2026 t-3 Breakout Shape, 1s Replay",
+        "# ETH Q1 2026 t-3 Breakout Optimization, 1s Replay",
         "",
         "Scope: research-only backtest work. No live or execution path was changed.",
         "",
@@ -630,12 +797,12 @@ def write_markdown(summary: dict, output_path: Path):
         "",
         "- Symbol/window: `ETHUSDT`, `2026-01-01 00:00:00+00:00` to `2026-03-31 23:59:59+00:00`",
         "- Execution bars: continuous `1s` bars rebuilt from raw Binance trades",
-        "- Baseline sizing: `dir2_zero_initial=true`, `zero_initial_mode=reentry_window`, `reentry_size_schedule=[0.20, 0.10]`, `max_trades_per_bar=2`",
+        "- Main comparison baseline: `live_intrabar_sma5_baseline_plus_t3_breakout` with t3 full-size schedule `[0.20, 0.10]`",
+        "- Original sizing baseline: `dir2_zero_initial=true`, `zero_initial_mode=reentry_window`, `reentry_size_schedule=[0.20, 0.10]`, `max_trades_per_bar=2`",
         "- Shared risk params: `stop_mode=atr`, `stop_loss_atr=0.05`, `trailing_stop_atr=0.3`, `delayed_trailing_activation=0.5`",
         "",
-        "## Replay Modes",
+        "## Replay Mode",
         "",
-        "- `same_bar_parity`: parity mode against the corrected runner. Signal-frame fields are reused inside each replayed signal bar, so this mode is for apples-to-apples research comparison only.",
         "- `live_intrabar_sma5`: live-safe intrabar mode. Each replayed second updates the current signal bar close/high/low from data seen so far and computes `sma5/ma5` from four closed signal bars plus the current realtime close.",
         "",
         "## Breakout Shapes",
@@ -644,10 +811,15 @@ def write_markdown(summary: dict, output_path: Path):
         "- Added long: `prev_t3.high > prev_t2.high`, `prev_t3.high > prev_t1.high`, `prev_t1.high > prev_t2.high`, and current price crosses `prev_t3.high`.",
         "- The short side uses the symmetric low-side condition.",
         "",
+        "## Optimization Variants",
+        "",
+        "- `live_intrabar_sma5_t3_half_size`: t3_swing real reentry sizing `[0.10, 0.05]`; original_t2 stays `[0.20, 0.10]`.",
+        "- `live_intrabar_sma5_t3_half_size_cooldown1/2`: 30min-only half-size t3 plus a t3-only cooldown of 1 or 2 signal bars after a t3 lock.",
+        "",
         "## Results",
         "",
-        "| Timeframe | Replay Mode | Scenario | Final Balance | Return | Max DD | Trades | Win Rate | Sharpe | Entry Mix | Breakout Locks |",
-        "|---|---|---|---:|---:|---:|---:|---:|---:|---|---|",
+        "| Timeframe | Scenario | T3 Schedule | T3 Cooldown | Final Balance | Return | Max DD | Trades | Win Rate | Sharpe | Entry Mix | Breakout Locks |",
+        "|---|---|---|---:|---:|---:|---:|---:|---:|---:|---|---|",
     ]
     for result in summary["results"]:
         timeframe = result["timeframe"]
@@ -660,29 +832,53 @@ def write_markdown(summary: dict, output_path: Path):
                 if counts:
                     lock_parts.append(f"{side} " + "/".join(f"{k}:{v}" for k, v in counts.items()))
             lock_text = "; ".join(lock_parts)
+            params = scenario["params"]
+            t3_schedule = params.get("t3_reentry_size_schedule")
+            t3_schedule_text = str(t3_schedule) if t3_schedule else "baseline"
             lines.append(
-                f"| `{timeframe}` | `{scenario['replay_mode']}` | `{scenario['scenario']}` | {s['final_balance']:,.2f} | "
+                f"| `{timeframe}` | `{scenario['scenario']}` | `{t3_schedule_text}` | {params.get('t3_cooldown_bars', 0)} | {s['final_balance']:,.2f} | "
                 f"{s['return_pct']:.2f}% | {s['max_dd_pct']:.2f}% | {s['trades']} | "
                 f"{s['win_rate_pct']:.2f}% | {s['sharpe']:.2f} | `{entry_mix}` | `{lock_text}` |"
             )
-    lines.extend(["", "## Delta vs Baseline", ""])
-    lines.append("| Timeframe | Replay Mode | Final Balance Delta | Return Delta | Max DD Delta | Trades Delta | Win Rate Delta | Sharpe Delta |")
+    lines.extend(["", "## Delta vs Full-Size t3 Baseline", ""])
+    lines.append("| Timeframe | Scenario | Final Balance Delta | Return Delta | Max DD Delta | Trades Delta | Win Rate Delta | Sharpe Delta |")
     lines.append("|---|---|---:|---:|---:|---:|---:|---:|")
     for result in summary["results"]:
-        for replay_mode, d in result["delta_vs_baseline_by_mode"].items():
+        for scenario_name, d in result["delta_vs_full_t3_baseline"].items():
             lines.append(
-                f"| `{result['timeframe']}` | `{replay_mode}` | {d['final_balance_delta']:,.2f} | "
+                f"| `{result['timeframe']}` | `{scenario_name}` | {d['final_balance_delta']:,.2f} | "
                 f"{d['return_pct_delta']:.2f} pp | {d['max_dd_pct_delta']:.2f} pp | "
                 f"{d['trades_delta']} | {d['win_rate_pct_delta']:.2f} pp | {d['sharpe_delta']:.2f} |"
             )
+    lines.extend(["", "## Breakout Attribution", ""])
+    lines.append("| Timeframe | Scenario | Shape | Trades | Win Rate | Avg PnL | Median PnL | PnL Std | Worst PnL | Net PnL | Shape PnL DD | Profit Factor |")
+    lines.append("|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|")
+    for result in summary["results"]:
+        for scenario in result["scenarios"]:
+            for shape_name, a in scenario.get("attribution", {}).items():
+                lines.append(
+                    f"| `{result['timeframe']}` | `{scenario['scenario']}` | `{shape_name}` | {a['trades']} | "
+                    f"{a['win_rate_pct']:.2f}% | {a['avg_pnl_pct']:.4f}% | {a['median_pnl_pct']:.4f}% | "
+                    f"{a['pnl_std_pct']:.4f}% | {a['worst_pnl_pct']:.4f}% | "
+                    f"{a['net_pnl_value']:,.2f} | {a['max_pnl_drawdown']:,.2f} | {a['profit_factor']} |"
+                )
     lines.extend(
         [
             "",
             "## Read",
             "",
-            "The variant keeps the baseline logic and only broadens the initial breakout lock shape. Because `dir2_zero_initial=true`, the lock itself remains a proof gate; real sizing still starts from the reentry window as `20%` then `10%` inside the same signal bar.",
+            "The optimization keeps the `live_intrabar_sma5_baseline_plus_t3_breakout` signal logic as the comparison baseline and only changes t3_swing sizing/cooldown. Because `dir2_zero_initial=true`, the lock itself remains a proof gate; real sizing still starts from the reentry window.",
             "",
-            "The key read is the `live_intrabar_sma5` delta, because that mode avoids using final current-bar signal high/low/close/ATR before those values are available in replay time.",
+            "The key read is whether the t3-only risk constraints improve Sharpe or drawdown relative to full-size t3 without giving back too much return.",
+            "",
+            "## Conclusion",
+            "",
+            "- `4h`: do not reduce t3_swing size. The full-size t3 baseline remains the best version here: half-size gives up `21.01 pp` return with no Sharpe or MaxDD improvement.",
+            "- `1h`: half-size is a partial risk constraint, not an optimization. MaxDD improves by `0.11 pp`, but return drops `95.75 pp` and Sharpe is unchanged.",
+            "- `30min`: half-size plus cooldown1 is the best risk-constrained variant among the tested options, but it is still not better than full-size t3 overall. It improves MaxDD by `0.24 pp`, reduces trades by `4`, and adds only `0.01` Sharpe, while giving up `78.31 pp` return.",
+            "- `30min cooldown2`: reduces more trades (`-33`) but does not improve Sharpe beyond baseline and gives up the most return among 30min variants.",
+            "",
+            "The attribution supports the PR comment's interpretation: t3_swing is real positive alpha, especially on `4h` where it has higher win rate, average PnL, median PnL, lower worst trade, and stronger profit factor than original_t2. The Sharpe pressure on shorter frames is not fixed by simply halving t3 size; the next useful constraint should be signal-quality filtering rather than just smaller sizing.",
             "",
         ]
     )
@@ -699,11 +895,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--chunksize", type=int, default=2_000_000)
     parser.add_argument(
         "--summary-json",
-        default="research/eth_2026_q1_1s_breakout_t3_shape_vs_baseline_summary.json",
+        default="research/eth_2026_q1_1s_t3_secondary_alpha_optimization_summary.json",
     )
     parser.add_argument(
         "--markdown",
-        default="research/20260427_eth_q1_breakout_t3_shape_compare.md",
+        default="research/20260427_eth_q1_t3_secondary_alpha_optimization.md",
     )
     return parser.parse_args()
 
@@ -730,8 +926,14 @@ def main():
             },
             "scenarios": [],
         }
-        summaries_by_mode = {}
-        for breakout_shape, replay_mode, scenario_name in SCENARIOS:
+        summaries_by_name = {}
+        for scenario_config in SCENARIOS:
+            allowed_timeframes = scenario_config.get("timeframes")
+            if allowed_timeframes and timeframe not in allowed_timeframes:
+                continue
+            breakout_shape = scenario_config["breakout_shape"]
+            replay_mode = scenario_config["replay_mode"]
+            scenario_name = scenario_config["scenario"]
             started = time.time()
             ledger, diagnostics = run_second_bar_replay(
                 second_bars,
@@ -739,6 +941,8 @@ def main():
                 initial_balance=args.initial_balance,
                 breakout_shape=breakout_shape,
                 replay_mode=replay_mode,
+                t3_reentry_size_schedule=scenario_config["t3_reentry_size_schedule"],
+                t3_cooldown_bars=scenario_config["t3_cooldown_bars"],
             )
             elapsed = round(time.time() - started, 2)
             ledger_path = Path(
@@ -746,12 +950,18 @@ def main():
             )
             ledger.to_csv(ledger_path, index=False)
             summary = summarize_run(ledger, args.initial_balance)
+            params = {
+                **COMMON_REPLAY_KWARGS,
+                "t3_reentry_size_schedule": scenario_config["t3_reentry_size_schedule"],
+                "t3_cooldown_bars": scenario_config["t3_cooldown_bars"],
+            }
             scenario = {
                 "scenario": scenario_name,
                 "breakout_shape": breakout_shape,
                 "replay_mode": replay_mode,
-                "params": COMMON_REPLAY_KWARGS,
+                "params": params,
                 "summary": summary,
+                "attribution": summarize_breakout_attribution(ledger),
                 "diagnostics": diagnostics,
                 "ledger_path": str(ledger_path),
                 "elapsed_seconds": elapsed,
@@ -762,12 +972,15 @@ def main():
                 f"trades={summary['trades']} final={summary['final_balance']:.2f} elapsed={elapsed}s",
                 flush=True,
             )
-            summaries_by_mode[(replay_mode, breakout_shape)] = summary
-        result["delta_vs_baseline_by_mode"] = {}
-        for replay_mode in sorted({scenario[1] for scenario in SCENARIOS}):
-            result["delta_vs_baseline_by_mode"][replay_mode] = _scenario_delta(
-                summaries_by_mode[(replay_mode, "baseline")],
-                summaries_by_mode[(replay_mode, "baseline_plus_t3")],
+            summaries_by_name[scenario_name] = summary
+        result["delta_vs_full_t3_baseline"] = {}
+        baseline_summary = summaries_by_name["live_intrabar_sma5_baseline_plus_t3_breakout"]
+        for scenario_name, scenario_summary in summaries_by_name.items():
+            if scenario_name == "live_intrabar_sma5_baseline_plus_t3_breakout":
+                continue
+            result["delta_vs_full_t3_baseline"][scenario_name] = _scenario_delta(
+                baseline_summary,
+                scenario_summary,
             )
         all_results.append(result)
 
@@ -775,7 +988,8 @@ def main():
         "window": {"start": start.isoformat(), "end": end.isoformat()},
         "build_stats": {**build_stats, "derived_one_min_rows": derived_one_min_rows},
         "results": all_results,
-        "note": "Research-only comparison. Variant adds the t-3 breakout shape while keeping baseline sizing/risk parameters and compares same-bar parity with live intrabar SMA5 replay.",
+        "baseline_scenario": "live_intrabar_sma5_baseline_plus_t3_breakout",
+        "note": "Research-only optimization. Baseline is live_intrabar_sma5_baseline_plus_t3_breakout; variants only change t3_swing sizing/cooldown and preserve original_t2 sizing.",
     }
     summary_path = Path(args.summary_json)
     summary_path.write_text(json.dumps(summary, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")

--- a/research/eth_q1_breakout_t3_shape_compare.py
+++ b/research/eth_q1_breakout_t3_shape_compare.py
@@ -66,37 +66,17 @@ SCENARIOS = [
         "t3_cooldown_bars": 0,
         "timeframes": ["30min"],
         "t3_quality_filters": {"min_sma_atr_separation": 0.25},
+        "quality_filter_shapes": ["t3_swing"],
     },
     {
-        "scenario": "B_trend_sep_0p25",
+        "scenario": "all_breakouts_sep_0p25",
         "breakout_shape": "baseline_plus_t3",
         "replay_mode": "live_intrabar_sma5",
         "t3_reentry_size_schedule": [0.20, 0.10],
         "t3_cooldown_bars": 0,
         "timeframes": ["30min"],
-        "t3_quality_filters": {"trend": True, "min_sma_atr_separation": 0.25},
-    },
-    {
-        "scenario": "C_atr_pct30_sep_0p25",
-        "breakout_shape": "baseline_plus_t3",
-        "replay_mode": "live_intrabar_sma5",
-        "t3_reentry_size_schedule": [0.20, 0.10],
-        "t3_cooldown_bars": 0,
-        "timeframes": ["30min"],
-        "t3_quality_filters": {"min_atr_percentile": 30.0, "min_sma_atr_separation": 0.25},
-    },
-    {
-        "scenario": "D_trend_atr_pct30_sep_0p25",
-        "breakout_shape": "baseline_plus_t3",
-        "replay_mode": "live_intrabar_sma5",
-        "t3_reentry_size_schedule": [0.20, 0.10],
-        "t3_cooldown_bars": 0,
-        "timeframes": ["30min"],
-        "t3_quality_filters": {
-            "trend": True,
-            "min_atr_percentile": 30.0,
-            "min_sma_atr_separation": 0.25,
-        },
+        "t3_quality_filters": {"min_sma_atr_separation": 0.25},
+        "quality_filter_shapes": ["original_t2", "t3_swing"],
     },
 ]
 
@@ -401,6 +381,7 @@ def run_second_bar_replay(
     t3_reentry_size_schedule=None,
     t3_cooldown_bars: int = 0,
     t3_quality_filters=None,
+    quality_filter_shapes=None,
 ):
     if replay_mode not in {"same_bar_parity", "live_intrabar_sma5"}:
         raise ValueError(f"unknown replay mode: {replay_mode}")
@@ -435,6 +416,7 @@ def run_second_bar_replay(
         t3_reentry_size_schedule = [float(v) for v in t3_reentry_size_schedule]
     t3_cooldown_bars = int(t3_cooldown_bars)
     t3_quality_filters = t3_quality_filters or {}
+    quality_filter_shapes = set(quality_filter_shapes or ["t3_swing"])
 
     last_exit_bar_index = -999
     reentry_timeout = 1
@@ -495,7 +477,7 @@ def run_second_bar_replay(
                     triggered, breakout_level, shape_name = _long_breakout(sig, high_value, breakout_shape)
                     if trades_in_bar == 0 and triggered:
                         quality_reject_reason = ""
-                        if shape_name == "t3_swing":
+                        if shape_name in quality_filter_shapes:
                             quality_reject_reason = _t3_quality_reject_reason(
                                 sig,
                                 "long",
@@ -590,7 +572,7 @@ def run_second_bar_replay(
                     triggered, breakout_level, shape_name = _short_breakout(sig, low_value, breakout_shape)
                     if trades_in_bar == 0 and triggered:
                         quality_reject_reason = ""
-                        if shape_name == "t3_swing":
+                        if shape_name in quality_filter_shapes:
                             quality_reject_reason = _t3_quality_reject_reason(
                                 sig,
                                 "short",
@@ -920,10 +902,8 @@ def write_markdown(summary: dict, output_path: Path):
         "",
         "## Optimization Variants",
         "",
-        "- `A_sep_0p25`: t3 requires `abs(breakout_level - sma5) >= 0.25 * atr`.",
-        "- `B_trend_sep_0p25`: A plus trend direction filter.",
-        "- `C_atr_pct30_sep_0p25`: A plus ATR percentile >= `30%`.",
-        "- `D_trend_atr_pct30_sep_0p25`: A plus trend direction and ATR percentile >= `30%`.",
+        "- `A_sep_0p25`: only the added t3 breakout requires `abs(breakout_level - sma5) >= 0.25 * atr`.",
+        "- `all_breakouts_sep_0p25`: both original_t2 and added t3 breakouts require `abs(breakout_level - sma5) >= 0.25 * atr`.",
         "",
         "## Results",
         "",
@@ -982,16 +962,13 @@ def write_markdown(summary: dict, output_path: Path):
             "",
             "## Read",
             "",
-            "This run keeps the `t3_sma5_baseline` sizing and only filters the added t3 breakout lock. The original_t2 path is left unchanged, so deltas isolate signal-quality filtering rather than position sizing.",
+            "`A_sep_0p25` is the prior t3-only separation filter. `all_breakouts_sep_0p25` applies the same `0.25 * atr` SMA5 separation gate to both the original_t2 breakout and the added t3_swing breakout.",
+            "",
+            "On this Q1 30min replay, extending the separation gate to original_t2 is defensive: it cuts 663 trades, improves MaxDD by 0.68 pp, win rate by 1.71 pp, and Sharpe by 1.20 versus `t3_sma5_baseline`, but gives up 132.36 pp of return.",
             "",
             "## Conclusion",
             "",
-            "- A (`sep_0p25`) is still the best primary candidate: return improves `+4.22 pp`, MaxDD improves `0.06 pp`, Sharpe improves `+0.07`, and trades drop `25`.",
-            "- Adding trend on top of A is defensive but gives back too much return: B improves Sharpe more (`+0.15`) and cuts `115` trades, but return falls `16.61 pp` vs baseline and `20.83 pp` vs A.",
-            "- Adding ATR percentile on top of A is the better defensive overlay: C improves MaxDD `0.31 pp`, Sharpe `+0.19`, win rate `+0.72 pp`, and cuts `214` trades, while giving back `12.24 pp` vs baseline and `16.46 pp` vs A.",
-            "- Adding both filters on top of A over-constrains the signal: D has the highest Sharpe delta (`+0.23`) and lowest trade count, but loses `31.67 pp` return vs baseline.",
-            "",
-            "Recommended ranking: A for primary 30min candidate; C as the risk-off candidate when drawdown/trade count matters more than raw return.",
+            "Keep `A_sep_0p25` as the return-oriented candidate. Treat `all_breakouts_sep_0p25` as a risk-constrained variant rather than a primary return upgrade, because filtering original_t2 removes too much profitable flow despite the cleaner Sharpe/MaxDD profile.",
             "",
         ]
     )
@@ -1008,11 +985,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--chunksize", type=int, default=2_000_000)
     parser.add_argument(
         "--summary-json",
-        default="research/eth_2026_q1_30min_t3_sma5_sep_0p25_marginal_summary.json",
+        default="research/eth_2026_q1_30min_t2_t3_sep_0p25_summary.json",
     )
     parser.add_argument(
         "--markdown",
-        default="research/20260427_eth_q1_30min_t3_sma5_sep_0p25_marginal.md",
+        default="research/20260427_eth_q1_30min_t2_t3_sep_0p25.md",
     )
     return parser.parse_args()
 
@@ -1057,6 +1034,7 @@ def main():
                 t3_reentry_size_schedule=scenario_config["t3_reentry_size_schedule"],
                 t3_cooldown_bars=scenario_config["t3_cooldown_bars"],
                 t3_quality_filters=scenario_config.get("t3_quality_filters"),
+                quality_filter_shapes=scenario_config.get("quality_filter_shapes"),
             )
             elapsed = round(time.time() - started, 2)
             ledger_path = Path(
@@ -1069,6 +1047,7 @@ def main():
                 "t3_reentry_size_schedule": scenario_config["t3_reentry_size_schedule"],
                 "t3_cooldown_bars": scenario_config["t3_cooldown_bars"],
                 "t3_quality_filters": scenario_config.get("t3_quality_filters", {}),
+                "quality_filter_shapes": scenario_config.get("quality_filter_shapes", ["t3_swing"]),
             }
             scenario = {
                 "scenario": scenario_name,

--- a/research/eth_q1_breakout_t3_shape_compare.py
+++ b/research/eth_q1_breakout_t3_shape_compare.py
@@ -59,31 +59,31 @@ SCENARIOS = [
         "t3_quality_filters": {},
     },
     {
-        "scenario": "t3_sma5_trend_filter",
+        "scenario": "t3_sma5_trend_and_atr_pct30",
         "breakout_shape": "baseline_plus_t3",
         "replay_mode": "live_intrabar_sma5",
         "t3_reentry_size_schedule": [0.20, 0.10],
         "t3_cooldown_bars": 0,
         "timeframes": ["30min"],
-        "t3_quality_filters": {"trend": True},
+        "t3_quality_filters": {"trend": True, "min_atr_percentile": 30.0},
     },
     {
-        "scenario": "t3_sma5_sma_atr_sep_0p1",
+        "scenario": "t3_sma5_sma_atr_sep_0p25",
         "breakout_shape": "baseline_plus_t3",
         "replay_mode": "live_intrabar_sma5",
         "t3_reentry_size_schedule": [0.20, 0.10],
         "t3_cooldown_bars": 0,
         "timeframes": ["30min"],
-        "t3_quality_filters": {"min_sma_atr_separation": 0.10},
+        "t3_quality_filters": {"min_sma_atr_separation": 0.25},
     },
     {
-        "scenario": "t3_sma5_atr_percentile_gte_30",
+        "scenario": "t3_sma5_sma_atr_sep_0p50",
         "breakout_shape": "baseline_plus_t3",
         "replay_mode": "live_intrabar_sma5",
         "t3_reentry_size_schedule": [0.20, 0.10],
         "t3_cooldown_bars": 0,
         "timeframes": ["30min"],
-        "t3_quality_filters": {"min_atr_percentile": 30.0},
+        "t3_quality_filters": {"min_sma_atr_separation": 0.50},
     },
 ]
 
@@ -907,9 +907,9 @@ def write_markdown(summary: dict, output_path: Path):
         "",
         "## Optimization Variants",
         "",
-        "- `t3_sma5_trend_filter`: t3 long requires `close_now > sma5` and `sma5_slope > 0`; t3 short requires `close_now < sma5` and `sma5_slope < 0`.",
-        "- `t3_sma5_sma_atr_sep_0p1`: t3 requires `abs(breakout_level - sma5) >= 0.1 * atr`.",
-        "- `t3_sma5_atr_percentile_gte_30`: t3 requires the signal bar ATR percentile to be at least `30%` over the rolling ATR sample.",
+        "- `t3_sma5_trend_and_atr_pct30`: combines the trend filter with ATR percentile >= `30%`.",
+        "- `t3_sma5_sma_atr_sep_0p25`: t3 requires `abs(breakout_level - sma5) >= 0.25 * atr`.",
+        "- `t3_sma5_sma_atr_sep_0p50`: t3 requires `abs(breakout_level - sma5) >= 0.50 * atr`.",
         "",
         "## Results",
         "",
@@ -972,11 +972,11 @@ def write_markdown(summary: dict, output_path: Path):
             "",
             "## Conclusion",
             "",
-            "- `t3_sma5_trend_filter` is the cleanest Sharpe improvement in this batch: Sharpe improves `+0.14`, trades drop `84`, and win rate improves `+0.17 pp`, while return gives back `13.03 pp`. MaxDD is unchanged.",
-            "- `t3_sma5_atr_percentile_gte_30` is the best risk/trade-count filter: trades drop `191`, MaxDD improves `0.25 pp`, win rate improves `+0.41 pp`, and Sharpe improves `+0.12`, while return gives back `14.23 pp`.",
-            "- `t3_sma5_sma_atr_sep_0p1` has no effect on this Q1 30min replay. The `0.1 * atr` threshold is too loose for this signal path.",
+            "- `t3_sma5_sma_atr_sep_0p25` is the best candidate in this run. It improves return by `+4.22 pp`, MaxDD by `0.06 pp`, Sharpe by `+0.07`, win rate by `+0.32 pp`, and reduces trades by `25`.",
+            "- `t3_sma5_trend_and_atr_pct30` is a defensive filter. It improves MaxDD by `0.25 pp`, Sharpe by `+0.22`, and reduces trades by `239`, but gives back `26.59 pp` return.",
+            "- `t3_sma5_sma_atr_sep_0p50` is too strict for a primary 30min setting. It improves MaxDD by `0.23 pp`, Sharpe by `+0.19`, and win rate by `+1.00 pp`, but gives back `55.67 pp` return.",
             "",
-            "Next useful experiment: combine `trend_filter` and `atr_percentile_gte_30`, then separately try stricter SMA separation thresholds such as `0.25 * atr` and `0.50 * atr`.",
+            "Recommended next candidate for live-aligned research is `t3_sma5_sma_atr_sep_0p25`, because it is the only tested filter that improves return and risk metrics together against `t3_sma5_baseline`.",
             "",
         ]
     )
@@ -993,11 +993,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--chunksize", type=int, default=2_000_000)
     parser.add_argument(
         "--summary-json",
-        default="research/eth_2026_q1_30min_t3_sma5_quality_filtering_summary.json",
+        default="research/eth_2026_q1_30min_t3_sma5_combo_separation_summary.json",
     )
     parser.add_argument(
         "--markdown",
-        default="research/20260427_eth_q1_30min_t3_sma5_quality_filtering.md",
+        default="research/20260427_eth_q1_30min_t3_sma5_combo_separation.md",
     )
     return parser.parse_args()
 

--- a/research/eth_q1_breakout_t3_shape_compare.py
+++ b/research/eth_q1_breakout_t3_shape_compare.py
@@ -59,16 +59,7 @@ SCENARIOS = [
         "t3_quality_filters": {},
     },
     {
-        "scenario": "t3_sma5_trend_and_atr_pct30",
-        "breakout_shape": "baseline_plus_t3",
-        "replay_mode": "live_intrabar_sma5",
-        "t3_reentry_size_schedule": [0.20, 0.10],
-        "t3_cooldown_bars": 0,
-        "timeframes": ["30min"],
-        "t3_quality_filters": {"trend": True, "min_atr_percentile": 30.0},
-    },
-    {
-        "scenario": "t3_sma5_sma_atr_sep_0p25",
+        "scenario": "A_sep_0p25",
         "breakout_shape": "baseline_plus_t3",
         "replay_mode": "live_intrabar_sma5",
         "t3_reentry_size_schedule": [0.20, 0.10],
@@ -77,13 +68,35 @@ SCENARIOS = [
         "t3_quality_filters": {"min_sma_atr_separation": 0.25},
     },
     {
-        "scenario": "t3_sma5_sma_atr_sep_0p50",
+        "scenario": "B_trend_sep_0p25",
         "breakout_shape": "baseline_plus_t3",
         "replay_mode": "live_intrabar_sma5",
         "t3_reentry_size_schedule": [0.20, 0.10],
         "t3_cooldown_bars": 0,
         "timeframes": ["30min"],
-        "t3_quality_filters": {"min_sma_atr_separation": 0.50},
+        "t3_quality_filters": {"trend": True, "min_sma_atr_separation": 0.25},
+    },
+    {
+        "scenario": "C_atr_pct30_sep_0p25",
+        "breakout_shape": "baseline_plus_t3",
+        "replay_mode": "live_intrabar_sma5",
+        "t3_reentry_size_schedule": [0.20, 0.10],
+        "t3_cooldown_bars": 0,
+        "timeframes": ["30min"],
+        "t3_quality_filters": {"min_atr_percentile": 30.0, "min_sma_atr_separation": 0.25},
+    },
+    {
+        "scenario": "D_trend_atr_pct30_sep_0p25",
+        "breakout_shape": "baseline_plus_t3",
+        "replay_mode": "live_intrabar_sma5",
+        "t3_reentry_size_schedule": [0.20, 0.10],
+        "t3_cooldown_bars": 0,
+        "timeframes": ["30min"],
+        "t3_quality_filters": {
+            "trend": True,
+            "min_atr_percentile": 30.0,
+            "min_sma_atr_separation": 0.25,
+        },
     },
 ]
 
@@ -907,9 +920,10 @@ def write_markdown(summary: dict, output_path: Path):
         "",
         "## Optimization Variants",
         "",
-        "- `t3_sma5_trend_and_atr_pct30`: combines the trend filter with ATR percentile >= `30%`.",
-        "- `t3_sma5_sma_atr_sep_0p25`: t3 requires `abs(breakout_level - sma5) >= 0.25 * atr`.",
-        "- `t3_sma5_sma_atr_sep_0p50`: t3 requires `abs(breakout_level - sma5) >= 0.50 * atr`.",
+        "- `A_sep_0p25`: t3 requires `abs(breakout_level - sma5) >= 0.25 * atr`.",
+        "- `B_trend_sep_0p25`: A plus trend direction filter.",
+        "- `C_atr_pct30_sep_0p25`: A plus ATR percentile >= `30%`.",
+        "- `D_trend_atr_pct30_sep_0p25`: A plus trend direction and ATR percentile >= `30%`.",
         "",
         "## Results",
         "",
@@ -972,11 +986,12 @@ def write_markdown(summary: dict, output_path: Path):
             "",
             "## Conclusion",
             "",
-            "- `t3_sma5_sma_atr_sep_0p25` is the best candidate in this run. It improves return by `+4.22 pp`, MaxDD by `0.06 pp`, Sharpe by `+0.07`, win rate by `+0.32 pp`, and reduces trades by `25`.",
-            "- `t3_sma5_trend_and_atr_pct30` is a defensive filter. It improves MaxDD by `0.25 pp`, Sharpe by `+0.22`, and reduces trades by `239`, but gives back `26.59 pp` return.",
-            "- `t3_sma5_sma_atr_sep_0p50` is too strict for a primary 30min setting. It improves MaxDD by `0.23 pp`, Sharpe by `+0.19`, and win rate by `+1.00 pp`, but gives back `55.67 pp` return.",
+            "- A (`sep_0p25`) is still the best primary candidate: return improves `+4.22 pp`, MaxDD improves `0.06 pp`, Sharpe improves `+0.07`, and trades drop `25`.",
+            "- Adding trend on top of A is defensive but gives back too much return: B improves Sharpe more (`+0.15`) and cuts `115` trades, but return falls `16.61 pp` vs baseline and `20.83 pp` vs A.",
+            "- Adding ATR percentile on top of A is the better defensive overlay: C improves MaxDD `0.31 pp`, Sharpe `+0.19`, win rate `+0.72 pp`, and cuts `214` trades, while giving back `12.24 pp` vs baseline and `16.46 pp` vs A.",
+            "- Adding both filters on top of A over-constrains the signal: D has the highest Sharpe delta (`+0.23`) and lowest trade count, but loses `31.67 pp` return vs baseline.",
             "",
-            "Recommended next candidate for live-aligned research is `t3_sma5_sma_atr_sep_0p25`, because it is the only tested filter that improves return and risk metrics together against `t3_sma5_baseline`.",
+            "Recommended ranking: A for primary 30min candidate; C as the risk-off candidate when drawdown/trade count matters more than raw return.",
             "",
         ]
     )
@@ -993,11 +1008,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--chunksize", type=int, default=2_000_000)
     parser.add_argument(
         "--summary-json",
-        default="research/eth_2026_q1_30min_t3_sma5_combo_separation_summary.json",
+        default="research/eth_2026_q1_30min_t3_sma5_sep_0p25_marginal_summary.json",
     )
     parser.add_argument(
         "--markdown",
-        default="research/20260427_eth_q1_30min_t3_sma5_combo_separation.md",
+        default="research/20260427_eth_q1_30min_t3_sma5_sep_0p25_marginal.md",
     )
     return parser.parse_args()
 


### PR DESCRIPTION
## 目的
单独新增 BTCUSDT 30m 增强 live 策略与一键启动模板，对齐 research 里的 `live_intrabar_sma5_baseline_plus_t3_breakout+sep_0p25` 方向，同时保留原 `bk-default` 和原 BTCUSDT 30m 模板。

主要内容：
- 增加 t3 breakout / sep_0p25 系列 ETH Q1 research 报告与 summary。
- 新增 `bk-live-intrabar-sma5-t3-sep` 策略引擎 key。
- 新增 `strategy-bk-btc-30m-enhanced` 策略和 `binance-testnet-btc-30m-enhanced` 一键启动模板。
- live signal state 增加 `prevBar3`，用于识别 `t3_swing`。
- 增强策略启用 `baseline_plus_t3`，并只对 `t3_swing` 应用 `t3_min_sma_atr_separation=0.25`。
- 原模板和旧 `bk-default` 默认行为保留。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [x] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main)
  - 未改变；增强模板仍默认 `manual-review`，模板 payload 不硬编码 dispatchMode。
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？
  - 不存在；模板仍是 Binance testnet sandbox 绑定。
- [x] DB migration 是否具备向下兼容幂等性？
  - 新增 `026_btc_30m_enhanced_strategy.sql` 使用 `on conflict (id) do nothing`。
- [x] 配置字段有没有无意被混改？
  - 新字段只挂在增强策略/增强模板：`breakout_shape=baseline_plus_t3`、`t3_min_sma_atr_separation=0.25`、`use_sma5_intraday_structure=true`。

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

已验证：
- `go test ./...`
- `python3.9 -m py_compile research/eth_q1_breakout_t3_shape_compare.py`
- `bash scripts/check_high_risk_defaults.sh`
- pre-push hook：backend checks、frontend build、migration safety、env/high-risk safety checks 全部通过。

## Root Cause / Context
Research 侧已经验证 `A_sep_0p25` 是更合适的 30min 候选：只过滤新增 `t3_swing`，不把 sep_0p25 扩展到 `original_t2`，避免砍掉过多 profitable flow。本 PR 将该口径作为独立 live 策略承载，而不是修改旧策略默认行为。