### PR TITLE
[codex] Add signal runtime restart control API

### DIFF
--- a/cmd/bktrader-ctl/runtime.go
+++ b/cmd/bktrader-ctl/runtime.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -13,6 +14,7 @@ func init() {
 	runtimeRestartCmd.Flags().String("kind", "signal", "runtime 类型 (signal)")
 	runtimeRestartCmd.Flags().Bool("force", false, "强制重启 signal runtime")
 	runtimeRestartCmd.Flags().Bool("confirm", false, "确认执行重启操作")
+	runtimeRestartCmd.Flags().String("reason", "", "重启原因；--force 时必填")
 }
 
 var runtimeCmd = &cobra.Command{
@@ -42,10 +44,16 @@ var runtimeRestartCmd = &cobra.Command{
 		}
 		kind, _ := cmd.Flags().GetString("kind")
 		force, _ := cmd.Flags().GetBool("force")
+		reason, _ := cmd.Flags().GetString("reason")
+		if force && strings.TrimSpace(reason) == "" && !dryRun {
+			return fmt.Errorf("--force 需要提供 --reason")
+		}
 		payload := map[string]any{
 			"runtimeId":   args[0],
 			"runtimeKind": kind,
 			"force":       force,
+			"confirm":     confirm,
+			"reason":      reason,
 		}
 		client := getClient()
 		resp, err := client.Request("POST", "/api/v1/runtime/restart", payload)

--- a/cmd/bktrader-ctl/runtime.go
+++ b/cmd/bktrader-ctl/runtime.go
@@ -1,10 +1,18 @@
 package main
 
-import "github.com/spf13/cobra"
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
 
 func init() {
 	runtimeCmd.AddCommand(runtimeStatusCmd)
+	runtimeCmd.AddCommand(runtimeRestartCmd)
 	rootCmd.AddCommand(runtimeCmd)
+	runtimeRestartCmd.Flags().String("kind", "signal", "runtime 类型 (signal)")
+	runtimeRestartCmd.Flags().Bool("force", false, "强制重启 signal runtime")
+	runtimeRestartCmd.Flags().Bool("confirm", false, "确认执行重启操作")
 }
 
 var runtimeCmd = &cobra.Command{
@@ -18,6 +26,29 @@ var runtimeStatusCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		client := getClient()
 		resp, err := client.Request("GET", "/api/v1/runtime/status", nil)
+		handleResponse(resp, err)
+		return nil
+	},
+}
+
+var runtimeRestartCmd = &cobra.Command{
+	Use:   "restart <runtimeId>",
+	Short: "重启 runtime [MUTATING]",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		confirm, _ := cmd.Flags().GetBool("confirm")
+		if !confirm && !dryRun {
+			return fmt.Errorf("操作需要 --confirm 确认")
+		}
+		kind, _ := cmd.Flags().GetString("kind")
+		force, _ := cmd.Flags().GetBool("force")
+		payload := map[string]any{
+			"runtimeId":   args[0],
+			"runtimeKind": kind,
+			"force":       force,
+		}
+		client := getClient()
+		resp, err := client.Request("POST", "/api/v1/runtime/restart", payload)
 		handleResponse(resp, err)
 		return nil
 	},

--- a/docs/runtime-supervisor.md
+++ b/docs/runtime-supervisor.md
@@ -243,7 +243,7 @@ POST /runtime/resume-auto-restart
 - `start` / `restart` 只能写入期望状态或触发应用内恢复，不得绕过业务安全校验。
 - `stop` 必须写入 `desiredStatus=STOPPED`，使 scanner 和 supervisor 不再自动拉起。
 - `resume-auto-restart` 只能解除 suppressed，不代表立即允许交易。
-- 当前统一控制 API 的第一步只落 `POST /api/v1/runtime/restart`，且只支持 `runtimeKind=signal`；它复用现有 signal runtime stop/start 安全检查，不做 live session 自动 dispatch，也不做 Docker/container restart。
+- 当前统一控制 API 的第一步只落 `POST /api/v1/runtime/restart`，且只支持 `runtimeKind=signal`；请求必须显式传入 `confirm=true`，`force=true` 时必须传入非空 `reason` 并写入 runtime state 审计字段。该接口复用现有 signal runtime stop/start 安全检查，不做 live session 自动 dispatch，也不做 Docker/container restart。
 
 ## 6. 推进阶段
 

--- a/docs/runtime-supervisor.md
+++ b/docs/runtime-supervisor.md
@@ -243,6 +243,7 @@ POST /runtime/resume-auto-restart
 - `start` / `restart` 只能写入期望状态或触发应用内恢复，不得绕过业务安全校验。
 - `stop` 必须写入 `desiredStatus=STOPPED`，使 scanner 和 supervisor 不再自动拉起。
 - `resume-auto-restart` 只能解除 suppressed，不代表立即允许交易。
+- 当前统一控制 API 的第一步只落 `POST /api/v1/runtime/restart`，且只支持 `runtimeKind=signal`；它复用现有 signal runtime stop/start 安全检查，不做 live session 自动 dispatch，也不做 Docker/container restart。
 
 ## 6. 推进阶段
 

--- a/internal/http/registry.go
+++ b/internal/http/registry.go
@@ -16,6 +16,7 @@ var APIRegistry = []RouteEntry{
 	{Path: "/healthz", Methods: []string{"GET"}, Module: "system", CLICommand: "status", Idempotent: true, RiskLevel: "L0"},
 	{Path: "/api/v1/overview", Methods: []string{"GET"}, Module: "system", CLICommand: "status", Idempotent: true, RiskLevel: "L0"},
 	{Path: "/api/v1/runtime/status", Methods: []string{"GET"}, Module: "runtime", CLICommand: "runtime status", Idempotent: true, RiskLevel: "L0"},
+	{Path: "/api/v1/runtime/restart", Methods: []string{"POST"}, Module: "runtime", CLICommand: "runtime restart", Idempotent: false, RiskLevel: "L1"},
 	{Path: "/api/v1/supervisor/status", Methods: []string{"GET"}, Module: "supervisor", CLICommand: "supervisor status", Idempotent: true, RiskLevel: "L0"},
 
 	// Auth

--- a/internal/http/router.go
+++ b/internal/http/router.go
@@ -38,6 +38,7 @@ func NewRouter(cfg config.Config, platform *service.Platform) http.Handler {
 	registerLogRoutes(mux, platform)
 	registerStreamRoutes(mux, platform, cfg)
 	registerRuntimeStatusRoutes(mux, platform, cfg)
+	registerRuntimeControlRoutes(mux, platform, cfg)
 	registerSupervisorStatusRoutes(mux, platform)
 
 	// 系统概览端点

--- a/internal/http/runtime_control.go
+++ b/internal/http/runtime_control.go
@@ -13,6 +13,8 @@ type runtimeRestartRequest struct {
 	RuntimeID   string `json:"runtimeId"`
 	RuntimeKind string `json:"runtimeKind"`
 	Force       bool   `json:"force"`
+	Confirm     bool   `json:"confirm"`
+	Reason      string `json:"reason,omitempty"`
 }
 
 func registerRuntimeControlRoutes(mux *http.ServeMux, platform *service.Platform, cfg config.Config) {
@@ -35,9 +37,22 @@ func registerRuntimeControlRoutes(mux *http.ServeMux, platform *service.Platform
 			writeError(w, http.StatusBadRequest, "runtimeId is required")
 			return
 		}
+		if !request.Confirm {
+			writeError(w, http.StatusBadRequest, "confirm=true is required for runtime restart")
+			return
+		}
+		reason := strings.TrimSpace(request.Reason)
+		if request.Force && reason == "" {
+			writeError(w, http.StatusBadRequest, "reason is required when force=true")
+			return
+		}
 		switch strings.ToLower(strings.TrimSpace(request.RuntimeKind)) {
 		case "signal", "signal-runtime":
-			item, err := platform.RestartSignalRuntimeSessionWithForce(runtimeID, request.Force)
+			item, err := platform.RestartSignalRuntimeSessionWithOptions(runtimeID, service.SignalRuntimeRestartOptions{
+				Force:  request.Force,
+				Reason: reason,
+				Source: "api",
+			})
 			if err != nil {
 				writeRuntimeControlError(w, err)
 				return
@@ -49,6 +64,8 @@ func registerRuntimeControlRoutes(mux *http.ServeMux, platform *service.Platform
 				"runtimeKind":   "signal",
 				"desiredStatus": item.State["desiredStatus"],
 				"actualStatus":  item.State["actualStatus"],
+				"force":         request.Force,
+				"reason":        reason,
 				"runtime":       item,
 			})
 		case "":

--- a/internal/http/runtime_control.go
+++ b/internal/http/runtime_control.go
@@ -1,0 +1,73 @@
+package http
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/wuyaocheng/bktrader/internal/config"
+	"github.com/wuyaocheng/bktrader/internal/service"
+)
+
+type runtimeRestartRequest struct {
+	RuntimeID   string `json:"runtimeId"`
+	RuntimeKind string `json:"runtimeKind"`
+	Force       bool   `json:"force"`
+}
+
+func registerRuntimeControlRoutes(mux *http.ServeMux, platform *service.Platform, cfg config.Config) {
+	mux.HandleFunc("/api/v1/runtime/restart", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		if !cfg.RuntimeActionsEnabled() {
+			writeError(w, http.StatusConflict, "runtime action restart is disabled for BKTRADER_ROLE="+cfg.ProcessRole)
+			return
+		}
+		var request runtimeRestartRequest
+		if err := decodeJSON(r, &request); err != nil {
+			writeError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		runtimeID := strings.TrimSpace(request.RuntimeID)
+		if runtimeID == "" {
+			writeError(w, http.StatusBadRequest, "runtimeId is required")
+			return
+		}
+		switch strings.ToLower(strings.TrimSpace(request.RuntimeKind)) {
+		case "signal", "signal-runtime":
+			item, err := platform.RestartSignalRuntimeSessionWithForce(runtimeID, request.Force)
+			if err != nil {
+				writeRuntimeControlError(w, err)
+				return
+			}
+			writeJSON(w, http.StatusAccepted, map[string]any{
+				"status":        "accepted",
+				"message":       "runtime restart intent accepted; execution is asynchronous and must be confirmed through actualStatus",
+				"runtimeId":     item.ID,
+				"runtimeKind":   "signal",
+				"desiredStatus": item.State["desiredStatus"],
+				"actualStatus":  item.State["actualStatus"],
+				"runtime":       item,
+			})
+		case "":
+			writeError(w, http.StatusBadRequest, "runtimeKind is required")
+		default:
+			writeError(w, http.StatusBadRequest, "unsupported runtimeKind: "+request.RuntimeKind)
+		}
+	})
+}
+
+func writeRuntimeControlError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, service.ErrLiveControlOperationInProgress),
+		errors.Is(err, service.ErrLiveAccountOperationInProgress),
+		errors.Is(err, service.ErrRuntimeLeaseNotAcquired):
+		writeError(w, http.StatusConflict, err.Error())
+	case errors.Is(err, service.ErrActivePositionsOrOrders):
+		writeError(w, http.StatusBadRequest, err.Error())
+	default:
+		writeError(w, http.StatusBadRequest, err.Error())
+	}
+}

--- a/internal/http/runtime_control_test.go
+++ b/internal/http/runtime_control_test.go
@@ -1,0 +1,77 @@
+package http
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/wuyaocheng/bktrader/internal/config"
+	"github.com/wuyaocheng/bktrader/internal/service"
+	"github.com/wuyaocheng/bktrader/internal/store/memory"
+)
+
+func TestRuntimeRestartRouteAcceptsSignalRuntimeRestart(t *testing.T) {
+	platform := service.NewPlatform(memory.NewStore())
+	runtimeSession, err := platform.CreateSignalRuntimeSession("live-main", "strategy-bk-1d")
+	if err != nil {
+		t.Fatalf("CreateSignalRuntimeSession failed: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	registerRuntimeControlRoutes(mux, platform, config.Config{ProcessRole: "monolith"})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/runtime/restart", strings.NewReader(`{"runtimeId":"`+runtimeSession.ID+`","runtimeKind":"signal","force":true}`))
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	var payload struct {
+		Status        string `json:"status"`
+		RuntimeID     string `json:"runtimeId"`
+		RuntimeKind   string `json:"runtimeKind"`
+		DesiredStatus string `json:"desiredStatus"`
+		ActualStatus  string `json:"actualStatus"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode response failed: %v", err)
+	}
+	if payload.Status != "accepted" || payload.RuntimeID != runtimeSession.ID || payload.RuntimeKind != "signal" {
+		t.Fatalf("unexpected restart response: %+v", payload)
+	}
+	if payload.DesiredStatus != "RUNNING" {
+		t.Fatalf("expected desiredStatus RUNNING, got %s", payload.DesiredStatus)
+	}
+	if payload.ActualStatus != "STARTING" && payload.ActualStatus != "RUNNING" {
+		t.Fatalf("expected actualStatus STARTING/RUNNING, got %s", payload.ActualStatus)
+	}
+	if _, err := platform.StopSignalRuntimeSessionWithForce(runtimeSession.ID, true); err != nil {
+		t.Fatalf("cleanup runtime failed: %v", err)
+	}
+}
+
+func TestRuntimeRestartRouteRejectsDisabledRuntimeActions(t *testing.T) {
+	mux := http.NewServeMux()
+	registerRuntimeControlRoutes(mux, service.NewPlatform(memory.NewStore()), config.Config{ProcessRole: "supervisor"})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/runtime/restart", strings.NewReader(`{"runtimeId":"runtime-1","runtimeKind":"signal"}`))
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestRuntimeRestartRouteRejectsUnsupportedRuntimeKind(t *testing.T) {
+	mux := http.NewServeMux()
+	registerRuntimeControlRoutes(mux, service.NewPlatform(memory.NewStore()), config.Config{ProcessRole: "monolith"})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/runtime/restart", strings.NewReader(`{"runtimeId":"runtime-1","runtimeKind":"live-session"}`))
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d body=%s", rec.Code, rec.Body.String())
+	}
+}

--- a/internal/http/runtime_control_test.go
+++ b/internal/http/runtime_control_test.go
@@ -23,7 +23,7 @@ func TestRuntimeRestartRouteAcceptsSignalRuntimeRestart(t *testing.T) {
 	registerRuntimeControlRoutes(mux, platform, config.Config{ProcessRole: "monolith"})
 
 	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/runtime/restart", strings.NewReader(`{"runtimeId":"`+runtimeSession.ID+`","runtimeKind":"signal","force":true}`))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/runtime/restart", strings.NewReader(`{"runtimeId":"`+runtimeSession.ID+`","runtimeKind":"signal","force":true,"confirm":true,"reason":"operator requested rebinding"}`))
 	mux.ServeHTTP(rec, req)
 	if rec.Code != http.StatusAccepted {
 		t.Fatalf("expected 202, got %d body=%s", rec.Code, rec.Body.String())
@@ -34,6 +34,8 @@ func TestRuntimeRestartRouteAcceptsSignalRuntimeRestart(t *testing.T) {
 		RuntimeKind   string `json:"runtimeKind"`
 		DesiredStatus string `json:"desiredStatus"`
 		ActualStatus  string `json:"actualStatus"`
+		Force         bool   `json:"force"`
+		Reason        string `json:"reason"`
 	}
 	if err := json.NewDecoder(rec.Body).Decode(&payload); err != nil {
 		t.Fatalf("decode response failed: %v", err)
@@ -47,8 +49,63 @@ func TestRuntimeRestartRouteAcceptsSignalRuntimeRestart(t *testing.T) {
 	if payload.ActualStatus != "STARTING" && payload.ActualStatus != "RUNNING" {
 		t.Fatalf("expected actualStatus STARTING/RUNNING, got %s", payload.ActualStatus)
 	}
+	if !payload.Force || payload.Reason != "operator requested rebinding" {
+		t.Fatalf("expected force/reason echoed, got %+v", payload)
+	}
+	stored, err := platform.GetSignalRuntimeSession(runtimeSession.ID)
+	if err != nil {
+		t.Fatalf("GetSignalRuntimeSession failed: %v", err)
+	}
+	if got := stored.State["restartRequestedForce"]; got != true {
+		t.Fatalf("expected restartRequestedForce true, got %#v", got)
+	}
+	if got := stored.State["restartRequestedReason"]; got != "operator requested rebinding" {
+		t.Fatalf("expected restartRequestedReason, got %#v", got)
+	}
+	if got := stored.State["restartRequestedSource"]; got != "api" {
+		t.Fatalf("expected restartRequestedSource api, got %#v", got)
+	}
+	if got := stored.State["restartRequestedAt"]; got == "" {
+		t.Fatalf("expected restartRequestedAt, got %#v", got)
+	}
 	if _, err := platform.StopSignalRuntimeSessionWithForce(runtimeSession.ID, true); err != nil {
 		t.Fatalf("cleanup runtime failed: %v", err)
+	}
+}
+
+func TestRuntimeRestartRouteRequiresConfirm(t *testing.T) {
+	platform := service.NewPlatform(memory.NewStore())
+	runtimeSession, err := platform.CreateSignalRuntimeSession("live-main", "strategy-bk-1d")
+	if err != nil {
+		t.Fatalf("CreateSignalRuntimeSession failed: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	registerRuntimeControlRoutes(mux, platform, config.Config{ProcessRole: "monolith"})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/runtime/restart", strings.NewReader(`{"runtimeId":"`+runtimeSession.ID+`","runtimeKind":"signal"}`))
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestRuntimeRestartRouteRequiresReasonForForce(t *testing.T) {
+	platform := service.NewPlatform(memory.NewStore())
+	runtimeSession, err := platform.CreateSignalRuntimeSession("live-main", "strategy-bk-1d")
+	if err != nil {
+		t.Fatalf("CreateSignalRuntimeSession failed: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	registerRuntimeControlRoutes(mux, platform, config.Config{ProcessRole: "monolith"})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/runtime/restart", strings.NewReader(`{"runtimeId":"`+runtimeSession.ID+`","runtimeKind":"signal","confirm":true,"force":true}`))
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d body=%s", rec.Code, rec.Body.String())
 	}
 }
 
@@ -57,7 +114,7 @@ func TestRuntimeRestartRouteRejectsDisabledRuntimeActions(t *testing.T) {
 	registerRuntimeControlRoutes(mux, service.NewPlatform(memory.NewStore()), config.Config{ProcessRole: "supervisor"})
 
 	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/runtime/restart", strings.NewReader(`{"runtimeId":"runtime-1","runtimeKind":"signal"}`))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/runtime/restart", strings.NewReader(`{"runtimeId":"runtime-1","runtimeKind":"signal","confirm":true}`))
 	mux.ServeHTTP(rec, req)
 	if rec.Code != http.StatusConflict {
 		t.Fatalf("expected 409, got %d body=%s", rec.Code, rec.Body.String())
@@ -69,7 +126,7 @@ func TestRuntimeRestartRouteRejectsUnsupportedRuntimeKind(t *testing.T) {
 	registerRuntimeControlRoutes(mux, service.NewPlatform(memory.NewStore()), config.Config{ProcessRole: "monolith"})
 
 	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/runtime/restart", strings.NewReader(`{"runtimeId":"runtime-1","runtimeKind":"live-session"}`))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/runtime/restart", strings.NewReader(`{"runtimeId":"runtime-1","runtimeKind":"live-session","confirm":true}`))
 	mux.ServeHTTP(rec, req)
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d body=%s", rec.Code, rec.Body.String())

--- a/internal/service/signal_runtime_sessions.go
+++ b/internal/service/signal_runtime_sessions.go
@@ -22,6 +22,8 @@ type signalRuntimeRun struct {
 	releaseOnce  sync.Once
 }
 
+const liveControlOperationSignalRuntimeRestart liveControlOperationKind = "signal-runtime-restart"
+
 func (r *signalRuntimeRun) releaseRuntimeLease() {
 	if r == nil || r.releaseLease == nil {
 		return
@@ -392,6 +394,35 @@ func (p *Platform) startSignalRuntimeSession(parent context.Context, sessionID s
 
 func (p *Platform) StopSignalRuntimeSession(sessionID string) (domain.SignalRuntimeSession, error) {
 	return p.StopSignalRuntimeSessionWithForce(sessionID, false)
+}
+
+func (p *Platform) RestartSignalRuntimeSession(sessionID string) (domain.SignalRuntimeSession, error) {
+	return p.RestartSignalRuntimeSessionWithForce(sessionID, false)
+}
+
+func (p *Platform) RestartSignalRuntimeSessionWithForce(sessionID string, force bool) (domain.SignalRuntimeSession, error) {
+	existing, err := p.GetSignalRuntimeSession(sessionID)
+	if err != nil {
+		return domain.SignalRuntimeSession{}, err
+	}
+	requested := liveControlOperationInfo{
+		Operation:        liveControlOperationSignalRuntimeRestart,
+		AccountID:        existing.AccountID,
+		StrategyID:       existing.StrategyID,
+		RuntimeSessionID: existing.ID,
+	}
+	release, acquired, current, lockErr := p.tryStartLiveControlOperation(requested)
+	if lockErr != nil {
+		return domain.SignalRuntimeSession{}, lockErr
+	}
+	if !acquired {
+		return domain.SignalRuntimeSession{}, liveControlOperationInProgressError(requested, current)
+	}
+	defer release()
+	if _, err := p.stopSignalRuntimeSessionWithForceLocked(existing, force); err != nil {
+		return domain.SignalRuntimeSession{}, err
+	}
+	return p.startSignalRuntimeSession(context.Background(), existing.ID)
 }
 
 func (p *Platform) StopSignalRuntimeSessionWithForce(sessionID string, force bool) (domain.SignalRuntimeSession, error) {

--- a/internal/service/signal_runtime_sessions.go
+++ b/internal/service/signal_runtime_sessions.go
@@ -24,6 +24,12 @@ type signalRuntimeRun struct {
 
 const liveControlOperationSignalRuntimeRestart liveControlOperationKind = "signal-runtime-restart"
 
+type SignalRuntimeRestartOptions struct {
+	Force  bool
+	Reason string
+	Source string
+}
+
 func (r *signalRuntimeRun) releaseRuntimeLease() {
 	if r == nil || r.releaseLease == nil {
 		return
@@ -401,6 +407,10 @@ func (p *Platform) RestartSignalRuntimeSession(sessionID string) (domain.SignalR
 }
 
 func (p *Platform) RestartSignalRuntimeSessionWithForce(sessionID string, force bool) (domain.SignalRuntimeSession, error) {
+	return p.RestartSignalRuntimeSessionWithOptions(sessionID, SignalRuntimeRestartOptions{Force: force})
+}
+
+func (p *Platform) RestartSignalRuntimeSessionWithOptions(sessionID string, options SignalRuntimeRestartOptions) (domain.SignalRuntimeSession, error) {
 	existing, err := p.GetSignalRuntimeSession(sessionID)
 	if err != nil {
 		return domain.SignalRuntimeSession{}, err
@@ -419,10 +429,30 @@ func (p *Platform) RestartSignalRuntimeSessionWithForce(sessionID string, force 
 		return domain.SignalRuntimeSession{}, liveControlOperationInProgressError(requested, current)
 	}
 	defer release()
-	if _, err := p.stopSignalRuntimeSessionWithForceLocked(existing, force); err != nil {
+	now := time.Now().UTC()
+	existing.State = signalRuntimeRestartAuditState(existing.State, options, now)
+	existing.UpdatedAt = now
+	if _, err := p.stopSignalRuntimeSessionWithForceLocked(existing, options.Force); err != nil {
 		return domain.SignalRuntimeSession{}, err
 	}
 	return p.startSignalRuntimeSession(context.Background(), existing.ID)
+}
+
+func signalRuntimeRestartAuditState(state map[string]any, options SignalRuntimeRestartOptions, now time.Time) map[string]any {
+	out := cloneMetadata(state)
+	out["restartRequestedAt"] = now.UTC().Format(time.RFC3339)
+	out["restartRequestedForce"] = options.Force
+	if reason := strings.TrimSpace(options.Reason); reason != "" {
+		out["restartRequestedReason"] = reason
+	} else {
+		delete(out, "restartRequestedReason")
+	}
+	if source := strings.TrimSpace(options.Source); source != "" {
+		out["restartRequestedSource"] = source
+	} else {
+		delete(out, "restartRequestedSource")
+	}
+	return out
 }
 
 func (p *Platform) StopSignalRuntimeSessionWithForce(sessionID string, force bool) (domain.SignalRuntimeSession, error) {

--- a/internal/service/signal_runtime_sessions_persistence_test.go
+++ b/internal/service/signal_runtime_sessions_persistence_test.go
@@ -194,6 +194,73 @@ func TestStopSignalRuntimeSessionCancelsRunnerAndReleasesLeaseOnce(t *testing.T)
 	}
 }
 
+func TestRestartSignalRuntimeSessionStopsThenStarts(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	runtimeSession, err := platform.CreateSignalRuntimeSession("live-main", "strategy-bk-1d")
+	if err != nil {
+		t.Fatalf("CreateSignalRuntimeSession failed: %v", err)
+	}
+	if _, err := platform.StartSignalRuntimeSession(runtimeSession.ID); err != nil {
+		t.Fatalf("StartSignalRuntimeSession failed: %v", err)
+	}
+
+	restarted, err := platform.RestartSignalRuntimeSessionWithForce(runtimeSession.ID, true)
+	if err != nil {
+		t.Fatalf("RestartSignalRuntimeSessionWithForce failed: %v", err)
+	}
+	if restarted.Status != "RUNNING" {
+		t.Fatalf("expected restarted runtime status RUNNING, got %s", restarted.Status)
+	}
+	if got := stringValue(restarted.State["desiredStatus"]); got != "RUNNING" {
+		t.Fatalf("expected desiredStatus RUNNING, got %s", got)
+	}
+	if actual := stringValue(restarted.State["actualStatus"]); actual != "STARTING" && actual != "RUNNING" {
+		t.Fatalf("expected actualStatus STARTING/RUNNING, got %s", actual)
+	}
+	if _, err := platform.StopSignalRuntimeSessionWithForce(runtimeSession.ID, true); err != nil {
+		t.Fatalf("cleanup runtime failed: %v", err)
+	}
+}
+
+func TestRestartSignalRuntimeSessionWithoutForceKeepsRunningWhenExposureExists(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	runtimeSession, err := platform.CreateSignalRuntimeSession("live-main", "strategy-bk-1d")
+	if err != nil {
+		t.Fatalf("CreateSignalRuntimeSession failed: %v", err)
+	}
+	if _, err := platform.StartSignalRuntimeSession(runtimeSession.ID); err != nil {
+		t.Fatalf("StartSignalRuntimeSession failed: %v", err)
+	}
+	if _, err := platform.store.CreateOrder(domain.Order{
+		AccountID:         "live-main",
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "SELL",
+		Type:              "LIMIT",
+		Quantity:          0.002,
+		Price:             70000,
+	}); err != nil {
+		t.Fatalf("seed order failed: %v", err)
+	}
+
+	if _, err := platform.RestartSignalRuntimeSession(runtimeSession.ID); !errors.Is(err, ErrActivePositionsOrOrders) {
+		t.Fatalf("expected active exposure error, got %v", err)
+	}
+	stored, err := platform.GetSignalRuntimeSession(runtimeSession.ID)
+	if err != nil {
+		t.Fatalf("GetSignalRuntimeSession failed: %v", err)
+	}
+	if stored.Status != "RUNNING" {
+		t.Fatalf("expected blocked restart to keep runtime RUNNING, got %s", stored.Status)
+	}
+	if got := stringValue(stored.State["desiredStatus"]); got != "RUNNING" {
+		t.Fatalf("expected blocked restart to keep desiredStatus RUNNING, got %s", got)
+	}
+	if _, err := platform.StopSignalRuntimeSessionWithForce(runtimeSession.ID, true); err != nil {
+		t.Fatalf("cleanup runtime failed: %v", err)
+	}
+}
+
 type blockingSignalRuntimeStore struct {
 	*memory.Store
 	entered        chan struct{}

--- a/internal/service/signal_runtime_sessions_persistence_test.go
+++ b/internal/service/signal_runtime_sessions_persistence_test.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/wuyaocheng/bktrader/internal/domain"
 	"github.com/wuyaocheng/bktrader/internal/store/memory"
@@ -200,13 +201,15 @@ func TestRestartSignalRuntimeSessionStopsThenStarts(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateSignalRuntimeSession failed: %v", err)
 	}
-	if _, err := platform.StartSignalRuntimeSession(runtimeSession.ID); err != nil {
-		t.Fatalf("StartSignalRuntimeSession failed: %v", err)
-	}
+	runtimeSession = markSignalRuntimeSessionRunningForTest(t, platform, runtimeSession)
 
-	restarted, err := platform.RestartSignalRuntimeSessionWithForce(runtimeSession.ID, true)
+	restarted, err := platform.RestartSignalRuntimeSessionWithOptions(runtimeSession.ID, SignalRuntimeRestartOptions{
+		Force:  true,
+		Reason: "operator requested rebinding",
+		Source: "test",
+	})
 	if err != nil {
-		t.Fatalf("RestartSignalRuntimeSessionWithForce failed: %v", err)
+		t.Fatalf("RestartSignalRuntimeSessionWithOptions failed: %v", err)
 	}
 	if restarted.Status != "RUNNING" {
 		t.Fatalf("expected restarted runtime status RUNNING, got %s", restarted.Status)
@@ -216,6 +219,18 @@ func TestRestartSignalRuntimeSessionStopsThenStarts(t *testing.T) {
 	}
 	if actual := stringValue(restarted.State["actualStatus"]); actual != "STARTING" && actual != "RUNNING" {
 		t.Fatalf("expected actualStatus STARTING/RUNNING, got %s", actual)
+	}
+	if got := boolValue(restarted.State["restartRequestedForce"]); !got {
+		t.Fatal("expected restartRequestedForce true")
+	}
+	if got := stringValue(restarted.State["restartRequestedReason"]); got != "operator requested rebinding" {
+		t.Fatalf("expected restartRequestedReason, got %s", got)
+	}
+	if got := stringValue(restarted.State["restartRequestedSource"]); got != "test" {
+		t.Fatalf("expected restartRequestedSource test, got %s", got)
+	}
+	if got := stringValue(restarted.State["restartRequestedAt"]); got == "" {
+		t.Fatal("expected restartRequestedAt")
 	}
 	if _, err := platform.StopSignalRuntimeSessionWithForce(runtimeSession.ID, true); err != nil {
 		t.Fatalf("cleanup runtime failed: %v", err)
@@ -228,9 +243,7 @@ func TestRestartSignalRuntimeSessionWithoutForceKeepsRunningWhenExposureExists(t
 	if err != nil {
 		t.Fatalf("CreateSignalRuntimeSession failed: %v", err)
 	}
-	if _, err := platform.StartSignalRuntimeSession(runtimeSession.ID); err != nil {
-		t.Fatalf("StartSignalRuntimeSession failed: %v", err)
-	}
+	runtimeSession = markSignalRuntimeSessionRunningForTest(t, platform, runtimeSession)
 	if _, err := platform.store.CreateOrder(domain.Order{
 		AccountID:         "live-main",
 		StrategyVersionID: "strategy-version-bk-1d-v010",
@@ -256,9 +269,31 @@ func TestRestartSignalRuntimeSessionWithoutForceKeepsRunningWhenExposureExists(t
 	if got := stringValue(stored.State["desiredStatus"]); got != "RUNNING" {
 		t.Fatalf("expected blocked restart to keep desiredStatus RUNNING, got %s", got)
 	}
+	if got := stringValue(stored.State["restartRequestedAt"]); got != "" {
+		t.Fatalf("expected blocked restart to avoid audit mutation, got %s", got)
+	}
 	if _, err := platform.StopSignalRuntimeSessionWithForce(runtimeSession.ID, true); err != nil {
 		t.Fatalf("cleanup runtime failed: %v", err)
 	}
+}
+
+func markSignalRuntimeSessionRunningForTest(t *testing.T, platform *Platform, session domain.SignalRuntimeSession) domain.SignalRuntimeSession {
+	t.Helper()
+	now := time.Now().UTC()
+	state := cloneMetadata(session.State)
+	state["health"] = "healthy"
+	state["desiredStatus"] = "RUNNING"
+	state["actualStatus"] = "RUNNING"
+	state["lastHeartbeatAt"] = now.Format(time.RFC3339)
+	session.Status = "RUNNING"
+	session.State = state
+	session.UpdatedAt = now
+	updated, err := platform.store.UpdateSignalRuntimeSession(session)
+	if err != nil {
+		t.Fatalf("UpdateSignalRuntimeSession failed: %v", err)
+	}
+	platform.cacheSignalRuntimeSession(updated)
+	return updated
 }
 
 type blockingSignalRuntimeStore struct {

--- a/internal/service/signal_runtime_sessions_persistence_test.go
+++ b/internal/service/signal_runtime_sessions_persistence_test.go
@@ -305,7 +305,10 @@ type blockingSignalRuntimeStore struct {
 }
 
 func (s *blockingSignalRuntimeStore) UpdateSignalRuntimeSession(session domain.SignalRuntimeSession) (domain.SignalRuntimeSession, error) {
-	if session.Status == "RUNNING" && stringValue(mapValue(session.State["lastEventSummary"])["type"]) == "runtime_started" {
+	if session.Status == "RUNNING" &&
+		stringValue(session.State["health"]) == "healthy" &&
+		stringValue(session.State["actualStatus"]) == "STARTING" &&
+		stringValue(mapValue(session.State["lastEventSummary"])["type"]) == "runtime_started" {
 		s.runningUpdates.Add(1)
 		s.enteredOnce.Do(func() { close(s.entered) })
 		<-s.release


### PR DESCRIPTION
## 目的
Follow issue #270，在 PR #295 的 read-only observability 基础上进入下一阶段：新增统一 runtime 控制 API 的最小切片。

本 PR 新增 `POST /api/v1/runtime/restart`，当前只支持 `runtimeKind=signal`，内部复用现有 signal runtime stop/start 安全检查，并通过 `bktrader-ctl runtime restart <runtimeId>` 暴露人工确认入口。

本 PR 不让 supervisor 自动调用 restart，不做 Docker/container restart，不改 live execution / dispatch 路径。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [x] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值无变化。
- [x] 不存在直接调用 `mainnet` 凭证或路由地址的硬编码。
- [x] 无 DB migration。
- [x] 无配置字段混改；没有新增默认自动恢复行为。
- [x] 不修改 `internal/service/live*.go`、`execution_strategy.go`、deployments 或 GitHub Actions。

## 验证方式与测试证据
- [x] `go test ./...`
- [x] `go build ./cmd/bktrader-ctl`
- [x] `go build ./cmd/platform-api`
- [x] `go build ./cmd/db-migrate`
- [x] `go run ./scripts/check-ctl-coverage`
- [x] `bash scripts/check_high_risk_defaults.sh`
- [x] `git diff --check`
- [x] `bktrader-ctl runtime restart --help`

## 主要改动
- 新增 `Platform.RestartSignalRuntimeSessionWithForce`，在同一个 control operation 下先 stop 再 start signal runtime。
- 新增 `POST /api/v1/runtime/restart`，返回 accepted，明确 actualStatus 仍需后续收敛确认。
- 新增 `bktrader-ctl runtime restart <runtimeId> --confirm [--force] [--kind signal]`。
- 补服务层和 HTTP 层测试，包括 active exposure 未 force 时拒绝且保持 RUNNING 的 failure path。
- 更新 `docs/runtime-supervisor.md` 记录本阶段边界。
