### PR TITLE
[codex] Alert on stuck live control pending

### DIFF
--- a/internal/service/alerts.go
+++ b/internal/service/alerts.go
@@ -14,6 +14,7 @@ const (
 	liveExitDispatchFailureLogDedupeTTL        = 6 * time.Hour
 	liveExitDispatchFailureLogDedupeMaxEntries = 512
 	liveAccountSyncStaleAlertGrace             = 30 * time.Second
+	liveSessionControlPendingAlertThreshold    = 2 * time.Minute
 )
 
 type liveAccountSyncStaleness string
@@ -337,6 +338,9 @@ func (p *Platform) ListAlerts() ([]domain.PlatformAlert, error) {
 
 	for _, session := range liveSessions {
 		state := cloneMetadata(session.State)
+		if alert, ok := buildLiveSessionControlPendingAlert(session, state, accountByID[session.AccountID].Name, strategyNameByID[session.StrategyID], time.Now().UTC()); ok {
+			appendAlert(alert)
+		}
 		if p.liveSessionEvaluationQuiet("LIVE", session.Status, state) {
 			appendAlert(domain.PlatformAlert{
 				ID:           fmt.Sprintf("live-strategy-eval-quiet-%s", session.ID),
@@ -447,6 +451,76 @@ func (p *Platform) ListAlerts() ([]domain.PlatformAlert, error) {
 		return 1
 	})
 	return alerts, nil
+}
+
+func buildLiveSessionControlPendingAlert(session domain.LiveSession, state map[string]any, accountName, strategyName string, now time.Time) (domain.PlatformAlert, bool) {
+	desired := strings.ToUpper(strings.TrimSpace(stringValue(state["desiredStatus"])))
+	if desired == "" {
+		return domain.PlatformAlert{}, false
+	}
+	actual := strings.ToUpper(strings.TrimSpace(stringValue(state["actualStatus"])))
+	if actual == "" {
+		actual = liveSessionActualStatusFromSession(session)
+	}
+	if actual == "ERROR" {
+		return domain.PlatformAlert{}, false
+	}
+	inProgress := actual == "STARTING" || actual == "STOPPING"
+	if desired == actual && !inProgress {
+		return domain.PlatformAlert{}, false
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	pendingSince, ok := liveSessionControlPendingSince(state, inProgress)
+	if !ok {
+		return domain.PlatformAlert{}, false
+	}
+	pendingSeconds := int64(now.UTC().Sub(pendingSince.UTC()).Seconds())
+	if pendingSeconds < int64(liveSessionControlPendingAlertThreshold.Seconds()) {
+		return domain.PlatformAlert{}, false
+	}
+	action := firstNonEmpty(strings.TrimSpace(stringValue(state["lastControlAction"])), liveSessionControlActionFromDesired(desired))
+	return domain.PlatformAlert{
+		ID:           fmt.Sprintf("live-control-pending-%s", session.ID),
+		Scope:        "live",
+		Level:        "warning",
+		Title:        "实盘控制收敛超时",
+		Detail:       fmt.Sprintf("控制意图 %s 已等待 %d 秒仍未收敛，desired=%s actual=%s", firstNonEmpty(action, "control"), pendingSeconds, desired, actual),
+		AccountID:    session.AccountID,
+		AccountName:  accountName,
+		StrategyID:   session.StrategyID,
+		StrategyName: strategyName,
+		Anchor:       "live",
+		EventTime:    pendingSince,
+		Metadata: map[string]any{
+			"liveSessionId":    session.ID,
+			"controlRequestId": stringValue(state["controlRequestId"]),
+			"controlVersion":   liveSessionControlVersion(state),
+			"action":           action,
+			"desiredStatus":    desired,
+			"actualStatus":     actual,
+			"pendingSeconds":   pendingSeconds,
+			"thresholdSeconds": int64(liveSessionControlPendingAlertThreshold.Seconds()),
+		},
+	}, true
+}
+
+func liveSessionControlPendingSince(state map[string]any, inProgress bool) (time.Time, bool) {
+	requestedAt, requestedOK := parseLiveSessionControlTime(state["controlRequestedAt"])
+	updatedAt, updatedOK := parseLiveSessionControlTime(state["lastControlUpdateAt"])
+	if inProgress && updatedOK {
+		if !requestedOK || updatedAt.After(requestedAt) {
+			return updatedAt.UTC(), true
+		}
+	}
+	if requestedOK {
+		return requestedAt.UTC(), true
+	}
+	if updatedOK {
+		return updatedAt.UTC(), true
+	}
+	return time.Time{}, false
 }
 
 func (p *Platform) buildLiveExitDispatchFailureAlert(session domain.LiveSession, state map[string]any, accountName, strategyName string) (domain.PlatformAlert, bool) {

--- a/internal/service/health_state_test.go
+++ b/internal/service/health_state_test.go
@@ -893,3 +893,105 @@ func TestLiveSessionEvaluationQuietMatchesAlertsAndSnapshot(t *testing.T) {
 		t.Fatal("expected stopped live session snapshot to suppress evaluationQuiet")
 	}
 }
+
+func TestListAlertsShowsStuckLiveControlPending(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	session, err := platform.store.GetLiveSession("live-session-main")
+	if err != nil {
+		t.Fatalf("get live session failed: %v", err)
+	}
+	now := time.Now().UTC()
+	state := cloneMetadata(session.State)
+	state["desiredStatus"] = "RUNNING"
+	state["actualStatus"] = "STARTING"
+	state["lastControlAction"] = "start"
+	state["controlRequestId"] = "control-request-stuck"
+	state["controlVersion"] = 7
+	state["controlRequestedAt"] = now.Add(-10 * time.Minute).Format(time.RFC3339)
+	state["lastControlUpdateAt"] = now.Add(-3 * time.Minute).Format(time.RFC3339)
+	session.State = state
+	session.Status = "STOPPED"
+	if _, err := platform.store.UpdateLiveSession(session); err != nil {
+		t.Fatalf("update live session failed: %v", err)
+	}
+
+	alerts, err := platform.ListAlerts()
+	if err != nil {
+		t.Fatalf("list alerts failed: %v", err)
+	}
+	found := false
+	for _, alert := range alerts {
+		if alert.ID != "live-control-pending-"+session.ID {
+			continue
+		}
+		found = true
+		if alert.Level != "warning" {
+			t.Fatalf("expected warning level, got %s", alert.Level)
+		}
+		if got := stringValue(alert.Metadata["controlRequestId"]); got != "control-request-stuck" {
+			t.Fatalf("expected request id metadata, got %s", got)
+		}
+		if got := liveSessionControlVersionKey(alert.Metadata, "controlVersion"); got != 7 {
+			t.Fatalf("expected control version 7, got %d", got)
+		}
+		if got := stringValue(alert.Metadata["actualStatus"]); got != "STARTING" {
+			t.Fatalf("expected actual STARTING metadata, got %s", got)
+		}
+		pending, _ := toFloat64(alert.Metadata["pendingSeconds"])
+		if int64(pending) < int64(liveSessionControlPendingAlertThreshold.Seconds()) {
+			t.Fatalf("expected pending seconds over threshold, got %.0f", pending)
+		}
+	}
+	if !found {
+		t.Fatal("expected live control pending alert")
+	}
+}
+
+func TestListAlertsSuppressesFreshOrErrorLiveControlPending(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	session, err := platform.store.GetLiveSession("live-session-main")
+	if err != nil {
+		t.Fatalf("get live session failed: %v", err)
+	}
+	now := time.Now().UTC()
+	state := cloneMetadata(session.State)
+	state["desiredStatus"] = "STOPPED"
+	state["actualStatus"] = "STOPPING"
+	state["lastControlAction"] = "stop"
+	state["controlRequestId"] = "control-request-fresh"
+	state["controlVersion"] = 9
+	state["controlRequestedAt"] = now.Add(-30 * time.Second).Format(time.RFC3339)
+	state["lastControlUpdateAt"] = now.Add(-10 * time.Second).Format(time.RFC3339)
+	session.State = state
+	session.Status = "RUNNING"
+	if _, err := platform.store.UpdateLiveSession(session); err != nil {
+		t.Fatalf("update live session failed: %v", err)
+	}
+
+	alerts, err := platform.ListAlerts()
+	if err != nil {
+		t.Fatalf("list fresh alerts failed: %v", err)
+	}
+	for _, alert := range alerts {
+		if alert.ID == "live-control-pending-"+session.ID {
+			t.Fatal("expected fresh pending control alert to be suppressed")
+		}
+	}
+
+	state["actualStatus"] = "ERROR"
+	state["lastControlErrorAt"] = now.Add(-10 * time.Minute).Format(time.RFC3339)
+	state["lastControlError"] = "adapter unavailable"
+	session.State = state
+	if _, err := platform.store.UpdateLiveSession(session); err != nil {
+		t.Fatalf("update error live session failed: %v", err)
+	}
+	alerts, err = platform.ListAlerts()
+	if err != nil {
+		t.Fatalf("list error alerts failed: %v", err)
+	}
+	for _, alert := range alerts {
+		if alert.ID == "live-control-pending-"+session.ID {
+			t.Fatal("expected ERROR control state not to emit pending alert")
+		}
+	}
+}


### PR DESCRIPTION
## 目的
Phase 4 for #282: expose stuck LiveSession control requests as platform alerts so operators can detect control intents that are not converging.

Changes:
- Adds a `live-control-pending-*` warning alert when a LiveSession control request remains pending beyond an internal 2 minute threshold.
- Detects both not-picked-up desired/actual mismatch and long `STARTING` / `STOPPING` in-progress states.
- Suppresses the alert for fresh pending requests and for `actualStatus=ERROR`, since ERROR already has explicit failure semantics.
- Includes control metadata: `liveSessionId`, `controlRequestId`, `controlVersion`, action, desired/actual status, pending seconds, threshold seconds.

Root cause / motivation:
Phase 4 audit events made control request history queryable, but operators still needed a direct alert signal for stuck pending controls that do not reach terminal success/error in time.

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [x] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) - No change.
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？ - No.
- [x] DB migration 是否具备向下兼容幂等性？ - No DB migration.
- [x] 配置字段有没有无意被混改？ - No config schema/default changes; threshold is an internal constant.

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

Local validation:
- `go test ./internal/service -run 'TestListAlertsShowsStuckLiveControlPending|TestListAlertsSuppressesFreshOrErrorLiveControlPending|TestLiveSessionEvaluationQuietMatchesAlertsAndSnapshot'`
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
- `go build ./cmd/bktrader-ctl`
