### PR TITLE
[codex] Document live control reset ops rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,16 @@ npm run build
 10. 自动 resume / dispatch 必须有显式前置条件
 11. 精度和容差只能有一个入口 — 必须使用 `internal/service/precision_tolerance.go`
 
+### Live 控制面 reset 运维规则
+
+`bktrader-ctl live control-reset` / `/api/v1/live/sessions/:id/control-reset` 是异常修复工具，不是常规启停流程。任何 Agent 或人工在建议、执行、排查该操作时必须遵守：
+
+1. **只用于异常**：仅当 LiveSession 控制面 stuck / ERROR / orphan active request 且已确认普通 start/stop/retry 不适用时使用。
+2. **必须先 dry-run**：先执行 `bktrader-ctl live control-reset <session-id> --dry-run --reason "<真实原因>" --json`，再人工核对 runner 日志、控制意图和真实会话状态。
+3. **reason 必须真实可追溯**：`--reason` / `reason` 不得填写空泛文本，必须说明可审计的事实依据，例如 runner 重启、已核对 exchange flat、已确认 active request orphan。
+
+reset 只清理控制面状态并写 `manual_reset` 审计事件；它不启动/停止 runner、不 dispatch、不 reconcile、不调用交易所 adapter。
+
 ## 8. 高频踩坑模式速查
 
 **改 `internal/` 代码前先自查**，详细案例见 [docs/pr-lessons-learned.md](docs/pr-lessons-learned.md)：

--- a/docs/bktrader-ctl-install-deploy.md
+++ b/docs/bktrader-ctl-install-deploy.md
@@ -103,18 +103,18 @@ bktrader-ctl order cancel <order-id> --confirm --json
 - `notify test`
 - `update`
 
-卡住的 LiveSession 控制状态只允许人工显式重置，固定流程如下：
+卡住的 LiveSession 控制状态只允许人工显式重置；它不是常规启停手段，固定流程如下：
 
 1. `--dry-run` 预览当前 stuck/error/active request 状态。
 2. 人工确认 runner 日志、控制意图与真实会话状态。
-3. 带 `--confirm` 和非空 `--reason` 执行 reset。
+3. 带 `--confirm` 和非空 `--reason` 执行 reset；`reason` 必须写真实、可追溯的依据。
 
 ```bash
 bktrader-ctl live control-reset <session-id> --dry-run --reason "operator verified runner state" --json
 bktrader-ctl live control-reset <session-id> --confirm --reason "operator verified runner state" --json
 ```
 
-reset 只清理控制面 stuck/error/active request 状态并写入 `controlEvents` 审计，不会启动或停止 runner。`--reason` 必须填写，用于后续审计。
+reset 只清理控制面 stuck/error/orphan active request 状态并写入 `controlEvents` 审计，不会启动或停止 runner。`--reason` 必须填写，用于后续审计；不要使用 “fix issue” / “manual reset” 这类不可追溯描述。
 
 ## 5. 手动更新 CLI
 


### PR DESCRIPTION
## 目的
把 Live 控制面 reset 的运维规范写进长期入口，避免后续 Agent 或人工把 reset 当成常规启停手段。

本次明确三条规则：

- reset 只用于 stuck / ERROR / orphan active request 等异常修复，不是常规操作
- 必须先 `--dry-run`，再人工核对 runner 日志、控制意图和真实会话状态
- `--reason` / `reason` 必须真实可追溯，不能写空泛描述

落点：

- `AGENTS.md`：LLM/Agent 优先读取的硬规则入口
- `docs/bktrader-ctl-install-deploy.md`：运维/CLI 使用流程文档

## 本次改动风险定级 (参照 agent-risk-model.md)
- [x] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) - 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？- 无
- [x] DB migration 是否具备向下兼容幂等性？- 无 DB migration
- [x] 配置字段有没有无意被混改？- 无

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [x] 无需跑后端或无需编译的文档性修改
- [ ] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

Validation:

- `git diff --check`
