### PR TITLE
[codex] delete orphaned live signal runtime

### DIFF
--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -226,11 +226,20 @@ func (p *Platform) deleteLiveSessionWithForceLocked(session domain.LiveSession, 
 			return err
 		}
 	}
-	if _, err := p.stopLinkedLiveSignalRuntime(session); err != nil {
+	runtimeSession, err := p.stopLinkedLiveSignalRuntime(session)
+	if err != nil {
 		logger.Warn("stop linked signal runtime before live session delete failed", "error", err)
 		return err
 	}
-	return p.store.DeleteLiveSession(session.ID)
+	if err := p.store.DeleteLiveSession(session.ID); err != nil {
+		return err
+	}
+	if runtimeSession.ID != "" &&
+		strings.EqualFold(runtimeSession.Status, "STOPPED") &&
+		!p.runtimeReferencedByActiveLiveSession(runtimeSession.ID, session.ID) {
+		return p.deleteSignalRuntimeSessionWithForceLocked(runtimeSession, true)
+	}
+	return nil
 }
 
 func (p *Platform) UpdateLiveSession(sessionID, alias, accountID, strategyID string, overrides map[string]any) (domain.LiveSession, error) {
@@ -4402,6 +4411,29 @@ func (p *Platform) stopLinkedLiveSignalRuntime(session domain.LiveSession) (doma
 		return domain.SignalRuntimeSession{}, err
 	}
 	return runtimeSession, nil
+}
+
+func (p *Platform) runtimeReferencedByActiveLiveSession(runtimeID, excludeLiveSessionID string) bool {
+	runtimeID = strings.TrimSpace(runtimeID)
+	if runtimeID == "" {
+		return false
+	}
+	sessions, err := p.ListLiveSessions()
+	if err != nil {
+		return true
+	}
+	for _, session := range sessions {
+		if session.ID == excludeLiveSessionID {
+			continue
+		}
+		if strings.EqualFold(session.Status, "DELETED") || strings.EqualFold(session.Status, "STOPPED") {
+			continue
+		}
+		if liveSessionReferencesRuntime(session, runtimeID) {
+			return true
+		}
+	}
+	return false
 }
 
 func (p *Platform) liveSessionLinkedRuntimeDesiredStopped(session domain.LiveSession) bool {

--- a/internal/service/safety_checks_test.go
+++ b/internal/service/safety_checks_test.go
@@ -157,7 +157,7 @@ func TestStopLiveSessionWithForceStopsLinkedRuntimeWhenLiveAlreadyStopped(t *tes
 	}
 }
 
-func TestDeleteLiveSessionWithForceStopsLinkedRuntimeBeforeDelete(t *testing.T) {
+func TestDeleteLiveSessionWithForceDeletesStoppedLinkedRuntimeWhenUnreferenced(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
 	session, err := platform.store.GetLiveSession("live-session-main")
 	if err != nil {
@@ -178,15 +178,89 @@ func TestDeleteLiveSessionWithForceStopsLinkedRuntimeBeforeDelete(t *testing.T) 
 	if got := stringValue(deleted.State["deletedAt"]); got == "" {
 		t.Fatal("expected deletedAt to be set")
 	}
+	if got := stringValue(deleted.State["signalRuntimeStatus"]); got != "STOPPED" {
+		t.Fatalf("expected live session signalRuntimeStatus STOPPED before delete, got %s", got)
+	}
+	if _, err := platform.GetSignalRuntimeSession(runtime.ID); !isSignalRuntimeSessionNotFoundError(err) {
+		t.Fatalf("expected unreferenced linked runtime to be deleted, got %v", err)
+	}
+}
+
+func TestDeleteLiveSessionWithForceKeepsLinkedRuntimeReferencedByActiveLiveSession(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	session, err := platform.store.GetLiveSession("live-session-main")
+	if err != nil {
+		t.Fatalf("get live session failed: %v", err)
+	}
+	runtime := mustCreateLinkedLiveRuntime(t, platform, session, "RUNNING", "RUNNING")
+	other, err := platform.store.CreateLiveSession(session.AccountID, session.StrategyID)
+	if err != nil {
+		t.Fatalf("create second live session failed: %v", err)
+	}
+	other, err = platform.store.UpdateLiveSessionStatus(other.ID, "RUNNING")
+	if err != nil {
+		t.Fatalf("mark second live session running failed: %v", err)
+	}
+	otherState := cloneMetadata(other.State)
+	otherState["signalRuntimeSessionId"] = runtime.ID
+	if _, err := platform.store.UpdateLiveSessionState(other.ID, otherState); err != nil {
+		t.Fatalf("link runtime into second live session failed: %v", err)
+	}
+
+	if err := platform.DeleteLiveSessionWithForce(session.ID, false); err != nil {
+		t.Fatalf("delete live session failed: %v", err)
+	}
 	updatedRuntime, err := platform.GetSignalRuntimeSession(runtime.ID)
 	if err != nil {
-		t.Fatalf("reload runtime failed: %v", err)
+		t.Fatalf("expected linked runtime to remain while referenced by active live session, got %v", err)
 	}
 	if updatedRuntime.Status != "STOPPED" {
-		t.Fatalf("expected linked runtime STOPPED before live delete, got %s", updatedRuntime.Status)
+		t.Fatalf("expected linked runtime STOPPED, got %s", updatedRuntime.Status)
 	}
 	if got := stringValue(updatedRuntime.State["desiredStatus"]); got != "STOPPED" {
 		t.Fatalf("expected linked runtime desiredStatus STOPPED, got %s", got)
+	}
+}
+
+func TestStartStoppedLiveSessionRecreatesMissingRuntime(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	configureTestLiveRESTReconcileAdapter(t, platform, "test-start-recreates-runtime", []map[string]any{})
+	session, err := platform.store.GetLiveSession("live-session-main")
+	if err != nil {
+		t.Fatalf("get live session failed: %v", err)
+	}
+	oldRuntime := mustCreateLinkedLiveRuntime(t, platform, session, "STOPPED", "STOPPED")
+	session, err = platform.store.UpdateLiveSessionStatus(session.ID, "STOPPED")
+	if err != nil {
+		t.Fatalf("mark live session stopped failed: %v", err)
+	}
+	if err := platform.deleteSignalRuntimeSessionWithForceLocked(oldRuntime, true); err != nil {
+		t.Fatalf("delete old runtime failed: %v", err)
+	}
+
+	started, err := platform.StartLiveSession(session.ID)
+	if err != nil {
+		t.Fatalf("StartLiveSession failed to recreate missing runtime: %v", err)
+	}
+	if started.Status != "RUNNING" {
+		t.Fatalf("expected live session RUNNING after start, got %s", started.Status)
+	}
+	newRuntimeID := stringValue(started.State["signalRuntimeSessionId"])
+	if newRuntimeID == "" {
+		t.Fatal("expected start to link a recreated runtime")
+	}
+	if newRuntimeID == oldRuntime.ID {
+		t.Fatalf("expected recreated runtime id to differ from deleted runtime %s", oldRuntime.ID)
+	}
+	if _, err := platform.GetSignalRuntimeSession(oldRuntime.ID); !isSignalRuntimeSessionNotFoundError(err) {
+		t.Fatalf("expected old runtime to remain deleted, got %v", err)
+	}
+	newRuntime, err := platform.GetSignalRuntimeSession(newRuntimeID)
+	if err != nil {
+		t.Fatalf("load recreated runtime failed: %v", err)
+	}
+	if newRuntime.Status != "RUNNING" {
+		t.Fatalf("expected recreated runtime RUNNING, got %s", newRuntime.Status)
 	}
 }
 


### PR DESCRIPTION
## 目的
修复删除 live session 后关联 signal runtime 只被 STOP、没有被清理，导致旧 runtime session 残留的问题。

本次改动保持删除 live session 的既有安全前置条件不变，只在软删除 live session 成功后追加受保护的 runtime 清理：

- 先停止当前 live session 关联的 signal runtime。
- 软删除 live session。
- 仅当 runtime 已经是 `STOPPED`，且没有其他非 `DELETED` / 非 `STOPPED` 的 live session 仍通过 `signalRuntimeSessionId` 或 `lastSignalRuntimeSessionId` 引用它时，才删除 runtime。
- 如果检查其他 live session 引用失败，默认保守认为仍有引用，不删除 runtime。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [x] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) - 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？- 不涉及
- [x] DB migration 是否具备向下兼容幂等性？- 不涉及 migration
- [x] 配置字段有没有无意被混改？- 无配置改动

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

本地已验证：

```bash
go test ./internal/service -run 'TestDeleteLiveSessionWithForce(DeletesStoppedLinkedRuntimeWhenUnreferenced|KeepsLinkedRuntimeReferencedByActiveLiveSession|KeepsSessionWhenLinkedRuntimeStopFails)'
go build ./cmd/platform-api
go build ./cmd/db-migrate
go test ./...
```
