### PR TITLE
[codex] Clarify live control summary output

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@
     - **信号监控**: `bktrader-ctl live list` 查看所有实盘会话状态。
     - **订单/持仓**: `bktrader-ctl order/position list` 管理活跃订单与仓位。
     - **日志溯源**: `bktrader-ctl logs system/events/trace` 实时跟踪系统事件与特定订单链路。
+    - **Live 控制观测**: `bktrader-ctl logs live-control-summary` 汇总控制请求、收敛延迟、错误码与当前 pending/error 快照；其中历史计数和延迟受 `--from/--to` 过滤，当前快照不受时间过滤。
 - **Agent 友好**: 所有命令均支持 `--json` 输出，便于 AI Agent 进行结构化分析与自动化操作。
 
 ## 🧠 知识图谱 (Knowledge Graph)

--- a/cmd/bktrader-ctl/logs.go
+++ b/cmd/bktrader-ctl/logs.go
@@ -1,10 +1,14 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"net/url"
 	"os"
+	"sort"
+	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/wuyaocheng/bktrader/internal/ctlclient"
@@ -90,7 +94,7 @@ var logsLiveControlSummaryCmd = &cobra.Command{
 			path += "?" + v.Encode()
 		}
 		resp, err := client.Request("GET", path, nil)
-		handleResponse(resp, err)
+		handleLiveControlSummaryResponse(resp, err)
 		return nil
 	},
 }
@@ -199,4 +203,82 @@ func init() {
 	logsLiveControlSummaryCmd.Flags().String("to", "", "结束时间 (RFC3339 或 Unix 秒/毫秒)")
 	logsStreamCmd.Flags().String("source", "", "流来源 (system,http,alert,timeline)")
 	logsTraceCmd.Flags().String("order-id", "", "要追踪的订单 ID")
+}
+
+type liveControlSummaryResponse struct {
+	GeneratedAt    time.Time                         `json:"generatedAt"`
+	TotalEvents    int                               `json:"totalEvents"`
+	Requests       int                               `json:"requests"`
+	RunnerPickups  int                               `json:"runnerPickups"`
+	Succeeded      int                               `json:"succeeded"`
+	Failed         int                               `json:"failed"`
+	StaleDiscarded int                               `json:"staleDiscarded"`
+	CurrentPending int                               `json:"currentPending"`
+	CurrentErrors  int                               `json:"currentErrors"`
+	Latency        liveControlLatencyMetricsResponse `json:"latency"`
+	ByErrorCode    map[string]int                    `json:"byErrorCode,omitempty"`
+}
+
+type liveControlLatencyMetricsResponse struct {
+	PickupMs   liveControlLatencyStatsResponse `json:"pickupMs"`
+	SuccessMs  liveControlLatencyStatsResponse `json:"successMs"`
+	FailureMs  liveControlLatencyStatsResponse `json:"failureMs"`
+	TerminalMs liveControlLatencyStatsResponse `json:"terminalMs"`
+}
+
+type liveControlLatencyStatsResponse struct {
+	Count   int     `json:"count"`
+	Min     int64   `json:"min,omitempty"`
+	Max     int64   `json:"max,omitempty"`
+	Average float64 `json:"average,omitempty"`
+}
+
+func handleLiveControlSummaryResponse(data []byte, err error) {
+	if err != nil || outputJSON {
+		handleResponse(data, err)
+		return
+	}
+	var summary liveControlSummaryResponse
+	if decodeErr := json.Unmarshal(data, &summary); decodeErr != nil {
+		handleResponse(data, nil)
+		return
+	}
+	var out bytes.Buffer
+	fmt.Fprintf(&out, "Live control summary\n")
+	fmt.Fprintf(&out, "generatedAt: %s\n", summary.GeneratedAt.Format(time.RFC3339))
+	fmt.Fprintf(&out, "note: historical counters and latency honor --from/--to; currentPending/currentErrors are current snapshots and ignore --from/--to.\n")
+	fmt.Fprintf(&out, "\nHistorical events:\n")
+	fmt.Fprintf(&out, "  total=%d requests=%d pickedUp=%d succeeded=%d failed=%d staleDiscarded=%d\n",
+		summary.TotalEvents, summary.Requests, summary.RunnerPickups, summary.Succeeded, summary.Failed, summary.StaleDiscarded)
+	fmt.Fprintf(&out, "\nLatency (ms):\n")
+	printLiveControlLatencyStats(&out, "pickup", summary.Latency.PickupMs)
+	printLiveControlLatencyStats(&out, "success", summary.Latency.SuccessMs)
+	printLiveControlLatencyStats(&out, "failure", summary.Latency.FailureMs)
+	printLiveControlLatencyStats(&out, "terminal", summary.Latency.TerminalMs)
+	fmt.Fprintf(&out, "\nCurrent snapshot:\n")
+	fmt.Fprintf(&out, "  pending=%d errors=%d\n", summary.CurrentPending, summary.CurrentErrors)
+	if len(summary.ByErrorCode) > 0 {
+		fmt.Fprintf(&out, "\nError codes:\n")
+		for _, code := range sortedLiveControlSummaryKeys(summary.ByErrorCode) {
+			fmt.Fprintf(&out, "  %s=%d\n", code, summary.ByErrorCode[code])
+		}
+	}
+	fmt.Print(strings.TrimRight(out.String(), "\n") + "\n")
+}
+
+func printLiveControlLatencyStats(out *bytes.Buffer, label string, stats liveControlLatencyStatsResponse) {
+	if stats.Count == 0 {
+		fmt.Fprintf(out, "  %s: count=0\n", label)
+		return
+	}
+	fmt.Fprintf(out, "  %s: count=%d avg=%.1f min=%d max=%d\n", label, stats.Count, stats.Average, stats.Min, stats.Max)
+}
+
+func sortedLiveControlSummaryKeys(values map[string]int) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
 }

--- a/docs/bktrader-ctl-install-deploy.md
+++ b/docs/bktrader-ctl-install-deploy.md
@@ -63,7 +63,10 @@ bktrader-ctl order list --json
 bktrader-ctl position list --json
 bktrader-ctl logs system --json
 bktrader-ctl logs events --json
+bktrader-ctl logs live-control-summary
 ```
+
+`logs live-control-summary` 的 `totalEvents` / `failed` / `latency` 等历史指标受 `--from` / `--to` 过滤；`currentPending` / `currentErrors` 是当前状态快照，不受时间过滤。需要机器读取时继续加 `--json`。
 
 排查单个订单或链路时：
 

--- a/internal/http/registry.go
+++ b/internal/http/registry.go
@@ -47,6 +47,7 @@ var APIRegistry = []RouteEntry{
 	// Logs & Charts
 	{Path: "/api/v1/logs/system", Methods: []string{"GET"}, Module: "logs", CLICommand: "logs system", Idempotent: true, RiskLevel: "L0"},
 	{Path: "/api/v1/logs/events", Methods: []string{"GET"}, Module: "logs", CLICommand: "logs event", Idempotent: true, RiskLevel: "L0"},
+	{Path: "/api/v1/logs/live-control/summary", Methods: []string{"GET"}, Module: "logs", CLICommand: "logs live-control-summary", Idempotent: true, RiskLevel: "L0"},
 	{Path: "/api/v1/logs/stream", Methods: []string{"GET"}, Module: "logs", CLICommand: "logs stream", Idempotent: true, RiskLevel: "L0"},
 	{Path: "/api/v1/chart/candles", Methods: []string{"GET"}, Module: "chart", CLICommand: "chart candles", Idempotent: true, RiskLevel: "L0"},
 }


### PR DESCRIPTION
## 目的
补 #282 Phase 4.x 的可读化说明，避免把 Live control summary 的历史指标和当前快照混读。

本 PR 做两件事：
- `bktrader-ctl logs live-control-summary` 默认输出改为人类可读摘要，并明确：历史 counters/latency 受 `--from/--to` 过滤，`currentPending/currentErrors` 是当前状态快照，不受时间过滤。
- README / bktrader-ctl 安装文档 / API registry 补齐该命令和 endpoint 说明。

`--json` 仍保留原始 JSON，不改变机器读取接口。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [x] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) - 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？- 无
- [x] DB migration 是否具备向下兼容幂等性？- 无 DB migration
- [x] 配置字段有没有无意被混改？- 无配置字段变更

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

Local validation:
- `go test ./cmd/bktrader-ctl`
- `go test ./internal/http -run 'TestLogRoutesExposeLiveControlSummary|TestAPIRegistry'`
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
- `go build ./cmd/bktrader-ctl`
