### PR TITLE
fix(live): use live market replay for enhanced 30m engine

### DIFF
--- a/internal/service/live_market_data.go
+++ b/internal/service/live_market_data.go
@@ -551,7 +551,7 @@ func (p *Platform) buildLiveExecutionPlanFromMarketData(
 
 	var result map[string]any
 	switch normalized := normalizeStrategyEngineKey(engineKey); normalized {
-	case "bk-default":
+	case "bk-default", "bk-live-intrabar-sma5-t3-sep":
 		result, err = runStrategyReplayOnMinuteBars(cfg, signals, minuteBars)
 	default:
 		result, err = engine.Run(context)

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -1056,6 +1056,90 @@ func TestBuildLiveExecutionPlanFromMarketDataAcceptsTickExecutionSource(t *testi
 	}
 }
 
+func TestBuildLiveExecutionPlanFromMarketDataUsesLiveSnapshotForEnhanced30m(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+
+	session, err := platform.CreateLiveSession("", "live-main", "strategy-bk-btc-30m-enhanced", map[string]any{
+		"symbol":              "BTCUSDT",
+		"signalTimeframe":     "30m",
+		"executionDataSource": "tick",
+	})
+	if err != nil {
+		t.Fatalf("create live session failed: %v", err)
+	}
+
+	version, err := platform.resolveCurrentStrategyVersion(session.StrategyID)
+	if err != nil {
+		t.Fatalf("resolve strategy version failed: %v", err)
+	}
+	parameters, err := platform.resolveLiveSessionParameters(session, version)
+	if err != nil {
+		t.Fatalf("resolve live session parameters failed: %v", err)
+	}
+	engine, engineKey, err := platform.resolveStrategyEngine(version.ID, parameters)
+	if err != nil {
+		t.Fatalf("resolve strategy engine failed: %v", err)
+	}
+	if got := normalizeStrategyEngineKey(engineKey); got != "bk-live-intrabar-sma5-t3-sep" {
+		t.Fatalf("expected enhanced engine, got %s", got)
+	}
+
+	signalCandles := make([]candleBar, 0, 48)
+	minuteBars := make([]candleBar, 0, 48)
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	for i := 0; i < 48; i++ {
+		ts := start.Add(time.Duration(i) * 30 * time.Minute)
+		open := 100.0 + float64(i)*0.5
+		close := open + 0.25
+		high := close + 0.75
+		low := open - 0.75
+		signalCandles = append(signalCandles, candleBar{
+			Time:   ts,
+			Open:   open,
+			High:   high,
+			Low:    low,
+			Close:  close,
+			Volume: 10 + float64(i),
+		})
+		minuteBars = append(minuteBars, candleBar{
+			Time:   ts.Add(time.Minute),
+			Open:   open,
+			High:   high,
+			Low:    low,
+			Close:  close,
+			Volume: 1,
+		})
+	}
+	signalBars, err := buildStrategySignalBarsFromCandles(signalCandles)
+	if err != nil {
+		t.Fatalf("build signal bars failed: %v", err)
+	}
+
+	platform.liveMarketMu.Lock()
+	platform.liveMarketData["BTCUSDT"] = liveMarketSnapshot{
+		Symbol:     "BTCUSDT",
+		MinuteBars: minuteBars,
+		SignalBars: map[string][]strategySignalBar{"30m": signalBars},
+		UpdatedAt:  time.Now().UTC(),
+	}
+	platform.liveMarketMu.Unlock()
+
+	plan, err := platform.buildLiveExecutionPlanFromMarketData(
+		session,
+		version,
+		engine,
+		engineKey,
+		parameters,
+		defaultExecutionSemantics(ExecutionModeLive, parameters),
+	)
+	if err != nil {
+		t.Fatalf("build enhanced 30m live execution plan failed: %v", err)
+	}
+	if plan == nil {
+		t.Fatal("expected plan slice, got nil")
+	}
+}
+
 func TestResolveLiveSessionParametersDefaultsMissingStopsToTrailingForLive(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
 


### PR DESCRIPTION
## 目的
修复 BTCUSDT 30m Enhanced 实盘策略触发后没有策略评估/decision 的问题。通过 bktrader-ctl 查看生产日志，live session 每次从 signal runtime 触发后都报 `unsupported signal timeframe: 30m`，导致评估路径提前失败。

原因是 `bk-live-intrabar-sma5-t3-sep` 在 live market plan 构建时掉回了离线 `engine.Run(context)` replay loader；该 loader 当前不支持 30m。修复后增强引擎和默认引擎一样使用已预热的 live market snapshot + minute cache 构建 execution plan。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [x] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) — 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？— 无
- [x] DB migration 是否具备向下兼容幂等性？— 不涉及 DB migration
- [x] 配置字段有没有无意被混改？— 无，仅调整 enhanced engine 的 live replay 数据源路径

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

验证：
- `go test ./internal/service -run 'TestBuildLiveExecutionPlanFromMarketData(UsesLiveSnapshotForEnhanced30m|AcceptsTickExecutionSource)'`
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
- `git push` pre-push harness passed