### PR TITLE
[codex] Add supervisor fallback readiness fields

### DIFF
--- a/docs/runtime-supervisor.md
+++ b/docs/runtime-supervisor.md
@@ -360,7 +360,7 @@ func ClearRestartState(state map[string]any, keys []string)
 当前只读候选状态：
 
 - `GET /api/v1/supervisor/status` 的每个 target 会返回 `serviceState`，包含连续失败次数、失败阈值、最近失败/恢复时间，以及是否已成为 `containerFallbackCandidate`。
-- 当 target 已成为容器兜底候选时，状态中会额外返回 `containerFallbackPlan`；当前 `action=container-restart` 只是计划语义，`executable=false`。默认会返回 `blockedReason=container-restart-disabled`；即使 `SUPERVISOR_CONTAINER_RESTART_ENABLED=true`，在 executor 尚未配置前也只会返回 `blockedReason=container-executor-not-configured`，用于明确“候选”不等于“已允许执行”。
+- 当 target 已成为容器兜底候选时，状态中会额外返回 `containerFallbackPlan`；当前 `action=container-restart` 只是计划语义。该计划显式返回 `enabled`、`executorConfigured`、`executable` 三个 readiness 字段：默认 `enabled=false`、`executorConfigured=false`、`executable=false`，并返回 `blockedReason=container-restart-disabled`；即使 `SUPERVISOR_CONTAINER_RESTART_ENABLED=true`，在 executor 尚未配置前也只会返回 `enabled=true`、`executorConfigured=false`、`executable=false`、`blockedReason=container-executor-not-configured`，用于明确“候选”不等于“已允许执行”。
 - 当前 service fallback 只把 `/healthz` 不可达或非 2xx、`/api/v1/runtime/status` 连接不可达视为服务级失败；`/runtime/status` JSON decode 失败不会触发容器兜底候选，避免把业务状态或响应格式问题误判成需要重启容器。
 - 达到 `SUPERVISOR_SERVICE_FAILURE_THRESHOLD` 后只记录 `containerFallbackCandidate=true` 和原因，不调用 Docker API，不挂载 Docker socket，不执行容器 restart。
 - 后续真正执行容器级 restart 前，仍需单独设计 executor、backoff、人工抑制、权限边界和部署安全审查。

--- a/internal/service/runtime_supervisor.go
+++ b/internal/service/runtime_supervisor.go
@@ -79,11 +79,13 @@ type RuntimeSupervisorServiceState struct {
 }
 
 type RuntimeSupervisorContainerFallbackPlan struct {
-	Action        string `json:"action"`
-	Candidate     bool   `json:"candidate"`
-	Executable    bool   `json:"executable"`
-	BlockedReason string `json:"blockedReason,omitempty"`
-	Reason        string `json:"reason,omitempty"`
+	Action             string `json:"action"`
+	Candidate          bool   `json:"candidate"`
+	Enabled            bool   `json:"enabled"`
+	ExecutorConfigured bool   `json:"executorConfigured"`
+	Executable         bool   `json:"executable"`
+	BlockedReason      string `json:"blockedReason,omitempty"`
+	Reason             string `json:"reason,omitempty"`
 }
 
 type runtimeSupervisorServiceState struct {
@@ -367,16 +369,22 @@ func runtimeSupervisorContainerFallbackPlan(state RuntimeSupervisorServiceState,
 	if !state.ContainerFallbackCandidate {
 		return nil
 	}
-	blockedReason := "container-restart-disabled"
-	if options.EnableContainerFallback {
+	executorConfigured := false
+	executable := options.EnableContainerFallback && executorConfigured
+	blockedReason := ""
+	if !options.EnableContainerFallback {
+		blockedReason = "container-restart-disabled"
+	} else if !executorConfigured {
 		blockedReason = "container-executor-not-configured"
 	}
 	return &RuntimeSupervisorContainerFallbackPlan{
-		Action:        "container-restart",
-		Candidate:     true,
-		Executable:    false,
-		BlockedReason: blockedReason,
-		Reason:        state.ContainerFallbackReason,
+		Action:             "container-restart",
+		Candidate:          true,
+		Enabled:            options.EnableContainerFallback,
+		ExecutorConfigured: executorConfigured,
+		Executable:         executable,
+		BlockedReason:      blockedReason,
+		Reason:             state.ContainerFallbackReason,
 	}
 }
 

--- a/internal/service/runtime_supervisor_test.go
+++ b/internal/service/runtime_supervisor_test.go
@@ -172,6 +172,9 @@ func TestRuntimeSupervisorMarksContainerFallbackCandidateAfterServiceFailures(t 
 	if second.ContainerFallbackPlan.Executable || second.ContainerFallbackPlan.BlockedReason != "container-restart-disabled" {
 		t.Fatalf("expected fallback plan to stay blocked without explicit opt-in, got %+v", second.ContainerFallbackPlan)
 	}
+	if second.ContainerFallbackPlan.Enabled || second.ContainerFallbackPlan.ExecutorConfigured {
+		t.Fatalf("expected fallback readiness to show disabled/no executor, got %+v", second.ContainerFallbackPlan)
+	}
 	if second.ContainerFallbackPlan.Reason != second.ServiceState.ContainerFallbackReason {
 		t.Fatalf("expected fallback plan reason to mirror service state, got %+v", second.ContainerFallbackPlan)
 	}
@@ -223,6 +226,9 @@ func TestRuntimeSupervisorContainerFallbackOptInStillRequiresExecutor(t *testing
 	}
 	if target.ContainerFallbackPlan.Executable || target.ContainerFallbackPlan.BlockedReason != "container-executor-not-configured" {
 		t.Fatalf("expected opt-in plan to stay blocked without executor, got %+v", target.ContainerFallbackPlan)
+	}
+	if !target.ContainerFallbackPlan.Enabled || target.ContainerFallbackPlan.ExecutorConfigured {
+		t.Fatalf("expected opt-in readiness to show enabled/no executor, got %+v", target.ContainerFallbackPlan)
 	}
 }
 

--- a/web/console/src/pages/SupervisorStage.tsx
+++ b/web/console/src/pages/SupervisorStage.tsx
@@ -168,7 +168,7 @@ export function SupervisorStage() {
     return () => window.clearInterval(timer);
   }, [loadSnapshot]);
 
-  const { runtimeRows, controlActionRows, fallbackCount, attentionCount, fullyReachableTargets } = useMemo(() => {
+  const { runtimeRows, controlActionRows, fallbackCount, executableFallbackCount, attentionCount, fullyReachableTargets } = useMemo(() => {
     const targets = snapshot?.targets ?? [];
     const runtimes = targets.flatMap((target) =>
       (target.status?.runtimes ?? []).map((runtime) => ({
@@ -185,6 +185,7 @@ export function SupervisorStage() {
         }))
       ),
       fallbackCount: targets.filter((target) => target.serviceState.containerFallbackCandidate).length,
+      executableFallbackCount: targets.filter((target) => target.containerFallbackPlan?.executable).length,
       attentionCount: runtimes.filter(runtimeNeedsAttention).length,
       fullyReachableTargets: targets.filter((target) => isProbeOK(target.healthz) && isProbeOK(target.runtimeStatus)).length,
     };
@@ -259,7 +260,7 @@ export function SupervisorStage() {
                 icon={ShieldAlert}
                 label="Fallback"
                 value={fallbackCount}
-                detail="container candidates"
+                detail={`${executableFallbackCount} executable`}
                 tone={fallbackCount > 0 ? 'danger' : 'neutral'}
               />
               <MetricCard
@@ -304,6 +305,7 @@ export function SupervisorStage() {
                           target.containerFallbackPlan?.blockedReason ||
                           target.containerFallbackPlan?.reason ||
                           target.serviceState.containerFallbackReason;
+                        const fallbackPlan = target.containerFallbackPlan;
                         return (
                           <TableRow key={`${target.name}:${target.baseUrl}`}>
                             <TableCell>
@@ -334,9 +336,21 @@ export function SupervisorStage() {
                             </TableCell>
                             <TableCell>
                               <div className="flex max-w-[220px] flex-col gap-1">
-                                <Badge variant={target.serviceState.containerFallbackCandidate ? 'destructive' : 'neutral'}>
-                                  {target.serviceState.containerFallbackCandidate ? 'candidate' : 'clear'}
-                                </Badge>
+                                <div className="flex flex-wrap gap-1">
+                                  <Badge variant={target.serviceState.containerFallbackCandidate ? 'destructive' : 'neutral'}>
+                                    {target.serviceState.containerFallbackCandidate ? 'candidate' : 'clear'}
+                                  </Badge>
+                                  {fallbackPlan && (
+                                    <Badge variant={fallbackPlan.enabled ? 'secondary' : 'neutral'}>
+                                      {fallbackPlan.enabled ? 'opt-in' : 'disabled'}
+                                    </Badge>
+                                  )}
+                                  {fallbackPlan && (
+                                    <Badge variant={fallbackPlan.executorConfigured ? 'success' : 'neutral'}>
+                                      {fallbackPlan.executorConfigured ? 'executor ready' : 'no executor'}
+                                    </Badge>
+                                  )}
+                                </div>
                                 {fallbackDetail && (
                                   <span className="truncate text-xs text-[var(--bk-text-muted)]" title={fallbackDetail}>
                                     {fallbackDetail}

--- a/web/console/src/types/domain.ts
+++ b/web/console/src/types/domain.ts
@@ -379,6 +379,8 @@ export type RuntimeSupervisorServiceState = {
 export type RuntimeSupervisorContainerFallbackPlan = {
   action: string;
   candidate: boolean;
+  enabled: boolean;
+  executorConfigured: boolean;
   executable: boolean;
   blockedReason?: string;
   reason?: string;


### PR DESCRIPTION
## 目的
继续推进 #270 的容器 fallback 控制面，但仍保持执行面阻断。本 PR 让 `containerFallbackPlan` 显式返回 readiness 字段，Dashboard 也能直接看到 fallback 是否 opt-in、executor 是否配置、当前是否 executable。

具体改动：
- `containerFallbackPlan` 新增 `enabled`、`executorConfigured`、`executable` 显式字段。
- 默认仍是 `enabled=false`、`executorConfigured=false`、`executable=false`，blocked reason 为 `container-restart-disabled`。
- 即使 `SUPERVISOR_CONTAINER_RESTART_ENABLED=true`，当前仍因 executor 未配置保持 `executable=false`，blocked reason 为 `container-executor-not-configured`。
- Supervisor Dashboard 的 Fallback 区域显示 opt-in / executor 状态，并在 summary 里显示 executable 数量。
- 文档同步说明候选、启用、executor、可执行之间的边界。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [x] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值无变化。
- [x] 不存在直接调用 `mainnet` 凭证或路由地址的硬编码。
- [x] 无 DB migration。
- [x] 未新增环境变量；`SUPERVISOR_CONTAINER_RESTART_ENABLED` 语义保持不变。
- [x] 未调用 Docker API，未挂载 Docker socket，未修改 deployments，未执行容器 restart。

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

本地验证：
- `go test ./internal/service`
- `cd web/console && ./node_modules/.bin/tsc --noEmit src/pages/SupervisorStage.tsx --jsx react-jsx --esModuleInterop --target esnext --module esnext --moduleResolution Bundler --allowSyntheticDefaultImports`
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
- `cd web/console && npm run build`
- `git diff --check`
