### PR TITLE
[codex] Add opt-in supervisor application restart

### DIFF
--- a/docs/runtime-supervisor.md
+++ b/docs/runtime-supervisor.md
@@ -319,9 +319,17 @@ func ClearRestartState(state map[string]any, keys []string)
 - `BKTRADER_ROLE=supervisor` 只启动 read-only supervisor，不启动 live / signal / dashboard / notification 业务组件。
 - `SUPERVISOR_TARGETS` 使用逗号分隔，支持 `name=http://host:port` 或直接填写 base URL。
 - `SUPERVISOR_BEARER_TOKEN` 可选；设置后 read-only collector 会对所有 targets 的 `/healthz` 与 `/api/v1/runtime/status` 请求附加 `Authorization: Bearer <token>`，用于采集受鉴权保护的内网 runtime API。
-- 当前只采集 `/healthz` 和 `/api/v1/runtime/status`，不调用任何控制 API。
+- 默认只采集 `/healthz` 和 `/api/v1/runtime/status`，不调用任何控制 API。
 - `GET /api/v1/supervisor/status` 返回最近一次 read-only supervisor 采集快照。
 - `bktrader-ctl runtime status --json` 和 `bktrader-ctl supervisor status --json` 提供 CLI 只读巡检入口。
+- `SUPERVISOR_APPLICATION_RESTART_ENABLED=false` 为默认值；只有显式设为 `true` 时，supervisor 才会对满足全部条件的 signal runtime 提交应用内 `POST /api/v1/runtime/restart`：
+  - 目标服务 `/healthz` 可达且成功。
+  - `/api/v1/runtime/status` 可读。
+  - runtimeKind 为 `signal`。
+  - `desiredStatus=RUNNING` 且 `actualStatus=ERROR`。
+  - `autoRestartSuppressed=false` 且 `restartSeverity` 不是 `fatal`。
+  - `nextRestartAt` 存在且已经到期。
+  - 提交 restart 时固定 `force=false`、`confirm=true`，并带上 supervisor reason；同一个 target/runtime/`nextRestartAt` 只提交一次。
 
 验收标准：
 

--- a/internal/app/server.go
+++ b/internal/app/server.go
@@ -194,13 +194,16 @@ func StartRuntimeComponents(ctx context.Context, platform *service.Platform, cfg
 		if len(targets) == 0 {
 			logger.Warn("read-only runtime supervisor disabled because SUPERVISOR_TARGETS is empty")
 		} else {
-			supervisor := service.NewRuntimeSupervisor(targets, &http.Client{Timeout: time.Duration(cfg.SupervisorHTTPTimeoutSeconds) * time.Second})
+			supervisor := service.NewRuntimeSupervisorWithOptions(targets, &http.Client{Timeout: time.Duration(cfg.SupervisorHTTPTimeoutSeconds) * time.Second}, service.RuntimeSupervisorOptions{
+				EnableApplicationRestart: cfg.SupervisorAppRestartEnabled,
+			})
 			platform.SetRuntimeSupervisor(supervisor)
 			supervisor.Start(ctx, time.Duration(cfg.SupervisorPollIntervalSeconds)*time.Second)
-			logger.Info("read-only runtime supervisor started",
+			logger.Info("runtime supervisor started",
 				"target_count", len(supervisor.Targets()),
 				"poll_interval_seconds", cfg.SupervisorPollIntervalSeconds,
 				"http_timeout_seconds", cfg.SupervisorHTTPTimeoutSeconds,
+				"application_restart_enabled", cfg.SupervisorAppRestartEnabled,
 			)
 		}
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -71,6 +71,7 @@ type Config struct {
 	SupervisorBearerToken         string   // 只读 supervisor 请求目标服务时使用的全局 Bearer token
 	SupervisorPollIntervalSeconds int      // 只读 supervisor 轮询间隔（秒）
 	SupervisorHTTPTimeoutSeconds  int      // 只读 supervisor HTTP 超时（秒）
+	SupervisorAppRestartEnabled   bool     // supervisor 是否允许按 runtime status 到期计划提交应用内 restart（默认关闭）
 }
 
 // Load 从环境变量加载配置，未设置的使用默认值。
@@ -151,6 +152,7 @@ func Load() Config {
 		SupervisorBearerToken:          strings.TrimSpace(os.Getenv("SUPERVISOR_BEARER_TOKEN")),
 		SupervisorPollIntervalSeconds:  intFromEnvWithMin("SUPERVISOR_POLL_INTERVAL_SECONDS", 30, 5),
 		SupervisorHTTPTimeoutSeconds:   intFromEnvWithMin("SUPERVISOR_HTTP_TIMEOUT_SECONDS", 5, 1),
+		SupervisorAppRestartEnabled:    boolFromEnv("SUPERVISOR_APPLICATION_RESTART_ENABLED", false),
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -107,6 +107,7 @@ func TestLoadReadsSupervisorEnv(t *testing.T) {
 	t.Setenv("SUPERVISOR_BEARER_TOKEN", " supervisor-token ")
 	t.Setenv("SUPERVISOR_POLL_INTERVAL_SECONDS", "45")
 	t.Setenv("SUPERVISOR_HTTP_TIMEOUT_SECONDS", "3")
+	t.Setenv("SUPERVISOR_APPLICATION_RESTART_ENABLED", "true")
 
 	cfg := Load()
 	if len(cfg.SupervisorTargets) != 2 {
@@ -123,6 +124,9 @@ func TestLoadReadsSupervisorEnv(t *testing.T) {
 	}
 	if cfg.SupervisorHTTPTimeoutSeconds != 3 {
 		t.Fatalf("expected supervisor HTTP timeout 3, got %d", cfg.SupervisorHTTPTimeoutSeconds)
+	}
+	if !cfg.SupervisorAppRestartEnabled {
+		t.Fatal("expected supervisor application restart to be enabled")
 	}
 }
 

--- a/internal/service/runtime_supervisor.go
+++ b/internal/service/runtime_supervisor.go
@@ -1,9 +1,11 @@
 package service
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/url"
@@ -13,6 +15,10 @@ import (
 )
 
 const defaultRuntimeSupervisorHTTPTimeout = 5 * time.Second
+
+type RuntimeSupervisorOptions struct {
+	EnableApplicationRestart bool
+}
 
 type RuntimeSupervisorTarget struct {
 	Name        string `json:"name"`
@@ -29,12 +35,13 @@ type RuntimeSupervisorProbe struct {
 }
 
 type RuntimeSupervisorTargetSnapshot struct {
-	Name          string                 `json:"name"`
-	BaseURL       string                 `json:"baseUrl"`
-	CheckedAt     time.Time              `json:"checkedAt"`
-	Healthz       RuntimeSupervisorProbe `json:"healthz"`
-	RuntimeStatus RuntimeSupervisorProbe `json:"runtimeStatus"`
-	Status        *RuntimeStatusSnapshot `json:"status,omitempty"`
+	Name           string                           `json:"name"`
+	BaseURL        string                           `json:"baseUrl"`
+	CheckedAt      time.Time                        `json:"checkedAt"`
+	Healthz        RuntimeSupervisorProbe           `json:"healthz"`
+	RuntimeStatus  RuntimeSupervisorProbe           `json:"runtimeStatus"`
+	Status         *RuntimeStatusSnapshot           `json:"status,omitempty"`
+	ControlActions []RuntimeSupervisorControlAction `json:"controlActions,omitempty"`
 }
 
 type RuntimeSupervisorSnapshot struct {
@@ -42,12 +49,26 @@ type RuntimeSupervisorSnapshot struct {
 	Targets   []RuntimeSupervisorTargetSnapshot `json:"targets"`
 }
 
+type RuntimeSupervisorControlAction struct {
+	Action      string    `json:"action"`
+	Path        string    `json:"path"`
+	RuntimeID   string    `json:"runtimeId"`
+	RuntimeKind string    `json:"runtimeKind"`
+	Reason      string    `json:"reason,omitempty"`
+	Submitted   bool      `json:"submitted"`
+	StatusCode  int       `json:"statusCode,omitempty"`
+	Error       string    `json:"error,omitempty"`
+	RequestedAt time.Time `json:"requestedAt"`
+}
+
 type RuntimeSupervisor struct {
 	targets []RuntimeSupervisorTarget
 	client  *http.Client
+	options RuntimeSupervisorOptions
 
-	mu       sync.RWMutex
-	snapshot RuntimeSupervisorSnapshot
+	mu                sync.RWMutex
+	snapshot          RuntimeSupervisorSnapshot
+	submittedRestarts map[string]string
 }
 
 func (p *Platform) SetRuntimeSupervisor(supervisor *RuntimeSupervisor) {
@@ -67,6 +88,10 @@ func (p *Platform) RuntimeSupervisorSnapshot() (RuntimeSupervisorSnapshot, bool)
 }
 
 func NewRuntimeSupervisor(targets []RuntimeSupervisorTarget, client *http.Client) *RuntimeSupervisor {
+	return NewRuntimeSupervisorWithOptions(targets, client, RuntimeSupervisorOptions{})
+}
+
+func NewRuntimeSupervisorWithOptions(targets []RuntimeSupervisorTarget, client *http.Client, options RuntimeSupervisorOptions) *RuntimeSupervisor {
 	normalized := make([]RuntimeSupervisorTarget, 0, len(targets))
 	for i, target := range targets {
 		baseURL := strings.TrimRight(strings.TrimSpace(target.BaseURL), "/")
@@ -85,8 +110,10 @@ func NewRuntimeSupervisor(targets []RuntimeSupervisorTarget, client *http.Client
 		client = &http.Client{Timeout: defaultRuntimeSupervisorHTTPTimeout}
 	}
 	return &RuntimeSupervisor{
-		targets: normalized,
-		client:  client,
+		targets:           normalized,
+		client:            client,
+		options:           options,
+		submittedRestarts: make(map[string]string),
 	}
 }
 
@@ -141,6 +168,7 @@ func (s *RuntimeSupervisor) Collect(ctx context.Context) RuntimeSupervisorSnapsh
 		targetSnapshot.RuntimeStatus = s.fetchJSON(ctx, target, "/api/v1/runtime/status", &status)
 		if targetSnapshot.RuntimeStatus.Error == "" && targetSnapshot.RuntimeStatus.Reachable {
 			targetSnapshot.Status = &status
+			targetSnapshot.ControlActions = s.submitApplicationRestarts(ctx, target, status, targetSnapshot.Healthz, now)
 		}
 		snapshot.Targets = append(snapshot.Targets, targetSnapshot)
 	}
@@ -190,6 +218,7 @@ func (s *RuntimeSupervisor) collectAndLog(ctx context.Context, logger *slog.Logg
 	snapshot := s.Collect(ctx)
 	unreachable := 0
 	runtimeErrors := 0
+	controlActions := 0
 	for _, target := range snapshot.Targets {
 		if !target.Healthz.Reachable || target.Healthz.Error != "" {
 			unreachable++
@@ -197,12 +226,125 @@ func (s *RuntimeSupervisor) collectAndLog(ctx context.Context, logger *slog.Logg
 		if target.RuntimeStatus.Error != "" {
 			runtimeErrors++
 		}
+		controlActions += len(target.ControlActions)
 	}
-	logger.Info("read-only runtime supervisor snapshot collected",
+	logger.Info("runtime supervisor snapshot collected",
 		"target_count", len(snapshot.Targets),
 		"unreachable_count", unreachable,
 		"runtime_error_count", runtimeErrors,
+		"control_action_count", controlActions,
+		"application_restart_enabled", s.options.EnableApplicationRestart,
 	)
+}
+
+func (s *RuntimeSupervisor) submitApplicationRestarts(ctx context.Context, target RuntimeSupervisorTarget, status RuntimeStatusSnapshot, healthz RuntimeSupervisorProbe, now time.Time) []RuntimeSupervisorControlAction {
+	if s == nil || !s.options.EnableApplicationRestart {
+		return nil
+	}
+	if !healthz.Reachable || healthz.Error != "" {
+		return nil
+	}
+	actions := make([]RuntimeSupervisorControlAction, 0)
+	for _, runtime := range status.Runtimes {
+		if !runtimeSupervisorRestartDue(runtime, now) {
+			continue
+		}
+		if !s.markRuntimeRestartSubmitted(target, runtime) {
+			continue
+		}
+		action := s.submitRuntimeRestart(ctx, target, runtime, now)
+		actions = append(actions, action)
+	}
+	return actions
+}
+
+func (s *RuntimeSupervisor) markRuntimeRestartSubmitted(target RuntimeSupervisorTarget, runtime RuntimeStatus) bool {
+	if s == nil {
+		return false
+	}
+	nextRestartAt := strings.TrimSpace(runtime.NextRestartAt)
+	if nextRestartAt == "" {
+		return false
+	}
+	key := runtimeSupervisorRestartKey(target, runtime)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.submittedRestarts == nil {
+		s.submittedRestarts = make(map[string]string)
+	}
+	if s.submittedRestarts[key] == nextRestartAt {
+		return false
+	}
+	s.submittedRestarts[key] = nextRestartAt
+	return true
+}
+
+func runtimeSupervisorRestartKey(target RuntimeSupervisorTarget, runtime RuntimeStatus) string {
+	return strings.TrimSpace(target.Name) + "|" + strings.TrimSpace(target.BaseURL) + "|" + strings.TrimSpace(runtime.RuntimeKind) + "|" + strings.TrimSpace(runtime.RuntimeID)
+}
+
+func runtimeSupervisorRestartDue(runtime RuntimeStatus, now time.Time) bool {
+	if strings.TrimSpace(runtime.RuntimeID) == "" {
+		return false
+	}
+	if !strings.EqualFold(strings.TrimSpace(runtime.RuntimeKind), "signal") {
+		return false
+	}
+	if !strings.EqualFold(strings.TrimSpace(runtime.DesiredStatus), "RUNNING") {
+		return false
+	}
+	if !strings.EqualFold(strings.TrimSpace(runtime.ActualStatus), "ERROR") {
+		return false
+	}
+	if runtime.AutoRestartSuppressed {
+		return false
+	}
+	if strings.EqualFold(strings.TrimSpace(runtime.RestartSeverity), "fatal") {
+		return false
+	}
+	nextRestartAt, ok := ParseRestartTime(map[string]any{"nextRestartAt": runtime.NextRestartAt}, "nextRestartAt")
+	if !ok {
+		return false
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	return !nextRestartAt.After(now.UTC())
+}
+
+func (s *RuntimeSupervisor) submitRuntimeRestart(ctx context.Context, target RuntimeSupervisorTarget, runtime RuntimeStatus, now time.Time) RuntimeSupervisorControlAction {
+	reason := runtimeSupervisorRestartReason(target, runtime)
+	action := RuntimeSupervisorControlAction{
+		Action:      "restart",
+		Path:        "/api/v1/runtime/restart",
+		RuntimeID:   runtime.RuntimeID,
+		RuntimeKind: runtime.RuntimeKind,
+		Reason:      reason,
+		RequestedAt: now.UTC(),
+	}
+	payload := map[string]any{
+		"runtimeId":   runtime.RuntimeID,
+		"runtimeKind": runtime.RuntimeKind,
+		"confirm":     true,
+		"force":       false,
+		"reason":      reason,
+	}
+	statusCode, err := s.postJSON(ctx, target, action.Path, payload)
+	action.StatusCode = statusCode
+	if err != nil {
+		action.Error = err.Error()
+		return action
+	}
+	action.Submitted = true
+	return action
+}
+
+func runtimeSupervisorRestartReason(target RuntimeSupervisorTarget, runtime RuntimeStatus) string {
+	reason := strings.TrimSpace(runtime.RestartReason)
+	if reason == "" {
+		reason = "runtime-error"
+	}
+	return fmt.Sprintf("supervisor scheduled application restart: target=%s runtime=%s reason=%s", strings.TrimSpace(target.Name), runtime.RuntimeID, reason)
 }
 
 func (s *RuntimeSupervisor) fetchJSON(ctx context.Context, target RuntimeSupervisorTarget, path string, out any) RuntimeSupervisorProbe {
@@ -239,6 +381,35 @@ func (s *RuntimeSupervisor) fetchJSON(ctx context.Context, target RuntimeSupervi
 		probe.Error = err.Error()
 	}
 	return probe
+}
+
+func (s *RuntimeSupervisor) postJSON(ctx context.Context, target RuntimeSupervisorTarget, path string, payload any) (int, error) {
+	endpoint, err := runtimeSupervisorEndpoint(target.BaseURL, path)
+	if err != nil {
+		return 0, err
+	}
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(payload); err != nil {
+		return 0, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, &body)
+	if err != nil {
+		return 0, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if token := strings.TrimSpace(target.BearerToken); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		message, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return resp.StatusCode, fmt.Errorf("http status %d: %s", resp.StatusCode, strings.TrimSpace(string(message)))
+	}
+	return resp.StatusCode, nil
 }
 
 func runtimeSupervisorEndpoint(baseURL, path string) (string, error) {

--- a/internal/service/runtime_supervisor.go
+++ b/internal/service/runtime_supervisor.go
@@ -249,16 +249,19 @@ func (s *RuntimeSupervisor) submitApplicationRestarts(ctx context.Context, targe
 		if !runtimeSupervisorRestartDue(runtime, now) {
 			continue
 		}
-		if !s.markRuntimeRestartSubmitted(target, runtime) {
+		if s.runtimeRestartAlreadySubmitted(target, runtime) {
 			continue
 		}
 		action := s.submitRuntimeRestart(ctx, target, runtime, now)
+		if action.Submitted {
+			s.markRuntimeRestartSubmitted(target, runtime)
+		}
 		actions = append(actions, action)
 	}
 	return actions
 }
 
-func (s *RuntimeSupervisor) markRuntimeRestartSubmitted(target RuntimeSupervisorTarget, runtime RuntimeStatus) bool {
+func (s *RuntimeSupervisor) runtimeRestartAlreadySubmitted(target RuntimeSupervisorTarget, runtime RuntimeStatus) bool {
 	if s == nil {
 		return false
 	}
@@ -267,16 +270,26 @@ func (s *RuntimeSupervisor) markRuntimeRestartSubmitted(target RuntimeSupervisor
 		return false
 	}
 	key := runtimeSupervisorRestartKey(target, runtime)
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.submittedRestarts[key] == nextRestartAt
+}
+
+func (s *RuntimeSupervisor) markRuntimeRestartSubmitted(target RuntimeSupervisorTarget, runtime RuntimeStatus) {
+	if s == nil {
+		return
+	}
+	nextRestartAt := strings.TrimSpace(runtime.NextRestartAt)
+	if nextRestartAt == "" {
+		return
+	}
+	key := runtimeSupervisorRestartKey(target, runtime)
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.submittedRestarts == nil {
 		s.submittedRestarts = make(map[string]string)
 	}
-	if s.submittedRestarts[key] == nextRestartAt {
-		return false
-	}
 	s.submittedRestarts[key] = nextRestartAt
-	return true
 }
 
 func runtimeSupervisorRestartKey(target RuntimeSupervisorTarget, runtime RuntimeStatus) string {

--- a/internal/service/runtime_supervisor_test.go
+++ b/internal/service/runtime_supervisor_test.go
@@ -240,6 +240,125 @@ func TestRuntimeSupervisorSubmitsDueSignalRestartWhenEnabled(t *testing.T) {
 	}
 }
 
+func TestRuntimeSupervisorRetriesRestartAfterFailedPost(t *testing.T) {
+	now := time.Now().UTC()
+	requested := make(map[string]int)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requested[r.Method+" "+r.URL.Path]++
+		switch r.URL.Path {
+		case "/healthz":
+			writeRuntimeSupervisorTestJSON(t, w, map[string]any{"status": "ok"})
+		case "/api/v1/runtime/status":
+			writeRuntimeSupervisorTestJSON(t, w, RuntimeStatusSnapshot{
+				Service:   "platform-api",
+				CheckedAt: now,
+				Runtimes: []RuntimeStatus{{
+					RuntimeID:       "signal-runtime-1",
+					RuntimeKind:     "signal",
+					DesiredStatus:   "RUNNING",
+					ActualStatus:    "ERROR",
+					RestartReason:   "runtime-error",
+					RestartSeverity: "transient",
+					NextRestartAt:   now.Add(-time.Second).Format(time.RFC3339),
+				}},
+			})
+		case "/api/v1/runtime/restart":
+			if requested["POST /api/v1/runtime/restart"] == 1 {
+				http.Error(w, "temporary restart failure", http.StatusInternalServerError)
+				return
+			}
+			writeRuntimeSupervisorTestJSONStatus(t, w, http.StatusAccepted, map[string]any{"status": "accepted"})
+		default:
+			t.Errorf("unexpected request path %s", r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	supervisor := NewRuntimeSupervisorWithOptions(
+		[]RuntimeSupervisorTarget{{Name: "api", BaseURL: server.URL}},
+		server.Client(),
+		RuntimeSupervisorOptions{EnableApplicationRestart: true},
+	)
+
+	first := supervisor.Collect(context.Background())
+	if requested["POST /api/v1/runtime/restart"] != 1 {
+		t.Fatalf("expected first restart POST, got %#v", requested)
+	}
+	if len(first.Targets) != 1 || len(first.Targets[0].ControlActions) != 1 {
+		t.Fatalf("expected first failed action to be recorded, got %#v", first.Targets)
+	}
+	firstAction := first.Targets[0].ControlActions[0]
+	if firstAction.Submitted || firstAction.StatusCode != http.StatusInternalServerError || firstAction.Error == "" {
+		t.Fatalf("expected failed restart action with error, got %+v", firstAction)
+	}
+
+	second := supervisor.Collect(context.Background())
+	if requested["POST /api/v1/runtime/restart"] != 2 {
+		t.Fatalf("expected failed restart plan to be retried, got %#v", requested)
+	}
+	if len(second.Targets) != 1 || len(second.Targets[0].ControlActions) != 1 {
+		t.Fatalf("expected second action to be recorded, got %#v", second.Targets)
+	}
+	secondAction := second.Targets[0].ControlActions[0]
+	if !secondAction.Submitted || secondAction.StatusCode != http.StatusAccepted || secondAction.Error != "" {
+		t.Fatalf("expected successful retry action, got %+v", secondAction)
+	}
+
+	third := supervisor.Collect(context.Background())
+	if requested["POST /api/v1/runtime/restart"] != 2 {
+		t.Fatalf("expected successful restart plan to be deduplicated, got %#v", requested)
+	}
+	if len(third.Targets) != 1 || len(third.Targets[0].ControlActions) != 0 {
+		t.Fatalf("expected no action after successful submit, got %#v", third.Targets)
+	}
+}
+
+func TestRuntimeSupervisorSkipsApplicationRestartWhenHealthzFails(t *testing.T) {
+	now := time.Now().UTC()
+	requested := make(map[string]int)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requested[r.Method+" "+r.URL.Path]++
+		switch r.URL.Path {
+		case "/healthz":
+			http.Error(w, "not ready", http.StatusServiceUnavailable)
+		case "/api/v1/runtime/status":
+			writeRuntimeSupervisorTestJSON(t, w, RuntimeStatusSnapshot{
+				Service:   "platform-api",
+				CheckedAt: now,
+				Runtimes: []RuntimeStatus{{
+					RuntimeID:       "signal-runtime-1",
+					RuntimeKind:     "signal",
+					DesiredStatus:   "RUNNING",
+					ActualStatus:    "ERROR",
+					RestartSeverity: "transient",
+					NextRestartAt:   now.Add(-time.Second).Format(time.RFC3339),
+				}},
+			})
+		case "/api/v1/runtime/restart":
+			t.Errorf("expected supervisor to skip restart when healthz fails")
+			w.WriteHeader(http.StatusForbidden)
+		default:
+			t.Errorf("unexpected request path %s", r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	supervisor := NewRuntimeSupervisorWithOptions(
+		[]RuntimeSupervisorTarget{{Name: "api", BaseURL: server.URL}},
+		server.Client(),
+		RuntimeSupervisorOptions{EnableApplicationRestart: true},
+	)
+	snapshot := supervisor.Collect(context.Background())
+	if requested["POST /api/v1/runtime/restart"] != 0 {
+		t.Fatalf("expected no restart POST when healthz fails, got %#v", requested)
+	}
+	if len(snapshot.Targets) != 1 || len(snapshot.Targets[0].ControlActions) != 0 {
+		t.Fatalf("expected no recorded control actions when healthz fails, got %#v", snapshot.Targets)
+	}
+}
+
 func TestRuntimeSupervisorSkipsApplicationRestartWhenSuppressedOrNotDue(t *testing.T) {
 	now := time.Now().UTC()
 	requested := make(map[string]int)
@@ -365,7 +484,13 @@ func TestParseRuntimeSupervisorTargetsSupportsNamedTargets(t *testing.T) {
 
 func writeRuntimeSupervisorTestJSON(t *testing.T, w http.ResponseWriter, payload any) {
 	t.Helper()
+	writeRuntimeSupervisorTestJSONStatus(t, w, http.StatusOK, payload)
+}
+
+func writeRuntimeSupervisorTestJSONStatus(t *testing.T, w http.ResponseWriter, status int, payload any) {
+	t.Helper()
 	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
 	if err := json.NewEncoder(w).Encode(payload); err != nil {
 		t.Errorf("write json failed: %v", err)
 	}

--- a/internal/service/runtime_supervisor_test.go
+++ b/internal/service/runtime_supervisor_test.go
@@ -120,6 +120,197 @@ func TestRuntimeSupervisorRecordsProbeFailuresWithoutControlActions(t *testing.T
 	}
 }
 
+func TestRuntimeSupervisorDefaultSkipsDueSignalRestart(t *testing.T) {
+	now := time.Now().UTC()
+	requested := make(map[string]int)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requested[r.Method+" "+r.URL.Path]++
+		switch r.URL.Path {
+		case "/healthz":
+			writeRuntimeSupervisorTestJSON(t, w, map[string]any{"status": "ok"})
+		case "/api/v1/runtime/status":
+			writeRuntimeSupervisorTestJSON(t, w, RuntimeStatusSnapshot{
+				Service:   "platform-api",
+				CheckedAt: now,
+				Runtimes: []RuntimeStatus{{
+					RuntimeID:       "signal-runtime-1",
+					RuntimeKind:     "signal",
+					DesiredStatus:   "RUNNING",
+					ActualStatus:    "ERROR",
+					RestartSeverity: "transient",
+					NextRestartAt:   now.Add(-time.Second).Format(time.RFC3339),
+				}},
+			})
+		case "/api/v1/runtime/restart":
+			t.Errorf("default supervisor must stay read-only")
+			w.WriteHeader(http.StatusForbidden)
+		default:
+			t.Errorf("unexpected request path %s", r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	supervisor := NewRuntimeSupervisor([]RuntimeSupervisorTarget{{Name: "api", BaseURL: server.URL}}, server.Client())
+	snapshot := supervisor.Collect(context.Background())
+	if requested["POST /api/v1/runtime/restart"] != 0 {
+		t.Fatalf("expected no restart POST by default, got %#v", requested)
+	}
+	if len(snapshot.Targets) != 1 || len(snapshot.Targets[0].ControlActions) != 0 {
+		t.Fatalf("expected no recorded control actions by default, got %#v", snapshot.Targets)
+	}
+}
+
+func TestRuntimeSupervisorSubmitsDueSignalRestartWhenEnabled(t *testing.T) {
+	const token = "supervisor-restart-token"
+	now := time.Now().UTC()
+	requested := make(map[string]int)
+	var restartPayload map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requested[r.Method+" "+r.URL.Path]++
+		if got := r.Header.Get("Authorization"); got != "Bearer "+token {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		switch r.URL.Path {
+		case "/healthz":
+			writeRuntimeSupervisorTestJSON(t, w, map[string]any{"status": "ok"})
+		case "/api/v1/runtime/status":
+			writeRuntimeSupervisorTestJSON(t, w, RuntimeStatusSnapshot{
+				Service:   "platform-api",
+				CheckedAt: now,
+				Runtimes: []RuntimeStatus{{
+					Service:         "platform-api",
+					RuntimeID:       "signal-runtime-1",
+					RuntimeKind:     "signal",
+					DesiredStatus:   "RUNNING",
+					ActualStatus:    "ERROR",
+					Health:          "error",
+					RestartReason:   "runtime-error",
+					RestartSeverity: "transient",
+					NextRestartAt:   now.Add(-time.Second).Format(time.RFC3339),
+				}},
+			})
+		case "/api/v1/runtime/restart":
+			if r.Method != http.MethodPost {
+				t.Errorf("expected POST restart, got %s", r.Method)
+			}
+			if err := json.NewDecoder(r.Body).Decode(&restartPayload); err != nil {
+				t.Errorf("decode restart payload failed: %v", err)
+			}
+			writeRuntimeSupervisorTestJSON(t, w, map[string]any{"status": "accepted"})
+		default:
+			t.Errorf("unexpected request path %s", r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	supervisor := NewRuntimeSupervisorWithOptions(
+		ParseRuntimeSupervisorTargets([]string{"api=" + server.URL}, token),
+		server.Client(),
+		RuntimeSupervisorOptions{EnableApplicationRestart: true},
+	)
+	snapshot := supervisor.Collect(context.Background())
+	if requested["POST /api/v1/runtime/restart"] != 1 {
+		t.Fatalf("expected one restart POST, got %#v", requested)
+	}
+	if restartPayload["runtimeId"] != "signal-runtime-1" || restartPayload["runtimeKind"] != "signal" {
+		t.Fatalf("unexpected restart payload identity: %#v", restartPayload)
+	}
+	if restartPayload["confirm"] != true || restartPayload["force"] != false {
+		t.Fatalf("expected confirm=true force=false, got %#v", restartPayload)
+	}
+	if got := stringValue(restartPayload["reason"]); got == "" {
+		t.Fatalf("expected restart reason in payload, got %#v", restartPayload)
+	}
+	if len(snapshot.Targets) != 1 || len(snapshot.Targets[0].ControlActions) != 1 {
+		t.Fatalf("expected one recorded control action, got %#v", snapshot.Targets)
+	}
+	action := snapshot.Targets[0].ControlActions[0]
+	if !action.Submitted || action.StatusCode != http.StatusOK || action.Error != "" {
+		t.Fatalf("expected submitted restart action, got %+v", action)
+	}
+	second := supervisor.Collect(context.Background())
+	if requested["POST /api/v1/runtime/restart"] != 1 {
+		t.Fatalf("expected duplicate restart plan to be submitted once, got %#v", requested)
+	}
+	if len(second.Targets) != 1 || len(second.Targets[0].ControlActions) != 0 {
+		t.Fatalf("expected duplicate restart plan to skip new control actions, got %#v", second.Targets)
+	}
+}
+
+func TestRuntimeSupervisorSkipsApplicationRestartWhenSuppressedOrNotDue(t *testing.T) {
+	now := time.Now().UTC()
+	requested := make(map[string]int)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requested[r.Method+" "+r.URL.Path]++
+		switch r.URL.Path {
+		case "/healthz":
+			writeRuntimeSupervisorTestJSON(t, w, map[string]any{"status": "ok"})
+		case "/api/v1/runtime/status":
+			writeRuntimeSupervisorTestJSON(t, w, RuntimeStatusSnapshot{
+				Service:   "platform-api",
+				CheckedAt: now,
+				Runtimes: []RuntimeStatus{
+					{
+						RuntimeID:             "suppressed-signal-runtime",
+						RuntimeKind:           "signal",
+						DesiredStatus:         "RUNNING",
+						ActualStatus:          "ERROR",
+						RestartSeverity:       "fatal",
+						NextRestartAt:         now.Add(-time.Second).Format(time.RFC3339),
+						AutoRestartSuppressed: true,
+					},
+					{
+						RuntimeID:       "future-signal-runtime",
+						RuntimeKind:     "signal",
+						DesiredStatus:   "RUNNING",
+						ActualStatus:    "ERROR",
+						RestartSeverity: "transient",
+						NextRestartAt:   now.Add(time.Hour).Format(time.RFC3339),
+					},
+					{
+						RuntimeKind:     "signal",
+						DesiredStatus:   "RUNNING",
+						ActualStatus:    "ERROR",
+						RestartSeverity: "transient",
+						NextRestartAt:   now.Add(-time.Second).Format(time.RFC3339),
+					},
+					{
+						RuntimeID:       "live-runtime",
+						RuntimeKind:     "live-session",
+						DesiredStatus:   "RUNNING",
+						ActualStatus:    "ERROR",
+						RestartSeverity: "transient",
+						NextRestartAt:   now.Add(-time.Second).Format(time.RFC3339),
+					},
+				},
+			})
+		case "/api/v1/runtime/restart":
+			t.Errorf("expected supervisor to skip restart for suppressed/not-due/non-signal runtimes")
+			w.WriteHeader(http.StatusForbidden)
+		default:
+			t.Errorf("unexpected request path %s", r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	supervisor := NewRuntimeSupervisorWithOptions(
+		[]RuntimeSupervisorTarget{{Name: "api", BaseURL: server.URL}},
+		server.Client(),
+		RuntimeSupervisorOptions{EnableApplicationRestart: true},
+	)
+	snapshot := supervisor.Collect(context.Background())
+	if requested["POST /api/v1/runtime/restart"] != 0 {
+		t.Fatalf("expected no restart POST, got %#v", requested)
+	}
+	if len(snapshot.Targets) != 1 || len(snapshot.Targets[0].ControlActions) != 0 {
+		t.Fatalf("expected no recorded control actions, got %#v", snapshot.Targets)
+	}
+}
+
 func TestRuntimeSupervisorBearerTokenAllowsProtectedTargets(t *testing.T) {
 	const token = "supervisor-secret"
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## 目的
跟进 #270 的下一阶段：让 supervisor 在显式开启 `SUPERVISOR_APPLICATION_RESTART_ENABLED=true` 后，能够基于 read-only runtime status 中已经到期的 signal runtime restart plan，提交应用内 `POST /api/v1/runtime/restart`。

默认行为仍保持 read-only；新增控制动作要求目标 `/healthz` 与 `/api/v1/runtime/status` 均可读，且仅处理 `runtimeKind=signal`、`desiredStatus=RUNNING`、`actualStatus=ERROR`、未 suppressed、非 fatal、`nextRestartAt` 已到期的 runtime。提交时固定 `confirm=true`、`force=false`，并按 target/runtime/`nextRestartAt` 去重。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [x] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) — 未变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？— 不存在
- [x] DB migration 是否具备向下兼容幂等性？— 不涉及 DB migration
- [x] 配置字段有没有无意被混改？— 新增 `SUPERVISOR_APPLICATION_RESTART_ENABLED`，默认 `false`

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

验证已执行：
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
- `go build ./cmd/bktrader-ctl`
- `go run ./scripts/check-ctl-coverage`
- `bash scripts/check_high_risk_defaults.sh`
- pre-push hook: graphify rebuild + safety sensors + frontend build（hook 看到了工作区中既有未提交前端文件；该文件不在本 PR）
