### PR TITLE
[codex] Add supervisor container restart opt-in

### DIFF
--- a/docs/runtime-supervisor.md
+++ b/docs/runtime-supervisor.md
@@ -320,6 +320,7 @@ func ClearRestartState(state map[string]any, keys []string)
 - `SUPERVISOR_TARGETS` 使用逗号分隔，支持 `name=http://host:port` 或直接填写 base URL。
 - `SUPERVISOR_BEARER_TOKEN` 可选；设置后 read-only collector 会对所有 targets 的 `/healthz` 与 `/api/v1/runtime/status` 请求附加 `Authorization: Bearer <token>`，用于采集受鉴权保护的内网 runtime API。
 - `SUPERVISOR_SERVICE_FAILURE_THRESHOLD=3` 为默认值；supervisor 会按 target 记录连续服务级失败次数，并在达到阈值后把该 target 标记为容器兜底候选，但当前阶段只暴露状态，不执行 Docker/container restart。
+- `SUPERVISOR_CONTAINER_RESTART_ENABLED=false` 为默认值；未显式设为 `true` 时，容器兜底计划只会返回 `blockedReason=container-restart-disabled`，不会进入 executor 阶段。
 - 默认只采集 `/healthz` 和 `/api/v1/runtime/status`，不调用任何控制 API。
 - `GET /api/v1/supervisor/status` 返回最近一次 read-only supervisor 采集快照。
 - `bktrader-ctl runtime status --json` 和 `bktrader-ctl supervisor status --json` 提供 CLI 只读巡检入口。
@@ -359,7 +360,7 @@ func ClearRestartState(state map[string]any, keys []string)
 当前只读候选状态：
 
 - `GET /api/v1/supervisor/status` 的每个 target 会返回 `serviceState`，包含连续失败次数、失败阈值、最近失败/恢复时间，以及是否已成为 `containerFallbackCandidate`。
-- 当 target 已成为容器兜底候选时，状态中会额外返回 `containerFallbackPlan`；当前 `action=container-restart` 只是计划语义，`executable=false` 且 `blockedReason=container-executor-not-configured`，用于明确“候选”不等于“已允许执行”。
+- 当 target 已成为容器兜底候选时，状态中会额外返回 `containerFallbackPlan`；当前 `action=container-restart` 只是计划语义，`executable=false`。默认会返回 `blockedReason=container-restart-disabled`；即使 `SUPERVISOR_CONTAINER_RESTART_ENABLED=true`，在 executor 尚未配置前也只会返回 `blockedReason=container-executor-not-configured`，用于明确“候选”不等于“已允许执行”。
 - 当前 service fallback 只把 `/healthz` 不可达或非 2xx、`/api/v1/runtime/status` 连接不可达视为服务级失败；`/runtime/status` JSON decode 失败不会触发容器兜底候选，避免把业务状态或响应格式问题误判成需要重启容器。
 - 达到 `SUPERVISOR_SERVICE_FAILURE_THRESHOLD` 后只记录 `containerFallbackCandidate=true` 和原因，不调用 Docker API，不挂载 Docker socket，不执行容器 restart。
 - 后续真正执行容器级 restart 前，仍需单独设计 executor、backoff、人工抑制、权限边界和部署安全审查。

--- a/internal/app/server.go
+++ b/internal/app/server.go
@@ -197,6 +197,7 @@ func StartRuntimeComponents(ctx context.Context, platform *service.Platform, cfg
 			supervisor := service.NewRuntimeSupervisorWithOptions(targets, &http.Client{Timeout: time.Duration(cfg.SupervisorHTTPTimeoutSeconds) * time.Second}, service.RuntimeSupervisorOptions{
 				EnableApplicationRestart: cfg.SupervisorAppRestartEnabled,
 				ServiceFailureThreshold:  cfg.SupervisorServiceFailThreshold,
+				EnableContainerFallback:  cfg.SupervisorContainerRestart,
 			})
 			platform.SetRuntimeSupervisor(supervisor)
 			supervisor.Start(ctx, time.Duration(cfg.SupervisorPollIntervalSeconds)*time.Second)
@@ -206,6 +207,7 @@ func StartRuntimeComponents(ctx context.Context, platform *service.Platform, cfg
 				"http_timeout_seconds", cfg.SupervisorHTTPTimeoutSeconds,
 				"application_restart_enabled", cfg.SupervisorAppRestartEnabled,
 				"service_failure_threshold", cfg.SupervisorServiceFailThreshold,
+				"container_restart_enabled", cfg.SupervisorContainerRestart,
 			)
 		}
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -73,6 +73,7 @@ type Config struct {
 	SupervisorHTTPTimeoutSeconds   int      // 只读 supervisor HTTP 超时（秒）
 	SupervisorAppRestartEnabled    bool     // supervisor 是否允许按 runtime status 到期计划提交应用内 restart（默认关闭）
 	SupervisorServiceFailThreshold int      // supervisor 标记容器兜底候选所需的连续服务级失败次数（默认 3）
+	SupervisorContainerRestart     bool     // supervisor 是否允许容器级 restart 进入 executor 阶段（默认关闭）
 }
 
 // Load 从环境变量加载配置，未设置的使用默认值。
@@ -155,6 +156,7 @@ func Load() Config {
 		SupervisorHTTPTimeoutSeconds:   intFromEnvWithMin("SUPERVISOR_HTTP_TIMEOUT_SECONDS", 5, 1),
 		SupervisorAppRestartEnabled:    boolFromEnv("SUPERVISOR_APPLICATION_RESTART_ENABLED", false),
 		SupervisorServiceFailThreshold: intFromEnvWithMin("SUPERVISOR_SERVICE_FAILURE_THRESHOLD", 3, 1),
+		SupervisorContainerRestart:     boolFromEnv("SUPERVISOR_CONTAINER_RESTART_ENABLED", false),
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -109,6 +109,7 @@ func TestLoadReadsSupervisorEnv(t *testing.T) {
 	t.Setenv("SUPERVISOR_HTTP_TIMEOUT_SECONDS", "3")
 	t.Setenv("SUPERVISOR_APPLICATION_RESTART_ENABLED", "true")
 	t.Setenv("SUPERVISOR_SERVICE_FAILURE_THRESHOLD", "4")
+	t.Setenv("SUPERVISOR_CONTAINER_RESTART_ENABLED", "true")
 
 	cfg := Load()
 	if len(cfg.SupervisorTargets) != 2 {
@@ -131,6 +132,9 @@ func TestLoadReadsSupervisorEnv(t *testing.T) {
 	}
 	if cfg.SupervisorServiceFailThreshold != 4 {
 		t.Fatalf("expected supervisor service failure threshold 4, got %d", cfg.SupervisorServiceFailThreshold)
+	}
+	if !cfg.SupervisorContainerRestart {
+		t.Fatal("expected supervisor container restart opt-in to be enabled")
 	}
 }
 

--- a/internal/service/runtime_supervisor.go
+++ b/internal/service/runtime_supervisor.go
@@ -22,6 +22,7 @@ const (
 type RuntimeSupervisorOptions struct {
 	EnableApplicationRestart bool
 	ServiceFailureThreshold  int
+	EnableContainerFallback  bool
 }
 
 type RuntimeSupervisorTarget struct {
@@ -208,7 +209,7 @@ func (s *RuntimeSupervisor) Collect(ctx context.Context) RuntimeSupervisorSnapsh
 		var status RuntimeStatusSnapshot
 		targetSnapshot.RuntimeStatus = s.fetchJSON(ctx, target, "/api/v1/runtime/status", &status)
 		targetSnapshot.ServiceState = s.updateServiceState(target, targetSnapshot.Healthz, targetSnapshot.RuntimeStatus, now)
-		targetSnapshot.ContainerFallbackPlan = runtimeSupervisorContainerFallbackPlan(targetSnapshot.ServiceState)
+		targetSnapshot.ContainerFallbackPlan = runtimeSupervisorContainerFallbackPlan(targetSnapshot.ServiceState, s.options)
 		if targetSnapshot.RuntimeStatus.Error == "" && targetSnapshot.RuntimeStatus.Reachable {
 			targetSnapshot.Status = &status
 			targetSnapshot.ControlActions = s.submitApplicationRestarts(ctx, target, status, targetSnapshot.Healthz, now)
@@ -282,6 +283,7 @@ func (s *RuntimeSupervisor) collectAndLog(ctx context.Context, logger *slog.Logg
 		"control_action_count", controlActions,
 		"application_restart_enabled", s.options.EnableApplicationRestart,
 		"service_failure_threshold", s.options.ServiceFailureThreshold,
+		"container_restart_enabled", s.options.EnableContainerFallback,
 		"container_fallback_candidate_count", containerFallbackCandidates,
 	)
 }
@@ -361,15 +363,19 @@ func runtimeSupervisorServiceStateSnapshot(state runtimeSupervisorServiceState, 
 	return out
 }
 
-func runtimeSupervisorContainerFallbackPlan(state RuntimeSupervisorServiceState) *RuntimeSupervisorContainerFallbackPlan {
+func runtimeSupervisorContainerFallbackPlan(state RuntimeSupervisorServiceState, options RuntimeSupervisorOptions) *RuntimeSupervisorContainerFallbackPlan {
 	if !state.ContainerFallbackCandidate {
 		return nil
+	}
+	blockedReason := "container-restart-disabled"
+	if options.EnableContainerFallback {
+		blockedReason = "container-executor-not-configured"
 	}
 	return &RuntimeSupervisorContainerFallbackPlan{
 		Action:        "container-restart",
 		Candidate:     true,
 		Executable:    false,
-		BlockedReason: "container-executor-not-configured",
+		BlockedReason: blockedReason,
 		Reason:        state.ContainerFallbackReason,
 	}
 }

--- a/internal/service/runtime_supervisor_test.go
+++ b/internal/service/runtime_supervisor_test.go
@@ -169,8 +169,8 @@ func TestRuntimeSupervisorMarksContainerFallbackCandidateAfterServiceFailures(t 
 	if second.ContainerFallbackPlan.Action != "container-restart" || !second.ContainerFallbackPlan.Candidate {
 		t.Fatalf("unexpected fallback plan identity, got %+v", second.ContainerFallbackPlan)
 	}
-	if second.ContainerFallbackPlan.Executable || second.ContainerFallbackPlan.BlockedReason != "container-executor-not-configured" {
-		t.Fatalf("expected fallback plan to stay blocked without executor, got %+v", second.ContainerFallbackPlan)
+	if second.ContainerFallbackPlan.Executable || second.ContainerFallbackPlan.BlockedReason != "container-restart-disabled" {
+		t.Fatalf("expected fallback plan to stay blocked without explicit opt-in, got %+v", second.ContainerFallbackPlan)
 	}
 	if second.ContainerFallbackPlan.Reason != second.ServiceState.ContainerFallbackReason {
 		t.Fatalf("expected fallback plan reason to mirror service state, got %+v", second.ContainerFallbackPlan)
@@ -189,6 +189,40 @@ func TestRuntimeSupervisorMarksContainerFallbackCandidateAfterServiceFailures(t 
 	}
 	if recovered.ServiceState.LastHealthyAt == nil {
 		t.Fatalf("expected healthy probe to record last healthy time, got %+v", recovered.ServiceState)
+	}
+}
+
+func TestRuntimeSupervisorContainerFallbackOptInStillRequiresExecutor(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/healthz":
+			http.Error(w, "not ready", http.StatusServiceUnavailable)
+		case "/api/v1/runtime/status":
+			writeRuntimeSupervisorTestJSON(t, w, RuntimeStatusSnapshot{Service: "platform-api"})
+		case "/api/v1/runtime/restart":
+			t.Errorf("container fallback opt-in must not call runtime control path %s", r.URL.Path)
+			w.WriteHeader(http.StatusForbidden)
+		default:
+			t.Errorf("unexpected request path %s", r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	supervisor := NewRuntimeSupervisorWithOptions(
+		[]RuntimeSupervisorTarget{{Name: "api", BaseURL: server.URL}},
+		server.Client(),
+		RuntimeSupervisorOptions{
+			ServiceFailureThreshold: 1,
+			EnableContainerFallback: true,
+		},
+	)
+	target := supervisor.Collect(context.Background()).Targets[0]
+	if target.ContainerFallbackPlan == nil {
+		t.Fatalf("expected fallback plan for candidate, got %+v", target)
+	}
+	if target.ContainerFallbackPlan.Executable || target.ContainerFallbackPlan.BlockedReason != "container-executor-not-configured" {
+		t.Fatalf("expected opt-in plan to stay blocked without executor, got %+v", target.ContainerFallbackPlan)
 	}
 }
 


### PR DESCRIPTION
## 目的
继续 issue #270 的容器级兜底阶段，但仍不实现 Docker/container restart。

本 PR 新增显式 opt-in 配置 `SUPERVISOR_CONTAINER_RESTART_ENABLED=false`，让容器级 restart 在未来进入 executor 前必须先经过环境配置显式开启：

- 默认：`containerFallbackPlan.blockedReason=container-restart-disabled`
- 显式开启后：由于当前仍没有 executor，`blockedReason=container-executor-not-configured`

这样可以把三层状态分清楚：

1. service 已达到 fallback candidate
2. container restart 是否显式 opt-in
3. executor 是否真实配置/可执行

本 PR 不调用 Docker API，不挂载 Docker socket，不改 deployments，不新增容器 restart 行为，也不改 dispatch/live 执行路径或默认交易安全参数。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [x] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) - 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？- 无
- [x] DB migration 是否具备向下兼容幂等性？- 未涉及
- [x] 配置字段有没有无意被混改？- 新增 opt-in 默认 false
- [x] Docker socket / deployments / workflow 是否改动？- 无

## 验证方式与测试证据
- [x] `gofmt -w internal/config/config.go internal/config/config_test.go internal/app/server.go internal/service/runtime_supervisor.go internal/service/runtime_supervisor_test.go`
- [x] `go test ./internal/config ./internal/app ./internal/service`
- [x] `go test ./...`
- [x] `go build ./cmd/platform-api`
- [x] `go build ./cmd/db-migrate`
- [x] `git diff --check`
