### PR TITLE
fix(live): align enhanced 30m stop loss ATR

### DIFF
--- a/db/migrations/026_btc_30m_enhanced_strategy.sql
+++ b/db/migrations/026_btc_30m_enhanced_strategy.sql
@@ -37,7 +37,7 @@ values (
         "t3_min_sma_atr_separation": 0.25,
         "use_sma5_intraday_structure": true,
         "stop_mode": "atr",
-        "stop_loss_atr": 0.05,
+        "stop_loss_atr": 0.3,
         "profit_protect_atr": 1.0,
         "trailing_stop_atr": 0.3,
         "delayed_trailing_activation_atr": 0.5,

--- a/db/migrations/027_btc_30m_enhanced_stop_loss_atr.sql
+++ b/db/migrations/027_btc_30m_enhanced_stop_loss_atr.sql
@@ -1,0 +1,12 @@
+update strategy_versions
+set parameters = jsonb_set(parameters, '{stop_loss_atr}', '0.3'::jsonb, true)
+where id = 'strategy-version-bk-btc-30m-enhanced-v010'
+  and strategy_id = 'strategy-bk-btc-30m-enhanced';
+
+update live_sessions
+set state = jsonb_set(state, '{stop_loss_atr}', '0.3'::jsonb, true)
+where strategy_id = 'strategy-bk-btc-30m-enhanced'
+  and (
+    state->>'launchTemplateKey' = 'binance-testnet-btc-30m-enhanced'
+    or state->>'strategyEngine' = 'bk-live-intrabar-sma5-t3-sep'
+  );

--- a/internal/service/live_launch_templates.go
+++ b/internal/service/live_launch_templates.go
@@ -270,7 +270,7 @@ func liveIntradayResearchBaselineOverrides(strategyEngine string) map[string]any
 func liveBTC30mEnhancedOverrides() map[string]any {
 	overrides := liveIntradayResearchBaselineOverrides("bk-live-intrabar-sma5-t3-sep")
 	overrides["max_trades_per_bar"] = domain.ResearchBaselineMaxTradesPerBar
-	overrides["stop_loss_atr"] = 0.05
+	overrides["stop_loss_atr"] = 0.3
 	overrides["sl_reentry_min_delay_seconds"] = 60
 	overrides["breakout_shape"] = "baseline_plus_t3"
 	overrides["t3_min_sma_atr_separation"] = 0.25

--- a/internal/service/live_launch_templates_test.go
+++ b/internal/service/live_launch_templates_test.go
@@ -156,9 +156,6 @@ func TestLiveLaunchTemplatesExposeBinanceTestnetVariants(t *testing.T) {
 				t.Fatalf("expected stop_mode=atr for %s, got %s", item.Key, got)
 			}
 			expectedStopLossATR := 0.3
-			if want.enhanced {
-				expectedStopLossATR = 0.05
-			}
 			if got := parseFloatValue(item.LaunchPayload.LiveSessionOverrides["stop_loss_atr"]); got != expectedStopLossATR {
 				t.Fatalf("expected stop_loss_atr=%v for %s, got %v", expectedStopLossATR, item.Key, got)
 			}

--- a/internal/store/memory/store.go
+++ b/internal/store/memory/store.go
@@ -154,7 +154,7 @@ func NewStore() *Store {
 			"t3_min_sma_atr_separation":       0.25,
 			"use_sma5_intraday_structure":     true,
 			"stop_mode":                       "atr",
-			"stop_loss_atr":                   0.05,
+			"stop_loss_atr":                   0.3,
 			"profit_protect_atr":              1.0,
 			"trailing_stop_atr":               0.3,
 			"delayed_trailing_activation_atr": 0.5,


### PR DESCRIPTION
## 目的
把 BTCUSDT 30m Enhanced 策略的 `stop_loss_atr` 对齐回测/基线配置 `0.3`。

生产排查发现最新 enhanced live session 使用的是增强模板，但策略版本参数、模板 override 和 session state 都是 `stop_loss_atr=0.05`。因此最新 SHORT 仓位的止损按 `entry + 0.05 * ATR` 计算，而不是预期的 `entry + 0.3 * ATR`。

这次改动：
- 修正新库初始化 migration `026` 中 enhanced strategy version 参数为 `0.3`
- 新增 `027` migration，修已部署库的 strategy version 参数和现有 enhanced live session state
- 修正 memory store seed 和 enhanced launch template override
- 更新启动模板测试，确保 enhanced 也使用 `0.3`

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [x] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) — 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？— 无
- [x] DB migration 是否具备向下兼容幂等性？— 是，`jsonb_set` 修正指定 enhanced strategy/live session state
- [x] 配置字段有没有无意被混改？— 只改 `strategy-bk-btc-30m-enhanced` 的 `stop_loss_atr`

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

验证：
- `go test ./internal/service -run 'TestLiveLaunchTemplatesExposeBinanceTestnetVariants|TestLaunchLiveFlowFromEnhanced'`
- `go test ./internal/store/memory`
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
- `git push` pre-push harness passed