### PR TITLE
[codex] Add live session control request versioning

### DIFF
--- a/internal/http/live.go
+++ b/internal/http/live.go
@@ -726,6 +726,8 @@ func liveSessionControlAcceptedPayload(session domain.LiveSession) map[string]an
 		"sessionId":        session.ID,
 		"desiredStatus":    state["desiredStatus"],
 		"actualStatus":     state["actualStatus"],
+		"controlRequestId": state["controlRequestId"],
+		"controlVersion":   state["controlVersion"],
 		"lastControlError": state["lastControlError"],
 		"session":          session,
 	}

--- a/internal/http/session_safety_test.go
+++ b/internal/http/session_safety_test.go
@@ -98,9 +98,11 @@ func TestLiveSessionControlIntentAcceptedForAPIRole(t *testing.T) {
 				t.Fatalf("expected 202 for api role control intent, got %d body=%s", rec.Code, rec.Body.String())
 			}
 			var payload struct {
-				DesiredStatus string             `json:"desiredStatus"`
-				ActualStatus  string             `json:"actualStatus"`
-				Session       domain.LiveSession `json:"session"`
+				DesiredStatus    string             `json:"desiredStatus"`
+				ActualStatus     string             `json:"actualStatus"`
+				ControlRequestID string             `json:"controlRequestId"`
+				ControlVersion   int64              `json:"controlVersion"`
+				Session          domain.LiveSession `json:"session"`
 			}
 			if err := json.NewDecoder(rec.Body).Decode(&payload); err != nil {
 				t.Fatalf("decode live session failed: %v", err)
@@ -110,6 +112,15 @@ func TestLiveSessionControlIntentAcceptedForAPIRole(t *testing.T) {
 			}
 			if payload.ActualStatus == "" {
 				t.Fatal("expected top-level actualStatus")
+			}
+			if payload.ControlRequestID == "" {
+				t.Fatal("expected top-level controlRequestId")
+			}
+			if payload.ControlVersion == 0 {
+				t.Fatal("expected top-level controlVersion")
+			}
+			if got := payload.Session.State["controlRequestId"]; got != payload.ControlRequestID {
+				t.Fatalf("expected session controlRequestId %s, got %#v", payload.ControlRequestID, got)
 			}
 			if got := payload.Session.State["desiredStatus"]; got != desired {
 				t.Fatalf("expected desiredStatus %s, got %#v", desired, got)

--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -240,8 +240,16 @@ func (p *Platform) deleteLiveSessionWithForceLocked(session domain.LiveSession, 
 	state["actualStatus"] = "STOPPED"
 	state["controlDeletedAt"] = time.Now().UTC().Format(time.RFC3339)
 	delete(state, "desiredStopForce")
+	delete(state, "controlRequestId")
+	delete(state, "controlVersion")
+	delete(state, "lastControlAction")
+	delete(state, "controlRequestedAt")
+	delete(state, "activeControlRequestId")
+	delete(state, "activeControlVersion")
 	delete(state, "lastControlError")
 	delete(state, "lastControlErrorAt")
+	delete(state, "lastControlErrorRequestId")
+	delete(state, "lastControlErrorVersion")
 	if _, err := p.store.UpdateLiveSessionState(session.ID, state); err != nil {
 		return err
 	}

--- a/internal/service/live_session_control.go
+++ b/internal/service/live_session_control.go
@@ -2,13 +2,26 @@ package service
 
 import (
 	"context"
+	"fmt"
+	"math"
+	"strconv"
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/wuyaocheng/bktrader/internal/domain"
 )
 
 const liveSessionControlScannerInterval = 5 * time.Second
+
+type liveSessionControlRequest struct {
+	ID      string
+	Version int64
+}
+
+type liveSessionControlStateCompareAndSwapStore interface {
+	UpdateLiveSessionStateIfControlRequest(sessionID, requestID string, version int64, state map[string]any) (domain.LiveSession, bool, error)
+}
 
 func (p *Platform) RequestLiveSessionStart(sessionID string) (domain.LiveSession, error) {
 	return p.requestLiveSessionDesiredStatus(sessionID, "RUNNING", false)
@@ -19,23 +32,45 @@ func (p *Platform) RequestLiveSessionStopWithForce(sessionID string, force bool)
 }
 
 func (p *Platform) requestLiveSessionDesiredStatus(sessionID, desired string, force bool) (domain.LiveSession, error) {
-	session, err := p.store.GetLiveSession(strings.TrimSpace(sessionID))
-	if err != nil {
-		return domain.LiveSession{}, err
+	sessionID = strings.TrimSpace(sessionID)
+	for attempt := 0; attempt < 3; attempt++ {
+		session, err := p.store.GetLiveSession(sessionID)
+		if err != nil {
+			return domain.LiveSession{}, err
+		}
+		state := cloneMetadata(session.State)
+		previous := liveSessionControlRequest{
+			ID:      strings.TrimSpace(stringValue(state["controlRequestId"])),
+			Version: liveSessionControlVersion(state),
+		}
+		now := time.Now().UTC()
+		version := previous.Version + 1
+		state["desiredStatus"] = desired
+		state["actualStatus"] = liveSessionActualStatusFromSession(session)
+		state["controlRequestId"] = uuid.NewString()
+		state["controlVersion"] = version
+		state["lastControlAction"] = strings.ToLower(desired)
+		state["controlRequestedAt"] = now.Format(time.RFC3339)
+		if desired == "STOPPED" {
+			state["lastControlAction"] = "stop"
+			state["desiredStopForce"] = force
+		} else {
+			state["lastControlAction"] = "start"
+			delete(state, "desiredStopForce")
+		}
+		delete(state, "activeControlRequestId")
+		delete(state, "activeControlVersion")
+		delete(state, "lastControlError")
+		delete(state, "lastControlErrorAt")
+		updated, ok, err := p.updateLiveSessionControlStateIfPrevious(session.ID, previous, state)
+		if err != nil {
+			return domain.LiveSession{}, err
+		}
+		if ok {
+			return updated, nil
+		}
 	}
-	state := cloneMetadata(session.State)
-	now := time.Now().UTC()
-	state["desiredStatus"] = desired
-	state["actualStatus"] = liveSessionActualStatusFromSession(session)
-	state["controlRequestedAt"] = now.Format(time.RFC3339)
-	if desired == "STOPPED" {
-		state["desiredStopForce"] = force
-	} else {
-		delete(state, "desiredStopForce")
-	}
-	delete(state, "lastControlError")
-	delete(state, "lastControlErrorAt")
-	return p.store.UpdateLiveSessionState(session.ID, state)
+	return domain.LiveSession{}, fmt.Errorf("live session control request changed concurrently: %s", sessionID)
 }
 
 func (p *Platform) StartLiveSessionControlScanner(ctx context.Context) {
@@ -77,59 +112,159 @@ func (p *Platform) scanLiveSessionControlRequests(ctx context.Context) {
 		if liveSessionControlErrorCurrent(session.State) {
 			continue
 		}
+		request, ok := liveSessionControlRequestFromState(session.State)
+		if !ok {
+			updated, updatedRequest, err := p.initializeLegacyLiveSessionControlRequest(session, desired)
+			if err != nil {
+				p.logger("service.live_session_control_scanner", "session_id", session.ID).Warn("initialize legacy live session control request failed", "error", err)
+				continue
+			}
+			session = updated
+			request = updatedRequest
+		}
 		switch desired {
 		case "RUNNING":
 			if strings.EqualFold(session.Status, "RUNNING") {
-				p.markLiveSessionControlActual(session, "RUNNING", nil)
+				p.markLiveSessionControlActual(session, request, "RUNNING", nil)
 				continue
 			}
-			p.executeLiveSessionControlStart(session)
+			p.executeLiveSessionControlStart(session, request)
 		case "STOPPED":
 			if strings.EqualFold(session.Status, "STOPPED") {
-				p.markLiveSessionControlActual(session, "STOPPED", nil)
+				p.markLiveSessionControlActual(session, request, "STOPPED", nil)
 				continue
 			}
-			p.executeLiveSessionControlStop(session)
+			p.executeLiveSessionControlStop(session, request)
 		}
 	}
 }
 
-func (p *Platform) executeLiveSessionControlStart(session domain.LiveSession) {
-	p.markLiveSessionControlActual(session, "STARTING", nil)
+func (p *Platform) initializeLegacyLiveSessionControlRequest(session domain.LiveSession, desired string) (domain.LiveSession, liveSessionControlRequest, error) {
+	state := cloneMetadata(session.State)
+	now := time.Now().UTC()
+	previous := liveSessionControlRequest{
+		ID:      strings.TrimSpace(stringValue(state["controlRequestId"])),
+		Version: liveSessionControlVersion(state),
+	}
+	request := liveSessionControlRequest{
+		ID:      uuid.NewString(),
+		Version: previous.Version + 1,
+	}
+	state["controlRequestId"] = request.ID
+	state["controlVersion"] = request.Version
+	if stringValue(state["controlRequestedAt"]) == "" {
+		state["controlRequestedAt"] = now.Format(time.RFC3339)
+	}
+	if stringValue(state["lastControlAction"]) == "" {
+		switch desired {
+		case "RUNNING":
+			state["lastControlAction"] = "start"
+		case "STOPPED":
+			state["lastControlAction"] = "stop"
+		}
+	}
+	updated, ok, err := p.updateLiveSessionControlStateIfPrevious(session.ID, previous, state)
+	if err != nil {
+		return domain.LiveSession{}, liveSessionControlRequest{}, err
+	}
+	if !ok {
+		return updated, liveSessionControlRequest{}, fmt.Errorf("live session control request changed concurrently: %s", session.ID)
+	}
+	return updated, request, nil
+}
+
+func (p *Platform) executeLiveSessionControlStart(session domain.LiveSession, request liveSessionControlRequest) {
+	if !p.markLiveSessionControlActual(session, request, "STARTING", nil) {
+		return
+	}
 	started, err := p.StartLiveSession(session.ID)
 	if err != nil {
-		p.markLiveSessionControlActual(session, "ERROR", err)
+		p.markLiveSessionControlActual(session, request, "ERROR", err)
 		return
 	}
-	p.markLiveSessionControlActual(started, "RUNNING", nil)
+	p.markLiveSessionControlActual(started, request, "RUNNING", nil)
 }
 
-func (p *Platform) executeLiveSessionControlStop(session domain.LiveSession) {
+func (p *Platform) executeLiveSessionControlStop(session domain.LiveSession, request liveSessionControlRequest) {
 	force := boolValue(session.State["desiredStopForce"])
-	p.markLiveSessionControlActual(session, "STOPPING", nil)
+	if !p.markLiveSessionControlActual(session, request, "STOPPING", nil) {
+		return
+	}
 	stopped, err := p.StopLiveSessionWithForce(session.ID, force)
 	if err != nil {
-		p.markLiveSessionControlActual(session, "ERROR", err)
+		p.markLiveSessionControlActual(session, request, "ERROR", err)
 		return
 	}
-	p.markLiveSessionControlActual(stopped, "STOPPED", nil)
+	p.markLiveSessionControlActual(stopped, request, "STOPPED", nil)
 }
 
-func (p *Platform) markLiveSessionControlActual(session domain.LiveSession, actual string, controlErr error) {
+func (p *Platform) markLiveSessionControlActual(session domain.LiveSession, request liveSessionControlRequest, actual string, controlErr error) bool {
+	latest, err := p.store.GetLiveSession(session.ID)
+	if err != nil {
+		p.logger("service.live_session_control_scanner", "session_id", session.ID).Warn("load live session control state failed", "error", err)
+		return false
+	}
+	if !liveSessionControlRequestMatches(latest.State, request) {
+		p.logger("service.live_session_control_scanner", "session_id", session.ID, "request_id", request.ID, "control_version", request.Version).Info("skip stale live session control update")
+		return false
+	}
 	state := cloneMetadata(session.State)
+	for key, value := range latest.State {
+		state[key] = value
+	}
 	now := time.Now().UTC()
 	state["actualStatus"] = actual
 	state["lastControlUpdateAt"] = now.Format(time.RFC3339)
+	state["activeControlRequestId"] = request.ID
+	state["activeControlVersion"] = request.Version
 	if controlErr != nil {
 		state["lastControlError"] = controlErr.Error()
 		state["lastControlErrorAt"] = now.Format(time.RFC3339)
+		state["lastControlErrorRequestId"] = request.ID
+		state["lastControlErrorVersion"] = request.Version
 	} else {
 		delete(state, "lastControlError")
 		delete(state, "lastControlErrorAt")
+		delete(state, "lastControlErrorRequestId")
+		delete(state, "lastControlErrorVersion")
 	}
-	if _, err := p.store.UpdateLiveSessionState(session.ID, state); err != nil {
+	if actual == "RUNNING" || actual == "STOPPED" || actual == "ERROR" {
+		delete(state, "activeControlRequestId")
+		delete(state, "activeControlVersion")
+		if controlErr == nil {
+			state["lastControlSucceededAt"] = now.Format(time.RFC3339)
+		}
+	}
+	updated, ok, err := p.updateLiveSessionControlStateIfCurrent(session.ID, request, state)
+	if err != nil {
 		p.logger("service.live_session_control_scanner", "session_id", session.ID).Warn("update live session control state failed", "error", err)
+		return false
 	}
+	if !ok {
+		p.logger("service.live_session_control_scanner", "session_id", session.ID, "request_id", request.ID, "control_version", request.Version).Info("skip stale live session control update")
+		return false
+	}
+	_ = updated
+	return true
+}
+
+func (p *Platform) updateLiveSessionControlStateIfCurrent(sessionID string, request liveSessionControlRequest, state map[string]any) (domain.LiveSession, bool, error) {
+	return p.updateLiveSessionControlStateIfPrevious(sessionID, request, state)
+}
+
+func (p *Platform) updateLiveSessionControlStateIfPrevious(sessionID string, previous liveSessionControlRequest, state map[string]any) (domain.LiveSession, bool, error) {
+	if store, ok := p.store.(liveSessionControlStateCompareAndSwapStore); ok {
+		return store.UpdateLiveSessionStateIfControlRequest(sessionID, previous.ID, previous.Version, state)
+	}
+	latest, err := p.store.GetLiveSession(sessionID)
+	if err != nil {
+		return domain.LiveSession{}, false, err
+	}
+	if stringValue(latest.State["controlRequestId"]) != previous.ID || liveSessionControlVersion(latest.State) != previous.Version {
+		return latest, false, nil
+	}
+	updated, err := p.store.UpdateLiveSessionState(sessionID, state)
+	return updated, err == nil, err
 }
 
 func liveSessionActualStatusFromSession(session domain.LiveSession) string {
@@ -147,6 +282,16 @@ func liveSessionActualStatusFromSession(session domain.LiveSession) string {
 }
 
 func liveSessionControlErrorCurrent(state map[string]any) bool {
+	if requestID := stringValue(state["controlRequestId"]); requestID != "" {
+		if errorRequestID := stringValue(state["lastControlErrorRequestId"]); errorRequestID != "" && errorRequestID != requestID {
+			return false
+		}
+	}
+	if version := liveSessionControlVersion(state); version > 0 {
+		if errorVersion := liveSessionControlVersionKey(state, "lastControlErrorVersion"); errorVersion > 0 && errorVersion != version {
+			return false
+		}
+	}
 	if !strings.EqualFold(stringValue(state["actualStatus"]), "ERROR") {
 		return false
 	}
@@ -156,6 +301,76 @@ func liveSessionControlErrorCurrent(state map[string]any) bool {
 		return true
 	}
 	return !requestedAt.After(errorAt)
+}
+
+func liveSessionControlRequestFromState(state map[string]any) (liveSessionControlRequest, bool) {
+	request := liveSessionControlRequest{
+		ID:      strings.TrimSpace(stringValue(state["controlRequestId"])),
+		Version: liveSessionControlVersion(state),
+	}
+	return request, request.ID != "" && request.Version > 0
+}
+
+func liveSessionControlRequestMatches(state map[string]any, request liveSessionControlRequest) bool {
+	current, ok := liveSessionControlRequestFromState(state)
+	return ok && current.ID == request.ID && current.Version == request.Version
+}
+
+func liveSessionControlVersion(state map[string]any) int64 {
+	return liveSessionControlVersionKey(state, "controlVersion")
+}
+
+func liveSessionControlVersionKey(state map[string]any, key string) int64 {
+	if state == nil {
+		return 0
+	}
+	switch value := state[key].(type) {
+	case int:
+		return int64(value)
+	case int8:
+		return int64(value)
+	case int16:
+		return int64(value)
+	case int32:
+		return int64(value)
+	case int64:
+		return value
+	case uint:
+		if uint64(value) > math.MaxInt64 {
+			return 0
+		}
+		return int64(value)
+	case uint8:
+		return int64(value)
+	case uint16:
+		return int64(value)
+	case uint32:
+		return int64(value)
+	case uint64:
+		if value > math.MaxInt64 {
+			return 0
+		}
+		return int64(value)
+	case float32:
+		return int64(value)
+	case float64:
+		return int64(value)
+	case string:
+		parsed, err := strconv.ParseInt(strings.TrimSpace(value), 10, 64)
+		if err == nil {
+			return parsed
+		}
+		parsedFloat, err := strconv.ParseFloat(strings.TrimSpace(value), 64)
+		if err == nil {
+			return int64(parsedFloat)
+		}
+	case fmt.Stringer:
+		parsed, err := strconv.ParseInt(strings.TrimSpace(value.String()), 10, 64)
+		if err == nil {
+			return parsed
+		}
+	}
+	return 0
 }
 
 func parseLiveSessionControlTime(value any) (time.Time, bool) {

--- a/internal/service/live_session_control_test.go
+++ b/internal/service/live_session_control_test.go
@@ -16,11 +16,8 @@ func TestScanLiveSessionControlRequestsStopsDesiredStoppedSession(t *testing.T) 
 	if err != nil {
 		t.Fatalf("set live session running failed: %v", err)
 	}
-	state := cloneMetadata(session.State)
-	state["desiredStatus"] = "STOPPED"
-	state["actualStatus"] = "RUNNING"
-	if _, err := store.UpdateLiveSessionState(session.ID, state); err != nil {
-		t.Fatalf("set desired stopped failed: %v", err)
+	if _, err := platform.RequestLiveSessionStopWithForce(session.ID, false); err != nil {
+		t.Fatalf("request stop failed: %v", err)
 	}
 
 	platform.scanLiveSessionControlRequests(context.Background())
@@ -34,6 +31,119 @@ func TestScanLiveSessionControlRequestsStopsDesiredStoppedSession(t *testing.T) 
 	}
 	if got := stringValue(updated.State["actualStatus"]); got != "STOPPED" {
 		t.Fatalf("expected actualStatus STOPPED, got %s", got)
+	}
+}
+
+func TestScanLiveSessionControlRequestsInitializesLegacyDesiredIntent(t *testing.T) {
+	store := memory.NewStore()
+	platform := NewPlatform(store)
+	session, err := store.UpdateLiveSessionStatus("live-session-main", "RUNNING")
+	if err != nil {
+		t.Fatalf("set live session running failed: %v", err)
+	}
+	state := cloneMetadata(session.State)
+	state["desiredStatus"] = "STOPPED"
+	state["actualStatus"] = "RUNNING"
+	if _, err := store.UpdateLiveSessionState(session.ID, state); err != nil {
+		t.Fatalf("set legacy desired stopped failed: %v", err)
+	}
+
+	platform.scanLiveSessionControlRequests(context.Background())
+
+	updated, err := store.GetLiveSession(session.ID)
+	if err != nil {
+		t.Fatalf("get live session failed: %v", err)
+	}
+	if updated.Status != "STOPPED" {
+		t.Fatalf("expected STOPPED status, got %s", updated.Status)
+	}
+	if got := stringValue(updated.State["controlRequestId"]); got == "" {
+		t.Fatal("expected scanner to initialize controlRequestId for legacy intent")
+	}
+	if got := liveSessionControlVersion(updated.State); got != 1 {
+		t.Fatalf("expected scanner to initialize controlVersion 1 for legacy intent, got %d", got)
+	}
+}
+
+func TestRequestLiveSessionControlAssignsRequestIdentityAndVersion(t *testing.T) {
+	store := memory.NewStore()
+	platform := NewPlatform(store)
+
+	started, err := platform.RequestLiveSessionStart("live-session-main")
+	if err != nil {
+		t.Fatalf("request start failed: %v", err)
+	}
+	firstRequestID := stringValue(started.State["controlRequestId"])
+	if firstRequestID == "" {
+		t.Fatal("expected controlRequestId on start request")
+	}
+	if got := liveSessionControlVersion(started.State); got != 1 {
+		t.Fatalf("expected first controlVersion 1, got %d", got)
+	}
+	if got := stringValue(started.State["lastControlAction"]); got != "start" {
+		t.Fatalf("expected lastControlAction start, got %s", got)
+	}
+
+	stopped, err := platform.RequestLiveSessionStopWithForce("live-session-main", true)
+	if err != nil {
+		t.Fatalf("request stop failed: %v", err)
+	}
+	if got := stringValue(stopped.State["controlRequestId"]); got == "" || got == firstRequestID {
+		t.Fatalf("expected new controlRequestId on stop request, got %s", got)
+	}
+	if got := liveSessionControlVersion(stopped.State); got != 2 {
+		t.Fatalf("expected second controlVersion 2, got %d", got)
+	}
+	if got := stringValue(stopped.State["lastControlAction"]); got != "stop" {
+		t.Fatalf("expected lastControlAction stop, got %s", got)
+	}
+}
+
+func TestLiveSessionControlStaleRequestCannotOverwriteNewerRequest(t *testing.T) {
+	store := memory.NewStore()
+	platform := NewPlatform(store)
+	session, err := store.UpdateLiveSessionStatus("live-session-main", "RUNNING")
+	if err != nil {
+		t.Fatalf("set live session running failed: %v", err)
+	}
+	stopRequest, err := platform.RequestLiveSessionStopWithForce(session.ID, true)
+	if err != nil {
+		t.Fatalf("request stop failed: %v", err)
+	}
+	staleRequest, ok := liveSessionControlRequestFromState(stopRequest.State)
+	if !ok {
+		t.Fatal("expected stop request identity")
+	}
+	if !platform.markLiveSessionControlActual(stopRequest, staleRequest, "STOPPING", nil) {
+		t.Fatal("expected current stop request to mark STOPPING")
+	}
+
+	startRequest, err := platform.RequestLiveSessionStart(session.ID)
+	if err != nil {
+		t.Fatalf("request start failed: %v", err)
+	}
+	if got := liveSessionControlVersion(startRequest.State); got != staleRequest.Version+1 {
+		t.Fatalf("expected newer request version, got %d after %d", got, staleRequest.Version)
+	}
+	if platform.markLiveSessionControlActual(stopRequest, staleRequest, "STOPPED", nil) {
+		t.Fatal("expected stale stop result to be discarded")
+	}
+
+	latest, err := store.GetLiveSession(session.ID)
+	if err != nil {
+		t.Fatalf("get live session failed: %v", err)
+	}
+	if got := stringValue(latest.State["desiredStatus"]); got != "RUNNING" {
+		t.Fatalf("expected newer desiredStatus RUNNING, got %s", got)
+	}
+	if got := stringValue(latest.State["actualStatus"]); got != "RUNNING" {
+		t.Fatalf("expected stale stop not to overwrite actualStatus, got %s", got)
+	}
+	if got := liveSessionControlVersion(latest.State); got != staleRequest.Version+1 {
+		t.Fatalf("expected newer controlVersion to remain, got %d", got)
+	}
+	if got := stringValue(latest.State["controlRequestId"]); got != stringValue(startRequest.State["controlRequestId"]) {
+		t.Fatalf("expected newer controlRequestId to remain, got %s", got)
 	}
 }
 

--- a/internal/store/memory/store.go
+++ b/internal/store/memory/store.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -1036,6 +1037,23 @@ func (s *Store) UpdateLiveSessionState(sessionID string, state map[string]any) (
 	return item, nil
 }
 
+func (s *Store) UpdateLiveSessionStateIfControlRequest(sessionID, requestID string, version int64, state map[string]any) (domain.LiveSession, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	item, ok := s.liveSessions[sessionID]
+	if !ok {
+		return domain.LiveSession{}, false, fmt.Errorf("live session not found: %s", sessionID)
+	}
+	currentRequestID := strings.TrimSpace(stringValue(item.State["controlRequestId"]))
+	currentVersion := int64Value(item.State["controlVersion"])
+	if currentRequestID != requestID || currentVersion != version {
+		return item, false, nil
+	}
+	item.State = state
+	s.liveSessions[sessionID] = item
+	return item, true, nil
+}
+
 func (s *Store) ListSignalRuntimeSessions() ([]domain.SignalRuntimeSession, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -1562,6 +1580,27 @@ func stringValue(value any) string {
 		return strings.TrimSpace(text)
 	}
 	return ""
+}
+
+func int64Value(value any) int64 {
+	switch typed := value.(type) {
+	case int:
+		return int64(typed)
+	case int64:
+		return typed
+	case float64:
+		return int64(typed)
+	case string:
+		parsed, err := strconv.ParseInt(strings.TrimSpace(typed), 10, 64)
+		if err == nil {
+			return parsed
+		}
+		parsedFloat, err := strconv.ParseFloat(strings.TrimSpace(typed), 64)
+		if err == nil {
+			return int64(parsedFloat)
+		}
+	}
+	return 0
 }
 
 func (s *Store) ListMarketBars(exchange, symbol, timeframe string, from, to int64, limit int) ([]domain.MarketBar, error) {

--- a/internal/store/postgres/live_sessions_test.go
+++ b/internal/store/postgres/live_sessions_test.go
@@ -106,3 +106,49 @@ func TestListLiveSessionsKeepsNonDeletedSessionWithLegacyDeletedAtState(t *testi
 	}
 	t.Fatalf("expected non-DELETED live session %s with legacy deletedAt state to remain listed", session.ID)
 }
+
+func TestUpdateLiveSessionStateIfControlRequestHandlesDirtyControlVersion(t *testing.T) {
+	dsn := os.Getenv("BKTRADER_TEST_POSTGRES_DSN")
+	if dsn == "" {
+		t.Skip("BKTRADER_TEST_POSTGRES_DSN is not set")
+	}
+	if err := Migrate(dsn); err != nil {
+		t.Fatalf("Migrate failed: %v", err)
+	}
+	store, err := New(dsn)
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	defer store.Close()
+
+	account, err := store.CreateAccount("Live Dirty Control Version Test", "LIVE", "binance-futures")
+	if err != nil {
+		t.Fatalf("CreateAccount failed: %v", err)
+	}
+	strategy, err := store.CreateStrategy("live-dirty-control-version-test", "live dirty control version test", map[string]any{
+		"strategyEngine": "bk-default",
+	})
+	if err != nil {
+		t.Fatalf("CreateStrategy failed: %v", err)
+	}
+	session, err := store.CreateLiveSession(account.ID, strategy["id"].(string))
+	if err != nil {
+		t.Fatalf("CreateLiveSession failed: %v", err)
+	}
+	session.State["controlRequestId"] = "dirty-request"
+	session.State["controlVersion"] = "abc"
+	if _, err := store.UpdateLiveSession(session); err != nil {
+		t.Fatalf("UpdateLiveSession failed: %v", err)
+	}
+
+	_, ok, err := store.UpdateLiveSessionStateIfControlRequest(session.ID, "dirty-request", 1, map[string]any{
+		"controlRequestId": "dirty-request",
+		"controlVersion":   int64(1),
+	})
+	if err != nil {
+		t.Fatalf("dirty controlVersion should not fail cast: %v", err)
+	}
+	if ok {
+		t.Fatal("expected dirty controlVersion to be treated as stale mismatch")
+	}
+}

--- a/internal/store/postgres/store.go
+++ b/internal/store/postgres/store.go
@@ -1358,6 +1358,36 @@ func (s *Store) UpdateLiveSessionState(sessionID string, state map[string]any) (
 	return s.GetLiveSession(sessionID)
 }
 
+func (s *Store) UpdateLiveSessionStateIfControlRequest(sessionID, requestID string, version int64, state map[string]any) (domain.LiveSession, bool, error) {
+	stateRaw, err := json.Marshal(state)
+	if err != nil {
+		return domain.LiveSession{}, false, fmt.Errorf("failed to marshal state: %w", err)
+	}
+	result, err := s.db.Exec(`
+		update live_sessions
+		set state = $4
+		where id = $1
+			and coalesce(state->>'controlRequestId', '') = $2
+			and case
+				when coalesce(state->>'controlVersion', '') ~ '^[0-9]+$'
+					then (state->>'controlVersion')::bigint
+				else 0
+			end = $3
+	`, sessionID, requestID, version, stateRaw)
+	if err != nil {
+		return domain.LiveSession{}, false, err
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return domain.LiveSession{}, false, err
+	}
+	latest, getErr := s.GetLiveSession(sessionID)
+	if getErr != nil {
+		return domain.LiveSession{}, false, getErr
+	}
+	return latest, rows > 0, nil
+}
+
 func (s *Store) ListSignalRuntimeSessions() ([]domain.SignalRuntimeSession, error) {
 	rows, err := s.db.Query(`
 		select id, account_id, strategy_id, status, runtime_adapter, transport, subscription_count, state, created_at, updated_at


### PR DESCRIPTION
## 目的
继续 #282 Phase 2：为 LiveSession declarative control 引入 `controlRequestId` / `controlVersion`，防止 runner 旧请求结果覆盖用户新提交的 start/stop intent。

#281 已合并，本 PR 已 rebase 到 `main`，只包含 #282 Phase 2 的 controlRequestId/controlVersion 改动。

Refs #282

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [x] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) - 未变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？- 不涉及
- [x] DB migration 是否具备向下兼容幂等性？- 无 DB migration，继续沿用 `live_sessions.state` JSONB
- [x] 配置字段有没有无意被混改？- 未新增 env/config 字段

## 改动说明
- Postgres CAS 对脏 `controlVersion` 使用 regex guard 安全解析，避免 `""` 或 `"abc"` 触发 cast 500。
- Legacy desired intent 初始化改为 CAS 写入，避免双 runner 初始化互相覆盖。
- 每次 start/stop intent 写入新的 `controlRequestId` 和递增 `controlVersion`。
- request 写入走 compare-and-swap，避免并发请求生成重复版本。
- runner 写 `STARTING/STOPPING/RUNNING/STOPPED/ERROR` 前校验 request id/version，旧请求结果会被丢弃。
- `activeControlRequestId/activeControlVersion` 只在处理中保留，终态清理。
- API accepted payload 暴露 `controlRequestId/controlVersion`。
- 兼容 legacy desired intent：scanner 会为已有 desired/actual 状态补 request identity 后再执行。

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

新增/覆盖测试：
- `TestRequestLiveSessionControlAssignsRequestIdentityAndVersion`
- `TestLiveSessionControlStaleRequestCannotOverwriteNewerRequest`
- `TestScanLiveSessionControlRequestsInitializesLegacyDesiredIntent`
- HTTP API role accepted payload 校验 `controlRequestId/controlVersion`

本地验证：

```bash
go test ./internal/service -run 'TestLiveSessionControl|TestScanLiveSessionControl|TestRecoverLiveTradingOnStartupSkipsLiveSessionDesiredStopped'
go test ./internal/http -run 'TestLiveSession'
go test ./internal/store/...
go test ./...
go build ./cmd/platform-api
go build ./cmd/db-migrate
go build ./cmd/bktrader-ctl
cd web/console && ./node_modules/.bin/tsc --noEmit src/pages/AccountStage.tsx --jsx react-jsx --esModuleInterop --target esnext --module esnext --moduleResolution Bundler --allowSyntheticDefaultImports
cd web/console && npm run build
```

## 最新 CI
- PR CI run 25055086190 已通过：Backend、Docker、High Risk Defenses、Detect changed areas 成功；ctl/frontend 因本 PR 未触发相关路径变更而跳过。