### PR TITLE
[codex] Add blocked container fallback plan

### DIFF
--- a/docs/runtime-supervisor.md
+++ b/docs/runtime-supervisor.md
@@ -359,6 +359,7 @@ func ClearRestartState(state map[string]any, keys []string)
 当前只读候选状态：
 
 - `GET /api/v1/supervisor/status` 的每个 target 会返回 `serviceState`，包含连续失败次数、失败阈值、最近失败/恢复时间，以及是否已成为 `containerFallbackCandidate`。
+- 当 target 已成为容器兜底候选时，状态中会额外返回 `containerFallbackPlan`；当前 `action=container-restart` 只是计划语义，`executable=false` 且 `blockedReason=container-executor-not-configured`，用于明确“候选”不等于“已允许执行”。
 - 当前 service fallback 只把 `/healthz` 不可达或非 2xx、`/api/v1/runtime/status` 连接不可达视为服务级失败；`/runtime/status` JSON decode 失败不会触发容器兜底候选，避免把业务状态或响应格式问题误判成需要重启容器。
 - 达到 `SUPERVISOR_SERVICE_FAILURE_THRESHOLD` 后只记录 `containerFallbackCandidate=true` 和原因，不调用 Docker API，不挂载 Docker socket，不执行容器 restart。
 - 后续真正执行容器级 restart 前，仍需单独设计 executor、backoff、人工抑制、权限边界和部署安全审查。

--- a/internal/service/runtime_supervisor.go
+++ b/internal/service/runtime_supervisor.go
@@ -39,14 +39,15 @@ type RuntimeSupervisorProbe struct {
 }
 
 type RuntimeSupervisorTargetSnapshot struct {
-	Name           string                           `json:"name"`
-	BaseURL        string                           `json:"baseUrl"`
-	CheckedAt      time.Time                        `json:"checkedAt"`
-	Healthz        RuntimeSupervisorProbe           `json:"healthz"`
-	RuntimeStatus  RuntimeSupervisorProbe           `json:"runtimeStatus"`
-	ServiceState   RuntimeSupervisorServiceState    `json:"serviceState"`
-	Status         *RuntimeStatusSnapshot           `json:"status,omitempty"`
-	ControlActions []RuntimeSupervisorControlAction `json:"controlActions,omitempty"`
+	Name                  string                                  `json:"name"`
+	BaseURL               string                                  `json:"baseUrl"`
+	CheckedAt             time.Time                               `json:"checkedAt"`
+	Healthz               RuntimeSupervisorProbe                  `json:"healthz"`
+	RuntimeStatus         RuntimeSupervisorProbe                  `json:"runtimeStatus"`
+	ServiceState          RuntimeSupervisorServiceState           `json:"serviceState"`
+	ContainerFallbackPlan *RuntimeSupervisorContainerFallbackPlan `json:"containerFallbackPlan,omitempty"`
+	Status                *RuntimeStatusSnapshot                  `json:"status,omitempty"`
+	ControlActions        []RuntimeSupervisorControlAction        `json:"controlActions,omitempty"`
 }
 
 type RuntimeSupervisorSnapshot struct {
@@ -74,6 +75,14 @@ type RuntimeSupervisorServiceState struct {
 	LastHealthyAt              *time.Time `json:"lastHealthyAt,omitempty"`
 	ContainerFallbackCandidate bool       `json:"containerFallbackCandidate"`
 	ContainerFallbackReason    string     `json:"containerFallbackReason,omitempty"`
+}
+
+type RuntimeSupervisorContainerFallbackPlan struct {
+	Action        string `json:"action"`
+	Candidate     bool   `json:"candidate"`
+	Executable    bool   `json:"executable"`
+	BlockedReason string `json:"blockedReason,omitempty"`
+	Reason        string `json:"reason,omitempty"`
 }
 
 type runtimeSupervisorServiceState struct {
@@ -199,6 +208,7 @@ func (s *RuntimeSupervisor) Collect(ctx context.Context) RuntimeSupervisorSnapsh
 		var status RuntimeStatusSnapshot
 		targetSnapshot.RuntimeStatus = s.fetchJSON(ctx, target, "/api/v1/runtime/status", &status)
 		targetSnapshot.ServiceState = s.updateServiceState(target, targetSnapshot.Healthz, targetSnapshot.RuntimeStatus, now)
+		targetSnapshot.ContainerFallbackPlan = runtimeSupervisorContainerFallbackPlan(targetSnapshot.ServiceState)
 		if targetSnapshot.RuntimeStatus.Error == "" && targetSnapshot.RuntimeStatus.Reachable {
 			targetSnapshot.Status = &status
 			targetSnapshot.ControlActions = s.submitApplicationRestarts(ctx, target, status, targetSnapshot.Healthz, now)
@@ -349,6 +359,19 @@ func runtimeSupervisorServiceStateSnapshot(state runtimeSupervisorServiceState, 
 		out.ContainerFallbackReason = fmt.Sprintf("service probes failed %d/%d: %s", state.ConsecutiveFailures, threshold, state.LastFailureReason)
 	}
 	return out
+}
+
+func runtimeSupervisorContainerFallbackPlan(state RuntimeSupervisorServiceState) *RuntimeSupervisorContainerFallbackPlan {
+	if !state.ContainerFallbackCandidate {
+		return nil
+	}
+	return &RuntimeSupervisorContainerFallbackPlan{
+		Action:        "container-restart",
+		Candidate:     true,
+		Executable:    false,
+		BlockedReason: "container-executor-not-configured",
+		Reason:        state.ContainerFallbackReason,
+	}
 }
 
 func runtimeSupervisorServiceKey(target RuntimeSupervisorTarget) string {

--- a/internal/service/runtime_supervisor_test.go
+++ b/internal/service/runtime_supervisor_test.go
@@ -153,12 +153,27 @@ func TestRuntimeSupervisorMarksContainerFallbackCandidateAfterServiceFailures(t 
 	if first.ServiceState.ConsecutiveFailures != 1 || first.ServiceState.ContainerFallbackCandidate {
 		t.Fatalf("expected first failure below fallback threshold, got %+v", first.ServiceState)
 	}
+	if first.ContainerFallbackPlan != nil {
+		t.Fatalf("expected no fallback plan below threshold, got %+v", first.ContainerFallbackPlan)
+	}
 	second := supervisor.Collect(context.Background()).Targets[0]
 	if second.ServiceState.ConsecutiveFailures != 2 || !second.ServiceState.ContainerFallbackCandidate {
 		t.Fatalf("expected second failure to become fallback candidate, got %+v", second.ServiceState)
 	}
 	if second.ServiceState.ContainerFallbackReason == "" || second.ServiceState.LastFailureReason == "" || second.ServiceState.LastFailureAt == nil {
 		t.Fatalf("expected fallback reason and failure metadata, got %+v", second.ServiceState)
+	}
+	if second.ContainerFallbackPlan == nil {
+		t.Fatalf("expected fallback plan for candidate, got %+v", second)
+	}
+	if second.ContainerFallbackPlan.Action != "container-restart" || !second.ContainerFallbackPlan.Candidate {
+		t.Fatalf("unexpected fallback plan identity, got %+v", second.ContainerFallbackPlan)
+	}
+	if second.ContainerFallbackPlan.Executable || second.ContainerFallbackPlan.BlockedReason != "container-executor-not-configured" {
+		t.Fatalf("expected fallback plan to stay blocked without executor, got %+v", second.ContainerFallbackPlan)
+	}
+	if second.ContainerFallbackPlan.Reason != second.ServiceState.ContainerFallbackReason {
+		t.Fatalf("expected fallback plan reason to mirror service state, got %+v", second.ContainerFallbackPlan)
 	}
 	if requested["POST /api/v1/runtime/restart"] != 0 {
 		t.Fatalf("expected no control action for service fallback candidate, got %#v", requested)
@@ -168,6 +183,9 @@ func TestRuntimeSupervisorMarksContainerFallbackCandidateAfterServiceFailures(t 
 	recovered := supervisor.Collect(context.Background()).Targets[0]
 	if recovered.ServiceState.ConsecutiveFailures != 0 || recovered.ServiceState.ContainerFallbackCandidate {
 		t.Fatalf("expected healthy probe to clear fallback candidate, got %+v", recovered.ServiceState)
+	}
+	if recovered.ContainerFallbackPlan != nil {
+		t.Fatalf("expected healthy probe to clear fallback plan, got %+v", recovered.ContainerFallbackPlan)
 	}
 	if recovered.ServiceState.LastHealthyAt == nil {
 		t.Fatalf("expected healthy probe to record last healthy time, got %+v", recovered.ServiceState)

--- a/web/console/src/pages/SupervisorStage.tsx
+++ b/web/console/src/pages/SupervisorStage.tsx
@@ -300,6 +300,10 @@ export function SupervisorStage() {
                       {targets.map((target) => {
                         const runtimeCount = target.status?.runtimes.length ?? 0;
                         const runtimeErrors = target.status?.runtimes.filter(runtimeNeedsAttention).length ?? 0;
+                        const fallbackDetail =
+                          target.containerFallbackPlan?.blockedReason ||
+                          target.containerFallbackPlan?.reason ||
+                          target.serviceState.containerFallbackReason;
                         return (
                           <TableRow key={`${target.name}:${target.baseUrl}`}>
                             <TableCell>
@@ -333,9 +337,9 @@ export function SupervisorStage() {
                                 <Badge variant={target.serviceState.containerFallbackCandidate ? 'destructive' : 'neutral'}>
                                   {target.serviceState.containerFallbackCandidate ? 'candidate' : 'clear'}
                                 </Badge>
-                                {target.serviceState.containerFallbackReason && (
-                                  <span className="truncate text-xs text-[var(--bk-text-muted)]" title={target.serviceState.containerFallbackReason}>
-                                    {target.serviceState.containerFallbackReason}
+                                {fallbackDetail && (
+                                  <span className="truncate text-xs text-[var(--bk-text-muted)]" title={fallbackDetail}>
+                                    {fallbackDetail}
                                   </span>
                                 )}
                               </div>

--- a/web/console/src/types/domain.ts
+++ b/web/console/src/types/domain.ts
@@ -376,6 +376,14 @@ export type RuntimeSupervisorServiceState = {
   containerFallbackReason?: string;
 };
 
+export type RuntimeSupervisorContainerFallbackPlan = {
+  action: string;
+  candidate: boolean;
+  executable: boolean;
+  blockedReason?: string;
+  reason?: string;
+};
+
 export type RuntimeSupervisorControlAction = {
   action: string;
   path: string;
@@ -395,6 +403,7 @@ export type RuntimeSupervisorTargetSnapshot = {
   healthz: RuntimeSupervisorProbe;
   runtimeStatus: RuntimeSupervisorProbe;
   serviceState: RuntimeSupervisorServiceState;
+  containerFallbackPlan?: RuntimeSupervisorContainerFallbackPlan;
   status?: RuntimeSupervisorStatus;
   controlActions?: RuntimeSupervisorControlAction[];
 };


### PR DESCRIPTION
## 目的
继续 issue #270 的容器级兜底阶段，但不直接实现 Docker/container restart。

本 PR 在 supervisor status 中把“容器兜底候选”和“可执行容器操作”显式拆开：当 target 达到 `containerFallbackCandidate=true` 时，返回 `containerFallbackPlan`，其中当前固定为：

- `action=container-restart`
- `candidate=true`
- `executable=false`
- `blockedReason=container-executor-not-configured`

这样 dashboard / CLI / 后续 executor 都能清楚看到：服务已进入容器兜底候选，但当前构建没有 executor，也没有执行许可。

本 PR 不调用 Docker API，不挂载 Docker socket，不改 deployments，不新增容器 restart 行为，也不改 dispatch/live 执行路径或默认安全参数。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [x] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) - 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？- 无
- [x] DB migration 是否具备向下兼容幂等性？- 未涉及
- [x] 配置字段有没有无意被混改？- 未涉及
- [x] Docker socket / deployments / workflow 是否改动？- 无

## 验证方式与测试证据
- [x] `gofmt -w internal/service/runtime_supervisor.go internal/service/runtime_supervisor_test.go`
- [x] `go test ./internal/service`
- [x] `go test ./...`
- [x] `go build ./cmd/platform-api`
- [x] `go build ./cmd/db-migrate`
- [x] `npm ci`（Node 20.6.1 下有现有 EBADENGINE warning）
- [x] `./node_modules/.bin/tsc --noEmit src/pages/AccountStage.tsx --jsx react-jsx --esModuleInterop --target esnext --module esnext --moduleResolution Bundler --allowSyntheticDefaultImports`
- [x] `./node_modules/.bin/tsc --noEmit src/pages/SupervisorStage.tsx --jsx react-jsx --esModuleInterop --target esnext --module esnext --moduleResolution Bundler --allowSyntheticDefaultImports --strict`
- [x] `npm run build`
- [x] `git diff --check`
