### PR TITLE
feat(execution): enforce 60s cooldown for all reentry types and limit-maker fallback

### DIFF
--- a/AGENTS.local.md
+++ b/AGENTS.local.md
@@ -1,0 +1,29 @@
+## bktrader-ctl 使用
+
+- 查看当前 CLI 版本：`bktrader-ctl version --json`
+- 登录并缓存 token：`bktrader-ctl auth login --json`
+- 检查当前身份：`bktrader-ctl auth me --json`
+- 查看平台状态：`bktrader-ctl status --json`
+- 告警：`bktrader-ctl alert list --json`
+- 系统日志：`bktrader-ctl logs system --json --limit 100`
+- 业务事件日志：`bktrader-ctl logs event --json`
+- HTTP 请求日志：`bktrader-ctl logs http --json`
+- 实时日志流：`bktrader-ctl logs stream --source system`
+- 订单全链路追踪：`bktrader-ctl logs trace --json --order-id <orderId>`
+- 账户列表 / 摘要 / 权益：`bktrader-ctl account list --json`、`bktrader-ctl account summary --json`、`bktrader-ctl account equity --json`
+- 账户同步 / 对账：`bktrader-ctl account sync <accountId> --confirm`、`bktrader-ctl account reconcile <accountId> --confirm`
+- 实盘会话列表 / 详情：`bktrader-ctl live list --json`、`bktrader-ctl live get <sessionId> --json`
+- 实盘启停 / 同步 / 删除：`bktrader-ctl live start|stop|sync|delete <sessionId> --confirm`
+- 实盘手动派单：`bktrader-ctl live dispatch <sessionId> --confirm`
+- 订单列表 / 详情 / 总数：`bktrader-ctl order list --json`、`bktrader-ctl order get <orderId> --json`、`bktrader-ctl order count --json`
+- 订单取消 / 同步：`bktrader-ctl order cancel <orderId> --confirm`、`bktrader-ctl order sync <orderId>`
+- 成交流水：`bktrader-ctl fill list --json`
+- 持仓列表 / 平仓：`bktrader-ctl position list --json`、`bktrader-ctl position close <positionId> --confirm`
+- 策略列表 / 引擎：`bktrader-ctl strategy list --json`、`bktrader-ctl strategy engines --json`
+- 信号源：`bktrader-ctl signal list --json`、`bktrader-ctl signal types --json`
+- 图表数据：`bktrader-ctl chart candles --json`、`bktrader-ctl chart indicators --json`
+- 回测：`bktrader-ctl backtest list --json`、`bktrader-ctl backtest options --json`、`bktrader-ctl backtest run --confirm`
+- 通知：`bktrader-ctl notify list --json`
+- 手动检查并更新 CLI：`bktrader-ctl update --confirm`
+- 变更类命令先用 --dry-run 预览；真正执行必须带 `--confirm`。
+- 具体参数不确定时先跑：`bktrader-ctl <command> --help`。

--- a/internal/service/execution_strategy.go
+++ b/internal/service/execution_strategy.go
@@ -210,6 +210,7 @@ func (bookAwareExecutionStrategy) BuildProposal(ctx ExecutionPlanningContext) (E
 	proposal.Metadata["executionProfileTimeInForce"] = profile.TimeInForce
 	proposal.Metadata["executionProfilePostOnly"] = profile.PostOnly
 	proposal.Metadata["executionProfileReduceOnly"] = profile.ReduceOnly
+	proposal.Metadata["executionProfileMaxSpreadBps"] = maxSpreadBps
 	proposal.Metadata["executionProfileWideSpreadMode"] = profile.WideSpreadMode
 	proposal.Metadata["executionStrategy"] = proposal.ExecutionStrategy
 	proposal.Metadata["signalSignature"] = signalSignature
@@ -381,6 +382,8 @@ func applySLReentryMinDelay(ctx ExecutionPlanningContext, proposal ExecutionProp
 	proposal.Reason = "sl-reentry-delay"
 	proposal.Metadata = cloneMetadata(proposal.Metadata)
 	proposal.Metadata["executionDecision"] = "wait-sl-reentry-delay"
+	proposal.Metadata["reentryDelayReasonTag"] = reasonTag
+	proposal.Metadata["reentryDelaySource"] = "last-sl-exit-fill"
 	proposal.Metadata["slReentryMinDelaySeconds"] = delaySeconds
 	proposal.Metadata["slReentryDelayElapsedSeconds"] = math.Max(0, elapsed.Seconds())
 	proposal.Metadata["slReentryDelayRemainingSeconds"] = math.Ceil(remaining.Seconds())
@@ -648,10 +651,10 @@ func resolveExecutionProfile(parameters map[string]any, intent SignalIntent) exe
 	case role == "entry" && reasonTag == "zero-initial-reentry":
 		overrideExecutionProfile(&profile, parameters, "executionEntry")
 		overrideExecutionProfile(&profile, parameters, "executionZeroInitialReentry")
-		if profile.MaxSpreadBps <= 0 {
+		if parseFloatValue(parameters["executionZeroInitialReentryMaxSpreadBps"]) <= 0 {
 			profile.MaxSpreadBps = 3.0
 		}
-		if profile.WideSpreadMode == "" {
+		if strings.TrimSpace(stringValue(parameters["executionZeroInitialReentryWideSpreadMode"])) == "" {
 			profile.WideSpreadMode = "limit-maker"
 		}
 		if profile.TimeoutFallbackType == "" {

--- a/internal/service/execution_strategy.go
+++ b/internal/service/execution_strategy.go
@@ -350,7 +350,10 @@ func (bookAwareExecutionStrategy) BuildProposal(ctx ExecutionPlanningContext) (E
 }
 
 func applySLReentryMinDelay(ctx ExecutionPlanningContext, proposal ExecutionProposal, reasonTag string) ExecutionProposal {
-	if !strings.EqualFold(strings.TrimSpace(proposal.Role), "entry") || reasonTag != "sl-reentry" {
+	if !strings.EqualFold(strings.TrimSpace(proposal.Role), "entry") {
+		return proposal
+	}
+	if reasonTag != "sl-reentry" && reasonTag != "zero-initial-reentry" && reasonTag != "pt-reentry" {
 		return proposal
 	}
 	delaySeconds := maxIntValue(firstNonZeroAny(ctx.Execution.Parameters["sl_reentry_min_delay_seconds"], ctx.Session.State["sl_reentry_min_delay_seconds"]), 0)
@@ -635,6 +638,18 @@ func resolveExecutionProfile(parameters map[string]any, intent SignalIntent) exe
 		}
 		if !profile.PostOnly {
 			profile.PostOnly = true
+		}
+		if profile.WideSpreadMode == "" {
+			profile.WideSpreadMode = "limit-maker"
+		}
+		if profile.TimeoutFallbackType == "" {
+			profile.TimeoutFallbackType = "MARKET"
+		}
+	case role == "entry" && reasonTag == "zero-initial-reentry":
+		overrideExecutionProfile(&profile, parameters, "executionEntry")
+		overrideExecutionProfile(&profile, parameters, "executionZeroInitialReentry")
+		if profile.MaxSpreadBps <= 0 {
+			profile.MaxSpreadBps = 3.0
 		}
 		if profile.WideSpreadMode == "" {
 			profile.WideSpreadMode = "limit-maker"

--- a/internal/service/live_launch_flow_template_test.go
+++ b/internal/service/live_launch_flow_template_test.go
@@ -241,6 +241,9 @@ func TestLaunchLiveFlowEnhancedTemplateUsesEnhancedStrategyAndEngine(t *testing.
 	if got := parseFloatValue(result.LiveSession.State["t3_min_sma_atr_separation"]); got != 0.25 {
 		t.Fatalf("expected t3 sep_0p25, got %v", got)
 	}
+	if got := maxIntValue(result.LiveSession.State["sl_reentry_min_delay_seconds"], 0); got != 60 {
+		t.Fatalf("expected enhanced live session SL-Reentry delay 60s, got %d", got)
+	}
 
 	bindings, err := platform.ListStrategySignalBindings("strategy-bk-btc-30m-enhanced")
 	if err != nil {

--- a/internal/service/live_launch_templates_test.go
+++ b/internal/service/live_launch_templates_test.go
@@ -198,6 +198,9 @@ func TestLiveLaunchTemplatesExposeBinanceTestnetVariants(t *testing.T) {
 				if got := parseFloatValue(item.LaunchPayload.LiveSessionOverrides["t3_min_sma_atr_separation"]); got != 0.25 {
 					t.Fatalf("expected t3 sep 0.25, got %v", got)
 				}
+				if got := maxIntValue(item.LaunchPayload.LiveSessionOverrides["sl_reentry_min_delay_seconds"], 0); got != 60 {
+					t.Fatalf("expected enhanced template SL-Reentry delay 60s, got %d", got)
+				}
 				if !boolValue(item.LaunchPayload.LiveSessionOverrides["use_sma5_intraday_structure"]) {
 					t.Fatalf("expected enhanced template to use SMA5 intraday structure")
 				}

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -1979,8 +1979,8 @@ func TestBookAwareExecutionStrategyDelaysSLReentryAfterStopLossFill(t *testing.T
 	if err != nil {
 		t.Fatalf("unexpected zero-initial proposal error: %v", err)
 	}
-	if unaffected.Status != "dispatchable" {
-		t.Fatalf("expected zero-initial reentry to ignore SL delay, got %s", unaffected.Status)
+	if unaffected.Status != "waiting-sl-reentry-delay" {
+		t.Fatalf("expected zero-initial reentry to wait for SL delay, got %s", unaffected.Status)
 	}
 }
 

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -1959,6 +1959,9 @@ func TestBookAwareExecutionStrategyDelaysSLReentryAfterStopLossFill(t *testing.T
 	if got := stringValue(delayed.Metadata["executionDecision"]); got != "wait-sl-reentry-delay" {
 		t.Fatalf("expected delay execution decision, got %s", got)
 	}
+	if got := stringValue(delayed.Metadata["reentryDelayReasonTag"]); got != "sl-reentry" {
+		t.Fatalf("expected delay reason tag sl-reentry, got %s", got)
+	}
 	if got := parseFloatValue(delayed.Metadata["slReentryDelayRemainingSeconds"]); got != 49 {
 		t.Fatalf("expected 49 seconds remaining, got %v", got)
 	}
@@ -1981,6 +1984,27 @@ func TestBookAwareExecutionStrategyDelaysSLReentryAfterStopLossFill(t *testing.T
 	}
 	if unaffected.Status != "waiting-sl-reentry-delay" {
 		t.Fatalf("expected zero-initial reentry to wait for SL delay, got %s", unaffected.Status)
+	}
+
+	ctx.Intent.Reason = "PT-Reentry"
+	ctx.Intent.SignalKind = "pt-reentry"
+	ptDelayed, err := strategy.BuildProposal(ctx)
+	if err != nil {
+		t.Fatalf("unexpected PT reentry delayed proposal error: %v", err)
+	}
+	if ptDelayed.Status != "waiting-sl-reentry-delay" {
+		t.Fatalf("expected PT-Reentry to wait for SL delay, got %s", ptDelayed.Status)
+	}
+	if got := stringValue(ptDelayed.Metadata["reentryDelayReasonTag"]); got != "pt-reentry" {
+		t.Fatalf("expected delay reason tag pt-reentry, got %s", got)
+	}
+	ctx.EventTime = lastSLFill.Add(60 * time.Second)
+	ptReady, err := strategy.BuildProposal(ctx)
+	if err != nil {
+		t.Fatalf("unexpected PT reentry ready proposal error: %v", err)
+	}
+	if ptReady.Status != "dispatchable" {
+		t.Fatalf("expected PT-Reentry to dispatch after delay, got %s", ptReady.Status)
 	}
 }
 
@@ -2238,6 +2262,52 @@ func TestBookAwareExecutionStrategyUsesMakerLimitOnWideSpreadWhenConfigured(t *t
 	}
 	if got := stringValue(proposal.Metadata["executionExpiresAt"]); got != eventTime.Add(45*time.Second).Format(time.RFC3339) {
 		t.Fatalf("expected execution expiry to be set, got %s", got)
+	}
+}
+
+func TestBookAwareExecutionStrategyUsesTightZeroInitialReentryMakerFallback(t *testing.T) {
+	strategy := bookAwareExecutionStrategy{}
+	proposal, err := strategy.BuildProposal(ExecutionPlanningContext{
+		Session: domain.LiveSession{},
+		Execution: StrategyExecutionContext{
+			Parameters: map[string]any{
+				"executionEntryMaxSpreadBps":   8.0,
+				"executionEntryWideSpreadMode": "limit-maker",
+			},
+		},
+		Intent: SignalIntent{
+			Action:      "entry",
+			Role:        "entry",
+			Reason:      "Zero-Initial-Reentry",
+			Side:        "BUY",
+			Symbol:      "BTCUSDT",
+			PriceHint:   68000,
+			PriceSource: "trade_tick.price",
+			Metadata: map[string]any{
+				"bestBid":           67999.0,
+				"bestAsk":           68005.0,
+				"spreadBps":         4.0,
+				"signalBarStateKey": "state-zero-initial",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if proposal.Status != "dispatchable" {
+		t.Fatalf("expected dispatchable maker proposal, got %s", proposal.Status)
+	}
+	if proposal.Type != "LIMIT" || proposal.TimeInForce != "GTX" || !proposal.PostOnly {
+		t.Fatalf("expected LIMIT GTX post-only proposal, got type=%s tif=%s postOnly=%v", proposal.Type, proposal.TimeInForce, proposal.PostOnly)
+	}
+	if proposal.LimitPrice != 67999.0 {
+		t.Fatalf("expected passive bid limit price, got %v", proposal.LimitPrice)
+	}
+	if got := stringValue(proposal.Metadata["executionDecision"]); got != "maker-resting" {
+		t.Fatalf("expected maker-resting decision, got %s", got)
+	}
+	if got := parseFloatValue(proposal.Metadata["executionProfileMaxSpreadBps"]); got != 3.0 {
+		t.Fatalf("expected zero-initial max spread default 3bps, got %v", got)
 	}
 }
 

--- a/research/20260428_eth_q1_30min_sl_reentry_filters.md
+++ b/research/20260428_eth_q1_30min_sl_reentry_filters.md
@@ -1,0 +1,53 @@
+# ETH Q1 2026 30min SL-Reentry Filters, 1s Replay
+
+Scope: research-only backtest work. No live or execution path was changed.
+
+## Setup
+
+- Symbol/window: `ETHUSDT`, `2026-01-01 00:00:00+00:00` to `2026-03-31 23:59:59+00:00`
+- Execution bars: continuous `1s` bars rebuilt from raw Binance trades
+- Signal timeframe: `30min`
+- Replay mode: `live_intrabar_sma5` with `baseline_plus_t3` breakout shape
+- Sizing baseline includes PR #261 semantics: `Zero-Initial-Reentry=20%`, `SL-Reentry=10%` when schedule is `[0.20, 0.10]`.
+
+## Results
+
+| Variant | Final Balance | Return | Max DD | Trades | Win Rate | Sharpe | SL-Reentry | <=10s | <=30s | <=60s | SL-Reentry -> SL | Avg SL-Reentry PnL |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| `baseline_sl_slot2` | 409,088.73 | 309.09% | -2.93% | 6077 | 65.94% | 10.96 | 5551 | 2943 | 3032 | 3097 | 100.00% | 82.30 |
+| `close_confirm` | 27,418.26 | -72.58% | -72.58% | 6475 | 7.38% | -1.93 | 5977 | 3162 | 3193 | 3228 | 100.00% | -4.41 |
+| `close_confirm_buffer_0p02atr` | 27,376.57 | -72.62% | -72.62% | 6473 | 7.35% | -1.95 | 5975 | 3159 | 3194 | 3230 | 100.00% | -4.42 |
+| `delay_10s` | 414,838.08 | 314.84% | -2.96% | 6066 | 66.27% | 10.96 | 5536 | 2787 | 2957 | 3041 | 100.00% | 83.49 |
+| `delay_20s` | 417,185.42 | 317.19% | -2.95% | 6049 | 66.57% | 11.00 | 5521 | 0 | 2889 | 2993 | 100.00% | 84.15 |
+| `delay_30s` | 417,396.17 | 317.40% | -2.83% | 6029 | 66.63% | 11.01 | 5501 | 0 | 2788 | 2944 | 100.00% | 84.31 |
+| `delay_60s` | 434,869.12 | 334.87% | -2.75% | 5987 | 67.18% | 11.07 | 5450 | 0 | 0 | 2762 | 100.00% | 88.27 |
+| `cooldown_1bar` | 215,122.78 | 115.12% | -1.69% | 3191 | 65.50% | 10.87 | 2643 | 4 | 5 | 15 | 100.00% | 48.73 |
+| `close_confirm_delay_10s` | 27,672.28 | -72.33% | -72.32% | 6456 | 7.42% | -1.89 | 5957 | 2925 | 3068 | 3138 | 100.00% | -4.45 |
+| `close_confirm_delay_30s` | 27,805.53 | -72.19% | -72.19% | 6423 | 7.43% | -1.94 | 5924 | 0 | 2839 | 3012 | 100.00% | -4.50 |
+
+## Delta vs Baseline
+
+| Variant | Final Balance Delta | Return Delta | Max DD Delta | Trades Delta | Win Rate Delta | Sharpe Delta | SL-Reentry Delta |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| `close_confirm` | -381,670.47 | -381.67 pp | -69.65 pp | 398 | -58.56 pp | -12.89 | 426 |
+| `close_confirm_buffer_0p02atr` | -381,712.16 | -381.71 pp | -69.69 pp | 396 | -58.59 pp | -12.91 | 424 |
+| `delay_10s` | 5,749.35 | 5.75 pp | -0.03 pp | -11 | 0.33 pp | 0.00 | -15 |
+| `delay_20s` | 8,096.69 | 8.10 pp | -0.02 pp | -28 | 0.63 pp | 0.04 | -30 |
+| `delay_30s` | 8,307.44 | 8.31 pp | 0.10 pp | -48 | 0.69 pp | 0.05 | -50 |
+| `delay_60s` | 25,780.39 | 25.78 pp | 0.18 pp | -90 | 1.24 pp | 0.11 | -101 |
+| `cooldown_1bar` | -193,965.95 | -193.97 pp | 1.24 pp | -2886 | -0.44 pp | -0.09 | -2908 |
+| `close_confirm_delay_10s` | -381,416.45 | -381.42 pp | -69.39 pp | 379 | -58.52 pp | -12.85 | 406 |
+| `close_confirm_delay_30s` | -381,283.20 | -381.28 pp | -69.26 pp | 346 | -58.51 pp | -12.90 | 373 |
+
+## Variants
+
+- `baseline_sl_slot2`: PR #261 sizing semantics only: SL-Reentry starts at schedule slot 2.
+- `close_confirm`: SL-Reentry requires reclaim by current 1s close.
+- `close_confirm_buffer_0p02atr`: SL-Reentry requires current 1s close reclaim with 0.02 ATR buffer.
+- `delay_10s`: SL-Reentry and Zero-Initial-Reentry wait at least 10s after the SL exit.
+- `delay_20s`: SL-Reentry and Zero-Initial-Reentry wait at least 20s after the SL exit.
+- `delay_30s`: SL-Reentry and Zero-Initial-Reentry wait at least 30s after the SL exit.
+- `delay_60s`: SL-Reentry and Zero-Initial-Reentry wait at least 60s after the SL exit.
+- `cooldown_1bar`: SL-Reentry waits until the next signal bar after an SL exit.
+- `close_confirm_delay_10s`: SL-Reentry requires current 1s close reclaim and at least 10s delay.
+- `close_confirm_delay_30s`: SL-Reentry requires current 1s close reclaim and at least 30s delay.

--- a/research/eth_2026_q1_30min_sl_reentry_filters_summary.json
+++ b/research/eth_2026_q1_30min_sl_reentry_filters_summary.json
@@ -1,0 +1,679 @@
+{
+  "window": {
+    "start": "2026-01-01T00:00:00+00:00",
+    "end": "2026-03-31T23:59:59+00:00"
+  },
+  "timeframe": "30min",
+  "replay_mode": "live_intrabar_sma5",
+  "breakout_shape": "baseline_plus_t3",
+  "common_params": {
+    "dir2_zero_initial": true,
+    "zero_initial_mode": "reentry_window",
+    "fixed_slippage": 0.0005,
+    "stop_loss_atr": 0.05,
+    "stop_mode": "atr",
+    "max_trades_per_bar": 2,
+    "reentry_size_schedule": [
+      0.2,
+      0.1
+    ],
+    "long_reentry_atr": 0.1,
+    "short_reentry_atr": 0.0,
+    "profit_protect_atr": 1.0,
+    "trailing_stop_atr": 0.3,
+    "delayed_trailing_activation": 0.5,
+    "reentry_anchor_levels": "wick",
+    "reentry_trigger_mode": "reclaim"
+  },
+  "build_stats": {
+    "raw_tick_rows": 748747244,
+    "kept_tick_rows": 748747172,
+    "sparse_second_rows": 7596268,
+    "continuous_second_rows": 7776000,
+    "first_second": "2026-01-01T00:00:00+00:00",
+    "last_second": "2026-03-31T23:59:59+00:00"
+  },
+  "signal_stats": {
+    "signal_rows": 4320,
+    "signal_start": "2026-01-01T00:00:00+00:00",
+    "signal_end": "2026-03-31T23:30:00+00:00",
+    "valid_sma5_rows": 4316,
+    "valid_atr_rows": 4307
+  },
+  "results": [
+    {
+      "variant": "baseline_sl_slot2",
+      "description": "PR #261 sizing semantics only: SL-Reentry starts at schedule slot 2.",
+      "params": {
+        "name": "baseline_sl_slot2",
+        "description": "PR #261 sizing semantics only: SL-Reentry starts at schedule slot 2."
+      },
+      "summary": {
+        "final_balance": 409088.73,
+        "return_pct": 309.09,
+        "max_dd_pct": -2.93,
+        "trades": 6077,
+        "win_rate_pct": 65.94,
+        "sharpe": 10.96,
+        "first_entry": "2026-01-01T10:22:41+00:00",
+        "last_exit": "2026-03-31T23:10:28+00:00",
+        "entry_reasons": {
+          "SL-Reentry": 5551,
+          "Zero-Initial-Reentry": 526
+        },
+        "exit_reasons": {
+          "SL": 6077
+        },
+        "entry_types": {
+          "BUY": 3041,
+          "SHORT": 3036
+        },
+        "integrity": {
+          "rows": 12154,
+          "entries": 6077,
+          "exits": 6077,
+          "zero_notional_entries": 0
+        }
+      },
+      "sl_reentry_diagnostics": {
+        "sl_reentry_count": 5551,
+        "fast_reentry_le_10s": 2943,
+        "fast_reentry_le_30s": 3032,
+        "fast_reentry_le_60s": 3097,
+        "sl_reentry_exit_sl_rate_pct": 100.0,
+        "sl_reentry_avg_pnl": 82.3
+      },
+      "diagnostics": {
+        "breakout_locks": {
+          "long": {
+            "original_t2": 189,
+            "t3_swing": 79
+          },
+          "short": {
+            "original_t2": 228,
+            "t3_swing": 61
+          }
+        },
+        "variant": {
+          "name": "baseline_sl_slot2",
+          "description": "PR #261 sizing semantics only: SL-Reentry starts at schedule slot 2."
+        }
+      },
+      "ledger_path": "research/tmp_eth_2026_q1_30min_1s_sl_reentry_baseline_sl_slot2_ledger.csv",
+      "elapsed_seconds": 176.0
+    },
+    {
+      "variant": "close_confirm",
+      "description": "SL-Reentry requires reclaim by current 1s close.",
+      "params": {
+        "name": "close_confirm",
+        "description": "SL-Reentry requires reclaim by current 1s close.",
+        "confirm": "close"
+      },
+      "summary": {
+        "final_balance": 27418.26,
+        "return_pct": -72.58,
+        "max_dd_pct": -72.58,
+        "trades": 6475,
+        "win_rate_pct": 7.38,
+        "sharpe": -1.93,
+        "first_entry": "2026-01-01T10:22:41+00:00",
+        "last_exit": "2026-03-31T23:00:03+00:00",
+        "entry_reasons": {
+          "SL-Reentry": 5977,
+          "Zero-Initial-Reentry": 498
+        },
+        "exit_reasons": {
+          "SL": 6475
+        },
+        "entry_types": {
+          "BUY": 3394,
+          "SHORT": 3081
+        },
+        "integrity": {
+          "rows": 12950,
+          "entries": 6475,
+          "exits": 6475,
+          "zero_notional_entries": 0
+        }
+      },
+      "sl_reentry_diagnostics": {
+        "sl_reentry_count": 5977,
+        "fast_reentry_le_10s": 3162,
+        "fast_reentry_le_30s": 3193,
+        "fast_reentry_le_60s": 3228,
+        "sl_reentry_exit_sl_rate_pct": 100.0,
+        "sl_reentry_avg_pnl": -4.41
+      },
+      "diagnostics": {
+        "breakout_locks": {
+          "long": {
+            "original_t2": 172,
+            "t3_swing": 73
+          },
+          "short": {
+            "original_t2": 196,
+            "t3_swing": 58
+          }
+        },
+        "variant": {
+          "name": "close_confirm",
+          "description": "SL-Reentry requires reclaim by current 1s close.",
+          "confirm": "close"
+        }
+      },
+      "ledger_path": "research/tmp_eth_2026_q1_30min_1s_sl_reentry_close_confirm_ledger.csv",
+      "elapsed_seconds": 246.0
+    },
+    {
+      "variant": "close_confirm_buffer_0p02atr",
+      "description": "SL-Reentry requires current 1s close reclaim with 0.02 ATR buffer.",
+      "params": {
+        "name": "close_confirm_buffer_0p02atr",
+        "description": "SL-Reentry requires current 1s close reclaim with 0.02 ATR buffer.",
+        "confirm": "close",
+        "buffer_atr": 0.02
+      },
+      "summary": {
+        "final_balance": 27376.57,
+        "return_pct": -72.62,
+        "max_dd_pct": -72.62,
+        "trades": 6473,
+        "win_rate_pct": 7.35,
+        "sharpe": -1.95,
+        "first_entry": "2026-01-01T10:22:41+00:00",
+        "last_exit": "2026-03-31T23:00:03+00:00",
+        "entry_reasons": {
+          "SL-Reentry": 5975,
+          "Zero-Initial-Reentry": 498
+        },
+        "exit_reasons": {
+          "SL": 6473
+        },
+        "entry_types": {
+          "BUY": 3366,
+          "SHORT": 3107
+        },
+        "integrity": {
+          "rows": 12946,
+          "entries": 6473,
+          "exits": 6473,
+          "zero_notional_entries": 0
+        }
+      },
+      "sl_reentry_diagnostics": {
+        "sl_reentry_count": 5975,
+        "fast_reentry_le_10s": 3159,
+        "fast_reentry_le_30s": 3194,
+        "fast_reentry_le_60s": 3230,
+        "sl_reentry_exit_sl_rate_pct": 100.0,
+        "sl_reentry_avg_pnl": -4.42
+      },
+      "diagnostics": {
+        "breakout_locks": {
+          "long": {
+            "original_t2": 173,
+            "t3_swing": 72
+          },
+          "short": {
+            "original_t2": 196,
+            "t3_swing": 58
+          }
+        },
+        "variant": {
+          "name": "close_confirm_buffer_0p02atr",
+          "description": "SL-Reentry requires current 1s close reclaim with 0.02 ATR buffer.",
+          "confirm": "close",
+          "buffer_atr": 0.02
+        }
+      },
+      "ledger_path": "research/tmp_eth_2026_q1_30min_1s_sl_reentry_close_confirm_buffer_0p02atr_ledger.csv",
+      "elapsed_seconds": 248.39
+    },
+    {
+      "variant": "delay_10s",
+      "description": "SL-Reentry and Zero-Initial-Reentry wait at least 10s after the SL exit.",
+      "params": {
+        "name": "delay_10s",
+        "description": "SL-Reentry and Zero-Initial-Reentry wait at least 10s after the SL exit.",
+        "delay_seconds": 10
+      },
+      "summary": {
+        "final_balance": 414838.08,
+        "return_pct": 314.84,
+        "max_dd_pct": -2.96,
+        "trades": 6066,
+        "win_rate_pct": 66.27,
+        "sharpe": 10.96,
+        "first_entry": "2026-01-01T10:22:41+00:00",
+        "last_exit": "2026-03-31T23:10:28+00:00",
+        "entry_reasons": {
+          "SL-Reentry": 5536,
+          "Zero-Initial-Reentry": 530
+        },
+        "exit_reasons": {
+          "SL": 6066
+        },
+        "entry_types": {
+          "SHORT": 3050,
+          "BUY": 3016
+        },
+        "integrity": {
+          "rows": 12132,
+          "entries": 6066,
+          "exits": 6066,
+          "zero_notional_entries": 0
+        }
+      },
+      "sl_reentry_diagnostics": {
+        "sl_reentry_count": 5536,
+        "fast_reentry_le_10s": 2787,
+        "fast_reentry_le_30s": 2957,
+        "fast_reentry_le_60s": 3041,
+        "sl_reentry_exit_sl_rate_pct": 100.0,
+        "sl_reentry_avg_pnl": 83.49
+      },
+      "diagnostics": {
+        "breakout_locks": {
+          "long": {
+            "original_t2": 190,
+            "t3_swing": 79
+          },
+          "short": {
+            "original_t2": 231,
+            "t3_swing": 63
+          }
+        },
+        "variant": {
+          "name": "delay_10s",
+          "description": "SL-Reentry and Zero-Initial-Reentry wait at least 10s after the SL exit.",
+          "delay_seconds": 10
+        }
+      },
+      "ledger_path": "research/tmp_eth_2026_q1_30min_1s_sl_reentry_delay_10s_ledger.csv",
+      "elapsed_seconds": 228.31
+    },
+    {
+      "variant": "delay_20s",
+      "description": "SL-Reentry and Zero-Initial-Reentry wait at least 20s after the SL exit.",
+      "params": {
+        "name": "delay_20s",
+        "description": "SL-Reentry and Zero-Initial-Reentry wait at least 20s after the SL exit.",
+        "delay_seconds": 20
+      },
+      "summary": {
+        "final_balance": 417185.42,
+        "return_pct": 317.19,
+        "max_dd_pct": -2.95,
+        "trades": 6049,
+        "win_rate_pct": 66.57,
+        "sharpe": 11.0,
+        "first_entry": "2026-01-01T10:22:41+00:00",
+        "last_exit": "2026-03-31T23:17:36+00:00",
+        "entry_reasons": {
+          "SL-Reentry": 5521,
+          "Zero-Initial-Reentry": 528
+        },
+        "exit_reasons": {
+          "SL": 6049
+        },
+        "entry_types": {
+          "SHORT": 3050,
+          "BUY": 2999
+        },
+        "integrity": {
+          "rows": 12098,
+          "entries": 6049,
+          "exits": 6049,
+          "zero_notional_entries": 0
+        }
+      },
+      "sl_reentry_diagnostics": {
+        "sl_reentry_count": 5521,
+        "fast_reentry_le_10s": 0,
+        "fast_reentry_le_30s": 2889,
+        "fast_reentry_le_60s": 2993,
+        "sl_reentry_exit_sl_rate_pct": 100.0,
+        "sl_reentry_avg_pnl": 84.15
+      },
+      "diagnostics": {
+        "breakout_locks": {
+          "long": {
+            "original_t2": 191,
+            "t3_swing": 80
+          },
+          "short": {
+            "original_t2": 231,
+            "t3_swing": 63
+          }
+        },
+        "variant": {
+          "name": "delay_20s",
+          "description": "SL-Reentry and Zero-Initial-Reentry wait at least 20s after the SL exit.",
+          "delay_seconds": 20
+        }
+      },
+      "ledger_path": "research/tmp_eth_2026_q1_30min_1s_sl_reentry_delay_20s_ledger.csv",
+      "elapsed_seconds": 223.64
+    },
+    {
+      "variant": "delay_30s",
+      "description": "SL-Reentry and Zero-Initial-Reentry wait at least 30s after the SL exit.",
+      "params": {
+        "name": "delay_30s",
+        "description": "SL-Reentry and Zero-Initial-Reentry wait at least 30s after the SL exit.",
+        "delay_seconds": 30
+      },
+      "summary": {
+        "final_balance": 417396.17,
+        "return_pct": 317.4,
+        "max_dd_pct": -2.83,
+        "trades": 6029,
+        "win_rate_pct": 66.63,
+        "sharpe": 11.01,
+        "first_entry": "2026-01-01T10:22:41+00:00",
+        "last_exit": "2026-03-31T23:17:36+00:00",
+        "entry_reasons": {
+          "SL-Reentry": 5501,
+          "Zero-Initial-Reentry": 528
+        },
+        "exit_reasons": {
+          "SL": 6029
+        },
+        "entry_types": {
+          "SHORT": 3045,
+          "BUY": 2984
+        },
+        "integrity": {
+          "rows": 12058,
+          "entries": 6029,
+          "exits": 6029,
+          "zero_notional_entries": 0
+        }
+      },
+      "sl_reentry_diagnostics": {
+        "sl_reentry_count": 5501,
+        "fast_reentry_le_10s": 0,
+        "fast_reentry_le_30s": 2788,
+        "fast_reentry_le_60s": 2944,
+        "sl_reentry_exit_sl_rate_pct": 100.0,
+        "sl_reentry_avg_pnl": 84.31
+      },
+      "diagnostics": {
+        "breakout_locks": {
+          "long": {
+            "original_t2": 191,
+            "t3_swing": 81
+          },
+          "short": {
+            "original_t2": 231,
+            "t3_swing": 63
+          }
+        },
+        "variant": {
+          "name": "delay_30s",
+          "description": "SL-Reentry and Zero-Initial-Reentry wait at least 30s after the SL exit.",
+          "delay_seconds": 30
+        }
+      },
+      "ledger_path": "research/tmp_eth_2026_q1_30min_1s_sl_reentry_delay_30s_ledger.csv",
+      "elapsed_seconds": 223.48
+    },
+    {
+      "variant": "delay_60s",
+      "description": "SL-Reentry and Zero-Initial-Reentry wait at least 60s after the SL exit.",
+      "params": {
+        "name": "delay_60s",
+        "description": "SL-Reentry and Zero-Initial-Reentry wait at least 60s after the SL exit.",
+        "delay_seconds": 60
+      },
+      "summary": {
+        "final_balance": 434869.12,
+        "return_pct": 334.87,
+        "max_dd_pct": -2.75,
+        "trades": 5987,
+        "win_rate_pct": 67.18,
+        "sharpe": 11.07,
+        "first_entry": "2026-01-01T10:22:41+00:00",
+        "last_exit": "2026-03-31T23:17:36+00:00",
+        "entry_reasons": {
+          "SL-Reentry": 5450,
+          "Zero-Initial-Reentry": 537
+        },
+        "exit_reasons": {
+          "SL": 5987
+        },
+        "entry_types": {
+          "SHORT": 3033,
+          "BUY": 2954
+        },
+        "integrity": {
+          "rows": 11974,
+          "entries": 5987,
+          "exits": 5987,
+          "zero_notional_entries": 0
+        }
+      },
+      "sl_reentry_diagnostics": {
+        "sl_reentry_count": 5450,
+        "fast_reentry_le_10s": 0,
+        "fast_reentry_le_30s": 0,
+        "fast_reentry_le_60s": 2762,
+        "sl_reentry_exit_sl_rate_pct": 100.0,
+        "sl_reentry_avg_pnl": 88.27
+      },
+      "diagnostics": {
+        "breakout_locks": {
+          "long": {
+            "original_t2": 198,
+            "t3_swing": 83
+          },
+          "short": {
+            "original_t2": 234,
+            "t3_swing": 64
+          }
+        },
+        "variant": {
+          "name": "delay_60s",
+          "description": "SL-Reentry and Zero-Initial-Reentry wait at least 60s after the SL exit.",
+          "delay_seconds": 60
+        }
+      },
+      "ledger_path": "research/tmp_eth_2026_q1_30min_1s_sl_reentry_delay_60s_ledger.csv",
+      "elapsed_seconds": 223.48
+    },
+    {
+      "variant": "cooldown_1bar",
+      "description": "SL-Reentry waits until the next signal bar after an SL exit.",
+      "params": {
+        "name": "cooldown_1bar",
+        "description": "SL-Reentry waits until the next signal bar after an SL exit.",
+        "cooldown_bars": 1
+      },
+      "summary": {
+        "final_balance": 215122.78,
+        "return_pct": 115.12,
+        "max_dd_pct": -1.69,
+        "trades": 3191,
+        "win_rate_pct": 65.5,
+        "sharpe": 10.87,
+        "first_entry": "2026-01-01T10:22:41+00:00",
+        "last_exit": "2026-03-31T23:09:24+00:00",
+        "entry_reasons": {
+          "SL-Reentry": 2643,
+          "Zero-Initial-Reentry": 548
+        },
+        "exit_reasons": {
+          "SL": 3191
+        },
+        "entry_types": {
+          "BUY": 1628,
+          "SHORT": 1563
+        },
+        "integrity": {
+          "rows": 6382,
+          "entries": 3191,
+          "exits": 3191,
+          "zero_notional_entries": 0
+        }
+      },
+      "sl_reentry_diagnostics": {
+        "sl_reentry_count": 2643,
+        "fast_reentry_le_10s": 4,
+        "fast_reentry_le_30s": 5,
+        "fast_reentry_le_60s": 15,
+        "sl_reentry_exit_sl_rate_pct": 100.0,
+        "sl_reentry_avg_pnl": 48.73
+      },
+      "diagnostics": {
+        "breakout_locks": {
+          "long": {
+            "original_t2": 190,
+            "t3_swing": 80
+          },
+          "short": {
+            "original_t2": 218,
+            "t3_swing": 61
+          }
+        },
+        "variant": {
+          "name": "cooldown_1bar",
+          "description": "SL-Reentry waits until the next signal bar after an SL exit.",
+          "cooldown_bars": 1
+        }
+      },
+      "ledger_path": "research/tmp_eth_2026_q1_30min_1s_sl_reentry_cooldown_1bar_ledger.csv",
+      "elapsed_seconds": 216.05
+    },
+    {
+      "variant": "close_confirm_delay_10s",
+      "description": "SL-Reentry requires current 1s close reclaim and at least 10s delay.",
+      "params": {
+        "name": "close_confirm_delay_10s",
+        "description": "SL-Reentry requires current 1s close reclaim and at least 10s delay.",
+        "confirm": "close",
+        "delay_seconds": 10
+      },
+      "summary": {
+        "final_balance": 27672.28,
+        "return_pct": -72.33,
+        "max_dd_pct": -72.32,
+        "trades": 6456,
+        "win_rate_pct": 7.42,
+        "sharpe": -1.89,
+        "first_entry": "2026-01-01T10:22:41+00:00",
+        "last_exit": "2026-03-31T23:00:12+00:00",
+        "entry_reasons": {
+          "SL-Reentry": 5957,
+          "Zero-Initial-Reentry": 499
+        },
+        "exit_reasons": {
+          "SL": 6456
+        },
+        "entry_types": {
+          "BUY": 3386,
+          "SHORT": 3070
+        },
+        "integrity": {
+          "rows": 12912,
+          "entries": 6456,
+          "exits": 6456,
+          "zero_notional_entries": 0
+        }
+      },
+      "sl_reentry_diagnostics": {
+        "sl_reentry_count": 5957,
+        "fast_reentry_le_10s": 2925,
+        "fast_reentry_le_30s": 3068,
+        "fast_reentry_le_60s": 3138,
+        "sl_reentry_exit_sl_rate_pct": 100.0,
+        "sl_reentry_avg_pnl": -4.45
+      },
+      "diagnostics": {
+        "breakout_locks": {
+          "long": {
+            "original_t2": 173,
+            "t3_swing": 73
+          },
+          "short": {
+            "original_t2": 196,
+            "t3_swing": 58
+          }
+        },
+        "variant": {
+          "name": "close_confirm_delay_10s",
+          "description": "SL-Reentry requires current 1s close reclaim and at least 10s delay.",
+          "confirm": "close",
+          "delay_seconds": 10
+        }
+      },
+      "ledger_path": "research/tmp_eth_2026_q1_30min_1s_sl_reentry_close_confirm_delay_10s_ledger.csv",
+      "elapsed_seconds": 239.0
+    },
+    {
+      "variant": "close_confirm_delay_30s",
+      "description": "SL-Reentry requires current 1s close reclaim and at least 30s delay.",
+      "params": {
+        "name": "close_confirm_delay_30s",
+        "description": "SL-Reentry requires current 1s close reclaim and at least 30s delay.",
+        "confirm": "close",
+        "delay_seconds": 30
+      },
+      "summary": {
+        "final_balance": 27805.53,
+        "return_pct": -72.19,
+        "max_dd_pct": -72.19,
+        "trades": 6423,
+        "win_rate_pct": 7.43,
+        "sharpe": -1.94,
+        "first_entry": "2026-01-01T10:22:41+00:00",
+        "last_exit": "2026-03-31T23:00:32+00:00",
+        "entry_reasons": {
+          "SL-Reentry": 5924,
+          "Zero-Initial-Reentry": 499
+        },
+        "exit_reasons": {
+          "SL": 6423
+        },
+        "entry_types": {
+          "BUY": 3359,
+          "SHORT": 3064
+        },
+        "integrity": {
+          "rows": 12846,
+          "entries": 6423,
+          "exits": 6423,
+          "zero_notional_entries": 0
+        }
+      },
+      "sl_reentry_diagnostics": {
+        "sl_reentry_count": 5924,
+        "fast_reentry_le_10s": 0,
+        "fast_reentry_le_30s": 2839,
+        "fast_reentry_le_60s": 3012,
+        "sl_reentry_exit_sl_rate_pct": 100.0,
+        "sl_reentry_avg_pnl": -4.5
+      },
+      "diagnostics": {
+        "breakout_locks": {
+          "long": {
+            "original_t2": 173,
+            "t3_swing": 73
+          },
+          "short": {
+            "original_t2": 197,
+            "t3_swing": 57
+          }
+        },
+        "variant": {
+          "name": "close_confirm_delay_30s",
+          "description": "SL-Reentry requires current 1s close reclaim and at least 30s delay.",
+          "confirm": "close",
+          "delay_seconds": 30
+        }
+      },
+      "ledger_path": "research/tmp_eth_2026_q1_30min_1s_sl_reentry_close_confirm_delay_30s_ledger.csv",
+      "elapsed_seconds": 239.21
+    }
+  ]
+}

--- a/research/eth_30min_sl_reentry_filters.py
+++ b/research/eth_30min_sl_reentry_filters.py
@@ -1,0 +1,644 @@
+#!/usr/bin/env python3
+"""ETH Q1 2026 30min 1s replay for SL-Reentry filters.
+
+Research-only script. It does not touch live/execution code paths.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from backTest import (
+    _compute_backtest_stats,
+    _get_reentry_window_real_order_size,
+    _resolve_reentry_price,
+    _resolve_regime_ready,
+)
+from eth_q1_breakout_t3_shape_compare import (
+    COMMON_REPLAY_KWARGS,
+    DEFAULT_TICK_FILES,
+    _as_utc_timestamp,
+    _intrabar_signal,
+    _long_breakout,
+    _open_position,
+    _short_breakout,
+    build_continuous_second_bars,
+    build_signal_frame,
+    summarize_run,
+)
+
+
+VARIANTS = [
+    {
+        "name": "baseline_sl_slot2",
+        "description": "PR #261 sizing semantics only: SL-Reentry starts at schedule slot 2.",
+    },
+    {
+        "name": "close_confirm",
+        "description": "SL-Reentry requires reclaim by current 1s close.",
+        "confirm": "close",
+    },
+    {
+        "name": "close_confirm_buffer_0p02atr",
+        "description": "SL-Reentry requires current 1s close reclaim with 0.02 ATR buffer.",
+        "confirm": "close",
+        "buffer_atr": 0.02,
+    },
+    {
+        "name": "delay_10s",
+        "description": "SL-Reentry and Zero-Initial-Reentry wait at least 10s after the SL exit.",
+        "delay_seconds": 10,
+    },
+    {
+        "name": "delay_20s",
+        "description": "SL-Reentry and Zero-Initial-Reentry wait at least 20s after the SL exit.",
+        "delay_seconds": 20,
+    },
+    {
+        "name": "delay_30s",
+        "description": "SL-Reentry and Zero-Initial-Reentry wait at least 30s after the SL exit.",
+        "delay_seconds": 30,
+    },
+    {
+        "name": "delay_60s",
+        "description": "SL-Reentry and Zero-Initial-Reentry wait at least 60s after the SL exit.",
+        "delay_seconds": 60,
+    },
+    {
+        "name": "cooldown_1bar",
+        "description": "SL-Reentry waits until the next signal bar after an SL exit.",
+        "cooldown_bars": 1,
+    },
+    {
+        "name": "close_confirm_delay_10s",
+        "description": "SL-Reentry requires current 1s close reclaim and at least 10s delay.",
+        "confirm": "close",
+        "delay_seconds": 10,
+    },
+    {
+        "name": "close_confirm_delay_30s",
+        "description": "SL-Reentry requires current 1s close reclaim and at least 30s delay.",
+        "confirm": "close",
+        "delay_seconds": 30,
+    },
+]
+
+
+def _sl_reentry_triggered(side: str, price: float, close_value: float, reentry_price: float, atr: float, variant: dict):
+    buffer_value = float(variant.get("buffer_atr", 0.0) or 0.0) * float(atr)
+    if str(variant.get("confirm", "")).lower() == "close":
+        if side == "long":
+            trigger = reentry_price + buffer_value
+            return close_value >= trigger, close_value
+        trigger = reentry_price - buffer_value
+        return close_value <= trigger, close_value
+    if side == "long":
+        return price >= reentry_price, reentry_price
+    return price <= reentry_price, reentry_price
+
+
+def _zero_initial_triggered(side: str, high_value: float, low_value: float, reentry_price: float):
+    if side == "long":
+        return high_value >= reentry_price, reentry_price
+    return low_value <= reentry_price, reentry_price
+
+
+def _reentry_notional_share(reason: str, trades_in_bar: int, schedule: list[float]) -> float:
+    if reason == "SL-Reentry" and len(schedule) > 1:
+        return schedule[1]
+    return _get_reentry_window_real_order_size(trades_in_bar, schedule)
+
+
+def run_variant_replay(
+    df_seconds: pd.DataFrame,
+    signal: pd.DataFrame,
+    *,
+    initial_balance: float,
+    variant: dict,
+):
+    balance = initial_balance
+    position = None
+    trade_logs = []
+    diagnostics = {
+        "breakout_locks": {"long": {}, "short": {}},
+        "variant": variant,
+    }
+    second_index = df_seconds.index
+    high_values = df_seconds["high"].to_numpy(dtype="float64", copy=False)
+    low_values = df_seconds["low"].to_numpy(dtype="float64", copy=False)
+    close_values = df_seconds["close"].to_numpy(dtype="float64", copy=False)
+
+    commission = 0.001
+    max_trades_per_bar = int(COMMON_REPLAY_KWARGS["max_trades_per_bar"])
+    slippage = float(COMMON_REPLAY_KWARGS["fixed_slippage"])
+    stop_mode = str(COMMON_REPLAY_KWARGS["stop_mode"])
+    stop_loss_atr = float(COMMON_REPLAY_KWARGS["stop_loss_atr"])
+    trailing_stop_atr = float(COMMON_REPLAY_KWARGS["trailing_stop_atr"])
+    delayed_trailing_activation = float(COMMON_REPLAY_KWARGS["delayed_trailing_activation"])
+    profit_protect_atr = float(COMMON_REPLAY_KWARGS["profit_protect_atr"])
+    long_reentry_atr = float(COMMON_REPLAY_KWARGS["long_reentry_atr"])
+    short_reentry_atr = float(COMMON_REPLAY_KWARGS["short_reentry_atr"])
+    reentry_anchor_levels = str(COMMON_REPLAY_KWARGS["reentry_anchor_levels"])
+    reentry_size_schedule = [float(v) for v in COMMON_REPLAY_KWARGS["reentry_size_schedule"]]
+    delay_seconds = int(variant.get("delay_seconds", 0) or 0)
+    cooldown_bars = int(variant.get("cooldown_bars", 0) or 0)
+
+    last_exit_bar_index = -999
+    reentry_timeout = 1
+    last_exit_reason = None
+    last_exit_side = None
+    last_exit_time = None
+    pending_zero_initial_side = None
+    pending_zero_initial_bar_index = -999
+
+    for i in range(len(signal) - 1):
+        start_t, end_t = signal.index[i], signal.index[i + 1]
+        start_pos = int(second_index.searchsorted(start_t, side="left"))
+        end_pos = int(second_index.searchsorted(end_t, side="right"))
+        if start_pos >= end_pos:
+            continue
+
+        base_sig = signal.iloc[i]
+        if pd.isna(base_sig["atr"]):
+            continue
+
+        trades_in_bar = 0
+        current_pos = start_pos
+        breakout_locked_this_bar = False
+        bar_high_so_far = -np.inf
+        bar_low_so_far = np.inf
+        live_sig = base_sig.to_dict()
+        live_sig["_closed_atr"] = float(base_sig["atr"])
+
+        if i - last_exit_bar_index > reentry_timeout:
+            last_exit_side = None
+            last_exit_time = None
+        if i - pending_zero_initial_bar_index > reentry_timeout:
+            pending_zero_initial_side = None
+
+        while current_pos < end_pos:
+            bar_time = second_index[current_pos]
+            high_value = high_values[current_pos]
+            low_value = low_values[current_pos]
+            close_value = close_values[current_pos]
+            bar_high_so_far = max(bar_high_so_far, high_value)
+            bar_low_so_far = min(bar_low_so_far, low_value)
+            sig = _intrabar_signal(live_sig, bar_high_so_far, bar_low_so_far, close_value)
+            long_regime_ready, short_regime_ready = _resolve_regime_ready(sig, "1d")
+
+            if position is None:
+                if long_regime_ready:
+                    triggered, _, shape_name = _long_breakout(sig, high_value, "baseline_plus_t3")
+                    if trades_in_bar == 0 and triggered:
+                        if not breakout_locked_this_bar:
+                            diagnostics["breakout_locks"]["long"][shape_name] = (
+                                diagnostics["breakout_locks"]["long"].get(shape_name, 0) + 1
+                            )
+                            breakout_locked_this_bar = True
+                        pending_zero_initial_side = "long"
+                        pending_zero_initial_bar_index = i
+
+                    position, balance, trades_in_bar = _maybe_open_reentry(
+                        side="long",
+                        bar_time=bar_time,
+                        high_value=high_value,
+                        low_value=low_value,
+                        close_value=close_value,
+                        sig=sig,
+                        has_zero_initial_window=(
+                            pending_zero_initial_side == "long"
+                            and (i - pending_zero_initial_bar_index <= reentry_timeout)
+                        ),
+                        has_exit_reentry_window=(
+                            last_exit_side == "long"
+                            and (i - last_exit_bar_index <= reentry_timeout)
+                            and (i - last_exit_bar_index) >= cooldown_bars
+                        ),
+                        last_exit_reason=last_exit_reason,
+                        last_exit_time=last_exit_time,
+                        delay_seconds=delay_seconds,
+                        trades_in_bar=trades_in_bar,
+                        max_trades_per_bar=max_trades_per_bar,
+                        reentry_size_schedule=reentry_size_schedule,
+                        balance=balance,
+                        slippage=slippage,
+                        stop_mode=stop_mode,
+                        stop_loss_atr=stop_loss_atr,
+                        reentry_anchor_levels=reentry_anchor_levels,
+                        reentry_atr=long_reentry_atr,
+                        variant=variant,
+                        trade_logs=trade_logs,
+                    )
+                    if position is not None:
+                        if last_exit_side == "long":
+                            last_exit_side = None
+                        if pending_zero_initial_side == "long":
+                            pending_zero_initial_side = None
+
+                elif short_regime_ready:
+                    triggered, _, shape_name = _short_breakout(sig, low_value, "baseline_plus_t3")
+                    if trades_in_bar == 0 and triggered:
+                        if not breakout_locked_this_bar:
+                            diagnostics["breakout_locks"]["short"][shape_name] = (
+                                diagnostics["breakout_locks"]["short"].get(shape_name, 0) + 1
+                            )
+                            breakout_locked_this_bar = True
+                        pending_zero_initial_side = "short"
+                        pending_zero_initial_bar_index = i
+
+                    position, balance, trades_in_bar = _maybe_open_reentry(
+                        side="short",
+                        bar_time=bar_time,
+                        high_value=high_value,
+                        low_value=low_value,
+                        close_value=close_value,
+                        sig=sig,
+                        has_zero_initial_window=(
+                            pending_zero_initial_side == "short"
+                            and (i - pending_zero_initial_bar_index <= reentry_timeout)
+                        ),
+                        has_exit_reentry_window=(
+                            last_exit_side == "short"
+                            and (i - last_exit_bar_index <= reentry_timeout)
+                            and (i - last_exit_bar_index) >= cooldown_bars
+                        ),
+                        last_exit_reason=last_exit_reason,
+                        last_exit_time=last_exit_time,
+                        delay_seconds=delay_seconds,
+                        trades_in_bar=trades_in_bar,
+                        max_trades_per_bar=max_trades_per_bar,
+                        reentry_size_schedule=reentry_size_schedule,
+                        balance=balance,
+                        slippage=slippage,
+                        stop_mode=stop_mode,
+                        stop_loss_atr=stop_loss_atr,
+                        reentry_anchor_levels=reentry_anchor_levels,
+                        reentry_atr=short_reentry_atr,
+                        variant=variant,
+                        trade_logs=trade_logs,
+                    )
+                    if position is not None:
+                        if last_exit_side == "short":
+                            last_exit_side = None
+                        if pending_zero_initial_side == "short":
+                            pending_zero_initial_side = None
+
+            else:
+                exit_triggered = False
+                exit_p = 0.0
+                reason = ""
+
+                if position["side"] == "long":
+                    prev_hwm = position.get("hwm", position["entry_p"])
+                    protected_before_bar = position.get("protected", False)
+                    profit_atr = (prev_hwm - position["entry_p"]) / sig["atr"] if sig["atr"] > 0 else 0
+                    if profit_atr >= delayed_trailing_activation:
+                        trailing_sl = prev_hwm - trailing_stop_atr * sig["atr"]
+                        position["sl"] = max(position["sl"], trailing_sl)
+                    if low_value <= position["sl"]:
+                        exit_p, reason, exit_triggered = position["sl"], "SL", True
+                    elif protected_before_bar and low_value <= sig["prev_low_1"]:
+                        exit_p, reason, exit_triggered = sig["prev_low_1"], "PT", True
+                    if not exit_triggered:
+                        position["hwm"] = max(prev_hwm, high_value)
+                        if not position["protected"] and high_value >= position["entry_p"] + profit_protect_atr * sig["atr"]:
+                            position["protected"] = True
+                        profit_atr = (position["hwm"] - position["entry_p"]) / sig["atr"] if sig["atr"] > 0 else 0
+                        if profit_atr >= delayed_trailing_activation:
+                            trailing_sl = position["hwm"] - trailing_stop_atr * sig["atr"]
+                            position["sl"] = max(position["sl"], trailing_sl)
+                else:
+                    prev_lwm = position.get("lwm", position["entry_p"])
+                    protected_before_bar = position.get("protected", False)
+                    profit_atr = (position["entry_p"] - prev_lwm) / sig["atr"] if sig["atr"] > 0 else 0
+                    if profit_atr >= delayed_trailing_activation:
+                        trailing_sl = prev_lwm + trailing_stop_atr * sig["atr"]
+                        position["sl"] = min(position["sl"], trailing_sl)
+                    if high_value >= position["sl"]:
+                        exit_p, reason, exit_triggered = position["sl"], "SL", True
+                    elif protected_before_bar and high_value >= sig["prev_high_1"]:
+                        exit_p, reason, exit_triggered = sig["prev_high_1"], "PT", True
+                    if not exit_triggered:
+                        position["lwm"] = min(prev_lwm, low_value)
+                        if not position["protected"] and low_value <= position["entry_p"] - profit_protect_atr * sig["atr"]:
+                            position["protected"] = True
+                        profit_atr = (position["entry_p"] - position["lwm"]) / sig["atr"] if sig["atr"] > 0 else 0
+                        if profit_atr >= delayed_trailing_activation:
+                            trailing_sl = position["lwm"] + trailing_stop_atr * sig["atr"]
+                            position["sl"] = min(position["sl"], trailing_sl)
+
+                if exit_triggered:
+                    side_mult = 1 if position["side"] == "long" else -1
+                    exit_p = exit_p * (1 - slippage) if position["side"] == "long" else exit_p * (1 + slippage)
+                    pnl = (
+                        side_mult
+                        * (exit_p - position["entry_p"])
+                        / position["entry_p"]
+                        * position["notional"]
+                        if position["notional"] > 0
+                        else 0.0
+                    )
+                    balance += pnl - (position["notional"] * commission)
+                    trade_logs.append(
+                        {
+                            "time": bar_time,
+                            "type": "EXIT",
+                            "price": exit_p,
+                            "reason": reason,
+                            "notional": position["notional"],
+                            "bal": balance,
+                            "pnl": pnl,
+                            "entry_reason": position.get("reason", ""),
+                        }
+                    )
+                    last_exit_reason = reason
+                    last_exit_side = position["side"]
+                    last_exit_bar_index = i
+                    last_exit_time = bar_time
+                    position = None
+
+            current_pos += 1
+
+    if position is not None and not df_seconds.empty:
+        last_bar_time = second_index[-1]
+        last_close = float(close_values[-1])
+        side_mult = 1 if position["side"] == "long" else -1
+        final_exit_p = last_close * (1 - slippage) if position["side"] == "long" else last_close * (1 + slippage)
+        pnl = (
+            side_mult * (final_exit_p - position["entry_p"]) / position["entry_p"] * position["notional"]
+            if position["notional"] > 0
+            else 0.0
+        )
+        balance += pnl - (position["notional"] * commission)
+        trade_logs.append(
+            {
+                "time": last_bar_time,
+                "type": "EXIT",
+                "price": final_exit_p,
+                "reason": "FinalMarkToMarket",
+                "notional": position["notional"],
+                "bal": balance,
+                "pnl": pnl,
+                "entry_reason": position.get("reason", ""),
+            }
+        )
+
+    return pd.DataFrame(trade_logs), diagnostics
+
+
+def _maybe_open_reentry(
+    *,
+    side: str,
+    bar_time: pd.Timestamp,
+    high_value: float,
+    low_value: float,
+    close_value: float,
+    sig: dict,
+    has_zero_initial_window: bool,
+    has_exit_reentry_window: bool,
+    last_exit_reason: str | None,
+    last_exit_time: pd.Timestamp | None,
+    delay_seconds: int,
+    trades_in_bar: int,
+    max_trades_per_bar: int,
+    reentry_size_schedule: list[float],
+    balance: float,
+    slippage: float,
+    stop_mode: str,
+    stop_loss_atr: float,
+    reentry_anchor_levels: str,
+    reentry_atr: float,
+    variant: dict,
+    trade_logs: list[dict],
+):
+    if not has_zero_initial_window and not has_exit_reentry_window:
+        return None, balance, trades_in_bar
+    reentry_price = _resolve_reentry_price(sig, side, reentry_anchor_levels, reentry_atr)
+    reason = "Zero-Initial-Reentry"
+    is_triggered = False
+    entry_p_raw = reentry_price
+    seconds_since_exit = None
+    if has_exit_reentry_window:
+        reason = "SL-Reentry" if last_exit_reason == "SL" else "PT-Reentry"
+    if last_exit_time is not None:
+        seconds_since_exit = (bar_time - last_exit_time).total_seconds()
+        if seconds_since_exit < delay_seconds:
+            return None, balance, trades_in_bar
+
+    if reason == "SL-Reentry":
+        trigger_price = high_value if side == "long" else low_value
+        is_triggered, entry_p_raw = _sl_reentry_triggered(
+            side,
+            trigger_price,
+            close_value,
+            reentry_price,
+            float(sig["atr"]),
+            variant,
+        )
+    else:
+        is_triggered, entry_p_raw = _zero_initial_triggered(side, high_value, low_value, reentry_price)
+    if not is_triggered or trades_in_bar >= max_trades_per_bar:
+        return None, balance, trades_in_bar
+
+    notional_share = _reentry_notional_share(reason, trades_in_bar, reentry_size_schedule)
+    entry_price = float(entry_p_raw) * (1 + slippage) if side == "long" else float(entry_p_raw) * (1 - slippage)
+    balance, position = _open_position(
+        balance,
+        sig,
+        side,
+        entry_price,
+        notional_share,
+        reason,
+        stop_mode,
+        stop_loss_atr,
+        "",
+        "live_intrabar_sma5",
+    )
+    position["reason"] = reason
+    trade_logs.append(
+        {
+            "time": bar_time,
+            "type": "BUY" if side == "long" else "SHORT",
+            "price": entry_price,
+            "reason": reason,
+            "notional": position["notional"],
+            "bal": balance,
+            "seconds_since_exit": seconds_since_exit,
+        }
+    )
+    return position, balance, trades_in_bar + 1
+
+
+def sl_reentry_diagnostics(ledger: pd.DataFrame) -> dict:
+    if ledger.empty:
+        return {}
+    entries = ledger[ledger["type"].isin(["BUY", "SHORT"])].reset_index(drop=True)
+    exits = ledger[ledger["type"] == "EXIT"].reset_index(drop=True)
+    sl_entries = entries[entries["reason"] == "SL-Reentry"].copy()
+    if sl_entries.empty:
+        return {
+            "sl_reentry_count": 0,
+            "fast_reentry_le_10s": 0,
+            "fast_reentry_le_30s": 0,
+            "fast_reentry_le_60s": 0,
+            "sl_reentry_exit_sl_rate_pct": 0.0,
+            "sl_reentry_avg_pnl": 0.0,
+        }
+    delays = pd.to_numeric(sl_entries.get("seconds_since_exit"), errors="coerce")
+    paired = []
+    entry_cursor = 0
+    for _, row in ledger.iterrows():
+        if row["type"] in {"BUY", "SHORT"}:
+            entry_cursor += 1
+            current_reason = row["reason"]
+        elif row["type"] == "EXIT" and "current_reason" in locals():
+            paired.append(
+                {
+                    "entry_reason": current_reason,
+                    "exit_reason": row["reason"],
+                    "pnl": float(row.get("pnl", 0.0) or 0.0),
+                }
+            )
+    pairs = pd.DataFrame(paired)
+    sl_pairs = pairs[pairs["entry_reason"] == "SL-Reentry"] if not pairs.empty else pairs
+    sl_exit_count = int((sl_pairs["exit_reason"] == "SL").sum()) if not sl_pairs.empty else 0
+    return {
+        "sl_reentry_count": int(len(sl_entries)),
+        "fast_reentry_le_10s": int((delays <= 10).sum()),
+        "fast_reentry_le_30s": int((delays <= 30).sum()),
+        "fast_reentry_le_60s": int((delays <= 60).sum()),
+        "sl_reentry_exit_sl_rate_pct": round(sl_exit_count / len(sl_entries) * 100, 2),
+        "sl_reentry_avg_pnl": round(float(sl_pairs["pnl"].mean()), 2) if not sl_pairs.empty else 0.0,
+    }
+
+
+def write_markdown(summary: dict, output_path: Path):
+    lines = [
+        "# ETH Q1 2026 30min SL-Reentry Filters, 1s Replay",
+        "",
+        "Scope: research-only backtest work. No live or execution path was changed.",
+        "",
+        "## Setup",
+        "",
+        "- Symbol/window: `ETHUSDT`, `2026-01-01 00:00:00+00:00` to `2026-03-31 23:59:59+00:00`",
+        "- Execution bars: continuous `1s` bars rebuilt from raw Binance trades",
+        "- Signal timeframe: `30min`",
+        "- Replay mode: `live_intrabar_sma5` with `baseline_plus_t3` breakout shape",
+        "- Sizing baseline includes PR #261 semantics: `Zero-Initial-Reentry=20%`, `SL-Reentry=10%` when schedule is `[0.20, 0.10]`.",
+        "",
+        "## Results",
+        "",
+        "| Variant | Final Balance | Return | Max DD | Trades | Win Rate | Sharpe | SL-Reentry | <=10s | <=30s | <=60s | SL-Reentry -> SL | Avg SL-Reentry PnL |",
+        "|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|",
+    ]
+    for result in summary["results"]:
+        s = result["summary"]
+        d = result["sl_reentry_diagnostics"]
+        lines.append(
+            f"| `{result['variant']}` | {s['final_balance']:,.2f} | {s['return_pct']:.2f}% | "
+            f"{s['max_dd_pct']:.2f}% | {s['trades']} | {s['win_rate_pct']:.2f}% | {s['sharpe']:.2f} | "
+            f"{d['sl_reentry_count']} | {d['fast_reentry_le_10s']} | {d['fast_reentry_le_30s']} | "
+            f"{d['fast_reentry_le_60s']} | {d['sl_reentry_exit_sl_rate_pct']:.2f}% | {d['sl_reentry_avg_pnl']:,.2f} |"
+        )
+    lines.extend(["", "## Delta vs Baseline", ""])
+    lines.append("| Variant | Final Balance Delta | Return Delta | Max DD Delta | Trades Delta | Win Rate Delta | Sharpe Delta | SL-Reentry Delta |")
+    lines.append("|---|---:|---:|---:|---:|---:|---:|---:|")
+    base = summary["results"][0]
+    for result in summary["results"][1:]:
+        s = result["summary"]
+        b = base["summary"]
+        d = result["sl_reentry_diagnostics"]
+        bd = base["sl_reentry_diagnostics"]
+        lines.append(
+            f"| `{result['variant']}` | {s['final_balance'] - b['final_balance']:,.2f} | "
+            f"{s['return_pct'] - b['return_pct']:.2f} pp | {s['max_dd_pct'] - b['max_dd_pct']:.2f} pp | "
+            f"{s['trades'] - b['trades']} | {s['win_rate_pct'] - b['win_rate_pct']:.2f} pp | "
+            f"{s['sharpe'] - b['sharpe']:.2f} | {d['sl_reentry_count'] - bd['sl_reentry_count']} |"
+        )
+    lines.extend(["", "## Variants", ""])
+    for variant in VARIANTS:
+        lines.append(f"- `{variant['name']}`: {variant['description']}")
+    lines.append("")
+    output_path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="ETH Q1 2026 30min SL-Reentry filter comparison")
+    parser.add_argument("--tick-files", nargs="+", default=DEFAULT_TICK_FILES)
+    parser.add_argument("--start", default="2026-01-01T00:00:00Z")
+    parser.add_argument("--end", default="2026-03-31T23:59:59Z")
+    parser.add_argument("--initial-balance", type=float, default=100000.0)
+    parser.add_argument("--chunksize", type=int, default=2_000_000)
+    parser.add_argument("--summary-json", default="research/eth_2026_q1_30min_sl_reentry_filters_summary.json")
+    parser.add_argument("--markdown", default="research/20260428_eth_q1_30min_sl_reentry_filters.md")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    start = _as_utc_timestamp(args.start)
+    end = _as_utc_timestamp(args.end)
+    second_bars, build_stats = build_continuous_second_bars(args.tick_files, start, end, args.chunksize)
+    _, signal = build_signal_frame(second_bars, "30min")
+
+    results = []
+    for variant in VARIANTS:
+        started = time.time()
+        ledger, diagnostics = run_variant_replay(
+            second_bars,
+            signal,
+            initial_balance=args.initial_balance,
+            variant=variant,
+        )
+        elapsed = round(time.time() - started, 2)
+        ledger_path = Path(f"research/tmp_eth_2026_q1_30min_1s_sl_reentry_{variant['name']}_ledger.csv")
+        ledger.to_csv(ledger_path, index=False)
+        summary = summarize_run(ledger, args.initial_balance)
+        sl_diag = sl_reentry_diagnostics(ledger)
+        result = {
+            "variant": variant["name"],
+            "description": variant["description"],
+            "params": variant,
+            "summary": summary,
+            "sl_reentry_diagnostics": sl_diag,
+            "diagnostics": diagnostics,
+            "ledger_path": str(ledger_path),
+            "elapsed_seconds": elapsed,
+        }
+        results.append(result)
+        print(
+            f"{variant['name']}: return={summary['return_pct']:.2f}% trades={summary['trades']} "
+            f"sl_reentry={sl_diag.get('sl_reentry_count', 0)} elapsed={elapsed}s",
+            flush=True,
+        )
+
+    output = {
+        "window": {"start": start.isoformat(), "end": end.isoformat()},
+        "timeframe": "30min",
+        "replay_mode": "live_intrabar_sma5",
+        "breakout_shape": "baseline_plus_t3",
+        "common_params": COMMON_REPLAY_KWARGS,
+        "build_stats": build_stats,
+        "signal_stats": {
+            "signal_rows": int(len(signal)),
+            "signal_start": signal.index[0].isoformat() if not signal.empty else "",
+            "signal_end": signal.index[-1].isoformat() if not signal.empty else "",
+            "valid_sma5_rows": int(signal["sma5"].notna().sum()),
+            "valid_atr_rows": int(signal["atr"].notna().sum()),
+        },
+        "results": results,
+    }
+    summary_path = Path(args.summary_json)
+    summary_path.write_text(json.dumps(output, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    write_markdown(output, Path(args.markdown))
+    print(json.dumps(output, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 目的
为 `Zero-Initial-Reentry`（以及 `PT-Reentry`）加入了与 `SL-Reentry` 相同的止损冷却保护时间（默认 60s）。
同时为 `Zero-Initial-Reentry` 增加了挂单回退保护（超过 3.0 bps 时自动回退至 limit-maker）。
并附带了 ETH Q1 1s 回测的结果，验证了增加 60s 冷却后在 ETH 上带来了 +25.78 个百分点的收益率提升，胜率提升 +1.24 pp，过滤了 101 次连续入场。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [x] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) -> 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？ -> 不存在
- [x] DB migration 是否具备向下兼容幂等性？ -> 不涉及
- [x] 配置字段有没有无意被混改？ -> 无

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩 -> 补充并修改了 `TestBookAwareExecutionStrategyDelaysSLReentryAfterStopLossFill` 以反映并断言拦截逻辑，`go test ./internal/service` 和全量编译验证通过。
