### PR TITLE
[codex] require explicit fill reconciliation sources

### DIFF
--- a/docs/fill-reconciliation-engine.md
+++ b/docs/fill-reconciliation-engine.md
@@ -16,11 +16,14 @@
 | appliedQty | 已经更新过 position 的数量。real 替换 synthetic/remainder 时，这部分不能再次应用。 |
 | filledQuantity | 本地订单视角的成交总量，必须与 real + synthetic/remainder 的合计保持一致。 |
 
-当前版本不新增 DB 字段。识别规则保持兼容：
+当前版本不新增 DB 字段，但 plan builder 不再自行猜 source。调用方必须把每条 fill 标准化为显式 `FillReconciliationInput{Fill, Source}`：
 
-- `exchange_trade_id != ""`：real fill；
-- `exchange_trade_id == "" && dedup_fallback_fingerprint != ""`：synthetic fill；
-- `dedup_fallback_fingerprint` 以 `synthetic-remainder|` 开头：remainder fill。
+- `real` 必须带稳定 `exchange_trade_id`；
+- `synthetic` 必须带 `dedup_fallback_fingerprint`；
+- `remainder` 必须带 `synthetic-remainder|` 前缀；
+- source 缺失或字段与 source 不匹配时直接返回 error。
+
+这样后续执行删除计划时，只会删除被上游明确标记为 `synthetic` 或 `remainder` 的本地 fill，避免依赖间接条件误删合法 fallback fill。
 
 长期可以评估增加 `fill_source` 字段，取值为 `real / synthetic / remainder / paper / manual`。
 
@@ -53,7 +56,9 @@
 阶段 1+2 只新增文档和纯函数：
 
 - `BuildFillReconciliationPlan` 读取 `domain.Order`、existing fills 和 incoming fills；
+- existing/incoming fills 必须带显式 source；
 - 输出 `DeleteFillIDs`、`CreateFills`、`ApplyPositionFills`、`UpdatedMetadata`、`Warnings`；
+- `remainingQuantity` 统一 clamp 到非负值，超额成交通过 `Warnings` 暴露；
 - 不接入 `finalizeExecutedOrder`；
 - 不修改 store 接口；
 - 不新增 migration；

--- a/internal/service/fill_reconcile.go
+++ b/internal/service/fill_reconcile.go
@@ -24,6 +24,11 @@ type FillReconcilePolicy struct {
 	AllowSyntheticFallback bool
 }
 
+type FillReconciliationInput struct {
+	Fill   domain.Fill
+	Source FillSource
+}
+
 type FillReconciliationPlan struct {
 	DeleteFillIDs      []string
 	CreateFills        []domain.Fill
@@ -32,7 +37,7 @@ type FillReconciliationPlan struct {
 	Warnings           []string
 }
 
-func BuildFillReconciliationPlan(order domain.Order, existing []domain.Fill, incoming []domain.Fill, policy FillReconcilePolicy) (FillReconciliationPlan, error) {
+func BuildFillReconciliationPlan(order domain.Order, existing []FillReconciliationInput, incoming []FillReconciliationInput, policy FillReconcilePolicy) (FillReconciliationPlan, error) {
 	_ = policy
 	plan := FillReconciliationPlan{
 		UpdatedMetadata: map[string]any{},
@@ -52,26 +57,27 @@ func BuildFillReconciliationPlan(order domain.Order, existing []domain.Fill, inc
 	var existingPlaceholderIDs []string
 	lastKnownPrice := order.Price
 
-	for _, fill := range existing {
+	for _, input := range existing {
+		fill, source, err := validateFillReconciliationInput(input)
+		if err != nil {
+			return plan, fmt.Errorf("existing fill %s: %w", input.Fill.ID, err)
+		}
 		if strings.TrimSpace(fill.OrderID) != "" && fill.OrderID != order.ID {
 			continue
-		}
-		if err := validateFillQuantity(fill); err != nil {
-			return plan, fmt.Errorf("existing fill %s: %w", fill.ID, err)
 		}
 		if tradingQuantityPositive(fill.Price) {
 			lastKnownPrice = fill.Price
 		}
 		existingTotalQty += fill.Quantity
-		if fillReconcileSource(fill) == FillSourceReal {
+		if source == FillSourceReal {
 			existingRealQty += fill.Quantity
 			existingRealTradeIDs[strings.TrimSpace(fill.ExchangeTradeID)] = struct{}{}
 			continue
 		}
-		fingerprint := strings.TrimSpace(fill.DedupFingerprint)
-		if fingerprint == "" {
+		if source != FillSourceSynthetic && source != FillSourceRemainder {
 			continue
 		}
+		fingerprint := strings.TrimSpace(fill.DedupFingerprint)
 		existingFallbackFingerprints[fingerprint] = struct{}{}
 		existingPlaceholderQty += fill.Quantity
 		if strings.TrimSpace(fill.ID) != "" {
@@ -81,22 +87,26 @@ func BuildFillReconciliationPlan(order domain.Order, existing []domain.Fill, inc
 
 	newRealQty := 0.0
 	hasNewRealFill := false
-	incomingHasRealFill := hasIncomingRealFill(incoming)
-	for _, fill := range incoming {
+	incomingHasRealFill, err := hasIncomingRealFill(incoming)
+	if err != nil {
+		return plan, err
+	}
+	for _, input := range incoming {
+		fill, source, err := validateFillReconciliationInput(input)
+		if err != nil {
+			return plan, fmt.Errorf("incoming fill: %w", err)
+		}
 		if strings.TrimSpace(fill.OrderID) == "" {
 			fill.OrderID = order.ID
 		}
 		if fill.OrderID != order.ID {
 			return plan, fmt.Errorf("incoming fill order mismatch: got %s want %s", fill.OrderID, order.ID)
 		}
-		if err := validateFillQuantity(fill); err != nil {
-			return plan, fmt.Errorf("incoming fill: %w", err)
-		}
 		if tradingQuantityPositive(fill.Price) {
 			lastKnownPrice = fill.Price
 		}
 
-		if fillReconcileSource(fill) == FillSourceReal {
+		if source == FillSourceReal {
 			tradeID := strings.TrimSpace(fill.ExchangeTradeID)
 			if _, exists := existingRealTradeIDs[tradeID]; exists {
 				continue
@@ -176,23 +186,17 @@ func BuildFillReconciliationPlan(order domain.Order, existing []domain.Fill, inc
 	return plan, nil
 }
 
-func fillReconcileSource(fill domain.Fill) FillSource {
-	if strings.TrimSpace(fill.ExchangeTradeID) != "" {
-		return FillSourceReal
-	}
-	if strings.HasPrefix(strings.TrimSpace(fill.DedupFingerprint), syntheticRemainderFingerprintPrefix) {
-		return FillSourceRemainder
-	}
-	return FillSourceSynthetic
-}
-
-func hasIncomingRealFill(fills []domain.Fill) bool {
-	for _, fill := range fills {
-		if fillReconcileSource(fill) == FillSourceReal {
-			return true
+func hasIncomingRealFill(fills []FillReconciliationInput) (bool, error) {
+	for _, input := range fills {
+		_, source, err := validateFillReconciliationInput(input)
+		if err != nil {
+			return false, fmt.Errorf("incoming fill: %w", err)
+		}
+		if source == FillSourceReal {
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
 }
 
 func splitApplyPositionFills(fills []domain.Fill, quantity float64) []domain.Fill {
@@ -202,7 +206,7 @@ func splitApplyPositionFills(fills []domain.Fill, quantity float64) []domain.Fil
 	remaining := quantity
 	var result []domain.Fill
 	for _, fill := range fills {
-		if fillReconcileSource(fill) != FillSourceReal || !tradingQuantityPositive(remaining) {
+		if strings.TrimSpace(fill.ExchangeTradeID) == "" || !tradingQuantityPositive(remaining) {
 			continue
 		}
 		apply := fill
@@ -226,8 +230,41 @@ func setFillReconcileMetadata(plan *FillReconciliationPlan, order domain.Order, 
 	if remainingQty < 0 && !tradingQuantityExceeds(-remainingQty, 0) {
 		remainingQty = 0
 	}
+	if remainingQty < 0 {
+		remainingQty = 0
+	}
 	plan.UpdatedMetadata["filledQuantity"] = filledQty
 	plan.UpdatedMetadata["remainingQuantity"] = remainingQty
+}
+
+func validateFillReconciliationInput(input FillReconciliationInput) (domain.Fill, FillSource, error) {
+	fill := input.Fill
+	source := input.Source
+	if source == "" {
+		return fill, source, errors.New("fill source is required")
+	}
+	switch source {
+	case FillSourceReal:
+		if strings.TrimSpace(fill.ExchangeTradeID) == "" {
+			return fill, source, errors.New("real fill requires exchange trade id")
+		}
+	case FillSourceSynthetic:
+		if strings.TrimSpace(fill.DedupFingerprint) == "" {
+			return fill, source, errors.New("synthetic fill requires dedup fingerprint")
+		}
+	case FillSourceRemainder:
+		if !strings.HasPrefix(strings.TrimSpace(fill.DedupFingerprint), syntheticRemainderFingerprintPrefix) {
+			return fill, source, errors.New("remainder fill requires synthetic-remainder fingerprint")
+		}
+	case FillSourcePaper:
+		return fill, source, errors.New("paper fills are not supported by live fill reconciliation")
+	default:
+		return fill, source, fmt.Errorf("unsupported fill source %q", source)
+	}
+	if err := validateFillQuantity(fill); err != nil {
+		return fill, source, err
+	}
+	return fill, source, nil
 }
 
 func validateFillQuantity(fill domain.Fill) error {

--- a/internal/service/fill_reconcile_test.go
+++ b/internal/service/fill_reconcile_test.go
@@ -12,7 +12,7 @@ func TestBuildFillReconciliationPlanCreatesNewRealFill(t *testing.T) {
 	order := fillReconcileTestOrder(1)
 	realFill := fillReconcileReal(order.ID, "trade-1", 1)
 
-	plan, err := BuildFillReconciliationPlan(order, nil, []domain.Fill{realFill}, FillReconcilePolicy{})
+	plan, err := BuildFillReconciliationPlan(order, nil, []FillReconciliationInput{fillReconcileInput(realFill, FillSourceReal)}, FillReconcilePolicy{})
 	if err != nil {
 		t.Fatalf("BuildFillReconciliationPlan failed: %v", err)
 	}
@@ -28,8 +28,8 @@ func TestBuildFillReconciliationPlanCreatesNewRealFill(t *testing.T) {
 
 func TestBuildFillReconciliationPlanReplacesSyntheticWithRealWithoutDoubleApply(t *testing.T) {
 	order := fillReconcileTestOrder(1)
-	existing := []domain.Fill{fillReconcileSynthetic("fill-synthetic", order.ID, 1)}
-	incoming := []domain.Fill{fillReconcileReal(order.ID, "trade-1", 1)}
+	existing := []FillReconciliationInput{fillReconcileInput(fillReconcileSynthetic("fill-synthetic", order.ID, 1), FillSourceSynthetic)}
+	incoming := []FillReconciliationInput{fillReconcileInput(fillReconcileReal(order.ID, "trade-1", 1), FillSourceReal)}
 
 	plan, err := BuildFillReconciliationPlan(order, existing, incoming, FillReconcilePolicy{})
 	if err != nil {
@@ -45,8 +45,8 @@ func TestBuildFillReconciliationPlanReplacesSyntheticWithRealWithoutDoubleApply(
 
 func TestBuildFillReconciliationPlanCreatesRemainderForPartialRealFill(t *testing.T) {
 	order := fillReconcileTestOrder(1)
-	existing := []domain.Fill{fillReconcileSynthetic("fill-synthetic", order.ID, 1)}
-	incoming := []domain.Fill{fillReconcileReal(order.ID, "trade-1", 0.4)}
+	existing := []FillReconciliationInput{fillReconcileInput(fillReconcileSynthetic("fill-synthetic", order.ID, 1), FillSourceSynthetic)}
+	incoming := []FillReconciliationInput{fillReconcileInput(fillReconcileReal(order.ID, "trade-1", 0.4), FillSourceReal)}
 
 	plan, err := BuildFillReconciliationPlan(order, existing, incoming, FillReconcilePolicy{})
 	if err != nil {
@@ -62,11 +62,11 @@ func TestBuildFillReconciliationPlanCreatesRemainderForPartialRealFill(t *testin
 
 func TestBuildFillReconciliationPlanBatchedRealFillsShrinkRemainder(t *testing.T) {
 	order := fillReconcileTestOrder(1)
-	existing := []domain.Fill{
-		fillReconcileReal(order.ID, "trade-1", 0.4),
-		fillReconcileRemainder("fill-remainder", order.ID, 0.6),
+	existing := []FillReconciliationInput{
+		fillReconcileInput(fillReconcileReal(order.ID, "trade-1", 0.4), FillSourceReal),
+		fillReconcileInput(fillReconcileRemainder("fill-remainder", order.ID, 0.6), FillSourceRemainder),
 	}
-	incoming := []domain.Fill{fillReconcileReal(order.ID, "trade-2", 0.3)}
+	incoming := []FillReconciliationInput{fillReconcileInput(fillReconcileReal(order.ID, "trade-2", 0.3), FillSourceReal)}
 
 	plan, err := BuildFillReconciliationPlan(order, existing, incoming, FillReconcilePolicy{})
 	if err != nil {
@@ -82,8 +82,8 @@ func TestBuildFillReconciliationPlanBatchedRealFillsShrinkRemainder(t *testing.T
 
 func TestBuildFillReconciliationPlanAppliesOnlyRealQtyBeyondSynthetic(t *testing.T) {
 	order := fillReconcileTestOrder(1)
-	existing := []domain.Fill{fillReconcileSynthetic("fill-synthetic", order.ID, 0.6)}
-	incoming := []domain.Fill{fillReconcileReal(order.ID, "trade-1", 1)}
+	existing := []FillReconciliationInput{fillReconcileInput(fillReconcileSynthetic("fill-synthetic", order.ID, 0.6), FillSourceSynthetic)}
+	incoming := []FillReconciliationInput{fillReconcileInput(fillReconcileReal(order.ID, "trade-1", 1), FillSourceReal)}
 
 	plan, err := BuildFillReconciliationPlan(order, existing, incoming, FillReconcilePolicy{})
 	if err != nil {
@@ -98,8 +98,8 @@ func TestBuildFillReconciliationPlanAppliesOnlyRealQtyBeyondSynthetic(t *testing
 
 func TestBuildFillReconciliationPlanSkipsDuplicateRealTradeID(t *testing.T) {
 	order := fillReconcileTestOrder(1)
-	existing := []domain.Fill{fillReconcileReal(order.ID, "trade-1", 1)}
-	incoming := []domain.Fill{fillReconcileReal(order.ID, "trade-1", 1)}
+	existing := []FillReconciliationInput{fillReconcileInput(fillReconcileReal(order.ID, "trade-1", 1), FillSourceReal)}
+	incoming := []FillReconciliationInput{fillReconcileInput(fillReconcileReal(order.ID, "trade-1", 1), FillSourceReal)}
 
 	plan, err := BuildFillReconciliationPlan(order, existing, incoming, FillReconcilePolicy{})
 	if err != nil {
@@ -117,14 +117,46 @@ func TestBuildFillReconciliationPlanSkipsDuplicateRealTradeID(t *testing.T) {
 
 func TestBuildFillReconciliationPlanRejectsInvalidQuantity(t *testing.T) {
 	order := fillReconcileTestOrder(1)
-	_, err := BuildFillReconciliationPlan(order, nil, []domain.Fill{{
+	_, err := BuildFillReconciliationPlan(order, nil, []FillReconciliationInput{fillReconcileInput(domain.Fill{
 		OrderID:         order.ID,
 		ExchangeTradeID: "trade-1",
 		Price:           68000,
 		Quantity:        math.NaN(),
-	}}, FillReconcilePolicy{})
+	}, FillSourceReal)}, FillReconcilePolicy{})
 	if err == nil {
 		t.Fatal("expected invalid quantity error")
+	}
+}
+
+func TestBuildFillReconciliationPlanRequiresExplicitFillSource(t *testing.T) {
+	order := fillReconcileTestOrder(1)
+	_, err := BuildFillReconciliationPlan(order, nil, []FillReconciliationInput{{Fill: fillReconcileReal(order.ID, "trade-1", 1)}}, FillReconcilePolicy{})
+	if err == nil {
+		t.Fatal("expected missing fill source error")
+	}
+}
+
+func TestBuildFillReconciliationPlanDoesNotDeleteSyntheticWithoutExplicitSource(t *testing.T) {
+	order := fillReconcileTestOrder(1)
+	existing := []FillReconciliationInput{fillReconcileInput(fillReconcileSynthetic("fill-synthetic", order.ID, 1), FillSourceReal)}
+	_, err := BuildFillReconciliationPlan(order, existing, nil, FillReconcilePolicy{})
+	if err == nil {
+		t.Fatal("expected source/id mismatch error")
+	}
+}
+
+func TestBuildFillReconciliationPlanClampsNegativeRemainingQuantity(t *testing.T) {
+	order := fillReconcileTestOrder(1)
+	existing := []FillReconciliationInput{fillReconcileInput(fillReconcileReal(order.ID, "trade-1", 1.2), FillSourceReal)}
+
+	plan, err := BuildFillReconciliationPlan(order, existing, nil, FillReconcilePolicy{})
+	if err != nil {
+		t.Fatalf("BuildFillReconciliationPlan failed: %v", err)
+	}
+
+	requireFillReconcileQuantity(t, metadataFloat(plan, "remainingQuantity"), 0)
+	if len(plan.Warnings) == 0 {
+		t.Fatal("expected overfill warning")
 	}
 }
 
@@ -147,6 +179,10 @@ func fillReconcileReal(orderID, tradeID string, quantity float64) domain.Fill {
 		Price:           68000,
 		Quantity:        quantity,
 	}
+}
+
+func fillReconcileInput(fill domain.Fill, source FillSource) FillReconciliationInput {
+	return FillReconciliationInput{Fill: fill, Source: source}
 }
 
 func fillReconcileSynthetic(id, orderID string, quantity float64) domain.Fill {


### PR DESCRIPTION
## 目的
Refs #272. Follow-up after #283.

在进入下一阶段接入前，先补齐两个安全前置项：
- `BuildFillReconciliationPlan` 不再从 `exchangeTradeID/dedupFingerprint` 间接猜 fill source，改为要求调用方传入显式 `FillReconciliationInput{Fill, Source}`。
- source 与字段不匹配时直接报错：real 必须有 `exchangeTradeID`，synthetic 必须有 dedup fingerprint，remainder 必须有 `synthetic-remainder|` 前缀。
- `remainingQuantity` 统一 clamp 到非负值；超额成交保留 warning，不让 metadata 暴露负 remaining。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [x] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(无变化)
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？(无)
- [x] DB migration 是否具备向下兼容幂等性？(无 migration)
- [x] 配置字段有没有无意被混改？(无)

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

验证已通过：
- `go test ./internal/service -run 'TestBuildFillReconciliationPlan|TestSyntheticUpgrade'`
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
