### PR TITLE
[codex] Add live session desired-state control

### DIFF
--- a/cmd/bktrader-ctl/live.go
+++ b/cmd/bktrader-ctl/live.go
@@ -1,9 +1,14 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"github.com/spf13/cobra"
+	"github.com/wuyaocheng/bktrader/internal/ctlclient"
 	"net/url"
+	"os"
+	"strings"
+	"time"
 )
 
 func init() {
@@ -58,12 +63,21 @@ var liveStartCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		confirm, _ := cmd.Flags().GetBool("confirm")
+		wait, _ := cmd.Flags().GetBool("wait")
+		timeout, _ := cmd.Flags().GetDuration("timeout")
 		if !confirm && !dryRun {
 			return fmt.Errorf("操作需要 --confirm 确认")
 		}
 		client := getClient()
 		resp, err := client.Request("POST", "/api/v1/live/sessions/"+url.PathEscape(args[0])+"/start", nil)
-		handleResponse(resp, err)
+		if err != nil || !wait || dryRun {
+			handleResponse(resp, err)
+			return nil
+		}
+		handleResponse(resp, nil)
+		if err := waitLiveSessionActualStatus(client, args[0], "RUNNING", timeout); err != nil {
+			return err
+		}
 		return nil
 	},
 }
@@ -75,6 +89,8 @@ var liveStopCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		confirm, _ := cmd.Flags().GetBool("confirm")
 		force, _ := cmd.Flags().GetBool("force")
+		wait, _ := cmd.Flags().GetBool("wait")
+		timeout, _ := cmd.Flags().GetDuration("timeout")
 		if !confirm && !dryRun {
 			return fmt.Errorf("操作需要 --confirm 确认")
 		}
@@ -84,7 +100,14 @@ var liveStopCmd = &cobra.Command{
 			path += "?force=true"
 		}
 		resp, err := client.Request("POST", path, nil)
-		handleResponse(resp, err)
+		if err != nil || !wait || dryRun {
+			handleResponse(resp, err)
+			return nil
+		}
+		handleResponse(resp, nil)
+		if err := waitLiveSessionActualStatus(client, args[0], "STOPPED", timeout); err != nil {
+			return err
+		}
 		return nil
 	},
 }
@@ -157,8 +180,79 @@ func init() {
 
 	// 安全确认标志
 	liveStartCmd.Flags().Bool("confirm", false, "确认执行启动操作")
+	liveStartCmd.Flags().Bool("wait", false, "等待 actualStatus 收敛")
+	liveStartCmd.Flags().Duration("timeout", 60*time.Second, "等待超时时间")
 	liveStopCmd.Flags().Bool("confirm", false, "确认执行停止操作")
 	liveStopCmd.Flags().Bool("force", false, "强制停止")
+	liveStopCmd.Flags().Bool("wait", false, "等待 actualStatus 收敛")
+	liveStopCmd.Flags().Duration("timeout", 60*time.Second, "等待超时时间")
 	liveDispatchCmd.Flags().Bool("confirm", false, "确认执行下单操作")
 	liveDeleteCmd.Flags().Bool("confirm", false, "确认执行删除操作")
+}
+
+type liveSessionControlView struct {
+	ID     string         `json:"id"`
+	Status string         `json:"status"`
+	State  map[string]any `json:"state"`
+}
+
+func waitLiveSessionActualStatus(client *ctlclient.Client, sessionID, target string, timeout time.Duration) error {
+	if timeout <= 0 {
+		timeout = 60 * time.Second
+	}
+	deadline := time.Now().Add(timeout)
+	target = strings.ToUpper(strings.TrimSpace(target))
+	for {
+		session, err := fetchLiveSessionControlView(client, sessionID)
+		if err != nil {
+			return err
+		}
+		actual := strings.ToUpper(liveSessionControlString(session.State["actualStatus"]))
+		if actual == "" {
+			actual = strings.ToUpper(strings.TrimSpace(session.Status))
+		}
+		if actual == target {
+			if outputJSON {
+				data, _ := json.Marshal(session)
+				fmt.Println(string(data))
+			} else {
+				fmt.Fprintf(os.Stderr, "actualStatus converged: %s\n", target)
+			}
+			return nil
+		}
+		if actual == "ERROR" {
+			return fmt.Errorf("live session control failed: desiredStatus=%s actualStatus=%s error=%s", liveSessionControlString(session.State["desiredStatus"]), actual, liveSessionControlString(session.State["lastControlError"]))
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timed out waiting for live session %s actualStatus=%s, last actualStatus=%s desiredStatus=%s", sessionID, target, actual, liveSessionControlString(session.State["desiredStatus"]))
+		}
+		time.Sleep(time.Second)
+	}
+}
+
+func liveSessionControlString(value any) string {
+	if value == nil {
+		return ""
+	}
+	return strings.TrimSpace(fmt.Sprint(value))
+}
+
+func fetchLiveSessionControlView(client *ctlclient.Client, sessionID string) (liveSessionControlView, error) {
+	data, err := client.Request("GET", "/api/v1/live/sessions?view=summary", nil)
+	if err != nil {
+		return liveSessionControlView{}, err
+	}
+	var sessions []liveSessionControlView
+	if err := json.Unmarshal(data, &sessions); err != nil {
+		return liveSessionControlView{}, err
+	}
+	for _, session := range sessions {
+		if session.ID == sessionID {
+			if session.State == nil {
+				session.State = map[string]any{}
+			}
+			return session, nil
+		}
+	}
+	return liveSessionControlView{}, fmt.Errorf("live session not found: %s", sessionID)
 }

--- a/internal/app/server.go
+++ b/internal/app/server.go
@@ -23,13 +23,14 @@ func NewServer(cfg config.Config) (*http.Server, error) {
 }
 
 type RuntimeOptions struct {
-	WarmLiveMarketData        bool
-	StartTelegram             bool
-	RecoverLiveTrading        bool
-	StartLiveSync             bool
-	StartDashboard            bool
-	StartRuntimeEventConsumer bool
-	StartSignalRuntimeScanner bool
+	WarmLiveMarketData             bool
+	StartTelegram                  bool
+	RecoverLiveTrading             bool
+	StartLiveSync                  bool
+	StartDashboard                 bool
+	StartRuntimeEventConsumer      bool
+	StartSignalRuntimeScanner      bool
+	StartLiveSessionControlScanner bool
 }
 
 func RuntimeOptionsForRole(role string) RuntimeOptions {
@@ -38,9 +39,10 @@ func RuntimeOptionsForRole(role string) RuntimeOptions {
 		return RuntimeOptions{StartDashboard: true}
 	case "live-runner":
 		return RuntimeOptions{
-			RecoverLiveTrading:        true,
-			StartLiveSync:             true,
-			StartRuntimeEventConsumer: true,
+			RecoverLiveTrading:             true,
+			StartLiveSync:                  true,
+			StartRuntimeEventConsumer:      true,
+			StartLiveSessionControlScanner: true,
 		}
 	case "signal-runtime-runner":
 		return RuntimeOptions{
@@ -51,13 +53,14 @@ func RuntimeOptionsForRole(role string) RuntimeOptions {
 		return RuntimeOptions{StartTelegram: true}
 	default:
 		return RuntimeOptions{
-			WarmLiveMarketData:        true,
-			StartTelegram:             true,
-			RecoverLiveTrading:        true,
-			StartLiveSync:             true,
-			StartDashboard:            true,
-			StartRuntimeEventConsumer: true,
-			StartSignalRuntimeScanner: true,
+			WarmLiveMarketData:             true,
+			StartTelegram:                  true,
+			RecoverLiveTrading:             true,
+			StartLiveSync:                  true,
+			StartDashboard:                 true,
+			StartRuntimeEventConsumer:      true,
+			StartSignalRuntimeScanner:      true,
+			StartLiveSessionControlScanner: true,
 		}
 	}
 }
@@ -85,6 +88,7 @@ func NewServerWithRuntimeOptions(cfg config.Config, runtime RuntimeOptions) (*ht
 		"dashboard", runtime.StartDashboard,
 		"runtime_event_consumer", runtime.StartRuntimeEventConsumer,
 		"signal_runtime_scanner", runtime.StartSignalRuntimeScanner,
+		"live_session_control_scanner", runtime.StartLiveSessionControlScanner,
 	)
 
 	return &http.Server{
@@ -177,6 +181,9 @@ func StartRuntimeComponents(ctx context.Context, platform *service.Platform, cfg
 	}
 	if runtime.StartSignalRuntimeScanner {
 		platform.StartSignalRuntimeScanner(ctx)
+	}
+	if runtime.StartLiveSessionControlScanner {
+		platform.StartLiveSessionControlScanner(ctx)
 	}
 }
 

--- a/internal/app/server_test.go
+++ b/internal/app/server_test.go
@@ -23,7 +23,7 @@ func TestRuntimeOptionsForLiveRunnerDoesNotStartSignalRuntimeScanner(t *testing.
 	if options.StartSignalRuntimeScanner {
 		t.Fatal("expected live-runner not to start signal runtime scanner")
 	}
-	if !options.RecoverLiveTrading || !options.StartLiveSync || !options.StartRuntimeEventConsumer {
+	if !options.RecoverLiveTrading || !options.StartLiveSync || !options.StartRuntimeEventConsumer || !options.StartLiveSessionControlScanner {
 		t.Fatalf("expected live-runner to keep live recovery/sync/event consumer, got %+v", options)
 	}
 }
@@ -36,7 +36,8 @@ func TestRuntimeOptionsForMonolithStartAllRuntimeComponents(t *testing.T) {
 		!options.StartLiveSync ||
 		!options.StartDashboard ||
 		!options.StartRuntimeEventConsumer ||
-		!options.StartSignalRuntimeScanner {
+		!options.StartSignalRuntimeScanner ||
+		!options.StartLiveSessionControlScanner {
 		t.Fatalf("expected monolith to start all runtime components, got %+v", options)
 	}
 }

--- a/internal/http/live.go
+++ b/internal/http/live.go
@@ -674,11 +674,7 @@ func registerLiveRoutes(mux *http.ServeMux, platform *service.Platform, cfg conf
 		action := parts[1]
 		switch action {
 		case "start":
-			if !cfg.RuntimeActionsEnabled() {
-				writeError(w, http.StatusConflict, "runtime action start is disabled for BKTRADER_ROLE="+cfg.ProcessRole)
-				return
-			}
-			item, err := platform.StartLiveSession(sessionID)
+			item, err := platform.RequestLiveSessionStart(sessionID)
 			if err != nil {
 				if errors.Is(err, service.ErrLiveControlOperationInProgress) {
 					writeError(w, http.StatusConflict, err.Error())
@@ -687,13 +683,9 @@ func registerLiveRoutes(mux *http.ServeMux, platform *service.Platform, cfg conf
 				writeError(w, http.StatusInternalServerError, err.Error())
 				return
 			}
-			writeJSON(w, http.StatusOK, item)
+			writeJSON(w, http.StatusAccepted, item)
 		case "stop":
-			if !cfg.RuntimeActionsEnabled() {
-				writeError(w, http.StatusConflict, "runtime action stop is disabled for BKTRADER_ROLE="+cfg.ProcessRole)
-				return
-			}
-			item, err := platform.StopLiveSessionWithForce(sessionID, queryFlagEnabled(r, "force"))
+			item, err := platform.RequestLiveSessionStopWithForce(sessionID, queryFlagEnabled(r, "force"))
 			if err != nil {
 				if errors.Is(err, service.ErrLiveControlOperationInProgress) {
 					writeError(w, http.StatusConflict, err.Error())
@@ -706,7 +698,7 @@ func registerLiveRoutes(mux *http.ServeMux, platform *service.Platform, cfg conf
 				writeError(w, http.StatusInternalServerError, err.Error())
 				return
 			}
-			writeJSON(w, http.StatusOK, item)
+			writeJSON(w, http.StatusAccepted, item)
 		case "dispatch":
 			if !cfg.RuntimeActionsEnabled() {
 				writeError(w, http.StatusConflict, "runtime action dispatch is disabled for BKTRADER_ROLE="+cfg.ProcessRole)

--- a/internal/http/session_safety_test.go
+++ b/internal/http/session_safety_test.go
@@ -4,8 +4,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"strings"
-	"sync"
 	"testing"
 
 	"github.com/wuyaocheng/bktrader/internal/config"
@@ -13,6 +11,11 @@ import (
 	"github.com/wuyaocheng/bktrader/internal/service"
 	"github.com/wuyaocheng/bktrader/internal/store/memory"
 )
+
+func boolValue(value any) bool {
+	v, ok := value.(bool)
+	return ok && v
+}
 
 func TestLiveSessionStopRouteRespectsForceQuery(t *testing.T) {
 	store := memory.NewStore()
@@ -35,22 +38,37 @@ func TestLiveSessionStopRouteRespectsForceQuery(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/live/sessions/live-session-main/stop", nil)
 	mux.ServeHTTP(rec, req)
-	if rec.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400 for blocked stop, got %d body=%s", rec.Code, rec.Body.String())
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("expected 202 for accepted stop intent, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	session, err := store.GetLiveSession("live-session-main")
+	if err != nil {
+		t.Fatalf("get live session failed: %v", err)
+	}
+	if got := stringValue(session.State["desiredStatus"]); got != "STOPPED" {
+		t.Fatalf("expected desiredStatus STOPPED, got %s", got)
+	}
+	if boolValue(session.State["desiredStopForce"]) {
+		t.Fatalf("did not expect desiredStopForce for normal stop")
 	}
 
 	rec = httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodPost, "/api/v1/live/sessions/live-session-main/stop?force=true", nil)
 	mux.ServeHTTP(rec, req)
-	if rec.Code != http.StatusOK {
-		t.Fatalf("expected 200 for forced stop, got %d body=%s", rec.Code, rec.Body.String())
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("expected 202 for accepted forced stop intent, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	session, err = store.GetLiveSession("live-session-main")
+	if err != nil {
+		t.Fatalf("get live session failed: %v", err)
+	}
+	if !boolValue(session.State["desiredStopForce"]) {
+		t.Fatalf("expected desiredStopForce for forced stop")
 	}
 }
 
 func TestLiveSessionRuntimeActionsDisabledForAPIRole(t *testing.T) {
 	cases := []string{
-		"/api/v1/live/sessions/live-session-main/start",
-		"/api/v1/live/sessions/live-session-main/stop",
 		"/api/v1/live/sessions/live-session-main/dispatch",
 		"/api/v1/live/sessions/live-session-main/sync",
 	}
@@ -70,40 +88,45 @@ func TestLiveSessionRuntimeActionsDisabledForAPIRole(t *testing.T) {
 	}
 }
 
-func TestLiveSessionDeleteRouteReturnsConflictDuringSamePairOperation(t *testing.T) {
-	store := &blockingLiveSessionStatusStore{
-		Store:       memory.NewStore(),
-		blockStatus: "STOPPED",
-		entered:     make(chan struct{}),
-		release:     make(chan struct{}),
-	}
+func TestLiveSessionStartStopRoutesAcceptedForAPIRole(t *testing.T) {
+	store := memory.NewStore()
 	platform := service.NewPlatform(store)
 	mux := http.NewServeMux()
-	registerLiveRoutes(mux, platform, config.Config{ProcessRole: "monolith"})
-
-	stopDone := make(chan *httptest.ResponseRecorder, 1)
-	go func() {
-		rec := httptest.NewRecorder()
-		req := httptest.NewRequest(http.MethodPost, "/api/v1/live/sessions/live-session-main/stop", nil)
-		mux.ServeHTTP(rec, req)
-		stopDone <- rec
-	}()
-	<-store.entered
+	registerLiveRoutes(mux, platform, config.Config{ProcessRole: "api"})
 
 	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodDelete, "/api/v1/live/sessions/live-session-main?force=true", nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/live/sessions/live-session-main/start", nil)
 	mux.ServeHTTP(rec, req)
-	if rec.Code != http.StatusConflict {
-		close(store.release)
-		t.Fatalf("expected 409 for concurrent delete, got %d body=%s", rec.Code, rec.Body.String())
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("expected 202 for api role start intent, got %d body=%s", rec.Code, rec.Body.String())
 	}
-	close(store.release)
-	if stopRec := <-stopDone; stopRec.Code != http.StatusOK {
-		t.Fatalf("expected original stop to complete with 200, got %d body=%s", stopRec.Code, stopRec.Body.String())
+	session, err := store.GetLiveSession("live-session-main")
+	if err != nil {
+		t.Fatalf("get live session failed: %v", err)
+	}
+	if got := stringValue(session.State["desiredStatus"]); got != "RUNNING" {
+		t.Fatalf("expected desiredStatus RUNNING, got %s", got)
+	}
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodPost, "/api/v1/live/sessions/live-session-main/stop?force=true", nil)
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("expected 202 for api role stop intent, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	session, err = store.GetLiveSession("live-session-main")
+	if err != nil {
+		t.Fatalf("get live session failed: %v", err)
+	}
+	if got := stringValue(session.State["desiredStatus"]); got != "STOPPED" {
+		t.Fatalf("expected desiredStatus STOPPED, got %s", got)
+	}
+	if !boolValue(session.State["desiredStopForce"]) {
+		t.Fatalf("expected desiredStopForce")
 	}
 }
 
-func TestLiveSessionStartRouteDoesNotReportMissingControlKeyAsConflict(t *testing.T) {
+func TestLiveSessionStartRouteWritesDesiredStateForCorruptedControlKey(t *testing.T) {
 	store := memory.NewStore()
 	session, err := store.GetLiveSession("live-session-main")
 	if err != nil {
@@ -120,11 +143,15 @@ func TestLiveSessionStartRouteDoesNotReportMissingControlKeyAsConflict(t *testin
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/live/sessions/live-session-main/start", nil)
 	mux.ServeHTTP(rec, req)
-	if rec.Code == http.StatusConflict {
-		t.Fatalf("missing live control key must not be reported as 409 conflict, body=%s", rec.Body.String())
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("expected 202 for desired start despite corrupted control key, got %d body=%s", rec.Code, rec.Body.String())
 	}
-	if rec.Code != http.StatusInternalServerError {
-		t.Fatalf("expected 500 for corrupted live session control key, got %d body=%s", rec.Code, rec.Body.String())
+	updated, err := store.GetLiveSession("live-session-main")
+	if err != nil {
+		t.Fatalf("get live session failed: %v", err)
+	}
+	if got := stringValue(updated.State["desiredStatus"]); got != "RUNNING" {
+		t.Fatalf("expected desiredStatus RUNNING, got %s", got)
 	}
 }
 
@@ -183,22 +210,6 @@ func TestLiveSessionDetailRouteFiltersStateFields(t *testing.T) {
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400 for unsupported detail field, got %d body=%s", rec.Code, rec.Body.String())
 	}
-}
-
-type blockingLiveSessionStatusStore struct {
-	*memory.Store
-	blockStatus string
-	entered     chan struct{}
-	release     chan struct{}
-	once        sync.Once
-}
-
-func (s *blockingLiveSessionStatusStore) UpdateLiveSessionStatus(sessionID, status string) (domain.LiveSession, error) {
-	if strings.EqualFold(status, s.blockStatus) {
-		s.once.Do(func() { close(s.entered) })
-		<-s.release
-	}
-	return s.Store.UpdateLiveSessionStatus(sessionID, status)
 }
 
 func TestLiveAccountStopRouteStopsRunningFlow(t *testing.T) {

--- a/internal/http/session_safety_test.go
+++ b/internal/http/session_safety_test.go
@@ -126,6 +126,51 @@ func TestLiveSessionStartStopRoutesAcceptedForAPIRole(t *testing.T) {
 	}
 }
 
+func TestLiveSessionDeleteCancelsPendingDesiredControlIntent(t *testing.T) {
+	store := memory.NewStore()
+	platform := service.NewPlatform(store)
+	mux := http.NewServeMux()
+	registerLiveRoutes(mux, platform, config.Config{ProcessRole: "api"})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/live/sessions/live-session-main/start", nil)
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("expected 202 for pending start intent, got %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodDelete, "/api/v1/live/sessions/live-session-main?force=true", nil)
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 for delete after pending intent, got %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	deleted, err := store.GetLiveSession("live-session-main")
+	if err != nil {
+		t.Fatalf("get live session failed: %v", err)
+	}
+	if deleted.Status != "DELETED" {
+		t.Fatalf("expected DELETED status, got %s", deleted.Status)
+	}
+	if got := stringValue(deleted.State["desiredStatus"]); got != "STOPPED" {
+		t.Fatalf("expected delete to cancel desiredStatus as STOPPED, got %s", got)
+	}
+	if got := stringValue(deleted.State["actualStatus"]); got != "STOPPED" {
+		t.Fatalf("expected delete to mark actualStatus STOPPED, got %s", got)
+	}
+
+	listed, err := store.ListLiveSessions()
+	if err != nil {
+		t.Fatalf("list live sessions failed: %v", err)
+	}
+	for _, item := range listed {
+		if item.ID == deleted.ID {
+			t.Fatalf("expected deleted session to be hidden from live session list")
+		}
+	}
+}
+
 func TestLiveSessionStartRouteWritesDesiredStateForCorruptedControlKey(t *testing.T) {
 	store := memory.NewStore()
 	session, err := store.GetLiveSession("live-session-main")

--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -230,6 +230,16 @@ func (p *Platform) deleteLiveSessionWithForceLocked(session domain.LiveSession, 
 		logger.Warn("stop linked signal runtime before live session delete failed", "error", err)
 		return err
 	}
+	state := cloneMetadata(session.State)
+	state["desiredStatus"] = "STOPPED"
+	state["actualStatus"] = "STOPPED"
+	state["controlDeletedAt"] = time.Now().UTC().Format(time.RFC3339)
+	delete(state, "desiredStopForce")
+	delete(state, "lastControlError")
+	delete(state, "lastControlErrorAt")
+	if _, err := p.store.UpdateLiveSessionState(session.ID, state); err != nil {
+		return err
+	}
 	return p.store.DeleteLiveSession(session.ID)
 }
 

--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -1661,6 +1661,15 @@ func (p *Platform) RecoverLiveTradingOnStartup(ctx context.Context) {
 		if !strings.EqualFold(session.Status, "RUNNING") {
 			continue
 		}
+		if strings.EqualFold(stringValue(session.State["desiredStatus"]), "STOPPED") {
+			state := cloneMetadata(session.State)
+			delete(state, "lastRecoveryError")
+			state["lastRecoveryAttemptAt"] = time.Now().UTC().Format(time.RFC3339)
+			state["lastRecoveryStatus"] = "skipped-live-desired-stopped"
+			_, _ = p.store.UpdateLiveSessionState(session.ID, state)
+			p.logger("service.live", "session_id", session.ID).Warn("skip live session recovery because live desiredStatus is STOPPED")
+			continue
+		}
 		requested := liveControlOperationInfo{
 			Operation:     liveControlOperationStartupRecovery,
 			AccountID:     session.AccountID,

--- a/internal/service/live_session_control.go
+++ b/internal/service/live_session_control.go
@@ -74,7 +74,7 @@ func (p *Platform) scanLiveSessionControlRequests(ctx context.Context) {
 		if desired == "" {
 			continue
 		}
-		if strings.EqualFold(stringValue(session.State["actualStatus"]), "ERROR") {
+		if liveSessionControlErrorCurrent(session.State) {
 			continue
 		}
 		switch desired {
@@ -144,4 +144,32 @@ func liveSessionActualStatusFromSession(session domain.LiveSession) string {
 		}
 		return "STOPPED"
 	}
+}
+
+func liveSessionControlErrorCurrent(state map[string]any) bool {
+	if !strings.EqualFold(stringValue(state["actualStatus"]), "ERROR") {
+		return false
+	}
+	requestedAt, requestedOK := parseLiveSessionControlTime(state["controlRequestedAt"])
+	errorAt, errorOK := parseLiveSessionControlTime(state["lastControlErrorAt"])
+	if !requestedOK || !errorOK {
+		return true
+	}
+	return !requestedAt.After(errorAt)
+}
+
+func parseLiveSessionControlTime(value any) (time.Time, bool) {
+	raw := strings.TrimSpace(stringValue(value))
+	if raw == "" {
+		return time.Time{}, false
+	}
+	parsed, err := time.Parse(time.RFC3339, raw)
+	if err == nil {
+		return parsed, true
+	}
+	parsed, err = time.Parse(time.RFC3339Nano, raw)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return parsed, true
 }

--- a/internal/service/live_session_control.go
+++ b/internal/service/live_session_control.go
@@ -1,0 +1,147 @@
+package service
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/wuyaocheng/bktrader/internal/domain"
+)
+
+const liveSessionControlScannerInterval = 5 * time.Second
+
+func (p *Platform) RequestLiveSessionStart(sessionID string) (domain.LiveSession, error) {
+	return p.requestLiveSessionDesiredStatus(sessionID, "RUNNING", false)
+}
+
+func (p *Platform) RequestLiveSessionStopWithForce(sessionID string, force bool) (domain.LiveSession, error) {
+	return p.requestLiveSessionDesiredStatus(sessionID, "STOPPED", force)
+}
+
+func (p *Platform) requestLiveSessionDesiredStatus(sessionID, desired string, force bool) (domain.LiveSession, error) {
+	session, err := p.store.GetLiveSession(strings.TrimSpace(sessionID))
+	if err != nil {
+		return domain.LiveSession{}, err
+	}
+	state := cloneMetadata(session.State)
+	now := time.Now().UTC()
+	state["desiredStatus"] = desired
+	state["actualStatus"] = liveSessionActualStatusFromSession(session)
+	state["controlRequestedAt"] = now.Format(time.RFC3339)
+	if desired == "STOPPED" {
+		state["desiredStopForce"] = force
+	} else {
+		delete(state, "desiredStopForce")
+	}
+	delete(state, "lastControlError")
+	delete(state, "lastControlErrorAt")
+	return p.store.UpdateLiveSessionState(session.ID, state)
+}
+
+func (p *Platform) StartLiveSessionControlScanner(ctx context.Context) {
+	logger := p.logger("service.live_session_control_scanner")
+	logger.Info("live session control scanner started")
+	go func() {
+		defer logger.Info("live session control scanner stopped")
+		p.scanLiveSessionControlRequests(ctx)
+		ticker := time.NewTicker(liveSessionControlScannerInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				p.scanLiveSessionControlRequests(ctx)
+			}
+		}
+	}()
+}
+
+func (p *Platform) scanLiveSessionControlRequests(ctx context.Context) {
+	if err := ctx.Err(); err != nil {
+		return
+	}
+	sessions, err := p.ListLiveSessions()
+	if err != nil {
+		p.logger("service.live_session_control_scanner").Warn("list live sessions failed", "error", err)
+		return
+	}
+	for _, session := range sessions {
+		if err := ctx.Err(); err != nil {
+			return
+		}
+		desired := strings.ToUpper(strings.TrimSpace(stringValue(session.State["desiredStatus"])))
+		if desired == "" {
+			continue
+		}
+		if strings.EqualFold(stringValue(session.State["actualStatus"]), "ERROR") {
+			continue
+		}
+		switch desired {
+		case "RUNNING":
+			if strings.EqualFold(session.Status, "RUNNING") {
+				p.markLiveSessionControlActual(session, "RUNNING", nil)
+				continue
+			}
+			p.executeLiveSessionControlStart(session)
+		case "STOPPED":
+			if strings.EqualFold(session.Status, "STOPPED") {
+				p.markLiveSessionControlActual(session, "STOPPED", nil)
+				continue
+			}
+			p.executeLiveSessionControlStop(session)
+		}
+	}
+}
+
+func (p *Platform) executeLiveSessionControlStart(session domain.LiveSession) {
+	p.markLiveSessionControlActual(session, "STARTING", nil)
+	started, err := p.StartLiveSession(session.ID)
+	if err != nil {
+		p.markLiveSessionControlActual(session, "ERROR", err)
+		return
+	}
+	p.markLiveSessionControlActual(started, "RUNNING", nil)
+}
+
+func (p *Platform) executeLiveSessionControlStop(session domain.LiveSession) {
+	force := boolValue(session.State["desiredStopForce"])
+	p.markLiveSessionControlActual(session, "STOPPING", nil)
+	stopped, err := p.StopLiveSessionWithForce(session.ID, force)
+	if err != nil {
+		p.markLiveSessionControlActual(session, "ERROR", err)
+		return
+	}
+	p.markLiveSessionControlActual(stopped, "STOPPED", nil)
+}
+
+func (p *Platform) markLiveSessionControlActual(session domain.LiveSession, actual string, controlErr error) {
+	state := cloneMetadata(session.State)
+	now := time.Now().UTC()
+	state["actualStatus"] = actual
+	state["lastControlUpdateAt"] = now.Format(time.RFC3339)
+	if controlErr != nil {
+		state["lastControlError"] = controlErr.Error()
+		state["lastControlErrorAt"] = now.Format(time.RFC3339)
+	} else {
+		delete(state, "lastControlError")
+		delete(state, "lastControlErrorAt")
+	}
+	if _, err := p.store.UpdateLiveSessionState(session.ID, state); err != nil {
+		p.logger("service.live_session_control_scanner", "session_id", session.ID).Warn("update live session control state failed", "error", err)
+	}
+}
+
+func liveSessionActualStatusFromSession(session domain.LiveSession) string {
+	switch strings.ToUpper(strings.TrimSpace(session.Status)) {
+	case "RUNNING":
+		return "RUNNING"
+	case "STOPPED":
+		return "STOPPED"
+	default:
+		if actual := strings.ToUpper(strings.TrimSpace(stringValue(session.State["actualStatus"]))); actual != "" && actual != "ERROR" {
+			return actual
+		}
+		return "STOPPED"
+	}
+}

--- a/internal/service/live_session_control_test.go
+++ b/internal/service/live_session_control_test.go
@@ -1,0 +1,155 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/wuyaocheng/bktrader/internal/domain"
+	"github.com/wuyaocheng/bktrader/internal/store/memory"
+)
+
+func TestScanLiveSessionControlRequestsStopsDesiredStoppedSession(t *testing.T) {
+	store := memory.NewStore()
+	platform := NewPlatform(store)
+	session, err := store.UpdateLiveSessionStatus("live-session-main", "RUNNING")
+	if err != nil {
+		t.Fatalf("set live session running failed: %v", err)
+	}
+	state := cloneMetadata(session.State)
+	state["desiredStatus"] = "STOPPED"
+	state["actualStatus"] = "RUNNING"
+	if _, err := store.UpdateLiveSessionState(session.ID, state); err != nil {
+		t.Fatalf("set desired stopped failed: %v", err)
+	}
+
+	platform.scanLiveSessionControlRequests(context.Background())
+
+	updated, err := store.GetLiveSession(session.ID)
+	if err != nil {
+		t.Fatalf("get live session failed: %v", err)
+	}
+	if updated.Status != "STOPPED" {
+		t.Fatalf("expected STOPPED status, got %s", updated.Status)
+	}
+	if got := stringValue(updated.State["actualStatus"]); got != "STOPPED" {
+		t.Fatalf("expected actualStatus STOPPED, got %s", got)
+	}
+}
+
+func TestScanLiveSessionControlRequestsPreservesStopSafetyUntilForceRequested(t *testing.T) {
+	store := memory.NewStore()
+	platform := NewPlatform(store)
+	session, err := store.UpdateLiveSessionStatus("live-session-main", "RUNNING")
+	if err != nil {
+		t.Fatalf("set live session running failed: %v", err)
+	}
+	if _, err := store.SavePosition(domain.Position{
+		AccountID:         session.AccountID,
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "LONG",
+		Quantity:          0.002,
+		EntryPrice:        69000,
+		MarkPrice:         69100,
+	}); err != nil {
+		t.Fatalf("save position failed: %v", err)
+	}
+	if _, err := platform.RequestLiveSessionStopWithForce(session.ID, false); err != nil {
+		t.Fatalf("request stop failed: %v", err)
+	}
+
+	platform.scanLiveSessionControlRequests(context.Background())
+
+	blocked, err := store.GetLiveSession(session.ID)
+	if err != nil {
+		t.Fatalf("get live session failed: %v", err)
+	}
+	if blocked.Status != "RUNNING" {
+		t.Fatalf("expected session to remain RUNNING after blocked stop, got %s", blocked.Status)
+	}
+	if got := stringValue(blocked.State["actualStatus"]); got != "ERROR" {
+		t.Fatalf("expected actualStatus ERROR, got %s", got)
+	}
+
+	platform.scanLiveSessionControlRequests(context.Background())
+	stillBlocked, err := store.GetLiveSession(session.ID)
+	if err != nil {
+		t.Fatalf("get live session failed: %v", err)
+	}
+	if stillBlocked.Status != "RUNNING" {
+		t.Fatalf("expected ERROR state not to auto retry, got %s", stillBlocked.Status)
+	}
+
+	if _, err := platform.RequestLiveSessionStopWithForce(session.ID, true); err != nil {
+		t.Fatalf("request forced stop failed: %v", err)
+	}
+	platform.scanLiveSessionControlRequests(context.Background())
+
+	stopped, err := store.GetLiveSession(session.ID)
+	if err != nil {
+		t.Fatalf("get live session failed: %v", err)
+	}
+	if stopped.Status != "STOPPED" {
+		t.Fatalf("expected forced stop to stop session, got %s", stopped.Status)
+	}
+	if got := stringValue(stopped.State["actualStatus"]); got != "STOPPED" {
+		t.Fatalf("expected actualStatus STOPPED after force, got %s", got)
+	}
+}
+
+func TestScanLiveSessionControlRequestsWritesErrorWithoutRetryingStart(t *testing.T) {
+	store := memory.NewStore()
+	platform := NewPlatform(store)
+	if _, err := platform.RequestLiveSessionStart("live-session-main"); err != nil {
+		t.Fatalf("request start failed: %v", err)
+	}
+
+	platform.scanLiveSessionControlRequests(context.Background())
+
+	failed, err := store.GetLiveSession("live-session-main")
+	if err != nil {
+		t.Fatalf("get live session failed: %v", err)
+	}
+	if failed.Status == "RUNNING" {
+		t.Fatal("expected start to fail for unconfigured live account")
+	}
+	if got := stringValue(failed.State["actualStatus"]); got != "ERROR" {
+		t.Fatalf("expected actualStatus ERROR, got %s", got)
+	}
+	if got := stringValue(failed.State["lastControlError"]); got == "" {
+		t.Fatal("expected lastControlError")
+	}
+
+	platform.scanLiveSessionControlRequests(context.Background())
+	stillFailed, err := store.GetLiveSession("live-session-main")
+	if err != nil {
+		t.Fatalf("get live session failed: %v", err)
+	}
+	if got := stringValue(stillFailed.State["actualStatus"]); got != "ERROR" {
+		t.Fatalf("expected ERROR not to auto retry, got %s", got)
+	}
+}
+
+func TestRecoverLiveTradingOnStartupSkipsLiveSessionDesiredStopped(t *testing.T) {
+	store := memory.NewStore()
+	platform := NewPlatform(store)
+	session, err := store.UpdateLiveSessionStatus("live-session-main", "RUNNING")
+	if err != nil {
+		t.Fatalf("set live session running failed: %v", err)
+	}
+	state := cloneMetadata(session.State)
+	state["desiredStatus"] = "STOPPED"
+	if _, err := store.UpdateLiveSessionState(session.ID, state); err != nil {
+		t.Fatalf("set desired stopped failed: %v", err)
+	}
+
+	platform.RecoverLiveTradingOnStartup(context.Background())
+
+	updated, err := store.GetLiveSession(session.ID)
+	if err != nil {
+		t.Fatalf("get live session failed: %v", err)
+	}
+	if got := stringValue(updated.State["lastRecoveryStatus"]); got != "skipped-live-desired-stopped" {
+		t.Fatalf("expected skipped-live-desired-stopped, got %s", got)
+	}
+}

--- a/internal/service/live_session_control_test.go
+++ b/internal/service/live_session_control_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/wuyaocheng/bktrader/internal/domain"
 	"github.com/wuyaocheng/bktrader/internal/store/memory"
@@ -127,6 +128,66 @@ func TestScanLiveSessionControlRequestsWritesErrorWithoutRetryingStart(t *testin
 	}
 	if got := stringValue(stillFailed.State["actualStatus"]); got != "ERROR" {
 		t.Fatalf("expected ERROR not to auto retry, got %s", got)
+	}
+}
+
+func TestLiveSessionControlErrorCurrentAllowsNewerRequest(t *testing.T) {
+	now := time.Now().UTC()
+	state := map[string]any{
+		"actualStatus":       "ERROR",
+		"controlRequestedAt": now.Add(-time.Minute).Format(time.RFC3339),
+		"lastControlErrorAt": now.Format(time.RFC3339),
+	}
+	if !liveSessionControlErrorCurrent(state) {
+		t.Fatal("expected current control error to block automatic retry")
+	}
+
+	state["controlRequestedAt"] = now.Add(time.Minute).Format(time.RFC3339)
+	if liveSessionControlErrorCurrent(state) {
+		t.Fatal("expected newer control request to wake scanner")
+	}
+}
+
+func TestDeleteLiveSessionCancelsPendingDesiredControlIntent(t *testing.T) {
+	store := memory.NewStore()
+	platform := NewPlatform(store)
+	if _, err := platform.RequestLiveSessionStart("live-session-main"); err != nil {
+		t.Fatalf("request start failed: %v", err)
+	}
+
+	if err := platform.DeleteLiveSessionWithForce("live-session-main", true); err != nil {
+		t.Fatalf("delete live session failed: %v", err)
+	}
+	platform.scanLiveSessionControlRequests(context.Background())
+
+	deleted, err := store.GetLiveSession("live-session-main")
+	if err != nil {
+		t.Fatalf("get live session failed: %v", err)
+	}
+	if deleted.Status != "DELETED" {
+		t.Fatalf("expected DELETED status, got %s", deleted.Status)
+	}
+	if got := stringValue(deleted.State["desiredStatus"]); got != "STOPPED" {
+		t.Fatalf("expected delete to cancel desiredStatus as STOPPED, got %s", got)
+	}
+	if got := stringValue(deleted.State["actualStatus"]); got != "STOPPED" {
+		t.Fatalf("expected delete to mark actualStatus STOPPED, got %s", got)
+	}
+	if got := stringValue(deleted.State["controlDeletedAt"]); got == "" {
+		t.Fatal("expected controlDeletedAt after delete")
+	}
+	if _, ok := deleted.State["desiredStopForce"]; ok {
+		t.Fatalf("expected desiredStopForce to be cleared, got %#v", deleted.State["desiredStopForce"])
+	}
+
+	listed, err := store.ListLiveSessions()
+	if err != nil {
+		t.Fatalf("list live sessions failed: %v", err)
+	}
+	for _, item := range listed {
+		if item.ID == deleted.ID {
+			t.Fatalf("expected deleted session to be hidden from scanner list")
+		}
 	}
 }
 

--- a/internal/service/signal_runtime_sessions_persistence_test.go
+++ b/internal/service/signal_runtime_sessions_persistence_test.go
@@ -203,7 +203,7 @@ type blockingSignalRuntimeStore struct {
 }
 
 func (s *blockingSignalRuntimeStore) UpdateSignalRuntimeSession(session domain.SignalRuntimeSession) (domain.SignalRuntimeSession, error) {
-	if session.Status == "RUNNING" {
+	if session.Status == "RUNNING" && stringValue(mapValue(session.State["lastEventSummary"])["type"]) == "runtime_started" {
 		s.runningUpdates.Add(1)
 		s.enteredOnce.Do(func() { close(s.entered) })
 		<-s.release

--- a/web/console/src/hooks/useDashboardRealtime.ts
+++ b/web/console/src/hooks/useDashboardRealtime.ts
@@ -20,10 +20,63 @@ function intervalFromEnv(raw: string | undefined, fallback: number, minimum: num
   return isNaN(parsed) ? fallback : Math.max(minimum, parsed);
 }
 
+type ConsoleNotification = { type: 'success' | 'error' | 'info'; message: string };
+
+function liveSessionControlStatus(session: LiveSession) {
+  const state = session.state ?? {};
+  const desired = String(state.desiredStatus ?? "").trim().toUpperCase();
+  const actual = String(state.actualStatus ?? "").trim().toUpperCase();
+  const error = String(state.lastControlError ?? "").trim();
+  return {
+    desired,
+    actual,
+    error,
+    key: `${desired}|${actual}|${error}`,
+  };
+}
+
+function notifyLiveSessionControlTransitions(
+  previousByID: Map<string, string>,
+  sessions: LiveSession[],
+  setNotification: (notification: ConsoleNotification | null) => void
+) {
+  const seen = new Set<string>();
+  for (const session of sessions) {
+    seen.add(session.id);
+    const current = liveSessionControlStatus(session);
+    const previousKey = previousByID.get(session.id);
+    previousByID.set(session.id, current.key);
+    if (!previousKey || previousKey === current.key || !current.desired) {
+      continue;
+    }
+    const [previousDesired, previousActual] = previousKey.split("|");
+    const wasPending = previousDesired !== "" && previousDesired !== previousActual;
+    if (current.actual === "ERROR") {
+      setNotification({
+        type: 'error',
+        message: `会话控制失败：${current.error || session.id}`,
+      });
+      continue;
+    }
+    if (wasPending && current.desired === current.actual) {
+      setNotification({
+        type: 'success',
+        message: current.actual === "RUNNING" ? `会话已启动完成：${session.id}` : `会话已停止完成：${session.id}`,
+      });
+    }
+  }
+  for (const id of Array.from(previousByID.keys())) {
+    if (!seen.has(id)) {
+      previousByID.delete(id);
+    }
+  }
+}
+
 export function useDashboardRealtime() {
   const setError = useUIStore(s => s.setError);
   const setLoading = useUIStore(s => s.setLoading);
   const setAuthSession = useUIStore(s => s.setAuthSession);
+  const setNotification = useUIStore(s => s.setNotification);
   const authSession = useUIStore(s => s.authSession);
 
   const setLiveSessions = useTradingStore(s => s.setLiveSessions);
@@ -36,6 +89,7 @@ export function useDashboardRealtime() {
 
   const [isFirstLoad, setIsFirstLoad] = useState(true);
   const realtimeLoadInFlightRef = useRef<Promise<void> | null>(null);
+  const liveSessionControlRef = useRef<Map<string, string>>(new Map());
 
   const isStreamEnabled = import.meta.env.VITE_DASHBOARD_STREAM_ENABLED === 'true';
   const { isConnected: isStreamConnected } = useDashboardStream(isStreamEnabled);
@@ -66,7 +120,9 @@ export function useDashboardRealtime() {
     const normalizedAlerts = Array.isArray(alertData) ? alertData : [];
     const normalizedNotifications = Array.isArray(notificationData) ? notificationData : [];
 
-    setLiveSessions((current) => mergeLiveSessionSnapshot(current, normalizedLiveSessions));
+    const mergedLiveSessions = mergeLiveSessionSnapshot(useTradingStore.getState().liveSessions, normalizedLiveSessions);
+    notifyLiveSessionControlTransitions(liveSessionControlRef.current, mergedLiveSessions, setNotification);
+    setLiveSessions(mergedLiveSessions);
     setPositions(normalizedPositions);
     setOrders(normalizedOrders);
     setFills(normalizedFills);

--- a/web/console/src/hooks/useTradingActions.ts
+++ b/web/console/src/hooks/useTradingActions.ts
@@ -597,6 +597,7 @@ export function useTradingActions(loadDashboard: () => Promise<void>) {
     setLiveFlowAction(account.id);
     setError(null);
     selectQuickLiveAccount(account.id);
+    let launchResult: LiveLaunchResult | null = null;
     
     try {
       const strategyBindings = strategySignalBindingMap[strategyId] ?? [];
@@ -604,7 +605,7 @@ export function useTradingActions(loadDashboard: () => Promise<void>) {
         window.location.hash = "signals";
         throw new Error("Launch live flow needs strategy signal bindings before it can continue");
       }
-      const launchResult = await fetchJSON<LiveLaunchResult>(`/api/v1/live/accounts/${account.id}/launch`, {
+      launchResult = await fetchJSON<LiveLaunchResult>(`/api/v1/live/accounts/${account.id}/launch`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -641,7 +642,17 @@ export function useTradingActions(loadDashboard: () => Promise<void>) {
       setNotification({ type: 'success', message: "已提交实盘流程启动意图" });
       window.location.hash = "live";
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to launch live flow");
+      const message = err instanceof Error ? err.message : "Failed to launch live flow";
+      const sessionId = launchResult?.liveSession?.id;
+      if (sessionId) {
+        await loadDashboard().catch(() => undefined);
+        const partialMessage = `会话已创建但启动意图未提交：${sessionId}。${message}`;
+        setError(partialMessage);
+        setNotification({ type: 'error', message: partialMessage });
+        window.location.hash = "live";
+        return;
+      }
+      setError(message);
     } finally {
       setLiveFlowAction(null);
     }

--- a/web/console/src/hooks/useTradingActions.ts
+++ b/web/console/src/hooks/useTradingActions.ts
@@ -303,11 +303,19 @@ export function useTradingActions(loadDashboard: () => Promise<void>) {
   async function stopLiveFlow(accountId: string, force = false) {
     setLiveFlowAction(accountId);
     try {
-      await fetchJSON(`/api/v1/live/accounts/${accountId}/stop${force ? '?force=true' : ''}`, { method: "POST" });
+      const sessions = validLiveSessions.filter((session: LiveSession) =>
+        session.accountId === accountId && String(session.status ?? "").toUpperCase() !== "STOPPED"
+      );
+      if (sessions.length === 0) {
+        throw new Error("No active live session found for this account");
+      }
+      await Promise.all(sessions.map((session: LiveSession) =>
+        fetchJSON(`/api/v1/live/sessions/${session.id}/stop${force ? '?force=true' : ''}`, { method: "POST" })
+      ));
       await loadDashboard();
       setNotification({
         type: 'success',
-        message: force ? "已强制停止账户实盘流程" : "已安全停止账户实盘流程",
+        message: force ? "已提交强制停止实盘流程意图" : "已提交停止实盘流程意图",
       });
       setError(null);
     } catch (err) {
@@ -596,7 +604,7 @@ export function useTradingActions(loadDashboard: () => Promise<void>) {
         window.location.hash = "signals";
         throw new Error("Launch live flow needs strategy signal bindings before it can continue");
       }
-      await fetchJSON(`/api/v1/live/accounts/${account.id}/launch`, {
+      const launchResult = await fetchJSON<LiveLaunchResult>(`/api/v1/live/accounts/${account.id}/launch`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -612,8 +620,8 @@ export function useTradingActions(loadDashboard: () => Promise<void>) {
             },
           },
           mirrorStrategySignals: true,
-          startRuntime: true,
-          startSession: true,
+          startRuntime: false,
+          startSession: false,
           liveSessionOverrides: {
             alias: liveSessionForm.alias,
             signalTimeframe: liveSessionForm.signalTimeframe,
@@ -625,8 +633,12 @@ export function useTradingActions(loadDashboard: () => Promise<void>) {
           },
         }),
       });
+      if (launchResult.liveSession?.id) {
+        await fetchJSON(`/api/v1/live/sessions/${launchResult.liveSession.id}/start`, { method: "POST" });
+      }
 
       await loadDashboard();
+      setNotification({ type: 'success', message: "已提交实盘流程启动意图" });
       window.location.hash = "live";
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to launch live flow");
@@ -643,9 +655,9 @@ export function useTradingActions(loadDashboard: () => Promise<void>) {
       await fetchJSON(`/api/v1/live/sessions/${sessionId}/${action}${force ? '?force=true' : ''}`, { method: "POST" });
       await loadDashboard();
       if (action === "stop") {
-        setNotification({ type: 'success', message: `已停用会话: ${sessionId}` });
+        setNotification({ type: 'success', message: `已提交停用意图: ${sessionId}` });
       } else {
-        setNotification({ type: 'success', message: `已启动会话: ${sessionId}` });
+        setNotification({ type: 'success', message: `已提交启动意图: ${sessionId}` });
       }
     } catch (err) {
       const message = err instanceof Error ? err.message : "Failed to execute live session action";

--- a/web/console/src/modals/LiveSessionModal.tsx
+++ b/web/console/src/modals/LiveSessionModal.tsx
@@ -479,8 +479,8 @@ export function LiveSessionModal({
           }}
         >
           {liveSessionLaunchAction
-            ? editingLiveSessionId ? "保存并启动中..." : "启动中..."
-            : editingLiveSessionId ? "保存并启动会话" : "立即创建并启动"}
+            ? editingLiveSessionId ? "保存并提交中..." : "提交中..."
+            : editingLiveSessionId ? "保存并提交启动" : "创建并提交启动"}
         </Button>
       </ModalActions>
     </SettingsModalFrame>

--- a/web/console/src/pages/AccountStage.tsx
+++ b/web/console/src/pages/AccountStage.tsx
@@ -678,9 +678,9 @@ export function AccountStage({
                              {liveFlowAction === account.id ? (
                                <div className="flex items-center gap-2"><RotateCw size={14} className="animate-spin" /> 处理中...</div>
                              ) : isLiveFlowRunning ? (
-                               <div className="flex items-center gap-2"><Square size={14} fill="currentColor" /> 停止实盘流程</div>
+                               <div className="flex items-center gap-2"><Square size={14} fill="currentColor" /> 提交停止意图</div>
                              ) : (
-                               <div className="flex items-center gap-2"><Play size={14} fill="currentColor" /> 启动实盘流程</div>
+                               <div className="flex items-center gap-2"><Play size={14} fill="currentColor" /> 提交启动意图</div>
                              )}
                           </Button>
                           <div className="grid grid-cols-2 gap-2">
@@ -1098,6 +1098,8 @@ export function AccountStage({
                  validLiveSessions.map((session) => {
                    const sessionState = getRecord(session.state);
                    const isRunning = String(session.status).toUpperCase() === "RUNNING";
+                   const desiredStatus = String(sessionState.desiredStatus ?? "").trim().toUpperCase();
+                   const actualStatus = String(sessionState.actualStatus ?? "").trim().toUpperCase();
                    const linkedRuntimeSessionId = String(
                      sessionState.signalRuntimeSessionId ?? sessionState.lastSignalRuntimeSessionId ?? ""
                    ).trim();
@@ -1133,6 +1135,11 @@ export function AccountStage({
                               </Badge>
                            </div>
                            <p className="text-[10px] font-mono text-[var(--bk-text-muted)]">{String(sessionState.symbol || "--")} · {session.strategyId}</p>
+                           {(desiredStatus || actualStatus) && desiredStatus !== actualStatus && (
+                             <p className="text-[10px] font-bold text-[var(--bk-status-warning)]">
+                               {desiredStatus || "--"} / {actualStatus || session.status}
+                             </p>
+                           )}
                            {linkedRuntimeStillActive && (
                              <p className="flex items-center gap-1.5 text-[10px] font-bold text-[var(--bk-status-warning)]">
                                <AlertTriangle size={12} />


### PR DESCRIPTION
## 目的
解决 #276：LiveSession start/stop 从 platform-api 直接执行 runtime action 改为 desired-state 控制面。

本 PR 将 UI/CLI/API 的 LiveSession start/stop 改成只写 `session.state.desiredStatus`，由 `live-runner` / monolith 的 control scanner 执行实际 start/stop，并写回 `actualStatus`。这样 `BKTRADER_ROLE=api` 下 UI/CLI 可以提交控制意图，不再撞 `RuntimeActionsEnabled()`，同时 `dispatch` / `sync` 仍保持 runtime action gate。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [x] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) — 未变化，仍为 `manual-review`。
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？— 不存在。
- [x] DB migration 是否具备向下兼容幂等性？— 无 DB migration，状态协议写入现有 `live_sessions.state`。
- [x] 配置字段有没有无意被混改？— 未新增 env/config 字段，仅新增 runtime option 开关并按 role 启动 scanner。

## 关键改动
- LiveSession start/stop API 返回 `202 Accepted`，只写 `desiredStatus` / `actualStatus` / `desiredStopForce` 等状态字段。
- 新增 `StartLiveSessionControlScanner`，只在 `live-runner` 和 monolith 启动，由 runner 执行实际 start/stop。
- stop 的 `force=true` 持久化为 `desiredStopForce=true`，runner 执行时复用现有强制停止语义。
- CLI `bktrader live start/stop` 增加 `--wait` / `--timeout`，可等待 `actualStatus` 收敛。
- 前端改为“提交启动/停止意图”，并监听 dashboard 刷新后的 `desiredStatus/actualStatus`，在完成或 ERROR 时 toast 通知。

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

已执行：

```bash
go test ./...
go build ./cmd/platform-api
go build ./cmd/db-migrate
go build ./cmd/bktrader-ctl
bash scripts/check_high_risk_defaults.sh
cd web/console && ./node_modules/.bin/tsc --noEmit src/pages/AccountStage.tsx --jsx react-jsx --esModuleInterop --target esnext --module esnext --moduleResolution Bundler --allowSyntheticDefaultImports
cd web/console && npm run build
git diff --check
```

Note: Codex assisted with implementation.
