### PR TITLE
[codex] Clarify missing live control metadata

### DIFF
--- a/web/console/src/pages/AccountStage.tsx
+++ b/web/console/src/pages/AccountStage.tsx
@@ -158,6 +158,13 @@ function liveControlPendingSince(state: Record<string, unknown>, actualStatus: s
   return requestedAt ?? updatedAt;
 }
 
+function latestLiveControlEvent(state: Record<string, unknown>): Record<string, unknown> {
+  const events = getList(state.controlEvents)
+    .map((item) => getRecord(item))
+    .filter((item) => String(item.type ?? item.phase ?? "").trim() !== "");
+  return events.length > 0 ? events[events.length - 1] : {};
+}
+
 function formatLiveControlDuration(ms: number): string {
   if (!Number.isFinite(ms) || ms < 0) {
     return "--";
@@ -1160,23 +1167,26 @@ export function AccountStage({
                      liveActualStatus !== "" &&
                      liveActualStatus !== "ERROR" &&
                      liveDesiredStatus !== liveActualStatus;
-                   const liveControlRequestId = String(sessionState.controlRequestId ?? "").trim();
-                   const liveControlVersion = String(sessionState.controlVersion ?? "").trim();
-                   const liveControlAction = String(sessionState.lastControlAction ?? "").trim();
+                   const latestControlEvent = latestLiveControlEvent(sessionState);
+                   const liveControlRequestId = String(sessionState.controlRequestId ?? latestControlEvent.controlRequestId ?? "").trim();
+                   const liveControlVersion = String(sessionState.controlVersion ?? latestControlEvent.controlVersion ?? "").trim();
+                   const liveControlAction = String(sessionState.lastControlAction ?? latestControlEvent.action ?? "").trim();
                    const liveControlRequestedAt = String(sessionState.controlRequestedAt ?? "").trim();
-                   const liveControlUpdatedAt = String(sessionState.lastControlUpdateAt ?? "").trim();
-                   const liveControlSucceededAt = String(sessionState.lastControlSucceededAt ?? "").trim();
+                   const liveControlUpdatedAt = String(sessionState.lastControlUpdateAt ?? latestControlEvent.eventTime ?? "").trim();
+                   const liveControlSucceededAt = String(sessionState.lastControlSucceededAt ?? (String(latestControlEvent.phase ?? "") === "succeeded" ? latestControlEvent.eventTime : "") ?? "").trim();
                    const liveControlErrorCode = String(sessionState.lastControlErrorCode ?? "").trim().toUpperCase();
-                   const liveControlErrorAt = String(sessionState.lastControlErrorAt ?? "").trim();
+                   const liveControlErrorAt = String(sessionState.lastControlErrorAt ?? (String(latestControlEvent.phase ?? "") === "failed" ? latestControlEvent.eventTime : "") ?? "").trim();
                    const liveControlError = liveActualStatus === "ERROR"
                      ? liveControlErrorMessage(liveControlErrorCode, String(sessionState.lastControlError ?? "").trim())
                      : "";
                    const liveControlPendingStart = liveControlConverging ? liveControlPendingSince(sessionState, liveActualStatus) : null;
                    const liveControlPendingFor = liveControlPendingStart ? formatLiveControlDuration(Date.now() - liveControlPendingStart.getTime()) : "";
-                   const hasLiveControlRequestMeta =
+                   const hasLiveControlIdentity =
                      liveControlRequestId ||
                      liveControlVersion ||
-                     liveControlAction ||
+                     liveControlAction;
+                   const hasLiveControlRequestMeta =
+                     hasLiveControlIdentity ||
                      liveControlRequestedAt ||
                      liveControlUpdatedAt ||
                      liveControlSucceededAt ||
@@ -1240,7 +1250,7 @@ export function AccountStage({
                                控制失败{liveControlErrorCode ? ` (${liveControlErrorCode})` : ""}：{liveControlError}
                              </p>
                            )}
-                           {hasLiveControlRequestMeta && (
+                           {hasLiveControlRequestMeta && hasLiveControlIdentity && (
                              <div className="mt-2 grid max-w-[min(100%,42rem)] grid-cols-2 gap-x-3 gap-y-1 rounded-[12px] border border-[var(--bk-border)] bg-[var(--bk-surface)] px-3 py-2 text-[10px] text-[var(--bk-text-muted)] sm:grid-cols-4">
                                <div className="min-w-0">
                                  <div className="font-black uppercase text-[8px] text-[var(--bk-text-muted)]">Action</div>
@@ -1261,6 +1271,11 @@ export function AccountStage({
                                  </div>
                                </div>
                              </div>
+                           )}
+                           {hasLiveControlRequestMeta && !hasLiveControlIdentity && (
+                             <p className="mt-2 text-[10px] font-bold text-[var(--bk-text-muted)]">
+                               暂无控制请求记录；下一次启动/停止提交后会显示 request、version 和 action。
+                             </p>
                            )}
                         </div>
                         <div className="flex items-center gap-1">


### PR DESCRIPTION
## 目的
修正 AccountStage Live control 元信息展示空壳问题。

用户反馈旧/legacy session 只有 `lastControlUpdateAt` 时，卡片会显示 Action/Version/Request 全是 `--`，看起来像没有信息。

本 PR 调整：
- 优先从 `session.state` 顶层读取 control request 元信息。
- 顶层缺失时，从最新 `state.controlEvents` 兜底读取 action/request/version/time。
- 如果仍然没有 request/version/action，则不再渲染空的四列元信息卡片，改为显示明确说明：暂无控制请求记录，下一次启动/停止后显示。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [x] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) - 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？- 无
- [x] DB migration 是否具备向下兼容幂等性？- 无 DB migration
- [x] 配置字段有没有无意被混改？- 无配置字段变更

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

Local validation:
- `cd web/console && ./node_modules/.bin/tsc --noEmit src/pages/AccountStage.tsx --jsx react-jsx --esModuleInterop --target esnext --module esnext --moduleResolution Bundler --allowSyntheticDefaultImports`
- `cd web/console && npm run build`
