### PR TITLE
[codex] Add runtime supervisor dashboard

### DIFF
--- a/docs/runtime-supervisor.md
+++ b/docs/runtime-supervisor.md
@@ -363,6 +363,10 @@ func ClearRestartState(state map[string]any, keys []string)
 - 达到 `SUPERVISOR_SERVICE_FAILURE_THRESHOLD` 后只记录 `containerFallbackCandidate=true` 和原因，不调用 Docker API，不挂载 Docker socket，不执行容器 restart。
 - 后续真正执行容器级 restart 前，仍需单独设计 executor、backoff、人工抑制、权限边界和部署安全审查。
 
+### Dashboard 视图
+
+前端 console 的 Runtime Supervisor 页面读取 `GET /api/v1/supervisor/status`，只展示 service target、runtime 状态、应用内控制动作和 `containerFallbackCandidate`。该页面不提交 runtime 或容器控制请求；真正执行容器级 restart 前仍需单独 PR 设计 executor、权限边界和部署安全审查。
+
 ## 7. 安全边界
 
 必须遵守：

--- a/web/console/src/components/layout/MainContent.tsx
+++ b/web/console/src/components/layout/MainContent.tsx
@@ -4,6 +4,7 @@ import { StrategyStage } from '../../pages/StrategyStage';
 import { AccountStage } from '../../pages/AccountStage';
 import { LogStage } from '../../pages/LogStage';
 import { RecoveryStage } from '../../pages/RecoveryStage';
+import { SupervisorStage } from '../../pages/SupervisorStage';
 import { useUIStore } from '../../store/useUIStore';
 
 interface MainContentProps {
@@ -66,6 +67,9 @@ export function MainContent({ actions, dockContent, strategies, quickLiveAccount
       )}
       {sidebarTab === 'recovery' && (
         <RecoveryStage />
+      )}
+      {sidebarTab === 'supervisor' && (
+        <SupervisorStage />
       )}
     </div>
   );

--- a/web/console/src/layouts/WorkbenchLayout.tsx
+++ b/web/console/src/layouts/WorkbenchLayout.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
-import { Activity, Briefcase, Settings, FileText } from 'lucide-react';
+import { Activity, Briefcase, Settings, FileText, ServerCog } from 'lucide-react';
+
+type SidebarTab = 'monitor' | 'strategy' | 'account' | 'log' | 'recovery' | 'supervisor';
 
 export interface WorkbenchLayoutProps {
-  sidebarTab: 'monitor' | 'strategy' | 'account' | 'log';
-  onSidebarTabChange: (tab: 'monitor' | 'strategy' | 'account' | 'log') => void;
+  sidebarTab: SidebarTab;
+  onSidebarTabChange: (tab: SidebarTab) => void;
   dockTab: 'pairs' | 'orders' | 'positions' | 'fills' | 'alerts';
   onDockTabChange: (tab: 'pairs' | 'orders' | 'positions' | 'fills' | 'alerts') => void;
   
@@ -55,6 +57,12 @@ export function WorkbenchLayout({
           label="日志查看台" 
           active={sidebarTab === 'log'} 
           onClick={() => onSidebarTabChange('log')} 
+        />
+        <SidebarItem
+          icon={<ServerCog size={22} />}
+          label="运行控制面"
+          active={sidebarTab === 'supervisor'}
+          onClick={() => onSidebarTabChange('supervisor')}
         />
       </aside>
 

--- a/web/console/src/pages/SupervisorStage.tsx
+++ b/web/console/src/pages/SupervisorStage.tsx
@@ -1,0 +1,491 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Clock3,
+  RefreshCw,
+  RotateCw,
+  ServerCog,
+  ShieldAlert,
+  Signal,
+  XCircle,
+} from 'lucide-react';
+import { Badge } from '../components/ui/badge';
+import { Button } from '../components/ui/button';
+import { Card, CardAction, CardContent, CardHeader, CardTitle } from '../components/ui/card';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '../components/ui/table';
+import { Separator } from '../components/ui/separator';
+import { cn } from '../lib/utils';
+import { fetchJSON } from '../utils/api';
+import { formatTime, shrink } from '../utils/format';
+import {
+  RuntimeSupervisorControlAction,
+  RuntimeSupervisorRuntimeStatus,
+  RuntimeSupervisorSnapshot,
+  RuntimeSupervisorTargetSnapshot,
+} from '../types/domain';
+
+type LoadState = 'idle' | 'loading' | 'loaded' | 'error';
+type BadgeVariant = NonNullable<React.ComponentProps<typeof Badge>['variant']>;
+
+const REFRESH_INTERVAL_MS = 15_000;
+
+function formatOptionalTime(value?: string) {
+  return value ? formatTime(value) : '--';
+}
+
+function isProbeOK(probe?: RuntimeSupervisorTargetSnapshot['healthz']) {
+  if (!probe?.reachable || probe.error) {
+    return false;
+  }
+  return probe.statusCode == null || (probe.statusCode >= 200 && probe.statusCode < 300);
+}
+
+function probeText(probe?: RuntimeSupervisorTargetSnapshot['healthz']) {
+  if (!probe) {
+    return 'missing';
+  }
+  if (!probe.reachable) {
+    return 'unreachable';
+  }
+  if (probe.statusCode != null) {
+    return `HTTP ${probe.statusCode}`;
+  }
+  return probe.error ? 'error' : 'reachable';
+}
+
+function statusVariant(value?: string): BadgeVariant {
+  const normalized = String(value || '').trim().toLowerCase();
+  if (['ok', 'ready', 'running', 'healthy'].includes(normalized)) {
+    return 'success';
+  }
+  if (['error', 'fatal', 'blocked', 'unreachable', 'suppressed'].includes(normalized)) {
+    return 'destructive';
+  }
+  if (['recovering', 'starting', 'stale', 'warning', 'degraded'].includes(normalized)) {
+    return 'secondary';
+  }
+  return 'neutral';
+}
+
+function ProbeBadge({ probe }: { probe: RuntimeSupervisorTargetSnapshot['healthz'] }) {
+  const ok = isProbeOK(probe);
+  return (
+    <div className="flex max-w-[220px] flex-col gap-1">
+      <Badge variant={ok ? 'success' : 'destructive'}>{probeText(probe)}</Badge>
+      {probe.error && (
+        <span className="truncate text-xs text-[var(--bk-text-muted)]" title={probe.error}>
+          {probe.error}
+        </span>
+      )}
+    </div>
+  );
+}
+
+function StatusBadge({ value, fallback = '--' }: { value?: string; fallback?: string }) {
+  const label = String(value || '').trim() || fallback;
+  return <Badge variant={statusVariant(label)}>{label}</Badge>;
+}
+
+function MetricCard({
+  icon: Icon,
+  label,
+  value,
+  detail,
+  tone = 'neutral',
+}: {
+  icon: React.ComponentType<{ className?: string }>;
+  label: string;
+  value: string | number;
+  detail: string;
+  tone?: 'neutral' | 'success' | 'warning' | 'danger';
+}) {
+  return (
+    <Card tone="bento" className="rounded-lg">
+      <CardContent className="flex items-center justify-between gap-3">
+        <div className="flex min-w-0 flex-col gap-1">
+          <span className="text-xs font-medium uppercase text-[var(--bk-text-muted)]">{label}</span>
+          <span className="text-2xl font-semibold tabular-nums text-[var(--bk-text-primary)]">{value}</span>
+          <span className="truncate text-xs text-[var(--bk-text-muted)]">{detail}</span>
+        </div>
+        <div
+          className={cn(
+            'flex size-10 shrink-0 items-center justify-center rounded-lg border',
+            tone === 'success' && 'border-[var(--bk-status-success)] bg-[var(--bk-status-success-soft)] text-[var(--bk-status-success)]',
+            tone === 'warning' && 'border-[var(--bk-status-warning)] bg-[var(--bk-status-warning-soft)] text-[var(--bk-status-warning)]',
+            tone === 'danger' && 'border-[var(--bk-status-danger)] bg-[var(--bk-status-danger-soft)] text-[var(--bk-status-danger)]',
+            tone === 'neutral' && 'border-[var(--bk-border)] bg-[var(--bk-surface-muted)] text-[var(--bk-text-muted)]'
+          )}
+        >
+          <Icon className="size-5" />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function runtimeNeedsAttention(runtime: RuntimeSupervisorRuntimeStatus) {
+  if (runtime.autoRestartSuppressed) {
+    return true;
+  }
+  const actual = String(runtime.actualStatus || '').toUpperCase();
+  const health = String(runtime.health || '').toLowerCase();
+  return actual === 'ERROR' || ['error', 'suppressed', 'unreachable', 'stale'].includes(health);
+}
+
+export function SupervisorStage() {
+  const [snapshot, setSnapshot] = useState<RuntimeSupervisorSnapshot | null>(null);
+  const [loadState, setLoadState] = useState<LoadState>('idle');
+  const [error, setError] = useState<string | null>(null);
+
+  const loadSnapshot = useCallback(async (silent = false) => {
+    if (!silent) {
+      setLoadState('loading');
+    }
+    try {
+      const payload = await fetchJSON<RuntimeSupervisorSnapshot>('/api/v1/supervisor/status');
+      setSnapshot(payload);
+      setError(null);
+      setLoadState('loaded');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '读取 supervisor 状态失败');
+      setLoadState('error');
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadSnapshot();
+    const timer = window.setInterval(() => {
+      void loadSnapshot(true);
+    }, REFRESH_INTERVAL_MS);
+    return () => window.clearInterval(timer);
+  }, [loadSnapshot]);
+
+  const { runtimeRows, controlActionRows, fallbackCount, attentionCount, reachableTargets } = useMemo(() => {
+    const targets = snapshot?.targets ?? [];
+    const runtimes = targets.flatMap((target) =>
+      (target.status?.runtimes ?? []).map((runtime) => ({
+        ...runtime,
+        targetName: target.name,
+      }))
+    );
+    return {
+      runtimeRows: runtimes,
+      controlActionRows: targets.flatMap((target) =>
+        (target.controlActions ?? []).map((action) => ({
+          ...action,
+          targetName: target.name,
+        }))
+      ),
+      fallbackCount: targets.filter((target) => target.serviceState.containerFallbackCandidate).length,
+      attentionCount: runtimes.filter(runtimeNeedsAttention).length,
+      reachableTargets: targets.filter((target) => isProbeOK(target.healthz) && isProbeOK(target.runtimeStatus)).length,
+    };
+  }, [snapshot]);
+
+  const targets = snapshot?.targets ?? [];
+  const isLoading = loadState === 'loading' || loadState === 'idle';
+
+  return (
+    <div className="absolute inset-0 overflow-y-auto bg-[var(--bk-canvas)] p-6">
+      <div className="mx-auto flex w-full max-w-[1600px] flex-col gap-6">
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div className="flex items-center gap-3">
+            <div className="flex size-11 items-center justify-center rounded-lg border border-[var(--bk-border-strong)] bg-[var(--bk-surface)] text-[var(--bk-accent)]">
+              <ServerCog className="size-5" />
+            </div>
+            <div className="flex flex-col gap-1">
+              <span className="text-xs font-semibold uppercase text-[var(--bk-text-muted)]">Runtime Supervisor</span>
+              <h1 className="text-2xl font-semibold text-[var(--bk-text-primary)]">统一运行态视图</h1>
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <Badge variant="neutral" className="h-7 rounded-lg">
+              <Clock3 className="size-3" />
+              {snapshot ? formatOptionalTime(snapshot.checkedAt) : '--'}
+            </Badge>
+            <Button
+              type="button"
+              size="icon-sm"
+              variant="bento-outline"
+              className="rounded-lg"
+              onClick={() => void loadSnapshot()}
+              disabled={isLoading}
+              title="刷新"
+              aria-label="刷新"
+            >
+              <RefreshCw className={cn('size-4', isLoading && 'animate-spin')} />
+            </Button>
+          </div>
+        </div>
+
+        <Separator className="bg-[var(--bk-border-strong)] opacity-60" />
+
+        {loadState === 'error' && !snapshot ? (
+          <Card tone="bento" className="rounded-lg">
+            <CardContent className="flex items-center gap-3 py-6">
+              <AlertTriangle className="size-5 text-[var(--bk-status-warning)]" />
+              <div className="flex flex-col gap-1">
+                <span className="font-medium text-[var(--bk-text-primary)]">Supervisor 状态不可用</span>
+                <span className="text-sm text-[var(--bk-text-muted)]">{error}</span>
+              </div>
+            </CardContent>
+          </Card>
+        ) : (
+          <>
+            <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+              <MetricCard
+                icon={ServerCog}
+                label="Targets"
+                value={targets.length}
+                detail={`${reachableTargets}/${targets.length} reachable`}
+                tone={reachableTargets === targets.length && targets.length > 0 ? 'success' : 'warning'}
+              />
+              <MetricCard
+                icon={Signal}
+                label="Runtimes"
+                value={runtimeRows.length}
+                detail={`${attentionCount} need attention`}
+                tone={attentionCount > 0 ? 'warning' : 'success'}
+              />
+              <MetricCard
+                icon={ShieldAlert}
+                label="Fallback"
+                value={fallbackCount}
+                detail="container candidates"
+                tone={fallbackCount > 0 ? 'danger' : 'neutral'}
+              />
+              <MetricCard
+                icon={RotateCw}
+                label="Controls"
+                value={controlActionRows.length}
+                detail="application restart intents"
+                tone={controlActionRows.some((action) => action.error) ? 'danger' : 'neutral'}
+              />
+            </div>
+
+            <Card tone="bento" className="rounded-lg">
+              <CardHeader>
+                <CardTitle>Service Targets</CardTitle>
+                <CardAction>
+                  {error ? <Badge variant="destructive">{error}</Badge> : <Badge variant="neutral">auto refresh 15s</Badge>}
+                </CardAction>
+              </CardHeader>
+              <CardContent>
+                {targets.length === 0 ? (
+                  <div className="flex h-28 items-center justify-center rounded-lg border border-dashed border-[var(--bk-border)] text-sm text-[var(--bk-text-muted)]">
+                    暂无 supervisor target
+                  </div>
+                ) : (
+                  <Table tone="bento">
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>Target</TableHead>
+                        <TableHead>Healthz</TableHead>
+                        <TableHead>Runtime API</TableHead>
+                        <TableHead>Failures</TableHead>
+                        <TableHead>Fallback</TableHead>
+                        <TableHead>Runtimes</TableHead>
+                        <TableHead>Checked</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {targets.map((target) => {
+                        const runtimeCount = target.status?.runtimes.length ?? 0;
+                        const runtimeErrors = target.status?.runtimes.filter(runtimeNeedsAttention).length ?? 0;
+                        return (
+                          <TableRow key={`${target.name}:${target.baseUrl}`}>
+                            <TableCell>
+                              <div className="flex max-w-[260px] flex-col gap-1">
+                                <span className="font-medium text-[var(--bk-text-primary)]">{target.name}</span>
+                                <span className="truncate text-xs text-[var(--bk-text-muted)]" title={target.baseUrl}>
+                                  {target.baseUrl}
+                                </span>
+                              </div>
+                            </TableCell>
+                            <TableCell>
+                              <ProbeBadge probe={target.healthz} />
+                            </TableCell>
+                            <TableCell>
+                              <ProbeBadge probe={target.runtimeStatus} />
+                            </TableCell>
+                            <TableCell>
+                              <div className="flex flex-col gap-1">
+                                <span className="font-mono text-sm tabular-nums">
+                                  {target.serviceState.consecutiveFailures}/{target.serviceState.failureThreshold}
+                                </span>
+                                {target.serviceState.lastFailureReason && (
+                                  <span className="max-w-[220px] truncate text-xs text-[var(--bk-text-muted)]" title={target.serviceState.lastFailureReason}>
+                                    {target.serviceState.lastFailureReason}
+                                  </span>
+                                )}
+                              </div>
+                            </TableCell>
+                            <TableCell>
+                              <div className="flex max-w-[220px] flex-col gap-1">
+                                <Badge variant={target.serviceState.containerFallbackCandidate ? 'destructive' : 'neutral'}>
+                                  {target.serviceState.containerFallbackCandidate ? 'candidate' : 'clear'}
+                                </Badge>
+                                {target.serviceState.containerFallbackReason && (
+                                  <span className="truncate text-xs text-[var(--bk-text-muted)]" title={target.serviceState.containerFallbackReason}>
+                                    {target.serviceState.containerFallbackReason}
+                                  </span>
+                                )}
+                              </div>
+                            </TableCell>
+                            <TableCell>
+                              <div className="flex items-center gap-2">
+                                <Badge variant={runtimeErrors > 0 ? 'destructive' : 'neutral'}>{runtimeCount}</Badge>
+                                {runtimeErrors > 0 && <span className="text-xs text-[var(--bk-text-muted)]">{runtimeErrors} attention</span>}
+                              </div>
+                            </TableCell>
+                            <TableCell>{formatOptionalTime(target.checkedAt)}</TableCell>
+                          </TableRow>
+                        );
+                      })}
+                    </TableBody>
+                  </Table>
+                )}
+              </CardContent>
+            </Card>
+
+            <Card tone="bento" className="rounded-lg">
+              <CardHeader>
+                <CardTitle>Runtime Status</CardTitle>
+                <CardAction>
+                  <Badge variant={attentionCount > 0 ? 'secondary' : 'success'}>
+                    {attentionCount > 0 ? `${attentionCount} attention` : 'healthy'}
+                  </Badge>
+                </CardAction>
+              </CardHeader>
+              <CardContent>
+                {runtimeRows.length === 0 ? (
+                  <div className="flex h-28 items-center justify-center rounded-lg border border-dashed border-[var(--bk-border)] text-sm text-[var(--bk-text-muted)]">
+                    暂无 runtime 状态
+                  </div>
+                ) : (
+                  <Table tone="bento">
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>Target</TableHead>
+                        <TableHead>Runtime</TableHead>
+                        <TableHead>Kind</TableHead>
+                        <TableHead>Desired</TableHead>
+                        <TableHead>Actual</TableHead>
+                        <TableHead>Health</TableHead>
+                        <TableHead>Restart</TableHead>
+                        <TableHead>Next</TableHead>
+                        <TableHead>Checked</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {runtimeRows.map((runtime) => (
+                        <TableRow key={`${runtime.targetName}:${runtime.runtimeKind}:${runtime.runtimeId}`}>
+                          <TableCell>{runtime.targetName}</TableCell>
+                          <TableCell>
+                            <div className="flex max-w-[220px] flex-col gap-1">
+                              <span className="font-mono text-xs text-[var(--bk-text-primary)]">{shrink(runtime.runtimeId)}</span>
+                              {runtime.accountId && <span className="text-xs text-[var(--bk-text-muted)]">{shrink(runtime.accountId)}</span>}
+                            </div>
+                          </TableCell>
+                          <TableCell><Badge variant="metal">{runtime.runtimeKind}</Badge></TableCell>
+                          <TableCell><StatusBadge value={runtime.desiredStatus} /></TableCell>
+                          <TableCell><StatusBadge value={runtime.actualStatus} /></TableCell>
+                          <TableCell>
+                            <div className="flex items-center gap-2">
+                              <StatusBadge value={runtime.health} />
+                              {runtime.autoRestartSuppressed && <Badge variant="destructive">suppressed</Badge>}
+                            </div>
+                          </TableCell>
+                          <TableCell>
+                            <div className="flex flex-col gap-1">
+                              <span className="font-mono text-sm tabular-nums">{runtime.restartAttempt}</span>
+                              {runtime.restartSeverity && <StatusBadge value={runtime.restartSeverity} />}
+                              {runtime.lastRestartError && (
+                                <span className="max-w-[220px] truncate text-xs text-[var(--bk-text-muted)]" title={runtime.lastRestartError}>
+                                  {runtime.lastRestartError}
+                                </span>
+                              )}
+                            </div>
+                          </TableCell>
+                          <TableCell>{formatOptionalTime(runtime.nextRestartAt)}</TableCell>
+                          <TableCell>{formatOptionalTime(runtime.lastCheckedAt)}</TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                )}
+              </CardContent>
+            </Card>
+
+            <Card tone="bento" className="rounded-lg">
+              <CardHeader>
+                <CardTitle>Control Actions</CardTitle>
+                <CardAction>
+                  <Badge variant="neutral">{controlActionRows.length}</Badge>
+                </CardAction>
+              </CardHeader>
+              <CardContent>
+                {controlActionRows.length === 0 ? (
+                  <div className="flex h-24 items-center justify-center rounded-lg border border-dashed border-[var(--bk-border)] text-sm text-[var(--bk-text-muted)]">
+                    暂无应用内控制动作
+                  </div>
+                ) : (
+                  <Table tone="bento">
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>Requested</TableHead>
+                        <TableHead>Target</TableHead>
+                        <TableHead>Action</TableHead>
+                        <TableHead>Runtime</TableHead>
+                        <TableHead>Status</TableHead>
+                        <TableHead>Reason</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {controlActionRows.map((action) => (
+                        <TableRow key={`${action.targetName}:${action.runtimeKind}:${action.runtimeId}:${action.requestedAt}`}>
+                          <TableCell>{formatOptionalTime(action.requestedAt)}</TableCell>
+                          <TableCell>{action.targetName}</TableCell>
+                          <TableCell><Badge variant="metal">{action.action}</Badge></TableCell>
+                          <TableCell>
+                            <div className="flex flex-col gap-1">
+                              <span className="font-mono text-xs">{shrink(action.runtimeId)}</span>
+                              <span className="text-xs text-[var(--bk-text-muted)]">{action.runtimeKind}</span>
+                            </div>
+                          </TableCell>
+                          <TableCell>
+                            <div className="flex items-center gap-2">
+                              {action.submitted ? (
+                                <CheckCircle2 className="size-4 text-[var(--bk-status-success)]" />
+                              ) : (
+                                <XCircle className="size-4 text-[var(--bk-status-danger)]" />
+                              )}
+                              <Badge variant={action.error ? 'destructive' : 'neutral'}>{action.statusCode || '--'}</Badge>
+                            </div>
+                          </TableCell>
+                          <TableCell>
+                            <span className="block max-w-[420px] truncate text-xs text-[var(--bk-text-muted)]" title={action.error || action.reason}>
+                              {action.error || action.reason || '--'}
+                            </span>
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                )}
+              </CardContent>
+            </Card>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/console/src/store/useUIStore.ts
+++ b/web/console/src/store/useUIStore.ts
@@ -9,7 +9,7 @@ import {
 import { readStoredAuthSession } from '../utils/auth';
 import { resolveUpdater } from './helpers';
 
-type SidebarTab = "monitor" | "strategy" | "account" | "log" | "recovery";
+type SidebarTab = "monitor" | "strategy" | "account" | "log" | "recovery" | "supervisor";
 type DockTab = "pairs" | "orders" | "positions" | "fills" | "alerts";
 
 export type SystemLogEntry = {
@@ -65,7 +65,7 @@ function readStoredConsoleNav(): { sidebarTab: SidebarTab; dockTab: DockTab } {
     }
 
     const parsed = JSON.parse(raw) as Partial<{ sidebarTab: SidebarTab; dockTab: DockTab }>;
-    const sidebarTab = parsed.sidebarTab === "strategy" || parsed.sidebarTab === "account" || parsed.sidebarTab === "monitor" || parsed.sidebarTab === "log" || parsed.sidebarTab === "recovery"
+    const sidebarTab = parsed.sidebarTab === "strategy" || parsed.sidebarTab === "account" || parsed.sidebarTab === "monitor" || parsed.sidebarTab === "log" || parsed.sidebarTab === "recovery" || parsed.sidebarTab === "supervisor"
       ? parsed.sidebarTab
       : DEFAULT_SIDEBAR_TAB;
     const dockTab = parsed.dockTab === "positions" || parsed.dockTab === "fills" || parsed.dockTab === "alerts" || parsed.dockTab === "orders" || parsed.dockTab === "pairs"

--- a/web/console/src/types/domain.ts
+++ b/web/console/src/types/domain.ts
@@ -330,6 +330,79 @@ export type SignalRuntimeSession = {
   updatedAt: string;
 };
 
+export type RuntimeSupervisorProbe = {
+  path: string;
+  statusCode?: number;
+  reachable: boolean;
+  error?: string;
+  payload?: Record<string, unknown>;
+};
+
+export type RuntimeSupervisorRuntimeStatus = {
+  service: string;
+  runtimeId: string;
+  runtimeKind: string;
+  accountId?: string;
+  strategyId?: string;
+  desiredStatus?: string;
+  actualStatus?: string;
+  health?: string;
+  restartAttempt: number;
+  nextRestartAt?: string;
+  restartBackoff?: string;
+  restartReason?: string;
+  restartSeverity?: string;
+  lastRestartError?: string;
+  autoRestartSuppressed: boolean;
+  lastHealthyAt?: string;
+  lastCheckedAt: string;
+  updatedAt?: string;
+};
+
+export type RuntimeSupervisorStatus = {
+  service: string;
+  checkedAt: string;
+  runtimes: RuntimeSupervisorRuntimeStatus[];
+};
+
+export type RuntimeSupervisorServiceState = {
+  consecutiveFailures: number;
+  failureThreshold: number;
+  lastFailureReason?: string;
+  lastFailureAt?: string;
+  lastHealthyAt?: string;
+  containerFallbackCandidate: boolean;
+  containerFallbackReason?: string;
+};
+
+export type RuntimeSupervisorControlAction = {
+  action: string;
+  path: string;
+  runtimeId: string;
+  runtimeKind: string;
+  reason?: string;
+  submitted: boolean;
+  statusCode?: number;
+  error?: string;
+  requestedAt: string;
+};
+
+export type RuntimeSupervisorTargetSnapshot = {
+  name: string;
+  baseUrl: string;
+  checkedAt: string;
+  healthz: RuntimeSupervisorProbe;
+  runtimeStatus: RuntimeSupervisorProbe;
+  serviceState: RuntimeSupervisorServiceState;
+  status?: RuntimeSupervisorStatus;
+  controlActions?: RuntimeSupervisorControlAction[];
+};
+
+export type RuntimeSupervisorSnapshot = {
+  checkedAt: string;
+  targets: RuntimeSupervisorTargetSnapshot[];
+};
+
 export type ReplayReasonStats = Record<string, Record<string, number>>;
 
 export type ReplaySample = Record<string, unknown>;


### PR DESCRIPTION
## 目的
继续 issue #270 下一阶段：新增只读 Runtime Supervisor dashboard，消费 `GET /api/v1/supervisor/status`，集中展示 service target、`/healthz` / runtime API probe、runtime 状态、应用内控制动作和 `containerFallbackCandidate`。

本 PR 不新增 runtime/container 控制请求，不改 Docker socket、部署配置、dispatch/live 执行路径或默认安全参数。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [x] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) - 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？- 无
- [x] DB migration 是否具备向下兼容幂等性？- 未涉及
- [x] 配置字段有没有无意被混改？- 未涉及

## 验证方式与测试证据
- [ ] 无需跑后端或无需编译的文档性修改
- [x] `npm ci`（仅安装依赖；Node 20.6.1 下有现有 EBADENGINE warning）
- [x] `./node_modules/.bin/tsc --noEmit src/pages/AccountStage.tsx --jsx react-jsx --esModuleInterop --target esnext --module esnext --moduleResolution Bundler --allowSyntheticDefaultImports`
- [x] `./node_modules/.bin/tsc --noEmit src/pages/SupervisorStage.tsx --jsx react-jsx --esModuleInterop --target esnext --module esnext --moduleResolution Bundler --allowSyntheticDefaultImports --strict`
- [x] `npm run build`
- [x] `git diff --check`
- [x] 本地 Vite 预览：`http://127.0.0.1:5174/` 返回 200

补充：AGENTS 中的单文件 `tsc` 示例如果不补 `--module esnext`，当前项目会因 `import.meta` 被 TS 默认 module 拦截；这里按 `tsconfig.json` 对齐后通过。另，`tsc --noEmit --project tsconfig.json` 当前会在 main 已存在的 `src/hooks/useTradingActions.ts` / `LiveLaunchResult.liveSession` 类型不一致处失败，本 PR 未顺手扩大到 live flow 修复。
