### PR TITLE
[codex] Clarify supervisor target reachability label

### DIFF
--- a/web/console/src/pages/SupervisorStage.tsx
+++ b/web/console/src/pages/SupervisorStage.tsx
@@ -168,7 +168,7 @@ export function SupervisorStage() {
     return () => window.clearInterval(timer);
   }, [loadSnapshot]);
 
-  const { runtimeRows, controlActionRows, fallbackCount, attentionCount, reachableTargets } = useMemo(() => {
+  const { runtimeRows, controlActionRows, fallbackCount, attentionCount, fullyReachableTargets } = useMemo(() => {
     const targets = snapshot?.targets ?? [];
     const runtimes = targets.flatMap((target) =>
       (target.status?.runtimes ?? []).map((runtime) => ({
@@ -186,7 +186,7 @@ export function SupervisorStage() {
       ),
       fallbackCount: targets.filter((target) => target.serviceState.containerFallbackCandidate).length,
       attentionCount: runtimes.filter(runtimeNeedsAttention).length,
-      reachableTargets: targets.filter((target) => isProbeOK(target.healthz) && isProbeOK(target.runtimeStatus)).length,
+      fullyReachableTargets: targets.filter((target) => isProbeOK(target.healthz) && isProbeOK(target.runtimeStatus)).length,
     };
   }, [snapshot]);
 
@@ -245,8 +245,8 @@ export function SupervisorStage() {
                 icon={ServerCog}
                 label="Targets"
                 value={targets.length}
-                detail={`${reachableTargets}/${targets.length} reachable`}
-                tone={reachableTargets === targets.length && targets.length > 0 ? 'success' : 'warning'}
+                detail={`${fullyReachableTargets}/${targets.length} fully reachable`}
+                tone={fullyReachableTargets === targets.length && targets.length > 0 ? 'success' : 'warning'}
               />
               <MetricCard
                 icon={Signal}


### PR DESCRIPTION
## 目的
跟进 #311 code review 的非阻塞建议：`reachableTargets` 实际要求 `/healthz` 和 `/api/v1/runtime/status` 两个 probe 都 OK，因此把变量和 UI 文案改成 `fullyReachableTargets` / `fully reachable`，避免和单纯网络可达混淆。

本 PR 只改前端展示文案和局部变量名，不新增控制请求，不改 backend、deployments、Docker socket、dispatch/live 执行路径或默认安全参数。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [x] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) - 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？- 无
- [x] DB migration 是否具备向下兼容幂等性？- 未涉及
- [x] 配置字段有没有无意被混改？- 未涉及

## 验证方式与测试证据
- [ ] 无需跑后端或无需编译的文档性修改
- [x] `./node_modules/.bin/tsc --noEmit src/pages/SupervisorStage.tsx --jsx react-jsx --esModuleInterop --target esnext --module esnext --moduleResolution Bundler --allowSyntheticDefaultImports --strict`
- [x] `npm run build`
- [x] `git diff --check`
