### PR TITLE
[codex] wire finalize through fill reconciliation plan

### DIFF
--- a/internal/service/fill_reconcile.go
+++ b/internal/service/fill_reconcile.go
@@ -111,6 +111,13 @@ func BuildFillReconciliationPlan(order domain.Order, existing []FillReconciliati
 			if _, exists := existingRealTradeIDs[tradeID]; exists {
 				continue
 			}
+			remainingRealQty := order.Quantity - existingRealQty - newRealQty
+			if !tradingQuantityPositive(remainingRealQty) {
+				continue
+			}
+			if tradingQuantityExceeds(fill.Quantity, remainingRealQty) {
+				fill.Quantity = remainingRealQty
+			}
 			existingRealTradeIDs[tradeID] = struct{}{}
 			hasNewRealFill = true
 			newRealQty += fill.Quantity
@@ -227,9 +234,6 @@ func setFillReconcileMetadata(plan *FillReconciliationPlan, order domain.Order, 
 		filledQty = 0
 	}
 	remainingQty := order.Quantity - filledQty
-	if remainingQty < 0 && !tradingQuantityExceeds(-remainingQty, 0) {
-		remainingQty = 0
-	}
 	if remainingQty < 0 {
 		remainingQty = 0
 	}

--- a/internal/service/fill_reconcile_test.go
+++ b/internal/service/fill_reconcile_test.go
@@ -115,6 +115,20 @@ func TestBuildFillReconciliationPlanSkipsDuplicateRealTradeID(t *testing.T) {
 	requireFillReconcileQuantity(t, metadataFloat(plan, "filledQuantity"), 1)
 }
 
+func TestBuildFillReconciliationPlanClampsIncomingRealToRemainingQuantity(t *testing.T) {
+	order := fillReconcileTestOrder(1)
+	incoming := []FillReconciliationInput{fillReconcileInput(fillReconcileReal(order.ID, "trade-1", 1.2), FillSourceReal)}
+
+	plan, err := BuildFillReconciliationPlan(order, nil, incoming, FillReconcilePolicy{})
+	if err != nil {
+		t.Fatalf("BuildFillReconciliationPlan failed: %v", err)
+	}
+
+	requireFillReconcileQuantity(t, sumRealQty(plan.CreateFills), 1)
+	requireFillReconcileQuantity(t, sumFillQty(plan.ApplyPositionFills), 1)
+	requireFillReconcileQuantity(t, metadataFloat(plan, "remainingQuantity"), 0)
+}
+
 func TestBuildFillReconciliationPlanRejectsInvalidQuantity(t *testing.T) {
 	order := fillReconcileTestOrder(1)
 	_, err := BuildFillReconciliationPlan(order, nil, []FillReconciliationInput{fillReconcileInput(domain.Fill{

--- a/internal/service/order.go
+++ b/internal/service/order.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/wuyaocheng/bktrader/internal/domain"
+	storepkg "github.com/wuyaocheng/bktrader/internal/store"
 )
 
 const (
@@ -1094,118 +1095,102 @@ func (p *Platform) finalizeExecutedOrder(account domain.Account, order domain.Or
 		return domain.Order{}, err
 	}
 
-	hasRealFill := false
-	for _, f := range newFills {
-		if strings.TrimSpace(f.ExchangeTradeID) != "" {
-			hasRealFill = true
-			break
-		}
-	}
-	syntheticQty := 0.0
-	if hasRealFill {
-		deletedQty, err := p.store.DeleteSyntheticFillsForOrder(order.ID)
-		if err != nil {
-			return domain.Order{}, fmt.Errorf("failed to delete synthetic fills before upgrade: %w", err)
-		}
-		syntheticQty = deletedQty
-	}
-
-	existingFilledQuantity, err := p.store.TotalFilledQuantityForOrder(order.ID)
+	existingFills, err := p.store.QueryFills(domain.FillQuery{OrderIDs: []string{order.ID}})
 	if err != nil {
 		return domain.Order{}, err
 	}
-	newFills = limitExecutionFillsToRemainingQuantity(newFills, order.Quantity-existingFilledQuantity)
-	lastPrice := order.Price
-	for _, fill := range newFills {
-		createdFill, err := p.store.CreateFill(fill)
-		if err != nil {
-			return domain.Order{}, err
-		}
+	existingInputs, err := fillReconciliationInputsFromStoredFills(existingFills)
+	if err != nil {
+		return domain.Order{}, err
+	}
+	incomingInputs, err := fillReconciliationInputsFromIncomingFills(order, newFills)
+	if err != nil {
+		return domain.Order{}, err
+	}
+	plan, err := BuildFillReconciliationPlan(order, existingInputs, incomingInputs, FillReconcilePolicy{AllowSyntheticFallback: true})
+	if err != nil {
+		return domain.Order{}, err
+	}
 
-		applyQty := createdFill.Quantity
-		if syntheticQty > 0 {
-			if syntheticQty >= applyQty {
-				syntheticQty -= applyQty
-				applyQty = 0
-			} else {
-				applyQty -= syntheticQty
-				syntheticQty = 0
+	var updatedOrder domain.Order
+	if err := p.store.WithFillSettlementTx(func(tx storepkg.FillSettlementStore) error {
+		if len(plan.DeleteFillIDs) > 0 {
+			if _, err := tx.DeleteFillsByID(plan.DeleteFillIDs); err != nil {
+				return fmt.Errorf("failed to delete synthetic fills before upgrade: %w", err)
 			}
 		}
 
-		executionPrice := createdFill.Price
-		if executionPrice <= 0 {
-			executionPrice = resolveExecutionPrice(order)
+		lastPrice := order.Price
+		for _, fill := range plan.CreateFills {
+			createdFill, err := tx.CreateFill(fill)
+			if err != nil {
+				return err
+			}
+			executionPrice := createdFill.Price
+			if executionPrice <= 0 {
+				executionPrice = resolveExecutionPrice(order)
+			}
+			lastPrice = executionPrice
 		}
-		lastPrice = executionPrice
 
-		if applyQty > 0 {
+		for _, fill := range plan.ApplyPositionFills {
+			executionPrice := fill.Price
+			if executionPrice <= 0 {
+				executionPrice = resolveExecutionPrice(order)
+			}
 			execOrder := order
-			execOrder.Quantity = applyQty
+			execOrder.Quantity = fill.Quantity
 			execOrder.Price = executionPrice
-			if err := p.applyExecutionFill(account, execOrder, executionPrice); err != nil {
-				return domain.Order{}, err
+			if err := p.applyExecutionFillWithStore(tx, account, execOrder, executionPrice); err != nil {
+				return err
 			}
 		}
-	}
 
-	if syntheticQty > 0 {
-		remainderFill := domain.Fill{
-			OrderID:          order.ID,
-			Price:            lastPrice,
-			Quantity:         syntheticQty,
-			Fee:              0,
-			DedupFingerprint: fmt.Sprintf("synthetic-remainder|%s|%.12f|%d", order.ID, syntheticQty, time.Now().UTC().UnixNano()),
+		filledQuantity, err := tx.TotalFilledQuantityForOrder(order.ID)
+		if err != nil {
+			return err
 		}
-		if _, err := p.store.CreateFill(remainderFill); err != nil {
-			return domain.Order{}, fmt.Errorf("failed to create synthetic remainder fill: %w", err)
+		order.Metadata["filledQuantity"] = filledQuantity
+		remainingQuantity := order.Quantity - filledQuantity
+		if remainingQuantity < 0 {
+			remainingQuantity = 0
 		}
-		// NOTE: We do not call applyExecutionFill for the remainder because its quantity
-		// was already applied to the position when the original synthetic fill was processed.
-	}
-	filledQuantity, err := p.store.TotalFilledQuantityForOrder(order.ID)
-	if err != nil {
-		return domain.Order{}, err
-	}
-	order.Metadata["filledQuantity"] = filledQuantity
-	remainingQuantity := order.Quantity - filledQuantity
-	if remainingQuantity < 0 && !tradingQuantityExceeds(-remainingQuantity, 0) {
-		remainingQuantity = 0
-	}
-	if remainingQuantity < 0 {
-		remainingQuantity = 0
-	}
-	order.Metadata["remainingQuantity"] = remainingQuantity
+		order.Metadata["remainingQuantity"] = remainingQuantity
 
-	orderCompletelyFilled := !tradingQuantityBelow(filledQuantity, order.Quantity)
-	if orderCompletelyFilled {
-		order.Status = "FILLED"
-		if !boolValue(order.Metadata["emptyTradeRetryRequired"]) {
-			delete(order.Metadata, liveSettlementSyncRequiredKey)
+		orderCompletelyFilled := !tradingQuantityBelow(filledQuantity, order.Quantity)
+		if orderCompletelyFilled {
+			order.Status = "FILLED"
+			if !boolValue(order.Metadata["emptyTradeRetryRequired"]) {
+				delete(order.Metadata, liveSettlementSyncRequiredKey)
+			}
+			delete(order.Metadata, liveSettlementSyncErrorKey)
+		} else if isTerminalOrderStatus(order.Status) && !strings.EqualFold(order.Status, "FILLED") {
+			if !boolValue(order.Metadata["emptyTradeRetryRequired"]) {
+				delete(order.Metadata, liveSettlementSyncRequiredKey)
+			}
+			delete(order.Metadata, liveSettlementSyncErrorKey)
+		} else if filledQuantity > 0 {
+			order.Status = "PARTIALLY_FILLED"
 		}
-		delete(order.Metadata, liveSettlementSyncErrorKey)
-	} else if isTerminalOrderStatus(order.Status) && !strings.EqualFold(order.Status, "FILLED") {
-		if !boolValue(order.Metadata["emptyTradeRetryRequired"]) {
-			delete(order.Metadata, liveSettlementSyncRequiredKey)
+		order.Price = lastPrice
+		markOrderLifecycle(order.Metadata, "filled", orderCompletelyFilled)
+		if order.Metadata["acceptedAt"] == nil {
+			order.Metadata["acceptedAt"] = time.Now().UTC().Format(time.RFC3339)
 		}
-		delete(order.Metadata, liveSettlementSyncErrorKey)
-	} else if filledQuantity > 0 {
-		order.Status = "PARTIALLY_FILLED"
-	}
-	order.Price = lastPrice
-	markOrderLifecycle(order.Metadata, "filled", orderCompletelyFilled)
-	if order.Metadata["acceptedAt"] == nil {
-		order.Metadata["acceptedAt"] = time.Now().UTC().Format(time.RFC3339)
-	}
-	if (len(newFills) > 0 || strings.TrimSpace(stringValue(order.Metadata["lastFilledAt"])) == "") && filledQuantity > 0 {
-		filledAt := time.Now().UTC()
-		if latestTradeTime := latestFillExchangeTradeTime(newFills); !latestTradeTime.IsZero() {
-			filledAt = latestTradeTime
+		if (len(newFills) > 0 || strings.TrimSpace(stringValue(order.Metadata["lastFilledAt"])) == "") && filledQuantity > 0 {
+			filledAt := time.Now().UTC()
+			if latestTradeTime := latestFillExchangeTradeTime(newFills); !latestTradeTime.IsZero() {
+				filledAt = latestTradeTime
+			}
+			order.Metadata["lastFilledAt"] = filledAt.Format(time.RFC3339)
 		}
-		order.Metadata["lastFilledAt"] = filledAt.Format(time.RFC3339)
-	}
-	updatedOrder, err := p.store.UpdateOrder(order)
-	if err != nil {
+		updated, err := tx.UpdateOrder(order)
+		if err != nil {
+			return err
+		}
+		updatedOrder = updated
+		return nil
+	}); err != nil {
 		return domain.Order{}, err
 	}
 	if strings.EqualFold(account.Mode, "LIVE") && len(newFills) > 0 {
@@ -1231,6 +1216,54 @@ func (p *Platform) finalizeExecutedOrder(account domain.Account, order domain.Or
 		levelLogger.Debug("paper order filled", "fill_count", len(newFills), "price", updatedOrder.Price)
 	}
 	return updatedOrder, nil
+}
+
+func fillReconciliationInputsFromStoredFills(fills []domain.Fill) ([]FillReconciliationInput, error) {
+	inputs := make([]FillReconciliationInput, 0, len(fills))
+	for _, fill := range fills {
+		source, ok := fillReconciliationSourceFromStoredFill(fill)
+		if !ok {
+			return nil, fmt.Errorf("stored fill %s has ambiguous source", fill.ID)
+		}
+		inputs = append(inputs, FillReconciliationInput{Fill: fill, Source: source})
+	}
+	return inputs, nil
+}
+
+func fillReconciliationInputsFromIncomingFills(order domain.Order, fills []domain.Fill) ([]FillReconciliationInput, error) {
+	inputs := make([]FillReconciliationInput, 0, len(fills))
+	for _, fill := range fills {
+		if strings.TrimSpace(fill.OrderID) == "" {
+			fill.OrderID = order.ID
+		}
+		source := FillSourceReal
+		if strings.TrimSpace(fill.ExchangeTradeID) == "" {
+			fill.DedupFingerprint = strings.TrimSpace(fill.DedupFingerprint)
+			if fill.DedupFingerprint == "" {
+				fill.DedupFingerprint = fill.FallbackFingerprint()
+			}
+			source = FillSourceSynthetic
+			if strings.HasPrefix(fill.DedupFingerprint, syntheticRemainderFingerprintPrefix) {
+				source = FillSourceRemainder
+			}
+		}
+		inputs = append(inputs, FillReconciliationInput{Fill: fill, Source: source})
+	}
+	return inputs, nil
+}
+
+func fillReconciliationSourceFromStoredFill(fill domain.Fill) (FillSource, bool) {
+	if strings.TrimSpace(fill.ExchangeTradeID) != "" {
+		return FillSourceReal, true
+	}
+	fingerprint := strings.TrimSpace(fill.DedupFingerprint)
+	if fingerprint == "" {
+		return "", false
+	}
+	if strings.HasPrefix(fingerprint, syntheticRemainderFingerprintPrefix) {
+		return FillSourceRemainder, true
+	}
+	return FillSourceSynthetic, true
 }
 
 func (p *Platform) filterExistingExecutionFills(orderID string, fills []domain.Fill) ([]domain.Fill, error) {
@@ -1434,6 +1467,10 @@ func (p *Platform) CountFills() (int, error) {
 // applyExecutionFill 根据已确认成交更新仓位。
 // 它是 paper/live 共用的持仓落账逻辑，只处理 canonical fill 之后的仓位变更。
 func (p *Platform) applyExecutionFill(account domain.Account, order domain.Order, executionPrice float64) error {
+	return p.applyExecutionFillWithStore(p.store, account, order, executionPrice)
+}
+
+func (p *Platform) applyExecutionFillWithStore(settlementStore storepkg.FillSettlementStore, account domain.Account, order domain.Order, executionPrice float64) error {
 	if boolValue(order.Metadata["reconcileRecovered"]) {
 		snapshotQty := liveSyncSnapshotPositionAmounts(account)[NormalizeSymbol(order.Symbol)]
 		if !tradingQuantityPositive(snapshotQty) {
@@ -1445,7 +1482,7 @@ func (p *Platform) applyExecutionFill(account domain.Account, order domain.Order
 			return nil
 		}
 	}
-	position, exists, err := p.store.FindPosition(account.ID, order.Symbol)
+	position, exists, err := settlementStore.FindPosition(account.ID, order.Symbol)
 	if err != nil {
 		return err
 	}
@@ -1458,7 +1495,7 @@ func (p *Platform) applyExecutionFill(account domain.Account, order domain.Order
 
 	// 无现有持仓 → 新开仓
 	if !exists {
-		_, err := p.store.SavePosition(domain.Position{
+		_, err := settlementStore.SavePosition(domain.Position{
 			AccountID:         account.ID,
 			StrategyVersionID: order.StrategyVersionID,
 			Symbol:            order.Symbol,
@@ -1477,7 +1514,7 @@ func (p *Platform) applyExecutionFill(account domain.Account, order domain.Order
 		position.Quantity = totalQty
 		position.MarkPrice = executionPrice
 		position.StrategyVersionID = firstNonEmpty(order.StrategyVersionID, position.StrategyVersionID)
-		_, err := p.store.SavePosition(position)
+		_, err := settlementStore.SavePosition(position)
 		return err
 	}
 
@@ -1485,16 +1522,16 @@ func (p *Platform) applyExecutionFill(account domain.Account, order domain.Order
 	if tradingQuantityBelow(order.Quantity, position.Quantity) {
 		position.Quantity = position.Quantity - order.Quantity
 		if position.Quantity <= 0 {
-			return p.store.DeletePosition(position.ID)
+			return settlementStore.DeletePosition(position.ID)
 		}
 		position.MarkPrice = executionPrice
-		_, err := p.store.SavePosition(position)
+		_, err := settlementStore.SavePosition(position)
 		return err
 	}
 
 	// 反方向 → 全部平仓
 	if tradingQuantityEqual(order.Quantity, position.Quantity) {
-		err := p.store.DeletePosition(position.ID)
+		err := settlementStore.DeletePosition(position.ID)
 		if err == nil && strings.EqualFold(account.Mode, "LIVE") {
 			liveSessionID := stringValue(order.Metadata["liveSessionId"])
 			decisionEventID := stringValue(order.Metadata["decisionEventId"])
@@ -1508,7 +1545,7 @@ func (p *Platform) applyExecutionFill(account domain.Account, order domain.Order
 				// for a given order in `enrichLiveTradePairs`.
 				// While `ws-sync` is an optimistic source, subsequent reconcile events can append a newer record
 				// with `VerifiedClosed=false` if residual position is detected.
-				_, _ = p.store.CreateOrderCloseVerification(domain.OrderCloseVerification{
+				_, _ = settlementStore.CreateOrderCloseVerification(domain.OrderCloseVerification{
 					LiveSessionID:        liveSessionID,
 					OrderID:              order.ID,
 					DecisionEventID:      decisionEventID,
@@ -1532,7 +1569,7 @@ func (p *Platform) applyExecutionFill(account domain.Account, order domain.Order
 	position.EntryPrice = executionPrice
 	position.MarkPrice = executionPrice
 	position.StrategyVersionID = firstNonEmpty(order.StrategyVersionID, position.StrategyVersionID)
-	_, err = p.store.SavePosition(position)
+	_, err = settlementStore.SavePosition(position)
 	return err
 }
 

--- a/internal/store/memory/fill_settlement_tx_test.go
+++ b/internal/store/memory/fill_settlement_tx_test.go
@@ -1,0 +1,37 @@
+package memory
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/wuyaocheng/bktrader/internal/domain"
+	storepkg "github.com/wuyaocheng/bktrader/internal/store"
+)
+
+func TestWithFillSettlementTxRollsBackFillOnError(t *testing.T) {
+	store := NewStore()
+	errSentinel := errors.New("stop after fill create")
+
+	err := store.WithFillSettlementTx(func(tx storepkg.FillSettlementStore) error {
+		if _, err := tx.CreateFill(domain.Fill{
+			OrderID:          "order-rollback",
+			Price:            68000,
+			Quantity:         1,
+			DedupFingerprint: "rollback-fill",
+		}); err != nil {
+			return err
+		}
+		return errSentinel
+	})
+	if !errors.Is(err, errSentinel) {
+		t.Fatalf("expected sentinel error, got %v", err)
+	}
+
+	fills, err := store.ListFills()
+	if err != nil {
+		t.Fatalf("ListFills failed: %v", err)
+	}
+	if len(fills) != 0 {
+		t.Fatalf("expected rollback to remove created fill, got %+v", fills)
+	}
+}

--- a/internal/store/memory/store.go
+++ b/internal/store/memory/store.go
@@ -717,6 +717,43 @@ func (s *Store) CreateFill(fill domain.Fill) (domain.Fill, error) {
 	return fill, nil
 }
 
+func (s *Store) DeleteFillsByID(fillIDs []string) (float64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	totalQty := 0.0
+	for _, id := range fillIDs {
+		item, ok := s.fills[id]
+		if !ok {
+			continue
+		}
+		totalQty += item.Quantity
+		delete(s.fills, id)
+	}
+	return totalQty, nil
+}
+
+func (s *Store) WithFillSettlementTx(fn func(storepkg.FillSettlementStore) error) error {
+	s.mu.RLock()
+	orders := cloneJSONValue(s.orders)
+	fills := cloneJSONValue(s.fills)
+	positions := cloneJSONValue(s.positions)
+	closeVerifications := cloneJSONValue(s.closeVerifications)
+	sequence := s.sequence
+	s.mu.RUnlock()
+
+	if err := fn(s); err != nil {
+		s.mu.Lock()
+		s.orders = orders
+		s.fills = fills
+		s.positions = positions
+		s.closeVerifications = closeVerifications
+		s.sequence = sequence
+		s.mu.Unlock()
+		return err
+	}
+	return nil
+}
+
 func (s *Store) DeleteSyntheticFillsForOrder(orderID string) (float64, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/store/postgres/fill_settlement_tx_test.go
+++ b/internal/store/postgres/fill_settlement_tx_test.go
@@ -1,0 +1,66 @@
+package postgres
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/wuyaocheng/bktrader/internal/domain"
+	storepkg "github.com/wuyaocheng/bktrader/internal/store"
+)
+
+func TestWithFillSettlementTxRollsBackFillOnError(t *testing.T) {
+	dsn := os.Getenv("BKTRADER_TEST_POSTGRES_DSN")
+	if dsn == "" {
+		t.Skip("BKTRADER_TEST_POSTGRES_DSN is not set")
+	}
+	if err := Migrate(dsn); err != nil {
+		t.Fatalf("Migrate failed: %v", err)
+	}
+	store, err := New(dsn)
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	defer store.Close()
+
+	account, err := store.GetAccount("paper-default")
+	if err != nil {
+		t.Fatalf("GetAccount failed: %v", err)
+	}
+	order, err := store.CreateOrder(domain.Order{
+		AccountID: account.ID,
+		Symbol:    "BTCUSDT",
+		Side:      "BUY",
+		Type:      "MARKET",
+		Quantity:  1,
+		Price:     68000,
+		Metadata:  map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("CreateOrder failed: %v", err)
+	}
+
+	errSentinel := errors.New("stop after fill create")
+	err = store.WithFillSettlementTx(func(tx storepkg.FillSettlementStore) error {
+		if _, err := tx.CreateFill(domain.Fill{
+			OrderID:          order.ID,
+			Price:            68000,
+			Quantity:         1,
+			DedupFingerprint: "rollback-fill-" + order.ID,
+		}); err != nil {
+			return err
+		}
+		return errSentinel
+	})
+	if !errors.Is(err, errSentinel) {
+		t.Fatalf("expected sentinel error, got %v", err)
+	}
+
+	fills, err := store.QueryFills(domain.FillQuery{OrderIDs: []string{order.ID}})
+	if err != nil {
+		t.Fatalf("QueryFills failed: %v", err)
+	}
+	if len(fills) != 0 {
+		t.Fatalf("expected rollback to remove created fill, got %+v", fills)
+	}
+}

--- a/internal/store/postgres/store.go
+++ b/internal/store/postgres/store.go
@@ -920,6 +920,272 @@ func (s *Store) CreateFill(fill domain.Fill) (domain.Fill, error) {
 	return fill, err
 }
 
+func (s *Store) DeleteFillsByID(fillIDs []string) (float64, error) {
+	if len(fillIDs) == 0 {
+		return 0, nil
+	}
+	placeholders := make([]string, 0, len(fillIDs))
+	args := make([]any, 0, len(fillIDs))
+	for i, id := range fillIDs {
+		placeholders = append(placeholders, fmt.Sprintf("$%d", i+1))
+		args = append(args, id)
+	}
+	var totalQty sql.NullFloat64
+	err := s.db.QueryRow(fmt.Sprintf(`
+		with deleted as (
+			delete from fills
+			where id in (%s)
+			returning quantity
+		)
+		select sum(quantity) from deleted
+	`, strings.Join(placeholders, ",")), args...).Scan(&totalQty)
+	if err != nil && err != sql.ErrNoRows {
+		return 0, err
+	}
+	if !totalQty.Valid {
+		return 0, nil
+	}
+	return totalQty.Float64, nil
+}
+
+func (s *Store) WithFillSettlementTx(fn func(storepkg.FillSettlementStore) error) error {
+	tx, err := s.db.BeginTx(context.Background(), nil)
+	if err != nil {
+		return err
+	}
+	if err := fn(fillSettlementTxStore{tx: tx}); err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+	return tx.Commit()
+}
+
+type fillSettlementTxStore struct {
+	tx *sql.Tx
+}
+
+type fillScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanFill(row fillScanner, fill domain.Fill) (domain.Fill, error) {
+	var (
+		exchangeTradeID     sql.NullString
+		exchangeTradeTime   sql.NullTime
+		fallbackFingerprint sql.NullString
+	)
+	err := row.Scan(
+		&fill.ID,
+		&fill.OrderID,
+		&exchangeTradeID,
+		&exchangeTradeTime,
+		&fallbackFingerprint,
+		&fill.Price,
+		&fill.Quantity,
+		&fill.Fee,
+		&fill.CreatedAt,
+	)
+	fill.ExchangeTradeID = exchangeTradeID.String
+	fill.DedupFingerprint = fallbackFingerprint.String
+	if exchangeTradeTime.Valid {
+		parsed := exchangeTradeTime.Time.UTC()
+		fill.ExchangeTradeTime = &parsed
+	} else {
+		fill.ExchangeTradeTime = nil
+	}
+	return fill, err
+}
+
+func (s fillSettlementTxStore) DeleteFillsByID(fillIDs []string) (float64, error) {
+	if len(fillIDs) == 0 {
+		return 0, nil
+	}
+	placeholders := make([]string, 0, len(fillIDs))
+	args := make([]any, 0, len(fillIDs))
+	for i, id := range fillIDs {
+		placeholders = append(placeholders, fmt.Sprintf("$%d", i+1))
+		args = append(args, id)
+	}
+	var totalQty sql.NullFloat64
+	err := s.tx.QueryRow(fmt.Sprintf(`
+		with deleted as (
+			delete from fills
+			where id in (%s)
+			returning quantity
+		)
+		select sum(quantity) from deleted
+	`, strings.Join(placeholders, ",")), args...).Scan(&totalQty)
+	if err != nil && err != sql.ErrNoRows {
+		return 0, err
+	}
+	if !totalQty.Valid {
+		return 0, nil
+	}
+	return totalQty.Float64, nil
+}
+
+func (s fillSettlementTxStore) CreateFill(fill domain.Fill) (domain.Fill, error) {
+	now := time.Now().UTC()
+	fill.ID = fmt.Sprintf("fill-%d", now.UnixNano())
+	fill.CreatedAt = now
+	if strings.TrimSpace(fill.ExchangeTradeID) == "" {
+		fill.DedupFingerprint = strings.TrimSpace(fill.DedupFingerprint)
+		if fill.DedupFingerprint == "" {
+			fill.DedupFingerprint = fill.FallbackFingerprint()
+		}
+	}
+
+	if strings.TrimSpace(fill.ExchangeTradeID) == "" {
+		row := s.tx.QueryRow(`
+			insert into fills (id, order_id, exchange_trade_id, exchange_trade_time, dedup_fallback_fingerprint, price, quantity, fee, created_at)
+			values ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+			on conflict (order_id, dedup_fallback_fingerprint) do update set
+				price = fills.price,
+				quantity = fills.quantity,
+				fee = fills.fee,
+				exchange_trade_time = coalesce(fills.exchange_trade_time, excluded.exchange_trade_time)
+			returning id, order_id, exchange_trade_id, exchange_trade_time, dedup_fallback_fingerprint, price, quantity, fee, created_at
+		`, fill.ID, fill.OrderID, nullIfEmpty(fill.ExchangeTradeID), fill.ExchangeTradeTime, fill.DedupFingerprint, fill.Price, fill.Quantity, fill.Fee, fill.CreatedAt)
+		return scanFill(row, fill)
+	}
+
+	row := s.tx.QueryRow(`
+		insert into fills (id, order_id, exchange_trade_id, exchange_trade_time, dedup_fallback_fingerprint, price, quantity, fee, created_at)
+		values ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+		on conflict (order_id, exchange_trade_id) do update set
+			price = fills.price,
+			quantity = fills.quantity,
+			fee = fills.fee,
+			exchange_trade_time = coalesce(fills.exchange_trade_time, excluded.exchange_trade_time)
+		returning id, order_id, exchange_trade_id, exchange_trade_time, dedup_fallback_fingerprint, price, quantity, fee, created_at
+	`, fill.ID, fill.OrderID, fill.ExchangeTradeID, fill.ExchangeTradeTime, nil, fill.Price, fill.Quantity, fill.Fee, fill.CreatedAt)
+	return scanFill(row, fill)
+}
+
+func (s fillSettlementTxStore) TotalFilledQuantityForOrder(orderID string) (float64, error) {
+	var total sql.NullFloat64
+	if err := s.tx.QueryRow(`
+		select coalesce(sum(quantity), 0)
+		from fills
+		where order_id = $1
+	`, orderID).Scan(&total); err != nil {
+		return 0, err
+	}
+	if !total.Valid {
+		return 0, nil
+	}
+	return total.Float64, nil
+}
+
+func (s fillSettlementTxStore) FindPosition(accountID, symbol string) (domain.Position, bool, error) {
+	var item domain.Position
+	var strategyVersionID sql.NullString
+	err := s.tx.QueryRow(`
+		select id, account_id, strategy_version_id, symbol, side, quantity, entry_price, mark_price, updated_at
+		from positions
+		where account_id = $1 and symbol = $2
+		order by updated_at desc
+		limit 1
+	`, accountID, symbol).Scan(&item.ID, &item.AccountID, &strategyVersionID, &item.Symbol, &item.Side, &item.Quantity, &item.EntryPrice, &item.MarkPrice, &item.UpdatedAt)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return domain.Position{}, false, nil
+		}
+		return domain.Position{}, false, err
+	}
+	item.StrategyVersionID = strategyVersionID.String
+	return item, true, nil
+}
+
+func (s fillSettlementTxStore) SavePosition(position domain.Position) (domain.Position, error) {
+	if position.Quantity <= 0 {
+		if strings.TrimSpace(position.ID) == "" {
+			return position, nil
+		}
+		return position, s.DeletePosition(position.ID)
+	}
+	now := time.Now().UTC()
+	position.UpdatedAt = now
+	if position.ID == "" {
+		position.ID = fmt.Sprintf("position-%d", now.UnixNano())
+		_, err := s.tx.Exec(`
+			insert into positions (id, account_id, strategy_version_id, symbol, side, quantity, entry_price, mark_price, updated_at)
+			values ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+		`, position.ID, position.AccountID, nullIfEmpty(position.StrategyVersionID), position.Symbol, position.Side, position.Quantity, position.EntryPrice, position.MarkPrice, position.UpdatedAt)
+		return position, err
+	}
+	_, err := s.tx.Exec(`
+		update positions
+		set account_id = $2,
+			strategy_version_id = $3,
+			symbol = $4,
+			side = $5,
+			quantity = $6,
+			entry_price = $7,
+			mark_price = $8,
+			updated_at = $9
+		where id = $1
+	`, position.ID, position.AccountID, nullIfEmpty(position.StrategyVersionID), position.Symbol, position.Side, position.Quantity, position.EntryPrice, position.MarkPrice, position.UpdatedAt)
+	return position, err
+}
+
+func (s fillSettlementTxStore) DeletePosition(positionID string) error {
+	_, err := s.tx.Exec(`delete from positions where id = $1`, positionID)
+	return err
+}
+
+func (s fillSettlementTxStore) UpdateOrder(order domain.Order) (domain.Order, error) {
+	order.NormalizeExecutionFlags()
+	if order.Metadata == nil {
+		order.Metadata = map[string]any{}
+	}
+	raw, _ := json.Marshal(order.Metadata)
+	_, err := s.tx.Exec(`
+		update orders
+		set account_id = $2,
+			strategy_version_id = $3,
+			symbol = $4,
+			side = $5,
+			type = $6,
+			status = $7,
+			quantity = $8,
+			price = $9,
+			metadata = $10
+		where id = $1
+	`, order.ID, order.AccountID, nullIfEmpty(order.StrategyVersionID), order.Symbol, order.Side, order.Type, order.Status, order.Quantity, order.Price, raw)
+	return order, err
+}
+
+func (s fillSettlementTxStore) CreateOrderCloseVerification(item domain.OrderCloseVerification) (domain.OrderCloseVerification, error) {
+	if item.ID == "" {
+		item.ID = fmt.Sprintf("order-close-verification-%d", time.Now().UTC().UnixNano())
+	}
+	item.Symbol = strings.ToUpper(strings.TrimSpace(item.Symbol))
+	if item.EventTime.IsZero() {
+		item.EventTime = time.Now().UTC()
+	}
+	if item.RecordedAt.IsZero() {
+		item.RecordedAt = time.Now().UTC()
+	}
+	if item.Metadata == nil {
+		item.Metadata = map[string]any{}
+	}
+	metadataRaw, _ := json.Marshal(item.Metadata)
+	_, err := s.tx.Exec(`
+		insert into order_close_verifications (
+			id, live_session_id, order_id, decision_event_id, account_id, strategy_id, symbol,
+			verified_closed, remaining_position_qty, verification_source, event_time, recorded_at, metadata
+		) values (
+			$1, $2, $3, $4, $5, $6, $7,
+			$8, $9, $10, $11, $12, $13
+		)
+	`,
+		item.ID, item.LiveSessionID, item.OrderID, nullIfEmpty(item.DecisionEventID), item.AccountID, item.StrategyID, item.Symbol,
+		item.VerifiedClosed, item.RemainingPositionQty, item.VerificationSource, item.EventTime, item.RecordedAt, metadataRaw,
+	)
+	return item, err
+}
+
 func (s *Store) DeleteSyntheticFillsForOrder(orderID string) (float64, error) {
 	var totalQty sql.NullFloat64
 	err := s.db.QueryRow(`

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -11,6 +11,17 @@ import (
 
 var ErrSignalRuntimeSessionNotFound = errors.New("signal runtime session not found")
 
+type FillSettlementStore interface {
+	DeleteFillsByID(fillIDs []string) (float64, error)
+	CreateFill(fill domain.Fill) (domain.Fill, error)
+	TotalFilledQuantityForOrder(orderID string) (float64, error)
+	FindPosition(accountID, symbol string) (domain.Position, bool, error)
+	SavePosition(position domain.Position) (domain.Position, error)
+	DeletePosition(positionID string) error
+	UpdateOrder(order domain.Order) (domain.Order, error)
+	CreateOrderCloseVerification(item domain.OrderCloseVerification) (domain.OrderCloseVerification, error)
+}
+
 // Repository 定义平台的数据持久化接口。
 // 支持可插拔的后端实现（memory/postgres），通过 STORE_BACKEND 配置切换。
 type Repository interface {
@@ -65,6 +76,10 @@ type Repository interface {
 	TotalFilledQuantityForOrder(orderID string) (float64, error)
 	// CreateFill 创建新成交记录。
 	CreateFill(fill domain.Fill) (domain.Fill, error)
+	// DeleteFillsByID 删除指定成交记录，并返回被删除的总数量。
+	DeleteFillsByID(fillIDs []string) (float64, error)
+	// WithFillSettlementTx 在同一个事务边界内执行 fill/order/position settlement。
+	WithFillSettlementTx(fn func(FillSettlementStore) error) error
 	// DeleteSyntheticFillsForOrder 删除指定订单的合成成交记录（没有 exchange_trade_id 的记录），并返回被删除的总数量。
 	DeleteSyntheticFillsForOrder(orderID string) (float64, error)
 


### PR DESCRIPTION
## 目的
Refs #272. Follow-up after #284.

让现有 `finalizeExecutedOrder` 接入成交一致性 plan，并补齐 settlement 原子性：
- 读取当前订单 fills，归一化为显式 source input；
- 调用 `BuildFillReconciliationPlan` 生成 delete/create/apply 计划；
- 新增 `WithFillSettlementTx` 窄事务接口，在同一事务内执行 fill 删除、fill 创建、position apply、order metadata/status 更新；
- 新增 `DeleteFillsByID` store 能力，按 plan 精确删除 synthetic/remainder fill，避免按间接条件误删；
- Postgres 使用 `BeginTx`；memory store 失败时回滚 orders/fills/positions/close verifications 快照；
- 补 memory/postgres 事务回滚测试，覆盖 CreateFill 成功后返回错误时 fill 不应残留。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [x] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(无变化)
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？(无)
- [x] DB migration 是否具备向下兼容幂等性？(无 migration)
- [x] 配置字段有没有无意被混改？(无)

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

验证已通过：
- `go test ./internal/store/memory ./internal/store/postgres ./internal/service -run 'TestWithFillSettlementTxRollsBackFillOnError|TestBuildFillReconciliationPlan|TestSyntheticUpgrade|TestFilledExitWithoutFillReportsDoesNotLeaveStaleShortPosition|TestRecoverRunningLiveSessionPreservesRemainingQuantityAfterPartialFillRestart' -count=1`
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
