### PR TITLE
Require explicit live fill source

### DIFF
--- a/internal/service/live_reconcile_test.go
+++ b/internal/service/live_reconcile_test.go
@@ -53,6 +53,7 @@ func TestReconcileLiveAccountRecoversMissingFilledOrder(t *testing.T) {
 				Price:    68010,
 				Quantity: 0.2,
 				Fee:      1.2,
+				Source:   FillSourceReal,
 				Metadata: map[string]any{
 					"exchangeOrderId": "9001",
 					"tradeId":         "trade-9001",
@@ -171,6 +172,7 @@ func TestReconcileLiveAccountSkipsHistoricalTerminalOrderWithoutLocalMatchAndWit
 			Price:    68010,
 			Quantity: 0.2,
 			Fee:      1.2,
+			Source:   FillSourceReal,
 			Metadata: map[string]any{
 				"exchangeOrderId": "9002",
 				"tradeId":         "trade-9002",
@@ -321,6 +323,7 @@ func TestReconcileLiveAccountReusesExistingOrderByExchangeOrderIDInsteadOfCreati
 			Price:    68010,
 			Quantity: 0.2,
 			Fee:      1.2,
+			Source:   FillSourceReal,
 			Metadata: map[string]any{
 				"exchangeOrderId": "9003",
 				"tradeId":         "trade-9003",
@@ -590,6 +593,7 @@ func TestReconcileLiveAccountDefersPositionAdoptForPendingImmediateFilledSettlem
 			Price:    75600.0,
 			Quantity: 0.002,
 			Fee:      0.04,
+			Source:   FillSourceReal,
 			Metadata: map[string]any{
 				"exchangeOrderId": "13056935018",
 				"tradeId":         "trade-13056935018",
@@ -1239,6 +1243,7 @@ func cloneReconcileTrades(source []LiveFillReport) []LiveFillReport {
 			Quantity:   item.Quantity,
 			Fee:        item.Fee,
 			FundingPnL: item.FundingPnL,
+			Source:     item.Source,
 			Metadata:   cloneMetadata(item.Metadata),
 		})
 	}

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -4452,7 +4452,8 @@ func TestSyncLatestLiveSessionOrderSyncsAfterUnknownOrderCancelRace(t *testing.T
 				Fills: []LiveFillReport{{
 					Quantity: order.Quantity,
 					Price:    69000.0,
-					Metadata: map[string]any{"tradeTime": "2026-04-27T13:09:46Z"},
+					Source:   FillSourceReal,
+					Metadata: map[string]any{"tradeId": "trade-cancel-race-1", "tradeTime": "2026-04-27T13:09:46Z"},
 				}},
 				Metadata: map[string]any{
 					"executedQty": order.Quantity,
@@ -10815,6 +10816,8 @@ func TestRecoverRunningLiveSessionPreservesRemainingQuantityAfterPartialFillRest
 				Fills: []LiveFillReport{{
 					Quantity: 0.004,
 					Price:    68950.0,
+					Source:   FillSourceReal,
+					Metadata: map[string]any{"tradeId": "trade-partial-fill-restart-1"},
 				}},
 			}, nil
 		},
@@ -11232,6 +11235,7 @@ func TestStartLiveSessionBackfillsFilledExitBeforeReconcileGateBlock(t *testing.
 					Price:    67950.0,
 					Quantity: order.Quantity,
 					Fee:      0.01,
+					Source:   FillSourceReal,
 					Metadata: map[string]any{
 						"exchangeOrderId": stringValue(order.Metadata["exchangeOrderId"]),
 						"tradeId":         "trade-terminal-fill-1",

--- a/internal/service/order.go
+++ b/internal/service/order.go
@@ -1112,7 +1112,7 @@ func (p *Platform) finalizeExecutedOrder(account domain.Account, order domain.Or
 		if err != nil {
 			return err
 		}
-		incomingInputs, err := fillReconciliationInputsFromIncomingFills(order, newFills)
+		incomingInputs, err := fillReconciliationInputsFromIncomingFills(order, newFills, !strings.EqualFold(account.Mode, "LIVE"))
 		if err != nil {
 			return err
 		}
@@ -1237,16 +1237,21 @@ func fillReconciliationInputsFromStoredFills(fills []domain.Fill) ([]FillReconci
 	return inputs, nil
 }
 
-func fillReconciliationInputsFromIncomingFills(order domain.Order, fills []domain.Fill) ([]FillReconciliationInput, error) {
+func fillReconciliationInputsFromIncomingFills(order domain.Order, fills []domain.Fill, allowLegacySourceFallback bool) ([]FillReconciliationInput, error) {
 	inputs := make([]FillReconciliationInput, 0, len(fills))
 	for _, fill := range fills {
 		if strings.TrimSpace(fill.OrderID) == "" {
 			fill.OrderID = order.ID
 		}
-		source := FillSourceReal
+		source := FillSource(strings.TrimSpace(fill.Source))
+		if source == "" && !allowLegacySourceFallback {
+			return nil, fmt.Errorf("incoming fill source is required for order %s", order.ID)
+		}
 		if strings.TrimSpace(fill.Source) != "" {
 			source = FillSource(strings.TrimSpace(fill.Source))
-		} else if strings.TrimSpace(fill.ExchangeTradeID) == "" {
+		} else if strings.TrimSpace(fill.ExchangeTradeID) != "" {
+			source = FillSourceReal
+		} else {
 			fill.DedupFingerprint = strings.TrimSpace(fill.DedupFingerprint)
 			if fill.DedupFingerprint == "" {
 				fill.DedupFingerprint = fill.FallbackFingerprint()
@@ -1254,6 +1259,12 @@ func fillReconciliationInputsFromIncomingFills(order domain.Order, fills []domai
 			source = FillSourceSynthetic
 			if strings.HasPrefix(fill.DedupFingerprint, syntheticRemainderFingerprintPrefix) {
 				source = FillSourceRemainder
+			}
+		}
+		if source == FillSourceSynthetic || source == FillSourceRemainder {
+			fill.DedupFingerprint = strings.TrimSpace(fill.DedupFingerprint)
+			if fill.DedupFingerprint == "" {
+				fill.DedupFingerprint = fill.FallbackFingerprint()
 			}
 		}
 		inputs = append(inputs, FillReconciliationInput{Fill: fill, Source: source})
@@ -1395,16 +1406,6 @@ func resolveLiveFillTradeID(report LiveFillReport) string {
 func resolveLiveFillSource(report LiveFillReport) FillSource {
 	if report.Source != "" {
 		return report.Source
-	}
-	metadata := mapValue(report.Metadata)
-	if boolValue(metadata["syntheticFill"]) {
-		return FillSourceSynthetic
-	}
-	if strings.TrimSpace(stringValue(metadata["dedupFingerprint"])) != "" {
-		return FillSourceSynthetic
-	}
-	if resolveLiveFillTradeID(report) != "" {
-		return FillSourceReal
 	}
 	return ""
 }

--- a/internal/service/order_test.go
+++ b/internal/service/order_test.go
@@ -205,6 +205,7 @@ func TestFinalizeExecutedOrderSkipsDuplicateExchangeTradeIDFills(t *testing.T) {
 	fill := domain.Fill{
 		OrderID:         order.ID,
 		ExchangeTradeID: "trade-1",
+		Source:          string(FillSourceReal),
 		Price:           68000,
 		Quantity:        0.1,
 		Fee:             1.23,
@@ -255,6 +256,39 @@ func TestFinalizeExecutedOrderSkipsDuplicateExchangeTradeIDFills(t *testing.T) {
 	}
 	if filledEventCount != 1 {
 		t.Fatalf("expected duplicate sync to keep one filled execution event, got %d", filledEventCount)
+	}
+}
+
+func TestFinalizeExecutedOrderRejectsLiveFillWithoutExplicitSource(t *testing.T) {
+	store := memory.NewStore()
+	platform := NewPlatform(store)
+
+	account, err := store.GetAccount("live-main")
+	if err != nil {
+		t.Fatalf("get account failed: %v", err)
+	}
+
+	order, err := store.CreateOrder(domain.Order{
+		AccountID: account.ID,
+		Symbol:    "BTCUSDT",
+		Side:      "BUY",
+		Type:      "MARKET",
+		Quantity:  0.1,
+		Price:     68000,
+		Metadata:  map[string]any{"executionMode": "live"},
+	})
+	if err != nil {
+		t.Fatalf("create order failed: %v", err)
+	}
+
+	_, err = platform.finalizeExecutedOrder(account, order, []domain.Fill{{
+		OrderID:         order.ID,
+		ExchangeTradeID: "trade-without-source",
+		Price:           68000,
+		Quantity:        0.1,
+	}})
+	if err == nil || !strings.Contains(err.Error(), "incoming fill source is required") {
+		t.Fatalf("expected missing live fill source error, got %v", err)
 	}
 }
 
@@ -351,6 +385,7 @@ func TestFinalizeExecutedOrderSkipsDuplicateFallbackFillsWithoutExchangeTradeID(
 	tradeTime := time.Date(2026, 4, 17, 12, 36, 0, 0, time.UTC)
 	fill := domain.Fill{
 		OrderID:           order.ID,
+		Source:            string(FillSourceSynthetic),
 		Price:             68000,
 		Quantity:          0.1,
 		Fee:               1.23,
@@ -400,6 +435,7 @@ func TestSyntheticUpgrade_PartialRealFills(t *testing.T) {
 
 	syntheticFill := domain.Fill{
 		OrderID:           order.ID,
+		Source:            string(FillSourceSynthetic),
 		Price:             68000,
 		Quantity:          1.0,
 		DedupFingerprint:  "synthetic-1.0",
@@ -413,6 +449,7 @@ func TestSyntheticUpgrade_PartialRealFills(t *testing.T) {
 	realFill := domain.Fill{
 		OrderID:           order.ID,
 		ExchangeTradeID:   "real-trade-1",
+		Source:            string(FillSourceReal),
 		Price:             68000,
 		Quantity:          0.4,
 		ExchangeTradeTime: &tradeTime,
@@ -535,6 +572,7 @@ func TestSyntheticUpgrade_RetryCleanup(t *testing.T) {
 		Fills: []LiveFillReport{{
 			Price:    68000,
 			Quantity: 1.0,
+			Source:   FillSourceReal,
 			Metadata: map[string]any{"tradeId": "real-trade-1"},
 		}},
 		Metadata: map[string]any{
@@ -576,6 +614,7 @@ func TestSyntheticUpgrade_BatchedRealFills(t *testing.T) {
 		Fills: []LiveFillReport{{
 			Price:    68000,
 			Quantity: 1.0,
+			Source:   FillSourceSynthetic,
 			Metadata: map[string]any{"syntheticFill": true},
 		}},
 	}
@@ -593,6 +632,7 @@ func TestSyntheticUpgrade_BatchedRealFills(t *testing.T) {
 		Fills: []LiveFillReport{{
 			Price:    68000,
 			Quantity: 0.4,
+			Source:   FillSourceReal,
 			Metadata: map[string]any{"tradeId": "real-1"},
 		}},
 	}
@@ -614,6 +654,7 @@ func TestSyntheticUpgrade_BatchedRealFills(t *testing.T) {
 		Fills: []LiveFillReport{{
 			Price:    68000,
 			Quantity: 0.3,
+			Source:   FillSourceReal,
 			Metadata: map[string]any{"tradeId": "real-2"},
 		}},
 	}
@@ -635,6 +676,7 @@ func TestSyntheticUpgrade_BatchedRealFills(t *testing.T) {
 		Fills: []LiveFillReport{{
 			Price:    68000,
 			Quantity: 0.3,
+			Source:   FillSourceReal,
 			Metadata: map[string]any{"tradeId": "real-3"},
 		}},
 	}
@@ -700,6 +742,7 @@ func TestFilledExitWithoutFillReportsDoesNotLeaveStaleShortPosition(t *testing.T
 	if _, err := platform.finalizeExecutedOrder(account, entryOrder, []domain.Fill{{
 		OrderID:         entryOrder.ID,
 		ExchangeTradeID: "entry-trade-1",
+		Source:          string(FillSourceReal),
 		Price:           75600.0,
 		Quantity:        0.002,
 	}}); err != nil {
@@ -756,6 +799,7 @@ func TestFilledExitWithoutFillReportsDoesNotLeaveStaleShortPosition(t *testing.T
 	if _, err := platform.finalizeExecutedOrder(account, syncedExit, []domain.Fill{{
 		OrderID:         syncedExit.ID,
 		ExchangeTradeID: "late-exit-trade-1",
+		Source:          string(FillSourceReal),
 		Price:           75600.1,
 		Quantity:        0.002,
 	}}); err != nil {
@@ -786,6 +830,7 @@ func TestFilledExitWithoutFillReportsDoesNotLeaveStaleShortPosition(t *testing.T
 	if _, err := platform.finalizeExecutedOrder(account, reentryOrder, []domain.Fill{{
 		OrderID:         reentryOrder.ID,
 		ExchangeTradeID: "reentry-trade-1",
+		Source:          string(FillSourceReal),
 		Price:           75600.0,
 		Quantity:        0.002,
 	}}); err != nil {
@@ -824,6 +869,7 @@ func TestFinalizeExecutedOrderUsesExchangeTradeTimeForLastFilledAt(t *testing.T)
 	tradeTime := time.Date(2026, 4, 17, 12, 36, 0, 0, time.UTC)
 	filledOrder, err := platform.finalizeExecutedOrder(account, order, []domain.Fill{{
 		OrderID:           order.ID,
+		Source:            string(FillSourceSynthetic),
 		Price:             68000,
 		Quantity:          0.1,
 		Fee:               1.23,
@@ -1371,6 +1417,7 @@ func TestApplyLiveSyncResultHealsStoredQuantityFromNormalizedSubmission(t *testi
 			Price:    68643.6,
 			Quantity: 0.002,
 			Fee:      0.01,
+			Source:   FillSourceReal,
 			Metadata: map[string]any{
 				"exchangeOrderId": "exchange-order-normalized-2",
 				"tradeId":         "trade-normalized-2",
@@ -1450,6 +1497,7 @@ func TestApplyLiveSyncResultSettlesClippedReduceOnlyFallbackClose(t *testing.T) 
 				Price:    77597.7,
 				Quantity: 0.001,
 				Fee:      0.01551954,
+				Source:   FillSourceReal,
 				Metadata: map[string]any{
 					"exchangeOrderId": "exchange-limit-exit",
 					"tradeId":         "trade-limit-1",
@@ -1460,6 +1508,7 @@ func TestApplyLiveSyncResultSettlesClippedReduceOnlyFallbackClose(t *testing.T) 
 				Price:    77597.7,
 				Quantity: 0.0014,
 				Fee:      0.02172735,
+				Source:   FillSourceReal,
 				Metadata: map[string]any{
 					"exchangeOrderId": "exchange-limit-exit",
 					"tradeId":         "trade-limit-2",
@@ -1470,6 +1519,7 @@ func TestApplyLiveSyncResultSettlesClippedReduceOnlyFallbackClose(t *testing.T) 
 				Price:    77597.7,
 				Quantity: 0.0014,
 				Fee:      0.02172735,
+				Source:   FillSourceReal,
 				Metadata: map[string]any{
 					"exchangeOrderId": "exchange-limit-exit",
 					"tradeId":         "trade-limit-3",
@@ -1536,6 +1586,7 @@ func TestApplyLiveSyncResultSettlesClippedReduceOnlyFallbackClose(t *testing.T) 
 			Price:    77593.4,
 			Quantity: 0.0091,
 			Fee:      0.28243997,
+			Source:   FillSourceReal,
 			Metadata: map[string]any{
 				"exchangeOrderId": "exchange-market-fallback",
 				"tradeId":         "trade-market-1",
@@ -1613,6 +1664,7 @@ func TestClosePositionImmediatelySettlesFilledLiveManualClose(t *testing.T) {
 				Price:    68100,
 				Quantity: 0.25,
 				Fee:      1.25,
+				Source:   FillSourceReal,
 				Metadata: map[string]any{
 					"exchangeOrderId": "exchange-order-filled-1",
 					"tradeId":         "trade-filled-1",
@@ -1688,6 +1740,7 @@ func TestClosePositionFilledLiveManualCloseClearsRecoverySessionState(t *testing
 				Price:    68150,
 				Quantity: 0.25,
 				Fee:      1.1,
+				Source:   FillSourceReal,
 				Metadata: map[string]any{
 					"exchangeOrderId": "exchange-order-filled-2",
 					"tradeId":         "trade-filled-2",
@@ -1774,6 +1827,7 @@ func TestSettleImmediatelyFilledLiveOrderReturnsSettledOrderWhenAccountRefreshFa
 				Price:    68200,
 				Quantity: 0.25,
 				Fee:      1.15,
+				Source:   FillSourceReal,
 				Metadata: map[string]any{
 					"exchangeOrderId": "exchange-order-filled-3",
 					"tradeId":         "trade-filled-3",
@@ -1862,6 +1916,7 @@ func TestImmediateFilledLiveOrderRepeatedSyncKeepsRetryMarkerAndFillDedupeStable
 				Price:    68250,
 				Quantity: 0.25,
 				Fee:      1.2,
+				Source:   FillSourceReal,
 				Metadata: map[string]any{
 					"exchangeOrderId": "exchange-order-filled-4",
 					"tradeId":         "trade-filled-4",
@@ -1976,6 +2031,7 @@ func TestImmediateFilledLiveOrderPartialSettlementKeepsRetryMarker(t *testing.T)
 			Price:    75600,
 			Quantity: 0.002,
 			Fee:      0.04,
+			Source:   FillSourceReal,
 			Metadata: map[string]any{
 				"exchangeOrderId": "exchange-order-partial",
 				"tradeId":         "trade-partial-1",
@@ -2468,6 +2524,7 @@ func TestFinalizeExecutedOrderFallsBackToNowWhenExchangeTradeTimeMissing(t *test
 	before := time.Now().UTC().Add(-time.Second)
 	filledOrder, err := platform.finalizeExecutedOrder(account, order, []domain.Fill{{
 		OrderID:  order.ID,
+		Source:   string(FillSourceSynthetic),
 		Price:    68000,
 		Quantity: 0.1,
 		Fee:      1.23,
@@ -2504,6 +2561,7 @@ func TestFinalizeExecutedOrderKeepsLastFilledAtOnDuplicateSync(t *testing.T) {
 	firstTradeTime := time.Date(2026, 4, 17, 12, 36, 0, 0, time.UTC)
 	fill := domain.Fill{
 		OrderID:           order.ID,
+		Source:            string(FillSourceSynthetic),
 		Price:             68000,
 		Quantity:          0.1,
 		Fee:               1.23,


### PR DESCRIPTION
## 目的
Closes #322

移除 live fill settlement 在 `finalizeExecutedOrder` 适配层对 incoming fill source 的最后一处 legacy guessing：LIVE 账号传入的 fill 必须显式携带 `Source`，不再根据 `exchangeTradeID` / `dedupFingerprint` 推断。非 LIVE 路径保留 legacy fallback，避免 paper/旧调用被本 PR 顺手打断。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [x] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) - 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？- 无
- [x] DB migration 是否具备向下兼容幂等性？- 无 DB migration
- [x] 配置字段有没有无意被混改？- 无配置改动

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

验证已跑：

```bash
go test ./internal/service -run 'TestFinalizeExecutedOrder|TestSyntheticUpgrade|TestBuildLiveSyncSettlement|TestReconcileLiveAccount'
go test ./internal/service
go test ./...
go build ./cmd/platform-api
go build ./cmd/db-migrate
```
