### PR TITLE
[codex] Add supervisor service fallback candidates

### DIFF
--- a/docs/runtime-supervisor.md
+++ b/docs/runtime-supervisor.md
@@ -319,6 +319,7 @@ func ClearRestartState(state map[string]any, keys []string)
 - `BKTRADER_ROLE=supervisor` 只启动 read-only supervisor，不启动 live / signal / dashboard / notification 业务组件。
 - `SUPERVISOR_TARGETS` 使用逗号分隔，支持 `name=http://host:port` 或直接填写 base URL。
 - `SUPERVISOR_BEARER_TOKEN` 可选；设置后 read-only collector 会对所有 targets 的 `/healthz` 与 `/api/v1/runtime/status` 请求附加 `Authorization: Bearer <token>`，用于采集受鉴权保护的内网 runtime API。
+- `SUPERVISOR_SERVICE_FAILURE_THRESHOLD=3` 为默认值；supervisor 会按 target 记录连续服务级失败次数，并在达到阈值后把该 target 标记为容器兜底候选，但当前阶段只暴露状态，不执行 Docker/container restart。
 - 默认只采集 `/healthz` 和 `/api/v1/runtime/status`，不调用任何控制 API。
 - `GET /api/v1/supervisor/status` 返回最近一次 read-only supervisor 采集快照。
 - `bktrader-ctl runtime status --json` 和 `bktrader-ctl supervisor status --json` 提供 CLI 只读巡检入口。
@@ -354,6 +355,13 @@ func ClearRestartState(state map[string]any, keys []string)
 - 容器 restart 有 backoff、日志和人工抑制机制。
 - `desiredStatus=STOPPED`、fatal suppressed 和人工 stop 都不会被容器级 supervisor 反复拉起。
 - Docker socket 或 node-agent 权限边界有单独安全审查。
+
+当前只读候选状态：
+
+- `GET /api/v1/supervisor/status` 的每个 target 会返回 `serviceState`，包含连续失败次数、失败阈值、最近失败/恢复时间，以及是否已成为 `containerFallbackCandidate`。
+- 当前 service fallback 只把 `/healthz` 不可达或非 2xx、`/api/v1/runtime/status` 连接不可达视为服务级失败；`/runtime/status` JSON decode 失败不会触发容器兜底候选，避免把业务状态或响应格式问题误判成需要重启容器。
+- 达到 `SUPERVISOR_SERVICE_FAILURE_THRESHOLD` 后只记录 `containerFallbackCandidate=true` 和原因，不调用 Docker API，不挂载 Docker socket，不执行容器 restart。
+- 后续真正执行容器级 restart 前，仍需单独设计 executor、backoff、人工抑制、权限边界和部署安全审查。
 
 ## 7. 安全边界
 

--- a/internal/app/server.go
+++ b/internal/app/server.go
@@ -196,6 +196,7 @@ func StartRuntimeComponents(ctx context.Context, platform *service.Platform, cfg
 		} else {
 			supervisor := service.NewRuntimeSupervisorWithOptions(targets, &http.Client{Timeout: time.Duration(cfg.SupervisorHTTPTimeoutSeconds) * time.Second}, service.RuntimeSupervisorOptions{
 				EnableApplicationRestart: cfg.SupervisorAppRestartEnabled,
+				ServiceFailureThreshold:  cfg.SupervisorServiceFailThreshold,
 			})
 			platform.SetRuntimeSupervisor(supervisor)
 			supervisor.Start(ctx, time.Duration(cfg.SupervisorPollIntervalSeconds)*time.Second)
@@ -204,6 +205,7 @@ func StartRuntimeComponents(ctx context.Context, platform *service.Platform, cfg
 				"poll_interval_seconds", cfg.SupervisorPollIntervalSeconds,
 				"http_timeout_seconds", cfg.SupervisorHTTPTimeoutSeconds,
 				"application_restart_enabled", cfg.SupervisorAppRestartEnabled,
+				"service_failure_threshold", cfg.SupervisorServiceFailThreshold,
 			)
 		}
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -67,11 +67,12 @@ type Config struct {
 	DashboardNotificationsPollMs   int    // 仪表盘 Notifications 轮询间隔 (ms)
 	DashboardMonitorHealthPollMs   int    // 仪表盘 Monitor Health 轮询间隔 (ms)
 
-	SupervisorTargets             []string // 只读 supervisor 采集目标，支持 name=url 或 base URL
-	SupervisorBearerToken         string   // 只读 supervisor 请求目标服务时使用的全局 Bearer token
-	SupervisorPollIntervalSeconds int      // 只读 supervisor 轮询间隔（秒）
-	SupervisorHTTPTimeoutSeconds  int      // 只读 supervisor HTTP 超时（秒）
-	SupervisorAppRestartEnabled   bool     // supervisor 是否允许按 runtime status 到期计划提交应用内 restart（默认关闭）
+	SupervisorTargets              []string // 只读 supervisor 采集目标，支持 name=url 或 base URL
+	SupervisorBearerToken          string   // 只读 supervisor 请求目标服务时使用的全局 Bearer token
+	SupervisorPollIntervalSeconds  int      // 只读 supervisor 轮询间隔（秒）
+	SupervisorHTTPTimeoutSeconds   int      // 只读 supervisor HTTP 超时（秒）
+	SupervisorAppRestartEnabled    bool     // supervisor 是否允许按 runtime status 到期计划提交应用内 restart（默认关闭）
+	SupervisorServiceFailThreshold int      // supervisor 标记容器兜底候选所需的连续服务级失败次数（默认 3）
 }
 
 // Load 从环境变量加载配置，未设置的使用默认值。
@@ -153,6 +154,7 @@ func Load() Config {
 		SupervisorPollIntervalSeconds:  intFromEnvWithMin("SUPERVISOR_POLL_INTERVAL_SECONDS", 30, 5),
 		SupervisorHTTPTimeoutSeconds:   intFromEnvWithMin("SUPERVISOR_HTTP_TIMEOUT_SECONDS", 5, 1),
 		SupervisorAppRestartEnabled:    boolFromEnv("SUPERVISOR_APPLICATION_RESTART_ENABLED", false),
+		SupervisorServiceFailThreshold: intFromEnvWithMin("SUPERVISOR_SERVICE_FAILURE_THRESHOLD", 3, 1),
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -108,6 +108,7 @@ func TestLoadReadsSupervisorEnv(t *testing.T) {
 	t.Setenv("SUPERVISOR_POLL_INTERVAL_SECONDS", "45")
 	t.Setenv("SUPERVISOR_HTTP_TIMEOUT_SECONDS", "3")
 	t.Setenv("SUPERVISOR_APPLICATION_RESTART_ENABLED", "true")
+	t.Setenv("SUPERVISOR_SERVICE_FAILURE_THRESHOLD", "4")
 
 	cfg := Load()
 	if len(cfg.SupervisorTargets) != 2 {
@@ -127,6 +128,9 @@ func TestLoadReadsSupervisorEnv(t *testing.T) {
 	}
 	if !cfg.SupervisorAppRestartEnabled {
 		t.Fatal("expected supervisor application restart to be enabled")
+	}
+	if cfg.SupervisorServiceFailThreshold != 4 {
+		t.Fatalf("expected supervisor service failure threshold 4, got %d", cfg.SupervisorServiceFailThreshold)
 	}
 }
 

--- a/internal/service/runtime_supervisor.go
+++ b/internal/service/runtime_supervisor.go
@@ -14,10 +14,14 @@ import (
 	"time"
 )
 
-const defaultRuntimeSupervisorHTTPTimeout = 5 * time.Second
+const (
+	defaultRuntimeSupervisorHTTPTimeout       = 5 * time.Second
+	defaultRuntimeSupervisorServiceFailThresh = 3
+)
 
 type RuntimeSupervisorOptions struct {
 	EnableApplicationRestart bool
+	ServiceFailureThreshold  int
 }
 
 type RuntimeSupervisorTarget struct {
@@ -40,6 +44,7 @@ type RuntimeSupervisorTargetSnapshot struct {
 	CheckedAt      time.Time                        `json:"checkedAt"`
 	Healthz        RuntimeSupervisorProbe           `json:"healthz"`
 	RuntimeStatus  RuntimeSupervisorProbe           `json:"runtimeStatus"`
+	ServiceState   RuntimeSupervisorServiceState    `json:"serviceState"`
 	Status         *RuntimeStatusSnapshot           `json:"status,omitempty"`
 	ControlActions []RuntimeSupervisorControlAction `json:"controlActions,omitempty"`
 }
@@ -61,6 +66,23 @@ type RuntimeSupervisorControlAction struct {
 	RequestedAt time.Time `json:"requestedAt"`
 }
 
+type RuntimeSupervisorServiceState struct {
+	ConsecutiveFailures        int        `json:"consecutiveFailures"`
+	FailureThreshold           int        `json:"failureThreshold"`
+	LastFailureReason          string     `json:"lastFailureReason,omitempty"`
+	LastFailureAt              *time.Time `json:"lastFailureAt,omitempty"`
+	LastHealthyAt              *time.Time `json:"lastHealthyAt,omitempty"`
+	ContainerFallbackCandidate bool       `json:"containerFallbackCandidate"`
+	ContainerFallbackReason    string     `json:"containerFallbackReason,omitempty"`
+}
+
+type runtimeSupervisorServiceState struct {
+	ConsecutiveFailures int
+	LastFailureReason   string
+	LastFailureAt       time.Time
+	LastHealthyAt       time.Time
+}
+
 type RuntimeSupervisor struct {
 	targets []RuntimeSupervisorTarget
 	client  *http.Client
@@ -69,6 +91,7 @@ type RuntimeSupervisor struct {
 	mu                sync.RWMutex
 	snapshot          RuntimeSupervisorSnapshot
 	submittedRestarts map[string]string
+	serviceStates     map[string]runtimeSupervisorServiceState
 }
 
 func (p *Platform) SetRuntimeSupervisor(supervisor *RuntimeSupervisor) {
@@ -92,6 +115,7 @@ func NewRuntimeSupervisor(targets []RuntimeSupervisorTarget, client *http.Client
 }
 
 func NewRuntimeSupervisorWithOptions(targets []RuntimeSupervisorTarget, client *http.Client, options RuntimeSupervisorOptions) *RuntimeSupervisor {
+	options = normalizeRuntimeSupervisorOptions(options)
 	normalized := make([]RuntimeSupervisorTarget, 0, len(targets))
 	for i, target := range targets {
 		baseURL := strings.TrimRight(strings.TrimSpace(target.BaseURL), "/")
@@ -114,7 +138,15 @@ func NewRuntimeSupervisorWithOptions(targets []RuntimeSupervisorTarget, client *
 		client:            client,
 		options:           options,
 		submittedRestarts: make(map[string]string),
+		serviceStates:     make(map[string]runtimeSupervisorServiceState),
 	}
+}
+
+func normalizeRuntimeSupervisorOptions(options RuntimeSupervisorOptions) RuntimeSupervisorOptions {
+	if options.ServiceFailureThreshold <= 0 {
+		options.ServiceFailureThreshold = defaultRuntimeSupervisorServiceFailThresh
+	}
+	return options
 }
 
 func ParseRuntimeSupervisorTargets(rawTargets []string, bearerToken ...string) []RuntimeSupervisorTarget {
@@ -166,6 +198,7 @@ func (s *RuntimeSupervisor) Collect(ctx context.Context) RuntimeSupervisorSnapsh
 
 		var status RuntimeStatusSnapshot
 		targetSnapshot.RuntimeStatus = s.fetchJSON(ctx, target, "/api/v1/runtime/status", &status)
+		targetSnapshot.ServiceState = s.updateServiceState(target, targetSnapshot.Healthz, targetSnapshot.RuntimeStatus, now)
 		if targetSnapshot.RuntimeStatus.Error == "" && targetSnapshot.RuntimeStatus.Reachable {
 			targetSnapshot.Status = &status
 			targetSnapshot.ControlActions = s.submitApplicationRestarts(ctx, target, status, targetSnapshot.Healthz, now)
@@ -219,6 +252,7 @@ func (s *RuntimeSupervisor) collectAndLog(ctx context.Context, logger *slog.Logg
 	unreachable := 0
 	runtimeErrors := 0
 	controlActions := 0
+	containerFallbackCandidates := 0
 	for _, target := range snapshot.Targets {
 		if !target.Healthz.Reachable || target.Healthz.Error != "" {
 			unreachable++
@@ -227,6 +261,9 @@ func (s *RuntimeSupervisor) collectAndLog(ctx context.Context, logger *slog.Logg
 			runtimeErrors++
 		}
 		controlActions += len(target.ControlActions)
+		if target.ServiceState.ContainerFallbackCandidate {
+			containerFallbackCandidates++
+		}
 	}
 	logger.Info("runtime supervisor snapshot collected",
 		"target_count", len(snapshot.Targets),
@@ -234,7 +271,88 @@ func (s *RuntimeSupervisor) collectAndLog(ctx context.Context, logger *slog.Logg
 		"runtime_error_count", runtimeErrors,
 		"control_action_count", controlActions,
 		"application_restart_enabled", s.options.EnableApplicationRestart,
+		"service_failure_threshold", s.options.ServiceFailureThreshold,
+		"container_fallback_candidate_count", containerFallbackCandidates,
 	)
+}
+
+func (s *RuntimeSupervisor) updateServiceState(target RuntimeSupervisorTarget, healthz, runtimeStatus RuntimeSupervisorProbe, now time.Time) RuntimeSupervisorServiceState {
+	if s == nil {
+		return RuntimeSupervisorServiceState{FailureThreshold: defaultRuntimeSupervisorServiceFailThresh}
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	now = now.UTC()
+	failed, reason := runtimeSupervisorServiceProbeFailure(healthz, runtimeStatus)
+	key := runtimeSupervisorServiceKey(target)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.serviceStates == nil {
+		s.serviceStates = make(map[string]runtimeSupervisorServiceState)
+	}
+	state := s.serviceStates[key]
+	if failed {
+		state.ConsecutiveFailures++
+		state.LastFailureReason = reason
+		state.LastFailureAt = now
+	} else {
+		state.ConsecutiveFailures = 0
+		state.LastFailureReason = ""
+		state.LastHealthyAt = now
+	}
+	s.serviceStates[key] = state
+	return runtimeSupervisorServiceStateSnapshot(state, s.options.ServiceFailureThreshold)
+}
+
+func runtimeSupervisorServiceProbeFailure(healthz, runtimeStatus RuntimeSupervisorProbe) (bool, string) {
+	if !healthz.Reachable {
+		return true, runtimeSupervisorProbeFailureReason("healthz-unreachable", healthz)
+	}
+	if healthz.Error != "" {
+		return true, runtimeSupervisorProbeFailureReason("healthz-unhealthy", healthz)
+	}
+	if !runtimeStatus.Reachable {
+		return true, runtimeSupervisorProbeFailureReason("runtime-status-unreachable", runtimeStatus)
+	}
+	return false, ""
+}
+
+func runtimeSupervisorProbeFailureReason(prefix string, probe RuntimeSupervisorProbe) string {
+	err := strings.TrimSpace(probe.Error)
+	if err == "" {
+		return prefix
+	}
+	return prefix + ": " + err
+}
+
+func runtimeSupervisorServiceStateSnapshot(state runtimeSupervisorServiceState, threshold int) RuntimeSupervisorServiceState {
+	if threshold <= 0 {
+		threshold = defaultRuntimeSupervisorServiceFailThresh
+	}
+	out := RuntimeSupervisorServiceState{
+		ConsecutiveFailures: state.ConsecutiveFailures,
+		FailureThreshold:    threshold,
+		LastFailureReason:   state.LastFailureReason,
+	}
+	if !state.LastFailureAt.IsZero() {
+		lastFailureAt := state.LastFailureAt.UTC()
+		out.LastFailureAt = &lastFailureAt
+	}
+	if !state.LastHealthyAt.IsZero() {
+		lastHealthyAt := state.LastHealthyAt.UTC()
+		out.LastHealthyAt = &lastHealthyAt
+	}
+	if state.ConsecutiveFailures >= threshold && state.LastFailureReason != "" {
+		out.ContainerFallbackCandidate = true
+		out.ContainerFallbackReason = fmt.Sprintf("service probes failed %d/%d: %s", state.ConsecutiveFailures, threshold, state.LastFailureReason)
+	}
+	return out
+}
+
+func runtimeSupervisorServiceKey(target RuntimeSupervisorTarget) string {
+	return strings.TrimSpace(target.Name) + "|" + strings.TrimSpace(target.BaseURL)
 }
 
 func (s *RuntimeSupervisor) submitApplicationRestarts(ctx context.Context, target RuntimeSupervisorTarget, status RuntimeStatusSnapshot, healthz RuntimeSupervisorProbe, now time.Time) []RuntimeSupervisorControlAction {

--- a/internal/service/runtime_supervisor_test.go
+++ b/internal/service/runtime_supervisor_test.go
@@ -120,6 +120,97 @@ func TestRuntimeSupervisorRecordsProbeFailuresWithoutControlActions(t *testing.T
 	}
 }
 
+func TestRuntimeSupervisorMarksContainerFallbackCandidateAfterServiceFailures(t *testing.T) {
+	requested := make(map[string]int)
+	healthy := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requested[r.Method+" "+r.URL.Path]++
+		switch r.URL.Path {
+		case "/healthz":
+			if !healthy {
+				http.Error(w, "not ready", http.StatusServiceUnavailable)
+				return
+			}
+			writeRuntimeSupervisorTestJSON(t, w, map[string]any{"status": "ok"})
+		case "/api/v1/runtime/status":
+			writeRuntimeSupervisorTestJSON(t, w, RuntimeStatusSnapshot{Service: "platform-api"})
+		case "/api/v1/runtime/restart":
+			t.Errorf("service fallback planning must not call control path %s", r.URL.Path)
+			w.WriteHeader(http.StatusForbidden)
+		default:
+			t.Errorf("unexpected request path %s", r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	supervisor := NewRuntimeSupervisorWithOptions(
+		[]RuntimeSupervisorTarget{{Name: "api", BaseURL: server.URL}},
+		server.Client(),
+		RuntimeSupervisorOptions{ServiceFailureThreshold: 2},
+	)
+	first := supervisor.Collect(context.Background()).Targets[0]
+	if first.ServiceState.ConsecutiveFailures != 1 || first.ServiceState.ContainerFallbackCandidate {
+		t.Fatalf("expected first failure below fallback threshold, got %+v", first.ServiceState)
+	}
+	second := supervisor.Collect(context.Background()).Targets[0]
+	if second.ServiceState.ConsecutiveFailures != 2 || !second.ServiceState.ContainerFallbackCandidate {
+		t.Fatalf("expected second failure to become fallback candidate, got %+v", second.ServiceState)
+	}
+	if second.ServiceState.ContainerFallbackReason == "" || second.ServiceState.LastFailureReason == "" || second.ServiceState.LastFailureAt == nil {
+		t.Fatalf("expected fallback reason and failure metadata, got %+v", second.ServiceState)
+	}
+	if requested["POST /api/v1/runtime/restart"] != 0 {
+		t.Fatalf("expected no control action for service fallback candidate, got %#v", requested)
+	}
+
+	healthy = true
+	recovered := supervisor.Collect(context.Background()).Targets[0]
+	if recovered.ServiceState.ConsecutiveFailures != 0 || recovered.ServiceState.ContainerFallbackCandidate {
+		t.Fatalf("expected healthy probe to clear fallback candidate, got %+v", recovered.ServiceState)
+	}
+	if recovered.ServiceState.LastHealthyAt == nil {
+		t.Fatalf("expected healthy probe to record last healthy time, got %+v", recovered.ServiceState)
+	}
+}
+
+func TestRuntimeSupervisorDoesNotPlanContainerFallbackForRuntimeStatusDecodeError(t *testing.T) {
+	requested := make(map[string]int)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requested[r.Method+" "+r.URL.Path]++
+		switch r.URL.Path {
+		case "/healthz":
+			writeRuntimeSupervisorTestJSON(t, w, map[string]any{"status": "ok"})
+		case "/api/v1/runtime/status":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{"))
+		case "/api/v1/runtime/restart":
+			t.Errorf("runtime status decode errors must not trigger control paths")
+			w.WriteHeader(http.StatusForbidden)
+		default:
+			t.Errorf("unexpected request path %s", r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	supervisor := NewRuntimeSupervisorWithOptions(
+		[]RuntimeSupervisorTarget{{Name: "api", BaseURL: server.URL}},
+		server.Client(),
+		RuntimeSupervisorOptions{ServiceFailureThreshold: 1},
+	)
+	target := supervisor.Collect(context.Background()).Targets[0]
+	if target.RuntimeStatus.Error == "" {
+		t.Fatalf("expected runtime status decode error, got %+v", target.RuntimeStatus)
+	}
+	if target.ServiceState.ConsecutiveFailures != 0 || target.ServiceState.ContainerFallbackCandidate {
+		t.Fatalf("expected decode error to stay outside service fallback planning, got %+v", target.ServiceState)
+	}
+	if requested["POST /api/v1/runtime/restart"] != 0 {
+		t.Fatalf("expected no control action for decode error, got %#v", requested)
+	}
+}
+
 func TestRuntimeSupervisorDefaultSkipsDueSignalRestart(t *testing.T) {
 	now := time.Now().UTC()
 	requested := make(map[string]int)


### PR DESCRIPTION
## 目的
跟进 #270 的容器级兜底恢复阶段，但先落一个安全的只读小切片：supervisor 按 target 维护服务级连续失败计数，并在达到阈值后把该 target 标记为 `containerFallbackCandidate`。

本 PR 不引入 Docker API、不挂载 Docker socket、不改 `deployments/`，也不执行容器 restart。它只把未来 Docker fallback 所需的候选判定状态暴露到 `GET /api/v1/supervisor/status`，用于后续 executor/backoff/人工抑制机制单独审查。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [x] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) — 未变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？— 不存在
- [x] DB migration 是否具备向下兼容幂等性？— 不涉及 DB migration
- [x] 配置字段有没有无意被混改？— 新增 `SUPERVISOR_SERVICE_FAILURE_THRESHOLD`，默认 `3`，只影响只读候选状态阈值

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

验证已执行：
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
- `go build ./cmd/bktrader-ctl`
- `go run ./scripts/check-ctl-coverage`
- `bash scripts/check_high_risk_defaults.sh`