### PR TITLE
fix(live): align zero reentry window lifetime

### DIFF
--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -4058,6 +4058,9 @@ func preserveLiveSessionNonRegressiveFacts(state map[string]any, latest map[stri
 		}
 	}
 	preserveLatestSLExitFillFact(state, latest)
+	if liveSLReentryWindowConsumed(state) {
+		delete(state, "lastSLExitReentrySide")
+	}
 }
 
 func liveSessionNonRegressiveFactKeys() []string {
@@ -4069,6 +4072,9 @@ func liveSessionNonRegressiveFactKeys() []string {
 		"lastStrategyDecisionEventFingerprint",
 		"lastStrategyDecisionEventIntentSignature",
 		"lastDispatchedDecisionEventId",
+		"lastSLExitReentryConsumedOrderId",
+		"lastSLExitReentryConsumedAt",
+		"lastSLExitReentryConsumedReason",
 	}
 }
 

--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -4086,6 +4086,7 @@ func preserveLatestSLExitFillFact(state map[string]any, latest map[string]any) {
 		"lastSLExitOrderId",
 		"lastSLExitStatus",
 		"lastSLExitSignalBarStateKey",
+		"lastSLExitReentrySide",
 	} {
 		if value, ok := latest[key]; ok {
 			state[key] = value

--- a/internal/service/live_execution.go
+++ b/internal/service/live_execution.go
@@ -1357,7 +1357,7 @@ func (p *Platform) syncLatestLiveSessionOrder(session domain.LiveSession, eventT
 			recordExecutionSyncResultHealth(state, eventTime, order.Status, nil)
 		}
 		proposalMap := mapValue(order.Metadata["executionProposal"])
-		maybeIncrementLiveSessionReentryCount(state, proposalMap, order.ID, order.Status)
+		maybeIncrementLiveSessionReentryCount(state, proposalMap, order.ID, order.Status, eventTime)
 		recordLiveSessionStopLossExitFill(state, proposalMap, order, eventTime)
 		state["lastSyncedOrderId"] = order.ID
 		state["lastSyncedOrderStatus"] = order.Status
@@ -1402,7 +1402,7 @@ func (p *Platform) syncLatestLiveSessionOrder(session domain.LiveSession, eventT
 					delete(state, "lastSyncError")
 					delete(state, "lastCancelFallbackSyncError")
 					proposalMap := mapValue(order.Metadata["executionProposal"])
-					maybeIncrementLiveSessionReentryCount(state, proposalMap, syncedOrder.ID, syncedOrder.Status)
+					maybeIncrementLiveSessionReentryCount(state, proposalMap, syncedOrder.ID, syncedOrder.Status, eventTime)
 					recordLiveSessionStopLossExitFill(state, proposalMap, syncedOrder, eventTime)
 					state["lastSyncedOrderId"] = syncedOrder.ID
 					state["lastSyncedOrderStatus"] = syncedOrder.Status
@@ -1497,7 +1497,7 @@ func (p *Platform) syncLatestLiveSessionOrder(session domain.LiveSession, eventT
 	}
 	delete(state, "lastSyncError")
 	proposalMap := mapValue(order.Metadata["executionProposal"])
-	maybeIncrementLiveSessionReentryCount(state, proposalMap, syncedOrder.ID, syncedOrder.Status)
+	maybeIncrementLiveSessionReentryCount(state, proposalMap, syncedOrder.ID, syncedOrder.Status, eventTime)
 	recordLiveSessionStopLossExitFill(state, proposalMap, syncedOrder, eventTime)
 	state["lastSyncedOrderId"] = syncedOrder.ID
 	state["lastSyncedOrderStatus"] = syncedOrder.Status
@@ -1610,13 +1610,16 @@ func shouldAdvanceLivePlanForOrderStatus(status string) bool {
 	}
 }
 
-func maybeIncrementLiveSessionReentryCount(state map[string]any, proposalMap map[string]any, orderID, status string) {
+func maybeIncrementLiveSessionReentryCount(state map[string]any, proposalMap map[string]any, orderID, status string, eventTime time.Time) {
 	if state == nil || !strings.EqualFold(strings.TrimSpace(status), "FILLED") {
 		return
 	}
 	reasonTag := normalizeStrategyReasonTag(stringValue(proposalMap["reason"]))
 	if reasonTag != "zero-initial-reentry" && reasonTag != "sl-reentry" && reasonTag != "pt-reentry" {
 		return
+	}
+	if reasonTag == "zero-initial-reentry" {
+		clearLivePendingZeroInitialWindow(state, eventTime, "zero-initial-reentry-filled")
 	}
 	if orderID != "" && stringValue(state["lastCountedReentryOrderId"]) == orderID {
 		return
@@ -1658,8 +1661,22 @@ func recordLiveSessionStopLossExitFill(state map[string]any, proposalMap map[str
 	state["lastSLExitFilledAt"] = filledAt.UTC().Format(time.RFC3339)
 	state["lastSLExitOrderId"] = order.ID
 	state["lastSLExitStatus"] = order.Status
+	if side := liveEntrySideAfterExitSide(stringValue(proposalMap["side"])); side != "" {
+		state["lastSLExitReentrySide"] = side
+	}
 	if key := liveProposalSignalBarTradeLimitKey(proposalMap); key != "" {
 		state["lastSLExitSignalBarStateKey"] = key
+	}
+}
+
+func liveEntrySideAfterExitSide(exitSide string) string {
+	switch strings.ToUpper(strings.TrimSpace(exitSide)) {
+	case "BUY":
+		return "SELL"
+	case "SELL", "SHORT":
+		return "BUY"
+	default:
+		return ""
 	}
 }
 

--- a/internal/service/live_execution.go
+++ b/internal/service/live_execution.go
@@ -1661,6 +1661,9 @@ func recordLiveSessionStopLossExitFill(state map[string]any, proposalMap map[str
 	state["lastSLExitFilledAt"] = filledAt.UTC().Format(time.RFC3339)
 	state["lastSLExitOrderId"] = order.ID
 	state["lastSLExitStatus"] = order.Status
+	delete(state, "lastSLExitReentryConsumedOrderId")
+	delete(state, "lastSLExitReentryConsumedAt")
+	delete(state, "lastSLExitReentryConsumedReason")
 	if side := liveEntrySideAfterExitSide(stringValue(proposalMap["side"])); side != "" {
 		state["lastSLExitReentrySide"] = side
 	}

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -4982,6 +4982,55 @@ func TestUpdateLiveSessionStatePreservingNonRegressiveFactsKeepsLatestSLExitFill
 	}
 }
 
+func TestUpdateLiveSessionStatePreservingNonRegressiveFactsKeepsSLReentryConsumptionGuard(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	session, err := platform.CreateLiveSession("", "live-main", "strategy-bk-1d", map[string]any{
+		"symbol":          "BTCUSDT",
+		"signalTimeframe": "30m",
+	})
+	if err != nil {
+		t.Fatalf("create live session failed: %v", err)
+	}
+	fillTime := time.Date(2026, 4, 28, 1, 55, 18, 0, time.UTC)
+	consumedAt := fillTime.Add(90 * time.Second)
+	session, err = platform.store.UpdateLiveSessionState(session.ID, map[string]any{
+		"symbol":                               "BTCUSDT",
+		"signalTimeframe":                      "30m",
+		"lastSLExitFilledAt":                   fillTime.Format(time.RFC3339),
+		"lastSLExitOrderId":                    "order-sl-latest",
+		"lastSLExitStatus":                     "FILLED",
+		"lastSLExitSignalBarStateKey":          "BTCUSDT|30m|2026-04-28T01:30:00Z",
+		"lastSLExitReentryConsumedOrderId":     "order-sl-latest",
+		"lastSLExitReentryConsumedAt":          consumedAt.Format(time.RFC3339),
+		"lastSLExitReentryConsumedReason":      "consumed-on-derive",
+		"lastDispatchedDecisionEventId":        "strategy-decision-event-consumed",
+		"lastStrategyDecisionEventFingerprint": "fingerprint-consumed",
+	})
+	if err != nil {
+		t.Fatalf("seed live session state failed: %v", err)
+	}
+
+	staleState := cloneMetadata(session.State)
+	staleState["lastSLExitReentrySide"] = "SELL"
+	delete(staleState, "lastSLExitReentryConsumedOrderId")
+	delete(staleState, "lastSLExitReentryConsumedAt")
+	delete(staleState, "lastSLExitReentryConsumedReason")
+
+	updated, err := platform.updateLiveSessionStatePreservingNonRegressiveFacts(session.ID, staleState)
+	if err != nil {
+		t.Fatalf("update live session state failed: %v", err)
+	}
+	if got := stringValue(updated.State["lastSLExitReentryConsumedOrderId"]); got != "order-sl-latest" {
+		t.Fatalf("expected consumed SL reentry order id to survive stale write, got %q", got)
+	}
+	if got := stringValue(updated.State["lastSLExitReentryConsumedReason"]); got != "consumed-on-derive" {
+		t.Fatalf("expected consumed reason to survive stale write, got %q", got)
+	}
+	if got := stringValue(updated.State["lastSLExitReentrySide"]); got != "" {
+		t.Fatalf("expected consumed guard to prevent stale reentry side resurrection, got %q", got)
+	}
+}
+
 func TestLiveSessionNonRegressiveFactKeysIncludeSignalBarTradeLimitFacts(t *testing.T) {
 	keys := liveSessionNonRegressiveFactKeys()
 	for _, required := range []string{

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -4730,6 +4730,7 @@ func TestSyncLatestLiveSessionOrderReturnsFallbackSyncErrorAfterUnknownOrderCanc
 }
 
 func TestMaybeIncrementLiveSessionReentryCountOnlyCountsFilledReentries(t *testing.T) {
+	eventTime := time.Date(2026, 4, 22, 3, 0, 10, 0, time.UTC)
 	state := map[string]any{
 		"sessionReentryCount": 0.0,
 	}
@@ -4737,36 +4738,59 @@ func TestMaybeIncrementLiveSessionReentryCountOnlyCountsFilledReentries(t *testi
 		"reason":            "SL-Reentry",
 		"signalBarStateKey": "bar-1",
 	}
-	maybeIncrementLiveSessionReentryCount(state, proposal, "order-1", "NEW")
+	maybeIncrementLiveSessionReentryCount(state, proposal, "order-1", "NEW", eventTime)
 	if got := parseFloatValue(state["sessionReentryCount"]); got != 0 {
 		t.Fatalf("expected no increment for NEW order, got %v", got)
 	}
-	maybeIncrementLiveSessionReentryCount(state, proposal, "order-1", "FILLED")
+	maybeIncrementLiveSessionReentryCount(state, proposal, "order-1", "FILLED", eventTime)
 	if got := parseFloatValue(state["sessionReentryCount"]); got != 1 {
 		t.Fatalf("expected increment on FILLED reentry, got %v", got)
 	}
-	maybeIncrementLiveSessionReentryCount(state, proposal, "order-1", "FILLED")
+	maybeIncrementLiveSessionReentryCount(state, proposal, "order-1", "FILLED", eventTime)
 	if got := parseFloatValue(state["sessionReentryCount"]); got != 1 {
 		t.Fatalf("expected duplicate FILLED sync to be ignored, got %v", got)
 	}
 }
 
 func TestMaybeIncrementLiveSessionReentryCountCountsZeroInitialWindowEntry(t *testing.T) {
-	state := map[string]any{}
+	eventTime := time.Date(2026, 4, 22, 3, 0, 10, 0, time.UTC)
+	state := map[string]any{
+		livePendingZeroInitialWindowStateKey: map[string]any{
+			"side":            "BUY",
+			"symbol":          "BTCUSDT",
+			"signalTimeframe": "30m",
+			"armedAt":         eventTime.Format(time.RFC3339),
+			"signalBarStart":  time.Date(2026, 4, 22, 3, 0, 0, 0, time.UTC).Format(time.RFC3339),
+			"expiresAt":       time.Date(2026, 4, 22, 4, 0, 0, 0, time.UTC).Format(time.RFC3339),
+			"breakoutBacked":  true,
+			"openReason":      liveZeroInitialWindowOpenReasonBreakoutLocked,
+		},
+	}
 	proposal := map[string]any{
 		"reason":            "Zero-Initial-Reentry",
 		"signalBarStateKey": "bar-1",
 	}
-	maybeIncrementLiveSessionReentryCount(state, proposal, "order-1", "FILLED")
+	maybeIncrementLiveSessionReentryCount(state, proposal, "order-1", "FILLED", eventTime)
 	if got := parseFloatValue(state["sessionReentryCount"]); got != 1 {
 		t.Fatalf("expected zero-initial window entry to count as first bar trade, got %v", got)
 	}
 	if got := stringValue(state["lastSignalBarStateKey"]); got != "bar-1" {
 		t.Fatalf("expected signal bar key to be recorded, got %s", got)
 	}
+	if pending := mapValue(state[livePendingZeroInitialWindowStateKey]); len(pending) != 0 {
+		t.Fatalf("expected filled zero-initial entry to consume pending window, got %+v", pending)
+	}
+	timeline := metadataList(state["timeline"])
+	if len(timeline) != 1 || stringValue(timeline[0]["title"]) != "zero-initial-window-consumed" {
+		t.Fatalf("expected zero window consumed timeline event, got %+v", timeline)
+	}
+	if got := stringValue(mapValue(timeline[0]["metadata"])["reason"]); got != "zero-initial-reentry-filled" {
+		t.Fatalf("expected zero-initial-reentry-filled consume reason, got %s", got)
+	}
 }
 
 func TestMaybeIncrementLiveSessionReentryCountUsesPerBarIdentity(t *testing.T) {
+	eventTime := time.Date(2026, 4, 22, 3, 30, 10, 0, time.UTC)
 	state := map[string]any{
 		"lastSignalBarStateKey": "BTCUSDT|30m|2026-04-22T03:00:00Z",
 		"sessionReentryCount":   2.0,
@@ -4778,7 +4802,7 @@ func TestMaybeIncrementLiveSessionReentryCountUsesPerBarIdentity(t *testing.T) {
 			liveSignalBarTradeLimitKeyField: "BTCUSDT|30m|2026-04-22T03:30:00Z",
 		},
 	}
-	maybeIncrementLiveSessionReentryCount(state, proposal, "order-2", "FILLED")
+	maybeIncrementLiveSessionReentryCount(state, proposal, "order-2", "FILLED", eventTime)
 	if got := parseFloatValue(state["sessionReentryCount"]); got != 1 {
 		t.Fatalf("expected new per-bar identity to reset reentry count before increment, got %v", got)
 	}
@@ -4793,6 +4817,7 @@ func TestRecordLiveSessionStopLossExitFillUsesExchangeFillTime(t *testing.T) {
 	proposal := map[string]any{
 		"role":   "exit",
 		"reason": "SL",
+		"side":   "BUY",
 		"metadata": map[string]any{
 			liveSignalBarTradeLimitKeyField: "BTCUSDT|30m|2026-04-28T01:30:00Z",
 		},
@@ -4813,6 +4838,9 @@ func TestRecordLiveSessionStopLossExitFillUsesExchangeFillTime(t *testing.T) {
 	}
 	if got := stringValue(state["lastSLExitSignalBarStateKey"]); got != "BTCUSDT|30m|2026-04-28T01:30:00Z" {
 		t.Fatalf("expected SL exit bar identity to be recorded, got %q", got)
+	}
+	if got := stringValue(state["lastSLExitReentrySide"]); got != "SELL" {
+		t.Fatalf("expected SL exit BUY side to arm SELL reentry side, got %q", got)
 	}
 
 	recordLiveSessionStopLossExitFill(state, map[string]any{"role": "exit", "reason": "PT"}, domain.Order{
@@ -4912,6 +4940,7 @@ func TestUpdateLiveSessionStatePreservingNonRegressiveFactsKeepsLatestSLExitFill
 		"lastSLExitOrderId":            "order-sl-latest",
 		"lastSLExitStatus":             "FILLED",
 		"lastSLExitSignalBarStateKey":  "BTCUSDT|30m|2026-04-28T01:30:00Z",
+		"lastSLExitReentrySide":        "SELL",
 		"lastStrategyEvaluationStatus": "intent-ready",
 	})
 	if err != nil {
@@ -4921,6 +4950,7 @@ func TestUpdateLiveSessionStatePreservingNonRegressiveFactsKeepsLatestSLExitFill
 	staleState := cloneMetadata(session.State)
 	staleState["lastSLExitFilledAt"] = latestFill.Add(-1 * time.Minute).Format(time.RFC3339)
 	staleState["lastSLExitOrderId"] = "order-sl-older"
+	delete(staleState, "lastSLExitReentrySide")
 
 	updated, err := platform.updateLiveSessionStatePreservingNonRegressiveFacts(session.ID, staleState)
 	if err != nil {
@@ -4931,6 +4961,9 @@ func TestUpdateLiveSessionStatePreservingNonRegressiveFactsKeepsLatestSLExitFill
 	}
 	if got := stringValue(updated.State["lastSLExitOrderId"]); got != "order-sl-latest" {
 		t.Fatalf("expected latest SL exit order id to survive stale write, got %q", got)
+	}
+	if got := stringValue(updated.State["lastSLExitReentrySide"]); got != "SELL" {
+		t.Fatalf("expected latest SL exit reentry side to survive stale write, got %q", got)
 	}
 
 	newerFill := latestFill.Add(2 * time.Minute)

--- a/internal/service/live_zero_initial.go
+++ b/internal/service/live_zero_initial.go
@@ -60,25 +60,31 @@ func prepareLivePlanStepForSignalEvaluation(
 	if hasActivePosition {
 		return updatedState, nextPlannedEvent, nextPlannedPrice, nextPlannedSide, nextPlannedRole, nextPlannedReason
 	}
-	if updatedState, alignedEvent, alignedPrice, alignedSide, alignedRole, alignedReason, ok := liveSLReentryWindowPlanStep(
+	var alignedEvent time.Time
+	var alignedPrice float64
+	var alignedSide, alignedRole, alignedReason string
+	var ok bool
+	updatedState, alignedEvent, alignedPrice, alignedSide, alignedRole, alignedReason, ok = liveSLReentryWindowPlanStep(
 		updatedState,
 		parameters,
 		signalBarStates,
 		symbol,
 		signalTimeframe,
 		eventTime,
-	); ok {
+	)
+	if ok {
 		clearLivePendingZeroInitialWindow(updatedState, eventTime, "sl-exit-reentry-priority")
 		return updatedState, alignedEvent, alignedPrice, alignedSide, alignedRole, alignedReason
 	}
-	if updatedState, alignedEvent, alignedPrice, alignedSide, alignedRole, alignedReason, ok := liveZeroInitialWindowPlanStep(
+	updatedState, alignedEvent, alignedPrice, alignedSide, alignedRole, alignedReason, ok = liveZeroInitialWindowPlanStep(
 		updatedState,
 		parameters,
 		signalBarStates,
 		symbol,
 		signalTimeframe,
 		eventTime,
-	); ok {
+	)
+	if ok {
 		if livePendingZeroInitialWindowShouldYieldSLReentry(updatedState, signalBarStates, symbol, signalTimeframe, eventTime) {
 			clearLivePendingZeroInitialWindow(updatedState, eventTime, "sl-exit-reentry-priority")
 			return updatedState, alignedEvent, alignedPrice, alignedSide, alignedRole, "SL-Reentry"
@@ -171,7 +177,7 @@ func prepareLivePlanStepForSignalEvaluation(
 		)
 	}
 	appendTimelineEvent(updatedState, "strategy", eventTime, "zero-initial-window-armed", timelineMetadata)
-	updatedState, alignedEvent, alignedPrice, alignedSide, alignedRole, alignedReason, _ := liveZeroInitialWindowPlanStep(updatedState, parameters, signalBarStates, symbol, signalTimeframe, eventTime)
+	updatedState, alignedEvent, alignedPrice, alignedSide, alignedRole, alignedReason, _ = liveZeroInitialWindowPlanStep(updatedState, parameters, signalBarStates, symbol, signalTimeframe, eventTime)
 	return updatedState, alignedEvent, alignedPrice, alignedSide, alignedRole, alignedReason
 }
 
@@ -249,6 +255,26 @@ func clearLivePendingZeroInitialWindow(state map[string]any, eventTime time.Time
 		livePendingZeroInitialWindowStateKey: pending,
 		"reason":                             firstNonEmpty(strings.TrimSpace(reason), "consumed"),
 	})
+}
+
+func liveSLReentryWindowConsumed(state map[string]any) bool {
+	orderID := strings.TrimSpace(stringValue(state["lastSLExitOrderId"]))
+	if orderID == "" {
+		return false
+	}
+	return strings.TrimSpace(stringValue(state["lastSLExitReentryConsumedOrderId"])) == orderID
+}
+
+func consumeLiveSLReentryWindow(state map[string]any, eventTime time.Time, reason string) {
+	if state == nil {
+		return
+	}
+	if orderID := strings.TrimSpace(stringValue(state["lastSLExitOrderId"])); orderID != "" {
+		state["lastSLExitReentryConsumedOrderId"] = orderID
+	}
+	state["lastSLExitReentryConsumedAt"] = eventTime.UTC().Format(time.RFC3339)
+	state["lastSLExitReentryConsumedReason"] = firstNonEmpty(strings.TrimSpace(reason), "consumed")
+	delete(state, "lastSLExitReentrySide")
 }
 
 func liveZeroInitialWindowHasBreakoutProof(pending map[string]any) bool {
@@ -368,6 +394,28 @@ func liveSignalBarKeyWithinReentryWindow(lastKey, currentKey, signalTimeframe st
 		return false
 	}
 	return currentStart.Sub(lastStart) <= step
+}
+
+func liveSignalBarKeyPastReentryWindow(lastKey, currentKey, signalTimeframe string) bool {
+	lastSymbol, lastTimeframe, lastStart, ok := parseLiveSignalBarTradeLimitKey(lastKey)
+	if !ok {
+		return false
+	}
+	currentSymbol, currentTimeframe, currentStart, ok := parseLiveSignalBarTradeLimitKey(currentKey)
+	if !ok {
+		return false
+	}
+	if lastSymbol != "" && currentSymbol != "" && lastSymbol != currentSymbol {
+		return false
+	}
+	if lastTimeframe != "" && currentTimeframe != "" && lastTimeframe != currentTimeframe {
+		return false
+	}
+	step := liveSignalBarStep(firstNonEmpty(signalTimeframe, currentTimeframe, lastTimeframe))
+	if step <= 0 || currentStart.Before(lastStart) {
+		return false
+	}
+	return currentStart.Sub(lastStart) > step
 }
 
 func parseLiveSignalBarTradeLimitKey(key string) (string, string, time.Time, bool) {
@@ -498,6 +546,9 @@ func liveSLReentryWindowPlanStep(
 	if parseFloatValue(state["sessionReentryCount"]) <= 0 {
 		return state, time.Time{}, 0, "", "", "", false
 	}
+	if strings.TrimSpace(stringValue(state["lastSLExitOrderId"])) == "" || liveSLReentryWindowConsumed(state) {
+		return state, time.Time{}, 0, "", "", "", false
+	}
 	side := strings.ToUpper(strings.TrimSpace(stringValue(state["lastSLExitReentrySide"])))
 	if side == "" {
 		return state, time.Time{}, 0, "", "", "", false
@@ -513,12 +564,16 @@ func liveSLReentryWindowPlanStep(
 	currentBarKey := resolveSignalBarTradeLimitKey(signalBarState, symbol, signalTimeframe)
 	lastSLBarKey := strings.TrimSpace(stringValue(state["lastSLExitSignalBarStateKey"]))
 	if !liveSignalBarKeyWithinReentryWindow(lastSLBarKey, currentBarKey, signalTimeframe) {
+		if liveSignalBarKeyPastReentryWindow(lastSLBarKey, currentBarKey, signalTimeframe) {
+			consumeLiveSLReentryWindow(state, eventTime, "expired")
+		}
 		return state, time.Time{}, 0, "", "", "", false
 	}
 	price := resolveLiveReentryPlanPrice(parameters, signalBarState, side)
 	if price <= 0 {
 		return state, time.Time{}, 0, "", "", "", false
 	}
+	consumeLiveSLReentryWindow(state, eventTime, "consumed-on-derive")
 	return state, liveCurrentSignalBarStart(signalBarState, eventTime), price, side, "entry", "SL-Reentry", true
 }
 

--- a/internal/service/live_zero_initial.go
+++ b/internal/service/live_zero_initial.go
@@ -60,6 +60,17 @@ func prepareLivePlanStepForSignalEvaluation(
 	if hasActivePosition {
 		return updatedState, nextPlannedEvent, nextPlannedPrice, nextPlannedSide, nextPlannedRole, nextPlannedReason
 	}
+	if updatedState, alignedEvent, alignedPrice, alignedSide, alignedRole, alignedReason, ok := liveSLReentryWindowPlanStep(
+		updatedState,
+		parameters,
+		signalBarStates,
+		symbol,
+		signalTimeframe,
+		eventTime,
+	); ok {
+		clearLivePendingZeroInitialWindow(updatedState, eventTime, "sl-exit-reentry-priority")
+		return updatedState, alignedEvent, alignedPrice, alignedSide, alignedRole, alignedReason
+	}
 	if updatedState, alignedEvent, alignedPrice, alignedSide, alignedRole, alignedReason, ok := liveZeroInitialWindowPlanStep(
 		updatedState,
 		parameters,
@@ -104,15 +115,8 @@ func prepareLivePlanStepForSignalEvaluation(
 		return updatedState, nextPlannedEvent, nextPlannedPrice, nextPlannedSide, nextPlannedRole, nextPlannedReason
 	}
 
-	current := mapValue(signalBarState["current"])
-	currentBarStart := parseOptionalRFC3339(stringValue(current["barStart"]))
-	if currentBarStart.IsZero() {
-		currentBarStart = eventTime.UTC()
-	}
-	step := resolutionToDuration(liveSignalResolution(signalTimeframe))
-	if step <= 0 {
-		step = 4 * time.Hour
-	}
+	currentBarStart := liveCurrentSignalBarStart(signalBarState, eventTime)
+	expiresAt := liveZeroInitialWindowExpiresAt(currentBarStart, signalTimeframe)
 	side := "BUY"
 	if shortReady {
 		side = "SELL"
@@ -123,7 +127,7 @@ func prepareLivePlanStepForSignalEvaluation(
 		"signalTimeframe":           strings.ToLower(strings.TrimSpace(signalTimeframe)),
 		"armedAt":                   eventTime.UTC().Format(time.RFC3339),
 		"signalBarStart":            currentBarStart.UTC().Format(time.RFC3339),
-		"expiresAt":                 currentBarStart.UTC().Add(2 * step).Format(time.RFC3339),
+		"expiresAt":                 expiresAt.UTC().Format(time.RFC3339),
 		"breakoutBacked":            true,
 		"openReason":                liveZeroInitialWindowOpenReasonBreakoutLocked,
 		"breakoutPrice":             breakoutPrice,
@@ -200,14 +204,14 @@ func refreshLiveZeroInitialWindowState(
 		delete(state, livePendingZeroInitialWindowStateKey)
 		return state
 	}
+	pending = normalizeLiveZeroInitialWindowTiming(pending, signalTimeframe)
 	expiresAt := parseOptionalRFC3339(stringValue(pending["expiresAt"]))
 	if !expiresAt.IsZero() && !eventTime.UTC().Before(expiresAt.UTC()) {
 		delete(state, livePendingZeroInitialWindowStateKey)
 		return state
 	}
 	if signalBarState, _ := pickSignalBarState(signalBarStates, symbol, signalTimeframe); signalBarState != nil {
-		current := mapValue(signalBarState["current"])
-		if currentBarStart := parseOptionalRFC3339(stringValue(current["barStart"])); !currentBarStart.IsZero() {
+		if currentBarStart := liveCurrentSignalBarStart(signalBarState, time.Time{}); !currentBarStart.IsZero() {
 			pendingBarStart := parseOptionalRFC3339(stringValue(pending["signalBarStart"]))
 			if !pendingBarStart.IsZero() && currentBarStart.UTC().Before(pendingBarStart.UTC()) {
 				delete(state, livePendingZeroInitialWindowStateKey)
@@ -274,11 +278,108 @@ func livePendingZeroInitialWindowOpen(sessionState map[string]any, symbol, signa
 		pendingTimeframe != strings.ToLower(strings.TrimSpace(signalTimeframe)) {
 		return false
 	}
+	pending = normalizeLiveZeroInitialWindowTiming(pending, signalTimeframe)
 	expiresAt := parseOptionalRFC3339(stringValue(pending["expiresAt"]))
 	if !expiresAt.IsZero() && !eventTime.UTC().Before(expiresAt.UTC()) {
 		return false
 	}
 	return true
+}
+
+func normalizeLiveZeroInitialWindowTiming(pending map[string]any, signalTimeframe string) map[string]any {
+	normalized := cloneMetadata(pending)
+	barStart := parseOptionalRFC3339(stringValue(normalized["signalBarStart"]))
+	if barStart.IsZero() {
+		return normalized
+	}
+	barStart = liveCanonicalSignalBarStart(barStart, signalTimeframe)
+	if barStart.IsZero() {
+		return normalized
+	}
+	normalized["signalBarStart"] = barStart.UTC().Format(time.RFC3339)
+	expiresAt := liveZeroInitialWindowExpiresAt(barStart, signalTimeframe)
+	if !expiresAt.IsZero() {
+		normalized["expiresAt"] = expiresAt.UTC().Format(time.RFC3339)
+	}
+	return normalized
+}
+
+func liveCurrentSignalBarStart(signalBarState map[string]any, fallback time.Time) time.Time {
+	current := mapValue(signalBarState["current"])
+	if current == nil {
+		return fallback.UTC()
+	}
+	return liveCanonicalSignalBarStart(resolveBreakoutSignalTime(current["barStart"], fallback), firstNonEmpty(
+		stringValue(signalBarState["timeframe"]),
+		stringValue(current["timeframe"]),
+	))
+}
+
+func liveCanonicalSignalBarStart(value time.Time, signalTimeframe string) time.Time {
+	if value.IsZero() {
+		return time.Time{}
+	}
+	step := liveSignalBarStep(signalTimeframe)
+	if step <= 0 {
+		return value.UTC()
+	}
+	utc := value.UTC()
+	nanos := utc.UnixNano()
+	stepNanos := int64(step)
+	return time.Unix(0, nanos-(nanos%stepNanos)).UTC()
+}
+
+func liveZeroInitialWindowExpiresAt(barStart time.Time, signalTimeframe string) time.Time {
+	if barStart.IsZero() {
+		return time.Time{}
+	}
+	step := liveSignalBarStep(signalTimeframe)
+	if step <= 0 {
+		return barStart.UTC()
+	}
+	return barStart.UTC().Add(2 * step)
+}
+
+func liveSignalBarStep(signalTimeframe string) time.Duration {
+	step := resolutionToDuration(liveSignalResolution(signalTimeframe))
+	if step <= 0 {
+		return 4 * time.Hour
+	}
+	return step
+}
+
+func liveSignalBarKeyWithinReentryWindow(lastKey, currentKey, signalTimeframe string) bool {
+	lastSymbol, lastTimeframe, lastStart, ok := parseLiveSignalBarTradeLimitKey(lastKey)
+	if !ok {
+		return false
+	}
+	currentSymbol, currentTimeframe, currentStart, ok := parseLiveSignalBarTradeLimitKey(currentKey)
+	if !ok {
+		return false
+	}
+	if lastSymbol != "" && currentSymbol != "" && lastSymbol != currentSymbol {
+		return false
+	}
+	if lastTimeframe != "" && currentTimeframe != "" && lastTimeframe != currentTimeframe {
+		return false
+	}
+	step := liveSignalBarStep(firstNonEmpty(signalTimeframe, currentTimeframe, lastTimeframe))
+	if step <= 0 || currentStart.Before(lastStart) {
+		return false
+	}
+	return currentStart.Sub(lastStart) <= step
+}
+
+func parseLiveSignalBarTradeLimitKey(key string) (string, string, time.Time, bool) {
+	parts := strings.Split(strings.TrimSpace(key), "|")
+	if len(parts) != 3 {
+		return "", "", time.Time{}, false
+	}
+	barStart := parseOptionalRFC3339(parts[2])
+	if barStart.IsZero() {
+		return "", "", time.Time{}, false
+	}
+	return NormalizeSymbol(parts[0]), strings.ToLower(strings.TrimSpace(parts[1])), barStart.UTC(), true
 }
 
 func liveBootstrapPlanStepFromSignalBar(
@@ -291,10 +392,7 @@ func liveBootstrapPlanStepFromSignalBar(
 		return time.Time{}, 0, "", false
 	}
 	current := mapValue(signalBarState["current"])
-	plannedEvent := parseOptionalRFC3339(stringValue(current["barStart"]))
-	if plannedEvent.IsZero() {
-		plannedEvent = eventTime.UTC()
-	}
+	plannedEvent := liveCurrentSignalBarStart(signalBarState, eventTime)
 	price := parseFloatValue(current["close"])
 	if price <= 0 {
 		price = fallbackPrice
@@ -342,7 +440,7 @@ func liveStaleExitReentryContext(
 	if currentClose > 0 {
 		context["currentClose"] = currentClose
 	}
-	if currentBarStart := parseOptionalRFC3339(stringValue(current["barStart"])); !currentBarStart.IsZero() {
+	if currentBarStart := liveCurrentSignalBarStart(signalBarState, time.Time{}); !currentBarStart.IsZero() {
 		context["currentBarStart"] = currentBarStart.UTC().Format(time.RFC3339)
 	}
 	if nextPlannedPrice > 0 && currentClose > 0 {
@@ -384,12 +482,44 @@ func liveZeroInitialWindowPlanStep(
 	if price <= 0 {
 		return state, time.Time{}, 0, "", "", "", false
 	}
-	current := mapValue(signalBarState["current"])
-	plannedEvent := parseOptionalRFC3339(stringValue(current["barStart"]))
-	if plannedEvent.IsZero() {
-		plannedEvent = eventTime.UTC()
-	}
+	plannedEvent := liveCurrentSignalBarStart(signalBarState, eventTime)
 	return state, plannedEvent.UTC(), price, side, "entry", "Zero-Initial-Reentry", true
+}
+
+func liveSLReentryWindowPlanStep(
+	sessionState map[string]any,
+	parameters map[string]any,
+	signalBarStates map[string]any,
+	symbol string,
+	signalTimeframe string,
+	eventTime time.Time,
+) (map[string]any, time.Time, float64, string, string, string, bool) {
+	state := cloneMetadata(sessionState)
+	if parseFloatValue(state["sessionReentryCount"]) <= 0 {
+		return state, time.Time{}, 0, "", "", "", false
+	}
+	side := strings.ToUpper(strings.TrimSpace(stringValue(state["lastSLExitReentrySide"])))
+	if side == "" {
+		return state, time.Time{}, 0, "", "", "", false
+	}
+	lastSLExitAt := parseOptionalRFC3339(stringValue(state["lastSLExitFilledAt"]))
+	if lastSLExitAt.IsZero() || lastSLExitAt.UTC().After(eventTime.UTC()) {
+		return state, time.Time{}, 0, "", "", "", false
+	}
+	signalBarState, _ := pickSignalBarState(signalBarStates, symbol, signalTimeframe)
+	if signalBarState == nil {
+		return state, time.Time{}, 0, "", "", "", false
+	}
+	currentBarKey := resolveSignalBarTradeLimitKey(signalBarState, symbol, signalTimeframe)
+	lastSLBarKey := strings.TrimSpace(stringValue(state["lastSLExitSignalBarStateKey"]))
+	if !liveSignalBarKeyWithinReentryWindow(lastSLBarKey, currentBarKey, signalTimeframe) {
+		return state, time.Time{}, 0, "", "", "", false
+	}
+	price := resolveLiveReentryPlanPrice(parameters, signalBarState, side)
+	if price <= 0 {
+		return state, time.Time{}, 0, "", "", "", false
+	}
+	return state, liveCurrentSignalBarStart(signalBarState, eventTime), price, side, "entry", "SL-Reentry", true
 }
 
 func livePendingZeroInitialWindowShouldYieldSLReentry(

--- a/internal/service/live_zero_initial_test.go
+++ b/internal/service/live_zero_initial_test.go
@@ -476,4 +476,145 @@ func TestPrepareLivePlanStepForSignalEvaluationUsesRecordedSLReentryWindow(t *te
 	if pending := mapValue(updated[livePendingZeroInitialWindowStateKey]); len(pending) != 0 {
 		t.Fatalf("expected no pending zero window for recorded SL reentry, got %+v", pending)
 	}
+	if got := stringValue(updated["lastSLExitReentryConsumedOrderId"]); got != "order-sl" {
+		t.Fatalf("expected recorded SL reentry to consume order-sl, got %q", got)
+	}
+	if got := stringValue(updated["lastSLExitReentryConsumedReason"]); got != "consumed-on-derive" {
+		t.Fatalf("expected consumed-on-derive reason, got %q", got)
+	}
+	if got := stringValue(updated["lastSLExitReentrySide"]); got != "" {
+		t.Fatalf("expected derived SL reentry to clear armed side, got %q", got)
+	}
+}
+
+func TestPrepareLivePlanStepForSignalEvaluationConsumesRecordedSLReentryWindowOnce(t *testing.T) {
+	slBarStart := time.Date(2026, 4, 28, 11, 30, 0, 0, time.UTC)
+	currentBarStart := slBarStart.Add(30 * time.Minute)
+	eventTime, state, signalStates := recordedSLReentryWindowFixture(slBarStart, currentBarStart)
+
+	updated, _, _, _, gotRole, gotReason := prepareLivePlanStepForSignalEvaluation(
+		state,
+		map[string]any{
+			"dir2_zero_initial": true,
+			"zero_initial_mode": "reentry_window",
+			"short_reentry_atr": 0.0,
+		},
+		signalStates,
+		"BTCUSDT",
+		"30m",
+		map[string]any{},
+		eventTime,
+		76170.4,
+		"trigger.price",
+		currentBarStart.Add(-2*time.Hour),
+		76444.6,
+		"SELL",
+		"entry",
+		"Initial",
+	)
+	if gotRole != "entry" || gotReason != "SL-Reentry" {
+		t.Fatalf("expected first evaluation to derive SL-Reentry, got role=%s reason=%s", gotRole, gotReason)
+	}
+	if got := stringValue(updated["lastSLExitReentryConsumedOrderId"]); got != "order-sl" {
+		t.Fatalf("expected consumed order id order-sl after first derive, got %q", got)
+	}
+
+	second, _, _, _, gotRole, gotReason := prepareLivePlanStepForSignalEvaluation(
+		updated,
+		map[string]any{
+			"dir2_zero_initial": true,
+			"zero_initial_mode": "reentry_window",
+			"short_reentry_atr": 0.0,
+		},
+		signalStates,
+		"BTCUSDT",
+		"30m",
+		map[string]any{},
+		eventTime.Add(time.Second),
+		76170.4,
+		"trigger.price",
+		currentBarStart,
+		76444.6,
+		"SELL",
+		"entry",
+		"Initial",
+	)
+	if gotReason == "SL-Reentry" {
+		t.Fatalf("expected consumed SL fill not to derive SL-Reentry again, got role=%s reason=%s", gotRole, gotReason)
+	}
+	if got := stringValue(second["lastSLExitReentryConsumedOrderId"]); got != "order-sl" {
+		t.Fatalf("expected consumed order id to remain order-sl, got %q", got)
+	}
+	if got := stringValue(second["lastSLExitReentrySide"]); got != "" {
+		t.Fatalf("expected consumed SL reentry side to stay cleared, got %q", got)
+	}
+}
+
+func TestPrepareLivePlanStepForSignalEvaluationExpiresRecordedSLReentryWindowAfterNextBar(t *testing.T) {
+	slBarStart := time.Date(2026, 4, 28, 11, 30, 0, 0, time.UTC)
+	currentBarStart := slBarStart.Add(time.Hour)
+	eventTime, state, signalStates := recordedSLReentryWindowFixture(slBarStart, currentBarStart)
+
+	updated, _, _, _, gotRole, gotReason := prepareLivePlanStepForSignalEvaluation(
+		state,
+		map[string]any{
+			"dir2_zero_initial": true,
+			"zero_initial_mode": "reentry_window",
+			"short_reentry_atr": 0.0,
+		},
+		signalStates,
+		"BTCUSDT",
+		"30m",
+		map[string]any{},
+		eventTime,
+		76170.4,
+		"trigger.price",
+		currentBarStart,
+		76444.6,
+		"SELL",
+		"entry",
+		"Initial",
+	)
+	if gotReason == "SL-Reentry" {
+		t.Fatalf("expected third signal bar not to derive SL-Reentry, got role=%s reason=%s", gotRole, gotReason)
+	}
+	if got := stringValue(updated["lastSLExitReentryConsumedOrderId"]); got != "order-sl" {
+		t.Fatalf("expected expired SL reentry window to consume order-sl, got %q", got)
+	}
+	if got := stringValue(updated["lastSLExitReentryConsumedReason"]); got != "expired" {
+		t.Fatalf("expected expired consume reason, got %q", got)
+	}
+	if got := stringValue(updated["lastSLExitReentrySide"]); got != "" {
+		t.Fatalf("expected expired SL reentry side to be cleared, got %q", got)
+	}
+}
+
+func recordedSLReentryWindowFixture(slBarStart time.Time, currentBarStart time.Time) (time.Time, map[string]any, map[string]any) {
+	eventTime := currentBarStart.Add(7 * time.Second)
+	state := map[string]any{
+		"sessionReentryCount":         2.0,
+		"lastSLExitFilledAt":          slBarStart.Add(12*time.Minute + 57*time.Second).Format(time.RFC3339),
+		"lastSLExitOrderId":           "order-sl",
+		"lastSLExitSignalBarStateKey": "BTCUSDT|30m|" + slBarStart.Format(time.RFC3339),
+		"lastSLExitReentrySide":       "SELL",
+	}
+	signalStates := map[string]any{
+		signalBindingMatchKey("binance-kline", "signal", "BTCUSDT", map[string]any{"timeframe": "30m"}): map[string]any{
+			"symbol":    "BTCUSDT",
+			"timeframe": "30m",
+			"sma5":      76344.76,
+			"atr14":     231.3,
+			"current": map[string]any{
+				"barStart": strconv.FormatInt(currentBarStart.UnixMilli(), 10),
+				"close":    76170.4,
+				"high":     76206.3,
+				"low":      76170.4,
+			},
+			"prevBar1": map[string]any{
+				"high": 76483.7,
+				"low":  76157.7,
+			},
+		},
+	}
+	return eventTime, state, signalStates
 }

--- a/internal/service/live_zero_initial_test.go
+++ b/internal/service/live_zero_initial_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"strconv"
 	"testing"
 	"time"
 )
@@ -77,6 +78,101 @@ func TestPrepareLivePlanStepForSignalEvaluationExpiresStaleExitReentryWindow(t *
 	}
 	if parseFloatValue(context["staleAgeSeconds"]) <= parseFloatValue(context["staleWindowSeconds"]) {
 		t.Fatalf("expected stale age to exceed stale window in context, got %+v", context)
+	}
+}
+
+func TestPrepareLivePlanStepForSignalEvaluationUsesSignalBarBoundaryForMillisBarStart(t *testing.T) {
+	barStart := time.Date(2026, 4, 28, 11, 0, 0, 0, time.UTC)
+	eventTime := barStart.Add(12*time.Minute + 14*time.Second)
+	signalStates := map[string]any{
+		signalBindingMatchKey("binance-kline", "signal", "BTCUSDT", map[string]any{"timeframe": "30m"}): map[string]any{
+			"symbol":    "BTCUSDT",
+			"timeframe": "30m",
+			"sma5":      76561.0,
+			"atr14":     230.0,
+			"current": map[string]any{
+				"barStart": strconv.FormatInt(barStart.UnixMilli(), 10),
+				"close":    76440.0,
+				"high":     76483.7,
+				"low":      76440.0,
+			},
+			"prevBar1": map[string]any{
+				"high": 76564.2,
+				"low":  76470.2,
+			},
+			"prevBar2": map[string]any{
+				"high": 76565.7,
+				"low":  76444.6,
+			},
+		},
+	}
+
+	state, gotEvent, _, _, gotRole, gotReason := prepareLivePlanStepForSignalEvaluation(
+		map[string]any{},
+		map[string]any{
+			"dir2_zero_initial": true,
+			"zero_initial_mode": "reentry_window",
+			"short_reentry_atr": 0.0,
+		},
+		signalStates,
+		"BTCUSDT",
+		"30m",
+		map[string]any{},
+		eventTime,
+		76444.5,
+		"trigger.price",
+		barStart.Add(-2*time.Hour),
+		76444.6,
+		"SELL",
+		"entry",
+		"Initial",
+	)
+	if gotRole != "entry" || gotReason != "Zero-Initial-Reentry" {
+		t.Fatalf("expected breakout-backed zero window entry, got role=%s reason=%s", gotRole, gotReason)
+	}
+	if !gotEvent.Equal(barStart) {
+		t.Fatalf("expected planned event to use signal bar boundary %s, got %s", barStart, gotEvent)
+	}
+	pending := mapValue(state[livePendingZeroInitialWindowStateKey])
+	if got := stringValue(pending["signalBarStart"]); got != barStart.Format(time.RFC3339) {
+		t.Fatalf("expected pending signal bar start at bar boundary, got %s", got)
+	}
+	if got := stringValue(pending["expiresAt"]); got != barStart.Add(time.Hour).Format(time.RFC3339) {
+		t.Fatalf("expected 30m zero window to expire after current+next bar, got %s", got)
+	}
+}
+
+func TestRefreshLiveZeroInitialWindowStateExpiresLegacyEventTimeWindowAtBarBoundary(t *testing.T) {
+	barStart := time.Date(2026, 4, 28, 11, 0, 0, 0, time.UTC)
+	eventTime := barStart.Add(time.Hour + 7*time.Second)
+	state := map[string]any{
+		livePendingZeroInitialWindowStateKey: map[string]any{
+			"side":            "SELL",
+			"symbol":          "BTCUSDT",
+			"signalTimeframe": "30m",
+			"armedAt":         barStart.Add(12*time.Minute + 14*time.Second).Format(time.RFC3339),
+			"signalBarStart":  barStart.Add(12*time.Minute + 14*time.Second).Format(time.RFC3339),
+			"expiresAt":       barStart.Add(72*time.Minute + 14*time.Second).Format(time.RFC3339),
+			"breakoutBacked":  true,
+			"openReason":      liveZeroInitialWindowOpenReasonBreakoutLocked,
+		},
+	}
+	signalStates := map[string]any{
+		signalBindingMatchKey("binance-kline", "signal", "BTCUSDT", map[string]any{"timeframe": "30m"}): map[string]any{
+			"symbol":    "BTCUSDT",
+			"timeframe": "30m",
+			"current": map[string]any{
+				"barStart": strconv.FormatInt(barStart.Add(time.Hour).UnixMilli(), 10),
+				"close":    76170.4,
+				"high":     76206.3,
+				"low":      76170.4,
+			},
+		},
+	}
+
+	updated := refreshLiveZeroInitialWindowState(state, signalStates, "BTCUSDT", "30m", map[string]any{}, eventTime)
+	if pending := mapValue(updated[livePendingZeroInitialWindowStateKey]); len(pending) != 0 {
+		t.Fatalf("expected legacy event-time zero window to expire at signal bar boundary, got %+v", pending)
 	}
 }
 
@@ -315,5 +411,69 @@ func TestPrepareLivePlanStepForSignalEvaluationKeepsPendingWindowLatentWhilePosi
 	}
 	if pending := mapValue(reactivated[livePendingZeroInitialWindowStateKey]); stringValue(pending["side"]) != "BUY" {
 		t.Fatalf("expected pending zero initial window to remain available until a real reentry consumes it, got %+v", pending)
+	}
+}
+
+func TestPrepareLivePlanStepForSignalEvaluationUsesRecordedSLReentryWindow(t *testing.T) {
+	slBarStart := time.Date(2026, 4, 28, 11, 30, 0, 0, time.UTC)
+	currentBarStart := slBarStart.Add(30 * time.Minute)
+	eventTime := currentBarStart.Add(7 * time.Second)
+	state := map[string]any{
+		"sessionReentryCount":         2.0,
+		"lastSLExitFilledAt":          slBarStart.Add(12*time.Minute + 57*time.Second).Format(time.RFC3339),
+		"lastSLExitOrderId":           "order-sl",
+		"lastSLExitSignalBarStateKey": "BTCUSDT|30m|" + slBarStart.Format(time.RFC3339),
+		"lastSLExitReentrySide":       "SELL",
+	}
+	signalStates := map[string]any{
+		signalBindingMatchKey("binance-kline", "signal", "BTCUSDT", map[string]any{"timeframe": "30m"}): map[string]any{
+			"symbol":    "BTCUSDT",
+			"timeframe": "30m",
+			"sma5":      76344.76,
+			"atr14":     231.3,
+			"current": map[string]any{
+				"barStart": strconv.FormatInt(currentBarStart.UnixMilli(), 10),
+				"close":    76170.4,
+				"high":     76206.3,
+				"low":      76170.4,
+			},
+			"prevBar1": map[string]any{
+				"high": 76483.7,
+				"low":  76157.7,
+			},
+		},
+	}
+
+	updated, gotEvent, gotPrice, gotSide, gotRole, gotReason := prepareLivePlanStepForSignalEvaluation(
+		state,
+		map[string]any{
+			"dir2_zero_initial": true,
+			"zero_initial_mode": "reentry_window",
+			"short_reentry_atr": 0.0,
+		},
+		signalStates,
+		"BTCUSDT",
+		"30m",
+		map[string]any{},
+		eventTime,
+		76170.4,
+		"trigger.price",
+		currentBarStart.Add(-2*time.Hour),
+		76444.6,
+		"SELL",
+		"entry",
+		"Initial",
+	)
+	if gotRole != "entry" || gotReason != "SL-Reentry" || gotSide != "SELL" {
+		t.Fatalf("expected recorded SL exit to arm SL-Reentry, got side=%s role=%s reason=%s", gotSide, gotRole, gotReason)
+	}
+	if !gotEvent.Equal(currentBarStart) {
+		t.Fatalf("expected current signal bar event %s, got %s", currentBarStart, gotEvent)
+	}
+	if gotPrice != 76483.7 {
+		t.Fatalf("expected short reentry price from prev high, got %v", gotPrice)
+	}
+	if pending := mapValue(updated[livePendingZeroInitialWindowStateKey]); len(pending) != 0 {
+		t.Fatalf("expected no pending zero window for recorded SL reentry, got %+v", pending)
 	}
 }


### PR DESCRIPTION
## 目的
修复生产增强 30m live 中 pending zero-initial window 生命周期比回测更宽的问题。

Root cause:
- live zero window 使用 `parseOptionalRFC3339(current["barStart"])` 解析 signal bar 起点，但生产 kline 的 `barStart` 是 Binance 毫秒字符串，解析失败后 fallback 到 tick event time，导致 30m window 从 `11:12:14` 延到 `12:12:14`，而不是按 signal bar 边界 `11:00 -> 12:00` 过期。
- filled `Zero-Initial-Reentry` 没有消费 pending zero window，后续 SL 后仍可能继续复用同一个 breakout-backed zero window。

本 PR 将 live 对齐回测语义：
- zero window 的 `signalBarStart` / `expiresAt` 使用 signal bar 边界计算，支持毫秒 barStart。
- legacy event-time pending window 会被规范化到对应 signal bar 边界后再判断过期。
- filled `Zero-Initial-Reentry` 会消费 pending zero window。
- SL fill 记录下一笔 reentry side，并允许同一根或下一根 signal bar 生成 `SL-Reentry`，避免消费 zero window 后丢失回测里的 exit reentry 语义。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [x] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) — 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？— 无
- [x] DB migration 是否具备向下兼容幂等性？— 不涉及 migration
- [x] 配置字段有没有无意被混改？— 无配置默认值变化，仅新增 live session state 派生字段 `lastSLExitReentrySide`

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

本地验证：
- `go test ./internal/service -run 'TestPrepareLivePlanStepForSignalEvaluation(UsesSignalBarBoundaryForMillisBarStart|UsesRecordedSLReentryWindow|KeepsPendingWindowLatentWhilePositionActive|ConvertsPendingZeroWindowAfterSLExit|DoesNotConvertPendingZeroWindowForPreviousSLBar|DoesNotConvertPendingZeroWindowWithoutSLBarKey)|TestRefreshLiveZeroInitialWindowStateExpiresLegacyEventTimeWindowAtBarBoundary|TestMaybeIncrementLiveSessionReentryCount(OnlyCountsFilledReentries|CountsZeroInitialWindowEntry|UsesPerBarIdentity)|TestRecordLiveSessionStopLossExitFillUsesExchangeFillTime|TestUpdateLiveSessionStatePreservingNonRegressiveFactsKeepsLatestSLExitFill'`
- `go test ./internal/service`
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
- pre-push harness passed