### PR TITLE
[codex] Add live control status CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@
 - **核心功能**:
     - **状态概览**: `bktrader-ctl status` 查看系统整体运行健康度。
     - **账户管理**: `bktrader-ctl account list/summary` 查看账户权益与 PnL。
-    - **信号监控**: `bktrader-ctl live list` 查看所有实盘会话状态。
+    - **信号监控**: `bktrader-ctl live list` 查看所有实盘会话状态，`bktrader-ctl live control-status` 查看 desired/actual、requestId/version、pending 时长和错误建议。
     - **订单/持仓**: `bktrader-ctl order/position list` 管理活跃订单与仓位。
     - **日志溯源**: `bktrader-ctl logs system/events/trace` 实时跟踪系统事件与特定订单链路。
     - **Live 控制观测**: `bktrader-ctl logs live-control-summary` 汇总控制请求、收敛延迟、错误码与当前 pending/error 快照；其中历史计数和延迟受 `--from/--to` 过滤，当前快照不受时间过滤。

--- a/cmd/bktrader-ctl/live.go
+++ b/cmd/bktrader-ctl/live.go
@@ -1,19 +1,22 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/spf13/cobra"
-	"github.com/wuyaocheng/bktrader/internal/ctlclient"
 	"net/url"
 	"os"
 	"strings"
 	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/wuyaocheng/bktrader/internal/ctlclient"
 )
 
 func init() {
 	liveCmd.AddCommand(liveListCmd)
 	liveCmd.AddCommand(liveGetCmd)
+	liveCmd.AddCommand(liveControlStatusCmd)
 	liveCmd.AddCommand(liveStartCmd)
 	liveCmd.AddCommand(liveStopCmd)
 	liveCmd.AddCommand(liveDispatchCmd)
@@ -53,6 +56,43 @@ var liveGetCmd = &cobra.Command{
 		client := getClient()
 		resp, err := client.Request("GET", "/api/v1/live/sessions/"+url.PathEscape(args[0])+"/detail", nil)
 		handleResponse(resp, err)
+		return nil
+	},
+}
+
+var liveControlStatusCmd = &cobra.Command{
+	Use:   "control-status [sessionId]",
+	Short: "查看实盘控制面状态 [IDEMPOTENT]",
+	Args:  cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client := getClient()
+		sessions, err := fetchLiveSessionControlViews(client)
+		if err != nil {
+			return err
+		}
+		if len(args) == 1 {
+			filtered := sessions[:0]
+			for _, session := range sessions {
+				if session.ID == args[0] {
+					filtered = append(filtered, session)
+				}
+			}
+			sessions = filtered
+			if len(sessions) == 0 {
+				return fmt.Errorf("live session not found: %s", args[0])
+			}
+		}
+		now := time.Now().UTC()
+		statuses := make([]liveSessionControlStatus, 0, len(sessions))
+		for _, session := range sessions {
+			statuses = append(statuses, buildLiveSessionControlStatus(session, now))
+		}
+		if outputJSON {
+			data, _ := json.Marshal(statuses)
+			fmt.Println(string(data))
+			return nil
+		}
+		printLiveSessionControlStatuses(statuses)
 		return nil
 	},
 }
@@ -197,9 +237,34 @@ func init() {
 }
 
 type liveSessionControlView struct {
-	ID     string         `json:"id"`
-	Status string         `json:"status"`
-	State  map[string]any `json:"state"`
+	ID         string         `json:"id"`
+	Alias      string         `json:"alias,omitempty"`
+	AccountID  string         `json:"accountId,omitempty"`
+	StrategyID string         `json:"strategyId,omitempty"`
+	Status     string         `json:"status"`
+	State      map[string]any `json:"state"`
+}
+
+type liveSessionControlStatus struct {
+	ID               string `json:"id"`
+	Alias            string `json:"alias,omitempty"`
+	AccountID        string `json:"accountId,omitempty"`
+	StrategyID       string `json:"strategyId,omitempty"`
+	Status           string `json:"status"`
+	DesiredStatus    string `json:"desiredStatus,omitempty"`
+	ActualStatus     string `json:"actualStatus,omitempty"`
+	Action           string `json:"action,omitempty"`
+	ControlRequestID string `json:"controlRequestId,omitempty"`
+	ControlVersion   string `json:"controlVersion,omitempty"`
+	Pending          bool   `json:"pending"`
+	PendingSeconds   int64  `json:"pendingSeconds,omitempty"`
+	RequestedAt      string `json:"requestedAt,omitempty"`
+	UpdatedAt        string `json:"updatedAt,omitempty"`
+	SucceededAt      string `json:"succeededAt,omitempty"`
+	ErrorAt          string `json:"errorAt,omitempty"`
+	ErrorCode        string `json:"errorCode,omitempty"`
+	Error            string `json:"error,omitempty"`
+	Hint             string `json:"hint,omitempty"`
 }
 
 func waitLiveSessionActualStatus(client *ctlclient.Client, sessionID, target string, timeout time.Duration) error {
@@ -265,22 +330,153 @@ func liveSessionControlErrorHint(code string) string {
 	}
 }
 
-func fetchLiveSessionControlView(client *ctlclient.Client, sessionID string) (liveSessionControlView, error) {
-	data, err := client.Request("GET", "/api/v1/live/sessions?view=summary", nil)
-	if err != nil {
-		return liveSessionControlView{}, err
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
 	}
-	var sessions []liveSessionControlView
-	if err := json.Unmarshal(data, &sessions); err != nil {
+	return ""
+}
+
+func fetchLiveSessionControlView(client *ctlclient.Client, sessionID string) (liveSessionControlView, error) {
+	sessions, err := fetchLiveSessionControlViews(client)
+	if err != nil {
 		return liveSessionControlView{}, err
 	}
 	for _, session := range sessions {
 		if session.ID == sessionID {
-			if session.State == nil {
-				session.State = map[string]any{}
-			}
 			return session, nil
 		}
 	}
 	return liveSessionControlView{}, fmt.Errorf("live session not found: %s", sessionID)
+}
+
+func fetchLiveSessionControlViews(client *ctlclient.Client) ([]liveSessionControlView, error) {
+	data, err := client.Request("GET", "/api/v1/live/sessions?view=summary", nil)
+	if err != nil {
+		return nil, err
+	}
+	var sessions []liveSessionControlView
+	if err := json.Unmarshal(data, &sessions); err != nil {
+		return nil, err
+	}
+	for i := range sessions {
+		if sessions[i].State == nil {
+			sessions[i].State = map[string]any{}
+		}
+	}
+	return sessions, nil
+}
+
+func buildLiveSessionControlStatus(session liveSessionControlView, now time.Time) liveSessionControlStatus {
+	state := session.State
+	desired := strings.ToUpper(liveSessionControlString(state["desiredStatus"]))
+	actual := strings.ToUpper(liveSessionControlString(state["actualStatus"]))
+	if actual == "" {
+		actual = strings.ToUpper(strings.TrimSpace(session.Status))
+	}
+	status := liveSessionControlStatus{
+		ID:               session.ID,
+		Alias:            session.Alias,
+		AccountID:        session.AccountID,
+		StrategyID:       session.StrategyID,
+		Status:           session.Status,
+		DesiredStatus:    desired,
+		ActualStatus:     actual,
+		Action:           liveSessionControlString(state["lastControlAction"]),
+		ControlRequestID: liveSessionControlString(state["controlRequestId"]),
+		ControlVersion:   liveSessionControlString(state["controlVersion"]),
+		RequestedAt:      liveSessionControlString(state["controlRequestedAt"]),
+		UpdatedAt:        liveSessionControlString(state["lastControlUpdateAt"]),
+		SucceededAt:      liveSessionControlString(state["lastControlSucceededAt"]),
+		ErrorAt:          liveSessionControlString(state["lastControlErrorAt"]),
+		ErrorCode:        liveSessionControlString(state["lastControlErrorCode"]),
+		Error:            liveSessionControlString(state["lastControlError"]),
+	}
+	status.Pending = liveSessionControlStatusPending(status.DesiredStatus, status.ActualStatus)
+	if status.Pending {
+		if since, ok := liveSessionControlPendingSinceForStatus(state, status.ActualStatus); ok && !now.IsZero() && now.After(since) {
+			status.PendingSeconds = int64(now.Sub(since).Seconds())
+		}
+	}
+	if status.ErrorCode != "" || status.ActualStatus == "ERROR" {
+		status.Hint = liveSessionControlErrorHint(status.ErrorCode)
+	}
+	return status
+}
+
+func liveSessionControlStatusPending(desired, actual string) bool {
+	actual = strings.ToUpper(strings.TrimSpace(actual))
+	if actual == "" || actual == "ERROR" {
+		return false
+	}
+	if actual == "STARTING" || actual == "STOPPING" {
+		return true
+	}
+	desired = strings.ToUpper(strings.TrimSpace(desired))
+	return desired != "" && desired != actual
+}
+
+func liveSessionControlPendingSinceForStatus(state map[string]any, actual string) (time.Time, bool) {
+	requestedAt, requestedOK := parseLiveSessionControlStatusTime(state["controlRequestedAt"])
+	updatedAt, updatedOK := parseLiveSessionControlStatusTime(state["lastControlUpdateAt"])
+	if strings.EqualFold(actual, "STARTING") || strings.EqualFold(actual, "STOPPING") {
+		if updatedOK && (!requestedOK || updatedAt.After(requestedAt)) {
+			return updatedAt, true
+		}
+	}
+	if requestedOK {
+		return requestedAt, true
+	}
+	return updatedAt, updatedOK
+}
+
+func parseLiveSessionControlStatusTime(value any) (time.Time, bool) {
+	raw := liveSessionControlString(value)
+	if raw == "" {
+		return time.Time{}, false
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, raw)
+	if err == nil {
+		return parsed.UTC(), true
+	}
+	parsed, err = time.Parse(time.RFC3339, raw)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return parsed.UTC(), true
+}
+
+func printLiveSessionControlStatuses(statuses []liveSessionControlStatus) {
+	var out bytes.Buffer
+	for i, status := range statuses {
+		if i > 0 {
+			out.WriteByte('\n')
+		}
+		label := status.ID
+		if status.Alias != "" {
+			label += " (" + status.Alias + ")"
+		}
+		fmt.Fprintf(&out, "%s\n", label)
+		fmt.Fprintf(&out, "  status=%s desired=%s actual=%s pending=%t", status.Status, firstNonEmpty(status.DesiredStatus, "-"), firstNonEmpty(status.ActualStatus, "-"), status.Pending)
+		if status.PendingSeconds > 0 {
+			fmt.Fprintf(&out, " pendingSeconds=%d", status.PendingSeconds)
+		}
+		out.WriteByte('\n')
+		fmt.Fprintf(&out, "  action=%s requestId=%s version=%s\n", firstNonEmpty(status.Action, "-"), firstNonEmpty(status.ControlRequestID, "-"), firstNonEmpty(status.ControlVersion, "-"))
+		if status.RequestedAt != "" || status.UpdatedAt != "" || status.SucceededAt != "" || status.ErrorAt != "" {
+			fmt.Fprintf(&out, "  requestedAt=%s updatedAt=%s succeededAt=%s errorAt=%s\n",
+				firstNonEmpty(status.RequestedAt, "-"),
+				firstNonEmpty(status.UpdatedAt, "-"),
+				firstNonEmpty(status.SucceededAt, "-"),
+				firstNonEmpty(status.ErrorAt, "-"),
+			)
+		}
+		if status.ErrorCode != "" || status.Error != "" {
+			fmt.Fprintf(&out, "  errorCode=%s error=%s\n", firstNonEmpty(status.ErrorCode, "-"), firstNonEmpty(status.Error, "-"))
+			fmt.Fprintf(&out, "  hint=%s\n", firstNonEmpty(status.Hint, "check live-runner logs"))
+		}
+	}
+	fmt.Print(out.String())
 }

--- a/cmd/bktrader-ctl/live.go
+++ b/cmd/bktrader-ctl/live.go
@@ -65,6 +65,8 @@ var liveControlStatusCmd = &cobra.Command{
 	Short: "查看实盘控制面状态 [IDEMPOTENT]",
 	Args:  cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		onlyPending, _ := cmd.Flags().GetBool("only-pending")
+		onlyError, _ := cmd.Flags().GetBool("only-error")
 		client := getClient()
 		sessions, err := fetchLiveSessionControlViews(client)
 		if err != nil {
@@ -87,6 +89,7 @@ var liveControlStatusCmd = &cobra.Command{
 		for _, session := range sessions {
 			statuses = append(statuses, buildLiveSessionControlStatus(session, now))
 		}
+		statuses = filterLiveSessionControlStatuses(statuses, onlyPending, onlyError)
 		if outputJSON {
 			data, _ := json.Marshal(statuses)
 			fmt.Println(string(data))
@@ -223,6 +226,8 @@ func init() {
 	liveTemplateCmd.AddCommand(liveTemplateListCmd)
 
 	liveListCmd.Flags().String("view", "", "视图类型 (e.g. summary)")
+	liveControlStatusCmd.Flags().Bool("only-pending", false, "只显示尚未收敛的控制请求")
+	liveControlStatusCmd.Flags().Bool("only-error", false, "只显示 actualStatus=ERROR 或存在控制错误的会话")
 
 	// 安全确认标志
 	liveStartCmd.Flags().Bool("confirm", false, "确认执行启动操作")
@@ -404,6 +409,23 @@ func buildLiveSessionControlStatus(session liveSessionControlView, now time.Time
 		status.Hint = liveSessionControlErrorHint(status.ErrorCode)
 	}
 	return status
+}
+
+func filterLiveSessionControlStatuses(statuses []liveSessionControlStatus, onlyPending, onlyError bool) []liveSessionControlStatus {
+	if !onlyPending && !onlyError {
+		return statuses
+	}
+	filtered := make([]liveSessionControlStatus, 0, len(statuses))
+	for _, status := range statuses {
+		if onlyPending && status.Pending {
+			filtered = append(filtered, status)
+			continue
+		}
+		if onlyError && (strings.EqualFold(status.ActualStatus, "ERROR") || strings.TrimSpace(status.ErrorCode) != "" || strings.TrimSpace(status.Error) != "") {
+			filtered = append(filtered, status)
+		}
+	}
+	return filtered
 }
 
 func liveSessionControlStatusPending(desired, actual string) bool {

--- a/cmd/bktrader-ctl/live_test.go
+++ b/cmd/bktrader-ctl/live_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestBuildLiveSessionControlStatusPendingDuration(t *testing.T) {
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	session := liveSessionControlView{
+		ID:         "live-1",
+		AccountID:  "account-1",
+		StrategyID: "strategy-1",
+		Status:     "STOPPED",
+		State: map[string]any{
+			"desiredStatus":       "RUNNING",
+			"actualStatus":        "STARTING",
+			"lastControlAction":   "start",
+			"controlRequestId":    "request-1",
+			"controlVersion":      3,
+			"controlRequestedAt":  now.Add(-5 * time.Minute).Format(time.RFC3339Nano),
+			"lastControlUpdateAt": now.Add(-90 * time.Second).Format(time.RFC3339Nano),
+		},
+	}
+
+	status := buildLiveSessionControlStatus(session, now)
+	if !status.Pending {
+		t.Fatal("expected STARTING status to be pending")
+	}
+	if status.PendingSeconds != 90 {
+		t.Fatalf("expected pending duration to use lastControlUpdateAt for in-progress control, got %d", status.PendingSeconds)
+	}
+	if status.ControlVersion != "3" {
+		t.Fatalf("expected stringified control version 3, got %s", status.ControlVersion)
+	}
+}
+
+func TestBuildLiveSessionControlStatusErrorHint(t *testing.T) {
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	session := liveSessionControlView{
+		ID:     "live-1",
+		Status: "RUNNING",
+		State: map[string]any{
+			"desiredStatus":        "STOPPED",
+			"actualStatus":         "ERROR",
+			"lastControlErrorCode": "ACTIVE_POSITIONS_OR_ORDERS",
+			"lastControlError":     "active position exists",
+		},
+	}
+
+	status := buildLiveSessionControlStatus(session, now)
+	if status.Pending {
+		t.Fatal("expected ERROR status not to be pending")
+	}
+	if status.Hint != "close positions/orders first or retry stop with --force" {
+		t.Fatalf("unexpected error hint: %s", status.Hint)
+	}
+}

--- a/cmd/bktrader-ctl/live_test.go
+++ b/cmd/bktrader-ctl/live_test.go
@@ -56,3 +56,26 @@ func TestBuildLiveSessionControlStatusErrorHint(t *testing.T) {
 		t.Fatalf("unexpected error hint: %s", status.Hint)
 	}
 }
+
+func TestFilterLiveSessionControlStatuses(t *testing.T) {
+	statuses := []liveSessionControlStatus{
+		{ID: "running", ActualStatus: "RUNNING"},
+		{ID: "pending", DesiredStatus: "RUNNING", ActualStatus: "STARTING", Pending: true},
+		{ID: "error", ActualStatus: "ERROR", ErrorCode: "CONFIG_ERROR"},
+	}
+
+	pending := filterLiveSessionControlStatuses(statuses, true, false)
+	if len(pending) != 1 || pending[0].ID != "pending" {
+		t.Fatalf("expected only pending status, got %#v", pending)
+	}
+
+	errors := filterLiveSessionControlStatuses(statuses, false, true)
+	if len(errors) != 1 || errors[0].ID != "error" {
+		t.Fatalf("expected only error status, got %#v", errors)
+	}
+
+	combined := filterLiveSessionControlStatuses(statuses, true, true)
+	if len(combined) != 2 || combined[0].ID != "pending" || combined[1].ID != "error" {
+		t.Fatalf("expected pending and error statuses, got %#v", combined)
+	}
+}

--- a/docs/bktrader-ctl-install-deploy.md
+++ b/docs/bktrader-ctl-install-deploy.md
@@ -60,6 +60,8 @@ bktrader-ctl account list --json
 bktrader-ctl account summary --json
 bktrader-ctl live list --json
 bktrader-ctl live control-status
+bktrader-ctl live control-status --only-pending
+bktrader-ctl live control-status --only-error
 bktrader-ctl order list --json
 bktrader-ctl position list --json
 bktrader-ctl logs system --json

--- a/docs/bktrader-ctl-install-deploy.md
+++ b/docs/bktrader-ctl-install-deploy.md
@@ -59,6 +59,7 @@ bktrader-ctl status --json
 bktrader-ctl account list --json
 bktrader-ctl account summary --json
 bktrader-ctl live list --json
+bktrader-ctl live control-status
 bktrader-ctl order list --json
 bktrader-ctl position list --json
 bktrader-ctl logs system --json


### PR DESCRIPTION
## 目的
补 #282 Phase 4.x 的 CLI control status 视图，让运维可以直接查看 LiveSession 当前控制状态，而不是只看原始 JSON。

本 PR 新增：
- `bktrader-ctl live control-status [sessionId]`
- 默认人类可读输出 desired/actual、requestId/version、action、pendingSeconds、last errorCode/error/hint
- `--json` 输出结构化数组，方便机器读取
- 文档入口更新

实现边界：复用现有 `GET /api/v1/live/sessions?view=summary`，不新增 API，不改 live-runner/start/stop/CAS/dispatch 语义。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [x] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) - 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？- 无
- [x] DB migration 是否具备向下兼容幂等性？- 无 DB migration
- [x] 配置字段有没有无意被混改？- 无配置字段变更

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

Local validation:
- `go test ./cmd/bktrader-ctl`
- `go run ./scripts/check-ctl-coverage`
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
- `go build ./cmd/bktrader-ctl`
