### PR TITLE
[codex] guard unprotected alert id stability

### DIFF
--- a/internal/service/health_state_test.go
+++ b/internal/service/health_state_test.go
@@ -354,6 +354,48 @@ func TestListAlertsShowsAuthoritativeSyncWarningForLocalRecoveryFallback(t *test
 	}
 }
 
+func TestListAlertsUsesStableLiveUnprotectedPositionID(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	session, err := platform.store.GetLiveSession("live-session-main")
+	if err != nil {
+		t.Fatalf("get live session failed: %v", err)
+	}
+
+	state := cloneMetadata(session.State)
+	state["symbol"] = "BTCUSDT"
+	state["protectionRecoveryStatus"] = "unprotected-open-position"
+	state["positionRecoveryStatus"] = "unprotected-open-position"
+	state["protectionRecoveryAuthoritative"] = true
+	state["lastProtectionRecoveryAt"] = time.Date(2026, 4, 28, 1, 0, 0, 0, time.UTC).Format(time.RFC3339)
+	session.State = state
+	if _, err := platform.store.UpdateLiveSession(session); err != nil {
+		t.Fatalf("update live session failed: %v", err)
+	}
+
+	alerts, err := platform.ListAlerts()
+	if err != nil {
+		t.Fatalf("list alerts failed: %v", err)
+	}
+
+	expectedID := "live-unprotected-position-" + session.ID
+	found := false
+	for _, alert := range alerts {
+		if alert.Title != "恢复持仓无保护" {
+			continue
+		}
+		found = true
+		if alert.ID != expectedID {
+			t.Fatalf("expected stable session-scoped alert ID %s, got %s", expectedID, alert.ID)
+		}
+		if strings.Contains(alert.ID, "BTCUSDT") {
+			t.Fatalf("expected alert ID not to include symbol, got %s", alert.ID)
+		}
+	}
+	if !found {
+		t.Fatal("expected unprotected-position alert to be present")
+	}
+}
+
 func TestListAlertsShowsCriticalLiveExitDispatchFailure(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
 	session, err := platform.store.GetLiveSession("live-session-main")


### PR DESCRIPTION
## 目的

补一条回归测试，锁定 `恢复持仓无保护` 告警 ID 必须保持 session 维度稳定，避免未来把 symbol / position 拼进 ID 后绕过 Telegram 15 分钟去抖窗口。

本次只改测试，不改变运行时行为。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [x] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) - 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？- 无
- [x] DB migration 是否具备向下兼容幂等性？- 不涉及
- [x] 配置字段有没有无意被混改？- 无配置字段变更

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

验证命令：

```sh
/opt/homebrew/bin/go test ./internal/service -run 'TestListAlertsUsesStableLiveUnprotectedPositionID|TestTelegram'
/opt/homebrew/bin/go test ./internal/service
```
