### PR TITLE
fix fill fee refresh upserts

### DIFF
--- a/internal/service/fill_reconcile.go
+++ b/internal/service/fill_reconcile.go
@@ -49,7 +49,7 @@ func BuildFillReconciliationPlan(order domain.Order, existing []FillReconciliati
 		return plan, fmt.Errorf("order quantity must be positive: %v", order.Quantity)
 	}
 
-	existingRealTradeIDs := map[string]struct{}{}
+	existingRealFillsByTradeID := map[string]domain.Fill{}
 	existingFallbackFingerprints := map[string]struct{}{}
 	existingRealQty := 0.0
 	existingPlaceholderQty := 0.0
@@ -71,7 +71,7 @@ func BuildFillReconciliationPlan(order domain.Order, existing []FillReconciliati
 		existingTotalQty += fill.Quantity
 		if source == FillSourceReal {
 			existingRealQty += fill.Quantity
-			existingRealTradeIDs[strings.TrimSpace(fill.ExchangeTradeID)] = struct{}{}
+			existingRealFillsByTradeID[strings.TrimSpace(fill.ExchangeTradeID)] = fill
 			continue
 		}
 		if source != FillSourceSynthetic && source != FillSourceRemainder {
@@ -108,7 +108,10 @@ func BuildFillReconciliationPlan(order domain.Order, existing []FillReconciliati
 
 		if source == FillSourceReal {
 			tradeID := strings.TrimSpace(fill.ExchangeTradeID)
-			if _, exists := existingRealTradeIDs[tradeID]; exists {
+			if existingFill, exists := existingRealFillsByTradeID[tradeID]; exists {
+				if fill.Fee != 0 && !tradingQuantityEqual(fill.Fee, existingFill.Fee) {
+					plan.CreateFills = append(plan.CreateFills, fill)
+				}
 				continue
 			}
 			remainingRealQty := order.Quantity - existingRealQty - newRealQty
@@ -118,7 +121,7 @@ func BuildFillReconciliationPlan(order domain.Order, existing []FillReconciliati
 			if tradingQuantityExceeds(fill.Quantity, remainingRealQty) {
 				fill.Quantity = remainingRealQty
 			}
-			existingRealTradeIDs[tradeID] = struct{}{}
+			existingRealFillsByTradeID[tradeID] = fill
 			hasNewRealFill = true
 			newRealQty += fill.Quantity
 			plan.CreateFills = append(plan.CreateFills, fill)

--- a/internal/service/fill_reconcile_test.go
+++ b/internal/service/fill_reconcile_test.go
@@ -115,6 +115,32 @@ func TestBuildFillReconciliationPlanSkipsDuplicateRealTradeID(t *testing.T) {
 	requireFillReconcileQuantity(t, metadataFloat(plan, "filledQuantity"), 1)
 }
 
+func TestBuildFillReconciliationPlanRefreshesDuplicateRealFee(t *testing.T) {
+	order := fillReconcileTestOrder(1)
+	existingFill := fillReconcileReal(order.ID, "trade-1", 1)
+	existingFill.Fee = 0
+	incomingFill := fillReconcileReal(order.ID, "trade-1", 1)
+	incomingFill.Fee = 0.1234
+	existing := []FillReconciliationInput{fillReconcileInput(existingFill, FillSourceReal)}
+	incoming := []FillReconciliationInput{fillReconcileInput(incomingFill, FillSourceReal)}
+
+	plan, err := BuildFillReconciliationPlan(order, existing, incoming, FillReconcilePolicy{})
+	if err != nil {
+		t.Fatalf("BuildFillReconciliationPlan failed: %v", err)
+	}
+
+	if len(plan.CreateFills) != 1 {
+		t.Fatalf("expected duplicate real fill fee refresh to upsert one fill, got %+v", plan.CreateFills)
+	}
+	if plan.CreateFills[0].Fee != 0.1234 {
+		t.Fatalf("expected refreshed fee 0.1234, got %v", plan.CreateFills[0].Fee)
+	}
+	if len(plan.ApplyPositionFills) != 0 {
+		t.Fatalf("expected fee refresh to apply no position fills, got %+v", plan.ApplyPositionFills)
+	}
+	requireFillReconcileQuantity(t, metadataFloat(plan, "filledQuantity"), 1)
+}
+
 func TestBuildFillReconciliationPlanClampsIncomingRealToRemainingQuantity(t *testing.T) {
 	order := fillReconcileTestOrder(1)
 	incoming := []FillReconciliationInput{fillReconcileInput(fillReconcileReal(order.ID, "trade-1", 1.2), FillSourceReal)}

--- a/internal/service/order.go
+++ b/internal/service/order.go
@@ -1300,10 +1300,10 @@ func filterExistingExecutionFillsWithStore(store fillQueryStore, orderID string,
 		return nil, err
 	}
 	seen := make(map[string]struct{}, len(existing)+len(fills))
-	globalTradeSeen := make(map[string]struct{}, len(existing)+len(fills))
+	globalTradeSeen := make(map[string]domain.Fill, len(existing)+len(fills))
 	for _, item := range existing {
 		if item.ExchangeTradeID != "" {
-			globalTradeSeen[strings.TrimSpace(item.ExchangeTradeID)] = struct{}{}
+			globalTradeSeen[strings.TrimSpace(item.ExchangeTradeID)] = item
 		}
 		if item.OrderID != orderID {
 			continue
@@ -1321,10 +1321,15 @@ func filterExistingExecutionFillsWithStore(store fillQueryStore, orderID string,
 			fill.DedupFingerprint = fill.FallbackFingerprint()
 		}
 		if tradeID := strings.TrimSpace(fill.ExchangeTradeID); tradeID != "" {
-			if _, exists := globalTradeSeen[tradeID]; exists {
+			if existingFill, exists := globalTradeSeen[tradeID]; exists {
+				if fill.Fee == 0 || tradingQuantityEqual(fill.Fee, existingFill.Fee) {
+					continue
+				}
+				filtered = append(filtered, fill)
 				continue
+			} else {
+				globalTradeSeen[tradeID] = fill
 			}
-			globalTradeSeen[tradeID] = struct{}{}
 		}
 		key := buildFillDedupKey(fill)
 		if key == "" {

--- a/internal/service/order_test.go
+++ b/internal/service/order_test.go
@@ -452,6 +452,63 @@ func TestSyntheticUpgrade_PartialRealFills(t *testing.T) {
 	}
 }
 
+func TestFinalizeExecutedOrderRefreshesDuplicateRealFillFee(t *testing.T) {
+	store := memory.NewStore()
+	platform := NewPlatform(store)
+
+	account, _ := store.GetAccount("live-main")
+	order, _ := store.CreateOrder(domain.Order{
+		AccountID: account.ID,
+		Symbol:    "BTCUSDT",
+		Side:      "BUY",
+		Type:      "MARKET",
+		Quantity:  1.0,
+		Price:     68000,
+		Status:    "FILLED",
+		Metadata:  map[string]any{},
+	})
+
+	tradeTime := time.Now().UTC()
+	initialFill := domain.Fill{
+		OrderID:           order.ID,
+		ExchangeTradeID:   "real-trade-fee-refresh",
+		Source:            string(FillSourceReal),
+		Price:             68000,
+		Quantity:          1.0,
+		Fee:               0,
+		ExchangeTradeTime: &tradeTime,
+	}
+	filledOrder, err := platform.finalizeExecutedOrder(account, order, []domain.Fill{initialFill})
+	if err != nil {
+		t.Fatalf("first finalize failed: %v", err)
+	}
+
+	feeRefresh := initialFill
+	feeRefresh.Quantity = 0.5
+	feeRefresh.Fee = 0.1234
+	finalOrder, err := platform.finalizeExecutedOrder(account, filledOrder, []domain.Fill{feeRefresh})
+	if err != nil {
+		t.Fatalf("fee refresh finalize failed: %v", err)
+	}
+	if val := parseFloatValue(finalOrder.Metadata["filledQuantity"]); math.Abs(val-1.0) > 1e-9 {
+		t.Fatalf("expected order filledQuantity to remain 1.0, got %v", val)
+	}
+
+	fills, err := store.QueryFills(domain.FillQuery{OrderIDs: []string{order.ID}})
+	if err != nil {
+		t.Fatalf("QueryFills failed: %v", err)
+	}
+	if len(fills) != 1 {
+		t.Fatalf("expected fee refresh to keep one fill, got %+v", fills)
+	}
+	if fills[0].Fee != 0.1234 {
+		t.Fatalf("expected fee refresh to persist 0.1234, got %v", fills[0].Fee)
+	}
+	if fills[0].Quantity != 1.0 {
+		t.Fatalf("expected fee refresh to keep original quantity 1.0, got %v", fills[0].Quantity)
+	}
+}
+
 func TestSyntheticUpgrade_RetryCleanup(t *testing.T) {
 	store := memory.NewStore()
 	platform := NewPlatform(store)

--- a/internal/store/memory/fill_source_test.go
+++ b/internal/store/memory/fill_source_test.go
@@ -61,3 +61,54 @@ func TestCreateFillInfersSourceMemory(t *testing.T) {
 		t.Fatalf("expected synthetic source, got %q", syntheticFill.Source)
 	}
 }
+
+func TestCreateFillUpsertKeepsRealFeeMemory(t *testing.T) {
+	store := NewStore()
+
+	if _, err := store.CreateFill(domain.Fill{
+		OrderID:         "order-fee-upsert",
+		ExchangeTradeID: "trade-fee-upsert",
+		Source:          "real",
+		Price:           68000,
+		Quantity:        0.4,
+		Fee:             0,
+	}); err != nil {
+		t.Fatalf("CreateFill initial real failed: %v", err)
+	}
+
+	updated, err := store.CreateFill(domain.Fill{
+		OrderID:         "order-fee-upsert",
+		ExchangeTradeID: "trade-fee-upsert",
+		Source:          "real",
+		Price:           68000,
+		Quantity:        0.5,
+		Fee:             0.1234,
+	})
+	if err != nil {
+		t.Fatalf("CreateFill real fee upsert failed: %v", err)
+	}
+	if updated.Fee != 0.1234 {
+		t.Fatalf("expected fee to update from later real report, got %v", updated.Fee)
+	}
+	if updated.Quantity != 0.4 {
+		t.Fatalf("expected fee upsert to keep original quantity 0.4, got %v", updated.Quantity)
+	}
+
+	unchanged, err := store.CreateFill(domain.Fill{
+		OrderID:         "order-fee-upsert",
+		ExchangeTradeID: "trade-fee-upsert",
+		Source:          "real",
+		Price:           68000,
+		Quantity:        0.4,
+		Fee:             0,
+	})
+	if err != nil {
+		t.Fatalf("CreateFill zero fee upsert failed: %v", err)
+	}
+	if unchanged.Fee != 0.1234 {
+		t.Fatalf("expected later zero-fee retry to keep real fee, got %v", unchanged.Fee)
+	}
+	if unchanged.Quantity != 0.4 {
+		t.Fatalf("expected zero-fee retry to keep original quantity 0.4, got %v", unchanged.Quantity)
+	}
+}

--- a/internal/store/memory/store.go
+++ b/internal/store/memory/store.go
@@ -693,9 +693,11 @@ func (s *Store) CreateFill(fill domain.Fill) (domain.Fill, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if strings.TrimSpace(fill.ExchangeTradeID) != "" {
-		for _, item := range s.fills {
+		for id, item := range s.fills {
 			if item.OrderID == fill.OrderID && strings.EqualFold(strings.TrimSpace(item.ExchangeTradeID), strings.TrimSpace(fill.ExchangeTradeID)) {
-				return item, nil
+				updated := mergeExistingFill(item, fill)
+				s.fills[id] = updated
+				return updated, nil
 			}
 		}
 	} else {
@@ -703,9 +705,11 @@ func (s *Store) CreateFill(fill domain.Fill) (domain.Fill, error) {
 		if fill.DedupFingerprint == "" {
 			fill.DedupFingerprint = fill.FallbackFingerprint()
 		}
-		for _, item := range s.fills {
+		for id, item := range s.fills {
 			if item.OrderID == fill.OrderID && item.DedupFingerprint != "" && item.DedupFingerprint == fill.DedupFingerprint {
-				return item, nil
+				updated := mergeExistingFill(item, fill)
+				s.fills[id] = updated
+				return updated, nil
 			}
 		}
 	}
@@ -718,6 +722,18 @@ func (s *Store) CreateFill(fill domain.Fill) (domain.Fill, error) {
 	}
 	s.fills[fill.ID] = fill
 	return fill, nil
+}
+
+func mergeExistingFill(existing, incoming domain.Fill) domain.Fill {
+	existing.Source = normalizeFillSource(incoming)
+	if incoming.Fee != 0 {
+		existing.Fee = incoming.Fee
+	}
+	if existing.ExchangeTradeTime == nil && incoming.ExchangeTradeTime != nil {
+		resolved := incoming.ExchangeTradeTime.UTC()
+		existing.ExchangeTradeTime = &resolved
+	}
+	return existing
 }
 
 func normalizeFillSource(fill domain.Fill) string {

--- a/internal/store/postgres/fill_source_test.go
+++ b/internal/store/postgres/fill_source_test.go
@@ -144,6 +144,92 @@ func TestCreateFillUpsertUpdatesSourcePostgres(t *testing.T) {
 	}
 }
 
+func TestCreateFillUpsertUpdatesNonZeroFeePostgres(t *testing.T) {
+	dsn := os.Getenv("BKTRADER_TEST_POSTGRES_DSN")
+	if dsn == "" {
+		t.Skip("BKTRADER_TEST_POSTGRES_DSN is not set")
+	}
+	if err := Migrate(dsn); err != nil {
+		t.Fatalf("Migrate failed: %v", err)
+	}
+	store, err := New(dsn)
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	defer store.Close()
+
+	account, err := store.GetAccount("paper-default")
+	if err != nil {
+		t.Fatalf("GetAccount failed: %v", err)
+	}
+	order, err := store.CreateOrder(domain.Order{
+		AccountID: account.ID,
+		Symbol:    "BTCUSDT",
+		Side:      "BUY",
+		Type:      "MARKET",
+		Quantity:  1,
+		Price:     68000,
+		Metadata:  map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("CreateOrder failed: %v", err)
+	}
+
+	tradeID := "trade-fee-upsert-" + time.Now().UTC().Format("20060102150405.000000000")
+	if _, err := store.CreateFill(domain.Fill{
+		OrderID:         order.ID,
+		ExchangeTradeID: tradeID,
+		Source:          "real",
+		Price:           68000,
+		Quantity:        0.4,
+		Fee:             0,
+	}); err != nil {
+		t.Fatalf("CreateFill initial real failed: %v", err)
+	}
+	updated, err := store.CreateFill(domain.Fill{
+		OrderID:         order.ID,
+		ExchangeTradeID: tradeID,
+		Source:          "real",
+		Price:           68000,
+		Quantity:        0.5,
+		Fee:             0.1234,
+	})
+	if err != nil {
+		t.Fatalf("CreateFill real fee upsert failed: %v", err)
+	}
+	if updated.Fee != 0.1234 {
+		t.Fatalf("expected fee to update from later real report, got %v", updated.Fee)
+	}
+	if updated.Quantity != 0.4 {
+		t.Fatalf("expected fee upsert to keep original quantity 0.4, got %v", updated.Quantity)
+	}
+	unchanged, err := store.CreateFill(domain.Fill{
+		OrderID:         order.ID,
+		ExchangeTradeID: tradeID,
+		Source:          "real",
+		Price:           68000,
+		Quantity:        0.4,
+		Fee:             0,
+	})
+	if err != nil {
+		t.Fatalf("CreateFill zero fee upsert failed: %v", err)
+	}
+	if unchanged.Fee != 0.1234 {
+		t.Fatalf("expected later zero-fee retry to keep real fee, got %v", unchanged.Fee)
+	}
+	if unchanged.Quantity != 0.4 {
+		t.Fatalf("expected zero-fee retry to keep original quantity 0.4, got %v", unchanged.Quantity)
+	}
+
+	fills, err := store.QueryFills(domain.FillQuery{OrderIDs: []string{order.ID}})
+	if err != nil {
+		t.Fatalf("QueryFills failed: %v", err)
+	}
+	if len(fills) != 1 || fills[0].Fee != 0.1234 || fills[0].Quantity != 0.4 {
+		t.Fatalf("expected persisted upsert fee 0.1234 and quantity 0.4, got %+v", fills)
+	}
+}
+
 func TestFillSettlementTxCreateFillUpsertUpdatesSourcePostgres(t *testing.T) {
 	dsn := os.Getenv("BKTRADER_TEST_POSTGRES_DSN")
 	if dsn == "" {
@@ -182,6 +268,7 @@ func TestFillSettlementTxCreateFillUpsertUpdatesSourcePostgres(t *testing.T) {
 			Source:           "synthetic",
 			Price:            68000,
 			Quantity:         0.4,
+			Fee:              0,
 			DedupFingerprint: fingerprint,
 		}); err != nil {
 			return err
@@ -191,6 +278,7 @@ func TestFillSettlementTxCreateFillUpsertUpdatesSourcePostgres(t *testing.T) {
 			Source:           "remainder",
 			Price:            68000,
 			Quantity:         0.4,
+			Fee:              0.4567,
 			DedupFingerprint: fingerprint,
 		})
 		if err != nil {
@@ -198,6 +286,9 @@ func TestFillSettlementTxCreateFillUpsertUpdatesSourcePostgres(t *testing.T) {
 		}
 		if updated.Source != "remainder" {
 			t.Fatalf("expected tx upserted source remainder, got %q", updated.Source)
+		}
+		if updated.Fee != 0.4567 {
+			t.Fatalf("expected tx upserted fee 0.4567, got %v", updated.Fee)
 		}
 		return nil
 	}); err != nil {
@@ -208,7 +299,7 @@ func TestFillSettlementTxCreateFillUpsertUpdatesSourcePostgres(t *testing.T) {
 	if err != nil {
 		t.Fatalf("QueryFills failed: %v", err)
 	}
-	if len(fills) != 1 || fills[0].Source != "remainder" {
-		t.Fatalf("expected persisted tx source remainder, got %+v", fills)
+	if len(fills) != 1 || fills[0].Source != "remainder" || fills[0].Fee != 0.4567 {
+		t.Fatalf("expected persisted tx source remainder and fee 0.4567, got %+v", fills)
 	}
 }

--- a/internal/store/postgres/store.go
+++ b/internal/store/postgres/store.go
@@ -867,7 +867,7 @@ func (s *Store) CreateFill(fill domain.Fill) (domain.Fill, error) {
 			on conflict (order_id, dedup_fallback_fingerprint) do update set
 				price = fills.price,
 				quantity = fills.quantity,
-				fee = fills.fee,
+				fee = case when excluded.fee <> 0 then excluded.fee else fills.fee end,
 				fill_source = excluded.fill_source,
 				exchange_trade_time = coalesce(fills.exchange_trade_time, excluded.exchange_trade_time)
 			returning id, order_id, exchange_trade_id, exchange_trade_time, dedup_fallback_fingerprint, price, quantity, fee, fill_source, created_at
@@ -908,7 +908,7 @@ func (s *Store) CreateFill(fill domain.Fill) (domain.Fill, error) {
 		on conflict (order_id, exchange_trade_id) do update set
 			price = fills.price,
 			quantity = fills.quantity,
-			fee = fills.fee,
+			fee = case when excluded.fee <> 0 then excluded.fee else fills.fee end,
 			fill_source = excluded.fill_source,
 			exchange_trade_time = coalesce(fills.exchange_trade_time, excluded.exchange_trade_time)
 		returning id, order_id, exchange_trade_id, exchange_trade_time, dedup_fallback_fingerprint, price, quantity, fee, fill_source, created_at
@@ -1103,7 +1103,7 @@ func (s fillSettlementTxStore) CreateFill(fill domain.Fill) (domain.Fill, error)
 			on conflict (order_id, dedup_fallback_fingerprint) do update set
 				price = fills.price,
 				quantity = fills.quantity,
-				fee = fills.fee,
+				fee = case when excluded.fee <> 0 then excluded.fee else fills.fee end,
 				fill_source = excluded.fill_source,
 				exchange_trade_time = coalesce(fills.exchange_trade_time, excluded.exchange_trade_time)
 			returning id, order_id, exchange_trade_id, exchange_trade_time, dedup_fallback_fingerprint, price, quantity, fee, fill_source, created_at
@@ -1117,7 +1117,7 @@ func (s fillSettlementTxStore) CreateFill(fill domain.Fill) (domain.Fill, error)
 		on conflict (order_id, exchange_trade_id) do update set
 			price = fills.price,
 			quantity = fills.quantity,
-			fee = fills.fee,
+			fee = case when excluded.fee <> 0 then excluded.fee else fills.fee end,
 			fill_source = excluded.fill_source,
 			exchange_trade_time = coalesce(fills.exchange_trade_time, excluded.exchange_trade_time)
 		returning id, order_id, exchange_trade_id, exchange_trade_time, dedup_fallback_fingerprint, price, quantity, fee, fill_source, created_at


### PR DESCRIPTION
## 目的
修复 issue #272 closeout 后仍可能出现 live trade pair 费率/手续费为 0 的问题：当同一 `exchangeTradeID` 先落库为 0 fee，后续 Binance `userTrades` 带回真实 commission 时，原有去重和 upsert 逻辑会把真实 fee 丢掉。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [x] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
- [x] `dispatchMode` 默认值无变化
- [x] 不存在直接调用 `mainnet` 凭证或路由地址的硬编码
- [x] 无 DB migration
- [x] 未修改配置字段

## 验证方式与测试证据
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

验证命令：
- `go test ./internal/service -run 'TestBuildFillReconciliationPlan|TestFinalizeExecutedOrderRefreshesDuplicateRealFillFee|TestSyntheticUpgrade' -count=1`
- `go test ./internal/store/memory -run 'TestCreateFill.*Source|TestCreateFillUpsertKeepsRealFeeMemory' -count=1`
- `go test ./internal/store/postgres -run 'TestCreateFill.*Source|TestCreateFillUpsertUpdatesNonZeroFeePostgres|TestFillSettlementTxCreateFillUpsertUpdatesSourcePostgres' -count=1`
- `go test ./internal/store/... -count=1`
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
- `bash scripts/check_high_risk_defaults.sh`
- `git diff --check`
