### PR TITLE
[codex] persist fill reconciliation source

### DIFF
--- a/db/migrations/028_fill_source.sql
+++ b/db/migrations/028_fill_source.sql
@@ -1,0 +1,29 @@
+alter table fills
+add column if not exists fill_source text;
+
+update fills
+set fill_source = case
+    when exchange_trade_id is not null and btrim(exchange_trade_id) <> '' then 'real'
+    when dedup_fallback_fingerprint is not null and dedup_fallback_fingerprint like 'synthetic-remainder|%' then 'remainder'
+    when dedup_fallback_fingerprint is not null and btrim(dedup_fallback_fingerprint) <> '' then 'synthetic'
+    else 'real'
+end
+where fill_source is null or btrim(fill_source) = '';
+
+alter table fills
+alter column fill_source set default 'real';
+
+alter table fills
+alter column fill_source set not null;
+
+do $$
+begin
+    alter table fills
+    add constraint fills_fill_source_check
+    check (fill_source in ('real', 'synthetic', 'remainder', 'paper', 'manual'));
+exception
+    when duplicate_object then null;
+end $$;
+
+create index if not exists idx_fills_order_fill_source
+on fills (order_id, fill_source);

--- a/internal/domain/models.go
+++ b/internal/domain/models.go
@@ -238,7 +238,7 @@ type Fill struct {
 	ExchangeTradeID   string     `json:"exchangeTradeId,omitempty"`
 	ExchangeTradeTime *time.Time `json:"exchangeTradeTime,omitempty"`
 	DedupFingerprint  string     `json:"-"`
-	// Source is a transient reconciliation hint, not persisted.
+	// Source is an internal reconciliation source stored in fill_source, not exposed by fill JSON.
 	Source    string    `json:"-"`
 	Price     float64   `json:"price"`
 	Quantity  float64   `json:"quantity"`

--- a/internal/service/fill_reconcile.go
+++ b/internal/service/fill_reconcile.go
@@ -268,6 +268,7 @@ func validateFillReconciliationInput(input FillReconciliationInput) (domain.Fill
 	if err := validateFillQuantity(fill); err != nil {
 		return fill, source, err
 	}
+	fill.Source = string(source)
 	return fill, source, nil
 }
 

--- a/internal/service/order.go
+++ b/internal/service/order.go
@@ -1259,6 +1259,14 @@ func fillReconciliationInputsFromIncomingFills(order domain.Order, fills []domai
 }
 
 func fillReconciliationSourceFromStoredFill(fill domain.Fill) (FillSource, bool) {
+	if source := strings.TrimSpace(fill.Source); source != "" {
+		switch FillSource(source) {
+		case FillSourceReal, FillSourceSynthetic, FillSourceRemainder:
+			return FillSource(source), true
+		default:
+			return "", false
+		}
+	}
 	if strings.TrimSpace(fill.ExchangeTradeID) != "" {
 		return FillSourceReal, true
 	}

--- a/internal/store/memory/fill_source_test.go
+++ b/internal/store/memory/fill_source_test.go
@@ -1,0 +1,63 @@
+package memory
+
+import (
+	"testing"
+
+	"github.com/wuyaocheng/bktrader/internal/domain"
+)
+
+func TestCreateFillPersistsExplicitSourceMemory(t *testing.T) {
+	store := NewStore()
+
+	created, err := store.CreateFill(domain.Fill{
+		OrderID:          "order-source-explicit",
+		Source:           "remainder",
+		Price:            68000,
+		Quantity:         0.4,
+		DedupFingerprint: "synthetic-remainder|order-source-explicit|0.400000000000",
+	})
+	if err != nil {
+		t.Fatalf("CreateFill failed: %v", err)
+	}
+	if created.Source != "remainder" {
+		t.Fatalf("expected created source remainder, got %q", created.Source)
+	}
+
+	fills, err := store.ListFills()
+	if err != nil {
+		t.Fatalf("ListFills failed: %v", err)
+	}
+	if len(fills) != 1 || fills[0].Source != "remainder" {
+		t.Fatalf("expected listed fill source remainder, got %+v", fills)
+	}
+}
+
+func TestCreateFillInfersSourceMemory(t *testing.T) {
+	store := NewStore()
+
+	realFill, err := store.CreateFill(domain.Fill{
+		OrderID:         "order-source-infer",
+		ExchangeTradeID: "trade-1",
+		Price:           68000,
+		Quantity:        0.4,
+	})
+	if err != nil {
+		t.Fatalf("CreateFill real failed: %v", err)
+	}
+	if realFill.Source != "real" {
+		t.Fatalf("expected real source, got %q", realFill.Source)
+	}
+
+	syntheticFill, err := store.CreateFill(domain.Fill{
+		OrderID:          "order-source-infer",
+		Price:            68000,
+		Quantity:         0.6,
+		DedupFingerprint: "terminal-filled-order-fallback|order-source-infer",
+	})
+	if err != nil {
+		t.Fatalf("CreateFill synthetic failed: %v", err)
+	}
+	if syntheticFill.Source != "synthetic" {
+		t.Fatalf("expected synthetic source, got %q", syntheticFill.Source)
+	}
+}

--- a/internal/store/memory/store.go
+++ b/internal/store/memory/store.go
@@ -708,6 +708,7 @@ func (s *Store) CreateFill(fill domain.Fill) (domain.Fill, error) {
 			}
 		}
 	}
+	fill.Source = normalizeFillSource(fill)
 	fill.ID = s.nextID("fill")
 	fill.CreatedAt = time.Now().UTC()
 	if fill.ExchangeTradeTime != nil {
@@ -716,6 +717,24 @@ func (s *Store) CreateFill(fill domain.Fill) (domain.Fill, error) {
 	}
 	s.fills[fill.ID] = fill
 	return fill, nil
+}
+
+func normalizeFillSource(fill domain.Fill) string {
+	switch source := strings.TrimSpace(fill.Source); source {
+	case "real", "synthetic", "remainder", "paper", "manual":
+		return source
+	}
+	if strings.TrimSpace(fill.ExchangeTradeID) != "" {
+		return "real"
+	}
+	fingerprint := strings.TrimSpace(fill.DedupFingerprint)
+	if strings.HasPrefix(fingerprint, "synthetic-remainder|") {
+		return "remainder"
+	}
+	if fingerprint != "" {
+		return "synthetic"
+	}
+	return "real"
 }
 
 func (s *Store) DeleteFillsByID(fillIDs []string) (float64, error) {

--- a/internal/store/postgres/fill_source_test.go
+++ b/internal/store/postgres/fill_source_test.go
@@ -1,0 +1,214 @@
+package postgres
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/wuyaocheng/bktrader/internal/domain"
+	storepkg "github.com/wuyaocheng/bktrader/internal/store"
+)
+
+func TestCreateFillPersistsSourcePostgres(t *testing.T) {
+	dsn := os.Getenv("BKTRADER_TEST_POSTGRES_DSN")
+	if dsn == "" {
+		t.Skip("BKTRADER_TEST_POSTGRES_DSN is not set")
+	}
+	if err := Migrate(dsn); err != nil {
+		t.Fatalf("Migrate failed: %v", err)
+	}
+	store, err := New(dsn)
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	defer store.Close()
+
+	account, err := store.GetAccount("paper-default")
+	if err != nil {
+		t.Fatalf("GetAccount failed: %v", err)
+	}
+	order, err := store.CreateOrder(domain.Order{
+		AccountID: account.ID,
+		Symbol:    "BTCUSDT",
+		Side:      "BUY",
+		Type:      "MARKET",
+		Quantity:  1,
+		Price:     68000,
+		Metadata:  map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("CreateOrder failed: %v", err)
+	}
+
+	tradeID := "trade-source-" + time.Now().UTC().Format("20060102150405.000000000")
+	created, err := store.CreateFill(domain.Fill{
+		OrderID:         order.ID,
+		ExchangeTradeID: tradeID,
+		Source:          "real",
+		Price:           68000,
+		Quantity:        0.4,
+	})
+	if err != nil {
+		t.Fatalf("CreateFill failed: %v", err)
+	}
+	if created.Source != "real" {
+		t.Fatalf("expected created source real, got %q", created.Source)
+	}
+
+	fills, err := store.QueryFills(domain.FillQuery{OrderIDs: []string{order.ID}})
+	if err != nil {
+		t.Fatalf("QueryFills failed: %v", err)
+	}
+	if len(fills) != 1 || fills[0].Source != "real" {
+		t.Fatalf("expected queried fill source real, got %+v", fills)
+	}
+}
+
+func TestCreateFillUpsertUpdatesSourcePostgres(t *testing.T) {
+	dsn := os.Getenv("BKTRADER_TEST_POSTGRES_DSN")
+	if dsn == "" {
+		t.Skip("BKTRADER_TEST_POSTGRES_DSN is not set")
+	}
+	if err := Migrate(dsn); err != nil {
+		t.Fatalf("Migrate failed: %v", err)
+	}
+	store, err := New(dsn)
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	defer store.Close()
+
+	account, err := store.GetAccount("paper-default")
+	if err != nil {
+		t.Fatalf("GetAccount failed: %v", err)
+	}
+	order, err := store.CreateOrder(domain.Order{
+		AccountID: account.ID,
+		Symbol:    "BTCUSDT",
+		Side:      "BUY",
+		Type:      "MARKET",
+		Quantity:  1,
+		Price:     68000,
+		Metadata:  map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("CreateOrder failed: %v", err)
+	}
+
+	fingerprint := "source-upsert-" + time.Now().UTC().Format("20060102150405.000000000")
+	if _, err := store.CreateFill(domain.Fill{
+		OrderID:          order.ID,
+		Source:           "synthetic",
+		Price:            68000,
+		Quantity:         0.4,
+		DedupFingerprint: fingerprint,
+	}); err != nil {
+		t.Fatalf("CreateFill synthetic failed: %v", err)
+	}
+	updated, err := store.CreateFill(domain.Fill{
+		OrderID:          order.ID,
+		Source:           "remainder",
+		Price:            68000,
+		Quantity:         0.4,
+		DedupFingerprint: fingerprint,
+	})
+	if err != nil {
+		t.Fatalf("CreateFill remainder upsert failed: %v", err)
+	}
+	if updated.Source != "remainder" {
+		t.Fatalf("expected upserted fallback source remainder, got %q", updated.Source)
+	}
+
+	tradeID := "trade-upsert-" + time.Now().UTC().Format("20060102150405.000000000")
+	if _, err := store.CreateFill(domain.Fill{
+		OrderID:         order.ID,
+		ExchangeTradeID: tradeID,
+		Source:          "real",
+		Price:           68000,
+		Quantity:        0.1,
+	}); err != nil {
+		t.Fatalf("CreateFill real failed: %v", err)
+	}
+	manual, err := store.CreateFill(domain.Fill{
+		OrderID:         order.ID,
+		ExchangeTradeID: tradeID,
+		Source:          "manual",
+		Price:           68000,
+		Quantity:        0.1,
+	})
+	if err != nil {
+		t.Fatalf("CreateFill real source upsert failed: %v", err)
+	}
+	if manual.Source != "manual" {
+		t.Fatalf("expected real upsert source manual, got %q", manual.Source)
+	}
+}
+
+func TestFillSettlementTxCreateFillUpsertUpdatesSourcePostgres(t *testing.T) {
+	dsn := os.Getenv("BKTRADER_TEST_POSTGRES_DSN")
+	if dsn == "" {
+		t.Skip("BKTRADER_TEST_POSTGRES_DSN is not set")
+	}
+	if err := Migrate(dsn); err != nil {
+		t.Fatalf("Migrate failed: %v", err)
+	}
+	store, err := New(dsn)
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	defer store.Close()
+
+	account, err := store.GetAccount("paper-default")
+	if err != nil {
+		t.Fatalf("GetAccount failed: %v", err)
+	}
+	order, err := store.CreateOrder(domain.Order{
+		AccountID: account.ID,
+		Symbol:    "BTCUSDT",
+		Side:      "BUY",
+		Type:      "MARKET",
+		Quantity:  1,
+		Price:     68000,
+		Metadata:  map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("CreateOrder failed: %v", err)
+	}
+
+	fingerprint := "tx-source-upsert-" + time.Now().UTC().Format("20060102150405.000000000")
+	if err := store.WithFillSettlementTx(func(tx storepkg.FillSettlementStore) error {
+		if _, err := tx.CreateFill(domain.Fill{
+			OrderID:          order.ID,
+			Source:           "synthetic",
+			Price:            68000,
+			Quantity:         0.4,
+			DedupFingerprint: fingerprint,
+		}); err != nil {
+			return err
+		}
+		updated, err := tx.CreateFill(domain.Fill{
+			OrderID:          order.ID,
+			Source:           "remainder",
+			Price:            68000,
+			Quantity:         0.4,
+			DedupFingerprint: fingerprint,
+		})
+		if err != nil {
+			return err
+		}
+		if updated.Source != "remainder" {
+			t.Fatalf("expected tx upserted source remainder, got %q", updated.Source)
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("WithFillSettlementTx failed: %v", err)
+	}
+
+	fills, err := store.QueryFills(domain.FillQuery{OrderIDs: []string{order.ID}})
+	if err != nil {
+		t.Fatalf("QueryFills failed: %v", err)
+	}
+	if len(fills) != 1 || fills[0].Source != "remainder" {
+		t.Fatalf("expected persisted tx source remainder, got %+v", fills)
+	}
+}

--- a/internal/store/postgres/store.go
+++ b/internal/store/postgres/store.go
@@ -700,7 +700,7 @@ func (s *Store) UpdateOrder(order domain.Order) (domain.Order, error) {
 
 func (s *Store) ListFills() ([]domain.Fill, error) {
 	rows, err := s.db.Query(`
-		select id, order_id, exchange_trade_id, exchange_trade_time, dedup_fallback_fingerprint, price, quantity, fee, created_at
+		select id, order_id, exchange_trade_id, exchange_trade_time, dedup_fallback_fingerprint, price, quantity, fee, fill_source, created_at
 		from fills order by created_at asc
 	`)
 	if err != nil {
@@ -714,11 +714,13 @@ func (s *Store) ListFills() ([]domain.Fill, error) {
 		var exchangeTradeID sql.NullString
 		var exchangeTradeTime sql.NullTime
 		var fallbackFingerprint sql.NullString
-		if err := rows.Scan(&item.ID, &item.OrderID, &exchangeTradeID, &exchangeTradeTime, &fallbackFingerprint, &item.Price, &item.Quantity, &item.Fee, &item.CreatedAt); err != nil {
+		var fillSource sql.NullString
+		if err := rows.Scan(&item.ID, &item.OrderID, &exchangeTradeID, &exchangeTradeTime, &fallbackFingerprint, &item.Price, &item.Quantity, &item.Fee, &fillSource, &item.CreatedAt); err != nil {
 			return nil, err
 		}
 		item.ExchangeTradeID = exchangeTradeID.String
 		item.DedupFingerprint = fallbackFingerprint.String
+		item.Source = fillSource.String
 		if exchangeTradeTime.Valid {
 			parsed := exchangeTradeTime.Time.UTC()
 			item.ExchangeTradeTime = &parsed
@@ -730,7 +732,7 @@ func (s *Store) ListFills() ([]domain.Fill, error) {
 
 func (s *Store) ListFillsWithLimit(limit, offset int) ([]domain.Fill, error) {
 	query := `
-		select id, order_id, exchange_trade_id, exchange_trade_time, dedup_fallback_fingerprint, price, quantity, fee, created_at
+		select id, order_id, exchange_trade_id, exchange_trade_time, dedup_fallback_fingerprint, price, quantity, fee, fill_source, created_at
 		from fills order by created_at desc
 	`
 	var rows *sql.Rows
@@ -757,11 +759,13 @@ func (s *Store) ListFillsWithLimit(limit, offset int) ([]domain.Fill, error) {
 		var exchangeTradeID sql.NullString
 		var exchangeTradeTime sql.NullTime
 		var fallbackFingerprint sql.NullString
-		if err := rows.Scan(&item.ID, &item.OrderID, &exchangeTradeID, &exchangeTradeTime, &fallbackFingerprint, &item.Price, &item.Quantity, &item.Fee, &item.CreatedAt); err != nil {
+		var fillSource sql.NullString
+		if err := rows.Scan(&item.ID, &item.OrderID, &exchangeTradeID, &exchangeTradeTime, &fallbackFingerprint, &item.Price, &item.Quantity, &item.Fee, &fillSource, &item.CreatedAt); err != nil {
 			return nil, err
 		}
 		item.ExchangeTradeID = exchangeTradeID.String
 		item.DedupFingerprint = fallbackFingerprint.String
+		item.Source = fillSource.String
 		if exchangeTradeTime.Valid {
 			parsed := exchangeTradeTime.Time.UTC()
 			item.ExchangeTradeTime = &parsed
@@ -779,7 +783,7 @@ func (s *Store) CountFills() (int, error) {
 
 func (s *Store) QueryFills(query domain.FillQuery) ([]domain.Fill, error) {
 	sqlQuery := `
-		select id, order_id, exchange_trade_id, exchange_trade_time, dedup_fallback_fingerprint, price, quantity, fee, created_at
+		select id, order_id, exchange_trade_id, exchange_trade_time, dedup_fallback_fingerprint, price, quantity, fee, fill_source, created_at
 		from fills
 	`
 	args := []any{}
@@ -805,11 +809,13 @@ func (s *Store) QueryFills(query domain.FillQuery) ([]domain.Fill, error) {
 		var exchangeTradeID sql.NullString
 		var exchangeTradeTime sql.NullTime
 		var fallbackFingerprint sql.NullString
-		if err := rows.Scan(&item.ID, &item.OrderID, &exchangeTradeID, &exchangeTradeTime, &fallbackFingerprint, &item.Price, &item.Quantity, &item.Fee, &item.CreatedAt); err != nil {
+		var fillSource sql.NullString
+		if err := rows.Scan(&item.ID, &item.OrderID, &exchangeTradeID, &exchangeTradeTime, &fallbackFingerprint, &item.Price, &item.Quantity, &item.Fee, &fillSource, &item.CreatedAt); err != nil {
 			return nil, err
 		}
 		item.ExchangeTradeID = exchangeTradeID.String
 		item.DedupFingerprint = fallbackFingerprint.String
+		item.Source = fillSource.String
 		if exchangeTradeTime.Valid {
 			parsed := exchangeTradeTime.Time.UTC()
 			item.ExchangeTradeTime = &parsed
@@ -844,22 +850,25 @@ func (s *Store) CreateFill(fill domain.Fill) (domain.Fill, error) {
 			fill.DedupFingerprint = fill.FallbackFingerprint()
 		}
 	}
+	fill.Source = normalizeFillSource(fill)
 
 	if strings.TrimSpace(fill.ExchangeTradeID) == "" {
 		row := s.db.QueryRow(`
-			insert into fills (id, order_id, exchange_trade_id, exchange_trade_time, dedup_fallback_fingerprint, price, quantity, fee, created_at)
-			values ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+			insert into fills (id, order_id, exchange_trade_id, exchange_trade_time, dedup_fallback_fingerprint, price, quantity, fee, fill_source, created_at)
+			values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
 			on conflict (order_id, dedup_fallback_fingerprint) do update set
 				price = fills.price,
 				quantity = fills.quantity,
 				fee = fills.fee,
+				fill_source = excluded.fill_source,
 				exchange_trade_time = coalesce(fills.exchange_trade_time, excluded.exchange_trade_time)
-			returning id, order_id, exchange_trade_id, exchange_trade_time, dedup_fallback_fingerprint, price, quantity, fee, created_at
-		`, fill.ID, fill.OrderID, nullIfEmpty(fill.ExchangeTradeID), fill.ExchangeTradeTime, fill.DedupFingerprint, fill.Price, fill.Quantity, fill.Fee, fill.CreatedAt)
+			returning id, order_id, exchange_trade_id, exchange_trade_time, dedup_fallback_fingerprint, price, quantity, fee, fill_source, created_at
+		`, fill.ID, fill.OrderID, nullIfEmpty(fill.ExchangeTradeID), fill.ExchangeTradeTime, fill.DedupFingerprint, fill.Price, fill.Quantity, fill.Fee, fill.Source, fill.CreatedAt)
 		var (
 			exchangeTradeID     sql.NullString
 			exchangeTradeTime   sql.NullTime
 			fallbackFingerprint sql.NullString
+			fillSource          sql.NullString
 		)
 		err := row.Scan(
 			&fill.ID,
@@ -870,10 +879,12 @@ func (s *Store) CreateFill(fill domain.Fill) (domain.Fill, error) {
 			&fill.Price,
 			&fill.Quantity,
 			&fill.Fee,
+			&fillSource,
 			&fill.CreatedAt,
 		)
 		fill.ExchangeTradeID = exchangeTradeID.String
 		fill.DedupFingerprint = fallbackFingerprint.String
+		fill.Source = fillSource.String
 		if exchangeTradeTime.Valid {
 			parsed := exchangeTradeTime.Time.UTC()
 			fill.ExchangeTradeTime = &parsed
@@ -884,19 +895,21 @@ func (s *Store) CreateFill(fill domain.Fill) (domain.Fill, error) {
 	}
 
 	row := s.db.QueryRow(`
-		insert into fills (id, order_id, exchange_trade_id, exchange_trade_time, dedup_fallback_fingerprint, price, quantity, fee, created_at)
-		values ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+		insert into fills (id, order_id, exchange_trade_id, exchange_trade_time, dedup_fallback_fingerprint, price, quantity, fee, fill_source, created_at)
+		values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
 		on conflict (order_id, exchange_trade_id) do update set
 			price = fills.price,
 			quantity = fills.quantity,
 			fee = fills.fee,
+			fill_source = excluded.fill_source,
 			exchange_trade_time = coalesce(fills.exchange_trade_time, excluded.exchange_trade_time)
-		returning id, order_id, exchange_trade_id, exchange_trade_time, dedup_fallback_fingerprint, price, quantity, fee, created_at
-	`, fill.ID, fill.OrderID, fill.ExchangeTradeID, fill.ExchangeTradeTime, nil, fill.Price, fill.Quantity, fill.Fee, fill.CreatedAt)
+		returning id, order_id, exchange_trade_id, exchange_trade_time, dedup_fallback_fingerprint, price, quantity, fee, fill_source, created_at
+	`, fill.ID, fill.OrderID, fill.ExchangeTradeID, fill.ExchangeTradeTime, nil, fill.Price, fill.Quantity, fill.Fee, fill.Source, fill.CreatedAt)
 	var (
 		exchangeTradeID     sql.NullString
 		exchangeTradeTime   sql.NullTime
 		fallbackFingerprint sql.NullString
+		fillSource          sql.NullString
 	)
 	err := row.Scan(
 		&fill.ID,
@@ -907,10 +920,12 @@ func (s *Store) CreateFill(fill domain.Fill) (domain.Fill, error) {
 		&fill.Price,
 		&fill.Quantity,
 		&fill.Fee,
+		&fillSource,
 		&fill.CreatedAt,
 	)
 	fill.ExchangeTradeID = exchangeTradeID.String
 	fill.DedupFingerprint = fallbackFingerprint.String
+	fill.Source = fillSource.String
 	if exchangeTradeTime.Valid {
 		parsed := exchangeTradeTime.Time.UTC()
 		fill.ExchangeTradeTime = &parsed
@@ -968,11 +983,30 @@ type fillScanner interface {
 	Scan(dest ...any) error
 }
 
+func normalizeFillSource(fill domain.Fill) string {
+	switch source := strings.TrimSpace(fill.Source); source {
+	case "real", "synthetic", "remainder", "paper", "manual":
+		return source
+	}
+	if strings.TrimSpace(fill.ExchangeTradeID) != "" {
+		return "real"
+	}
+	fingerprint := strings.TrimSpace(fill.DedupFingerprint)
+	if strings.HasPrefix(fingerprint, "synthetic-remainder|") {
+		return "remainder"
+	}
+	if fingerprint != "" {
+		return "synthetic"
+	}
+	return "real"
+}
+
 func scanFill(row fillScanner, fill domain.Fill) (domain.Fill, error) {
 	var (
 		exchangeTradeID     sql.NullString
 		exchangeTradeTime   sql.NullTime
 		fallbackFingerprint sql.NullString
+		fillSource          sql.NullString
 	)
 	err := row.Scan(
 		&fill.ID,
@@ -983,10 +1017,12 @@ func scanFill(row fillScanner, fill domain.Fill) (domain.Fill, error) {
 		&fill.Price,
 		&fill.Quantity,
 		&fill.Fee,
+		&fillSource,
 		&fill.CreatedAt,
 	)
 	fill.ExchangeTradeID = exchangeTradeID.String
 	fill.DedupFingerprint = fallbackFingerprint.String
+	fill.Source = fillSource.String
 	if exchangeTradeTime.Valid {
 		parsed := exchangeTradeTime.Time.UTC()
 		fill.ExchangeTradeTime = &parsed
@@ -1034,31 +1070,34 @@ func (s fillSettlementTxStore) CreateFill(fill domain.Fill) (domain.Fill, error)
 			fill.DedupFingerprint = fill.FallbackFingerprint()
 		}
 	}
+	fill.Source = normalizeFillSource(fill)
 
 	if strings.TrimSpace(fill.ExchangeTradeID) == "" {
 		row := s.tx.QueryRow(`
-			insert into fills (id, order_id, exchange_trade_id, exchange_trade_time, dedup_fallback_fingerprint, price, quantity, fee, created_at)
-			values ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+			insert into fills (id, order_id, exchange_trade_id, exchange_trade_time, dedup_fallback_fingerprint, price, quantity, fee, fill_source, created_at)
+			values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
 			on conflict (order_id, dedup_fallback_fingerprint) do update set
 				price = fills.price,
 				quantity = fills.quantity,
 				fee = fills.fee,
+				fill_source = excluded.fill_source,
 				exchange_trade_time = coalesce(fills.exchange_trade_time, excluded.exchange_trade_time)
-			returning id, order_id, exchange_trade_id, exchange_trade_time, dedup_fallback_fingerprint, price, quantity, fee, created_at
-		`, fill.ID, fill.OrderID, nullIfEmpty(fill.ExchangeTradeID), fill.ExchangeTradeTime, fill.DedupFingerprint, fill.Price, fill.Quantity, fill.Fee, fill.CreatedAt)
+			returning id, order_id, exchange_trade_id, exchange_trade_time, dedup_fallback_fingerprint, price, quantity, fee, fill_source, created_at
+		`, fill.ID, fill.OrderID, nullIfEmpty(fill.ExchangeTradeID), fill.ExchangeTradeTime, fill.DedupFingerprint, fill.Price, fill.Quantity, fill.Fee, fill.Source, fill.CreatedAt)
 		return scanFill(row, fill)
 	}
 
 	row := s.tx.QueryRow(`
-		insert into fills (id, order_id, exchange_trade_id, exchange_trade_time, dedup_fallback_fingerprint, price, quantity, fee, created_at)
-		values ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+		insert into fills (id, order_id, exchange_trade_id, exchange_trade_time, dedup_fallback_fingerprint, price, quantity, fee, fill_source, created_at)
+		values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
 		on conflict (order_id, exchange_trade_id) do update set
 			price = fills.price,
 			quantity = fills.quantity,
 			fee = fills.fee,
+			fill_source = excluded.fill_source,
 			exchange_trade_time = coalesce(fills.exchange_trade_time, excluded.exchange_trade_time)
-		returning id, order_id, exchange_trade_id, exchange_trade_time, dedup_fallback_fingerprint, price, quantity, fee, created_at
-	`, fill.ID, fill.OrderID, fill.ExchangeTradeID, fill.ExchangeTradeTime, nil, fill.Price, fill.Quantity, fill.Fee, fill.CreatedAt)
+		returning id, order_id, exchange_trade_id, exchange_trade_time, dedup_fallback_fingerprint, price, quantity, fee, fill_source, created_at
+	`, fill.ID, fill.OrderID, fill.ExchangeTradeID, fill.ExchangeTradeTime, nil, fill.Price, fill.Quantity, fill.Fee, fill.Source, fill.CreatedAt)
 	return scanFill(row, fill)
 }
 


### PR DESCRIPTION
## 目的
为 #272 阶段 5 增加持久化 fill source 标记，避免 stored fill 继续只依赖 `exchange_trade_id` / `dedup_fallback_fingerprint` 推断 real / synthetic / remainder。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [x] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) - 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？- 无
- [x] DB migration 是否具备向下兼容幂等性？- `add column if not exists` / idempotent index / duplicate constraint guarded
- [x] 配置字段有没有无意被混改？- 无配置改动

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

验证已跑：

```bash
go test ./internal/store/memory ./internal/store/postgres ./internal/service -run 'TestCreateFill.*Source|TestBuildFillReconciliationPlan|TestSyntheticUpgrade|TestFinalizeExecutedOrder|TestBuildLiveSyncSettlement|TestBinanceTradeReportsSetRealFillSource' -count=1
go test ./...
go build ./cmd/platform-api
go build ./cmd/db-migrate
python3 scripts/check_migration_safety.py
bash scripts/check_high_risk_defaults.sh
```

说明：`check_migration_safety.py` 只报既有历史 migration 编号重复 `018` / `024`，本 PR 新增 `028_fill_source.sql` 未引入新重复编号。
