### PR TITLE
Add SL reentry delay guard

### DIFF
--- a/internal/service/execution_strategy.go
+++ b/internal/service/execution_strategy.go
@@ -256,6 +256,9 @@ func (bookAwareExecutionStrategy) BuildProposal(ctx ExecutionPlanningContext) (E
 		proposal.Metadata["executionDecision"] = "wait-market-price-unavailable"
 		return proposal, nil
 	}
+	if delayed := applySLReentryMinDelay(ctx, proposal, reasonTag); delayed.Status != proposal.Status {
+		return delayed, nil
+	}
 	if profile.ReduceOnly && reasonTag == "sl" {
 		slMaxSlippageBps := firstPositive(profile.SLMaxSlippageBps, 8)
 		if spreadBps > 0 && slMaxSlippageBps > 0 && spreadBps > slMaxSlippageBps {
@@ -344,6 +347,62 @@ func (bookAwareExecutionStrategy) BuildProposal(ctx ExecutionPlanningContext) (E
 	}
 	proposal.Metadata["executionDecision"] = "direct-dispatch"
 	return proposal, nil
+}
+
+func applySLReentryMinDelay(ctx ExecutionPlanningContext, proposal ExecutionProposal, reasonTag string) ExecutionProposal {
+	if !strings.EqualFold(strings.TrimSpace(proposal.Role), "entry") || reasonTag != "sl-reentry" {
+		return proposal
+	}
+	delaySeconds := maxIntValue(firstNonZeroAny(ctx.Execution.Parameters["sl_reentry_min_delay_seconds"], ctx.Session.State["sl_reentry_min_delay_seconds"]), 0)
+	if delaySeconds <= 0 {
+		return proposal
+	}
+	lastExitAt := parseOptionalRFC3339(firstNonEmpty(
+		stringValue(ctx.Session.State["lastSLExitFilledAt"]),
+		stringValue(ctx.Session.State["lastStopLossExitFilledAt"]),
+	))
+	if lastExitAt.IsZero() {
+		return proposal
+	}
+	eventTime := ctx.EventTime.UTC()
+	if eventTime.IsZero() {
+		eventTime = time.Now().UTC()
+	}
+	elapsed := eventTime.Sub(lastExitAt.UTC())
+	required := time.Duration(delaySeconds) * time.Second
+	if elapsed >= required {
+		return proposal
+	}
+	remaining := required - elapsed
+	proposal.Status = "waiting-sl-reentry-delay"
+	proposal.Reason = "sl-reentry-delay"
+	proposal.Metadata = cloneMetadata(proposal.Metadata)
+	proposal.Metadata["executionDecision"] = "wait-sl-reentry-delay"
+	proposal.Metadata["slReentryMinDelaySeconds"] = delaySeconds
+	proposal.Metadata["slReentryDelayElapsedSeconds"] = math.Max(0, elapsed.Seconds())
+	proposal.Metadata["slReentryDelayRemainingSeconds"] = math.Ceil(remaining.Seconds())
+	proposal.Metadata["lastSLExitFilledAt"] = lastExitAt.UTC().Format(time.RFC3339)
+	proposal.Metadata["slReentryDelayReadyAt"] = lastExitAt.UTC().Add(required).Format(time.RFC3339)
+	proposal.Metadata["executionDecisionContext"] = mergeExecutionDecisionContext(
+		mapValue(proposal.Metadata["executionDecisionContext"]),
+		map[string]any{
+			"slReentryDelayBranch":           true,
+			"slReentryMinDelaySeconds":       delaySeconds,
+			"slReentryDelayElapsedSeconds":   math.Max(0, elapsed.Seconds()),
+			"slReentryDelayRemainingSeconds": math.Ceil(remaining.Seconds()),
+			"lastSLExitFilledAt":             lastExitAt.UTC().Format(time.RFC3339),
+		},
+	)
+	return proposal
+}
+
+func firstNonZeroAny(values ...any) any {
+	for _, value := range values {
+		if parseFloatValue(value) > 0 {
+			return value
+		}
+	}
+	return nil
 }
 
 func normalizePositionSizingMode(raw any) string {

--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -5722,6 +5722,9 @@ func normalizeLiveSessionOverrides(overrides map[string]any) map[string]any {
 	if seconds := maxIntValue(overrides["dispatchCooldownSeconds"], 0); seconds > 0 {
 		normalized["dispatchCooldownSeconds"] = seconds
 	}
+	if seconds := maxIntValue(overrides["sl_reentry_min_delay_seconds"], 0); seconds > 0 {
+		normalized["sl_reentry_min_delay_seconds"] = seconds
+	}
 	if shape := strings.ToLower(strings.TrimSpace(stringValue(overrides["breakout_shape"]))); shape != "" {
 		normalized["breakout_shape"] = shape
 	}

--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -4004,6 +4004,7 @@ func preserveLiveSessionNonRegressiveFacts(state map[string]any, latest map[stri
 			state[key] = value
 		}
 	}
+	preserveLatestSLExitFillFact(state, latest)
 }
 
 func liveSessionNonRegressiveFactKeys() []string {
@@ -4015,6 +4016,27 @@ func liveSessionNonRegressiveFactKeys() []string {
 		"lastStrategyDecisionEventFingerprint",
 		"lastStrategyDecisionEventIntentSignature",
 		"lastDispatchedDecisionEventId",
+	}
+}
+
+func preserveLatestSLExitFillFact(state map[string]any, latest map[string]any) {
+	latestFilledAt := parseOptionalRFC3339(stringValue(latest["lastSLExitFilledAt"]))
+	if latestFilledAt.IsZero() {
+		return
+	}
+	stateFilledAt := parseOptionalRFC3339(stringValue(state["lastSLExitFilledAt"]))
+	if !stateFilledAt.IsZero() && !latestFilledAt.After(stateFilledAt) {
+		return
+	}
+	for _, key := range []string{
+		"lastSLExitFilledAt",
+		"lastSLExitOrderId",
+		"lastSLExitStatus",
+		"lastSLExitSignalBarStateKey",
+	} {
+		if value, ok := latest[key]; ok {
+			state[key] = value
+		}
 	}
 }
 
@@ -5206,6 +5228,7 @@ func (p *Platform) resolveLiveSessionParameters(session domain.LiveSession, vers
 		"max_trades_per_bar",
 		"dir2_zero_initial",
 		"zero_initial_mode",
+		"sl_reentry_min_delay_seconds",
 		"breakout_shape",
 		"t3_min_sma_atr_separation",
 		"use_sma5_intraday_structure",

--- a/internal/service/live_execution.go
+++ b/internal/service/live_execution.go
@@ -1651,6 +1651,10 @@ func recordLiveSessionStopLossExitFill(state map[string]any, proposalMap map[str
 	if filledAt.IsZero() {
 		filledAt = eventTime.UTC()
 	}
+	existingFilledAt := parseOptionalRFC3339(stringValue(state["lastSLExitFilledAt"]))
+	if !existingFilledAt.IsZero() && !filledAt.UTC().After(existingFilledAt.UTC()) {
+		return
+	}
 	state["lastSLExitFilledAt"] = filledAt.UTC().Format(time.RFC3339)
 	state["lastSLExitOrderId"] = order.ID
 	state["lastSLExitStatus"] = order.Status

--- a/internal/service/live_execution.go
+++ b/internal/service/live_execution.go
@@ -1356,12 +1356,14 @@ func (p *Platform) syncLatestLiveSessionOrder(session domain.LiveSession, eventT
 			state["lastSyncedAt"] = eventTime.UTC().Format(time.RFC3339)
 			recordExecutionSyncResultHealth(state, eventTime, order.Status, nil)
 		}
-		maybeIncrementLiveSessionReentryCount(state, mapValue(order.Metadata["executionProposal"]), order.ID, order.Status)
+		proposalMap := mapValue(order.Metadata["executionProposal"])
+		maybeIncrementLiveSessionReentryCount(state, proposalMap, order.ID, order.Status)
+		recordLiveSessionStopLossExitFill(state, proposalMap, order, eventTime)
 		state["lastSyncedOrderId"] = order.ID
 		state["lastSyncedOrderStatus"] = order.Status
 		state["lastDispatchedOrderStatus"] = order.Status
-		state["lastExecutionDispatch"] = executionDispatchSummary(mapValue(order.Metadata["executionProposal"]), order, false)
-		updateExecutionEventStats(state, mapValue(order.Metadata["executionProposal"]), mapValue(state["lastExecutionDispatch"]))
+		state["lastExecutionDispatch"] = executionDispatchSummary(proposalMap, order, false)
+		updateExecutionEventStats(state, proposalMap, mapValue(state["lastExecutionDispatch"]))
 		if shouldSyncLiveAccountAfterTerminalFilledOrder(order, state, eventTime) {
 			state["lastTerminalAccountSyncAttemptOrderId"] = order.ID
 			state["lastTerminalAccountSyncAttemptOrderStatus"] = order.Status
@@ -1399,7 +1401,9 @@ func (p *Platform) syncLatestLiveSessionOrder(session domain.LiveSession, eventT
 				if syncErr == nil {
 					delete(state, "lastSyncError")
 					delete(state, "lastCancelFallbackSyncError")
-					maybeIncrementLiveSessionReentryCount(state, mapValue(order.Metadata["executionProposal"]), syncedOrder.ID, syncedOrder.Status)
+					proposalMap := mapValue(order.Metadata["executionProposal"])
+					maybeIncrementLiveSessionReentryCount(state, proposalMap, syncedOrder.ID, syncedOrder.Status)
+					recordLiveSessionStopLossExitFill(state, proposalMap, syncedOrder, eventTime)
 					state["lastSyncedOrderId"] = syncedOrder.ID
 					state["lastSyncedOrderStatus"] = syncedOrder.Status
 					state["lastDispatchedOrderStatus"] = syncedOrder.Status
@@ -1410,8 +1414,8 @@ func (p *Platform) syncLatestLiveSessionOrder(session domain.LiveSession, eventT
 						recordLiveExecutionTimeoutMetadata(state, eventTime, order)
 						dispatchOrder = withExecutionSubmissionFallback(syncedOrder, order)
 					}
-					state["lastExecutionDispatch"] = executionDispatchSummary(mapValue(order.Metadata["executionProposal"]), dispatchOrder, false)
-					updateExecutionEventStats(state, mapValue(order.Metadata["executionProposal"]), mapValue(state["lastExecutionDispatch"]))
+					state["lastExecutionDispatch"] = executionDispatchSummary(proposalMap, dispatchOrder, false)
+					updateExecutionEventStats(state, proposalMap, mapValue(state["lastExecutionDispatch"]))
 					appendTimelineEvent(state, "order", eventTime, "live-order-cancel-fallback-synced", map[string]any{
 						"orderId":     order.ID,
 						"cancelError": cancelErr.Error(),
@@ -1492,20 +1496,22 @@ func (p *Platform) syncLatestLiveSessionOrder(session domain.LiveSession, eventT
 		return updated, err
 	}
 	delete(state, "lastSyncError")
-	maybeIncrementLiveSessionReentryCount(state, mapValue(order.Metadata["executionProposal"]), syncedOrder.ID, syncedOrder.Status)
+	proposalMap := mapValue(order.Metadata["executionProposal"])
+	maybeIncrementLiveSessionReentryCount(state, proposalMap, syncedOrder.ID, syncedOrder.Status)
+	recordLiveSessionStopLossExitFill(state, proposalMap, syncedOrder, eventTime)
 	state["lastSyncedOrderId"] = syncedOrder.ID
 	state["lastSyncedOrderStatus"] = syncedOrder.Status
 	state["lastDispatchedOrderStatus"] = syncedOrder.Status
 	state["lastSyncedAt"] = time.Now().UTC().Format(time.RFC3339)
 	recordExecutionSyncResultHealth(state, eventTime, syncedOrder.Status, nil)
-	state["lastExecutionDispatch"] = executionDispatchSummary(mapValue(order.Metadata["executionProposal"]), syncedOrder, false)
-	updateExecutionEventStats(state, mapValue(order.Metadata["executionProposal"]), mapValue(state["lastExecutionDispatch"]))
+	state["lastExecutionDispatch"] = executionDispatchSummary(proposalMap, syncedOrder, false)
+	updateExecutionEventStats(state, proposalMap, mapValue(state["lastExecutionDispatch"]))
 	if strings.EqualFold(syncedOrder.Status, "FILLED") {
 		if _, syncErr := p.requestLiveAccountSync(session.AccountID, "live-filled-order-sync"); syncErr != nil && !errors.Is(syncErr, ErrLiveAccountOperationInProgress) {
 			p.logger("service.live_execution", "session_id", session.ID, "account_id", session.AccountID).Warn("live account sync failed after filled order sync", "error", syncErr)
 		}
 	}
-	appendTimelineEvent(state, "order", eventTime, "live-order-synced", executionDispatchTimelineMetadata(mapValue(order.Metadata["executionProposal"]), syncedOrder, false))
+	appendTimelineEvent(state, "order", eventTime, "live-order-synced", executionDispatchTimelineMetadata(proposalMap, syncedOrder, false))
 	updated, err := p.store.UpdateLiveSessionState(session.ID, state)
 	if err != nil {
 		return domain.LiveSession{}, err
@@ -1628,6 +1634,28 @@ func maybeIncrementLiveSessionReentryCount(state map[string]any, proposalMap map
 	state["sessionReentryCount"] = reentryCount
 	if orderID != "" {
 		state["lastCountedReentryOrderId"] = orderID
+	}
+}
+
+func recordLiveSessionStopLossExitFill(state map[string]any, proposalMap map[string]any, order domain.Order, eventTime time.Time) {
+	if state == nil || !strings.EqualFold(strings.TrimSpace(order.Status), "FILLED") {
+		return
+	}
+	if !strings.EqualFold(strings.TrimSpace(stringValue(proposalMap["role"])), "exit") {
+		return
+	}
+	if normalizeStrategyReasonTag(stringValue(proposalMap["reason"])) != "sl" {
+		return
+	}
+	filledAt := parseOptionalRFC3339(stringValue(order.Metadata["lastFilledAt"]))
+	if filledAt.IsZero() {
+		filledAt = eventTime.UTC()
+	}
+	state["lastSLExitFilledAt"] = filledAt.UTC().Format(time.RFC3339)
+	state["lastSLExitOrderId"] = order.ID
+	state["lastSLExitStatus"] = order.Status
+	if key := liveProposalSignalBarTradeLimitKey(proposalMap); key != "" {
+		state["lastSLExitSignalBarStateKey"] = key
 	}
 }
 

--- a/internal/service/live_launch_templates.go
+++ b/internal/service/live_launch_templates.go
@@ -271,6 +271,7 @@ func liveBTC30mEnhancedOverrides() map[string]any {
 	overrides := liveIntradayResearchBaselineOverrides("bk-live-intrabar-sma5-t3-sep")
 	overrides["max_trades_per_bar"] = domain.ResearchBaselineMaxTradesPerBar
 	overrides["stop_loss_atr"] = 0.05
+	overrides["sl_reentry_min_delay_seconds"] = 60
 	overrides["breakout_shape"] = "baseline_plus_t3"
 	overrides["t3_min_sma_atr_separation"] = 0.25
 	overrides["use_sma5_intraday_structure"] = true

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -1157,6 +1157,28 @@ func TestResolveLiveSessionParametersPropagatesExecutionProfileOverrides(t *test
 	}
 }
 
+func TestResolveLiveSessionParametersPropagatesSLReentryDelay(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	session, err := platform.CreateLiveSession("", "live-main", "strategy-bk-1d", map[string]any{
+		"symbol":                       "BTCUSDT",
+		"sl_reentry_min_delay_seconds": 60,
+	})
+	if err != nil {
+		t.Fatalf("create live session failed: %v", err)
+	}
+	version, err := platform.resolveCurrentStrategyVersion(session.StrategyID)
+	if err != nil {
+		t.Fatalf("resolve strategy version failed: %v", err)
+	}
+	parameters, err := platform.resolveLiveSessionParameters(session, version)
+	if err != nil {
+		t.Fatalf("resolve live session parameters failed: %v", err)
+	}
+	if got := maxIntValue(parameters["sl_reentry_min_delay_seconds"], 0); got != 60 {
+		t.Fatalf("expected SL-Reentry delay to reach execution parameters, got %d", got)
+	}
+}
+
 func TestResolveLiveSessionParametersPrefersSignalBindingTimeframeOverStaleSessionState(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
 	if _, err := platform.BindStrategySignalSource("strategy-bk-1d", map[string]any{
@@ -4450,6 +4472,17 @@ func TestRecordLiveSessionStopLossExitFillUsesExchangeFillTime(t *testing.T) {
 	if got := stringValue(state["lastSLExitOrderId"]); got != "order-sl-1" {
 		t.Fatalf("expected PT fill not to overwrite SL exit fact, got %q", got)
 	}
+
+	newerFillTime := fillTime.Add(2 * time.Minute)
+	state["lastSLExitFilledAt"] = newerFillTime.Format(time.RFC3339)
+	state["lastSLExitOrderId"] = "order-sl-newer"
+	recordLiveSessionStopLossExitFill(state, proposal, order, fillTime.Add(5*time.Second))
+	if got := stringValue(state["lastSLExitFilledAt"]); got != newerFillTime.Format(time.RFC3339) {
+		t.Fatalf("expected older SL fill not to regress last SL exit time, got %q", got)
+	}
+	if got := stringValue(state["lastSLExitOrderId"]); got != "order-sl-newer" {
+		t.Fatalf("expected older SL fill not to regress last SL exit order id, got %q", got)
+	}
 }
 
 func TestUpdateLiveSessionStatePreservingNonRegressiveFactsKeepsLatestCountedBar(t *testing.T) {
@@ -4506,6 +4539,60 @@ func TestUpdateLiveSessionStatePreservingNonRegressiveFactsKeepsLatestCountedBar
 	}
 	if err := validateLiveSignalBarEntryTradeLimit(updated, proposal); err == nil {
 		t.Fatal("expected preserved per-bar reentry count to keep blocking same-bar entry")
+	}
+}
+
+func TestUpdateLiveSessionStatePreservingNonRegressiveFactsKeepsLatestSLExitFill(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	session, err := platform.CreateLiveSession("", "live-main", "strategy-bk-1d", map[string]any{
+		"symbol":          "BTCUSDT",
+		"signalTimeframe": "30m",
+	})
+	if err != nil {
+		t.Fatalf("create live session failed: %v", err)
+	}
+	latestFill := time.Date(2026, 4, 28, 1, 55, 18, 0, time.UTC)
+	session, err = platform.store.UpdateLiveSessionState(session.ID, map[string]any{
+		"symbol":                       "BTCUSDT",
+		"signalTimeframe":              "30m",
+		"lastSLExitFilledAt":           latestFill.Format(time.RFC3339),
+		"lastSLExitOrderId":            "order-sl-latest",
+		"lastSLExitStatus":             "FILLED",
+		"lastSLExitSignalBarStateKey":  "BTCUSDT|30m|2026-04-28T01:30:00Z",
+		"lastStrategyEvaluationStatus": "intent-ready",
+	})
+	if err != nil {
+		t.Fatalf("seed live session state failed: %v", err)
+	}
+
+	staleState := cloneMetadata(session.State)
+	staleState["lastSLExitFilledAt"] = latestFill.Add(-1 * time.Minute).Format(time.RFC3339)
+	staleState["lastSLExitOrderId"] = "order-sl-older"
+
+	updated, err := platform.updateLiveSessionStatePreservingNonRegressiveFacts(session.ID, staleState)
+	if err != nil {
+		t.Fatalf("update live session state failed: %v", err)
+	}
+	if got := stringValue(updated.State["lastSLExitFilledAt"]); got != latestFill.Format(time.RFC3339) {
+		t.Fatalf("expected latest SL exit fill time to survive stale write, got %q", got)
+	}
+	if got := stringValue(updated.State["lastSLExitOrderId"]); got != "order-sl-latest" {
+		t.Fatalf("expected latest SL exit order id to survive stale write, got %q", got)
+	}
+
+	newerFill := latestFill.Add(2 * time.Minute)
+	newerState := cloneMetadata(updated.State)
+	newerState["lastSLExitFilledAt"] = newerFill.Format(time.RFC3339)
+	newerState["lastSLExitOrderId"] = "order-sl-newer"
+	updated, err = platform.updateLiveSessionStatePreservingNonRegressiveFacts(session.ID, newerState)
+	if err != nil {
+		t.Fatalf("update newer live session state failed: %v", err)
+	}
+	if got := stringValue(updated.State["lastSLExitFilledAt"]); got != newerFill.Format(time.RFC3339) {
+		t.Fatalf("expected newer SL exit fill time to win, got %q", got)
+	}
+	if got := stringValue(updated.State["lastSLExitOrderId"]); got != "order-sl-newer" {
+		t.Fatalf("expected newer SL exit order id to win, got %q", got)
 	}
 }
 

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -1877,6 +1877,91 @@ func TestBookAwareExecutionStrategyStartsSLReentryAtSecondScheduleSlot(t *testin
 	}
 }
 
+func TestBookAwareExecutionStrategyDelaysSLReentryAfterStopLossFill(t *testing.T) {
+	strategy := bookAwareExecutionStrategy{}
+	account := domain.Account{
+		Metadata: map[string]any{
+			"liveSyncSnapshot": map[string]any{
+				"availableBalance": 1000.0,
+			},
+		},
+	}
+	lastSLFill := time.Date(2026, 4, 28, 1, 54, 18, 0, time.UTC)
+	intent := SignalIntent{
+		Action:        "entry",
+		Role:          "entry",
+		Reason:        "SL-Reentry",
+		Side:          "BUY",
+		Symbol:        "BTCUSDT",
+		SignalKind:    "sl-reentry",
+		DecisionState: "entry-ready",
+		PriceHint:     25000,
+		PriceSource:   "trade_tick.price",
+		Metadata: map[string]any{
+			"bestBid":           24999.5,
+			"bestAsk":           25000.0,
+			"spreadBps":         0.1,
+			"signalBarStateKey": "state-schedule",
+		},
+	}
+	ctx := ExecutionPlanningContext{
+		Session: domain.LiveSession{
+			State: map[string]any{
+				"positionSizingMode":   "reentry_size_schedule",
+				"defaultOrderQuantity": 0.002,
+				"lastSLExitFilledAt":   lastSLFill.Format(time.RFC3339),
+			},
+		},
+		Account: account,
+		Execution: StrategyExecutionContext{
+			Parameters: map[string]any{
+				"executionMaxSpreadBps":            8.0,
+				"reentry_size_schedule":            []float64{0.20, 0.10},
+				"sl_reentry_min_delay_seconds":     60,
+				"executionEntryMaxSlippageBps":     8.0,
+				"executionEntryMaxBookAgeMs":       500.0,
+				"executionEntryMinTopBookCoverage": 0.5,
+			},
+		},
+		EventTime: lastSLFill.Add(11 * time.Second),
+		Intent:    intent,
+	}
+
+	delayed, err := strategy.BuildProposal(ctx)
+	if err != nil {
+		t.Fatalf("unexpected delayed proposal error: %v", err)
+	}
+	if delayed.Status != "waiting-sl-reentry-delay" {
+		t.Fatalf("expected SL-Reentry to wait for delay, got %s", delayed.Status)
+	}
+	if got := stringValue(delayed.Metadata["executionDecision"]); got != "wait-sl-reentry-delay" {
+		t.Fatalf("expected delay execution decision, got %s", got)
+	}
+	if got := parseFloatValue(delayed.Metadata["slReentryDelayRemainingSeconds"]); got != 49 {
+		t.Fatalf("expected 49 seconds remaining, got %v", got)
+	}
+
+	ctx.EventTime = lastSLFill.Add(60 * time.Second)
+	ready, err := strategy.BuildProposal(ctx)
+	if err != nil {
+		t.Fatalf("unexpected ready proposal error: %v", err)
+	}
+	if ready.Status != "dispatchable" {
+		t.Fatalf("expected SL-Reentry to dispatch after delay, got %s", ready.Status)
+	}
+
+	ctx.EventTime = lastSLFill.Add(11 * time.Second)
+	ctx.Intent.Reason = "Zero-Initial-Reentry"
+	ctx.Intent.SignalKind = "zero-initial-reentry"
+	unaffected, err := strategy.BuildProposal(ctx)
+	if err != nil {
+		t.Fatalf("unexpected zero-initial proposal error: %v", err)
+	}
+	if unaffected.Status != "dispatchable" {
+		t.Fatalf("expected zero-initial reentry to ignore SL delay, got %s", unaffected.Status)
+	}
+}
+
 func TestBookAwareExecutionStrategyUsesPositionQuantityForScheduledReentryExits(t *testing.T) {
 	strategy := bookAwareExecutionStrategy{}
 	for _, tc := range []struct {
@@ -3465,6 +3550,7 @@ func TestNormalizeLiveSessionOverridesIncludesExecutionControls(t *testing.T) {
 		"executionSLExitOrderType":             "market",
 		"executionSLExitMaxSpreadBps":          999.0,
 		"executionSLMaxSlippageBps":            8.0,
+		"sl_reentry_min_delay_seconds":         60,
 	})
 	if got := stringValue(overrides["executionStrategy"]); got != "book-aware-v1" {
 		t.Fatalf("expected execution strategy override, got %s", got)
@@ -3522,6 +3608,9 @@ func TestNormalizeLiveSessionOverridesIncludesExecutionControls(t *testing.T) {
 	}
 	if got := parseFloatValue(overrides["executionSLMaxSlippageBps"]); got != 8.0 {
 		t.Fatalf("expected SL max slippage override, got %v", got)
+	}
+	if got := maxIntValue(overrides["sl_reentry_min_delay_seconds"], 0); got != 60 {
+		t.Fatalf("expected SL-Reentry delay override, got %d", got)
 	}
 }
 
@@ -3591,6 +3680,13 @@ func TestNormalizeLiveSessionOverridesIncludesT3BreakoutControls(t *testing.T) {
 	}
 	if _, ok := overrides["ignored_t3_min_sma_atr_separation"]; ok {
 		t.Fatalf("expected unknown t3 override key to be dropped, got %#v", overrides)
+	}
+}
+
+func TestLiveBTC30mEnhancedOverridesEnableSLReentryDelay(t *testing.T) {
+	overrides := liveBTC30mEnhancedOverrides()
+	if got := maxIntValue(overrides["sl_reentry_min_delay_seconds"], 0); got != 60 {
+		t.Fatalf("expected BTC 30m enhanced template to require 60s SL-Reentry delay, got %d", got)
 	}
 }
 
@@ -4313,6 +4409,46 @@ func TestMaybeIncrementLiveSessionReentryCountUsesPerBarIdentity(t *testing.T) {
 	}
 	if got := stringValue(state["lastSignalBarStateKey"]); got != "BTCUSDT|30m|2026-04-22T03:30:00Z" {
 		t.Fatalf("expected last signal bar key to track per-bar identity, got %s", got)
+	}
+}
+
+func TestRecordLiveSessionStopLossExitFillUsesExchangeFillTime(t *testing.T) {
+	fillTime := time.Date(2026, 4, 28, 1, 54, 18, 0, time.UTC)
+	state := map[string]any{}
+	proposal := map[string]any{
+		"role":   "exit",
+		"reason": "SL",
+		"metadata": map[string]any{
+			liveSignalBarTradeLimitKeyField: "BTCUSDT|30m|2026-04-28T01:30:00Z",
+		},
+	}
+	order := domain.Order{
+		ID:     "order-sl-1",
+		Status: "FILLED",
+		Metadata: map[string]any{
+			"lastFilledAt": fillTime.Format(time.RFC3339),
+		},
+	}
+	recordLiveSessionStopLossExitFill(state, proposal, order, fillTime.Add(5*time.Second))
+	if got := stringValue(state["lastSLExitFilledAt"]); got != fillTime.Format(time.RFC3339) {
+		t.Fatalf("expected last SL exit fill time from exchange fill, got %q", got)
+	}
+	if got := stringValue(state["lastSLExitOrderId"]); got != "order-sl-1" {
+		t.Fatalf("expected SL exit order id to be recorded, got %q", got)
+	}
+	if got := stringValue(state["lastSLExitSignalBarStateKey"]); got != "BTCUSDT|30m|2026-04-28T01:30:00Z" {
+		t.Fatalf("expected SL exit bar identity to be recorded, got %q", got)
+	}
+
+	recordLiveSessionStopLossExitFill(state, map[string]any{"role": "exit", "reason": "PT"}, domain.Order{
+		ID:     "order-pt-1",
+		Status: "FILLED",
+		Metadata: map[string]any{
+			"lastFilledAt": fillTime.Add(time.Minute).Format(time.RFC3339),
+		},
+	}, fillTime.Add(time.Minute))
+	if got := stringValue(state["lastSLExitOrderId"]); got != "order-sl-1" {
+		t.Fatalf("expected PT fill not to overwrite SL exit fact, got %q", got)
 	}
 }
 


### PR DESCRIPTION
## 目的
给 `SL-Reentry` 增加基于止损平仓成交时间的最小延迟保护，避免止损刚成交后在同一止损区域立刻重新开多/开空。

本 PR 延续 #261 的 sizing 修正：`SL-Reentry` 仍使用 schedule 第二档 10%，但新增 `sl_reentry_min_delay_seconds` 控制重新入场前至少等待多久。BTC 30m enhanced live template 先按 ETH 30m 1s bar research 结果启用 60 秒。

Root cause:
- 当前策略允许 `SL-Reentry` 在止损平仓后的 reentry window 内立即生成 entry proposal。
- live 的 dispatch 边界只看 proposal 是否 `dispatchable`，此前没有把“最近一次 SL exit 已成交多久”作为统一前置条件。

行为变化:
- SL exit 订单确认 `FILLED` 后，session state 记录 `lastSLExitFilledAt` / `lastSLExitOrderId`。
- 如果下一次 proposal 是 `SL-Reentry` 且未满足 `sl_reentry_min_delay_seconds`，proposal 状态变为 `waiting-sl-reentry-delay`，因此 auto-dispatch 和人工 dispatch 都会被现有 dispatch guard 拦住。
- 非 `SL-Reentry`（例如 `Zero-Initial-Reentry`）不受此延迟影响。
- 默认全局行为不变；仅 BTC 30m enhanced template 配置 `sl_reentry_min_delay_seconds=60`。

Research evidence:
- ETHUSDT 2026 Q1 / 30m / continuous 1s bar / `live_intrabar_sma5` / `baseline_plus_t3`
- baseline with #261 sizing: return 309.09%, max DD -2.93%, SL-Reentry 5551
- delay_60s: return 335.54%, max DD -2.75%, SL-Reentry 5448
- close confirmation variants were strongly negative, so this PR implements delay only.

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [x] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) - 无变化，仍由现有默认控制。
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？- 无。
- [x] DB migration 是否具备向下兼容幂等性？- 无 migration。
- [x] 配置字段有没有无意被混改？- 仅新增 `sl_reentry_min_delay_seconds`，并只在 BTC 30m enhanced template 启用 60 秒。

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

Local verification:
- `go test ./internal/service -run 'TestBookAwareExecutionStrategy(StartsSLReentryAtSecondScheduleSlot|DelaysSLReentryAfterStopLossFill)|TestRecordLiveSessionStopLossExitFillUsesExchangeFillTime|TestNormalizeLiveSessionOverridesIncludesExecutionControls|TestLiveBTC30mEnhancedOverridesEnableSLReentryDelay|TestMaybeIncrementLiveSessionReentryCount'`
- `go test ./internal/service`
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
- pre-push harness passed: graphify rebuild, high-risk defaults check, env safety check, backend checks.
