### PR TITLE
[codex] Add live control scanner observability

### DIFF
--- a/cmd/bktrader-ctl/logs.go
+++ b/cmd/bktrader-ctl/logs.go
@@ -206,17 +206,37 @@ func init() {
 }
 
 type liveControlSummaryResponse struct {
-	GeneratedAt    time.Time                         `json:"generatedAt"`
-	TotalEvents    int                               `json:"totalEvents"`
-	Requests       int                               `json:"requests"`
-	RunnerPickups  int                               `json:"runnerPickups"`
-	Succeeded      int                               `json:"succeeded"`
-	Failed         int                               `json:"failed"`
-	StaleDiscarded int                               `json:"staleDiscarded"`
-	CurrentPending int                               `json:"currentPending"`
-	CurrentErrors  int                               `json:"currentErrors"`
-	Latency        liveControlLatencyMetricsResponse `json:"latency"`
-	ByErrorCode    map[string]int                    `json:"byErrorCode,omitempty"`
+	GeneratedAt                 time.Time                         `json:"generatedAt"`
+	TotalEvents                 int                               `json:"totalEvents"`
+	Requests                    int                               `json:"requests"`
+	RunnerPickups               int                               `json:"runnerPickups"`
+	Succeeded                   int                               `json:"succeeded"`
+	Failed                      int                               `json:"failed"`
+	StaleDiscarded              int                               `json:"staleDiscarded"`
+	CurrentPending              int                               `json:"currentPending"`
+	CurrentErrors               int                               `json:"currentErrors"`
+	CurrentMaxPendingPickupMs   int64                             `json:"currentMaxPendingPickupMs,omitempty"`
+	StaleActiveControlRequests  int                               `json:"staleActiveControlRequests,omitempty"`
+	OrphanActiveControlRequests int                               `json:"orphanActiveControlRequests,omitempty"`
+	Scanner                     liveControlScannerResponse        `json:"scanner"`
+	Latency                     liveControlLatencyMetricsResponse `json:"latency"`
+	ByErrorCode                 map[string]int                    `json:"byErrorCode,omitempty"`
+}
+
+type liveControlScannerResponse struct {
+	ProcessRole      string `json:"processRole,omitempty"`
+	Enabled          bool   `json:"enabled"`
+	LastCancelAt     string `json:"lastCancelAt,omitempty"`
+	LastTickAt       string `json:"lastTickAt,omitempty"`
+	LastSuccessAt    string `json:"lastSuccessAt,omitempty"`
+	LastErrorAt      string `json:"lastErrorAt,omitempty"`
+	LastError        string `json:"lastError,omitempty"`
+	LastDurationMs   int64  `json:"lastDurationMs,omitempty"`
+	LastSessionCount int    `json:"lastSessionCount,omitempty"`
+	TickCount        int64  `json:"tickCount"`
+	SuccessCount     int64  `json:"successCount"`
+	CancelCount      int64  `json:"cancelCount"`
+	ErrorCount       int64  `json:"errorCount"`
 }
 
 type liveControlLatencyMetricsResponse struct {
@@ -256,7 +276,20 @@ func handleLiveControlSummaryResponse(data []byte, err error) {
 	printLiveControlLatencyStats(&out, "failure", summary.Latency.FailureMs)
 	printLiveControlLatencyStats(&out, "terminal", summary.Latency.TerminalMs)
 	fmt.Fprintf(&out, "\nCurrent snapshot:\n")
-	fmt.Fprintf(&out, "  pending=%d errors=%d\n", summary.CurrentPending, summary.CurrentErrors)
+	fmt.Fprintf(&out, "  pending=%d errors=%d maxPendingPickupMs=%d staleActive=%d orphanActive=%d\n",
+		summary.CurrentPending, summary.CurrentErrors, summary.CurrentMaxPendingPickupMs, summary.StaleActiveControlRequests, summary.OrphanActiveControlRequests)
+	fmt.Fprintf(&out, "\nScanner:\n")
+	fmt.Fprintf(&out, "  enabled=%t processRole=%s\n", summary.Scanner.Enabled, firstNonEmpty(summary.Scanner.ProcessRole, "--"))
+	if !summary.Scanner.Enabled {
+		fmt.Fprintf(&out, "  note=scanner is not started in this process; this is expected for api-only roles.\n")
+	}
+	fmt.Fprintf(&out, "  ticks=%d successes=%d cancels=%d errors=%d lastSessions=%d lastDurationMs=%d\n",
+		summary.Scanner.TickCount, summary.Scanner.SuccessCount, summary.Scanner.CancelCount, summary.Scanner.ErrorCount, summary.Scanner.LastSessionCount, summary.Scanner.LastDurationMs)
+	fmt.Fprintf(&out, "  lastTickAt=%s lastSuccessAt=%s lastCancelAt=%s lastErrorAt=%s\n",
+		firstNonEmpty(summary.Scanner.LastTickAt, "--"), firstNonEmpty(summary.Scanner.LastSuccessAt, "--"), firstNonEmpty(summary.Scanner.LastCancelAt, "--"), firstNonEmpty(summary.Scanner.LastErrorAt, "--"))
+	if strings.TrimSpace(summary.Scanner.LastError) != "" {
+		fmt.Fprintf(&out, "  lastError=%s\n", summary.Scanner.LastError)
+	}
 	if len(summary.ByErrorCode) > 0 {
 		fmt.Fprintf(&out, "\nError codes:\n")
 		for _, code := range sortedLiveControlSummaryKeys(summary.ByErrorCode) {

--- a/internal/domain/models.go
+++ b/internal/domain/models.go
@@ -530,6 +530,7 @@ type PlatformHealthSnapshot struct {
 	Status          string                                  `json:"status"`
 	AlertCounts     PlatformHealthAlertCounts               `json:"alertCounts"`
 	RuntimePolicy   RuntimePolicy                           `json:"runtimePolicy"`
+	LiveControl     map[string]any                          `json:"liveControl,omitempty"`
 	LiveAccounts    []PlatformHealthAccountSnapshot         `json:"liveAccounts"`
 	RuntimeSessions []PlatformHealthRuntimeSessionSnapshot  `json:"runtimeSessions"`
 	LiveSessions    []PlatformHealthStrategySessionSnapshot `json:"liveSessions"`

--- a/internal/service/alerts.go
+++ b/internal/service/alerts.go
@@ -341,6 +341,9 @@ func (p *Platform) ListAlerts() ([]domain.PlatformAlert, error) {
 		if alert, ok := buildLiveSessionControlPendingAlert(session, state, accountByID[session.AccountID].Name, strategyNameByID[session.StrategyID], time.Now().UTC()); ok {
 			appendAlert(alert)
 		}
+		if alert, ok := buildLiveSessionControlActiveRequestAlert(session, state, accountByID[session.AccountID].Name, strategyNameByID[session.StrategyID]); ok {
+			appendAlert(alert)
+		}
 		if p.liveSessionEvaluationQuiet("LIVE", session.Status, state) {
 			appendAlert(domain.PlatformAlert{
 				ID:           fmt.Sprintf("live-strategy-eval-quiet-%s", session.ID),
@@ -521,6 +524,45 @@ func liveSessionControlPendingSince(state map[string]any, inProgress bool) (time
 		return updatedAt.UTC(), true
 	}
 	return time.Time{}, false
+}
+
+func buildLiveSessionControlActiveRequestAlert(session domain.LiveSession, state map[string]any, accountName, strategyName string) (domain.PlatformAlert, bool) {
+	stale, orphan := liveSessionControlActiveRequestAnomalies(state)
+	if !stale && !orphan {
+		return domain.PlatformAlert{}, false
+	}
+	reason := "stale"
+	title := "实盘控制 active request 已过期"
+	detail := "activeControlRequest 与当前 controlRequest 不一致，请检查 live-runner 收敛日志"
+	if orphan {
+		reason = "orphan"
+		title = "实盘控制 active request 未清理"
+		detail = "activeControlRequest 仍存在但 actualStatus 已不在 STARTING/STOPPING"
+	}
+	eventTime := parseOptionalRFC3339(firstNonEmpty(stringValue(state["lastControlUpdateAt"]), stringValue(state["controlRequestedAt"])))
+	return domain.PlatformAlert{
+		ID:           fmt.Sprintf("live-control-active-request-%s", session.ID),
+		Scope:        "live",
+		Level:        "warning",
+		Title:        title,
+		Detail:       detail,
+		AccountID:    session.AccountID,
+		AccountName:  accountName,
+		StrategyID:   session.StrategyID,
+		StrategyName: strategyName,
+		Anchor:       "live",
+		EventTime:    eventTime,
+		Metadata: map[string]any{
+			"liveSessionId":          session.ID,
+			"reason":                 reason,
+			"controlRequestId":       stringValue(state["controlRequestId"]),
+			"controlVersion":         liveSessionControlVersion(state),
+			"activeControlRequestId": stringValue(state["activeControlRequestId"]),
+			"activeControlVersion":   liveSessionControlVersionKey(state, "activeControlVersion"),
+			"desiredStatus":          strings.ToUpper(strings.TrimSpace(stringValue(state["desiredStatus"]))),
+			"actualStatus":           strings.ToUpper(strings.TrimSpace(stringValue(state["actualStatus"]))),
+		},
+	}, true
 }
 
 func (p *Platform) buildLiveExitDispatchFailureAlert(session domain.LiveSession, state map[string]any, accountName, strategyName string) (domain.PlatformAlert, bool) {

--- a/internal/service/health_snapshot.go
+++ b/internal/service/health_snapshot.go
@@ -42,6 +42,7 @@ func (p *Platform) HealthSnapshot() (domain.PlatformHealthSnapshot, error) {
 		GeneratedAt:     generatedAt,
 		AlertCounts:     summarizePlatformHealthAlertCounts(alerts),
 		RuntimePolicy:   currentRuntimePolicyDomain(p.runtimePolicy),
+		LiveControl:     p.platformHealthLiveControlSnapshot(generatedAt, liveSessions),
 		LiveAccounts:    make([]domain.PlatformHealthAccountSnapshot, 0),
 		RuntimeSessions: make([]domain.PlatformHealthRuntimeSessionSnapshot, 0, len(runtimeSessions)),
 		LiveSessions:    make([]domain.PlatformHealthStrategySessionSnapshot, 0, len(liveSessions)),
@@ -148,6 +149,44 @@ func (p *Platform) HealthSnapshot() (domain.PlatformHealthSnapshot, error) {
 	})
 
 	return snapshot, nil
+}
+
+func (p *Platform) platformHealthLiveControlSnapshot(now time.Time, liveSessions []domain.LiveSession) map[string]any {
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	snapshot := map[string]any{
+		"scanner": p.LiveSessionControlScannerStatus(),
+	}
+	var currentPending int
+	var currentErrors int
+	var maxPendingPickupMs int64
+	var staleActive int
+	var orphanActive int
+	for _, session := range liveSessions {
+		if liveSessionControlPending(session.State) {
+			currentPending++
+		}
+		if strings.EqualFold(stringValue(session.State["actualStatus"]), "ERROR") {
+			currentErrors++
+		}
+		if pendingMs, ok := liveSessionControlPendingPickupMs(session.State, now); ok && pendingMs > maxPendingPickupMs {
+			maxPendingPickupMs = pendingMs
+		}
+		stale, orphan := liveSessionControlActiveRequestAnomalies(session.State)
+		if stale {
+			staleActive++
+		}
+		if orphan {
+			orphanActive++
+		}
+	}
+	snapshot["currentPending"] = currentPending
+	snapshot["currentErrors"] = currentErrors
+	snapshot["currentMaxPendingPickupMs"] = maxPendingPickupMs
+	snapshot["staleActiveControlRequests"] = staleActive
+	snapshot["orphanActiveControlRequests"] = orphanActive
+	return snapshot
 }
 
 func currentRuntimePolicyDomain(policy RuntimePolicy) domain.RuntimePolicy {

--- a/internal/service/health_state_test.go
+++ b/internal/service/health_state_test.go
@@ -995,3 +995,44 @@ func TestListAlertsSuppressesFreshOrErrorLiveControlPending(t *testing.T) {
 		}
 	}
 }
+
+func TestListAlertsShowsOrphanLiveControlActiveRequest(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	session, err := platform.store.GetLiveSession("live-session-main")
+	if err != nil {
+		t.Fatalf("get live session failed: %v", err)
+	}
+	now := time.Now().UTC()
+	state := cloneMetadata(session.State)
+	state["desiredStatus"] = "RUNNING"
+	state["actualStatus"] = "RUNNING"
+	state["controlRequestId"] = "control-request-orphan"
+	state["controlVersion"] = 13
+	state["activeControlRequestId"] = "control-request-orphan"
+	state["activeControlVersion"] = 13
+	state["controlRequestedAt"] = now.Add(-5 * time.Minute).Format(time.RFC3339)
+	state["lastControlUpdateAt"] = now.Add(-4 * time.Minute).Format(time.RFC3339)
+	session.State = state
+	session.Status = "RUNNING"
+	if _, err := platform.store.UpdateLiveSession(session); err != nil {
+		t.Fatalf("update live session failed: %v", err)
+	}
+
+	alerts, err := platform.ListAlerts()
+	if err != nil {
+		t.Fatalf("list alerts failed: %v", err)
+	}
+	for _, alert := range alerts {
+		if alert.ID != "live-control-active-request-"+session.ID {
+			continue
+		}
+		if got := stringValue(alert.Metadata["reason"]); got != "orphan" {
+			t.Fatalf("expected orphan metadata, got %s", got)
+		}
+		if got := stringValue(alert.Metadata["activeControlRequestId"]); got != "control-request-orphan" {
+			t.Fatalf("expected active request metadata, got %s", got)
+		}
+		return
+	}
+	t.Fatal("expected orphan live control active request alert")
+}

--- a/internal/service/live_session_control.go
+++ b/internal/service/live_session_control.go
@@ -87,6 +87,22 @@ type liveSessionControlStateCompareAndSwapStore interface {
 	UpdateLiveSessionStateIfControlRequest(sessionID, requestID string, version int64, state map[string]any) (domain.LiveSession, bool, error)
 }
 
+type LiveControlScannerStatus struct {
+	ProcessRole      string `json:"processRole,omitempty"`
+	Enabled          bool   `json:"enabled"`
+	LastCancelAt     string `json:"lastCancelAt,omitempty"`
+	LastTickAt       string `json:"lastTickAt,omitempty"`
+	LastSuccessAt    string `json:"lastSuccessAt,omitempty"`
+	LastErrorAt      string `json:"lastErrorAt,omitempty"`
+	LastError        string `json:"lastError,omitempty"`
+	LastDurationMs   int64  `json:"lastDurationMs,omitempty"`
+	LastSessionCount int    `json:"lastSessionCount,omitempty"`
+	TickCount        int64  `json:"tickCount"`
+	SuccessCount     int64  `json:"successCount"`
+	CancelCount      int64  `json:"cancelCount"`
+	ErrorCount       int64  `json:"errorCount"`
+}
+
 func (p *Platform) RequestLiveSessionStart(sessionID string) (domain.LiveSession, error) {
 	return p.requestLiveSessionDesiredStatus(sessionID, "RUNNING", false)
 }
@@ -150,6 +166,7 @@ func (p *Platform) requestLiveSessionDesiredStatus(sessionID, desired string, fo
 func (p *Platform) StartLiveSessionControlScanner(ctx context.Context) {
 	logger := p.logger("service.live_session_control_scanner")
 	logger.Info("live session control scanner started")
+	p.markLiveSessionControlScannerEnabled()
 	go func() {
 		defer logger.Info("live session control scanner stopped")
 		p.scanLiveSessionControlRequests(ctx)
@@ -167,17 +184,24 @@ func (p *Platform) StartLiveSessionControlScanner(ctx context.Context) {
 }
 
 func (p *Platform) scanLiveSessionControlRequests(ctx context.Context) {
+	startedAt := time.Now().UTC()
+	p.recordLiveSessionControlScannerTick(startedAt)
+	sessionCount, err := p.scanLiveSessionControlRequestsOnce(ctx)
+	p.recordLiveSessionControlScannerResult(startedAt, sessionCount, err)
+}
+
+func (p *Platform) scanLiveSessionControlRequestsOnce(ctx context.Context) (int, error) {
 	if err := ctx.Err(); err != nil {
-		return
+		return 0, err
 	}
 	sessions, err := p.ListLiveSessions()
 	if err != nil {
 		p.logger("service.live_session_control_scanner").Warn("list live sessions failed", "error", err)
-		return
+		return 0, err
 	}
 	for _, session := range sessions {
 		if err := ctx.Err(); err != nil {
-			return
+			return len(sessions), err
 		}
 		desired := strings.ToUpper(strings.TrimSpace(stringValue(session.State["desiredStatus"])))
 		if desired == "" {
@@ -211,6 +235,59 @@ func (p *Platform) scanLiveSessionControlRequests(ctx context.Context) {
 			p.executeLiveSessionControlStop(session, request)
 		}
 	}
+	return len(sessions), nil
+}
+
+func (p *Platform) recordLiveSessionControlScannerTick(t time.Time) {
+	if t.IsZero() {
+		t = time.Now().UTC()
+	}
+	p.liveControlScannerMu.Lock()
+	defer p.liveControlScannerMu.Unlock()
+	p.liveControlScanner.ProcessRole = p.processRole
+	p.liveControlScanner.Enabled = true
+	p.liveControlScanner.LastTickAt = t.UTC().Format(time.RFC3339Nano)
+	p.liveControlScanner.TickCount++
+}
+
+func (p *Platform) markLiveSessionControlScannerEnabled() {
+	p.liveControlScannerMu.Lock()
+	defer p.liveControlScannerMu.Unlock()
+	p.liveControlScanner.ProcessRole = p.processRole
+	p.liveControlScanner.Enabled = true
+}
+
+func (p *Platform) recordLiveSessionControlScannerResult(startedAt time.Time, sessionCount int, err error) {
+	now := time.Now().UTC()
+	p.liveControlScannerMu.Lock()
+	defer p.liveControlScannerMu.Unlock()
+	if !startedAt.IsZero() {
+		p.liveControlScanner.LastDurationMs = now.Sub(startedAt.UTC()).Milliseconds()
+	}
+	p.liveControlScanner.LastSessionCount = sessionCount
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		p.liveControlScanner.LastCancelAt = now.Format(time.RFC3339Nano)
+		p.liveControlScanner.SuccessCount++
+		p.liveControlScanner.CancelCount++
+		return
+	}
+	if err != nil {
+		p.liveControlScanner.LastErrorAt = now.Format(time.RFC3339Nano)
+		p.liveControlScanner.LastError = err.Error()
+		p.liveControlScanner.ErrorCount++
+		return
+	}
+	p.liveControlScanner.LastSuccessAt = now.Format(time.RFC3339Nano)
+	p.liveControlScanner.LastError = ""
+	p.liveControlScanner.SuccessCount++
+}
+
+func (p *Platform) LiveSessionControlScannerStatus() LiveControlScannerStatus {
+	p.liveControlScannerMu.RLock()
+	defer p.liveControlScannerMu.RUnlock()
+	status := p.liveControlScanner
+	status.ProcessRole = p.processRole
+	return status
 }
 
 func (p *Platform) initializeLegacyLiveSessionControlRequest(session domain.LiveSession, desired string) (domain.LiveSession, liveSessionControlRequest, error) {

--- a/internal/service/logs.go
+++ b/internal/service/logs.go
@@ -66,20 +66,24 @@ type UnifiedLogEventQuery struct {
 // operator-facing summary. It is intentionally derived from state.controlEvents
 // so Phase 4 observability does not introduce a new persistence surface.
 type LiveControlMetrics struct {
-	GeneratedAt    time.Time                         `json:"generatedAt"`
-	TotalEvents    int                               `json:"totalEvents"`
-	Requests       int                               `json:"requests"`
-	RunnerPickups  int                               `json:"runnerPickups"`
-	Succeeded      int                               `json:"succeeded"`
-	Failed         int                               `json:"failed"`
-	StaleDiscarded int                               `json:"staleDiscarded"`
-	CurrentPending int                               `json:"currentPending"`
-	CurrentErrors  int                               `json:"currentErrors"`
-	Latency        LiveControlLatencyMetrics         `json:"latency"`
-	ByErrorCode    map[string]int                    `json:"byErrorCode,omitempty"`
-	ByAccount      map[string]LiveControlMetricGroup `json:"byAccount,omitempty"`
-	ByStrategy     map[string]LiveControlMetricGroup `json:"byStrategy,omitempty"`
-	ByLiveSession  map[string]LiveControlMetricGroup `json:"byLiveSession,omitempty"`
+	GeneratedAt                 time.Time                         `json:"generatedAt"`
+	TotalEvents                 int                               `json:"totalEvents"`
+	Requests                    int                               `json:"requests"`
+	RunnerPickups               int                               `json:"runnerPickups"`
+	Succeeded                   int                               `json:"succeeded"`
+	Failed                      int                               `json:"failed"`
+	StaleDiscarded              int                               `json:"staleDiscarded"`
+	CurrentPending              int                               `json:"currentPending"`
+	CurrentErrors               int                               `json:"currentErrors"`
+	CurrentMaxPendingPickupMs   int64                             `json:"currentMaxPendingPickupMs,omitempty"`
+	StaleActiveControlRequests  int                               `json:"staleActiveControlRequests,omitempty"`
+	OrphanActiveControlRequests int                               `json:"orphanActiveControlRequests,omitempty"`
+	Scanner                     LiveControlScannerStatus          `json:"scanner"`
+	Latency                     LiveControlLatencyMetrics         `json:"latency"`
+	ByErrorCode                 map[string]int                    `json:"byErrorCode,omitempty"`
+	ByAccount                   map[string]LiveControlMetricGroup `json:"byAccount,omitempty"`
+	ByStrategy                  map[string]LiveControlMetricGroup `json:"byStrategy,omitempty"`
+	ByLiveSession               map[string]LiveControlMetricGroup `json:"byLiveSession,omitempty"`
 }
 
 type LiveControlLatencyMetrics struct {
@@ -446,6 +450,7 @@ func (p *Platform) LiveControlMetrics(query UnifiedLogEventQuery) (LiveControlMe
 	}
 	metrics := LiveControlMetrics{
 		GeneratedAt:   time.Now().UTC(),
+		Scanner:       p.LiveSessionControlScannerStatus(),
 		ByErrorCode:   make(map[string]int),
 		ByAccount:     make(map[string]LiveControlMetricGroup),
 		ByStrategy:    make(map[string]LiveControlMetricGroup),
@@ -457,6 +462,16 @@ func (p *Platform) LiveControlMetrics(query UnifiedLogEventQuery) (LiveControlMe
 		}
 		if liveSessionControlPending(session.State) {
 			metrics.CurrentPending++
+		}
+		if pendingMs, ok := liveSessionControlPendingPickupMs(session.State, metrics.GeneratedAt); ok && pendingMs > metrics.CurrentMaxPendingPickupMs {
+			metrics.CurrentMaxPendingPickupMs = pendingMs
+		}
+		staleActive, orphanActive := liveSessionControlActiveRequestAnomalies(session.State)
+		if staleActive {
+			metrics.StaleActiveControlRequests++
+		}
+		if orphanActive {
+			metrics.OrphanActiveControlRequests++
 		}
 		if strings.EqualFold(stringValue(session.State["actualStatus"]), "ERROR") {
 			metrics.CurrentErrors++
@@ -501,6 +516,43 @@ func liveSessionControlPending(state map[string]any) bool {
 	}
 	desired := strings.ToUpper(strings.TrimSpace(stringValue(state["desiredStatus"])))
 	return desired != "" && actual != "" && desired != actual
+}
+
+func liveSessionControlPendingPickupMs(state map[string]any, now time.Time) (int64, bool) {
+	desired := strings.ToUpper(strings.TrimSpace(stringValue(state["desiredStatus"])))
+	actual := strings.ToUpper(strings.TrimSpace(stringValue(state["actualStatus"])))
+	if desired == "" || actual == "" || desired == actual || actual == "ERROR" || actual == "STARTING" || actual == "STOPPING" {
+		return 0, false
+	}
+	requestedAt, ok := parseLiveSessionControlTime(state["controlRequestedAt"])
+	if !ok {
+		return 0, false
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	if now.Before(requestedAt) {
+		return 0, true
+	}
+	return now.UTC().Sub(requestedAt.UTC()).Milliseconds(), true
+}
+
+func liveSessionControlActiveRequestAnomalies(state map[string]any) (stale bool, orphan bool) {
+	activeID := strings.TrimSpace(stringValue(state["activeControlRequestId"]))
+	activeVersion := liveSessionControlVersionKey(state, "activeControlVersion")
+	if activeID == "" && activeVersion == 0 {
+		return false, false
+	}
+	currentID := strings.TrimSpace(stringValue(state["controlRequestId"]))
+	currentVersion := liveSessionControlVersion(state)
+	if activeID == "" || activeVersion == 0 || activeID != currentID || activeVersion != currentVersion {
+		return true, false
+	}
+	actual := strings.ToUpper(strings.TrimSpace(stringValue(state["actualStatus"])))
+	if actual != "STARTING" && actual != "STOPPING" {
+		return false, true
+	}
+	return false, false
 }
 
 func (m *LiveControlMetrics) recordLiveControlEvent(event UnifiedLogEvent) {

--- a/internal/service/logs_test.go
+++ b/internal/service/logs_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -224,5 +225,58 @@ func TestLiveControlMetricsAggregatesLatencyAndErrorCodes(t *testing.T) {
 	accountGroup := metrics.ByAccount[session.AccountID]
 	if accountGroup.Total != 5 || accountGroup.ErrorCodes[LiveSessionControlErrorCodeConfigError] != 1 {
 		t.Fatalf("unexpected account group: %#v", accountGroup)
+	}
+}
+
+func TestLiveControlMetricsReportsScannerAndCurrentAnomalies(t *testing.T) {
+	store := memory.NewStore()
+	platform := NewPlatform(store)
+	base := time.Now().UTC().Add(-5 * time.Minute)
+	platform.recordLiveSessionControlScannerTick(base)
+	platform.recordLiveSessionControlScannerResult(base, 3, nil)
+
+	session, err := store.GetLiveSession("live-session-main")
+	if err != nil {
+		t.Fatalf("get live session: %v", err)
+	}
+	state := cloneMetadata(session.State)
+	state["desiredStatus"] = "STOPPED"
+	state["actualStatus"] = "RUNNING"
+	state["controlRequestId"] = "request-current"
+	state["controlVersion"] = 12
+	state["controlRequestedAt"] = base.Format(time.RFC3339)
+	state["activeControlRequestId"] = "request-current"
+	state["activeControlVersion"] = 12
+	if _, err := store.UpdateLiveSessionState(session.ID, state); err != nil {
+		t.Fatalf("update live session state: %v", err)
+	}
+
+	metrics, err := platform.LiveControlMetrics(UnifiedLogEventQuery{LiveSessionID: session.ID})
+	if err != nil {
+		t.Fatalf("live control metrics: %v", err)
+	}
+	if metrics.Scanner.TickCount != 1 || metrics.Scanner.SuccessCount != 1 || metrics.Scanner.LastSessionCount != 3 || metrics.Scanner.LastSuccessAt == "" {
+		t.Fatalf("unexpected scanner metrics: %#v", metrics.Scanner)
+	}
+	if metrics.CurrentPending != 1 || metrics.CurrentMaxPendingPickupMs <= 0 {
+		t.Fatalf("expected current pending pickup age, got pending=%d max=%d", metrics.CurrentPending, metrics.CurrentMaxPendingPickupMs)
+	}
+	if metrics.OrphanActiveControlRequests != 1 || metrics.StaleActiveControlRequests != 0 {
+		t.Fatalf("expected orphan active request only, got stale=%d orphan=%d", metrics.StaleActiveControlRequests, metrics.OrphanActiveControlRequests)
+	}
+}
+
+func TestLiveControlScannerCancelDoesNotCountAsError(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	platform.scanLiveSessionControlRequests(ctx)
+	status := platform.LiveSessionControlScannerStatus()
+	if status.ErrorCount != 0 || status.LastError != "" || status.LastErrorAt != "" {
+		t.Fatalf("expected canceled scan not to count as error, got %#v", status)
+	}
+	if status.CancelCount != 1 || status.LastCancelAt == "" {
+		t.Fatalf("expected canceled scan accounting, got %#v", status)
 	}
 }

--- a/internal/service/platform.go
+++ b/internal/service/platform.go
@@ -49,6 +49,8 @@ type Platform struct {
 	liveAccountSyncRunning atomic.Int64
 	liveControlOpState     sync.Map // accountID|strategyID -> *liveControlOperationState
 	liveDispatchMu         sync.Map // liveSessionID -> *sync.Mutex; process-local guard, not distributed idempotency.
+	liveControlScannerMu   sync.RWMutex
+	liveControlScanner     LiveControlScannerStatus
 	runtimeSourceGateState sync.Map // runtimeSessionID -> last blocked source gate signature
 	runtimeEventPublisher  RuntimeEventPublisher
 	runtimeEventConsumerOn bool

--- a/web/console/src/types/domain.ts
+++ b/web/console/src/types/domain.ts
@@ -303,6 +303,7 @@ export type PlatformHealthSnapshot = {
   status: string;
   alertCounts: PlatformHealthAlertCounts;
   runtimePolicy: RuntimePolicy;
+  liveControl?: Record<string, unknown>;
   liveAccounts: PlatformHealthAccountSnapshot[];
   runtimeSessions: PlatformHealthRuntimeSessionSnapshot[];
   liveSessions: PlatformHealthStrategySessionSnapshot[];


### PR DESCRIPTION
## 目的
补齐 #282 Phase 4.x 最后一刀的 LiveSession control scanner 观测：

- runner scanner 最近 tick / 最近成功扫描 / 最近错误 / 扫描耗时 / 扫描 session 数
- pending request 等待 runner pickup 的最大时长
- stale / orphan `activeControlRequest` 检测
- 接入 `logs live-control-summary`、`/api/v1/logs/live-control/summary`、`/api/v1/monitor/health` 与 alerts

实现保持观测语义，不改变 start/stop/reconcile/runner 执行路径。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [x] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

说明：触及 `internal/service/live_session_control.go`，但只增加 scanner 观测状态与 summary/alert 派生，不改变控制流、锁、adapter 调用或 runtime action 权限。

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) - 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？- 无
- [x] DB migration 是否具备向下兼容幂等性？- 无 DB migration
- [x] 配置字段有没有无意被混改？- 无配置字段变更

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

本地验证：

- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
- `go build ./cmd/bktrader-ctl`
- `cd web/console && ./node_modules/.bin/tsc --noEmit src/pages/AccountStage.tsx --jsx react-jsx --esModuleInterop --target esnext --module esnext --moduleResolution Bundler --allowSyntheticDefaultImports`
- `cd web/console && npm run build`

新增/覆盖测试：

- `TestLiveControlMetricsReportsScannerAndCurrentAnomalies`
- `TestListAlertsShowsOrphanLiveControlActiveRequest`

Notes:

- scanner tick/success/error 是当前进程内观测，response 带 `scanner.enabled` 和 `scanner.processRole`，避免在 api-only 进程上误读。
- pending pickup 最大等待与 stale/orphan active request 是从 LiveSession state 派生，适合 platform-api 汇总展示。
