### PR TITLE
[codex] fix live session delete SQL parameter type

### DIFF
--- a/internal/store/postgres/store.go
+++ b/internal/store/postgres/store.go
@@ -1322,7 +1322,7 @@ func (s *Store) DeleteLiveSession(sessionID string) error {
 	result, err := s.db.Exec(`
 		update live_sessions
 		set status = 'DELETED',
-			state = coalesce(state, '{}'::jsonb) || jsonb_build_object('deletedAt', $2)
+			state = coalesce(state, '{}'::jsonb) || jsonb_build_object('deletedAt', $2::text)
 		where id = $1
 	`, sessionID, deletedAt)
 	if err != nil {


### PR DESCRIPTION
## 目的
修复删除 live session 时 PostgreSQL 报错 `pq: could not determine data type of parameter $2 (42P18)` 的问题。

根因是 `DeleteLiveSession` 的 SQL 在 `jsonb_build_object('deletedAt', $2)` 中没有给 `$2` 显式类型，PostgreSQL 无法在 variadic JSON 构造函数里推断参数类型。

本次最小修复为将 `$2` 显式 cast 为 `text`，保持当前 `deletedAt` 存储 RFC3339 字符串的语义不变。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [x] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) - 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？- 不涉及
- [x] DB migration 是否具备向下兼容幂等性？- 不涉及 migration
- [x] 配置字段有没有无意被混改？- 无配置改动

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

本地已验证：

```bash
go test ./internal/store/postgres
go build ./cmd/platform-api
go build ./cmd/db-migrate
go test ./...
```
