### PR TITLE
fix(live): classify post-SL zero-window entries as SL reentry

### DIFF
--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -970,6 +970,122 @@ func TestPrepareLivePlanStepForSignalEvaluationConvertsPendingZeroWindowAfterSLE
 	}
 }
 
+func TestPrepareLivePlanStepForSignalEvaluationDoesNotConvertPendingZeroWindowForPreviousSLBar(t *testing.T) {
+	barStart, eventTime, state, signalStates := pendingZeroWindowAfterSLExitFixture(
+		"BTCUSDT|30m|" + time.Date(2026, 4, 28, 10, 30, 0, 0, time.UTC).Format(time.RFC3339),
+	)
+
+	updated, _, _, gotSide, gotRole, gotReason := prepareLivePlanStepForSignalEvaluation(
+		state,
+		map[string]any{
+			"dir2_zero_initial": true,
+			"zero_initial_mode": "reentry_window",
+			"short_reentry_atr": 0.0,
+		},
+		signalStates,
+		"BTCUSDT",
+		"30m",
+		map[string]any{},
+		eventTime,
+		76442.8,
+		"trade_tick.price",
+		barStart,
+		76444.6,
+		"SELL",
+		"entry",
+		"Zero-Initial-Reentry",
+	)
+	if gotRole != "entry" || gotReason != "Zero-Initial-Reentry" || gotSide != "SELL" {
+		t.Fatalf("expected previous SL bar not to convert pending zero window, got side=%s role=%s reason=%s", gotSide, gotRole, gotReason)
+	}
+	if pending := mapValue(updated[livePendingZeroInitialWindowStateKey]); len(pending) == 0 {
+		t.Fatal("expected pending zero initial window to remain active")
+	}
+	if timeline := metadataList(updated["timeline"]); len(timeline) != 0 {
+		t.Fatalf("expected no zero window consume timeline event, got %+v", timeline)
+	}
+}
+
+func TestPrepareLivePlanStepForSignalEvaluationDoesNotConvertPendingZeroWindowWithoutSLBarKey(t *testing.T) {
+	barStart, eventTime, state, signalStates := pendingZeroWindowAfterSLExitFixture("")
+
+	updated, _, _, gotSide, gotRole, gotReason := prepareLivePlanStepForSignalEvaluation(
+		state,
+		map[string]any{
+			"dir2_zero_initial": true,
+			"zero_initial_mode": "reentry_window",
+			"short_reentry_atr": 0.0,
+		},
+		signalStates,
+		"BTCUSDT",
+		"30m",
+		map[string]any{},
+		eventTime,
+		76442.8,
+		"trade_tick.price",
+		barStart,
+		76444.6,
+		"SELL",
+		"entry",
+		"Zero-Initial-Reentry",
+	)
+	if gotRole != "entry" || gotReason != "Zero-Initial-Reentry" || gotSide != "SELL" {
+		t.Fatalf("expected missing SL bar key not to convert pending zero window, got side=%s role=%s reason=%s", gotSide, gotRole, gotReason)
+	}
+	if pending := mapValue(updated[livePendingZeroInitialWindowStateKey]); len(pending) == 0 {
+		t.Fatal("expected pending zero initial window to remain active")
+	}
+	if timeline := metadataList(updated["timeline"]); len(timeline) != 0 {
+		t.Fatalf("expected no zero window consume timeline event, got %+v", timeline)
+	}
+}
+
+func pendingZeroWindowAfterSLExitFixture(lastSLBarKey string) (time.Time, time.Time, map[string]any, map[string]any) {
+	barStart := time.Date(2026, 4, 28, 11, 0, 0, 0, time.UTC)
+	armedAt := barStart.Add(12*time.Minute + 14*time.Second)
+	slFilledAt := barStart.Add(13*time.Minute + 39*time.Second)
+	eventTime := barStart.Add(15*time.Minute + 7*time.Second)
+	barKey := "BTCUSDT|30m|" + barStart.Format(time.RFC3339)
+	state := map[string]any{
+		"lastSignalBarStateKey": barKey,
+		"sessionReentryCount":   1.0,
+		"lastSLExitFilledAt":    slFilledAt.Format(time.RFC3339),
+		"lastSLExitOrderId":     "order-sl",
+		livePendingZeroInitialWindowStateKey: map[string]any{
+			"side":            "SELL",
+			"symbol":          "BTCUSDT",
+			"signalTimeframe": "30m",
+			"armedAt":         armedAt.Format(time.RFC3339),
+			"signalBarStart":  barStart.Format(time.RFC3339),
+			"expiresAt":       barStart.Add(time.Hour).Format(time.RFC3339),
+			"breakoutBacked":  true,
+			"openReason":      liveZeroInitialWindowOpenReasonBreakoutLocked,
+		},
+	}
+	if strings.TrimSpace(lastSLBarKey) != "" {
+		state["lastSLExitSignalBarStateKey"] = lastSLBarKey
+	}
+	signalStates := map[string]any{
+		signalBindingMatchKey("binance-kline", "signal", "BTCUSDT", map[string]any{"timeframe": "30m"}): map[string]any{
+			"symbol":    "BTCUSDT",
+			"timeframe": "30m",
+			"sma5":      76561.48,
+			"atr14":     230.23571428571344,
+			"current": map[string]any{
+				"barStart": barStart.Format(time.RFC3339),
+				"close":    76471.5,
+				"high":     76565.7,
+				"low":      76440.0,
+			},
+			"prevBar1": map[string]any{
+				"high": 76564.2,
+				"low":  76470.2,
+			},
+		},
+	}
+	return barStart, eventTime, state, signalStates
+}
+
 func TestPrepareLivePlanStepForSignalEvaluationRequiresCurrentBreakoutPrice(t *testing.T) {
 	barStart := time.Date(2026, 4, 10, 0, 0, 0, 0, time.UTC)
 	signalStates := map[string]any{

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -887,6 +887,89 @@ func TestPrepareLivePlanStepForSignalEvaluationPrioritizesExitReentryOverZeroIni
 	}
 }
 
+func TestPrepareLivePlanStepForSignalEvaluationConvertsPendingZeroWindowAfterSLExit(t *testing.T) {
+	barStart := time.Date(2026, 4, 28, 11, 0, 0, 0, time.UTC)
+	armedAt := barStart.Add(12*time.Minute + 14*time.Second)
+	slFilledAt := barStart.Add(13*time.Minute + 39*time.Second)
+	eventTime := barStart.Add(15*time.Minute + 7*time.Second)
+	barKey := "BTCUSDT|30m|" + barStart.Format(time.RFC3339)
+	state := map[string]any{
+		"lastSignalBarStateKey":       barKey,
+		"sessionReentryCount":         1.0,
+		"lastSLExitFilledAt":          slFilledAt.Format(time.RFC3339),
+		"lastSLExitOrderId":           "order-sl",
+		"lastSLExitSignalBarStateKey": barKey,
+		livePendingZeroInitialWindowStateKey: map[string]any{
+			"side":            "SELL",
+			"symbol":          "BTCUSDT",
+			"signalTimeframe": "30m",
+			"armedAt":         armedAt.Format(time.RFC3339),
+			"signalBarStart":  barStart.Format(time.RFC3339),
+			"expiresAt":       barStart.Add(time.Hour).Format(time.RFC3339),
+			"breakoutBacked":  true,
+			"openReason":      liveZeroInitialWindowOpenReasonBreakoutLocked,
+		},
+	}
+	signalStates := map[string]any{
+		signalBindingMatchKey("binance-kline", "signal", "BTCUSDT", map[string]any{"timeframe": "30m"}): map[string]any{
+			"symbol":    "BTCUSDT",
+			"timeframe": "30m",
+			"sma5":      76561.48,
+			"atr14":     230.23571428571344,
+			"current": map[string]any{
+				"barStart": barStart.Format(time.RFC3339),
+				"close":    76471.5,
+				"high":     76565.7,
+				"low":      76440.0,
+			},
+			"prevBar1": map[string]any{
+				"high": 76564.2,
+				"low":  76470.2,
+			},
+		},
+	}
+
+	updated, gotEvent, gotPrice, gotSide, gotRole, gotReason := prepareLivePlanStepForSignalEvaluation(
+		state,
+		map[string]any{
+			"dir2_zero_initial": true,
+			"zero_initial_mode": "reentry_window",
+			"short_reentry_atr": 0.0,
+		},
+		signalStates,
+		"BTCUSDT",
+		"30m",
+		map[string]any{},
+		eventTime,
+		76442.8,
+		"trade_tick.price",
+		barStart,
+		76444.6,
+		"SELL",
+		"entry",
+		"Zero-Initial-Reentry",
+	)
+	if gotRole != "entry" || gotReason != "SL-Reentry" || gotSide != "SELL" {
+		t.Fatalf("expected pending zero window after SL exit to become SL-Reentry, got side=%s role=%s reason=%s", gotSide, gotRole, gotReason)
+	}
+	if !gotEvent.Equal(barStart) {
+		t.Fatalf("expected current bar event %s, got %s", barStart, gotEvent)
+	}
+	if gotPrice != 76564.2 {
+		t.Fatalf("expected reentry price from prev high, got %v", gotPrice)
+	}
+	if pending := mapValue(updated[livePendingZeroInitialWindowStateKey]); len(pending) != 0 {
+		t.Fatalf("expected pending zero initial window to be consumed after SL exit, got %+v", pending)
+	}
+	timeline := metadataList(updated["timeline"])
+	if len(timeline) != 1 || stringValue(timeline[0]["title"]) != "zero-initial-window-consumed" {
+		t.Fatalf("expected zero initial window consumed timeline event, got %+v", timeline)
+	}
+	if got := stringValue(mapValue(timeline[0]["metadata"])["reason"]); got != "sl-exit-reentry-priority" {
+		t.Fatalf("expected sl-exit-reentry-priority consume reason, got %s", got)
+	}
+}
+
 func TestPrepareLivePlanStepForSignalEvaluationRequiresCurrentBreakoutPrice(t *testing.T) {
 	barStart := time.Date(2026, 4, 10, 0, 0, 0, 0, time.UTC)
 	signalStates := map[string]any{

--- a/internal/service/live_zero_initial.go
+++ b/internal/service/live_zero_initial.go
@@ -68,6 +68,10 @@ func prepareLivePlanStepForSignalEvaluation(
 		signalTimeframe,
 		eventTime,
 	); ok {
+		if livePendingZeroInitialWindowShouldYieldSLReentry(updatedState, signalBarStates, symbol, signalTimeframe, eventTime) {
+			clearLivePendingZeroInitialWindow(updatedState, eventTime, "sl-exit-reentry-priority")
+			return updatedState, alignedEvent, alignedPrice, alignedSide, alignedRole, "SL-Reentry"
+		}
 		return updatedState, alignedEvent, alignedPrice, alignedSide, alignedRole, alignedReason
 	}
 	if hasActiveLivePositionSnapshot(currentPosition) || !isLivePlanStepStale(nextPlannedEvent, signalTimeframe, eventTime) {
@@ -386,6 +390,43 @@ func liveZeroInitialWindowPlanStep(
 		plannedEvent = eventTime.UTC()
 	}
 	return state, plannedEvent.UTC(), price, side, "entry", "Zero-Initial-Reentry", true
+}
+
+func livePendingZeroInitialWindowShouldYieldSLReentry(
+	sessionState map[string]any,
+	signalBarStates map[string]any,
+	symbol string,
+	signalTimeframe string,
+	eventTime time.Time,
+) bool {
+	pending := cloneMetadata(mapValue(sessionState[livePendingZeroInitialWindowStateKey]))
+	if len(pending) == 0 || !liveZeroInitialWindowHasBreakoutProof(pending) {
+		return false
+	}
+	if parseFloatValue(sessionState["sessionReentryCount"]) <= 0 {
+		return false
+	}
+	lastSLExitAt := parseOptionalRFC3339(stringValue(sessionState["lastSLExitFilledAt"]))
+	if lastSLExitAt.IsZero() || lastSLExitAt.UTC().After(eventTime.UTC()) {
+		return false
+	}
+	if armedAt := parseOptionalRFC3339(stringValue(pending["armedAt"])); !armedAt.IsZero() && lastSLExitAt.UTC().Before(armedAt.UTC()) {
+		return false
+	}
+	if pendingSymbol := NormalizeSymbol(stringValue(pending["symbol"])); pendingSymbol != "" && pendingSymbol != NormalizeSymbol(symbol) {
+		return false
+	}
+	if pendingTimeframe := strings.ToLower(strings.TrimSpace(stringValue(pending["signalTimeframe"]))); pendingTimeframe != "" &&
+		pendingTimeframe != strings.ToLower(strings.TrimSpace(signalTimeframe)) {
+		return false
+	}
+	signalBarState, _ := pickSignalBarState(signalBarStates, symbol, signalTimeframe)
+	currentBarKey := resolveSignalBarTradeLimitKey(signalBarState, symbol, signalTimeframe)
+	lastSLBarKey := strings.TrimSpace(stringValue(sessionState["lastSLExitSignalBarStateKey"]))
+	if currentBarKey != "" && lastSLBarKey != "" && currentBarKey != lastSLBarKey {
+		return false
+	}
+	return true
 }
 
 func resolveLiveReentryPlanPrice(parameters map[string]any, signalBarState map[string]any, side string) float64 {

--- a/internal/service/live_zero_initial.go
+++ b/internal/service/live_zero_initial.go
@@ -423,7 +423,7 @@ func livePendingZeroInitialWindowShouldYieldSLReentry(
 	signalBarState, _ := pickSignalBarState(signalBarStates, symbol, signalTimeframe)
 	currentBarKey := resolveSignalBarTradeLimitKey(signalBarState, symbol, signalTimeframe)
 	lastSLBarKey := strings.TrimSpace(stringValue(sessionState["lastSLExitSignalBarStateKey"]))
-	if currentBarKey != "" && lastSLBarKey != "" && currentBarKey != lastSLBarKey {
+	if currentBarKey == "" || lastSLBarKey == "" || currentBarKey != lastSLBarKey {
 		return false
 	}
 	return true


### PR DESCRIPTION
## 目的
修复生产中 SL 后第二笔 entry 仍标记为 `Zero-Initial-Reentry` 的问题。

生产排查链路：
- `11:12:30 UTC` 第一笔 `Zero-Initial-Reentry` 开空，schedule index 0 / 20%
- `11:13:39 UTC` `SL` 平空
- `11:14:31 UTC` 60s 冷却按预期拦截一次
- `11:15:07 UTC` 第二笔 entry 成交，仓位 index 1 / 10%，但 reason/signalKind 仍是 `Zero-Initial-Reentry`

原因是 live 侧 pending zero-initial window 在 SL exit 后仍优先产出下一笔 entry；回测逻辑在 exit window 与 zero window 同时存在时会优先标为 `SL-Reentry`。本 PR 让 live 在同一 signal bar 发现已有 SL fill 且 pending zero window 已经有一次 reentry count 后，消费 pending zero window，并把下一笔 entry 标为 `SL-Reentry`。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [x] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) — 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？— 无
- [x] DB migration 是否具备向下兼容幂等性？— 不涉及 migration
- [x] 配置字段有没有无意被混改？— 无，仅调整 live pending zero window 与 SL reentry 的分类优先级

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

验证：
- `go test ./internal/service -run 'TestPrepareLivePlanStepForSignalEvaluation(ConvertsPendingZeroWindowAfterSLExit|PrioritizesExitReentryOverZeroInitialWindow)|TestBookAwareExecutionStrategyDelaysSLReentryAfterStopLossFill'`
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
- `git push` pre-push harness passed