### PR TITLE
[codex] Emit live control config and adapter error codes

### DIFF
--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -2476,21 +2476,21 @@ func (p *Platform) StartLiveSession(sessionID string) (domain.LiveSession, error
 func (p *Platform) startLiveSessionLocked(session domain.LiveSession) (domain.LiveSession, error) {
 	logger := p.logger("service.live", "session_id", session.ID)
 	if strings.EqualFold(session.Status, "DELETED") {
-		return domain.LiveSession{}, fmt.Errorf("live session %s is deleted", session.ID)
+		return domain.LiveSession{}, liveControlConfigErrorf("live session %s is deleted", session.ID)
 	}
 	account, err := p.store.GetAccount(session.AccountID)
 	if err != nil {
-		return domain.LiveSession{}, err
+		return domain.LiveSession{}, wrapLiveControlConfigError(err)
 	}
 	if !strings.EqualFold(account.Mode, "LIVE") {
-		return domain.LiveSession{}, fmt.Errorf("live session %s is not bound to a LIVE account", session.ID)
+		return domain.LiveSession{}, liveControlConfigErrorf("live session %s is not bound to a LIVE account", session.ID)
 	}
 	if account.Status != "CONFIGURED" && account.Status != "READY" {
-		return domain.LiveSession{}, fmt.Errorf("live account %s is not configured", account.ID)
+		return domain.LiveSession{}, liveControlConfigErrorf("live account %s is not configured", account.ID)
 	}
 	if _, _, err := p.resolveLiveAdapterForAccount(account); err != nil {
 		logger.Warn("resolve live adapter failed", "error", err)
-		return domain.LiveSession{}, err
+		return domain.LiveSession{}, wrapLiveControlConfigError(err)
 	}
 	if syncedAccount, reconcileErr := p.triggerAuthoritativeLiveAccountReconcile(account.ID, "historical-takeover-activation", time.Now().UTC()); reconcileErr == nil {
 		account = syncedAccount
@@ -4318,7 +4318,7 @@ func (p *Platform) syncLiveSessionRuntime(session domain.LiveSession) (domain.Li
 		if updateErr != nil {
 			return domain.LiveSession{}, updateErr
 		}
-		return updated, err
+		return updated, wrapLiveControlConfigError(err)
 	}
 
 	requiredBindings := metadataList(plan["requiredBindings"])
@@ -4362,7 +4362,7 @@ func (p *Platform) syncLiveSessionRuntime(session domain.LiveSession) (domain.Li
 				if updateErr != nil {
 					return domain.LiveSession{}, updateErr
 				}
-				return updated, createErr
+				return updated, wrapLiveControlConfigError(createErr)
 			}
 		}
 		runtimeSessionID = runtimeSession.ID
@@ -4382,11 +4382,11 @@ func (p *Platform) ensureLiveSessionSignalRuntimeStarted(session domain.LiveSess
 		return session, nil
 	}
 	if !boolValue(session.State["signalRuntimeReady"]) {
-		return session, fmt.Errorf("live session %s signal runtime plan is not ready", session.ID)
+		return session, liveControlConfigErrorf("live session %s signal runtime plan is not ready", session.ID)
 	}
 	runtimeSessionID := stringValue(session.State["signalRuntimeSessionId"])
 	if runtimeSessionID == "" {
-		return domain.LiveSession{}, fmt.Errorf("live session %s has no linked signal runtime session", session.ID)
+		return domain.LiveSession{}, liveControlConfigErrorf("live session %s has no linked signal runtime session", session.ID)
 	}
 	runtimeSession, err := p.startSignalRuntimeSession(context.Background(), runtimeSessionID)
 	if err != nil {

--- a/internal/service/live_registry.go
+++ b/internal/service/live_registry.go
@@ -1204,7 +1204,7 @@ func fetchBinanceSymbolRules(creds binanceRESTCredentials, symbol string) (binan
 			return binanceSymbolRules{}, err
 		}
 		if strings.HasPrefix(err.Error(), "binance request failed:") {
-			return binanceSymbolRules{}, fmt.Errorf("binance exchangeInfo failed: %s", strings.TrimPrefix(err.Error(), "binance request failed: "))
+			return binanceSymbolRules{}, liveControlAdapterErrorf("binance exchangeInfo failed: %s", strings.TrimPrefix(err.Error(), "binance request failed: "))
 		}
 		return binanceSymbolRules{}, err
 	}
@@ -1386,7 +1386,7 @@ func doBinancePublicGET(baseURL, path string, params map[string]string, category
 func doBinanceSignedRequest(method string, creds binanceRESTCredentials, path string, params map[string]string, category binanceRESTRequestCategory) ([]byte, error) {
 	gate := binanceRESTLimiterState.gate(binanceRESTLimiterKey(creds.BaseURL))
 	if err := gate.acquire(category); err != nil {
-		return nil, err
+		return nil, wrapLiveControlAdapterError(err)
 	}
 	params = cloneStringMap(params)
 	delete(params, "signature")
@@ -1409,7 +1409,7 @@ func doBinanceSignedRequest(method string, creds binanceRESTCredentials, path st
 func doBinanceRESTRequest(method, baseURL, path, query string, headers map[string]string, body io.Reader, category binanceRESTRequestCategory) ([]byte, http.Header, error) {
 	gate := binanceRESTLimiterState.gate(binanceRESTLimiterKey(baseURL))
 	if err := gate.acquire(category); err != nil {
-		return nil, nil, err
+		return nil, nil, wrapLiveControlAdapterError(err)
 	}
 	return doBinanceRESTRequestAfterAcquire(method, baseURL, path, query, headers, body, category, gate)
 }
@@ -1428,12 +1428,12 @@ func doBinanceRESTRequestAfterAcquire(method, baseURL, path, query string, heade
 	}
 	response, err := http.DefaultClient.Do(request)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, wrapLiveControlAdapterError(err)
 	}
 	defer response.Body.Close()
 	responseBody, readErr := io.ReadAll(response.Body)
 	if readErr != nil {
-		return nil, response.Header, readErr
+		return nil, response.Header, wrapLiveControlAdapterError(readErr)
 	}
 	if response.StatusCode == http.StatusTooManyRequests {
 		if gate != nil {
@@ -1441,7 +1441,7 @@ func doBinanceRESTRequestAfterAcquire(method, baseURL, path, query string, heade
 		}
 	}
 	if response.StatusCode < 200 || response.StatusCode >= 300 {
-		return nil, response.Header, fmt.Errorf("binance request failed: %s %s", response.Status, strings.TrimSpace(string(responseBody)))
+		return nil, response.Header, liveControlAdapterErrorf("binance request failed: %s %s", response.Status, strings.TrimSpace(string(responseBody)))
 	}
 	return responseBody, response.Header, nil
 }

--- a/internal/service/live_registry_test.go
+++ b/internal/service/live_registry_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -9,6 +10,38 @@ import (
 	"testing"
 	"time"
 )
+
+func TestDoBinanceRESTRequestClassifiesHTTPFailureAsAdapterError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"code":-2015,"msg":"invalid api-key"}`, http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	previousLimiter := binanceRESTLimiterState
+	previousRate := binanceRESTRequestsPerSecond
+	previousBurst := binanceRESTBurst
+	binanceRESTLimiterState = newBinanceRESTLimiter()
+	binanceRESTRequestsPerSecond = 1000
+	binanceRESTBurst = 10
+	defer func() {
+		binanceRESTLimiterState = previousLimiter
+		binanceRESTRequestsPerSecond = previousRate
+		binanceRESTBurst = previousBurst
+	}()
+
+	_, _, err := doBinancePublicGET(server.URL, "/fapi/v1/exchangeInfo", map[string]string{
+		"symbol": "BTCUSDT",
+	}, binanceRESTCategoryMetadataRead)
+	if err == nil {
+		t.Fatal("expected HTTP failure")
+	}
+	if !errors.Is(err, ErrLiveControlAdapter) {
+		t.Fatalf("expected adapter error sentinel, got %v", err)
+	}
+	if got := liveSessionControlErrorCode(err); got != LiveSessionControlErrorCodeAdapterError {
+		t.Fatalf("expected %s, got %s", LiveSessionControlErrorCodeAdapterError, got)
+	}
+}
 
 func TestDoBinanceSignedRequestBacksOffAfter429(t *testing.T) {
 	var requestCount atomic.Int32

--- a/internal/service/live_session_control.go
+++ b/internal/service/live_session_control.go
@@ -24,6 +24,58 @@ const (
 	LiveSessionControlErrorCodeUnknown                    = "UNKNOWN"
 )
 
+var (
+	ErrLiveControlAdapter = errors.New("live control adapter error")
+	ErrLiveControlConfig  = errors.New("live control configuration error")
+)
+
+type liveControlClassError struct {
+	class error
+	cause error
+}
+
+func (e liveControlClassError) Error() string {
+	if e.cause != nil {
+		return e.cause.Error()
+	}
+	return e.class.Error()
+}
+
+func (e liveControlClassError) Unwrap() []error {
+	if e.cause == nil {
+		return []error{e.class}
+	}
+	return []error{e.class, e.cause}
+}
+
+func liveControlConfigErrorf(format string, args ...any) error {
+	return liveControlClassError{
+		class: ErrLiveControlConfig,
+		cause: fmt.Errorf(format, args...),
+	}
+}
+
+func wrapLiveControlConfigError(err error) error {
+	if err == nil || errors.Is(err, ErrLiveControlConfig) {
+		return err
+	}
+	return liveControlClassError{class: ErrLiveControlConfig, cause: err}
+}
+
+func liveControlAdapterErrorf(format string, args ...any) error {
+	return liveControlClassError{
+		class: ErrLiveControlAdapter,
+		cause: fmt.Errorf(format, args...),
+	}
+}
+
+func wrapLiveControlAdapterError(err error) error {
+	if err == nil || errors.Is(err, ErrLiveControlAdapter) {
+		return err
+	}
+	return liveControlClassError{class: ErrLiveControlAdapter, cause: err}
+}
+
 type liveSessionControlRequest struct {
 	ID      string
 	Version int64
@@ -293,6 +345,10 @@ func liveSessionControlErrorCode(err error) string {
 		return LiveSessionControlErrorCodeRuntimeLeaseNotAcquired
 	case errors.Is(err, ErrLiveControlOperationInProgress), errors.Is(err, ErrLiveAccountOperationInProgress):
 		return LiveSessionControlErrorCodeControlOperationInProgress
+	case errors.Is(err, ErrLiveControlConfig):
+		return LiveSessionControlErrorCodeConfigError
+	case errors.Is(err, ErrLiveControlAdapter):
+		return LiveSessionControlErrorCodeAdapterError
 	default:
 		return LiveSessionControlErrorCodeUnknown
 	}

--- a/internal/service/live_session_control_test.go
+++ b/internal/service/live_session_control_test.go
@@ -309,8 +309,8 @@ func TestScanLiveSessionControlRequestsWritesErrorWithoutRetryingStart(t *testin
 	if got := stringValue(failed.State["lastControlError"]); got == "" {
 		t.Fatal("expected lastControlError")
 	}
-	if got := stringValue(failed.State["lastControlErrorCode"]); got != LiveSessionControlErrorCodeUnknown {
-		t.Fatalf("expected lastControlErrorCode %s, got %s", LiveSessionControlErrorCodeUnknown, got)
+	if got := stringValue(failed.State["lastControlErrorCode"]); got != LiveSessionControlErrorCodeConfigError {
+		t.Fatalf("expected lastControlErrorCode %s, got %s", LiveSessionControlErrorCodeConfigError, got)
 	}
 
 	platform.scanLiveSessionControlRequests(context.Background())
@@ -333,6 +333,8 @@ func TestLiveSessionControlErrorCodeClassification(t *testing.T) {
 		{name: "runtime lease", err: fmt.Errorf("wrapped: %w", ErrRuntimeLeaseNotAcquired), want: LiveSessionControlErrorCodeRuntimeLeaseNotAcquired},
 		{name: "control operation", err: fmt.Errorf("wrapped: %w", ErrLiveControlOperationInProgress), want: LiveSessionControlErrorCodeControlOperationInProgress},
 		{name: "account operation", err: fmt.Errorf("wrapped: %w", ErrLiveAccountOperationInProgress), want: LiveSessionControlErrorCodeControlOperationInProgress},
+		{name: "config", err: wrapLiveControlConfigError(fmt.Errorf("live account is not configured")), want: LiveSessionControlErrorCodeConfigError},
+		{name: "adapter", err: wrapLiveControlAdapterError(fmt.Errorf("binance request failed: 500 Internal Server Error")), want: LiveSessionControlErrorCodeAdapterError},
 		{name: "unknown", err: fmt.Errorf("adapter returned unexpected status"), want: LiveSessionControlErrorCodeUnknown},
 	}
 	for _, tc := range cases {

--- a/internal/service/order.go
+++ b/internal/service/order.go
@@ -1411,15 +1411,15 @@ func latestFillExchangeTradeTime(fills []domain.Fill) time.Time {
 func (p *Platform) resolveLiveAdapterForAccount(account domain.Account) (LiveExecutionAdapter, map[string]any, error) {
 	binding := resolveLiveBinding(account)
 	if len(binding) == 0 {
-		return nil, nil, fmt.Errorf("live account %s has no adapter binding", account.ID)
+		return nil, nil, liveControlConfigErrorf("live account %s has no adapter binding", account.ID)
 	}
 	adapterKey := normalizeLiveAdapterKey(stringValue(binding["adapterKey"]))
 	adapter, ok := p.liveAdapters[adapterKey]
 	if !ok {
-		return nil, nil, fmt.Errorf("live adapter not registered: %s", adapterKey)
+		return nil, nil, liveControlConfigErrorf("live adapter not registered: %s", adapterKey)
 	}
 	if err := adapter.ValidateAccountConfig(binding); err != nil {
-		return nil, nil, err
+		return nil, nil, wrapLiveControlConfigError(err)
 	}
 	return adapter, binding, nil
 }

--- a/internal/service/signal_runtime_sessions.go
+++ b/internal/service/signal_runtime_sessions.go
@@ -320,7 +320,7 @@ func (p *Platform) startSignalRuntimeSession(parent context.Context, sessionID s
 		cancelRunner()
 		p.clearSignalRuntimeRun(sessionID, run)
 		logger.Warn("build signal runtime plan failed", "error", err)
-		return domain.SignalRuntimeSession{}, err
+		return domain.SignalRuntimeSession{}, wrapLiveControlConfigError(err)
 	}
 	if err := ctx.Err(); err != nil {
 		p.clearSignalRuntimeRun(sessionID, run)


### PR DESCRIPTION
## 目的
Phase 3.1 for #282: make the previously reserved LiveSession control error codes actually reachable.

Changes:
- classify LiveSession start-time configuration failures as `CONFIG_ERROR` while preserving the original error message
- classify Binance REST limiter/network/read/non-2xx failures as `ADAPTER_ERROR`
- keep existing safety classifications for active exposure, runtime lease races, and in-progress control operations
- add regression coverage for config classification and adapter HTTP failure classification

Root cause:
`CONFIG_ERROR` and `ADAPTER_ERROR` existed in UI/CLI copy, but the backend classifier only emitted active-exposure, lease, in-progress, or unknown codes.

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [x] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) - No change.
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？ - No.
- [x] DB migration 是否具备向下兼容幂等性？ - No DB migration.
- [x] 配置字段有没有无意被混改？ - No config schema/default changes.

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

Local validation after rebasing onto `main`:
- `go test ./internal/service -run 'TestScanLiveSessionControlRequestsWritesErrorWithoutRetryingStart|TestLiveSessionControlErrorCodeClassification|TestDoBinanceRESTRequestClassifiesHTTPFailureAsAdapterError'`
- `go test ./internal/http -run 'TestLiveSession'`
- `go test ./cmd/bktrader-ctl`
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
- `go build ./cmd/bktrader-ctl`

GitHub CI:
- https://github.com/folgercn/bktrader/actions/runs/25086960941
