### PR TITLE
[codex] Show live control status in AccountStage

### DIFF
--- a/web/console/src/pages/AccountStage.tsx
+++ b/web/console/src/pages/AccountStage.tsx
@@ -139,6 +139,43 @@ function liveControlErrorMessage(code: string, error: string): string {
   }
 }
 
+function parseLiveControlTime(value: unknown): Date | null {
+  const raw = String(value ?? "").trim();
+  if (!raw) {
+    return null;
+  }
+  const parsed = new Date(raw);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function liveControlPendingSince(state: Record<string, unknown>, actualStatus: string): Date | null {
+  const requestedAt = parseLiveControlTime(state.controlRequestedAt);
+  const updatedAt = parseLiveControlTime(state.lastControlUpdateAt);
+  const inProgress = actualStatus === "STARTING" || actualStatus === "STOPPING";
+  if (inProgress && updatedAt && (!requestedAt || updatedAt > requestedAt)) {
+    return updatedAt;
+  }
+  return requestedAt ?? updatedAt;
+}
+
+function formatLiveControlDuration(ms: number): string {
+  if (!Number.isFinite(ms) || ms < 0) {
+    return "--";
+  }
+  const totalSeconds = Math.floor(ms / 1000);
+  if (totalSeconds < 60) {
+    return `${totalSeconds}s`;
+  }
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  if (minutes < 60) {
+    return seconds > 0 ? `${minutes}m ${seconds}s` : `${minutes}m`;
+  }
+  const hours = Math.floor(minutes / 60);
+  const restMinutes = minutes % 60;
+  return restMinutes > 0 ? `${hours}h ${restMinutes}m` : `${hours}h`;
+}
+
 export function AccountStage({
   logout,
   openLiveAccountModal,
@@ -1123,10 +1160,27 @@ export function AccountStage({
                      liveActualStatus !== "" &&
                      liveActualStatus !== "ERROR" &&
                      liveDesiredStatus !== liveActualStatus;
+                   const liveControlRequestId = String(sessionState.controlRequestId ?? "").trim();
+                   const liveControlVersion = String(sessionState.controlVersion ?? "").trim();
+                   const liveControlAction = String(sessionState.lastControlAction ?? "").trim();
+                   const liveControlRequestedAt = String(sessionState.controlRequestedAt ?? "").trim();
+                   const liveControlUpdatedAt = String(sessionState.lastControlUpdateAt ?? "").trim();
+                   const liveControlSucceededAt = String(sessionState.lastControlSucceededAt ?? "").trim();
                    const liveControlErrorCode = String(sessionState.lastControlErrorCode ?? "").trim().toUpperCase();
+                   const liveControlErrorAt = String(sessionState.lastControlErrorAt ?? "").trim();
                    const liveControlError = liveActualStatus === "ERROR"
                      ? liveControlErrorMessage(liveControlErrorCode, String(sessionState.lastControlError ?? "").trim())
                      : "";
+                   const liveControlPendingStart = liveControlConverging ? liveControlPendingSince(sessionState, liveActualStatus) : null;
+                   const liveControlPendingFor = liveControlPendingStart ? formatLiveControlDuration(Date.now() - liveControlPendingStart.getTime()) : "";
+                   const hasLiveControlRequestMeta =
+                     liveControlRequestId ||
+                     liveControlVersion ||
+                     liveControlAction ||
+                     liveControlRequestedAt ||
+                     liveControlUpdatedAt ||
+                     liveControlSucceededAt ||
+                     liveControlErrorAt;
                    const linkedRuntimeSessionId = String(
                      sessionState.signalRuntimeSessionId ?? sessionState.lastSignalRuntimeSessionId ?? ""
                    ).trim();
@@ -1152,8 +1206,8 @@ export function AccountStage({
                      (linkedRuntimeSession ? signalRuntimeActionTargets(linkedRuntimeSession.id) : false) ||
                      ((liveSessionLaunchAction || launchingTemplate !== null) && quickLiveAccountId === session.accountId);
                    return (
-                     <div key={session.id} className="group flex items-center justify-between rounded-[20px] border border-[var(--bk-border)] bg-[var(--bk-surface-strong)] p-4 transition-all hover:bg-[var(--bk-surface)]">
-                        <div className="space-y-1">
+                     <div key={session.id} className="group flex items-center justify-between gap-3 rounded-[20px] border border-[var(--bk-border)] bg-[var(--bk-surface-strong)] p-4 transition-all hover:bg-[var(--bk-surface)]">
+                        <div className="min-w-0 flex-1 space-y-1">
                            <div className="flex items-center gap-2">
                               <span className="text-sm font-black text-[var(--bk-text-primary)]">
                                 {session.alias || (session.id.length > 28 ? session.id.slice(0, 18) + '...' + session.id.slice(-6) : session.id)}
@@ -1177,7 +1231,7 @@ export function AccountStage({
                            {liveControlConverging && (
                              <p className="flex items-center gap-1.5 text-[10px] font-bold text-[var(--bk-status-warning)]">
                                <AlertTriangle size={12} />
-                               控制意图 {liveDesiredStatus} 等待 runner 收敛，当前 {liveActualStatus}
+                               控制意图 {liveDesiredStatus} 等待 runner 收敛，当前 {liveActualStatus}{liveControlPendingFor ? `，已等待 ${liveControlPendingFor}` : ""}
                              </p>
                            )}
                            {liveControlError && (
@@ -1185,6 +1239,28 @@ export function AccountStage({
                                <AlertTriangle size={12} />
                                控制失败{liveControlErrorCode ? ` (${liveControlErrorCode})` : ""}：{liveControlError}
                              </p>
+                           )}
+                           {hasLiveControlRequestMeta && (
+                             <div className="mt-2 grid max-w-[min(100%,42rem)] grid-cols-2 gap-x-3 gap-y-1 rounded-[12px] border border-[var(--bk-border)] bg-[var(--bk-surface)] px-3 py-2 text-[10px] text-[var(--bk-text-muted)] sm:grid-cols-4">
+                               <div className="min-w-0">
+                                 <div className="font-black uppercase text-[8px] text-[var(--bk-text-muted)]">Action</div>
+                                 <div className="truncate font-mono font-bold text-[var(--bk-text-primary)]">{liveControlAction || "--"}</div>
+                               </div>
+                               <div className="min-w-0">
+                                 <div className="font-black uppercase text-[8px] text-[var(--bk-text-muted)]">Version</div>
+                                 <div className="truncate font-mono font-bold text-[var(--bk-text-primary)]">{liveControlVersion || "--"}</div>
+                               </div>
+                               <div className="min-w-0">
+                                 <div className="font-black uppercase text-[8px] text-[var(--bk-text-muted)]">Request</div>
+                                 <div className="truncate font-mono font-bold text-[var(--bk-text-primary)]">{liveControlRequestId ? shrink(liveControlRequestId) : "--"}</div>
+                               </div>
+                               <div className="min-w-0">
+                                 <div className="font-black uppercase text-[8px] text-[var(--bk-text-muted)]">{liveControlErrorAt ? "Error At" : liveControlSucceededAt ? "Succeeded" : "Updated"}</div>
+                                 <div className="truncate font-mono font-bold text-[var(--bk-text-primary)]">
+                                   {formatTime(liveControlErrorAt || liveControlSucceededAt || liveControlUpdatedAt || liveControlRequestedAt)}
+                                 </div>
+                               </div>
+                             </div>
                            )}
                         </div>
                         <div className="flex items-center gap-1">


### PR DESCRIPTION
## 目的
补 #282 Phase 4.x 的 Dashboard control status 展示，让 AccountStage 里的实盘会话卡片直接显示最近一次控制请求状态。

本 PR 新增前端展示：
- pending 文案显示已等待时长
- control request 元信息：action、controlVersion、controlRequestId、updated/succeeded/error time
- 保留现有 ERROR 文案和 errorCode hint

实现边界：只读取 `session.state.*`，不新增 API，不改 live-runner/start/stop/CAS/dispatch 语义。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [x] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) - 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？- 无
- [x] DB migration 是否具备向下兼容幂等性？- 无 DB migration
- [x] 配置字段有没有无意被混改？- 无配置字段变更

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

Local validation:
- `cd web/console && ./node_modules/.bin/tsc --noEmit src/pages/AccountStage.tsx --jsx react-jsx --esModuleInterop --target esnext --module esnext --moduleResolution Bundler --allowSyntheticDefaultImports`
- `cd web/console && npm run build`

Note: the AGENTS tsc command without `--module esnext` fails on existing `import.meta` usage in `src/utils/api.ts`; validation used `--module esnext` to match the Vite/tsconfig module setting.
