### PR TITLE
[codex] trim telegram notification noise

### DIFF
--- a/internal/service/telegram.go
+++ b/internal/service/telegram.go
@@ -23,10 +23,12 @@ var telegramBeijingLocation = func() *time.Location {
 }()
 
 const (
-	telegramFlapSendGrace    = 45 * time.Second
-	telegramFlapRecoverGrace = 60 * time.Second
-	telegramTradeEventLimit  = 50
-	telegramTradeEventWindow = 24 * time.Hour
+	telegramFlapSendGrace            = 45 * time.Second
+	telegramFlapRecoverGrace         = 60 * time.Second
+	telegramTradeEventLimit          = 50
+	telegramTradeEventWindow         = 24 * time.Hour
+	telegramUnprotectedPositionGrace = 15 * time.Minute
+	telegramPositionReportTradeQuiet = 15 * time.Minute
 )
 
 func (p *Platform) SendNotificationToTelegram(notificationID string) error {
@@ -311,10 +313,12 @@ func (p *Platform) DispatchTelegramTradeEvents(deliveryByID map[string]domain.No
 	if !config.Enabled || !config.TradeEventsEnabled || strings.TrimSpace(config.BotToken) == "" || strings.TrimSpace(config.ChatID) == "" {
 		return 0, nil
 	}
-	events, err := p.store.ListTelegramTradeEventCandidates(telegramNow().Add(-telegramTradeEventWindow), telegramTradeEventLimit)
+	now := telegramNow()
+	events, err := p.store.ListTelegramTradeEventCandidates(now.Add(-telegramTradeEventWindow), telegramTradeEventLimit)
 	if err != nil {
 		return 0, err
 	}
+	liveSessionLabelByID := p.telegramLiveSessionLabelByID()
 	sent := 0
 	var firstErr error
 	for _, event := range events {
@@ -328,7 +332,7 @@ func (p *Platform) DispatchTelegramTradeEvents(deliveryByID map[string]domain.No
 		if delivery, ok := deliveryByID[notificationID]; ok && strings.EqualFold(delivery.Status, "sent") {
 			continue
 		}
-		message := formatTelegramTradeEvent(event)
+		message := formatTelegramTradeEvent(event, liveSessionLabelByID)
 		if err := p.sendTelegramMessage(message); err != nil {
 			_, _ = p.store.UpsertNotificationDelivery(notificationID, "telegram", "failed", err.Error(), map[string]any{
 				"kind":      "trade-event",
@@ -348,6 +352,7 @@ func (p *Platform) DispatchTelegramTradeEvents(deliveryByID map[string]domain.No
 			"orderId":   event.OrderID,
 			"symbol":    event.Symbol,
 			"eventTime": event.EventTime.Format(time.RFC3339),
+			"sentAt":    now.Format(time.RFC3339),
 		})
 		if err != nil {
 			if firstErr == nil {
@@ -420,6 +425,12 @@ func (p *Platform) DispatchTelegramPositionReport(deliveryByID map[string]domain
 	if !telegramAccountsHaveOpenPosition(liveAccounts) {
 		return 0, nil
 	}
+	if telegramHasRecentTradeEventDelivery(deliveryByID, now, telegramPositionReportTradeQuiet) {
+		p.logger("service.telegram").Debug("skipping position report because a trade event was recently delivered",
+			"now", now.Format(time.RFC3339),
+			"quiet_window", telegramPositionReportTradeQuiet.String())
+		return 0, nil
+	}
 	summaries, err := p.ListAccountSummaries()
 	if err != nil {
 		return 0, err
@@ -464,7 +475,49 @@ func telegramAccountsHaveOpenPosition(accounts []domain.Account) bool {
 	return false
 }
 
-func formatTelegramTradeEvent(event domain.OrderExecutionEvent) string {
+func telegramHasRecentTradeEventDelivery(deliveryByID map[string]domain.NotificationDelivery, now time.Time, window time.Duration) bool {
+	if window <= 0 {
+		return false
+	}
+	for _, delivery := range deliveryByID {
+		if !strings.EqualFold(delivery.Channel, "telegram") {
+			continue
+		}
+		if stringValue(delivery.Metadata["kind"]) != "trade-event" {
+			continue
+		}
+		quietAnchor := parseOptionalRFC3339(firstNonEmpty(
+			stringValue(delivery.Metadata["sentAt"]),
+			stringValue(delivery.Metadata["eventTime"]),
+		))
+		if quietAnchor.IsZero() {
+			continue
+		}
+		age := now.UTC().Sub(quietAnchor.UTC())
+		if age >= 0 && age < window {
+			return true
+		}
+	}
+	return false
+}
+
+func (p *Platform) telegramLiveSessionLabelByID() map[string]string {
+	sessions, err := p.store.ListLiveSessions()
+	if err != nil {
+		p.logger("service.telegram").Warn("list live sessions for telegram labels failed", "error", err)
+		return nil
+	}
+	labels := make(map[string]string, len(sessions))
+	for _, session := range sessions {
+		label := firstNonEmpty(strings.TrimSpace(session.Alias), strings.TrimSpace(session.ID))
+		if label != "" {
+			labels[session.ID] = label
+		}
+	}
+	return labels
+}
+
+func formatTelegramTradeEvent(event domain.OrderExecutionEvent, liveSessionLabelByID map[string]string) string {
 	action := "开仓"
 	if telegramTradeEventIsClose(event) {
 		action = "平仓"
@@ -478,12 +531,7 @@ func formatTelegramTradeEvent(event domain.OrderExecutionEvent) string {
 	fee := firstNonZeroFloat(parseFloatValue(event.AdapterSync["totalFee"]), parseFloatValue(event.DispatchSummary["fee"]))
 	lines := []string{
 		fmt.Sprintf("📌 *%s成交* %s %s", action, NormalizeSymbol(event.Symbol), strings.ToUpper(strings.TrimSpace(event.Side))),
-		fmt.Sprintf("数量: %s", formatTelegramNumber(event.Quantity)),
-		fmt.Sprintf("价格: %s", formatTelegramNumber(price)),
-		fmt.Sprintf("订单: %s", event.OrderID),
-	}
-	if event.ExchangeOrderID != "" {
-		lines = append(lines, fmt.Sprintf("交易所订单: %s", event.ExchangeOrderID))
+		fmt.Sprintf("数量: %s  价格: %s", formatTelegramNumber(event.Quantity), formatTelegramNumber(price)),
 	}
 	if action == "平仓" {
 		lines = append(lines, fmt.Sprintf("已实现盈亏: %s", formatTelegramSignedNumber(realizedPnL)))
@@ -491,11 +539,8 @@ func formatTelegramTradeEvent(event domain.OrderExecutionEvent) string {
 	if fee != 0 {
 		lines = append(lines, fmt.Sprintf("手续费: %s", formatTelegramSignedNumber(-fee)))
 	}
-	if event.AccountID != "" {
-		lines = append(lines, fmt.Sprintf("账户: %s", event.AccountID))
-	}
 	if event.LiveSessionID != "" {
-		lines = append(lines, fmt.Sprintf("实盘会话: %s", event.LiveSessionID))
+		lines = append(lines, fmt.Sprintf("实盘会话: %s", firstNonEmpty(liveSessionLabelByID[event.LiveSessionID], event.LiveSessionID)))
 	}
 	if !event.EventTime.IsZero() {
 		lines = append(lines, fmt.Sprintf("北京时间: %s", formatTelegramBeijingTime(event.EventTime)))
@@ -637,6 +682,9 @@ func telegramDeliveryNeedsFlapSuppression(delivery domain.NotificationDelivery) 
 	if strings.HasPrefix(delivery.NotificationID, "live-preflight-runtime-error-") {
 		return true
 	}
+	if strings.HasPrefix(delivery.NotificationID, "live-unprotected-position-") {
+		return true
+	}
 	if delivery.Metadata == nil {
 		return false
 	}
@@ -659,16 +707,26 @@ func telegramFlapSuppressionKeyForAlert(alert domain.PlatformAlert) string {
 	if alert.Scope == "live" && strings.HasPrefix(alert.ID, "live-preflight-runtime-error-") {
 		return "live-preflight-runtime-error"
 	}
+	if alert.Scope == "live" && strings.HasPrefix(alert.ID, "live-unprotected-position-") {
+		return "live-unprotected-position"
+	}
 	return ""
 }
 
 func telegramFlapSuppressionKeyIsKnown(key string) bool {
 	switch key {
-	case "runtime-stale", "runtime-recovering", "live-warning-stale-source-states", "live-preflight-runtime-error":
+	case "runtime-stale", "runtime-recovering", "live-warning-stale-source-states", "live-preflight-runtime-error", "live-unprotected-position":
 		return true
 	default:
 		return false
 	}
+}
+
+func telegramFlapSendGraceForAlert(alert domain.PlatformAlert) time.Duration {
+	if telegramFlapSuppressionKeyForAlert(alert) == "live-unprotected-position" {
+		return telegramUnprotectedPositionGrace
+	}
+	return telegramFlapSendGrace
 }
 
 func (p *Platform) advanceTelegramFlapSuppressedActiveDelivery(
@@ -708,7 +766,7 @@ func (p *Platform) advanceTelegramFlapSuppressedActiveDelivery(
 				firstActiveAt = now
 				metadata["firstActiveAt"] = now.Format(time.RFC3339)
 			}
-			if now.Sub(firstActiveAt) < telegramFlapSendGrace {
+			if now.Sub(firstActiveAt) < telegramFlapSendGraceForAlert(item.Alert) {
 				nextDelivery, err := p.store.UpsertNotificationDelivery(item.ID, "telegram", "pending", "", metadata)
 				return nextDelivery, false, err
 			}

--- a/internal/service/telegram_test.go
+++ b/internal/service/telegram_test.go
@@ -156,15 +156,23 @@ func TestTelegramDispatchSendsFilledTradeEventsWithPnLAndDedup(t *testing.T) {
 	defer func() { telegramBaseURL = oldURL }()
 
 	store := memory.NewStore()
+	session, err := store.CreateLiveSession("account-live-1", "strategy-bk-1d")
+	if err != nil {
+		t.Fatalf("create live session failed: %v", err)
+	}
+	session.Alias = "BTC 1m testnet"
+	if _, err := store.UpdateLiveSession(session); err != nil {
+		t.Fatalf("update live session alias failed: %v", err)
+	}
 	now := time.Date(2026, 4, 22, 10, 0, 0, 0, time.UTC)
 	oldNow := telegramNow
 	telegramNow = func() time.Time { return now.Add(2 * time.Minute) }
 	defer func() { telegramNow = oldNow }()
-	_, err := store.CreateOrderExecutionEvent(domain.OrderExecutionEvent{
+	_, err = store.CreateOrderExecutionEvent(domain.OrderExecutionEvent{
 		ID:              "open-event-1",
 		OrderID:         "order-open-1",
 		AccountID:       "account-live-1",
-		LiveSessionID:   "live-session-1",
+		LiveSessionID:   session.ID,
 		Symbol:          "BTCUSDT",
 		Side:            "BUY",
 		EventType:       "filled",
@@ -182,7 +190,7 @@ func TestTelegramDispatchSendsFilledTradeEventsWithPnLAndDedup(t *testing.T) {
 		ID:              "close-event-1",
 		OrderID:         "order-close-1",
 		AccountID:       "account-live-1",
-		LiveSessionID:   "live-session-1",
+		LiveSessionID:   session.ID,
 		Symbol:          "BTCUSDT",
 		Side:            "SELL",
 		EventType:       "filled",
@@ -223,6 +231,14 @@ func TestTelegramDispatchSendsFilledTradeEventsWithPnLAndDedup(t *testing.T) {
 	}
 	if !strings.Contains(joined, "数量: 0.2") || !strings.Contains(joined, "价格: 64000") {
 		t.Fatalf("expected open qty and price, got: %s", joined)
+	}
+	if !strings.Contains(joined, "实盘会话: BTC 1m testnet") {
+		t.Fatalf("expected live session alias in trade messages, got: %s", joined)
+	}
+	for _, removed := range []string{"订单: order-open-1", "交易所订单:", "账户: account-live-1"} {
+		if strings.Contains(joined, removed) {
+			t.Fatalf("expected concise trade message without %q, got: %s", removed, joined)
+		}
 	}
 	if !strings.Contains(joined, "北京时间: 2026-04-22 18:00:00") || !strings.Contains(joined, "北京时间: 2026-04-22 18:01:00") {
 		t.Fatalf("expected Beijing time in trade messages, got: %s", joined)
@@ -641,6 +657,115 @@ func TestTelegramPositionReportSkipsEmptyPositions(t *testing.T) {
 	}
 }
 
+func TestTelegramPositionReportSkipsRecentTradeEvents(t *testing.T) {
+	messages := make([]string, 0)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var p map[string]any
+		json.Unmarshal(body, &p)
+		messages = append(messages, p["text"].(string))
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"ok":true}`))
+	}))
+	defer server.Close()
+
+	oldURL := telegramBaseURL
+	telegramBaseURL = server.URL
+	defer func() { telegramBaseURL = oldURL }()
+
+	now := time.Date(2026, 4, 22, 10, 1, 0, 0, time.UTC)
+	store := memory.NewStore()
+	account, err := store.GetAccount("live-main")
+	if err != nil {
+		t.Fatalf("get account failed: %v", err)
+	}
+	account.Metadata = map[string]any{
+		"liveSyncSnapshot": map[string]any{
+			"syncStatus": "SYNCED",
+			"syncedAt":   now.Format(time.RFC3339),
+			"positions": []map[string]any{{
+				"symbol":           "BTCUSDT",
+				"positionAmt":      0.0129,
+				"entryPrice":       77342.3,
+				"markPrice":        77359.3,
+				"positionSide":     "LONG",
+				"unrealizedProfit": 0.22,
+			}},
+		},
+	}
+	if _, err := store.UpdateAccount(account); err != nil {
+		t.Fatalf("update account failed: %v", err)
+	}
+
+	p := &Platform{
+		store: store,
+		telegramConfig: domain.TelegramConfig{
+			Enabled:                       true,
+			BotToken:                      "test-token",
+			ChatID:                        "123",
+			PositionReportEnabled:         true,
+			PositionReportIntervalMinutes: 30,
+		},
+	}
+	recentTradeDeliveries := map[string]domain.NotificationDelivery{
+		"trade-event:recent": {
+			NotificationID: "trade-event:recent",
+			Channel:        "telegram",
+			Status:         "sent",
+			Metadata: map[string]any{
+				"kind":      "trade-event",
+				"eventTime": now.Add(-2 * time.Minute).Format(time.RFC3339),
+			},
+		},
+	}
+	count, err := p.DispatchTelegramPositionReport(recentTradeDeliveries, now)
+	if err != nil {
+		t.Fatalf("dispatch recent trade position report failed: %v", err)
+	}
+	if count != 0 || len(messages) != 0 {
+		t.Fatalf("expected recent trade event to suppress position report, count=%d messages=%#v", count, messages)
+	}
+
+	delayedTradeDeliveries := map[string]domain.NotificationDelivery{
+		"trade-event:delayed": {
+			NotificationID: "trade-event:delayed",
+			Channel:        "telegram",
+			Status:         "sent",
+			Metadata: map[string]any{
+				"kind":      "trade-event",
+				"eventTime": now.Add(-20 * time.Minute).Format(time.RFC3339),
+				"sentAt":    now.Add(-2 * time.Minute).Format(time.RFC3339),
+			},
+		},
+	}
+	count, err = p.DispatchTelegramPositionReport(delayedTradeDeliveries, now)
+	if err != nil {
+		t.Fatalf("dispatch delayed trade position report failed: %v", err)
+	}
+	if count != 0 || len(messages) != 0 {
+		t.Fatalf("expected delayed sentAt to suppress position report, count=%d messages=%#v", count, messages)
+	}
+
+	oldTradeDeliveries := map[string]domain.NotificationDelivery{
+		"trade-event:old": {
+			NotificationID: "trade-event:old",
+			Channel:        "telegram",
+			Status:         "sent",
+			Metadata: map[string]any{
+				"kind":      "trade-event",
+				"eventTime": now.Add(-16 * time.Minute).Format(time.RFC3339),
+			},
+		},
+	}
+	count, err = p.DispatchTelegramPositionReport(oldTradeDeliveries, now)
+	if err != nil {
+		t.Fatalf("dispatch old trade position report failed: %v", err)
+	}
+	if count != 1 || len(messages) != 1 {
+		t.Fatalf("expected old trade event to allow position report, count=%d messages=%#v", count, messages)
+	}
+}
+
 func TestTelegramDispatchSuppressesFlappingRuntimeStaleAlerts(t *testing.T) {
 	var messages []string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -921,6 +1046,7 @@ func TestTelegramAlertNeedsFlapSuppressionForTransientRuntimeRecoveryIDs(t *test
 	cases := []domain.PlatformAlert{
 		{ID: "runtime-recovering-signal-runtime-1", Scope: "runtime"},
 		{ID: "live-preflight-runtime-error-account-1", Scope: "live"},
+		{ID: "live-unprotected-position-live-session-1", Scope: "live"},
 	}
 	for _, alert := range cases {
 		if !telegramAlertNeedsFlapSuppression(alert) {
@@ -931,5 +1057,99 @@ func TestTelegramAlertNeedsFlapSuppressionForTransientRuntimeRecoveryIDs(t *test
 	nonSuppressed := domain.PlatformAlert{ID: "live-preflight-account-1", Scope: "live"}
 	if telegramAlertNeedsFlapSuppression(nonSuppressed) {
 		t.Fatal("expected generic live preflight alert not to enable flap suppression")
+	}
+}
+
+func TestTelegramUnprotectedPositionUsesLongerFlapGrace(t *testing.T) {
+	alert := domain.PlatformAlert{ID: "live-unprotected-position-live-session-1", Scope: "live"}
+	if got := telegramFlapSendGraceForAlert(alert); got != telegramUnprotectedPositionGrace {
+		t.Fatalf("expected unprotected position grace %s, got %s", telegramUnprotectedPositionGrace, got)
+	}
+
+	runtimeAlert := domain.PlatformAlert{ID: "runtime-recovering-signal-runtime-1", Scope: "runtime"}
+	if got := telegramFlapSendGraceForAlert(runtimeAlert); got != telegramFlapSendGrace {
+		t.Fatalf("expected default flap grace %s, got %s", telegramFlapSendGrace, got)
+	}
+}
+
+func TestTelegramUnprotectedPositionFlapLifecycle(t *testing.T) {
+	messages := make([]string, 0)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var p map[string]any
+		json.Unmarshal(body, &p)
+		messages = append(messages, p["text"].(string))
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"ok":true}`))
+	}))
+	defer server.Close()
+
+	oldURL := telegramBaseURL
+	telegramBaseURL = server.URL
+	defer func() { telegramBaseURL = oldURL }()
+
+	platform := &Platform{
+		store: memory.NewStore(),
+		telegramConfig: domain.TelegramConfig{
+			Enabled:    true,
+			BotToken:   "test-token",
+			ChatID:     "123",
+			SendLevels: []string{"critical"},
+		},
+	}
+	base := time.Date(2026, 4, 28, 1, 0, 0, 0, time.UTC)
+	item := domain.PlatformNotification{
+		ID: "live-unprotected-position-live-session-1",
+		Alert: domain.PlatformAlert{
+			ID:        "live-unprotected-position-live-session-1",
+			Scope:     "live",
+			Level:     "critical",
+			Title:     "恢复持仓无保护",
+			Detail:    "已恢复持仓但未发现对应的止损/止盈保护订单",
+			EventTime: base,
+		},
+	}
+
+	delivery, shouldSend, err := platform.advanceTelegramFlapSuppressedActiveDelivery(item, domain.NotificationDelivery{}, false, base)
+	if err != nil {
+		t.Fatalf("initial unprotected delivery failed: %v", err)
+	}
+	if shouldSend || !strings.EqualFold(delivery.Status, "pending") || len(messages) != 0 {
+		t.Fatalf("expected 0min pending without send, status=%s send=%v messages=%#v", delivery.Status, shouldSend, messages)
+	}
+
+	delivery, shouldSend, err = platform.advanceTelegramFlapSuppressedActiveDelivery(item, delivery, true, base.Add(14*time.Minute))
+	if err != nil {
+		t.Fatalf("14min unprotected delivery failed: %v", err)
+	}
+	if shouldSend || !strings.EqualFold(delivery.Status, "pending") || len(messages) != 0 {
+		t.Fatalf("expected 14min pending without send, status=%s send=%v messages=%#v", delivery.Status, shouldSend, messages)
+	}
+
+	delivery, shouldSend, err = platform.advanceTelegramFlapSuppressedActiveDelivery(item, delivery, true, base.Add(15*time.Minute))
+	if err != nil {
+		t.Fatalf("15min unprotected delivery failed: %v", err)
+	}
+	if !shouldSend || !strings.EqualFold(delivery.Status, "sent") || len(messages) != 1 {
+		t.Fatalf("expected 15min send, status=%s send=%v messages=%#v", delivery.Status, shouldSend, messages)
+	}
+
+	resolvePending, recovered, err := platform.advanceTelegramFlapSuppressedRecoveredDelivery(delivery, base.Add(15*time.Minute+30*time.Second))
+	if err != nil {
+		t.Fatalf("30s recovery delivery failed: %v", err)
+	}
+	if recovered || !strings.EqualFold(resolvePending.Status, "resolve_pending") || len(messages) != 1 {
+		t.Fatalf("expected recovery grace pending, status=%s recovered=%v messages=%#v", resolvePending.Status, recovered, messages)
+	}
+
+	recoveredDelivery, recovered, err := platform.advanceTelegramFlapSuppressedRecoveredDelivery(resolvePending, base.Add(16*time.Minute+31*time.Second))
+	if err != nil {
+		t.Fatalf("91s recovery delivery failed: %v", err)
+	}
+	if !recovered || !strings.EqualFold(recoveredDelivery.Status, "recovered") || len(messages) != 2 {
+		t.Fatalf("expected recovery send after grace, status=%s recovered=%v messages=%#v", recoveredDelivery.Status, recovered, messages)
+	}
+	if !strings.Contains(messages[1], "✅ *[已恢复]* 恢复持仓无保护") {
+		t.Fatalf("expected recovered message, got: %s", messages[1])
 	}
 }


### PR DESCRIPTION
## 目的

精简 Telegram 开/平仓成交通知，降低开仓后无保护告警和持仓定时播报的噪音。

本次改动：
- 开/平仓成交 Telegram 文案只保留数量、价格、盈亏、实盘会话、北京时间，去掉订单号、交易所订单号、账户 ID。
- 实盘会话展示优先使用 alias，没有 alias 时回退 live session ID。
- `live-unprotected-position-*` 告警进入 Telegram 去抖，持续 15 分钟仍未恢复才发送。
- 持仓定时播报在最近 15 分钟已有交易事件投递时跳过。

Root cause：Telegram 投递层把内部排障字段和短暂保护状态直接发给用户，导致开仓/平仓附近重复刷屏；持仓播报也没有避开刚成交后的观察窗口。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [x] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) - 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？- 无
- [x] DB migration 是否具备向下兼容幂等性？- 不涉及
- [x] 配置字段有没有无意被混改？- 无配置字段变更

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

验证命令：

```sh
/opt/homebrew/bin/go test ./internal/service -run 'TestTelegram'
/opt/homebrew/bin/go test ./internal/service
```
