### PR TITLE
[codex] Record live control audit events

### DIFF
--- a/internal/service/live_session_control.go
+++ b/internal/service/live_session_control.go
@@ -122,13 +122,6 @@ func (p *Platform) requestLiveSessionDesiredStatus(sessionID, desired string, fo
 			state["lastControlAction"] = "start"
 			delete(state, "desiredStopForce")
 		}
-		request := liveSessionControlRequest{
-			ID:      stringValue(state["controlRequestId"]),
-			Version: version,
-		}
-		eventSession := session
-		eventSession.State = state
-		appendLiveSessionControlEvent(state, liveSessionControlEvent(eventSession, request, "request_accepted", desired, stringValue(state["actualStatus"]), nil, now))
 		delete(state, "activeControlRequestId")
 		delete(state, "activeControlVersion")
 		delete(state, "lastControlError")
@@ -136,6 +129,13 @@ func (p *Platform) requestLiveSessionDesiredStatus(sessionID, desired string, fo
 		delete(state, "lastControlErrorCode")
 		delete(state, "lastControlErrorRequestId")
 		delete(state, "lastControlErrorVersion")
+		request := liveSessionControlRequest{
+			ID:      stringValue(state["controlRequestId"]),
+			Version: version,
+		}
+		eventSession := session
+		eventSession.State = state
+		appendLiveSessionControlEvent(state, liveSessionControlEvent(eventSession, request, "request_accepted", desired, stringValue(state["actualStatus"]), nil, now))
 		updated, ok, err := p.updateLiveSessionControlStateIfPrevious(session.ID, previous, state)
 		if err != nil {
 			return domain.LiveSession{}, err

--- a/internal/service/live_session_control.go
+++ b/internal/service/live_session_control.go
@@ -15,6 +15,8 @@ import (
 
 const (
 	liveSessionControlScannerInterval = 5 * time.Second
+	liveSessionControlEventStateKey   = "controlEvents"
+	liveSessionControlEventMaxHistory = 50
 
 	LiveSessionControlErrorCodeActivePositionsOrOrders    = "ACTIVE_POSITIONS_OR_ORDERS"
 	LiveSessionControlErrorCodeRuntimeLeaseNotAcquired    = "RUNTIME_LEASE_NOT_ACQUIRED"
@@ -120,6 +122,13 @@ func (p *Platform) requestLiveSessionDesiredStatus(sessionID, desired string, fo
 			state["lastControlAction"] = "start"
 			delete(state, "desiredStopForce")
 		}
+		request := liveSessionControlRequest{
+			ID:      stringValue(state["controlRequestId"]),
+			Version: version,
+		}
+		eventSession := session
+		eventSession.State = state
+		appendLiveSessionControlEvent(state, liveSessionControlEvent(eventSession, request, "request_accepted", desired, stringValue(state["actualStatus"]), nil, now))
 		delete(state, "activeControlRequestId")
 		delete(state, "activeControlVersion")
 		delete(state, "lastControlError")
@@ -228,6 +237,9 @@ func (p *Platform) initializeLegacyLiveSessionControlRequest(session domain.Live
 			state["lastControlAction"] = "stop"
 		}
 	}
+	eventSession := session
+	eventSession.State = state
+	appendLiveSessionControlEvent(state, liveSessionControlEvent(eventSession, request, "legacy_request_initialized", desired, stringValue(state["actualStatus"]), nil, now))
 	updated, ok, err := p.updateLiveSessionControlStateIfPrevious(session.ID, previous, state)
 	if err != nil {
 		return domain.LiveSession{}, liveSessionControlRequest{}, err
@@ -271,6 +283,7 @@ func (p *Platform) markLiveSessionControlActual(session domain.LiveSession, requ
 	}
 	if !liveSessionControlRequestMatches(latest.State, request) {
 		p.logger("service.live_session_control_scanner", "session_id", session.ID, "request_id", request.ID, "control_version", request.Version).Info("skip stale live session control update")
+		p.recordLiveSessionControlStaleDiscard(latest, request, "actual_status_update")
 		return false
 	}
 	state := cloneMetadata(session.State)
@@ -282,6 +295,7 @@ func (p *Platform) markLiveSessionControlActual(session domain.LiveSession, requ
 	state["lastControlUpdateAt"] = now.Format(time.RFC3339)
 	state["activeControlRequestId"] = request.ID
 	state["activeControlVersion"] = request.Version
+	appendLiveSessionControlEvent(state, liveSessionControlEvent(latest, request, liveSessionControlEventPhase(actual, controlErr), stringValue(state["desiredStatus"]), actual, controlErr, now))
 	if controlErr != nil {
 		state["lastControlError"] = controlErr.Error()
 		state["lastControlErrorCode"] = liveSessionControlErrorCode(controlErr)
@@ -309,10 +323,32 @@ func (p *Platform) markLiveSessionControlActual(session domain.LiveSession, requ
 	}
 	if !ok {
 		p.logger("service.live_session_control_scanner", "session_id", session.ID, "request_id", request.ID, "control_version", request.Version).Info("skip stale live session control update")
+		if latest, loadErr := p.store.GetLiveSession(session.ID); loadErr == nil {
+			p.recordLiveSessionControlStaleDiscard(latest, request, "actual_status_commit")
+		}
 		return false
 	}
 	_ = updated
 	return true
+}
+
+func (p *Platform) recordLiveSessionControlStaleDiscard(session domain.LiveSession, request liveSessionControlRequest, reason string) {
+	state := cloneMetadata(session.State)
+	current, ok := liveSessionControlRequestFromState(state)
+	if !ok {
+		return
+	}
+	now := time.Now().UTC()
+	event := liveSessionControlEvent(session, request, "stale_update_discarded", stringValue(state["desiredStatus"]), stringValue(state["actualStatus"]), nil, now)
+	event["staleReason"] = reason
+	event["currentControlRequestId"] = stringValue(state["controlRequestId"])
+	event["currentControlVersion"] = liveSessionControlVersion(state)
+	appendLiveSessionControlEvent(state, event)
+	if _, updated, err := p.updateLiveSessionControlStateIfPrevious(session.ID, current, state); err != nil {
+		p.logger("service.live_session_control_scanner", "session_id", session.ID, "request_id", request.ID, "control_version", request.Version).Warn("record stale live session control event failed", "error", err)
+	} else if !updated {
+		p.logger("service.live_session_control_scanner", "session_id", session.ID, "request_id", request.ID, "control_version", request.Version).Info("skip stale live session control event update")
+	}
 }
 
 func (p *Platform) updateLiveSessionControlStateIfCurrent(sessionID string, request liveSessionControlRequest, state map[string]any) (domain.LiveSession, bool, error) {
@@ -351,6 +387,78 @@ func liveSessionControlErrorCode(err error) string {
 		return LiveSessionControlErrorCodeAdapterError
 	default:
 		return LiveSessionControlErrorCodeUnknown
+	}
+}
+
+func appendLiveSessionControlEvent(state map[string]any, event map[string]any) {
+	if state == nil || event == nil {
+		return
+	}
+	events := metadataList(state[liveSessionControlEventStateKey])
+	events = append(events, cloneMetadata(event))
+	if len(events) > liveSessionControlEventMaxHistory {
+		events = events[len(events)-liveSessionControlEventMaxHistory:]
+	}
+	state[liveSessionControlEventStateKey] = events
+}
+
+func liveSessionControlEvent(session domain.LiveSession, request liveSessionControlRequest, phase, desired, actual string, controlErr error, eventTime time.Time) map[string]any {
+	if eventTime.IsZero() {
+		eventTime = time.Now().UTC()
+	}
+	state := cloneMetadata(session.State)
+	event := map[string]any{
+		"id":               uuid.NewString(),
+		"type":             "live-control",
+		"phase":            phase,
+		"liveSessionId":    session.ID,
+		"accountId":        session.AccountID,
+		"strategyId":       session.StrategyID,
+		"sessionStatus":    session.Status,
+		"desiredStatus":    strings.ToUpper(strings.TrimSpace(desired)),
+		"actualStatus":     strings.ToUpper(strings.TrimSpace(actual)),
+		"controlRequestId": request.ID,
+		"controlVersion":   request.Version,
+		"action":           firstNonEmpty(stringValue(state["lastControlAction"]), liveSessionControlActionFromDesired(desired)),
+		"eventTime":        eventTime.UTC().Format(time.RFC3339Nano),
+		"recordedAt":       eventTime.UTC().Format(time.RFC3339Nano),
+	}
+	if force, ok := state["desiredStopForce"]; ok {
+		event["force"] = boolValue(force)
+	}
+	if requestedAt, ok := parseLiveSessionControlTime(state["controlRequestedAt"]); ok {
+		event["controlRequestedAt"] = requestedAt.UTC().Format(time.RFC3339Nano)
+		event["latencyMs"] = eventTime.UTC().Sub(requestedAt.UTC()).Milliseconds()
+	}
+	if controlErr != nil {
+		event["error"] = controlErr.Error()
+		event["errorCode"] = liveSessionControlErrorCode(controlErr)
+	}
+	return event
+}
+
+func liveSessionControlActionFromDesired(desired string) string {
+	switch strings.ToUpper(strings.TrimSpace(desired)) {
+	case "RUNNING":
+		return "start"
+	case "STOPPED":
+		return "stop"
+	default:
+		return strings.ToLower(strings.TrimSpace(desired))
+	}
+}
+
+func liveSessionControlEventPhase(actual string, controlErr error) string {
+	if controlErr != nil || strings.EqualFold(actual, "ERROR") {
+		return "failed"
+	}
+	switch strings.ToUpper(strings.TrimSpace(actual)) {
+	case "STARTING", "STOPPING":
+		return "runner_picked_up"
+	case "RUNNING", "STOPPED":
+		return "succeeded"
+	default:
+		return "actual_status_changed"
 	}
 }
 

--- a/internal/service/live_session_control_test.go
+++ b/internal/service/live_session_control_test.go
@@ -185,6 +185,28 @@ func TestScanLiveSessionControlRequestsPreservesStopSafetyUntilForceRequested(t 
 	if got := stringValue(blocked.State["lastControlErrorCode"]); got != LiveSessionControlErrorCodeActivePositionsOrOrders {
 		t.Fatalf("expected lastControlErrorCode %s, got %s", LiveSessionControlErrorCodeActivePositionsOrOrders, got)
 	}
+	events := metadataList(blocked.State[liveSessionControlEventStateKey])
+	if len(events) != 3 {
+		t.Fatalf("expected request, pickup, and failure events, got %d: %#v", len(events), events)
+	}
+	if got := stringValue(events[2]["phase"]); got != "failed" {
+		t.Fatalf("expected failed control event, got %s", got)
+	}
+	if got := stringValue(events[2]["errorCode"]); got != LiveSessionControlErrorCodeActivePositionsOrOrders {
+		t.Fatalf("expected failed event errorCode %s, got %s", LiveSessionControlErrorCodeActivePositionsOrOrders, got)
+	}
+	page, err := platform.ListLogEvents(UnifiedLogEventQuery{
+		Type:          "live-control",
+		Level:         "critical",
+		LiveSessionID: session.ID,
+		Limit:         10,
+	})
+	if err != nil {
+		t.Fatalf("list critical live control events: %v", err)
+	}
+	if len(page.Items) != 1 {
+		t.Fatalf("expected one critical live control event, got %d", len(page.Items))
+	}
 
 	platform.scanLiveSessionControlRequests(context.Background())
 	stillBlocked, err := store.GetLiveSession(session.ID)
@@ -403,6 +425,70 @@ func TestDeleteLiveSessionCancelsPendingDesiredControlIntent(t *testing.T) {
 		if item.ID == deleted.ID {
 			t.Fatalf("expected deleted session to be hidden from scanner list")
 		}
+	}
+}
+
+func TestLiveSessionControlRecordsAuditEvents(t *testing.T) {
+	store := memory.NewStore()
+	platform := NewPlatform(store)
+	session, err := store.UpdateLiveSessionStatus("live-session-main", "RUNNING")
+	if err != nil {
+		t.Fatalf("set live session running failed: %v", err)
+	}
+	requested, err := platform.RequestLiveSessionStopWithForce(session.ID, false)
+	if err != nil {
+		t.Fatalf("request stop failed: %v", err)
+	}
+	request, ok := liveSessionControlRequestFromState(requested.State)
+	if !ok {
+		t.Fatal("expected control request identity")
+	}
+
+	platform.scanLiveSessionControlRequests(context.Background())
+
+	stopped, err := store.GetLiveSession(session.ID)
+	if err != nil {
+		t.Fatalf("get live session failed: %v", err)
+	}
+	events := metadataList(stopped.State[liveSessionControlEventStateKey])
+	if len(events) != 3 {
+		t.Fatalf("expected request, pickup, and success events, got %d: %#v", len(events), events)
+	}
+	wantPhases := []string{"request_accepted", "runner_picked_up", "succeeded"}
+	for i, want := range wantPhases {
+		if got := stringValue(events[i]["phase"]); got != want {
+			t.Fatalf("event %d expected phase %s, got %s", i, want, got)
+		}
+		if got := stringValue(events[i]["controlRequestId"]); got != request.ID {
+			t.Fatalf("event %d expected request id %s, got %s", i, request.ID, got)
+		}
+		if got := liveSessionControlVersionKey(events[i], "controlVersion"); got != request.Version {
+			t.Fatalf("event %d expected version %d, got %d", i, request.Version, got)
+		}
+	}
+	if got := stringValue(events[0]["action"]); got != "stop" {
+		t.Fatalf("expected stop action, got %s", got)
+	}
+	if got := boolValue(events[0]["force"]); got {
+		t.Fatal("expected non-force audit event")
+	}
+
+	page, err := platform.ListLogEvents(UnifiedLogEventQuery{
+		Type:          "live-control",
+		LiveSessionID: session.ID,
+		Limit:         10,
+	})
+	if err != nil {
+		t.Fatalf("list live control log events: %v", err)
+	}
+	if len(page.Items) != 3 {
+		t.Fatalf("expected 3 unified live control events, got %d", len(page.Items))
+	}
+	if page.Items[0].Type != "live-control" || page.Items[0].Level != "info" {
+		t.Fatalf("unexpected newest live control event: %#v", page.Items[0])
+	}
+	if got := stringValue(page.Items[0].Metadata["phase"]); got != "succeeded" {
+		t.Fatalf("expected newest event to be succeeded, got %s", got)
 	}
 }
 

--- a/internal/service/logs.go
+++ b/internal/service/logs.go
@@ -188,6 +188,17 @@ func (p *Platform) ListLogEvents(query UnifiedLogEventQuery) (UnifiedLogEventPag
 			}
 		}
 	}
+	if normalizedType == "" || normalizedType == "live-control" {
+		items, err := p.queryLiveSessionControlEvents(query, cursor, fetchLimit)
+		if err != nil {
+			return UnifiedLogEventPage{}, err
+		}
+		for _, event := range items {
+			if matchesUnifiedLogLevel(event.Level, levelFilter) {
+				merged = append(merged, event)
+			}
+		}
+	}
 
 	sort.SliceStable(merged, func(i, j int) bool {
 		return unifiedLogEventLess(merged[i], merged[j])
@@ -340,6 +351,48 @@ func (p *Platform) queryPositionAccountSnapshots(query domain.PositionAccountSna
 	return limitPositionSnapshots(filtered, query.Limit), nil
 }
 
+func (p *Platform) queryLiveSessionControlEvents(query UnifiedLogEventQuery, cursor *domain.EventCursor, limit int) ([]UnifiedLogEvent, error) {
+	sessions, err := p.store.ListLiveSessions()
+	if err != nil {
+		return nil, err
+	}
+	filtered := make([]UnifiedLogEvent, 0)
+	for _, session := range sessions {
+		if strings.TrimSpace(query.AccountID) != "" && session.AccountID != strings.TrimSpace(query.AccountID) {
+			continue
+		}
+		if strings.TrimSpace(query.StrategyID) != "" && session.StrategyID != strings.TrimSpace(query.StrategyID) {
+			continue
+		}
+		if strings.TrimSpace(query.LiveSessionID) != "" && session.ID != strings.TrimSpace(query.LiveSessionID) {
+			continue
+		}
+		for _, entry := range metadataList(session.State[liveSessionControlEventStateKey]) {
+			event, ok := liveSessionControlToUnifiedLogEvent(session, entry)
+			if !ok {
+				continue
+			}
+			if !query.From.IsZero() && event.EventTime.Before(query.From.UTC()) {
+				continue
+			}
+			if !query.To.IsZero() && event.EventTime.After(query.To.UTC()) {
+				continue
+			}
+			if cursor != nil && !domain.EventBeforeCursor(event.EventTime, event.RecordedAt, event.ID, *cursor) {
+				continue
+			}
+			filtered = append(filtered, event)
+		}
+	}
+	sort.SliceStable(filtered, func(i, j int) bool {
+		return unifiedLogEventLess(filtered[i], filtered[j])
+	})
+	if limit > 0 && len(filtered) > limit {
+		return slices.Clone(filtered[:limit]), nil
+	}
+	return filtered, nil
+}
+
 func strategyDecisionToUnifiedLogEvent(item domain.StrategyDecisionEvent) UnifiedLogEvent {
 	level := "info"
 	if !item.SourceGateReady || item.MissingCount > 0 || item.StaleCount > 0 {
@@ -443,6 +496,94 @@ func positionSnapshotToUnifiedLogEvent(item domain.PositionAccountSnapshot) Unif
 	}
 }
 
+func liveSessionControlToUnifiedLogEvent(session domain.LiveSession, entry map[string]any) (UnifiedLogEvent, bool) {
+	id := strings.TrimSpace(stringValue(entry["id"]))
+	if id == "" {
+		return UnifiedLogEvent{}, false
+	}
+	eventTime := parseOptionalRFC3339(stringValue(entry["eventTime"]))
+	if eventTime.IsZero() {
+		return UnifiedLogEvent{}, false
+	}
+	recordedAt := parseOptionalRFC3339(stringValue(entry["recordedAt"]))
+	recordedAt = domain.NormalizeEventRecordedAt(recordedAt, eventTime)
+	phase := strings.TrimSpace(stringValue(entry["phase"]))
+	actual := strings.TrimSpace(stringValue(entry["actualStatus"]))
+	errorCode := strings.TrimSpace(stringValue(entry["errorCode"]))
+	level := "info"
+	if errorCode != "" || strings.EqualFold(phase, "failed") || strings.EqualFold(actual, "ERROR") {
+		level = "critical"
+	} else if strings.EqualFold(phase, "stale_update_discarded") {
+		level = "warning"
+	}
+	metadata := map[string]any{
+		"phase":            phase,
+		"action":           entry["action"],
+		"desiredStatus":    entry["desiredStatus"],
+		"actualStatus":     entry["actualStatus"],
+		"controlRequestId": entry["controlRequestId"],
+		"controlVersion":   entry["controlVersion"],
+		"errorCode":        entry["errorCode"],
+		"latencyMs":        entry["latencyMs"],
+	}
+	return UnifiedLogEvent{
+		ID:            id,
+		Source:        "event",
+		Type:          "live-control",
+		Level:         level,
+		Title:         liveSessionControlEventTitle(phase),
+		Message:       liveSessionControlEventMessage(entry),
+		EventTime:     eventTime.UTC(),
+		RecordedAt:    recordedAt,
+		AccountID:     firstNonEmpty(strings.TrimSpace(stringValue(entry["accountId"])), session.AccountID),
+		StrategyID:    firstNonEmpty(strings.TrimSpace(stringValue(entry["strategyId"])), session.StrategyID),
+		LiveSessionID: firstNonEmpty(strings.TrimSpace(stringValue(entry["liveSessionId"])), session.ID),
+		Metadata:      metadata,
+		Payload:       entry,
+	}, true
+}
+
+func liveSessionControlEventTitle(phase string) string {
+	switch strings.ToLower(strings.TrimSpace(phase)) {
+	case "request_accepted":
+		return "live control request accepted"
+	case "legacy_request_initialized":
+		return "live control request initialized"
+	case "runner_picked_up":
+		return "live control picked up"
+	case "succeeded":
+		return "live control succeeded"
+	case "failed":
+		return "live control failed"
+	case "stale_update_discarded":
+		return "live control stale update discarded"
+	default:
+		return "live control updated"
+	}
+}
+
+func liveSessionControlEventMessage(entry map[string]any) string {
+	action := strings.TrimSpace(stringValue(entry["action"]))
+	actual := strings.TrimSpace(stringValue(entry["actualStatus"]))
+	if err := strings.TrimSpace(stringValue(entry["error"])); err != "" {
+		return err
+	}
+	switch strings.ToLower(strings.TrimSpace(stringValue(entry["phase"]))) {
+	case "request_accepted":
+		return firstNonEmpty(action, "control") + " intent accepted"
+	case "legacy_request_initialized":
+		return firstNonEmpty(action, "control") + " legacy intent initialized"
+	case "runner_picked_up":
+		return "runner picked up " + firstNonEmpty(action, "control") + " intent"
+	case "succeeded":
+		return firstNonEmpty(action, "control") + " converged to " + firstNonEmpty(actual, "target status")
+	case "stale_update_discarded":
+		return "stale runner result discarded"
+	default:
+		return firstNonEmpty(actual, "live control state updated")
+	}
+}
+
 func encodeLogEventCursor(item UnifiedLogEvent) string {
 	payload, _ := json.Marshal(logEventCursor{
 		EventTime:  item.EventTime.UTC().Format(time.RFC3339Nano),
@@ -492,6 +633,8 @@ func normalizeUnifiedLogEventType(value string) string {
 		return "order-execution"
 	case "snapshot", "position-account-snapshot", "position_account_snapshot":
 		return "position-account-snapshot"
+	case "live-control", "live_control", "control":
+		return "live-control"
 	default:
 		return strings.ToLower(strings.TrimSpace(value))
 	}


### PR DESCRIPTION
## 目的
Phase 4 for #282: add the first observability/audit surface for LiveSession control requests without adding a new table or changing execution semantics.

Changes:
- stores bounded LiveSession control audit history in `live_sessions.state.controlEvents`
- records control request lifecycle events:
  - `request_accepted`
  - `legacy_request_initialized`
  - `runner_picked_up`
  - `succeeded`
  - `failed`
  - `stale_update_discarded`
- exposes those events through the existing `/api/v1/logs/events` aggregation as `type=live-control`
- includes request id/version, desired/actual status, action, force flag, error code, error text, and latencyMs where available
- keeps stale-discard audit writes guarded by the current control request CAS

Root cause / motivation:
After Phases 1-3.1, the control plane had correct desired/actual semantics and structured error codes, but operators still lacked a unified audit view for when a request was accepted, picked up, converged, failed, or discarded as stale.

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [x] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) - No change.
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？ - No.
- [x] DB migration 是否具备向下兼容幂等性？ - No DB migration; uses bounded JSONB history in existing session state.
- [x] 配置字段有没有无意被混改？ - No config schema/default changes.

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

Local validation:
- `go test ./internal/service -run 'TestScanLiveSessionControlRequestsPreservesStopSafetyUntilForceRequested|TestLiveSessionControlRecordsAuditEvents|TestListLogEventsSupportsPaginationAndFilters'`
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
- `go build ./cmd/bktrader-ctl`
