### PR TITLE
[codex] Add live session control error codes

### DIFF
--- a/cmd/bktrader-ctl/live.go
+++ b/cmd/bktrader-ctl/live.go
@@ -227,7 +227,14 @@ func waitLiveSessionActualStatus(client *ctlclient.Client, sessionID, target str
 			return nil
 		}
 		if actual == "ERROR" {
-			return fmt.Errorf("live session control failed: desiredStatus=%s actualStatus=%s error=%s", liveSessionControlString(session.State["desiredStatus"]), actual, liveSessionControlString(session.State["lastControlError"]))
+			errorCode := liveSessionControlString(session.State["lastControlErrorCode"])
+			return fmt.Errorf("live session control failed: desiredStatus=%s actualStatus=%s errorCode=%s error=%s hint=%s",
+				liveSessionControlString(session.State["desiredStatus"]),
+				actual,
+				errorCode,
+				liveSessionControlString(session.State["lastControlError"]),
+				liveSessionControlErrorHint(errorCode),
+			)
 		}
 		if time.Now().After(deadline) {
 			return fmt.Errorf("timed out waiting for live session %s actualStatus=%s, last actualStatus=%s desiredStatus=%s", sessionID, target, actual, liveSessionControlString(session.State["desiredStatus"]))
@@ -241,6 +248,21 @@ func liveSessionControlString(value any) string {
 		return ""
 	}
 	return strings.TrimSpace(fmt.Sprint(value))
+}
+
+func liveSessionControlErrorHint(code string) string {
+	switch strings.ToUpper(strings.TrimSpace(code)) {
+	case "ACTIVE_POSITIONS_OR_ORDERS":
+		return "close positions/orders first or retry stop with --force"
+	case "RUNTIME_LEASE_NOT_ACQUIRED", "CONTROL_OPERATION_IN_PROGRESS":
+		return "retry after the current runner/control operation finishes"
+	case "CONFIG_ERROR":
+		return "check live session/account/runtime configuration"
+	case "ADAPTER_ERROR":
+		return "check exchange adapter connectivity and logs"
+	default:
+		return "check live-runner logs"
+	}
 }
 
 func fetchLiveSessionControlView(client *ctlclient.Client, sessionID string) (liveSessionControlView, error) {

--- a/internal/http/live.go
+++ b/internal/http/live.go
@@ -721,15 +721,16 @@ func liveSessionControlAcceptedPayload(session domain.LiveSession) map[string]an
 		state = map[string]any{}
 	}
 	return map[string]any{
-		"status":           "accepted",
-		"message":          "control intent accepted; execution is asynchronous and must be confirmed through actualStatus",
-		"sessionId":        session.ID,
-		"desiredStatus":    state["desiredStatus"],
-		"actualStatus":     state["actualStatus"],
-		"controlRequestId": state["controlRequestId"],
-		"controlVersion":   state["controlVersion"],
-		"lastControlError": state["lastControlError"],
-		"session":          session,
+		"status":               "accepted",
+		"message":              "control intent accepted; execution is asynchronous and must be confirmed through actualStatus",
+		"sessionId":            session.ID,
+		"desiredStatus":        state["desiredStatus"],
+		"actualStatus":         state["actualStatus"],
+		"controlRequestId":     state["controlRequestId"],
+		"controlVersion":       state["controlVersion"],
+		"lastControlError":     state["lastControlError"],
+		"lastControlErrorCode": state["lastControlErrorCode"],
+		"session":              session,
 	}
 }
 

--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -247,6 +247,7 @@ func (p *Platform) deleteLiveSessionWithForceLocked(session domain.LiveSession, 
 	delete(state, "activeControlRequestId")
 	delete(state, "activeControlVersion")
 	delete(state, "lastControlError")
+	delete(state, "lastControlErrorCode")
 	delete(state, "lastControlErrorAt")
 	delete(state, "lastControlErrorRequestId")
 	delete(state, "lastControlErrorVersion")

--- a/internal/service/live_session_control.go
+++ b/internal/service/live_session_control.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"strconv"
@@ -12,7 +13,16 @@ import (
 	"github.com/wuyaocheng/bktrader/internal/domain"
 )
 
-const liveSessionControlScannerInterval = 5 * time.Second
+const (
+	liveSessionControlScannerInterval = 5 * time.Second
+
+	LiveSessionControlErrorCodeActivePositionsOrOrders    = "ACTIVE_POSITIONS_OR_ORDERS"
+	LiveSessionControlErrorCodeRuntimeLeaseNotAcquired    = "RUNTIME_LEASE_NOT_ACQUIRED"
+	LiveSessionControlErrorCodeControlOperationInProgress = "CONTROL_OPERATION_IN_PROGRESS"
+	LiveSessionControlErrorCodeAdapterError               = "ADAPTER_ERROR"
+	LiveSessionControlErrorCodeConfigError                = "CONFIG_ERROR"
+	LiveSessionControlErrorCodeUnknown                    = "UNKNOWN"
+)
 
 type liveSessionControlRequest struct {
 	ID      string
@@ -62,6 +72,9 @@ func (p *Platform) requestLiveSessionDesiredStatus(sessionID, desired string, fo
 		delete(state, "activeControlVersion")
 		delete(state, "lastControlError")
 		delete(state, "lastControlErrorAt")
+		delete(state, "lastControlErrorCode")
+		delete(state, "lastControlErrorRequestId")
+		delete(state, "lastControlErrorVersion")
 		updated, ok, err := p.updateLiveSessionControlStateIfPrevious(session.ID, previous, state)
 		if err != nil {
 			return domain.LiveSession{}, err
@@ -219,11 +232,13 @@ func (p *Platform) markLiveSessionControlActual(session domain.LiveSession, requ
 	state["activeControlVersion"] = request.Version
 	if controlErr != nil {
 		state["lastControlError"] = controlErr.Error()
+		state["lastControlErrorCode"] = liveSessionControlErrorCode(controlErr)
 		state["lastControlErrorAt"] = now.Format(time.RFC3339)
 		state["lastControlErrorRequestId"] = request.ID
 		state["lastControlErrorVersion"] = request.Version
 	} else {
 		delete(state, "lastControlError")
+		delete(state, "lastControlErrorCode")
 		delete(state, "lastControlErrorAt")
 		delete(state, "lastControlErrorRequestId")
 		delete(state, "lastControlErrorVersion")
@@ -265,6 +280,22 @@ func (p *Platform) updateLiveSessionControlStateIfPrevious(sessionID string, pre
 	}
 	updated, err := p.store.UpdateLiveSessionState(sessionID, state)
 	return updated, err == nil, err
+}
+
+func liveSessionControlErrorCode(err error) string {
+	if err == nil {
+		return ""
+	}
+	switch {
+	case errors.Is(err, ErrActivePositionsOrOrders):
+		return LiveSessionControlErrorCodeActivePositionsOrOrders
+	case errors.Is(err, ErrRuntimeLeaseNotAcquired):
+		return LiveSessionControlErrorCodeRuntimeLeaseNotAcquired
+	case errors.Is(err, ErrLiveControlOperationInProgress), errors.Is(err, ErrLiveAccountOperationInProgress):
+		return LiveSessionControlErrorCodeControlOperationInProgress
+	default:
+		return LiveSessionControlErrorCodeUnknown
+	}
 }
 
 func liveSessionActualStatusFromSession(session domain.LiveSession) string {

--- a/internal/service/live_session_control_test.go
+++ b/internal/service/live_session_control_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -181,6 +182,9 @@ func TestScanLiveSessionControlRequestsPreservesStopSafetyUntilForceRequested(t 
 	if got := stringValue(blocked.State["actualStatus"]); got != "ERROR" {
 		t.Fatalf("expected actualStatus ERROR, got %s", got)
 	}
+	if got := stringValue(blocked.State["lastControlErrorCode"]); got != LiveSessionControlErrorCodeActivePositionsOrOrders {
+		t.Fatalf("expected lastControlErrorCode %s, got %s", LiveSessionControlErrorCodeActivePositionsOrOrders, got)
+	}
 
 	platform.scanLiveSessionControlRequests(context.Background())
 	stillBlocked, err := store.GetLiveSession(session.ID)
@@ -245,6 +249,9 @@ func TestLiveSessionControlForceStopRecoversFromPreviousError(t *testing.T) {
 	if got := stringValue(failed.State["lastControlError"]); got == "" {
 		t.Fatal("expected lastControlError after blocked stop")
 	}
+	if got := stringValue(failed.State["lastControlErrorCode"]); got != LiveSessionControlErrorCodeActivePositionsOrOrders {
+		t.Fatalf("expected lastControlErrorCode %s, got %s", LiveSessionControlErrorCodeActivePositionsOrOrders, got)
+	}
 
 	if _, err := platform.RequestLiveSessionStopWithForce(session.ID, true); err != nil {
 		t.Fatalf("request force stop retry failed: %v", err)
@@ -255,6 +262,9 @@ func TestLiveSessionControlForceStopRecoversFromPreviousError(t *testing.T) {
 	}
 	if got := stringValue(retry.State["actualStatus"]); got == "ERROR" {
 		t.Fatal("expected force stop request to clear previous ERROR actualStatus")
+	}
+	if got := stringValue(retry.State["lastControlErrorCode"]); got != "" {
+		t.Fatalf("expected force stop request to clear previous error code, got %s", got)
 	}
 
 	platform.scanLiveSessionControlRequests(context.Background())
@@ -271,6 +281,9 @@ func TestLiveSessionControlForceStopRecoversFromPreviousError(t *testing.T) {
 	}
 	if got := stringValue(stopped.State["lastControlError"]); got != "" {
 		t.Fatalf("expected lastControlError cleared after recovery, got %s", got)
+	}
+	if got := stringValue(stopped.State["lastControlErrorCode"]); got != "" {
+		t.Fatalf("expected lastControlErrorCode cleared after recovery, got %s", got)
 	}
 }
 
@@ -296,6 +309,9 @@ func TestScanLiveSessionControlRequestsWritesErrorWithoutRetryingStart(t *testin
 	if got := stringValue(failed.State["lastControlError"]); got == "" {
 		t.Fatal("expected lastControlError")
 	}
+	if got := stringValue(failed.State["lastControlErrorCode"]); got != LiveSessionControlErrorCodeUnknown {
+		t.Fatalf("expected lastControlErrorCode %s, got %s", LiveSessionControlErrorCodeUnknown, got)
+	}
 
 	platform.scanLiveSessionControlRequests(context.Background())
 	stillFailed, err := store.GetLiveSession("live-session-main")
@@ -304,6 +320,27 @@ func TestScanLiveSessionControlRequestsWritesErrorWithoutRetryingStart(t *testin
 	}
 	if got := stringValue(stillFailed.State["actualStatus"]); got != "ERROR" {
 		t.Fatalf("expected ERROR not to auto retry, got %s", got)
+	}
+}
+
+func TestLiveSessionControlErrorCodeClassification(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{name: "active exposure", err: activePositionsOrOrdersError{}, want: LiveSessionControlErrorCodeActivePositionsOrOrders},
+		{name: "runtime lease", err: fmt.Errorf("wrapped: %w", ErrRuntimeLeaseNotAcquired), want: LiveSessionControlErrorCodeRuntimeLeaseNotAcquired},
+		{name: "control operation", err: fmt.Errorf("wrapped: %w", ErrLiveControlOperationInProgress), want: LiveSessionControlErrorCodeControlOperationInProgress},
+		{name: "account operation", err: fmt.Errorf("wrapped: %w", ErrLiveAccountOperationInProgress), want: LiveSessionControlErrorCodeControlOperationInProgress},
+		{name: "unknown", err: fmt.Errorf("adapter returned unexpected status"), want: LiveSessionControlErrorCodeUnknown},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := liveSessionControlErrorCode(tc.err); got != tc.want {
+				t.Fatalf("expected %s, got %s", tc.want, got)
+			}
+		})
 	}
 }
 

--- a/web/console/src/hooks/useDashboardRealtime.ts
+++ b/web/console/src/hooks/useDashboardRealtime.ts
@@ -27,12 +27,31 @@ function liveSessionControlStatus(session: LiveSession) {
   const desired = String(state.desiredStatus ?? "").trim().toUpperCase();
   const actual = String(state.actualStatus ?? "").trim().toUpperCase();
   const error = String(state.lastControlError ?? "").trim();
+  const errorCode = String(state.lastControlErrorCode ?? "").trim().toUpperCase();
   return {
     desired,
     actual,
     error,
-    key: `${desired}|${actual}|${error}`,
+    errorCode,
+    key: `${desired}|${actual}|${errorCode}|${error}`,
   };
+}
+
+function liveSessionControlErrorNotification(current: ReturnType<typeof liveSessionControlStatus>, sessionID: string) {
+  const detail = current.error || sessionID;
+  switch (current.errorCode) {
+    case "ACTIVE_POSITIONS_OR_ORDERS":
+      return `会话控制失败 (${current.errorCode})：${detail}。请先平仓/撤单，或确认风险后使用 force stop。`;
+    case "RUNTIME_LEASE_NOT_ACQUIRED":
+    case "CONTROL_OPERATION_IN_PROGRESS":
+      return `会话控制失败 (${current.errorCode})：${detail}。当前 runner/control 操作占用中，稍后重试。`;
+    case "CONFIG_ERROR":
+      return `会话控制失败 (${current.errorCode})：${detail}。请检查 live session、账户和 runtime 配置。`;
+    case "ADAPTER_ERROR":
+      return `会话控制失败 (${current.errorCode})：${detail}。请检查交易所适配器连接和 runner 日志。`;
+    default:
+      return current.errorCode ? `会话控制失败 (${current.errorCode})：${detail}` : `会话控制失败：${detail}`;
+  }
 }
 
 function notifyLiveSessionControlTransitions(
@@ -54,7 +73,7 @@ function notifyLiveSessionControlTransitions(
     if (current.actual === "ERROR") {
       setNotification({
         type: 'error',
-        message: `会话控制失败：${current.error || session.id}`,
+        message: liveSessionControlErrorNotification(current, session.id),
       });
       continue;
     }

--- a/web/console/src/pages/AccountStage.tsx
+++ b/web/console/src/pages/AccountStage.tsx
@@ -121,6 +121,24 @@ function statusLabelZh(status: string): string {
   }
 }
 
+function liveControlErrorMessage(code: string, error: string): string {
+  const normalized = String(code).trim().toUpperCase();
+  const detail = error || "runner 执行失败";
+  switch (normalized) {
+    case "ACTIVE_POSITIONS_OR_ORDERS":
+      return `${detail}。请先平仓/撤单，或确认风险后使用 force stop。`;
+    case "RUNTIME_LEASE_NOT_ACQUIRED":
+    case "CONTROL_OPERATION_IN_PROGRESS":
+      return `${detail}。当前 runner/control 操作占用中，稍后重试。`;
+    case "CONFIG_ERROR":
+      return `${detail}。请检查 live session、账户和 runtime 配置。`;
+    case "ADAPTER_ERROR":
+      return `${detail}。请检查交易所适配器连接和 runner 日志。`;
+    default:
+      return detail;
+  }
+}
+
 export function AccountStage({
   logout,
   openLiveAccountModal,
@@ -1105,8 +1123,9 @@ export function AccountStage({
                      liveActualStatus !== "" &&
                      liveActualStatus !== "ERROR" &&
                      liveDesiredStatus !== liveActualStatus;
+                   const liveControlErrorCode = String(sessionState.lastControlErrorCode ?? "").trim().toUpperCase();
                    const liveControlError = liveActualStatus === "ERROR"
-                     ? String(sessionState.lastControlError ?? "runner 执行失败").trim()
+                     ? liveControlErrorMessage(liveControlErrorCode, String(sessionState.lastControlError ?? "").trim())
                      : "";
                    const linkedRuntimeSessionId = String(
                      sessionState.signalRuntimeSessionId ?? sessionState.lastSignalRuntimeSessionId ?? ""
@@ -1164,7 +1183,7 @@ export function AccountStage({
                            {liveControlError && (
                              <p className="flex items-center gap-1.5 text-[10px] font-bold text-[var(--bk-status-danger)]">
                                <AlertTriangle size={12} />
-                               控制失败：{liveControlError}
+                               控制失败{liveControlErrorCode ? ` (${liveControlErrorCode})` : ""}：{liveControlError}
                              </p>
                            )}
                         </div>


### PR DESCRIPTION
## 目的
继续 #282 Phase 3：为 LiveSession control plane 增加 `lastControlErrorCode`，让 runner、API、CLI、UI 都能基于稳定错误码给出可操作提示，而不是只展示错误字符串。

Refs #282

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [x] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？- 未变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？- 不涉及
- [x] DB migration 是否具备向下兼容幂等性？- 无 DB migration，继续沿用 `live_sessions.state` JSONB
- [x] 配置字段有没有无意被混改？- 未新增 env/config 字段

## 改动说明
- runner control failure 写入 `lastControlErrorCode`。
- 新 start/stop request、成功收敛、delete cleanup 都会清理旧 error code。
- 初始错误码覆盖：
  - `ACTIVE_POSITIONS_OR_ORDERS`
  - `RUNTIME_LEASE_NOT_ACQUIRED`
  - `CONTROL_OPERATION_IN_PROGRESS`
  - `UNKNOWN`
- API accepted payload 返回 `lastControlErrorCode`。
- CLI `--wait` 失败输出包含 `errorCode` 和 hint。
- Dashboard toast 和 AccountStage error 展示基于 errorCode 给用户下一步建议。

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

新增/覆盖测试：
- stop 非 force + active position 写入 `ACTIVE_POSITIONS_OR_ORDERS`
- 新 force stop request 清理旧 `lastControlErrorCode`
- 成功收敛清理旧 `lastControlErrorCode`
- start 未配置失败落到 `UNKNOWN`
- sentinel error 分类表覆盖 runtime lease/control/account operation

本地验证：

```bash
go test ./internal/service -run 'TestLiveSessionControl|TestScanLiveSessionControl|TestRecoverLiveTradingOnStartupSkipsLiveSessionDesiredStopped'
go test ./internal/http -run 'TestLiveSession'
go test ./cmd/bktrader-ctl
go test ./...
go build ./cmd/platform-api
go build ./cmd/db-migrate
go build ./cmd/bktrader-ctl
cd web/console && ./node_modules/.bin/tsc --noEmit src/pages/AccountStage.tsx --jsx react-jsx --esModuleInterop --target esnext --module esnext --moduleResolution Bundler --allowSyntheticDefaultImports
cd web/console && npm run build
```
