### PR TITLE
[codex] Implement declarative live session control

### DIFF
--- a/cmd/bktrader-ctl/live.go
+++ b/cmd/bktrader-ctl/live.go
@@ -71,6 +71,9 @@ var liveStartCmd = &cobra.Command{
 		client := getClient()
 		resp, err := client.Request("POST", "/api/v1/live/sessions/"+url.PathEscape(args[0])+"/start", nil)
 		if err != nil || !wait || dryRun {
+			if err == nil && !wait && !dryRun {
+				fmt.Fprintln(os.Stderr, "accepted: control intent submitted only; use --wait to confirm actualStatus convergence")
+			}
 			handleResponse(resp, err)
 			return nil
 		}
@@ -101,6 +104,9 @@ var liveStopCmd = &cobra.Command{
 		}
 		resp, err := client.Request("POST", path, nil)
 		if err != nil || !wait || dryRun {
+			if err == nil && !wait && !dryRun {
+				fmt.Fprintln(os.Stderr, "accepted: control intent submitted only; use --wait to confirm actualStatus convergence")
+			}
 			handleResponse(resp, err)
 			return nil
 		}

--- a/internal/app/server_test.go
+++ b/internal/app/server_test.go
@@ -28,6 +28,16 @@ func TestRuntimeOptionsForLiveRunnerDoesNotStartSignalRuntimeScanner(t *testing.
 	}
 }
 
+func TestRuntimeOptionsForAPIDoesNotStartLiveSessionScanner(t *testing.T) {
+	options := RuntimeOptionsForRole("api")
+	if options.StartLiveSessionControlScanner {
+		t.Fatal("expected api role not to start live session scanner")
+	}
+	if !options.StartDashboard {
+		t.Fatal("expected api role to start dashboard")
+	}
+}
+
 func TestRuntimeOptionsForMonolithStartAllRuntimeComponents(t *testing.T) {
 	options := RuntimeOptionsForRole("monolith")
 	if !options.WarmLiveMarketData ||

--- a/internal/http/live.go
+++ b/internal/http/live.go
@@ -676,29 +676,17 @@ func registerLiveRoutes(mux *http.ServeMux, platform *service.Platform, cfg conf
 		case "start":
 			item, err := platform.RequestLiveSessionStart(sessionID)
 			if err != nil {
-				if errors.Is(err, service.ErrLiveControlOperationInProgress) {
-					writeError(w, http.StatusConflict, err.Error())
-					return
-				}
 				writeError(w, http.StatusInternalServerError, err.Error())
 				return
 			}
-			writeJSON(w, http.StatusAccepted, item)
+			writeJSON(w, http.StatusAccepted, liveSessionControlAcceptedPayload(item))
 		case "stop":
 			item, err := platform.RequestLiveSessionStopWithForce(sessionID, queryFlagEnabled(r, "force"))
 			if err != nil {
-				if errors.Is(err, service.ErrLiveControlOperationInProgress) {
-					writeError(w, http.StatusConflict, err.Error())
-					return
-				}
-				if errors.Is(err, service.ErrActivePositionsOrOrders) {
-					writeError(w, http.StatusBadRequest, err.Error())
-					return
-				}
 				writeError(w, http.StatusInternalServerError, err.Error())
 				return
 			}
-			writeJSON(w, http.StatusAccepted, item)
+			writeJSON(w, http.StatusAccepted, liveSessionControlAcceptedPayload(item))
 		case "dispatch":
 			if !cfg.RuntimeActionsEnabled() {
 				writeError(w, http.StatusConflict, "runtime action dispatch is disabled for BKTRADER_ROLE="+cfg.ProcessRole)
@@ -725,6 +713,22 @@ func registerLiveRoutes(mux *http.ServeMux, platform *service.Platform, cfg conf
 			writeError(w, http.StatusNotFound, "unsupported live session action")
 		}
 	})
+}
+
+func liveSessionControlAcceptedPayload(session domain.LiveSession) map[string]any {
+	state := session.State
+	if state == nil {
+		state = map[string]any{}
+	}
+	return map[string]any{
+		"status":           "accepted",
+		"message":          "control intent accepted; execution is asynchronous and must be confirmed through actualStatus",
+		"sessionId":        session.ID,
+		"desiredStatus":    state["desiredStatus"],
+		"actualStatus":     state["actualStatus"],
+		"lastControlError": state["lastControlError"],
+		"session":          session,
+	}
 }
 
 var allowedLiveSessionDetailFields = map[string]struct{}{

--- a/internal/http/session_safety_test.go
+++ b/internal/http/session_safety_test.go
@@ -17,7 +17,7 @@ func boolValue(value any) bool {
 	return ok && v
 }
 
-func TestLiveSessionStopRouteRespectsForceQuery(t *testing.T) {
+func TestLiveSessionStopRoutePersistsDesiredStopIntent(t *testing.T) {
 	store := memory.NewStore()
 	platform := service.NewPlatform(store)
 	if _, err := store.SavePosition(domain.Position{
@@ -41,29 +41,80 @@ func TestLiveSessionStopRouteRespectsForceQuery(t *testing.T) {
 	if rec.Code != http.StatusAccepted {
 		t.Fatalf("expected 202 for accepted stop intent, got %d body=%s", rec.Code, rec.Body.String())
 	}
-	session, err := store.GetLiveSession("live-session-main")
-	if err != nil {
-		t.Fatalf("get live session failed: %v", err)
+	var stopped struct {
+		DesiredStatus    string             `json:"desiredStatus"`
+		ActualStatus     string             `json:"actualStatus"`
+		LastControlError any                `json:"lastControlError"`
+		Session          domain.LiveSession `json:"session"`
 	}
-	if got := stringValue(session.State["desiredStatus"]); got != "STOPPED" {
-		t.Fatalf("expected desiredStatus STOPPED, got %s", got)
+	if err := json.NewDecoder(rec.Body).Decode(&stopped); err != nil {
+		t.Fatalf("decode stop intent failed: %v", err)
 	}
-	if boolValue(session.State["desiredStopForce"]) {
-		t.Fatalf("did not expect desiredStopForce for normal stop")
+	if stopped.DesiredStatus != "STOPPED" {
+		t.Fatalf("expected top-level desiredStatus STOPPED, got %s", stopped.DesiredStatus)
+	}
+	if stopped.ActualStatus != "STOPPED" {
+		t.Fatalf("expected top-level actualStatus STOPPED, got %s", stopped.ActualStatus)
+	}
+	if got := stopped.Session.State["desiredStatus"]; got != "STOPPED" {
+		t.Fatalf("expected desiredStatus STOPPED, got %#v", got)
+	}
+	if got := stopped.Session.State["desiredStopForce"]; got != false {
+		t.Fatalf("expected desiredStopForce false, got %#v", got)
 	}
 
 	rec = httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodPost, "/api/v1/live/sessions/live-session-main/stop?force=true", nil)
 	mux.ServeHTTP(rec, req)
 	if rec.Code != http.StatusAccepted {
-		t.Fatalf("expected 202 for accepted forced stop intent, got %d body=%s", rec.Code, rec.Body.String())
+		t.Fatalf("expected 202 for forced stop intent, got %d body=%s", rec.Code, rec.Body.String())
 	}
-	session, err = store.GetLiveSession("live-session-main")
-	if err != nil {
-		t.Fatalf("get live session failed: %v", err)
+	var forced struct {
+		Session domain.LiveSession `json:"session"`
 	}
-	if !boolValue(session.State["desiredStopForce"]) {
-		t.Fatalf("expected desiredStopForce for forced stop")
+	if err := json.NewDecoder(rec.Body).Decode(&forced); err != nil {
+		t.Fatalf("decode forced stop intent failed: %v", err)
+	}
+	if got := forced.Session.State["desiredStopForce"]; got != true {
+		t.Fatalf("expected desiredStopForce true, got %#v", got)
+	}
+}
+
+func TestLiveSessionControlIntentAcceptedForAPIRole(t *testing.T) {
+	cases := map[string]string{
+		"/api/v1/live/sessions/live-session-main/start": "RUNNING",
+		"/api/v1/live/sessions/live-session-main/stop":  "STOPPED",
+	}
+	for path, desired := range cases {
+		t.Run(path, func(t *testing.T) {
+			platform := service.NewPlatform(memory.NewStore())
+			mux := http.NewServeMux()
+			registerLiveRoutes(mux, platform, config.Config{ProcessRole: "api"})
+
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodPost, path, nil)
+			mux.ServeHTTP(rec, req)
+			if rec.Code != http.StatusAccepted {
+				t.Fatalf("expected 202 for api role control intent, got %d body=%s", rec.Code, rec.Body.String())
+			}
+			var payload struct {
+				DesiredStatus string             `json:"desiredStatus"`
+				ActualStatus  string             `json:"actualStatus"`
+				Session       domain.LiveSession `json:"session"`
+			}
+			if err := json.NewDecoder(rec.Body).Decode(&payload); err != nil {
+				t.Fatalf("decode live session failed: %v", err)
+			}
+			if payload.DesiredStatus != desired {
+				t.Fatalf("expected top-level desiredStatus %s, got %s", desired, payload.DesiredStatus)
+			}
+			if payload.ActualStatus == "" {
+				t.Fatal("expected top-level actualStatus")
+			}
+			if got := payload.Session.State["desiredStatus"]; got != desired {
+				t.Fatalf("expected desiredStatus %s, got %#v", desired, got)
+			}
+		})
 	}
 }
 
@@ -85,44 +136,6 @@ func TestLiveSessionRuntimeActionsDisabledForAPIRole(t *testing.T) {
 				t.Fatalf("expected 409 for api role runtime action, got %d body=%s", rec.Code, rec.Body.String())
 			}
 		})
-	}
-}
-
-func TestLiveSessionStartStopRoutesAcceptedForAPIRole(t *testing.T) {
-	store := memory.NewStore()
-	platform := service.NewPlatform(store)
-	mux := http.NewServeMux()
-	registerLiveRoutes(mux, platform, config.Config{ProcessRole: "api"})
-
-	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/live/sessions/live-session-main/start", nil)
-	mux.ServeHTTP(rec, req)
-	if rec.Code != http.StatusAccepted {
-		t.Fatalf("expected 202 for api role start intent, got %d body=%s", rec.Code, rec.Body.String())
-	}
-	session, err := store.GetLiveSession("live-session-main")
-	if err != nil {
-		t.Fatalf("get live session failed: %v", err)
-	}
-	if got := stringValue(session.State["desiredStatus"]); got != "RUNNING" {
-		t.Fatalf("expected desiredStatus RUNNING, got %s", got)
-	}
-
-	rec = httptest.NewRecorder()
-	req = httptest.NewRequest(http.MethodPost, "/api/v1/live/sessions/live-session-main/stop?force=true", nil)
-	mux.ServeHTTP(rec, req)
-	if rec.Code != http.StatusAccepted {
-		t.Fatalf("expected 202 for api role stop intent, got %d body=%s", rec.Code, rec.Body.String())
-	}
-	session, err = store.GetLiveSession("live-session-main")
-	if err != nil {
-		t.Fatalf("get live session failed: %v", err)
-	}
-	if got := stringValue(session.State["desiredStatus"]); got != "STOPPED" {
-		t.Fatalf("expected desiredStatus STOPPED, got %s", got)
-	}
-	if !boolValue(session.State["desiredStopForce"]) {
-		t.Fatalf("expected desiredStopForce")
 	}
 }
 
@@ -171,7 +184,7 @@ func TestLiveSessionDeleteCancelsPendingDesiredControlIntent(t *testing.T) {
 	}
 }
 
-func TestLiveSessionStartRouteWritesDesiredStateForCorruptedControlKey(t *testing.T) {
+func TestLiveSessionStartRoutePersistsDesiredStartIntentWithCorruptControlKey(t *testing.T) {
 	store := memory.NewStore()
 	session, err := store.GetLiveSession("live-session-main")
 	if err != nil {
@@ -189,7 +202,7 @@ func TestLiveSessionStartRouteWritesDesiredStateForCorruptedControlKey(t *testin
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/live/sessions/live-session-main/start", nil)
 	mux.ServeHTTP(rec, req)
 	if rec.Code != http.StatusAccepted {
-		t.Fatalf("expected 202 for desired start despite corrupted control key, got %d body=%s", rec.Code, rec.Body.String())
+		t.Fatalf("expected 202 for desired start intent, got %d body=%s", rec.Code, rec.Body.String())
 	}
 	updated, err := store.GetLiveSession("live-session-main")
 	if err != nil {

--- a/internal/service/live_session_control_test.go
+++ b/internal/service/live_session_control_test.go
@@ -98,6 +98,72 @@ func TestScanLiveSessionControlRequestsPreservesStopSafetyUntilForceRequested(t 
 	}
 }
 
+func TestLiveSessionControlForceStopRecoversFromPreviousError(t *testing.T) {
+	store := memory.NewStore()
+	platform := NewPlatform(store)
+	session, err := store.UpdateLiveSessionStatus("live-session-main", "RUNNING")
+	if err != nil {
+		t.Fatalf("set live session running failed: %v", err)
+	}
+	if _, err := store.SavePosition(domain.Position{
+		AccountID:         session.AccountID,
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "LONG",
+		Quantity:          0.002,
+		EntryPrice:        69000,
+		MarkPrice:         69100,
+	}); err != nil {
+		t.Fatalf("save position failed: %v", err)
+	}
+	if _, err := platform.RequestLiveSessionStopWithForce(session.ID, false); err != nil {
+		t.Fatalf("request non-force stop failed: %v", err)
+	}
+
+	platform.scanLiveSessionControlRequests(context.Background())
+
+	failed, err := store.GetLiveSession(session.ID)
+	if err != nil {
+		t.Fatalf("get failed live session failed: %v", err)
+	}
+	if failed.Status != "RUNNING" {
+		t.Fatalf("expected non-force stop to leave session RUNNING, got %s", failed.Status)
+	}
+	if got := stringValue(failed.State["actualStatus"]); got != "ERROR" {
+		t.Fatalf("expected actualStatus ERROR after blocked stop, got %s", got)
+	}
+	if got := stringValue(failed.State["lastControlError"]); got == "" {
+		t.Fatal("expected lastControlError after blocked stop")
+	}
+
+	if _, err := platform.RequestLiveSessionStopWithForce(session.ID, true); err != nil {
+		t.Fatalf("request force stop retry failed: %v", err)
+	}
+	retry, err := store.GetLiveSession(session.ID)
+	if err != nil {
+		t.Fatalf("get retry live session failed: %v", err)
+	}
+	if got := stringValue(retry.State["actualStatus"]); got == "ERROR" {
+		t.Fatal("expected force stop request to clear previous ERROR actualStatus")
+	}
+
+	platform.scanLiveSessionControlRequests(context.Background())
+
+	stopped, err := store.GetLiveSession(session.ID)
+	if err != nil {
+		t.Fatalf("get stopped live session failed: %v", err)
+	}
+	if stopped.Status != "STOPPED" {
+		t.Fatalf("expected force stop retry to stop session, got %s", stopped.Status)
+	}
+	if got := stringValue(stopped.State["actualStatus"]); got != "STOPPED" {
+		t.Fatalf("expected actualStatus STOPPED after force stop recovery, got %s", got)
+	}
+	if got := stringValue(stopped.State["lastControlError"]); got != "" {
+		t.Fatalf("expected lastControlError cleared after recovery, got %s", got)
+	}
+}
+
 func TestScanLiveSessionControlRequestsWritesErrorWithoutRetryingStart(t *testing.T) {
 	store := memory.NewStore()
 	platform := NewPlatform(store)

--- a/web/console/src/hooks/useTradingActions.ts
+++ b/web/console/src/hooks/useTradingActions.ts
@@ -666,9 +666,9 @@ export function useTradingActions(loadDashboard: () => Promise<void>) {
       await fetchJSON(`/api/v1/live/sessions/${sessionId}/${action}${force ? '?force=true' : ''}`, { method: "POST" });
       await loadDashboard();
       if (action === "stop") {
-        setNotification({ type: 'success', message: `已提交停用意图: ${sessionId}` });
+        setNotification({ type: 'info', message: `停用意图已提交，等待 runner 收敛: ${sessionId}` });
       } else {
-        setNotification({ type: 'success', message: `已提交启动意图: ${sessionId}` });
+        setNotification({ type: 'info', message: `启动意图已提交，等待 runner 收敛: ${sessionId}` });
       }
     } catch (err) {
       const message = err instanceof Error ? err.message : "Failed to execute live session action";

--- a/web/console/src/pages/AccountStage.tsx
+++ b/web/console/src/pages/AccountStage.tsx
@@ -1098,8 +1098,16 @@ export function AccountStage({
                  validLiveSessions.map((session) => {
                    const sessionState = getRecord(session.state);
                    const isRunning = String(session.status).toUpperCase() === "RUNNING";
-                   const desiredStatus = String(sessionState.desiredStatus ?? "").trim().toUpperCase();
-                   const actualStatus = String(sessionState.actualStatus ?? "").trim().toUpperCase();
+                   const liveDesiredStatus = String(sessionState.desiredStatus ?? "").trim().toUpperCase();
+                   const liveActualStatus = String(sessionState.actualStatus ?? "").trim().toUpperCase();
+                   const liveControlConverging =
+                     liveDesiredStatus !== "" &&
+                     liveActualStatus !== "" &&
+                     liveActualStatus !== "ERROR" &&
+                     liveDesiredStatus !== liveActualStatus;
+                   const liveControlError = liveActualStatus === "ERROR"
+                     ? String(sessionState.lastControlError ?? "runner 执行失败").trim()
+                     : "";
                    const linkedRuntimeSessionId = String(
                      sessionState.signalRuntimeSessionId ?? sessionState.lastSignalRuntimeSessionId ?? ""
                    ).trim();
@@ -1121,6 +1129,7 @@ export function AccountStage({
                    const sessionControlPending =
                      liveFlowAction === session.accountId ||
                      liveSessionActionTargets(session.id) ||
+                     liveControlConverging ||
                      (linkedRuntimeSession ? signalRuntimeActionTargets(linkedRuntimeSession.id) : false) ||
                      ((liveSessionLaunchAction || launchingTemplate !== null) && quickLiveAccountId === session.accountId);
                    return (
@@ -1135,15 +1144,27 @@ export function AccountStage({
                               </Badge>
                            </div>
                            <p className="text-[10px] font-mono text-[var(--bk-text-muted)]">{String(sessionState.symbol || "--")} · {session.strategyId}</p>
-                           {(desiredStatus || actualStatus) && desiredStatus !== actualStatus && (
+                           {(liveDesiredStatus || liveActualStatus) && liveDesiredStatus !== liveActualStatus && (
                              <p className="text-[10px] font-bold text-[var(--bk-status-warning)]">
-                               {desiredStatus || "--"} / {actualStatus || session.status}
+                               {liveDesiredStatus || "--"} / {liveActualStatus || session.status}
                              </p>
                            )}
                            {linkedRuntimeStillActive && (
                              <p className="flex items-center gap-1.5 text-[10px] font-bold text-[var(--bk-status-warning)]">
                                <AlertTriangle size={12} />
                                Live 已停止，但关联 runtime 仍处于 {linkedRuntimeStatus || linkedRuntimeDesiredStatus}，请先停止 runtime 或等待修复。
+                             </p>
+                           )}
+                           {liveControlConverging && (
+                             <p className="flex items-center gap-1.5 text-[10px] font-bold text-[var(--bk-status-warning)]">
+                               <AlertTriangle size={12} />
+                               控制意图 {liveDesiredStatus} 等待 runner 收敛，当前 {liveActualStatus}
+                             </p>
+                           )}
+                           {liveControlError && (
+                             <p className="flex items-center gap-1.5 text-[10px] font-bold text-[var(--bk-status-danger)]">
+                               <AlertTriangle size={12} />
+                               控制失败：{liveControlError}
                              </p>
                            )}
                         </div>


### PR DESCRIPTION
## 目的
解决 #276：LiveSession stop/start 从 platform-api 直接执行 runtime action 改为 desired/actual 状态驱动。

本 PR 将 UI/CLI/API 的 live session 启停改为提交控制意图：

```text
UI / CLI -> platform-api -> live_sessions.state.desiredStatus -> live-runner scanner -> Start/StopLiveSession locked path -> actualStatus
```

这样 `BKTRADER_ROLE=api` 下 start/stop 不再被 `RuntimeActionsEnabled=false` 拒绝，同时真实 runtime mutation 仍只由 runner 执行。

Closes #276

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [x] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) - 未变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？- 不涉及
- [x] DB migration 是否具备向下兼容幂等性？- 无 DB migration，沿用 `live_sessions.state` JSONB
- [x] 配置字段有没有无意被混改？- 未新增 env/config 字段

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

本地验证：

```bash
go test ./...
go build ./cmd/platform-api
go build ./cmd/db-migrate
go build ./cmd/bktrader-ctl
cd web/console && ./node_modules/.bin/tsc --noEmit src/pages/AccountStage.tsx --jsx react-jsx --esModuleInterop --target esnext --module esnext --moduleResolution Bundler --allowSyntheticDefaultImports
cd web/console && npm run build
```

说明：AGENTS.md 中的前端 tsc 命令未带 `--module`，当前 TypeScript 会因 `import.meta` 报 TS1343；本次验证补了 `--module esnext`，与 Vite/tsconfig 语义一致。

## Phase 2 scope
controlRequestId / controlVersion 不在本 PR 范围内，已沉淀到 #282 Phase 2；本 PR 仅作为 declarative live session control 的 Phase 1 落地。
