### PR TITLE
[codex] Add signal runtime supervisor restart backoff

### DIFF
--- a/internal/service/signal_runtime_scanner.go
+++ b/internal/service/signal_runtime_scanner.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 
@@ -10,6 +11,11 @@ import (
 )
 
 const signalRuntimeScannerInterval = 5 * time.Second
+
+var signalRuntimeSupervisorRestartBackoffs = []time.Duration{
+	time.Minute,
+	3 * time.Minute,
+}
 
 type signalRuntimeSessionStarter func(context.Context, string) (domain.SignalRuntimeSession, error)
 
@@ -44,6 +50,9 @@ func (p *Platform) scanSignalRuntimeSessions(ctx context.Context, starter signal
 		if !signalRuntimeSessionDesiredRunning(session) {
 			continue
 		}
+		if p.signalRuntimeSupervisorRestartDeferred(session, time.Now().UTC()) {
+			continue
+		}
 		if p.stopSignalRuntimeLinkedToStoppedLiveSession(session) {
 			continue
 		}
@@ -65,14 +74,109 @@ func (p *Platform) scanSignalRuntimeSessions(ctx context.Context, starter signal
 }
 
 func signalRuntimeSessionDesiredRunning(session domain.SignalRuntimeSession) bool {
-	if session.Status == "ERROR" || stringValue(session.State["actualStatus"]) == "ERROR" {
-		return false
-	}
 	desired := stringValue(session.State["desiredStatus"])
 	if desired != "" {
 		return desired == "RUNNING"
 	}
+	if session.Status == "ERROR" || stringValue(session.State["actualStatus"]) == "ERROR" {
+		return false
+	}
 	return session.Status == "RUNNING"
+}
+
+func (p *Platform) signalRuntimeSupervisorRestartDeferred(session domain.SignalRuntimeSession, now time.Time) bool {
+	if !strings.EqualFold(session.Status, "ERROR") && !strings.EqualFold(stringValue(session.State["actualStatus"]), "ERROR") {
+		return false
+	}
+	state := cloneMetadata(session.State)
+	if boolValue(state["autoRestartSuppressed"]) {
+		return true
+	}
+	if strings.EqualFold(stringValue(state["supervisorRestartSeverity"]), disconnectFatal.String()) {
+		return true
+	}
+	nextAt, ok := parseSignalRuntimeSupervisorTime(state["nextAutoRestartAt"])
+	if !ok {
+		p.scheduleSignalRuntimeSupervisorRestart(session, now)
+		return true
+	}
+	return now.Before(nextAt)
+}
+
+func (p *Platform) scheduleSignalRuntimeSupervisorRestart(session domain.SignalRuntimeSession, now time.Time) {
+	_ = p.updateSignalRuntimeSessionState(session.ID, func(updated *domain.SignalRuntimeSession) {
+		state := cloneMetadata(updated.State)
+		attempt := signalRuntimeSupervisorRestartAttempt(state)
+		if attempt <= 0 {
+			attempt = 1
+			state["supervisorRestartAttempt"] = attempt
+		}
+		backoff := signalRuntimeSupervisorRestartBackoff(attempt)
+		state["nextAutoRestartAt"] = now.Add(backoff).UTC().Format(time.RFC3339)
+		state["supervisorRestartBackoff"] = backoff.String()
+		state["supervisorRestartReason"] = "runtime-error"
+		updated.State = state
+		updated.UpdatedAt = now
+	})
+}
+
+func scheduleSignalRuntimeSupervisorRestartAfterTerminalError(state map[string]any, err error, now time.Time) {
+	severity := classifyDisconnectSeverity(err)
+	state["supervisorRestartSeverity"] = severity.String()
+	if severity == disconnectFatal {
+		state["autoRestartSuppressed"] = true
+		delete(state, "nextAutoRestartAt")
+		delete(state, "supervisorRestartBackoff")
+		return
+	}
+	if !strings.EqualFold(stringValue(state["desiredStatus"]), "RUNNING") {
+		delete(state, "nextAutoRestartAt")
+		delete(state, "supervisorRestartBackoff")
+		return
+	}
+	attempt := signalRuntimeSupervisorRestartAttempt(state) + 1
+	state["supervisorRestartAttempt"] = attempt
+	backoff := signalRuntimeSupervisorRestartBackoff(attempt)
+	state["nextAutoRestartAt"] = now.Add(backoff).UTC().Format(time.RFC3339)
+	state["supervisorRestartBackoff"] = backoff.String()
+	state["lastSupervisorError"] = err.Error()
+	delete(state, "autoRestartSuppressed")
+}
+
+func signalRuntimeSupervisorRestartBackoff(attempt int) time.Duration {
+	if attempt <= 1 {
+		return signalRuntimeSupervisorRestartBackoffs[0]
+	}
+	return signalRuntimeSupervisorRestartBackoffs[len(signalRuntimeSupervisorRestartBackoffs)-1]
+}
+
+func signalRuntimeSupervisorRestartAttempt(state map[string]any) int {
+	switch value := state["supervisorRestartAttempt"].(type) {
+	case int:
+		return value
+	case int64:
+		return int(value)
+	case float64:
+		return int(value)
+	case string:
+		var parsed int
+		if _, err := fmt.Sscanf(strings.TrimSpace(value), "%d", &parsed); err == nil {
+			return parsed
+		}
+	}
+	return 0
+}
+
+func parseSignalRuntimeSupervisorTime(value any) (time.Time, bool) {
+	raw := stringValue(value)
+	if raw == "" {
+		return time.Time{}, false
+	}
+	parsed, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return parsed, true
 }
 
 func (p *Platform) signalRuntimeSessionRunningOrStarting(sessionID string) bool {

--- a/internal/service/signal_runtime_scanner_test.go
+++ b/internal/service/signal_runtime_scanner_test.go
@@ -71,7 +71,7 @@ func TestScanSignalRuntimeSessionsSkipsLocalRunningSession(t *testing.T) {
 	}
 }
 
-func TestScanSignalRuntimeSessionsSkipsErroredDesiredRunningSession(t *testing.T) {
+func TestScanSignalRuntimeSessionsDefersErroredDesiredRunningSessionUntilBackoff(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
 	now := time.Date(2026, 4, 26, 18, 0, 0, 0, time.UTC)
 	session := mustCreateScannerRuntimeSession(t, platform, domain.SignalRuntimeSession{
@@ -80,8 +80,9 @@ func TestScanSignalRuntimeSessionsSkipsErroredDesiredRunningSession(t *testing.T
 		StrategyID: "strategy-1",
 		Status:     "ERROR",
 		State: map[string]any{
-			"desiredStatus": "RUNNING",
-			"actualStatus":  "ERROR",
+			"desiredStatus":     "RUNNING",
+			"actualStatus":      "ERROR",
+			"nextAutoRestartAt": time.Now().UTC().Add(time.Hour).Format(time.RFC3339),
 		},
 		CreatedAt: now,
 		UpdatedAt: now,
@@ -93,7 +94,100 @@ func TestScanSignalRuntimeSessionsSkipsErroredDesiredRunningSession(t *testing.T
 		return session, nil
 	})
 	if started != 0 {
-		t.Fatalf("expected scanner to leave errored desired-running session stopped for manual restart, got %d starts", started)
+		t.Fatalf("expected scanner to wait for supervisor backoff, got %d starts", started)
+	}
+}
+
+func TestScanSignalRuntimeSessionsRestartsErroredDesiredRunningSessionAfterBackoff(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	now := time.Date(2026, 4, 26, 18, 0, 0, 0, time.UTC)
+	session := mustCreateScannerRuntimeSession(t, platform, domain.SignalRuntimeSession{
+		ID:         "runtime-error-due",
+		AccountID:  "account-1",
+		StrategyID: "strategy-1",
+		Status:     "ERROR",
+		State: map[string]any{
+			"desiredStatus":            "RUNNING",
+			"actualStatus":             "ERROR",
+			"supervisorRestartAttempt": 1,
+			"nextAutoRestartAt":        time.Now().UTC().Add(-time.Second).Format(time.RFC3339),
+		},
+		CreatedAt: now,
+		UpdatedAt: now,
+	})
+
+	started := make([]string, 0)
+	platform.scanSignalRuntimeSessions(context.Background(), func(_ context.Context, sessionID string) (domain.SignalRuntimeSession, error) {
+		started = append(started, sessionID)
+		return session, nil
+	})
+	if len(started) != 1 || started[0] != session.ID {
+		t.Fatalf("expected scanner to restart errored desired-running session after backoff, got %#v", started)
+	}
+}
+
+func TestSetSessionTerminalErrorSchedulesOneThenRepeatingThreeMinuteSupervisorBackoff(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	now := time.Now().UTC()
+	session := mustCreateScannerRuntimeSession(t, platform, domain.SignalRuntimeSession{
+		ID:         "runtime-supervisor-backoff",
+		AccountID:  "account-1",
+		StrategyID: "strategy-1",
+		Status:     "RUNNING",
+		State: map[string]any{
+			"desiredStatus": "RUNNING",
+			"actualStatus":  "RUNNING",
+		},
+		CreatedAt: now,
+		UpdatedAt: now,
+	})
+
+	platform.setSessionTerminalError(session.ID, context.DeadlineExceeded)
+	first, err := platform.GetSignalRuntimeSession(session.ID)
+	if err != nil {
+		t.Fatalf("reload first terminal error failed: %v", err)
+	}
+	if got := signalRuntimeSupervisorRestartAttempt(first.State); got != 1 {
+		t.Fatalf("expected first supervisor attempt 1, got %d", got)
+	}
+	firstNext, ok := parseSignalRuntimeSupervisorTime(first.State["nextAutoRestartAt"])
+	if !ok {
+		t.Fatalf("expected first nextAutoRestartAt")
+	}
+	if delta := time.Until(firstNext); delta < 55*time.Second || delta > 65*time.Second {
+		t.Fatalf("expected first backoff about 1m, got %s", delta)
+	}
+
+	platform.setSessionTerminalError(session.ID, context.DeadlineExceeded)
+	second, err := platform.GetSignalRuntimeSession(session.ID)
+	if err != nil {
+		t.Fatalf("reload second terminal error failed: %v", err)
+	}
+	if got := signalRuntimeSupervisorRestartAttempt(second.State); got != 2 {
+		t.Fatalf("expected second supervisor attempt 2, got %d", got)
+	}
+	secondNext, ok := parseSignalRuntimeSupervisorTime(second.State["nextAutoRestartAt"])
+	if !ok {
+		t.Fatalf("expected second nextAutoRestartAt")
+	}
+	if delta := time.Until(secondNext); delta < 175*time.Second || delta > 185*time.Second {
+		t.Fatalf("expected second backoff about 3m, got %s", delta)
+	}
+
+	platform.setSessionTerminalError(session.ID, context.DeadlineExceeded)
+	third, err := platform.GetSignalRuntimeSession(session.ID)
+	if err != nil {
+		t.Fatalf("reload third terminal error failed: %v", err)
+	}
+	if got := signalRuntimeSupervisorRestartAttempt(third.State); got != 3 {
+		t.Fatalf("expected third supervisor attempt 3, got %d", got)
+	}
+	thirdNext, ok := parseSignalRuntimeSupervisorTime(third.State["nextAutoRestartAt"])
+	if !ok {
+		t.Fatalf("expected third nextAutoRestartAt")
+	}
+	if delta := time.Until(thirdNext); delta < 175*time.Second || delta > 185*time.Second {
+		t.Fatalf("expected third backoff to keep repeating about 3m, got %s", delta)
 	}
 }
 

--- a/internal/service/signal_runtime_ws.go
+++ b/internal/service/signal_runtime_ws.go
@@ -429,11 +429,12 @@ func (p *Platform) setSessionRecovering(sessionID string, lastErr error, attempt
 
 func (p *Platform) setSessionTerminalError(sessionID string, err error) {
 	_ = p.updateSignalRuntimeSessionState(sessionID, func(session *domain.SignalRuntimeSession) {
+		now := time.Now().UTC()
 		session.Status = "ERROR"
 		state := cloneMetadata(session.State)
 		state["health"] = "error"
 		state["actualStatus"] = "ERROR"
-		state["lastEventAt"] = time.Now().UTC().Format(time.RFC3339)
+		state["lastEventAt"] = now.Format(time.RFC3339)
 		state["lastEventSummary"] = map[string]any{
 			"type":    "runtime_error",
 			"message": err.Error(),
@@ -443,12 +444,13 @@ func (p *Platform) setSessionTerminalError(sessionID string, err error) {
 		delete(state, "reconnectNextBackoff")
 		delete(state, "reconnectSeverity")
 		delete(state, "reconnectAttemptStartedAtMs")
+		scheduleSignalRuntimeSupervisorRestartAfterTerminalError(state, err, now)
 		appendSignalRuntimeError(state, err.Error())
-		appendSignalRuntimeTimeline(state, time.Now().UTC(), "runtime", "error", map[string]any{
+		appendSignalRuntimeTimeline(state, now, "runtime", "error", map[string]any{
 			"message": err.Error(),
 		})
 		session.State = state
-		session.UpdatedAt = time.Now().UTC()
+		session.UpdatedAt = now
 	})
 	p.clearTickEvalThrottleSession(sessionID)
 	p.clearRuntimeEventPublishThrottleSession(sessionID)
@@ -609,6 +611,7 @@ func (p *Platform) runExchangeWebsocketLoop(
 		delete(state, "reconnectNextBackoff")
 		delete(state, "reconnectSeverity")
 		delete(state, "reconnectAttemptStartedAtMs")
+		clearSignalRuntimeSupervisorRestartState(state)
 		appendSignalRuntimeTimeline(state, now, "runtime", "subscribed", map[string]any{
 			"subscriptionCount": len(subscriptions),
 			"subscriptions":     subscriptionSummary,
@@ -708,6 +711,16 @@ func (p *Platform) runExchangeWebsocketLoop(
 			})
 		}
 	}
+}
+
+func clearSignalRuntimeSupervisorRestartState(state map[string]any) {
+	delete(state, "supervisorRestartAttempt")
+	delete(state, "nextAutoRestartAt")
+	delete(state, "supervisorRestartBackoff")
+	delete(state, "supervisorRestartReason")
+	delete(state, "supervisorRestartSeverity")
+	delete(state, "lastSupervisorError")
+	delete(state, "autoRestartSuppressed")
 }
 
 // validateSignalBarContinuityAfterReconnect checks if a signal bar close was missed

--- a/internal/service/signal_runtime_ws_test.go
+++ b/internal/service/signal_runtime_ws_test.go
@@ -228,6 +228,13 @@ func TestRunExchangeWebsocketLoopRecordsReconnectObservability(t *testing.T) {
 			"reconnectAttempt":            2,
 			"reconnectAttemptStartedAtMs": now.Add(-1500 * time.Millisecond).UnixMilli(),
 			"lastDisconnectAt":            now.Add(-2 * time.Second).Format(time.RFC3339),
+			"supervisorRestartAttempt":    3,
+			"nextAutoRestartAt":           now.Add(time.Minute).Format(time.RFC3339),
+			"supervisorRestartBackoff":    "3m0s",
+			"supervisorRestartReason":     "runtime-error",
+			"supervisorRestartSeverity":   "transient",
+			"lastSupervisorError":         "previous websocket timeout",
+			"autoRestartSuppressed":       false,
 		},
 		CreatedAt: now,
 		UpdatedAt: now,
@@ -286,6 +293,19 @@ func TestRunExchangeWebsocketLoopRecordsReconnectObservability(t *testing.T) {
 	}
 	if stringValue(stored.State["reconnectAttemptStartedAtMs"]) != "" {
 		t.Fatalf("expected reconnect attempt marker to be cleared, got %#v", stored.State)
+	}
+	for _, key := range []string{
+		"supervisorRestartAttempt",
+		"nextAutoRestartAt",
+		"supervisorRestartBackoff",
+		"supervisorRestartReason",
+		"supervisorRestartSeverity",
+		"lastSupervisorError",
+		"autoRestartSuppressed",
+	} {
+		if _, exists := stored.State[key]; exists {
+			t.Fatalf("expected supervisor restart field %s to be cleared after websocket subscribe success, got %#v", key, stored.State[key])
+		}
 	}
 }
 


### PR DESCRIPTION
## 目的
修复 signal runtime 在 WebSocket 内部重连耗尽后进入 `ERROR`，scanner 因 `actualStatus=ERROR` 永久跳过，导致 `desiredStatus=RUNNING` 的运行时无法自动自愈的问题。

本 PR 将 runtime 的“期望运行”和“当前失败”语义拆开：只要 `desiredStatus=RUNNING`，scanner 会在 supervisor 级别按退避时间自动重启。退避策略为第一次 1 分钟，第二次及以后固定 3 分钟，直到恢复成功或人工 stop。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [x] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) - 未变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？- 不涉及
- [x] DB migration 是否具备向下兼容幂等性？- 不涉及 migration
- [x] 配置字段有没有无意被混改？- 未新增配置字段，仅复用 runtime state

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

验证命令：

```sh
go test ./internal/service -run 'TestSetSessionTerminalErrorSchedulesOneThenRepeatingThreeMinuteSupervisorBackoff|TestScanSignalRuntimeSessions'
go test ./internal/service
go build ./cmd/platform-api
go build ./cmd/db-migrate
```

补充：`go test ./...` 除现有未跟踪 `scratch/` 目录内多个临时 `main` 重名导致 `github.com/wuyaocheng/bktrader/scratch` build failed 外，其它包通过。
