### PR TITLE
fix terminal synthetic fill autosync

### DIFF
--- a/internal/service/live_execution.go
+++ b/internal/service/live_execution.go
@@ -1334,7 +1334,11 @@ func (p *Platform) syncLatestLiveSessionOrder(session domain.LiveSession, eventT
 	}
 	state := cloneMetadata(session.State)
 	if isTerminalOrderStatus(order.Status) {
-		if shouldBackfillTerminalFilledLiveOrder(order, state) {
+		fills, err := p.store.QueryFills(domain.FillQuery{OrderIDs: []string{order.ID}})
+		if err != nil {
+			return session, err
+		}
+		if shouldBackfillTerminalFilledLiveOrder(order, state, eventTime, fills) {
 			state["lastSyncAttemptAt"] = eventTime.UTC().Format(time.RFC3339)
 			recordExecutionSyncAttemptHealth(state, eventTime)
 			syncedOrder, syncErr := p.SyncLiveOrder(order.ID)
@@ -1524,15 +1528,47 @@ func (p *Platform) syncLatestLiveSessionOrder(session domain.LiveSession, eventT
 	return updated, nil
 }
 
-func shouldBackfillTerminalFilledLiveOrder(order domain.Order, state map[string]any) bool {
+const terminalFilledOrderBackfillCooldown = 30 * time.Second
+
+func shouldBackfillTerminalFilledLiveOrder(order domain.Order, state map[string]any, eventTime time.Time, fills ...[]domain.Fill) bool {
 	if !strings.EqualFold(order.Status, "FILLED") {
 		return false
+	}
+	if len(fills) > 0 && terminalFilledOrderHasNonAuthoritativeFills(fills[0]) {
+		return terminalFilledOrderBackfillCooldownElapsed(state, eventTime)
 	}
 	if tradingQuantityBelow(parseFloatValue(order.Metadata["filledQuantity"]), order.Quantity) {
 		return true
 	}
 	if strings.TrimSpace(stringValue(order.Metadata["lastFilledAt"])) == "" {
 		return true
+	}
+	return false
+}
+
+func terminalFilledOrderBackfillCooldownElapsed(state map[string]any, eventTime time.Time) bool {
+	if eventTime.IsZero() {
+		return true
+	}
+	lastAttemptAt := parseOptionalRFC3339(stringValue(state["lastSyncAttemptAt"]))
+	if lastAttemptAt.IsZero() {
+		return true
+	}
+	return eventTime.UTC().Sub(lastAttemptAt.UTC()) >= terminalFilledOrderBackfillCooldown
+}
+
+func terminalFilledOrderHasNonAuthoritativeFills(fills []domain.Fill) bool {
+	for _, fill := range fills {
+		if !tradingQuantityPositive(fill.Quantity) {
+			continue
+		}
+		if strings.TrimSpace(fill.ExchangeTradeID) == "" {
+			return true
+		}
+		switch FillSource(strings.TrimSpace(fill.Source)) {
+		case FillSourceSynthetic, FillSourceRemainder:
+			return true
+		}
 	}
 	return false
 }

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -9327,8 +9327,167 @@ func TestShouldBackfillTerminalFilledLiveOrderSkipsCompleteFillWhenGateBlocked(t
 		"positionReconcileGateBlocking": true,
 		"positionReconcileGateScenario": "db-position-exchange-missing",
 	}
-	if shouldBackfillTerminalFilledLiveOrder(order, state) {
+	if shouldBackfillTerminalFilledLiveOrder(order, state, time.Date(2026, 4, 26, 3, 36, 53, 0, time.UTC)) {
 		t.Fatal("expected complete terminal fill not to be repeatedly backfilled while reconcile gate is blocked")
+	}
+}
+
+func TestShouldBackfillTerminalFilledLiveOrderBackfillsSyntheticFill(t *testing.T) {
+	order := domain.Order{
+		ID:       "order-terminal-synthetic",
+		Status:   "FILLED",
+		Quantity: 0.013,
+		Metadata: map[string]any{
+			"filledQuantity": 0.013,
+			"lastFilledAt":   time.Date(2026, 4, 29, 3, 35, 12, 0, time.UTC).Format(time.RFC3339),
+		},
+	}
+	fills := []domain.Fill{{
+		OrderID:  order.ID,
+		Source:   string(FillSourceSynthetic),
+		Price:    76784.4,
+		Quantity: 0.013,
+		Fee:      0,
+	}}
+	if !shouldBackfillTerminalFilledLiveOrder(order, nil, time.Date(2026, 4, 29, 3, 35, 42, 0, time.UTC), fills) {
+		t.Fatal("expected complete terminal synthetic fill to be backfilled")
+	}
+}
+
+func TestShouldBackfillTerminalFilledLiveOrderThrottlesRecentSyntheticBackfill(t *testing.T) {
+	now := time.Date(2026, 4, 29, 3, 35, 42, 0, time.UTC)
+	order := domain.Order{
+		ID:       "order-terminal-synthetic-throttle",
+		Status:   "FILLED",
+		Quantity: 0.013,
+		Metadata: map[string]any{
+			"filledQuantity": 0.013,
+			"lastFilledAt":   now.Add(-30 * time.Second).Format(time.RFC3339),
+		},
+	}
+	state := map[string]any{
+		"lastSyncAttemptAt": now.Add(-10 * time.Second).Format(time.RFC3339),
+	}
+	fills := []domain.Fill{{
+		OrderID:  order.ID,
+		Source:   string(FillSourceSynthetic),
+		Price:    76784.4,
+		Quantity: 0.013,
+		Fee:      0,
+	}}
+	if shouldBackfillTerminalFilledLiveOrder(order, state, now, fills) {
+		t.Fatal("expected recent synthetic backfill attempt to be throttled")
+	}
+	if !shouldBackfillTerminalFilledLiveOrder(order, state, now.Add(21*time.Second), fills) {
+		t.Fatal("expected synthetic backfill after cooldown")
+	}
+}
+
+func TestSyncLatestLiveSessionOrderBackfillsSyntheticTerminalFill(t *testing.T) {
+	platform, session, _, _, _ := prepareLiveDecisionTelemetryFixture(t)
+	var syncCount int64
+	tradeTime := time.Date(2026, 4, 29, 3, 35, 12, 0, time.UTC)
+	platform.registerLiveAdapter(testLiveAccountSyncAdapter{
+		key: "test-terminal-synthetic-backfill",
+		syncOrderFunc: func(_ domain.Account, order domain.Order, _ map[string]any) (LiveOrderSync, error) {
+			atomic.AddInt64(&syncCount, 1)
+			return LiveOrderSync{
+				Status:   "FILLED",
+				SyncedAt: tradeTime.Format(time.RFC3339),
+				Fills: []LiveFillReport{{
+					Price:    76784.4,
+					Quantity: order.Quantity,
+					Fee:      0.39927888,
+					Source:   FillSourceReal,
+					Metadata: map[string]any{
+						"tradeId":   "481518956",
+						"tradeTime": tradeTime.Format(time.RFC3339),
+					},
+				}},
+				Metadata: map[string]any{
+					"executedQty":      order.Quantity,
+					"avgPrice":         76784.4,
+					"updateTime":       tradeTime.Format(time.RFC3339),
+					"tradeReportCount": 1,
+					"totalFee":         0.39927888,
+				},
+				Terminal: true,
+			}, nil
+		},
+	})
+
+	account, err := platform.store.GetAccount(session.AccountID)
+	if err != nil {
+		t.Fatalf("get account failed: %v", err)
+	}
+	account.Status = "READY"
+	account.Metadata = cloneMetadata(account.Metadata)
+	account.Metadata["liveBinding"] = map[string]any{
+		"adapterKey":     "test-terminal-synthetic-backfill",
+		"connectionMode": "mock",
+		"executionMode":  "rest",
+	}
+	if _, err := platform.store.UpdateAccount(account); err != nil {
+		t.Fatalf("update account failed: %v", err)
+	}
+
+	order, err := platform.store.CreateOrder(domain.Order{
+		AccountID:         session.AccountID,
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "SELL",
+		Type:              "MARKET",
+		Status:            "FILLED",
+		Quantity:          0.013,
+		Price:             76784.4,
+		Metadata: map[string]any{
+			"source":            "live-session-intent",
+			"liveSessionId":     session.ID,
+			"executionProposal": map[string]any{"role": "exit", "side": "SELL", "symbol": "BTCUSDT"},
+			"filledQuantity":    0.013,
+			"lastFilledAt":      tradeTime.Format(time.RFC3339),
+		},
+	})
+	if err != nil {
+		t.Fatalf("create live order failed: %v", err)
+	}
+	if _, err := platform.store.CreateFill(domain.Fill{
+		OrderID:          order.ID,
+		Source:           string(FillSourceSynthetic),
+		Price:            76784.4,
+		Quantity:         0.013,
+		Fee:              0,
+		DedupFingerprint: "terminal-filled-order-fallback|" + order.ID,
+	}); err != nil {
+		t.Fatalf("create synthetic fill failed: %v", err)
+	}
+	state := cloneMetadata(session.State)
+	state["lastDispatchedOrderId"] = order.ID
+	state["lastDispatchedOrderStatus"] = "FILLED"
+	session, err = platform.store.UpdateLiveSessionState(session.ID, state)
+	if err != nil {
+		t.Fatalf("update live session state failed: %v", err)
+	}
+
+	updated, err := platform.syncLatestLiveSessionOrder(session, tradeTime.Add(10*time.Minute))
+	if err != nil {
+		t.Fatalf("sync latest live session order failed: %v", err)
+	}
+	if got := atomic.LoadInt64(&syncCount); got != 1 {
+		t.Fatalf("expected synthetic terminal fill to trigger one order sync, got %d", got)
+	}
+	if got := stringValue(updated.State["lastSyncedOrderId"]); got != order.ID {
+		t.Fatalf("expected synced order id %s, got %s", order.ID, got)
+	}
+	fills, err := platform.store.QueryFills(domain.FillQuery{OrderIDs: []string{order.ID}})
+	if err != nil {
+		t.Fatalf("query fills failed: %v", err)
+	}
+	if len(fills) != 1 {
+		t.Fatalf("expected synthetic fill to be replaced by one real fill, got %+v", fills)
+	}
+	if fills[0].ExchangeTradeID != "481518956" || fills[0].Source != string(FillSourceReal) || fills[0].Fee != 0.39927888 {
+		t.Fatalf("expected real fee fill after backfill sync, got %+v", fills[0])
 	}
 }
 


### PR DESCRIPTION
## 目的
修复 terminal `FILLED` 订单已经有 `filledQuantity/lastFilledAt` 后，仍保留 synthetic fill、缺少 `exchangeTradeId`、手续费为 0 时不会自动继续 `order sync` 的问题。

这次线上表现是订单数量已经对上，系统误判 settlement 完成，但真实 Binance `userTrades` 还没拉回来，导致前端显示“等待同步 / 手续费 0”。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [x] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
- [x] `dispatchMode` 默认值无变化
- [x] 不存在直接调用 `mainnet` 凭证或路由地址的硬编码
- [x] 无 DB migration
- [x] 未修改配置字段

## 验证方式与测试证据
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

验证命令：
- `go test ./internal/service -run 'TestShouldBackfillTerminalFilledLiveOrder|TestSyncLatestLiveSessionOrderBackfillsSyntheticTerminalFill|TestSyncLatestLiveSessionOrderSyncsAfterUnknownOrderCancelRace' -count=1`
- `go test ./internal/service -count=1`
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
- `bash scripts/check_high_risk_defaults.sh`
- `git diff --check`
