### PR TITLE
[codex] add fill reconciliation plan builder

### DIFF
--- a/docs/fill-reconciliation-engine.md
+++ b/docs/fill-reconciliation-engine.md
@@ -1,0 +1,62 @@
+# Fill Reconciliation Engine
+
+## 目标
+
+成交一致性引擎用于把交易所权威成交明细和本地 `fills` 表收敛到同一套规则。它解决的问题来自 PR #271：订单已经 `FILLED`，但 Binance 成交明细延迟返回，系统先用 synthetic fill 更新仓位，后续真实成交到达时再替换 synthetic fill，并且不能重复更新 position。
+
+本引擎的边界是纯计算：输入订单、本地已存在 fills、交易所新到 fills，输出删除、创建、position 增量和订单 metadata 更新计划。引擎不直接写数据库，不直接更新 position，也不直接调用交易所。
+
+## 术语
+
+| 术语 | 含义 |
+| --- | --- |
+| real fill | 交易所权威成交，有稳定 `exchange_trade_id`。手续费、realizedPnL 等权威值应来自它。 |
+| synthetic fill | 本地兜底成交。用于订单已终态但交易所成交明细暂时为空时维持 filledQuantity 和 position 一致。 |
+| remainder fill | synthetic 被部分 real 替换后剩余的占位数量。它代表已经应用到 position、但还没有真实成交明细覆盖的数量。 |
+| appliedQty | 已经更新过 position 的数量。real 替换 synthetic/remainder 时，这部分不能再次应用。 |
+| filledQuantity | 本地订单视角的成交总量，必须与 real + synthetic/remainder 的合计保持一致。 |
+
+当前版本不新增 DB 字段。识别规则保持兼容：
+
+- `exchange_trade_id != ""`：real fill；
+- `exchange_trade_id == "" && dedup_fallback_fingerprint != ""`：synthetic fill；
+- `dedup_fallback_fingerprint` 以 `synthetic-remainder|` 开头：remainder fill。
+
+长期可以评估增加 `fill_source` 字段，取值为 `real / synthetic / remainder / paper / manual`。
+
+## 一致性规则
+
+1. real fill 是权威来源，一旦到达就应替换 synthetic/remainder。
+2. 已由 synthetic/remainder 应用到 position 的数量，后续 real fill 到达时不能重复应用。
+3. real 数量小于原 synthetic/remainder 数量时，补 remainder，保证本地 filledQuantity 不倒退。
+4. real 分批到达时逐步缩小 remainder，直到完全真实化。
+5. real 数量超过已应用 synthetic/remainder 时，只把超出的数量作为 position 增量。
+6. 完全没有 real fill 时，synthetic fallback 必须由上游 retry policy 决定；引擎只处理已经进入输入的 fill。
+
+## 标准化输入方向
+
+后续 adapter 应先把交易所成交归一化为统一结构，再交给引擎。字段映射示例：
+
+| 统一字段 | Binance | OKX | Bybit |
+| --- | --- | --- | --- |
+| `ExchangeOrderID` | `orderId` | `ordId` | `orderId` |
+| `ExchangeTradeID` | `id` / `tradeId` | `tradeId` | `execId` |
+| `Price` | `price` | `fillPx` | `execPrice` |
+| `Quantity` | `qty` | `fillSz` | `execQty` |
+| `Fee` | `commission` | `fillFee` | `execFee` |
+| `FeeAsset` | `commissionAsset` | fee currency | fee currency |
+| `RealizedPnL` | `realizedPnl` | `fillPnl` | `closedPnl` |
+| `TradeTime` | `time` | `fillTime` | `execTime` |
+
+## 当前阶段实现
+
+阶段 1+2 只新增文档和纯函数：
+
+- `BuildFillReconciliationPlan` 读取 `domain.Order`、existing fills 和 incoming fills；
+- 输出 `DeleteFillIDs`、`CreateFills`、`ApplyPositionFills`、`UpdatedMetadata`、`Warnings`；
+- 不接入 `finalizeExecutedOrder`；
+- 不修改 store 接口；
+- 不新增 migration；
+- 不改变 Binance、testnet、mainnet 或 `dispatchMode` 默认行为。
+
+后续阶段再让 `finalizeExecutedOrder` 按 plan 执行删除、创建、position 增量应用，并把 adapter 原始字段逐步收敛到统一 fill report。

--- a/internal/service/fill_reconcile.go
+++ b/internal/service/fill_reconcile.go
@@ -1,0 +1,245 @@
+package service
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"strings"
+
+	"github.com/wuyaocheng/bktrader/internal/domain"
+)
+
+const syntheticRemainderFingerprintPrefix = "synthetic-remainder|"
+
+type FillSource string
+
+const (
+	FillSourceReal      FillSource = "real"
+	FillSourceSynthetic FillSource = "synthetic"
+	FillSourceRemainder FillSource = "remainder"
+	FillSourcePaper     FillSource = "paper"
+)
+
+type FillReconcilePolicy struct {
+	AllowSyntheticFallback bool
+}
+
+type FillReconciliationPlan struct {
+	DeleteFillIDs      []string
+	CreateFills        []domain.Fill
+	ApplyPositionFills []domain.Fill
+	UpdatedMetadata    map[string]any
+	Warnings           []string
+}
+
+func BuildFillReconciliationPlan(order domain.Order, existing []domain.Fill, incoming []domain.Fill, policy FillReconcilePolicy) (FillReconciliationPlan, error) {
+	_ = policy
+	plan := FillReconciliationPlan{
+		UpdatedMetadata: map[string]any{},
+	}
+	if strings.TrimSpace(order.ID) == "" {
+		return plan, errors.New("order id is required")
+	}
+	if invalidFillQuantity(order.Quantity) || !tradingQuantityPositive(order.Quantity) {
+		return plan, fmt.Errorf("order quantity must be positive: %v", order.Quantity)
+	}
+
+	existingRealTradeIDs := map[string]struct{}{}
+	existingFallbackFingerprints := map[string]struct{}{}
+	existingRealQty := 0.0
+	existingPlaceholderQty := 0.0
+	existingTotalQty := 0.0
+	var existingPlaceholderIDs []string
+	lastKnownPrice := order.Price
+
+	for _, fill := range existing {
+		if strings.TrimSpace(fill.OrderID) != "" && fill.OrderID != order.ID {
+			continue
+		}
+		if err := validateFillQuantity(fill); err != nil {
+			return plan, fmt.Errorf("existing fill %s: %w", fill.ID, err)
+		}
+		if tradingQuantityPositive(fill.Price) {
+			lastKnownPrice = fill.Price
+		}
+		existingTotalQty += fill.Quantity
+		if fillReconcileSource(fill) == FillSourceReal {
+			existingRealQty += fill.Quantity
+			existingRealTradeIDs[strings.TrimSpace(fill.ExchangeTradeID)] = struct{}{}
+			continue
+		}
+		fingerprint := strings.TrimSpace(fill.DedupFingerprint)
+		if fingerprint == "" {
+			continue
+		}
+		existingFallbackFingerprints[fingerprint] = struct{}{}
+		existingPlaceholderQty += fill.Quantity
+		if strings.TrimSpace(fill.ID) != "" {
+			existingPlaceholderIDs = append(existingPlaceholderIDs, fill.ID)
+		}
+	}
+
+	newRealQty := 0.0
+	hasNewRealFill := false
+	incomingHasRealFill := hasIncomingRealFill(incoming)
+	for _, fill := range incoming {
+		if strings.TrimSpace(fill.OrderID) == "" {
+			fill.OrderID = order.ID
+		}
+		if fill.OrderID != order.ID {
+			return plan, fmt.Errorf("incoming fill order mismatch: got %s want %s", fill.OrderID, order.ID)
+		}
+		if err := validateFillQuantity(fill); err != nil {
+			return plan, fmt.Errorf("incoming fill: %w", err)
+		}
+		if tradingQuantityPositive(fill.Price) {
+			lastKnownPrice = fill.Price
+		}
+
+		if fillReconcileSource(fill) == FillSourceReal {
+			tradeID := strings.TrimSpace(fill.ExchangeTradeID)
+			if _, exists := existingRealTradeIDs[tradeID]; exists {
+				continue
+			}
+			existingRealTradeIDs[tradeID] = struct{}{}
+			hasNewRealFill = true
+			newRealQty += fill.Quantity
+			plan.CreateFills = append(plan.CreateFills, fill)
+			continue
+		}
+
+		if incomingHasRealFill {
+			continue
+		}
+		fingerprint := strings.TrimSpace(fill.DedupFingerprint)
+		if fingerprint == "" {
+			fingerprint = fill.FallbackFingerprint()
+			fill.DedupFingerprint = fingerprint
+		}
+		if _, exists := existingFallbackFingerprints[fingerprint]; exists {
+			continue
+		}
+		remainingQty := order.Quantity - existingTotalQty
+		if !tradingQuantityPositive(remainingQty) {
+			continue
+		}
+		if tradingQuantityExceeds(fill.Quantity, remainingQty) {
+			fill.Quantity = remainingQty
+		}
+		plan.CreateFills = append(plan.CreateFills, fill)
+		plan.ApplyPositionFills = append(plan.ApplyPositionFills, fill)
+		existingTotalQty += fill.Quantity
+	}
+
+	if hasNewRealFill {
+		plan.DeleteFillIDs = append(plan.DeleteFillIDs, existingPlaceholderIDs...)
+		applyRealQty := newRealQty
+		if tradingQuantityPositive(existingPlaceholderQty) {
+			if tradingQuantityExceeds(existingPlaceholderQty, applyRealQty) || tradingQuantityEqual(existingPlaceholderQty, applyRealQty) {
+				applyRealQty = 0
+			} else {
+				applyRealQty -= existingPlaceholderQty
+			}
+		}
+		if tradingQuantityPositive(applyRealQty) {
+			plan.ApplyPositionFills = append(plan.ApplyPositionFills, splitApplyPositionFills(plan.CreateFills, applyRealQty)...)
+		}
+
+		remainderQty := existingPlaceholderQty - newRealQty
+		if tradingQuantityPositive(remainderQty) {
+			plan.CreateFills = append(plan.CreateFills, domain.Fill{
+				OrderID:          order.ID,
+				Price:            firstPositive(lastKnownPrice, order.Price),
+				Quantity:         remainderQty,
+				Fee:              0,
+				DedupFingerprint: fmt.Sprintf("%s%s|%.12f", syntheticRemainderFingerprintPrefix, order.ID, remainderQty),
+			})
+		} else if remainderQty < 0 && !tradingQuantityExceeds(-remainderQty, 0) {
+			remainderQty = 0
+		}
+
+		filledQty := existingRealQty + newRealQty
+		if tradingQuantityPositive(remainderQty) {
+			filledQty += remainderQty
+		}
+		setFillReconcileMetadata(&plan, order, filledQty)
+		if tradingQuantityExceeds(filledQty, order.Quantity) {
+			plan.Warnings = append(plan.Warnings, fmt.Sprintf("real fill quantity exceeds order quantity: filled=%.12f order=%.12f", filledQty, order.Quantity))
+		}
+		return plan, nil
+	}
+
+	setFillReconcileMetadata(&plan, order, existingTotalQty)
+	if tradingQuantityExceeds(existingTotalQty, order.Quantity) {
+		plan.Warnings = append(plan.Warnings, fmt.Sprintf("fill quantity exceeds order quantity: filled=%.12f order=%.12f", existingTotalQty, order.Quantity))
+	}
+	return plan, nil
+}
+
+func fillReconcileSource(fill domain.Fill) FillSource {
+	if strings.TrimSpace(fill.ExchangeTradeID) != "" {
+		return FillSourceReal
+	}
+	if strings.HasPrefix(strings.TrimSpace(fill.DedupFingerprint), syntheticRemainderFingerprintPrefix) {
+		return FillSourceRemainder
+	}
+	return FillSourceSynthetic
+}
+
+func hasIncomingRealFill(fills []domain.Fill) bool {
+	for _, fill := range fills {
+		if fillReconcileSource(fill) == FillSourceReal {
+			return true
+		}
+	}
+	return false
+}
+
+func splitApplyPositionFills(fills []domain.Fill, quantity float64) []domain.Fill {
+	if !tradingQuantityPositive(quantity) {
+		return nil
+	}
+	remaining := quantity
+	var result []domain.Fill
+	for _, fill := range fills {
+		if fillReconcileSource(fill) != FillSourceReal || !tradingQuantityPositive(remaining) {
+			continue
+		}
+		apply := fill
+		if tradingQuantityExceeds(apply.Quantity, remaining) {
+			apply.Quantity = remaining
+		}
+		result = append(result, apply)
+		remaining -= apply.Quantity
+		if remaining < 0 && !tradingQuantityExceeds(-remaining, 0) {
+			remaining = 0
+		}
+	}
+	return result
+}
+
+func setFillReconcileMetadata(plan *FillReconciliationPlan, order domain.Order, filledQty float64) {
+	if filledQty < 0 && !tradingQuantityExceeds(-filledQty, 0) {
+		filledQty = 0
+	}
+	remainingQty := order.Quantity - filledQty
+	if remainingQty < 0 && !tradingQuantityExceeds(-remainingQty, 0) {
+		remainingQty = 0
+	}
+	plan.UpdatedMetadata["filledQuantity"] = filledQty
+	plan.UpdatedMetadata["remainingQuantity"] = remainingQty
+}
+
+func validateFillQuantity(fill domain.Fill) error {
+	if invalidFillQuantity(fill.Quantity) {
+		return fmt.Errorf("quantity must be finite: %v", fill.Quantity)
+	}
+	if !tradingQuantityPositive(fill.Quantity) {
+		return fmt.Errorf("quantity must be positive: %v", fill.Quantity)
+	}
+	return nil
+}
+
+func invalidFillQuantity(value float64) bool {
+	return math.IsNaN(value) || math.IsInf(value, 0)
+}

--- a/internal/service/fill_reconcile_test.go
+++ b/internal/service/fill_reconcile_test.go
@@ -1,0 +1,218 @@
+package service
+
+import (
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/wuyaocheng/bktrader/internal/domain"
+)
+
+func TestBuildFillReconciliationPlanCreatesNewRealFill(t *testing.T) {
+	order := fillReconcileTestOrder(1)
+	realFill := fillReconcileReal(order.ID, "trade-1", 1)
+
+	plan, err := BuildFillReconciliationPlan(order, nil, []domain.Fill{realFill}, FillReconcilePolicy{})
+	if err != nil {
+		t.Fatalf("BuildFillReconciliationPlan failed: %v", err)
+	}
+
+	requireFillReconcileQuantity(t, sumFillQty(plan.CreateFills), 1)
+	requireFillReconcileQuantity(t, sumFillQty(plan.ApplyPositionFills), 1)
+	requireFillReconcileQuantity(t, metadataFloat(plan, "filledQuantity"), 1)
+	requireFillReconcileQuantity(t, metadataFloat(plan, "remainingQuantity"), 0)
+	if len(plan.DeleteFillIDs) != 0 {
+		t.Fatalf("expected no deletes, got %v", plan.DeleteFillIDs)
+	}
+}
+
+func TestBuildFillReconciliationPlanReplacesSyntheticWithRealWithoutDoubleApply(t *testing.T) {
+	order := fillReconcileTestOrder(1)
+	existing := []domain.Fill{fillReconcileSynthetic("fill-synthetic", order.ID, 1)}
+	incoming := []domain.Fill{fillReconcileReal(order.ID, "trade-1", 1)}
+
+	plan, err := BuildFillReconciliationPlan(order, existing, incoming, FillReconcilePolicy{})
+	if err != nil {
+		t.Fatalf("BuildFillReconciliationPlan failed: %v", err)
+	}
+
+	requireFillReconcileDeleteIDs(t, plan.DeleteFillIDs, "fill-synthetic")
+	requireFillReconcileQuantity(t, sumRealQty(plan.CreateFills), 1)
+	requireFillReconcileQuantity(t, sumRemainderQty(plan.CreateFills), 0)
+	requireFillReconcileQuantity(t, sumFillQty(plan.ApplyPositionFills), 0)
+	requireFillReconcileQuantity(t, metadataFloat(plan, "filledQuantity"), 1)
+}
+
+func TestBuildFillReconciliationPlanCreatesRemainderForPartialRealFill(t *testing.T) {
+	order := fillReconcileTestOrder(1)
+	existing := []domain.Fill{fillReconcileSynthetic("fill-synthetic", order.ID, 1)}
+	incoming := []domain.Fill{fillReconcileReal(order.ID, "trade-1", 0.4)}
+
+	plan, err := BuildFillReconciliationPlan(order, existing, incoming, FillReconcilePolicy{})
+	if err != nil {
+		t.Fatalf("BuildFillReconciliationPlan failed: %v", err)
+	}
+
+	requireFillReconcileDeleteIDs(t, plan.DeleteFillIDs, "fill-synthetic")
+	requireFillReconcileQuantity(t, sumRealQty(plan.CreateFills), 0.4)
+	requireFillReconcileQuantity(t, sumRemainderQty(plan.CreateFills), 0.6)
+	requireFillReconcileQuantity(t, sumFillQty(plan.ApplyPositionFills), 0)
+	requireFillReconcileQuantity(t, metadataFloat(plan, "filledQuantity"), 1)
+}
+
+func TestBuildFillReconciliationPlanBatchedRealFillsShrinkRemainder(t *testing.T) {
+	order := fillReconcileTestOrder(1)
+	existing := []domain.Fill{
+		fillReconcileReal(order.ID, "trade-1", 0.4),
+		fillReconcileRemainder("fill-remainder", order.ID, 0.6),
+	}
+	incoming := []domain.Fill{fillReconcileReal(order.ID, "trade-2", 0.3)}
+
+	plan, err := BuildFillReconciliationPlan(order, existing, incoming, FillReconcilePolicy{})
+	if err != nil {
+		t.Fatalf("BuildFillReconciliationPlan failed: %v", err)
+	}
+
+	requireFillReconcileDeleteIDs(t, plan.DeleteFillIDs, "fill-remainder")
+	requireFillReconcileQuantity(t, sumRealQty(plan.CreateFills), 0.3)
+	requireFillReconcileQuantity(t, sumRemainderQty(plan.CreateFills), 0.3)
+	requireFillReconcileQuantity(t, sumFillQty(plan.ApplyPositionFills), 0)
+	requireFillReconcileQuantity(t, metadataFloat(plan, "filledQuantity"), 1)
+}
+
+func TestBuildFillReconciliationPlanAppliesOnlyRealQtyBeyondSynthetic(t *testing.T) {
+	order := fillReconcileTestOrder(1)
+	existing := []domain.Fill{fillReconcileSynthetic("fill-synthetic", order.ID, 0.6)}
+	incoming := []domain.Fill{fillReconcileReal(order.ID, "trade-1", 1)}
+
+	plan, err := BuildFillReconciliationPlan(order, existing, incoming, FillReconcilePolicy{})
+	if err != nil {
+		t.Fatalf("BuildFillReconciliationPlan failed: %v", err)
+	}
+
+	requireFillReconcileQuantity(t, sumRealQty(plan.CreateFills), 1)
+	requireFillReconcileQuantity(t, sumRemainderQty(plan.CreateFills), 0)
+	requireFillReconcileQuantity(t, sumFillQty(plan.ApplyPositionFills), 0.4)
+	requireFillReconcileQuantity(t, metadataFloat(plan, "filledQuantity"), 1)
+}
+
+func TestBuildFillReconciliationPlanSkipsDuplicateRealTradeID(t *testing.T) {
+	order := fillReconcileTestOrder(1)
+	existing := []domain.Fill{fillReconcileReal(order.ID, "trade-1", 1)}
+	incoming := []domain.Fill{fillReconcileReal(order.ID, "trade-1", 1)}
+
+	plan, err := BuildFillReconciliationPlan(order, existing, incoming, FillReconcilePolicy{})
+	if err != nil {
+		t.Fatalf("BuildFillReconciliationPlan failed: %v", err)
+	}
+
+	if len(plan.CreateFills) != 0 {
+		t.Fatalf("expected duplicate real fill to create nothing, got %+v", plan.CreateFills)
+	}
+	if len(plan.ApplyPositionFills) != 0 {
+		t.Fatalf("expected duplicate real fill to apply nothing, got %+v", plan.ApplyPositionFills)
+	}
+	requireFillReconcileQuantity(t, metadataFloat(plan, "filledQuantity"), 1)
+}
+
+func TestBuildFillReconciliationPlanRejectsInvalidQuantity(t *testing.T) {
+	order := fillReconcileTestOrder(1)
+	_, err := BuildFillReconciliationPlan(order, nil, []domain.Fill{{
+		OrderID:         order.ID,
+		ExchangeTradeID: "trade-1",
+		Price:           68000,
+		Quantity:        math.NaN(),
+	}}, FillReconcilePolicy{})
+	if err == nil {
+		t.Fatal("expected invalid quantity error")
+	}
+}
+
+func fillReconcileTestOrder(quantity float64) domain.Order {
+	return domain.Order{
+		ID:       "order-1",
+		Symbol:   "BTCUSDT",
+		Side:     "BUY",
+		Type:     "MARKET",
+		Quantity: quantity,
+		Price:    68000,
+		Metadata: map[string]any{},
+	}
+}
+
+func fillReconcileReal(orderID, tradeID string, quantity float64) domain.Fill {
+	return domain.Fill{
+		OrderID:         orderID,
+		ExchangeTradeID: tradeID,
+		Price:           68000,
+		Quantity:        quantity,
+	}
+}
+
+func fillReconcileSynthetic(id, orderID string, quantity float64) domain.Fill {
+	return domain.Fill{
+		ID:               id,
+		OrderID:          orderID,
+		Price:            68000,
+		Quantity:         quantity,
+		DedupFingerprint: "synthetic|" + id,
+	}
+}
+
+func fillReconcileRemainder(id, orderID string, quantity float64) domain.Fill {
+	fill := fillReconcileSynthetic(id, orderID, quantity)
+	fill.DedupFingerprint = syntheticRemainderFingerprintPrefix + orderID
+	return fill
+}
+
+func requireFillReconcileDeleteIDs(t *testing.T, got []string, want ...string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("expected delete ids %v, got %v", want, got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("expected delete ids %v, got %v", want, got)
+		}
+	}
+}
+
+func requireFillReconcileQuantity(t *testing.T, got, want float64) {
+	t.Helper()
+	if !tradingQuantityEqual(got, want) {
+		t.Fatalf("expected quantity %.12f, got %.12f", want, got)
+	}
+}
+
+func metadataFloat(plan FillReconciliationPlan, key string) float64 {
+	value, _ := plan.UpdatedMetadata[key].(float64)
+	return value
+}
+
+func sumFillQty(fills []domain.Fill) float64 {
+	total := 0.0
+	for _, fill := range fills {
+		total += fill.Quantity
+	}
+	return total
+}
+
+func sumRealQty(fills []domain.Fill) float64 {
+	total := 0.0
+	for _, fill := range fills {
+		if strings.TrimSpace(fill.ExchangeTradeID) != "" {
+			total += fill.Quantity
+		}
+	}
+	return total
+}
+
+func sumRemainderQty(fills []domain.Fill) float64 {
+	total := 0.0
+	for _, fill := range fills {
+		if strings.HasPrefix(strings.TrimSpace(fill.DedupFingerprint), syntheticRemainderFingerprintPrefix) {
+			total += fill.Quantity
+		}
+	}
+	return total
+}


### PR DESCRIPTION
## 目的
Refs #272.

新增成交一致性引擎的阶段 1+2 基础：
- 新增 `docs/fill-reconciliation-engine.md`，固化 real / synthetic / remainder / appliedQty / filledQuantity 术语、PR #271 背景、多交易所字段归一化方向和后续接入边界。
- 新增 `BuildFillReconciliationPlan` 纯计算函数，输出 delete/create/apply/metadata/warnings 计划，不调用 store、不写 DB、不接入现有 `finalizeExecutedOrder`。
- 新增单元测试覆盖 synthetic -> real、partial real、batched real、real > synthetic、duplicate real、invalid quantity failure path。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [x] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(无变化)
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？(无)
- [x] DB migration 是否具备向下兼容幂等性？(无 migration)
- [x] 配置字段有没有无意被混改？(无)

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

验证已通过：
- `go test ./internal/service -run 'TestBuildFillReconciliationPlan|TestSyntheticUpgrade'`
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
