### PR TITLE
[codex] add exchange fill report source mapping

### DIFF
--- a/internal/domain/models.go
+++ b/internal/domain/models.go
@@ -238,10 +238,12 @@ type Fill struct {
 	ExchangeTradeID   string     `json:"exchangeTradeId,omitempty"`
 	ExchangeTradeTime *time.Time `json:"exchangeTradeTime,omitempty"`
 	DedupFingerprint  string     `json:"-"`
-	Price             float64    `json:"price"`
-	Quantity          float64    `json:"quantity"`
-	Fee               float64    `json:"fee"` // 手续费
-	CreatedAt         time.Time  `json:"createdAt"`
+	// Source is a transient reconciliation hint, not persisted.
+	Source    string    `json:"-"`
+	Price     float64   `json:"price"`
+	Quantity  float64   `json:"quantity"`
+	Fee       float64   `json:"fee"` // 手续费
+	CreatedAt time.Time `json:"createdAt"`
 }
 
 func (f Fill) FallbackFingerprint() string {

--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -1536,8 +1536,10 @@ func buildLiveReconcileSyncResult(order domain.Order, payload map[string]any, tr
 			Price:    avgPrice,
 			Quantity: filledQty,
 			Fee:      0,
+			Source:   FillSourceSynthetic,
 			Metadata: map[string]any{
 				"source":          "binance-all-orders",
+				"reportSource":    "binance-all-orders",
 				"exchangeOrderId": exchangeOrderID,
 				"clientOrderId":   clientOrderID,
 				"tradeTime":       syncedAt,

--- a/internal/service/live_registry.go
+++ b/internal/service/live_registry.go
@@ -50,7 +50,55 @@ type LiveFillReport struct {
 	Quantity   float64        `json:"quantity"`
 	Fee        float64        `json:"fee"`
 	FundingPnL float64        `json:"fundingPnl"`
+	Source     FillSource     `json:"source,omitempty"`
 	Metadata   map[string]any `json:"metadata,omitempty"`
+}
+
+type ExchangeFillReport struct {
+	Exchange        string         `json:"exchange,omitempty"`
+	AdapterKey      string         `json:"adapterKey,omitempty"`
+	AccountID       string         `json:"accountId,omitempty"`
+	OrderID         string         `json:"orderId,omitempty"`
+	ExchangeOrderID string         `json:"exchangeOrderId,omitempty"`
+	ExchangeTradeID string         `json:"exchangeTradeId,omitempty"`
+	Symbol          string         `json:"symbol,omitempty"`
+	Side            string         `json:"side,omitempty"`
+	Price           float64        `json:"price"`
+	Quantity        float64        `json:"quantity"`
+	Fee             float64        `json:"fee"`
+	FeeAsset        string         `json:"feeAsset,omitempty"`
+	RealizedPnL     float64        `json:"realizedPnl,omitempty"`
+	FundingPnL      float64        `json:"fundingPnl,omitempty"`
+	TradeTime       string         `json:"tradeTime,omitempty"`
+	Source          FillSource     `json:"source"`
+	Raw             map[string]any `json:"raw,omitempty"`
+}
+
+func (report ExchangeFillReport) LiveFillReport() LiveFillReport {
+	metadata := map[string]any{
+		"source":          "exchange-fill-report",
+		"reportSource":    "exchange-fill-report",
+		"exchange":        report.Exchange,
+		"adapterKey":      report.AdapterKey,
+		"accountId":       report.AccountID,
+		"orderId":         report.OrderID,
+		"exchangeOrderId": report.ExchangeOrderID,
+		"tradeId":         report.ExchangeTradeID,
+		"commissionAsset": report.FeeAsset,
+		"realizedPnl":     report.RealizedPnL,
+		"tradeTime":       report.TradeTime,
+	}
+	if report.Raw != nil {
+		metadata["raw"] = report.Raw
+	}
+	return LiveFillReport{
+		Price:      report.Price,
+		Quantity:   report.Quantity,
+		Fee:        report.Fee,
+		FundingPnL: report.FundingPnL,
+		Source:     report.Source,
+		Metadata:   metadata,
+	}
 }
 
 type LiveOrderSync struct {
@@ -537,8 +585,10 @@ func (a binanceFuturesLiveAdapter) syncRESTOrder(account domain.Account, order d
 				Price:    avgPrice,
 				Quantity: filledQty,
 				Fee:      0,
+				Source:   FillSourceSynthetic,
 				Metadata: map[string]any{
 					"source":          "binance-order-query",
+					"reportSource":    "binance-order-query",
 					"exchange":        account.Exchange,
 					"adapterKey":      a.Key(),
 					"exchangeOrderId": normalizeBinanceOrderID(payload["orderId"], order.Metadata["exchangeOrderId"]),
@@ -691,25 +741,27 @@ func (a binanceFuturesLiveAdapter) tradeReportsFromBinanceTrades(account domain.
 		if qty <= 0 {
 			continue
 		}
-		reports = append(reports, LiveFillReport{
-			Price:      parseFloatValue(trade["price"]),
-			Quantity:   qty,
-			Fee:        parseFloatValue(trade["commission"]),
-			FundingPnL: 0,
-			Metadata: map[string]any{
-				"source":          "binance-user-trades",
-				"exchange":        account.Exchange,
-				"adapterKey":      a.Key(),
-				"exchangeOrderId": normalizeBinanceOrderID(trade["orderId"], fallbackOrderID),
-				"tradeId":         stringifyBinanceID(trade["id"]),
-				"commissionAsset": stringValue(trade["commissionAsset"]),
-				"realizedPnl":     parseFloatValue(trade["realizedPnl"]),
-				"maker":           trade["maker"],
-				"buyer":           trade["buyer"],
-				"tradeTime":       parseBinanceMillisToRFC3339(trade["time"]),
-				"executionMode":   "rest",
-			},
-		})
+		reports = append(reports, ExchangeFillReport{
+			Exchange:        account.Exchange,
+			AdapterKey:      a.Key(),
+			AccountID:       account.ID,
+			ExchangeOrderID: normalizeBinanceOrderID(trade["orderId"], fallbackOrderID),
+			ExchangeTradeID: stringifyBinanceID(trade["id"]),
+			Price:           parseFloatValue(trade["price"]),
+			Quantity:        qty,
+			Fee:             parseFloatValue(trade["commission"]),
+			FeeAsset:        stringValue(trade["commissionAsset"]),
+			RealizedPnL:     parseFloatValue(trade["realizedPnl"]),
+			TradeTime:       parseBinanceMillisToRFC3339(trade["time"]),
+			Source:          FillSourceReal,
+			Raw:             trade,
+		}.LiveFillReport())
+		metadata := reports[len(reports)-1].Metadata
+		metadata["source"] = "binance-user-trades"
+		metadata["reportSource"] = "binance-user-trades"
+		metadata["maker"] = trade["maker"]
+		metadata["buyer"] = trade["buyer"]
+		metadata["executionMode"] = "rest"
 	}
 	return reports
 }

--- a/internal/service/order.go
+++ b/internal/service/order.go
@@ -1004,6 +1004,7 @@ func buildLiveSyncSettlement(order domain.Order, syncResult LiveOrderSync) ([]do
 			ExchangeTradeID:   resolveLiveFillTradeID(report),
 			ExchangeTradeTime: resolveLiveFillTradeTime(report),
 			DedupFingerprint:  strings.TrimSpace(stringValue(mapValue(report.Metadata)["dedupFingerprint"])),
+			Source:            string(resolveLiveFillSource(report)),
 			Price:             price,
 			Quantity:          report.Quantity,
 			Fee:               report.Fee - report.FundingPnL,
@@ -1062,7 +1063,9 @@ func buildTerminalFilledFallbackReport(order domain.Order, syncResult LiveOrderS
 		stringValue(metadata["exchangeOrderId"]),
 		stringValue(order.Metadata["exchangeOrderId"]),
 	)
-	metadata["source"] = firstNonEmpty(stringValue(metadata["source"]), "terminal-filled-order-fallback")
+	reportSource := firstNonEmpty(stringValue(metadata["reportSource"]), stringValue(metadata["source"]), "terminal-filled-order-fallback")
+	metadata["source"] = firstNonEmpty(stringValue(metadata["source"]), reportSource)
+	metadata["reportSource"] = reportSource
 	metadata["exchangeOrderId"] = exchangeOrderID
 	metadata["clientOrderId"] = firstNonEmpty(stringValue(metadata["clientOrderId"]), order.ID)
 	metadata["tradeTime"] = tradeTime
@@ -1072,6 +1075,7 @@ func buildTerminalFilledFallbackReport(order domain.Order, syncResult LiveOrderS
 		Price:    price,
 		Quantity: fallbackQty,
 		Fee:      0,
+		Source:   FillSourceSynthetic,
 		Metadata: metadata,
 	}, true
 }
@@ -1237,7 +1241,9 @@ func fillReconciliationInputsFromIncomingFills(order domain.Order, fills []domai
 			fill.OrderID = order.ID
 		}
 		source := FillSourceReal
-		if strings.TrimSpace(fill.ExchangeTradeID) == "" {
+		if strings.TrimSpace(fill.Source) != "" {
+			source = FillSource(strings.TrimSpace(fill.Source))
+		} else if strings.TrimSpace(fill.ExchangeTradeID) == "" {
 			fill.DedupFingerprint = strings.TrimSpace(fill.DedupFingerprint)
 			if fill.DedupFingerprint == "" {
 				fill.DedupFingerprint = fill.FallbackFingerprint()
@@ -1360,6 +1366,23 @@ func resolveLiveFillTradeID(report LiveFillReport) string {
 		stringifyBinanceID(metadata["tradeId"]),
 		stringifyBinanceID(metadata["exchangeTradeId"]),
 	))
+}
+
+func resolveLiveFillSource(report LiveFillReport) FillSource {
+	if report.Source != "" {
+		return report.Source
+	}
+	metadata := mapValue(report.Metadata)
+	if boolValue(metadata["syntheticFill"]) {
+		return FillSourceSynthetic
+	}
+	if strings.TrimSpace(stringValue(metadata["dedupFingerprint"])) != "" {
+		return FillSourceSynthetic
+	}
+	if resolveLiveFillTradeID(report) != "" {
+		return FillSourceReal
+	}
+	return ""
 }
 
 func resolveLiveFillTradeTime(report LiveFillReport) *time.Time {

--- a/internal/service/order_test.go
+++ b/internal/service/order_test.go
@@ -113,6 +113,62 @@ func TestBuildLiveSyncSettlementKeepsExchangeTradeIDEmptyWithoutRealTradeID(t *t
 	}
 }
 
+func TestBuildLiveSyncSettlementPropagatesExplicitFillSource(t *testing.T) {
+	order := domain.Order{ID: "order-1", Symbol: "BTCUSDT"}
+
+	fills, _, _ := buildLiveSyncSettlement(order, LiveOrderSync{
+		Status: "FILLED",
+		Fills: []LiveFillReport{{
+			Price:    68000,
+			Quantity: 0.1,
+			Fee:      1.23,
+			Source:   FillSourceReal,
+			Metadata: map[string]any{
+				"exchangeOrderId": "exchange-order-1",
+				"tradeId":         "trade-1",
+				"tradeTime":       "2026-04-17T12:36:00Z",
+			},
+		}},
+	})
+
+	if len(fills) != 1 {
+		t.Fatalf("expected one fill, got %d", len(fills))
+	}
+	if got := fills[0].Source; got != string(FillSourceReal) {
+		t.Fatalf("expected real fill source, got %q", got)
+	}
+}
+
+func TestBinanceTradeReportsSetRealFillSource(t *testing.T) {
+	adapter := binanceFuturesLiveAdapter{}
+	reports := adapter.tradeReportsFromBinanceTrades(domain.Account{
+		ID:       "live-main",
+		Exchange: "binance-futures",
+	}, []map[string]any{{
+		"id":              "12345",
+		"orderId":         "67890",
+		"price":           "68000",
+		"qty":             "0.1",
+		"commission":      "1.23",
+		"commissionAsset": "USDT",
+		"realizedPnl":     "2.34",
+		"time":            float64(time.Date(2026, 4, 17, 12, 36, 0, 0, time.UTC).UnixMilli()),
+	}}, nil)
+
+	if len(reports) != 1 {
+		t.Fatalf("expected one report, got %d", len(reports))
+	}
+	if reports[0].Source != FillSourceReal {
+		t.Fatalf("expected real report source, got %q", reports[0].Source)
+	}
+	if got := stringValue(reports[0].Metadata["reportSource"]); got != "binance-user-trades" {
+		t.Fatalf("expected report source binance-user-trades, got %q", got)
+	}
+	if got := stringValue(reports[0].Metadata["tradeId"]); got != "12345" {
+		t.Fatalf("expected trade id 12345, got %q", got)
+	}
+}
+
 func TestFinalizeExecutedOrderSkipsDuplicateExchangeTradeIDFills(t *testing.T) {
 	store := memory.NewStore()
 	platform := NewPlatform(store)


### PR DESCRIPTION
## 目的
Refs #272. Follow-up after #285.

推进阶段 4 的最小切片：新增交易所无关的 `ExchangeFillReport`，并让 Binance REST 成交报告先产出显式 source，减少 `finalizeExecutedOrder` 对 incoming fill 的 source 推断。

本次改动：
- 新增 `ExchangeFillReport` 标准结构，覆盖 exchange / adapter / account / order / trade id / price / quantity / fee / fee asset / realizedPnL / fundingPnL / tradeTime / source / raw。
- `LiveFillReport` 增加显式 `Source FillSource`。
- Binance `/fapi/v1/userTrades` 归一化为 `ExchangeFillReport{Source: real}` 再转为 `LiveFillReport`。
- Binance order-query / all-orders / terminal fallback synthetic fill 明确标记 `Source: synthetic`。
- `buildLiveSyncSettlement` 把 report source 传入 transient `domain.Fill.Source`，`finalize` 优先使用该 source。
- 保留 legacy 兼容：旧测试或手工直接构造 `domain.Fill` 未带 source 时，仍按现有字段推断。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [x] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(无变化)
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？(无)
- [x] DB migration 是否具备向下兼容幂等性？(无 migration)
- [x] 配置字段有没有无意被混改？(无)

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

验证已通过：
- `go test ./internal/service -run 'TestBuildLiveSyncSettlement|TestBinanceTradeReportsSetRealFillSource|TestBuildFillReconciliationPlan|TestSyntheticUpgrade' -count=1`
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
