### PR TITLE
[codex] add exchange fill report mappers

### DIFF
--- a/docs/fill-reconciliation-engine.md
+++ b/docs/fill-reconciliation-engine.md
@@ -25,7 +25,7 @@
 
 这样后续执行删除计划时，只会删除被上游明确标记为 `synthetic` 或 `remainder` 的本地 fill，避免依赖间接条件误删合法 fallback fill。
 
-长期可以评估增加 `fill_source` 字段，取值为 `real / synthetic / remainder / paper / manual`。
+当前已经增加 `fill_source` 字段，取值为 `real / synthetic / remainder / paper / manual`。`domain.Fill.Source` 是内部 reconciliation source，不通过 fill JSON 对外输出。
 
 ## 一致性规则
 
@@ -51,17 +51,20 @@
 | `RealizedPnL` | `realizedPnl` | `fillPnl` | `closedPnl` |
 | `TradeTime` | `time` | `fillTime` | `execTime` |
 
-## 当前阶段实现
+## 当前实现
 
-阶段 1+2 只新增文档和纯函数：
+当前已经完成以下收口：
 
 - `BuildFillReconciliationPlan` 读取 `domain.Order`、existing fills 和 incoming fills；
 - existing/incoming fills 必须带显式 source；
 - 输出 `DeleteFillIDs`、`CreateFills`、`ApplyPositionFills`、`UpdatedMetadata`、`Warnings`；
 - `remainingQuantity` 统一 clamp 到非负值，超额成交通过 `Warnings` 暴露；
-- 不接入 `finalizeExecutedOrder`；
-- 不修改 store 接口；
-- 不新增 migration；
+- `finalizeExecutedOrder` 已按 plan 执行删除、创建、position 增量应用；
+- fill/order/position settlement 已进入同一事务边界；
+- 同一订单 settlement 在 Postgres 中通过 order row lock 串行化；
+- `fills.fill_source` 已持久化，memory/postgres store 均读写 source；
+- Binance user trades 已映射到 `ExchangeFillReport`；
+- OKX / Bybit 成交 payload 已有统一 mapper 和测试，后续 live adapter 只需要调用 mapper；
 - 不改变 Binance、testnet、mainnet 或 `dispatchMode` 默认行为。
 
-后续阶段再让 `finalizeExecutedOrder` 按 plan 执行删除、创建、position 增量应用，并把 adapter 原始字段逐步收敛到统一 fill report。
+后续阶段再把 OKX / Bybit live adapter 接入实际 REST/WS 成交流，并复用当前 `ExchangeFillReport` mapper，不在 adapter 内重写 synthetic upgrade 算法。

--- a/internal/service/live_registry.go
+++ b/internal/service/live_registry.go
@@ -74,6 +74,22 @@ type ExchangeFillReport struct {
 	Raw             map[string]any `json:"raw,omitempty"`
 }
 
+type exchangeFillReportPayloadMapping struct {
+	ReportSource         string
+	ExchangeOrderIDField string
+	ExchangeTradeIDField string
+	SymbolField          string
+	SideField            string
+	PriceField           string
+	QuantityField        string
+	FeeField             string
+	FeeAssetField        string
+	RealizedPnLField     string
+	FundingPnLField      string
+	TradeTimeField       string
+	MetadataFields       []string
+}
+
 func (report ExchangeFillReport) LiveFillReport() LiveFillReport {
 	metadata := map[string]any{
 		"source":          "exchange-fill-report",
@@ -84,6 +100,9 @@ func (report ExchangeFillReport) LiveFillReport() LiveFillReport {
 		"orderId":         report.OrderID,
 		"exchangeOrderId": report.ExchangeOrderID,
 		"tradeId":         report.ExchangeTradeID,
+		"symbol":          report.Symbol,
+		"side":            report.Side,
+		"feeAsset":        report.FeeAsset,
 		"commissionAsset": report.FeeAsset,
 		"realizedPnl":     report.RealizedPnL,
 		"tradeTime":       report.TradeTime,
@@ -99,6 +118,75 @@ func (report ExchangeFillReport) LiveFillReport() LiveFillReport {
 		Source:     report.Source,
 		Metadata:   metadata,
 	}
+}
+
+func liveFillReportsFromExchangePayloads(account domain.Account, adapterKey string, payloads []map[string]any, fallbackOrderID any, mapping exchangeFillReportPayloadMapping) []LiveFillReport {
+	reports := make([]LiveFillReport, 0, len(payloads))
+	for _, payload := range payloads {
+		qty := parseFloatValue(payload[mapping.QuantityField])
+		if qty <= 0 {
+			continue
+		}
+		report := ExchangeFillReport{
+			Exchange:        account.Exchange,
+			AdapterKey:      adapterKey,
+			AccountID:       account.ID,
+			ExchangeOrderID: normalizeExchangeID(payload[mapping.ExchangeOrderIDField], fallbackOrderID),
+			ExchangeTradeID: stringifyExchangeID(payload[mapping.ExchangeTradeIDField]),
+			Symbol:          stringValue(payload[mapping.SymbolField]),
+			Side:            stringValue(payload[mapping.SideField]),
+			Price:           parseFloatValue(payload[mapping.PriceField]),
+			Quantity:        qty,
+			Fee:             parseFloatValue(payload[mapping.FeeField]),
+			FeeAsset:        stringValue(payload[mapping.FeeAssetField]),
+			RealizedPnL:     parseFloatValue(payload[mapping.RealizedPnLField]),
+			FundingPnL:      parseFloatValue(payload[mapping.FundingPnLField]),
+			TradeTime:       parseExchangeMillisToRFC3339(payload[mapping.TradeTimeField]),
+			Source:          FillSourceReal,
+			Raw:             payload,
+		}
+		reports = append(reports, report.LiveFillReport())
+		metadata := reports[len(reports)-1].Metadata
+		metadata["source"] = mapping.ReportSource
+		metadata["reportSource"] = mapping.ReportSource
+		metadata["executionMode"] = "rest"
+		for _, field := range mapping.MetadataFields {
+			metadata[field] = payload[field]
+		}
+	}
+	return reports
+}
+
+func okxFillReportsFromTradePayloads(account domain.Account, adapterKey string, payloads []map[string]any, fallbackOrderID any) []LiveFillReport {
+	return liveFillReportsFromExchangePayloads(account, adapterKey, payloads, fallbackOrderID, exchangeFillReportPayloadMapping{
+		ReportSource:         "okx-fills",
+		ExchangeOrderIDField: "ordId",
+		ExchangeTradeIDField: "tradeId",
+		SymbolField:          "instId",
+		SideField:            "side",
+		PriceField:           "fillPx",
+		QuantityField:        "fillSz",
+		FeeField:             "fillFee",
+		FeeAssetField:        "feeCcy",
+		RealizedPnLField:     "fillPnl",
+		TradeTimeField:       "fillTime",
+	})
+}
+
+func bybitFillReportsFromExecutionPayloads(account domain.Account, adapterKey string, payloads []map[string]any, fallbackOrderID any) []LiveFillReport {
+	return liveFillReportsFromExchangePayloads(account, adapterKey, payloads, fallbackOrderID, exchangeFillReportPayloadMapping{
+		ReportSource:         "bybit-executions",
+		ExchangeOrderIDField: "orderId",
+		ExchangeTradeIDField: "execId",
+		SymbolField:          "symbol",
+		SideField:            "side",
+		PriceField:           "execPrice",
+		QuantityField:        "execQty",
+		FeeField:             "execFee",
+		FeeAssetField:        "feeCurrency",
+		RealizedPnLField:     "closedPnl",
+		TradeTimeField:       "execTime",
+	})
 }
 
 type LiveOrderSync struct {
@@ -735,35 +823,18 @@ func (a binanceFuturesLiveAdapter) fetchRESTTradeReportsForSymbol(account domain
 }
 
 func (a binanceFuturesLiveAdapter) tradeReportsFromBinanceTrades(account domain.Account, trades []map[string]any, fallbackOrderID any) []LiveFillReport {
-	reports := make([]LiveFillReport, 0, len(trades))
-	for _, trade := range trades {
-		qty := parseFloatValue(trade["qty"])
-		if qty <= 0 {
-			continue
-		}
-		reports = append(reports, ExchangeFillReport{
-			Exchange:        account.Exchange,
-			AdapterKey:      a.Key(),
-			AccountID:       account.ID,
-			ExchangeOrderID: normalizeBinanceOrderID(trade["orderId"], fallbackOrderID),
-			ExchangeTradeID: stringifyBinanceID(trade["id"]),
-			Price:           parseFloatValue(trade["price"]),
-			Quantity:        qty,
-			Fee:             parseFloatValue(trade["commission"]),
-			FeeAsset:        stringValue(trade["commissionAsset"]),
-			RealizedPnL:     parseFloatValue(trade["realizedPnl"]),
-			TradeTime:       parseBinanceMillisToRFC3339(trade["time"]),
-			Source:          FillSourceReal,
-			Raw:             trade,
-		}.LiveFillReport())
-		metadata := reports[len(reports)-1].Metadata
-		metadata["source"] = "binance-user-trades"
-		metadata["reportSource"] = "binance-user-trades"
-		metadata["maker"] = trade["maker"]
-		metadata["buyer"] = trade["buyer"]
-		metadata["executionMode"] = "rest"
-	}
-	return reports
+	return liveFillReportsFromExchangePayloads(account, a.Key(), trades, fallbackOrderID, exchangeFillReportPayloadMapping{
+		ReportSource:         "binance-user-trades",
+		ExchangeOrderIDField: "orderId",
+		ExchangeTradeIDField: "id",
+		PriceField:           "price",
+		QuantityField:        "qty",
+		FeeField:             "commission",
+		FeeAssetField:        "commissionAsset",
+		RealizedPnLField:     "realizedPnl",
+		TradeTimeField:       "time",
+		MetadataFields:       []string{"maker", "buyer"},
+	})
 }
 
 func normalizeCredentialRefs(value any) map[string]any {
@@ -1473,13 +1544,21 @@ func mapBinanceOrderStatus(status string) string {
 }
 
 func normalizeBinanceOrderID(primary any, fallback any) string {
-	if value := stringifyBinanceID(primary); value != "" {
-		return value
-	}
-	return stringifyBinanceID(fallback)
+	return normalizeExchangeID(primary, fallback)
 }
 
 func stringifyBinanceID(value any) string {
+	return stringifyExchangeID(value)
+}
+
+func normalizeExchangeID(primary any, fallback any) string {
+	if value := stringifyExchangeID(primary); value != "" {
+		return value
+	}
+	return stringifyExchangeID(fallback)
+}
+
+func stringifyExchangeID(value any) string {
 	switch v := value.(type) {
 	case nil:
 		return ""
@@ -1507,9 +1586,13 @@ func stringifyBinanceID(value any) string {
 }
 
 func parseBinanceMillisToRFC3339(value any) string {
+	return parseExchangeMillisToRFC3339(value)
+}
+
+func parseExchangeMillisToRFC3339(value any) string {
 	millis, ok := toInt64(value)
 	if !ok || millis <= 0 {
-		return ""
+		return strings.TrimSpace(stringValue(value))
 	}
 	return time.UnixMilli(millis).UTC().Format(time.RFC3339)
 }

--- a/internal/service/live_registry_test.go
+++ b/internal/service/live_registry_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -9,6 +10,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/wuyaocheng/bktrader/internal/domain"
 )
 
 func TestDoBinanceRESTRequestClassifiesHTTPFailureAsAdapterError(t *testing.T) {
@@ -293,5 +296,93 @@ func TestBinanceRESTGateDoesNotConsumeTokensDuringBackoff(t *testing.T) {
 func TestBinanceRESTGateUnknownCategoryDefaultsToLowestPriority(t *testing.T) {
 	if got := normalizeBinanceRESTRequestCategory(binanceRESTRequestCategory("new-background-class")); got != binanceRESTCategoryMarketData {
 		t.Fatalf("expected unknown category to default to lowest priority, got %s", got)
+	}
+}
+
+func TestOKXFillReportsNormalizeTradePayloads(t *testing.T) {
+	reports := okxFillReportsFromTradePayloads(domain.Account{
+		ID:       "live-okx",
+		Exchange: "OKX",
+	}, "okx-live", []map[string]any{{
+		"tradeId":  "okx-trade-1",
+		"ordId":    "okx-order-1",
+		"instId":   "BTC-USDT-SWAP",
+		"side":     "buy",
+		"fillPx":   "68000.5",
+		"fillSz":   "0.2",
+		"fillFee":  "1.25",
+		"feeCcy":   "USDT",
+		"fillPnl":  "3.5",
+		"fillTime": "1777389360000",
+	}}, nil)
+
+	if len(reports) != 1 {
+		t.Fatalf("expected one report, got %d", len(reports))
+	}
+	assertLiveFillReport(t, reports[0], FillSourceReal, "okx-fills", "okx-order-1", "okx-trade-1", "BTC-USDT-SWAP", "buy", 68000.5, 0.2, 1.25, "USDT", 3.5)
+	if got := stringValue(reports[0].Metadata["tradeTime"]); got != "2026-04-28T15:16:00Z" {
+		t.Fatalf("expected normalized OKX trade time, got %q", got)
+	}
+}
+
+func TestBybitFillReportsNormalizeExecutionPayloads(t *testing.T) {
+	reports := bybitFillReportsFromExecutionPayloads(domain.Account{
+		ID:       "live-bybit",
+		Exchange: "Bybit",
+	}, "bybit-live", []map[string]any{{
+		"execId":      "bybit-exec-1",
+		"orderId":     "bybit-order-1",
+		"symbol":      "BTCUSDT",
+		"side":        "Sell",
+		"execPrice":   "68100.5",
+		"execQty":     "0.3",
+		"execFee":     "1.75",
+		"feeCurrency": "USDT",
+		"closedPnl":   "4.5",
+		"execTime":    json.Number("1777389360000"),
+	}}, nil)
+
+	if len(reports) != 1 {
+		t.Fatalf("expected one report, got %d", len(reports))
+	}
+	assertLiveFillReport(t, reports[0], FillSourceReal, "bybit-executions", "bybit-order-1", "bybit-exec-1", "BTCUSDT", "Sell", 68100.5, 0.3, 1.75, "USDT", 4.5)
+}
+
+func TestExchangeFillReportMapperSkipsNonPositiveQuantity(t *testing.T) {
+	reports := okxFillReportsFromTradePayloads(domain.Account{ID: "live-okx", Exchange: "OKX"}, "okx-live", []map[string]any{{
+		"tradeId": "skip-zero",
+		"ordId":   "okx-order-1",
+		"fillPx":  "68000.5",
+		"fillSz":  "0",
+	}}, nil)
+	if len(reports) != 0 {
+		t.Fatalf("expected zero-quantity payload to be skipped, got %+v", reports)
+	}
+}
+
+func assertLiveFillReport(t *testing.T, report LiveFillReport, source FillSource, reportSource, orderID, tradeID, symbol, side string, price, quantity, fee float64, feeAsset string, realizedPnL float64) {
+	t.Helper()
+	if report.Source != source {
+		t.Fatalf("expected source %q, got %q", source, report.Source)
+	}
+	if report.Price != price || report.Quantity != quantity || report.Fee != fee {
+		t.Fatalf("unexpected price/quantity/fee: %+v", report)
+	}
+	metadata := report.Metadata
+	checks := map[string]string{
+		"reportSource":    reportSource,
+		"exchangeOrderId": orderID,
+		"tradeId":         tradeID,
+		"symbol":          symbol,
+		"side":            side,
+		"feeAsset":        feeAsset,
+	}
+	for key, want := range checks {
+		if got := stringValue(metadata[key]); got != want {
+			t.Fatalf("expected metadata[%s]=%q, got %q", key, want, got)
+		}
+	}
+	if got := parseFloatValue(metadata["realizedPnl"]); got != realizedPnL {
+		t.Fatalf("expected realizedPnl %v, got %v", realizedPnL, got)
 	}
 }


### PR DESCRIPTION
## 目的
推进 #272 阶段 6 的第一步：把多交易所成交字段归一化收口到统一 `ExchangeFillReport` mapper。当前不注册 OKX / Bybit live adapter，不新增真实下单路径；只提供 mapper 和测试，后续 adapter 接入时复用，避免在 adapter 内重写 synthetic upgrade 逻辑。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [x] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) - 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？- 无
- [x] DB migration 是否具备向下兼容幂等性？- 本 PR 无 migration
- [x] 配置字段有没有无意被混改？- 无配置改动

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

验证已跑：

```bash
go test ./internal/service -run 'TestOKXFillReportsNormalizeTradePayloads|TestBybitFillReportsNormalizeExecutionPayloads|TestExchangeFillReportMapperSkipsNonPositiveQuantity|TestBinanceTradeReportsSetRealFillSource' -count=1
go test ./...
go build ./cmd/platform-api && go build ./cmd/db-migrate
python3 scripts/check_migration_safety.py
bash scripts/check_high_risk_defaults.sh
```

说明：`check_migration_safety.py` 只报既有历史 migration 编号重复 `018` / `024`，本 PR 没有新增 migration。
