### PR TITLE
[codex] Align live trailing activation with watermarks

### DIFF
--- a/internal/service/strategy_optimization_test.go
+++ b/internal/service/strategy_optimization_test.go
@@ -98,6 +98,40 @@ func TestEvaluateLiveExitStateKeepsTrailingStopActiveAfterPullbackBelowActivatio
 	}
 }
 
+func TestEvaluateLiveExitStateKeepsShortTrailingStopActiveAfterPullbackBelowActivation(t *testing.T) {
+	parameters := map[string]any{
+		"trailing_stop_atr":               0.3,
+		"delayed_trailing_activation_atr": 0.5,
+		"stop_loss_atr":                   0.05,
+		"stop_mode":                       "atr",
+	}
+	signalBarState := map[string]any{
+		"atr14":    1000.0,
+		"current":  map[string]any{"close": 49800.0},
+		"prevBar1": map[string]any{"high": 50500.0, "low": 49500.0},
+		"prevBar2": map[string]any{"high": 50600.0, "low": 49400.0},
+	}
+	currentPosition := map[string]any{
+		"found":      true,
+		"side":       "SHORT",
+		"entryPrice": 50000.0,
+		"quantity":   1.0,
+	}
+	sessionState := map[string]any{}
+
+	evaluateLivePositionState(parameters, currentPosition, signalBarState, 49400.0, sessionState)
+	state := evaluateLiveExitState(parameters, currentPosition, signalBarState, 49800.0, sessionState, "SL")
+	if !boolValue(state["ready"]) {
+		t.Fatalf("expected pullback through short trailing stop to be exit-ready, got waitReason=%s", stringValue(state["waitReason"]))
+	}
+	if got := stringValue(state["targetPriceSource"]); got != "trailing-stop" {
+		t.Fatalf("expected targetPriceSource trailing-stop after short pullback, got %s", got)
+	}
+	if got := parseFloatValue(state["stopLoss"]); got != 49700.0 {
+		t.Fatalf("expected short trailing stop to stay at 49700 after pullback, got %v", got)
+	}
+}
+
 func TestReentryDecayLogic(t *testing.T) {
 	session := domain.LiveSession{
 		State: map[string]any{

--- a/internal/service/strategy_optimization_test.go
+++ b/internal/service/strategy_optimization_test.go
@@ -64,6 +64,40 @@ func TestEvaluateLivePositionStateTrailingStop(t *testing.T) {
 	}
 }
 
+func TestEvaluateLiveExitStateKeepsTrailingStopActiveAfterPullbackBelowActivation(t *testing.T) {
+	parameters := map[string]any{
+		"trailing_stop_atr":               0.3,
+		"delayed_trailing_activation_atr": 0.5,
+		"stop_loss_atr":                   0.05,
+		"stop_mode":                       "atr",
+	}
+	signalBarState := map[string]any{
+		"atr14":    1000.0,
+		"current":  map[string]any{"close": 50200.0},
+		"prevBar1": map[string]any{"high": 50500.0, "low": 49500.0},
+		"prevBar2": map[string]any{"high": 50600.0, "low": 49400.0},
+	}
+	currentPosition := map[string]any{
+		"found":      true,
+		"side":       "LONG",
+		"entryPrice": 50000.0,
+		"quantity":   1.0,
+	}
+	sessionState := map[string]any{}
+
+	evaluateLivePositionState(parameters, currentPosition, signalBarState, 50600.0, sessionState)
+	state := evaluateLiveExitState(parameters, currentPosition, signalBarState, 50200.0, sessionState, "SL")
+	if !boolValue(state["ready"]) {
+		t.Fatalf("expected pullback through trailing stop to be exit-ready, got waitReason=%s", stringValue(state["waitReason"]))
+	}
+	if got := stringValue(state["targetPriceSource"]); got != "trailing-stop" {
+		t.Fatalf("expected targetPriceSource trailing-stop after pullback, got %s", got)
+	}
+	if got := parseFloatValue(state["stopLoss"]); got != 50300.0 {
+		t.Fatalf("expected trailing stop to stay at 50300 after pullback, got %v", got)
+	}
+}
+
 func TestReentryDecayLogic(t *testing.T) {
 	session := domain.LiveSession{
 		State: map[string]any{

--- a/internal/service/strategy_registry.go
+++ b/internal/service/strategy_registry.go
@@ -1259,9 +1259,9 @@ func deriveLivePositionState(parameters map[string]any, currentPosition map[stri
 			profitATR := 0.0
 			if sig.ATR > 0 {
 				if side == "long" {
-					profitATR = (marketPrice - entryPrice) / sig.ATR
+					profitATR = (hwm - entryPrice) / sig.ATR
 				} else if side == "short" {
-					profitATR = (entryPrice - marketPrice) / sig.ATR
+					profitATR = (entryPrice - lwm) / sig.ATR
 				}
 			}
 			if profitATR < delayedActivation {


### PR DESCRIPTION
## 目的
修复 live 中 trailing stop 激活状态会在价格回撤后退回普通 SL 的问题，使 live 与 research/replay 的 HWM/LWM trailing 语义对齐。

Root cause：live 原本用当前 `marketPrice` 相对入场价判断 `delayed_trailing_activation_atr`，而 research/replay 用持仓期间的 `HWM/LWM` 判断历史最大浮盈。价格先触发 TSL 再回撤时，live 可能重新判定 trailing inactive，导致 `stopLossSource` 退回 `initial-stop`。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [x] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) - 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？- 不涉及
- [x] DB migration 是否具备向下兼容幂等性？- 不涉及 DB migration
- [x] 配置字段有没有无意被混改？- 无配置字段变更

## 修改内容
- live trailing activation 从当前价判断改为基于 `hwm/lwm` 判断，与 `strategy_replay.go` / research 中只收紧不放宽的 trailing stop 行为一致。
- 新增回归测试覆盖 `50000 -> 50600 -> 50200` 的 long 场景，确认 TSL 激活后回撤仍保持 `targetPriceSource=trailing-stop`，且 `stopLoss=50300`。

## 验证方式与测试证据
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

已执行：
```bash
go test ./internal/service -run 'TestEvaluateLive(PositionStateTrailingStop|ExitStateKeepsTrailingStopActiveAfterPullbackBelowActivation|ExitStateUsesTrailingStopDiagnosticsForLong|DeriveLivePositionStateDoesNotReuseCachedTrailingStopWhenTrailingInactive)'
go test ./internal/service
```

Push 时 pre-push hook 也已自动运行 graphify rebuild 与 repository safety sensors，high risk defaults/env safety checks 均通过。