### PR TITLE
[codex] Add live control metrics summary

### DIFF
--- a/cmd/bktrader-ctl/logs.go
+++ b/cmd/bktrader-ctl/logs.go
@@ -13,6 +13,7 @@ import (
 func init() {
 	logsCmd.AddCommand(logsSystemCmd)
 	logsCmd.AddCommand(logsEventCmd)
+	logsCmd.AddCommand(logsLiveControlSummaryCmd)
 	logsCmd.AddCommand(logsHTTPCmd)
 	logsCmd.AddCommand(logsStreamCmd)
 	logsCmd.AddCommand(logsTraceCmd)
@@ -60,6 +61,35 @@ var logsEventCmd = &cobra.Command{
 
 		client := getClient()
 		resp, err := client.Request("GET", "/api/v1/logs/events?"+v.Encode(), nil)
+		handleResponse(resp, err)
+		return nil
+	},
+}
+
+var logsLiveControlSummaryCmd = &cobra.Command{
+	Use:   "live-control-summary",
+	Short: "查询 LiveSession 控制面指标汇总 [IDEMPOTENT]",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		v := url.Values{}
+		for flag, queryKey := range map[string]string{
+			"account-id":      "accountId",
+			"strategy-id":     "strategyId",
+			"live-session-id": "liveSessionId",
+			"from":            "from",
+			"to":              "to",
+		} {
+			value, _ := cmd.Flags().GetString(flag)
+			if value != "" {
+				v.Set(queryKey, value)
+			}
+		}
+
+		client := getClient()
+		path := "/api/v1/logs/live-control/summary"
+		if len(v) > 0 {
+			path += "?" + v.Encode()
+		}
+		resp, err := client.Request("GET", path, nil)
 		handleResponse(resp, err)
 		return nil
 	},
@@ -162,6 +192,11 @@ func init() {
 	logsSystemCmd.Flags().String("level", "", "日志级别")
 	logsSystemCmd.Flags().String("component", "", "组件名称")
 	logsEventCmd.Flags().String("order-id", "", "订单 ID 过滤")
+	logsLiveControlSummaryCmd.Flags().String("account-id", "", "账户 ID 过滤")
+	logsLiveControlSummaryCmd.Flags().String("strategy-id", "", "策略 ID 过滤")
+	logsLiveControlSummaryCmd.Flags().String("live-session-id", "", "实盘会话 ID 过滤")
+	logsLiveControlSummaryCmd.Flags().String("from", "", "开始时间 (RFC3339 或 Unix 秒/毫秒)")
+	logsLiveControlSummaryCmd.Flags().String("to", "", "结束时间 (RFC3339 或 Unix 秒/毫秒)")
 	logsStreamCmd.Flags().String("source", "", "流来源 (system,http,alert,timeline)")
 	logsTraceCmd.Flags().String("order-id", "", "要追踪的订单 ID")
 }

--- a/internal/http/logs.go
+++ b/internal/http/logs.go
@@ -57,6 +57,24 @@ func registerLogRoutes(mux *http.ServeMux, platform *service.Platform) {
 		writeJSON(w, http.StatusOK, page)
 	})
 
+	mux.HandleFunc("/api/v1/logs/live-control/summary", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		query, err := parseUnifiedLogEventQuery(r)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		metrics, err := platform.LiveControlMetrics(query)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		writeJSON(w, http.StatusOK, metrics)
+	})
+
 	mux.HandleFunc("/api/v1/logs/system", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			w.WriteHeader(http.StatusMethodNotAllowed)

--- a/internal/http/logs_test.go
+++ b/internal/http/logs_test.go
@@ -177,6 +177,62 @@ func TestLogRoutesExposeUnifiedEvents(t *testing.T) {
 	}
 }
 
+func TestLogRoutesExposeLiveControlSummary(t *testing.T) {
+	store := memory.NewStore()
+	platform := service.NewPlatform(store)
+	mux := http.NewServeMux()
+	registerLogRoutes(mux, platform)
+
+	base := time.Date(2026, 4, 29, 10, 0, 0, 0, time.UTC)
+	session, err := store.GetLiveSession("live-session-main")
+	if err != nil {
+		t.Fatalf("get live session: %v", err)
+	}
+	state := map[string]any{
+		"desiredStatus": "RUNNING",
+		"actualStatus":  "ERROR",
+		"controlEvents": []any{
+			map[string]any{
+				"id":               "control-summary-event-1",
+				"phase":            "failed",
+				"eventTime":        base.Format(time.RFC3339Nano),
+				"recordedAt":       base.Format(time.RFC3339Nano),
+				"liveSessionId":    session.ID,
+				"accountId":        session.AccountID,
+				"strategyId":       session.StrategyID,
+				"controlRequestId": "request-1",
+				"controlVersion":   1,
+				"desiredStatus":    "RUNNING",
+				"actualStatus":     "ERROR",
+				"action":           "start",
+				"errorCode":        service.LiveSessionControlErrorCodeAdapterError,
+				"latencyMs":        2200,
+			},
+		},
+	}
+	if _, err := store.UpdateLiveSessionState(session.ID, state); err != nil {
+		t.Fatalf("update live session state: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/logs/live-control/summary?liveSessionId="+session.ID, nil)
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 for live control summary, got %d", rec.Code)
+	}
+	var metrics service.LiveControlMetrics
+	if err := json.NewDecoder(rec.Body).Decode(&metrics); err != nil {
+		t.Fatalf("decode live control metrics: %v", err)
+	}
+	if metrics.Failed != 1 || metrics.ByErrorCode[service.LiveSessionControlErrorCodeAdapterError] != 1 {
+		t.Fatalf("unexpected live control metrics: %#v", metrics)
+	}
+	if metrics.CurrentErrors != 1 || metrics.CurrentPending != 0 {
+		t.Fatalf("expected current error without pending, got pending=%d errors=%d", metrics.CurrentPending, metrics.CurrentErrors)
+	}
+}
+
 func TestLogStreamEndpointWritesSSE(t *testing.T) {
 	logging.ResetForTests()
 	t.Cleanup(logging.ResetForTests)

--- a/internal/service/logs.go
+++ b/internal/service/logs.go
@@ -4,8 +4,10 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"math"
 	"slices"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -58,6 +60,50 @@ type UnifiedLogEventQuery struct {
 	From             time.Time
 	To               time.Time
 	Limit            int
+}
+
+// LiveControlMetrics aggregates the bounded live control audit history into an
+// operator-facing summary. It is intentionally derived from state.controlEvents
+// so Phase 4 observability does not introduce a new persistence surface.
+type LiveControlMetrics struct {
+	GeneratedAt    time.Time                         `json:"generatedAt"`
+	TotalEvents    int                               `json:"totalEvents"`
+	Requests       int                               `json:"requests"`
+	RunnerPickups  int                               `json:"runnerPickups"`
+	Succeeded      int                               `json:"succeeded"`
+	Failed         int                               `json:"failed"`
+	StaleDiscarded int                               `json:"staleDiscarded"`
+	CurrentPending int                               `json:"currentPending"`
+	CurrentErrors  int                               `json:"currentErrors"`
+	Latency        LiveControlLatencyMetrics         `json:"latency"`
+	ByErrorCode    map[string]int                    `json:"byErrorCode,omitempty"`
+	ByAccount      map[string]LiveControlMetricGroup `json:"byAccount,omitempty"`
+	ByStrategy     map[string]LiveControlMetricGroup `json:"byStrategy,omitempty"`
+	ByLiveSession  map[string]LiveControlMetricGroup `json:"byLiveSession,omitempty"`
+}
+
+type LiveControlLatencyMetrics struct {
+	PickupMs   LiveControlLatencyStats `json:"pickupMs"`
+	SuccessMs  LiveControlLatencyStats `json:"successMs"`
+	FailureMs  LiveControlLatencyStats `json:"failureMs"`
+	TerminalMs LiveControlLatencyStats `json:"terminalMs"`
+}
+
+type LiveControlLatencyStats struct {
+	Count   int     `json:"count"`
+	Min     int64   `json:"min,omitempty"`
+	Max     int64   `json:"max,omitempty"`
+	Average float64 `json:"average,omitempty"`
+}
+
+type LiveControlMetricGroup struct {
+	Total          int            `json:"total"`
+	Requests       int            `json:"requests"`
+	RunnerPickups  int            `json:"runnerPickups"`
+	Succeeded      int            `json:"succeeded"`
+	Failed         int            `json:"failed"`
+	StaleDiscarded int            `json:"staleDiscarded"`
+	ErrorCodes     map[string]int `json:"errorCodes,omitempty"`
 }
 
 type logEventCursor struct {
@@ -391,6 +437,193 @@ func (p *Platform) queryLiveSessionControlEvents(query UnifiedLogEventQuery, cur
 		return slices.Clone(filtered[:limit]), nil
 	}
 	return filtered, nil
+}
+
+func (p *Platform) LiveControlMetrics(query UnifiedLogEventQuery) (LiveControlMetrics, error) {
+	sessions, err := p.store.ListLiveSessions()
+	if err != nil {
+		return LiveControlMetrics{}, err
+	}
+	metrics := LiveControlMetrics{
+		GeneratedAt:   time.Now().UTC(),
+		ByErrorCode:   make(map[string]int),
+		ByAccount:     make(map[string]LiveControlMetricGroup),
+		ByStrategy:    make(map[string]LiveControlMetricGroup),
+		ByLiveSession: make(map[string]LiveControlMetricGroup),
+	}
+	for _, session := range sessions {
+		if !liveControlMetricsSessionMatches(session, query) {
+			continue
+		}
+		if liveSessionControlPending(session.State) {
+			metrics.CurrentPending++
+		}
+		if strings.EqualFold(stringValue(session.State["actualStatus"]), "ERROR") {
+			metrics.CurrentErrors++
+		}
+		for _, entry := range metadataList(session.State[liveSessionControlEventStateKey]) {
+			event, ok := liveSessionControlToUnifiedLogEvent(session, entry)
+			if !ok {
+				continue
+			}
+			if !query.From.IsZero() && event.EventTime.Before(query.From.UTC()) {
+				continue
+			}
+			if !query.To.IsZero() && event.EventTime.After(query.To.UTC()) {
+				continue
+			}
+			metrics.recordLiveControlEvent(event)
+		}
+	}
+	return metrics, nil
+}
+
+func liveControlMetricsSessionMatches(session domain.LiveSession, query UnifiedLogEventQuery) bool {
+	if strings.TrimSpace(query.AccountID) != "" && session.AccountID != strings.TrimSpace(query.AccountID) {
+		return false
+	}
+	if strings.TrimSpace(query.StrategyID) != "" && session.StrategyID != strings.TrimSpace(query.StrategyID) {
+		return false
+	}
+	if strings.TrimSpace(query.LiveSessionID) != "" && session.ID != strings.TrimSpace(query.LiveSessionID) {
+		return false
+	}
+	return true
+}
+
+func liveSessionControlPending(state map[string]any) bool {
+	actual := strings.ToUpper(strings.TrimSpace(stringValue(state["actualStatus"])))
+	if actual == "ERROR" {
+		return false
+	}
+	if actual == "STARTING" || actual == "STOPPING" {
+		return true
+	}
+	desired := strings.ToUpper(strings.TrimSpace(stringValue(state["desiredStatus"])))
+	return desired != "" && actual != "" && desired != actual
+}
+
+func (m *LiveControlMetrics) recordLiveControlEvent(event UnifiedLogEvent) {
+	m.TotalEvents++
+	phase := strings.ToLower(strings.TrimSpace(stringValue(event.Metadata["phase"])))
+	errorCode := strings.ToUpper(strings.TrimSpace(stringValue(event.Metadata["errorCode"])))
+	latencyMs, hasLatency := int64MetadataValue(event.Metadata["latencyMs"])
+
+	switch phase {
+	case "request_accepted", "legacy_request_initialized":
+		m.Requests++
+	case "runner_picked_up":
+		m.RunnerPickups++
+		if hasLatency {
+			m.Latency.PickupMs.Add(latencyMs)
+		}
+	case "succeeded":
+		m.Succeeded++
+		if hasLatency {
+			m.Latency.SuccessMs.Add(latencyMs)
+			m.Latency.TerminalMs.Add(latencyMs)
+		}
+	case "failed":
+		m.Failed++
+		if errorCode != "" {
+			m.ByErrorCode[errorCode]++
+		}
+		if hasLatency {
+			m.Latency.FailureMs.Add(latencyMs)
+			m.Latency.TerminalMs.Add(latencyMs)
+		}
+	case "stale_update_discarded":
+		m.StaleDiscarded++
+	}
+	m.recordLiveControlGroup(m.ByAccount, event.AccountID, phase, errorCode)
+	m.recordLiveControlGroup(m.ByStrategy, event.StrategyID, phase, errorCode)
+	m.recordLiveControlGroup(m.ByLiveSession, event.LiveSessionID, phase, errorCode)
+}
+
+func (m *LiveControlMetrics) recordLiveControlGroup(groups map[string]LiveControlMetricGroup, key, phase, errorCode string) {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return
+	}
+	group := groups[key]
+	group.Total++
+	switch phase {
+	case "request_accepted", "legacy_request_initialized":
+		group.Requests++
+	case "runner_picked_up":
+		group.RunnerPickups++
+	case "succeeded":
+		group.Succeeded++
+	case "failed":
+		group.Failed++
+		if errorCode != "" {
+			if group.ErrorCodes == nil {
+				group.ErrorCodes = make(map[string]int)
+			}
+			group.ErrorCodes[errorCode]++
+		}
+	case "stale_update_discarded":
+		group.StaleDiscarded++
+	}
+	groups[key] = group
+}
+
+func (s *LiveControlLatencyStats) Add(value int64) {
+	if value < 0 {
+		return
+	}
+	if s.Count == 0 || value < s.Min {
+		s.Min = value
+	}
+	if value > s.Max {
+		s.Max = value
+	}
+	s.Average = ((s.Average * float64(s.Count)) + float64(value)) / float64(s.Count+1)
+	s.Count++
+}
+
+func int64MetadataValue(value any) (int64, bool) {
+	switch v := value.(type) {
+	case int:
+		return int64(v), true
+	case int8:
+		return int64(v), true
+	case int16:
+		return int64(v), true
+	case int32:
+		return int64(v), true
+	case int64:
+		return v, true
+	case uint:
+		if uint64(v) > math.MaxInt64 {
+			return 0, false
+		}
+		return int64(v), true
+	case uint8:
+		return int64(v), true
+	case uint16:
+		return int64(v), true
+	case uint32:
+		return int64(v), true
+	case uint64:
+		if v > math.MaxInt64 {
+			return 0, false
+		}
+		return int64(v), true
+	case float32:
+		return int64(v), true
+	case float64:
+		return int64(v), true
+	case string:
+		parsed, err := time.ParseDuration(strings.TrimSpace(v))
+		if err == nil {
+			return parsed.Milliseconds(), true
+		}
+		numeric, err := strconv.ParseInt(strings.TrimSpace(v), 10, 64)
+		return numeric, err == nil
+	default:
+		return 0, false
+	}
 }
 
 func strategyDecisionToUnifiedLogEvent(item domain.StrategyDecisionEvent) UnifiedLogEvent {

--- a/internal/service/logs_test.go
+++ b/internal/service/logs_test.go
@@ -106,3 +106,123 @@ func TestListLogEventsSupportsPaginationAndFilters(t *testing.T) {
 		t.Fatalf("unexpected filtered item: %#v", item)
 	}
 }
+
+func TestLiveControlMetricsAggregatesLatencyAndErrorCodes(t *testing.T) {
+	store := memory.NewStore()
+	platform := NewPlatform(store)
+	base := time.Date(2026, 4, 29, 9, 0, 0, 0, time.UTC)
+
+	session, err := store.GetLiveSession("live-session-main")
+	if err != nil {
+		t.Fatalf("get live session: %v", err)
+	}
+	state := cloneMetadata(session.State)
+	state["desiredStatus"] = "RUNNING"
+	state["actualStatus"] = "STARTING"
+	state["controlRequestId"] = "request-2"
+	state["controlVersion"] = 2
+	state["controlRequestedAt"] = base.Add(-5 * time.Minute).Format(time.RFC3339)
+	state[liveSessionControlEventStateKey] = []any{
+		map[string]any{
+			"id":               "control-event-1",
+			"phase":            "request_accepted",
+			"eventTime":        base.Add(-30 * time.Second).Format(time.RFC3339Nano),
+			"recordedAt":       base.Add(-30 * time.Second).Format(time.RFC3339Nano),
+			"liveSessionId":    session.ID,
+			"accountId":        session.AccountID,
+			"strategyId":       session.StrategyID,
+			"controlRequestId": "request-1",
+			"controlVersion":   1,
+			"desiredStatus":    "RUNNING",
+			"actualStatus":     "STOPPED",
+			"action":           "start",
+		},
+		map[string]any{
+			"id":               "control-event-2",
+			"phase":            "runner_picked_up",
+			"eventTime":        base.Add(-25 * time.Second).Format(time.RFC3339Nano),
+			"recordedAt":       base.Add(-25 * time.Second).Format(time.RFC3339Nano),
+			"liveSessionId":    session.ID,
+			"accountId":        session.AccountID,
+			"strategyId":       session.StrategyID,
+			"controlRequestId": "request-1",
+			"controlVersion":   1,
+			"desiredStatus":    "RUNNING",
+			"actualStatus":     "STARTING",
+			"action":           "start",
+			"latencyMs":        1500,
+		},
+		map[string]any{
+			"id":               "control-event-3",
+			"phase":            "succeeded",
+			"eventTime":        base.Add(-20 * time.Second).Format(time.RFC3339Nano),
+			"recordedAt":       base.Add(-20 * time.Second).Format(time.RFC3339Nano),
+			"liveSessionId":    session.ID,
+			"accountId":        session.AccountID,
+			"strategyId":       session.StrategyID,
+			"controlRequestId": "request-1",
+			"controlVersion":   1,
+			"desiredStatus":    "RUNNING",
+			"actualStatus":     "RUNNING",
+			"action":           "start",
+			"latencyMs":        4500,
+		},
+		map[string]any{
+			"id":               "control-event-4",
+			"phase":            "failed",
+			"eventTime":        base.Add(-10 * time.Second).Format(time.RFC3339Nano),
+			"recordedAt":       base.Add(-10 * time.Second).Format(time.RFC3339Nano),
+			"liveSessionId":    session.ID,
+			"accountId":        session.AccountID,
+			"strategyId":       session.StrategyID,
+			"controlRequestId": "request-2",
+			"controlVersion":   2,
+			"desiredStatus":    "RUNNING",
+			"actualStatus":     "ERROR",
+			"action":           "start",
+			"errorCode":        LiveSessionControlErrorCodeConfigError,
+			"latencyMs":        8000,
+		},
+		map[string]any{
+			"id":               "control-event-5",
+			"phase":            "stale_update_discarded",
+			"eventTime":        base.Add(-5 * time.Second).Format(time.RFC3339Nano),
+			"recordedAt":       base.Add(-5 * time.Second).Format(time.RFC3339Nano),
+			"liveSessionId":    session.ID,
+			"accountId":        session.AccountID,
+			"strategyId":       session.StrategyID,
+			"controlRequestId": "request-old",
+			"controlVersion":   1,
+			"desiredStatus":    "RUNNING",
+			"actualStatus":     "STARTING",
+			"action":           "start",
+		},
+	}
+	if _, err := store.UpdateLiveSessionState(session.ID, state); err != nil {
+		t.Fatalf("update live session state: %v", err)
+	}
+
+	metrics, err := platform.LiveControlMetrics(UnifiedLogEventQuery{LiveSessionID: session.ID})
+	if err != nil {
+		t.Fatalf("live control metrics: %v", err)
+	}
+	if metrics.TotalEvents != 5 || metrics.Requests != 1 || metrics.RunnerPickups != 1 || metrics.Succeeded != 1 || metrics.Failed != 1 || metrics.StaleDiscarded != 1 {
+		t.Fatalf("unexpected counters: %#v", metrics)
+	}
+	if metrics.CurrentPending != 1 || metrics.CurrentErrors != 0 {
+		t.Fatalf("expected current pending without current error, got pending=%d errors=%d", metrics.CurrentPending, metrics.CurrentErrors)
+	}
+	if got := metrics.ByErrorCode[LiveSessionControlErrorCodeConfigError]; got != 1 {
+		t.Fatalf("expected CONFIG_ERROR count 1, got %d", got)
+	}
+	if metrics.Latency.PickupMs.Count != 1 || metrics.Latency.PickupMs.Min != 1500 {
+		t.Fatalf("unexpected pickup latency: %#v", metrics.Latency.PickupMs)
+	}
+	if metrics.Latency.TerminalMs.Count != 2 || metrics.Latency.TerminalMs.Min != 4500 || metrics.Latency.TerminalMs.Max != 8000 || metrics.Latency.TerminalMs.Average != 6250 {
+		t.Fatalf("unexpected terminal latency: %#v", metrics.Latency.TerminalMs)
+	}
+	accountGroup := metrics.ByAccount[session.AccountID]
+	if accountGroup.Total != 5 || accountGroup.ErrorCodes[LiveSessionControlErrorCodeConfigError] != 1 {
+		t.Fatalf("unexpected account group: %#v", accountGroup)
+	}
+}


### PR DESCRIPTION
## 目的
为 #282 Phase 4.x 补 LiveSession 控制面观测汇总：基于已落地的 `live_sessions.state.controlEvents` 计算 control latency、errorCode 聚合、stale discard 计数和当前 pending/error 数量，并提供只读 HTTP/CLI 查询入口。

本 PR 不新增 DB migration，不改变 live-runner scanner、start/stop、CAS 或 dispatch 语义。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [x] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) - 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？- 无
- [x] DB migration 是否具备向下兼容幂等性？- 无 DB migration
- [x] 配置字段有没有无意被混改？- 无配置字段变更

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

Local validation:
- `go test ./internal/service -run 'TestLiveControlMetricsAggregatesLatencyAndErrorCodes|TestListLogEventsSupportsPaginationAndFilters'`
- `go test ./internal/http -run 'TestLogRoutesExposeLiveControlSummary|TestLogRoutesExposeUnifiedEvents'`
- `go test ./cmd/bktrader-ctl`
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
- `go build ./cmd/bktrader-ctl`
