### PR TITLE
[codex] serialize fill settlement by order

### DIFF
--- a/internal/service/order.go
+++ b/internal/service/order.go
@@ -1094,30 +1094,33 @@ func (p *Platform) finalizeExecutedOrder(account domain.Account, order domain.Or
 	if len(fills) == 0 {
 		return p.store.UpdateOrder(order)
 	}
-	newFills, err := p.filterExistingExecutionFills(order.ID, fills)
-	if err != nil {
-		return domain.Order{}, err
-	}
-
-	existingFills, err := p.store.QueryFills(domain.FillQuery{OrderIDs: []string{order.ID}})
-	if err != nil {
-		return domain.Order{}, err
-	}
-	existingInputs, err := fillReconciliationInputsFromStoredFills(existingFills)
-	if err != nil {
-		return domain.Order{}, err
-	}
-	incomingInputs, err := fillReconciliationInputsFromIncomingFills(order, newFills)
-	if err != nil {
-		return domain.Order{}, err
-	}
-	plan, err := BuildFillReconciliationPlan(order, existingInputs, incomingInputs, FillReconcilePolicy{AllowSyntheticFallback: true})
-	if err != nil {
-		return domain.Order{}, err
-	}
 
 	var updatedOrder domain.Order
-	if err := p.store.WithFillSettlementTx(func(tx storepkg.FillSettlementStore) error {
+	var newFills []domain.Fill
+	if err := p.store.WithFillSettlementTx(order.ID, func(tx storepkg.FillSettlementStore) error {
+		filteredFills, err := filterExistingExecutionFillsWithStore(tx, order.ID, fills)
+		if err != nil {
+			return err
+		}
+		newFills = filteredFills
+
+		existingFills, err := tx.QueryFills(domain.FillQuery{OrderIDs: []string{order.ID}})
+		if err != nil {
+			return err
+		}
+		existingInputs, err := fillReconciliationInputsFromStoredFills(existingFills)
+		if err != nil {
+			return err
+		}
+		incomingInputs, err := fillReconciliationInputsFromIncomingFills(order, newFills)
+		if err != nil {
+			return err
+		}
+		plan, err := BuildFillReconciliationPlan(order, existingInputs, incomingInputs, FillReconcilePolicy{AllowSyntheticFallback: true})
+		if err != nil {
+			return err
+		}
+
 		if len(plan.DeleteFillIDs) > 0 {
 			if _, err := tx.DeleteFillsByID(plan.DeleteFillIDs); err != nil {
 				return fmt.Errorf("failed to delete synthetic fills before upgrade: %w", err)
@@ -1281,10 +1284,18 @@ func fillReconciliationSourceFromStoredFill(fill domain.Fill) (FillSource, bool)
 }
 
 func (p *Platform) filterExistingExecutionFills(orderID string, fills []domain.Fill) ([]domain.Fill, error) {
+	return filterExistingExecutionFillsWithStore(p.store, orderID, fills)
+}
+
+type fillQueryStore interface {
+	QueryFills(query domain.FillQuery) ([]domain.Fill, error)
+}
+
+func filterExistingExecutionFillsWithStore(store fillQueryStore, orderID string, fills []domain.Fill) ([]domain.Fill, error) {
 	if len(fills) == 0 {
 		return nil, nil
 	}
-	existing, err := p.store.ListFills()
+	existing, err := store.QueryFills(domain.FillQuery{OrderIDs: []string{orderID}})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/service/order_test.go
+++ b/internal/service/order_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	neturl "net/url"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -255,6 +256,74 @@ func TestFinalizeExecutedOrderSkipsDuplicateExchangeTradeIDFills(t *testing.T) {
 	if filledEventCount != 1 {
 		t.Fatalf("expected duplicate sync to keep one filled execution event, got %d", filledEventCount)
 	}
+}
+
+func TestFinalizeExecutedOrderSerializesConcurrentSettlementForSameOrder(t *testing.T) {
+	store := memory.NewStore()
+	platform := NewPlatform(store)
+
+	account, err := store.GetAccount("live-main")
+	if err != nil {
+		t.Fatalf("get account failed: %v", err)
+	}
+	order, err := store.CreateOrder(domain.Order{
+		AccountID:         account.ID,
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "BUY",
+		Type:              "MARKET",
+		Quantity:          1,
+		Price:             68000,
+		Status:            "ACCEPTED",
+		Metadata:          map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("create order failed: %v", err)
+	}
+
+	start := make(chan struct{})
+	errs := make(chan error, 2)
+	var wg sync.WaitGroup
+	for _, fill := range []domain.Fill{
+		{OrderID: order.ID, ExchangeTradeID: "concurrent-trade-1", Source: string(FillSourceReal), Price: 68000, Quantity: 0.6},
+		{OrderID: order.ID, ExchangeTradeID: "concurrent-trade-2", Source: string(FillSourceReal), Price: 68000, Quantity: 0.6},
+	} {
+		fill := fill
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			_, err := platform.finalizeExecutedOrder(account, order, []domain.Fill{fill})
+			errs <- err
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent finalize failed: %v", err)
+		}
+	}
+
+	fills, err := store.QueryFills(domain.FillQuery{OrderIDs: []string{order.ID}})
+	if err != nil {
+		t.Fatalf("query fills failed: %v", err)
+	}
+	totalFillQty := 0.0
+	for _, fill := range fills {
+		totalFillQty += fill.Quantity
+	}
+	requireFillReconcileQuantity(t, totalFillQty, 1)
+
+	position, found, err := store.FindPosition(account.ID, "BTCUSDT")
+	if err != nil {
+		t.Fatalf("find position failed: %v", err)
+	}
+	if !found {
+		t.Fatal("expected position to be opened")
+	}
+	requireFillReconcileQuantity(t, position.Quantity, 1)
 }
 
 func TestFinalizeExecutedOrderSkipsDuplicateFallbackFillsWithoutExchangeTradeID(t *testing.T) {

--- a/internal/store/memory/fill_settlement_tx_test.go
+++ b/internal/store/memory/fill_settlement_tx_test.go
@@ -12,7 +12,7 @@ func TestWithFillSettlementTxRollsBackFillOnError(t *testing.T) {
 	store := NewStore()
 	errSentinel := errors.New("stop after fill create")
 
-	err := store.WithFillSettlementTx(func(tx storepkg.FillSettlementStore) error {
+	err := store.WithFillSettlementTx("", func(tx storepkg.FillSettlementStore) error {
 		if _, err := tx.CreateFill(domain.Fill{
 			OrderID:          "order-rollback",
 			Price:            68000,

--- a/internal/store/memory/store.go
+++ b/internal/store/memory/store.go
@@ -14,7 +14,8 @@ import (
 )
 
 type Store struct {
-	mu sync.RWMutex
+	mu           sync.RWMutex
+	settlementMu sync.Mutex
 
 	strategies         map[string]domain.Strategy
 	strategyVersion    map[string]domain.StrategyVersion
@@ -752,7 +753,13 @@ func (s *Store) DeleteFillsByID(fillIDs []string) (float64, error) {
 	return totalQty, nil
 }
 
-func (s *Store) WithFillSettlementTx(fn func(storepkg.FillSettlementStore) error) error {
+func (s *Store) WithFillSettlementTx(orderID string, fn func(storepkg.FillSettlementStore) error) error {
+	_ = orderID
+	// The memory backend keeps settlement simple by serializing all settlement work.
+	// Postgres uses the order row lock to serialize only the same order.
+	s.settlementMu.Lock()
+	defer s.settlementMu.Unlock()
+
 	s.mu.RLock()
 	orders := cloneJSONValue(s.orders)
 	fills := cloneJSONValue(s.fills)

--- a/internal/store/postgres/fill_settlement_tx_test.go
+++ b/internal/store/postgres/fill_settlement_tx_test.go
@@ -41,7 +41,7 @@ func TestWithFillSettlementTxRollsBackFillOnError(t *testing.T) {
 	}
 
 	errSentinel := errors.New("stop after fill create")
-	err = store.WithFillSettlementTx(func(tx storepkg.FillSettlementStore) error {
+	err = store.WithFillSettlementTx(order.ID, func(tx storepkg.FillSettlementStore) error {
 		if _, err := tx.CreateFill(domain.Fill{
 			OrderID:          order.ID,
 			Price:            68000,

--- a/internal/store/postgres/fill_source_test.go
+++ b/internal/store/postgres/fill_source_test.go
@@ -176,7 +176,7 @@ func TestFillSettlementTxCreateFillUpsertUpdatesSourcePostgres(t *testing.T) {
 	}
 
 	fingerprint := "tx-source-upsert-" + time.Now().UTC().Format("20060102150405.000000000")
-	if err := store.WithFillSettlementTx(func(tx storepkg.FillSettlementStore) error {
+	if err := store.WithFillSettlementTx(order.ID, func(tx storepkg.FillSettlementStore) error {
 		if _, err := tx.CreateFill(domain.Fill{
 			OrderID:          order.ID,
 			Source:           "synthetic",

--- a/internal/store/postgres/store.go
+++ b/internal/store/postgres/store.go
@@ -782,6 +782,14 @@ func (s *Store) CountFills() (int, error) {
 }
 
 func (s *Store) QueryFills(query domain.FillQuery) ([]domain.Fill, error) {
+	return queryFills(s.db, query)
+}
+
+type fillQueryer interface {
+	Query(query string, args ...any) (*sql.Rows, error)
+}
+
+func queryFills(q fillQueryer, query domain.FillQuery) ([]domain.Fill, error) {
 	sqlQuery := `
 		select id, order_id, exchange_trade_id, exchange_trade_time, dedup_fallback_fingerprint, price, quantity, fee, fill_source, created_at
 		from fills
@@ -797,7 +805,7 @@ func (s *Store) QueryFills(query domain.FillQuery) ([]domain.Fill, error) {
 	}
 	sqlQuery += ` order by created_at asc `
 
-	rows, err := s.db.Query(sqlQuery, args...)
+	rows, err := q.Query(sqlQuery, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -963,10 +971,22 @@ func (s *Store) DeleteFillsByID(fillIDs []string) (float64, error) {
 	return totalQty.Float64, nil
 }
 
-func (s *Store) WithFillSettlementTx(fn func(storepkg.FillSettlementStore) error) error {
+func (s *Store) WithFillSettlementTx(orderID string, fn func(storepkg.FillSettlementStore) error) error {
 	tx, err := s.db.BeginTx(context.Background(), nil)
 	if err != nil {
 		return err
+	}
+	if strings.TrimSpace(orderID) != "" {
+		var lockedOrderID string
+		if err := tx.QueryRow(`
+			select id
+			from orders
+			where id = $1
+			for update
+		`, strings.TrimSpace(orderID)).Scan(&lockedOrderID); err != nil {
+			_ = tx.Rollback()
+			return err
+		}
 	}
 	if err := fn(fillSettlementTxStore{tx: tx}); err != nil {
 		_ = tx.Rollback()
@@ -977,6 +997,10 @@ func (s *Store) WithFillSettlementTx(fn func(storepkg.FillSettlementStore) error
 
 type fillSettlementTxStore struct {
 	tx *sql.Tx
+}
+
+func (s fillSettlementTxStore) QueryFills(query domain.FillQuery) ([]domain.Fill, error) {
+	return queryFills(s.tx, query)
 }
 
 type fillScanner interface {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -12,6 +12,7 @@ import (
 var ErrSignalRuntimeSessionNotFound = errors.New("signal runtime session not found")
 
 type FillSettlementStore interface {
+	QueryFills(query domain.FillQuery) ([]domain.Fill, error)
 	DeleteFillsByID(fillIDs []string) (float64, error)
 	CreateFill(fill domain.Fill) (domain.Fill, error)
 	TotalFilledQuantityForOrder(orderID string) (float64, error)
@@ -78,8 +79,8 @@ type Repository interface {
 	CreateFill(fill domain.Fill) (domain.Fill, error)
 	// DeleteFillsByID 删除指定成交记录，并返回被删除的总数量。
 	DeleteFillsByID(fillIDs []string) (float64, error)
-	// WithFillSettlementTx 在同一个事务边界内执行 fill/order/position settlement。
-	WithFillSettlementTx(fn func(FillSettlementStore) error) error
+	// WithFillSettlementTx 在同一个事务边界内锁定订单并执行 fill/order/position settlement。
+	WithFillSettlementTx(orderID string, fn func(FillSettlementStore) error) error
 	// DeleteSyntheticFillsForOrder 删除指定订单的合成成交记录（没有 exchange_trade_id 的记录），并返回被删除的总数量。
 	DeleteSyntheticFillsForOrder(orderID string) (float64, error)
 


### PR DESCRIPTION
## 目的
为 #272 补同一订单 fill settlement 的串行化保护，避免多个 retry/sync/finalize 同时基于同一份 existing fills 快照 build plan，导致重复 apply position 或重复错误落账。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [x] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) - 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？- 无
- [x] DB migration 是否具备向下兼容幂等性？- 本 PR 无 migration
- [x] 配置字段有没有无意被混改？- 无配置改动

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

验证已跑：

```bash
go test ./internal/service -run 'TestFinalizeExecutedOrderSerializesConcurrentSettlementForSameOrder|TestFinalizeExecutedOrder|TestSyntheticUpgrade' -count=1
go test ./internal/store/memory ./internal/store/postgres -run 'TestWithFillSettlementTx|TestCreateFill.*Source|TestFillSettlementTxCreateFillUpsertUpdatesSourcePostgres' -count=1
go test ./...
go build ./cmd/platform-api
go build ./cmd/db-migrate
python3 scripts/check_migration_safety.py
bash scripts/check_high_risk_defaults.sh
```

说明：`check_migration_safety.py` 只报既有历史 migration 编号重复 `018` / `024`，本 PR 没有新增 migration。
