### PR TITLE
[codex] Add supervisor status CLI summary

### DIFF
--- a/cmd/bktrader-ctl/supervisor.go
+++ b/cmd/bktrader-ctl/supervisor.go
@@ -1,6 +1,13 @@
 package main
 
-import "github.com/spf13/cobra"
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
 
 func init() {
 	supervisorCmd.AddCommand(supervisorStatusCmd)
@@ -18,7 +25,202 @@ var supervisorStatusCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		client := getClient()
 		resp, err := client.Request("GET", "/api/v1/supervisor/status", nil)
-		handleResponse(resp, err)
+		handleSupervisorStatusResponse(resp, err)
 		return nil
 	},
+}
+
+type supervisorStatusSnapshot struct {
+	CheckedAt string                     `json:"checkedAt"`
+	Targets   []supervisorTargetSnapshot `json:"targets"`
+}
+
+type supervisorTargetSnapshot struct {
+	Name                  string                           `json:"name"`
+	BaseURL               string                           `json:"baseUrl"`
+	CheckedAt             string                           `json:"checkedAt"`
+	Healthz               supervisorProbe                  `json:"healthz"`
+	RuntimeStatus         supervisorProbe                  `json:"runtimeStatus"`
+	ServiceState          supervisorServiceState           `json:"serviceState"`
+	ContainerFallbackPlan *supervisorContainerFallbackPlan `json:"containerFallbackPlan,omitempty"`
+	Status                *supervisorRuntimeStatusSnapshot `json:"status,omitempty"`
+	ControlActions        []supervisorControlAction        `json:"controlActions,omitempty"`
+}
+
+type supervisorProbe struct {
+	Path       string `json:"path"`
+	StatusCode int    `json:"statusCode,omitempty"`
+	Reachable  bool   `json:"reachable"`
+	Error      string `json:"error,omitempty"`
+}
+
+type supervisorServiceState struct {
+	ConsecutiveFailures        int    `json:"consecutiveFailures"`
+	FailureThreshold           int    `json:"failureThreshold"`
+	LastFailureReason          string `json:"lastFailureReason,omitempty"`
+	ContainerFallbackCandidate bool   `json:"containerFallbackCandidate"`
+	ContainerFallbackReason    string `json:"containerFallbackReason,omitempty"`
+}
+
+type supervisorContainerFallbackPlan struct {
+	Action             string `json:"action"`
+	Candidate          bool   `json:"candidate"`
+	Enabled            bool   `json:"enabled"`
+	ExecutorConfigured bool   `json:"executorConfigured"`
+	Executable         bool   `json:"executable"`
+	BlockedReason      string `json:"blockedReason,omitempty"`
+	Reason             string `json:"reason,omitempty"`
+}
+
+type supervisorRuntimeStatusSnapshot struct {
+	Service  string                    `json:"service"`
+	Runtimes []supervisorRuntimeStatus `json:"runtimes"`
+}
+
+type supervisorRuntimeStatus struct {
+	RuntimeID             string `json:"runtimeId"`
+	RuntimeKind           string `json:"runtimeKind"`
+	DesiredStatus         string `json:"desiredStatus"`
+	ActualStatus          string `json:"actualStatus"`
+	Health                string `json:"health"`
+	AutoRestartSuppressed bool   `json:"autoRestartSuppressed"`
+}
+
+type supervisorControlAction struct {
+	Action    string `json:"action"`
+	RuntimeID string `json:"runtimeId"`
+	Error     string `json:"error,omitempty"`
+}
+
+func handleSupervisorStatusResponse(data []byte, err error) {
+	if err != nil || outputJSON {
+		handleResponse(data, err)
+		return
+	}
+	summary, decodeErr := buildSupervisorStatusSummary(data)
+	if decodeErr != nil {
+		handleResponse(data, nil)
+		return
+	}
+	fmt.Print(summary)
+}
+
+func buildSupervisorStatusSummary(data []byte) (string, error) {
+	var snapshot supervisorStatusSnapshot
+	if err := json.Unmarshal(data, &snapshot); err != nil {
+		return "", err
+	}
+	targets := len(snapshot.Targets)
+	fullyReachable := 0
+	runtimeCount := 0
+	runtimeAttention := 0
+	fallbackCandidates := 0
+	fallbackExecutable := 0
+	controlActions := 0
+
+	for _, target := range snapshot.Targets {
+		if supervisorProbeOK(target.Healthz) && supervisorProbeOK(target.RuntimeStatus) {
+			fullyReachable++
+		}
+		if target.ServiceState.ContainerFallbackCandidate {
+			fallbackCandidates++
+		}
+		if target.ContainerFallbackPlan != nil && target.ContainerFallbackPlan.Executable {
+			fallbackExecutable++
+		}
+		if target.Status != nil {
+			runtimeCount += len(target.Status.Runtimes)
+			for _, runtime := range target.Status.Runtimes {
+				if supervisorRuntimeNeedsAttention(runtime) {
+					runtimeAttention++
+				}
+			}
+		}
+		controlActions += len(target.ControlActions)
+	}
+
+	var out bytes.Buffer
+	fmt.Fprintln(&out, "Runtime supervisor snapshot")
+	fmt.Fprintf(&out, "checkedAt: %s\n", firstNonEmpty(snapshot.CheckedAt, "--"))
+	fmt.Fprintf(&out, "targets: total=%d fullyReachable=%d fallbackCandidates=%d fallbackExecutable=%d runtimes=%d attention=%d controlActions=%d\n",
+		targets, fullyReachable, fallbackCandidates, fallbackExecutable, runtimeCount, runtimeAttention, controlActions)
+	for _, target := range snapshot.Targets {
+		fmt.Fprintf(&out, "\n- %s %s\n", firstNonEmpty(target.Name, "--"), firstNonEmpty(target.BaseURL, "--"))
+		fmt.Fprintf(&out, "  probes: healthz=%s runtimeStatus=%s\n", supervisorProbeText(target.Healthz), supervisorProbeText(target.RuntimeStatus))
+		fmt.Fprintf(&out, "  serviceState: failures=%d/%d fallback=%s\n",
+			target.ServiceState.ConsecutiveFailures,
+			target.ServiceState.FailureThreshold,
+			supervisorFallbackStateText(target.ServiceState),
+		)
+		if strings.TrimSpace(target.ServiceState.LastFailureReason) != "" {
+			fmt.Fprintf(&out, "  lastFailure=%s\n", target.ServiceState.LastFailureReason)
+		}
+		if target.ContainerFallbackPlan != nil {
+			plan := target.ContainerFallbackPlan
+			fmt.Fprintf(&out, "  fallbackPlan: action=%s enabled=%t executorConfigured=%t executable=%t blockedReason=%s\n",
+				firstNonEmpty(plan.Action, "--"),
+				plan.Enabled,
+				plan.ExecutorConfigured,
+				plan.Executable,
+				firstNonEmpty(plan.BlockedReason, "--"),
+			)
+		}
+		if target.Status != nil {
+			attention := 0
+			for _, runtime := range target.Status.Runtimes {
+				if supervisorRuntimeNeedsAttention(runtime) {
+					attention++
+				}
+			}
+			fmt.Fprintf(&out, "  runtimes: total=%d attention=%d service=%s\n", len(target.Status.Runtimes), attention, firstNonEmpty(target.Status.Service, "--"))
+		}
+		if len(target.ControlActions) > 0 {
+			errors := 0
+			for _, action := range target.ControlActions {
+				if strings.TrimSpace(action.Error) != "" {
+					errors++
+				}
+			}
+			fmt.Fprintf(&out, "  controlActions: total=%d errors=%d\n", len(target.ControlActions), errors)
+		}
+	}
+	return strings.TrimRight(out.String(), "\n") + "\n", nil
+}
+
+func supervisorProbeOK(probe supervisorProbe) bool {
+	if !probe.Reachable || strings.TrimSpace(probe.Error) != "" {
+		return false
+	}
+	return probe.StatusCode == 0 || (probe.StatusCode >= 200 && probe.StatusCode < 300)
+}
+
+func supervisorProbeText(probe supervisorProbe) string {
+	status := "unreachable"
+	if probe.Reachable {
+		if probe.StatusCode > 0 {
+			status = fmt.Sprintf("HTTP %d", probe.StatusCode)
+		} else {
+			status = "reachable"
+		}
+	}
+	if strings.TrimSpace(probe.Error) != "" {
+		return status + " error=" + probe.Error
+	}
+	return status
+}
+
+func supervisorFallbackStateText(state supervisorServiceState) string {
+	if state.ContainerFallbackCandidate {
+		return "candidate"
+	}
+	return "clear"
+}
+
+func supervisorRuntimeNeedsAttention(runtime supervisorRuntimeStatus) bool {
+	if runtime.AutoRestartSuppressed {
+		return true
+	}
+	actual := strings.ToUpper(strings.TrimSpace(runtime.ActualStatus))
+	health := strings.ToLower(strings.TrimSpace(runtime.Health))
+	return actual == "ERROR" || health == "error" || health == "suppressed" || health == "unreachable" || health == "stale"
 }

--- a/cmd/bktrader-ctl/supervisor_test.go
+++ b/cmd/bktrader-ctl/supervisor_test.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildSupervisorStatusSummaryShowsFallbackReadiness(t *testing.T) {
+	payload := []byte(`{
+		"checkedAt":"2026-04-29T08:00:00Z",
+		"targets":[{
+			"name":"api",
+			"baseUrl":"http://127.0.0.1:8080",
+			"healthz":{"path":"/healthz","statusCode":503,"reachable":true,"error":"http 503"},
+			"runtimeStatus":{"path":"/api/v1/runtime/status","statusCode":200,"reachable":true},
+			"serviceState":{
+				"consecutiveFailures":3,
+				"failureThreshold":3,
+				"lastFailureReason":"healthz-unhealthy: http 503",
+				"containerFallbackCandidate":true,
+				"containerFallbackReason":"service probes failed 3/3"
+			},
+			"containerFallbackPlan":{
+				"action":"container-restart",
+				"candidate":true,
+				"enabled":true,
+				"executorConfigured":false,
+				"executable":false,
+				"blockedReason":"container-executor-not-configured"
+			},
+			"status":{
+				"service":"platform-api",
+				"runtimes":[{
+					"runtimeId":"signal-1",
+					"runtimeKind":"signal",
+					"desiredStatus":"RUNNING",
+					"actualStatus":"ERROR",
+					"health":"recovering"
+				}]
+			},
+			"controlActions":[{"action":"runtime-restart","runtimeId":"signal-1"}]
+		}]
+	}`)
+
+	summary, err := buildSupervisorStatusSummary(payload)
+	if err != nil {
+		t.Fatalf("build supervisor summary failed: %v", err)
+	}
+	expected := []string{
+		"Runtime supervisor snapshot",
+		"targets: total=1 fullyReachable=0 fallbackCandidates=1 fallbackExecutable=0 runtimes=1 attention=1 controlActions=1",
+		"fallbackPlan: action=container-restart enabled=true executorConfigured=false executable=false blockedReason=container-executor-not-configured",
+		"lastFailure=healthz-unhealthy: http 503",
+	}
+	for _, want := range expected {
+		if !strings.Contains(summary, want) {
+			t.Fatalf("expected summary to contain %q, got:\n%s", want, summary)
+		}
+	}
+}
+
+func TestBuildSupervisorStatusSummaryHandlesClearTarget(t *testing.T) {
+	payload := []byte(`{
+		"checkedAt":"2026-04-29T08:00:00Z",
+		"targets":[{
+			"name":"api",
+			"baseUrl":"http://127.0.0.1:8080",
+			"healthz":{"path":"/healthz","statusCode":200,"reachable":true},
+			"runtimeStatus":{"path":"/api/v1/runtime/status","statusCode":200,"reachable":true},
+			"serviceState":{"consecutiveFailures":0,"failureThreshold":3,"containerFallbackCandidate":false},
+			"status":{"service":"platform-api","runtimes":[]}
+		}]
+	}`)
+
+	summary, err := buildSupervisorStatusSummary(payload)
+	if err != nil {
+		t.Fatalf("build supervisor summary failed: %v", err)
+	}
+	expected := []string{
+		"targets: total=1 fullyReachable=1 fallbackCandidates=0 fallbackExecutable=0 runtimes=0 attention=0 controlActions=0",
+		"serviceState: failures=0/3 fallback=clear",
+		"runtimes: total=0 attention=0 service=platform-api",
+	}
+	for _, want := range expected {
+		if !strings.Contains(summary, want) {
+			t.Fatalf("expected summary to contain %q, got:\n%s", want, summary)
+		}
+	}
+	if strings.Contains(summary, "fallbackPlan:") {
+		t.Fatalf("did not expect fallback plan for clear target, got:\n%s", summary)
+	}
+}

--- a/docs/runtime-supervisor.md
+++ b/docs/runtime-supervisor.md
@@ -323,7 +323,7 @@ func ClearRestartState(state map[string]any, keys []string)
 - `SUPERVISOR_CONTAINER_RESTART_ENABLED=false` 为默认值；未显式设为 `true` 时，容器兜底计划只会返回 `blockedReason=container-restart-disabled`，不会进入 executor 阶段。
 - 默认只采集 `/healthz` 和 `/api/v1/runtime/status`，不调用任何控制 API。
 - `GET /api/v1/supervisor/status` 返回最近一次 read-only supervisor 采集快照。
-- `bktrader-ctl runtime status --json` 和 `bktrader-ctl supervisor status --json` 提供 CLI 只读巡检入口。
+- `bktrader-ctl runtime status --json` 和 `bktrader-ctl supervisor status --json` 提供 CLI 只读巡检入口；`bktrader-ctl supervisor status` 的人类可读输出会汇总 target reachability、runtime attention、control action 数量，以及 container fallback 的 `enabled` / `executorConfigured` / `executable` readiness。
 - `SUPERVISOR_APPLICATION_RESTART_ENABLED=false` 为默认值；只有显式设为 `true` 时，supervisor 才会对满足全部条件的 signal runtime 提交应用内 `POST /api/v1/runtime/restart`：
   - 目标服务 `/healthz` 可达且成功。
   - `/api/v1/runtime/status` 可读。


### PR DESCRIPTION
## 目的
继续推进 #270 的只读可观测面：`bktrader-ctl supervisor status` 在非 `--json` 模式下输出巡检摘要，直接显示 target reachability、runtime attention、control action 数量，以及 container fallback 的 `enabled` / `executorConfigured` / `executable` readiness。

`--json` 路径保持原样，仍直接返回 `/api/v1/supervisor/status` 的结构化响应，方便 LLM/脚本读取。

本 PR 不做容器 executor，不调用 Docker API，不修改 deployments，不改变任何自动恢复默认值。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [x] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值无变化。
- [x] 不存在直接调用 `mainnet` 凭证或路由地址的硬编码。
- [x] 无 DB migration。
- [x] 未新增或修改配置字段。
- [x] 未调用 Docker API，未挂载 Docker socket，未修改 deployments，未执行容器 restart。

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

本地验证：
- `go test ./cmd/bktrader-ctl`
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
- `go build ./cmd/bktrader-ctl`
- `git diff --check`
