### PR TITLE
[codex] Expose supervisor policy snapshot

### DIFF
--- a/cmd/bktrader-ctl/supervisor.go
+++ b/cmd/bktrader-ctl/supervisor.go
@@ -32,7 +32,15 @@ var supervisorStatusCmd = &cobra.Command{
 
 type supervisorStatusSnapshot struct {
 	CheckedAt string                     `json:"checkedAt"`
+	Policy    *supervisorPolicy          `json:"policy,omitempty"`
 	Targets   []supervisorTargetSnapshot `json:"targets"`
+}
+
+type supervisorPolicy struct {
+	ApplicationRestartEnabled   bool `json:"applicationRestartEnabled"`
+	ServiceFailureThreshold     int  `json:"serviceFailureThreshold"`
+	ContainerRestartEnabled     bool `json:"containerRestartEnabled"`
+	ContainerExecutorConfigured bool `json:"containerExecutorConfigured"`
 }
 
 type supervisorTargetSnapshot struct {
@@ -142,6 +150,14 @@ func buildSupervisorStatusSummary(data []byte) (string, error) {
 	var out bytes.Buffer
 	fmt.Fprintln(&out, "Runtime supervisor snapshot")
 	fmt.Fprintf(&out, "checkedAt: %s\n", firstNonEmpty(snapshot.CheckedAt, "--"))
+	if snapshot.Policy != nil {
+		fmt.Fprintf(&out, "policy: applicationRestartEnabled=%t serviceFailureThreshold=%d containerRestartEnabled=%t containerExecutorConfigured=%t\n",
+			snapshot.Policy.ApplicationRestartEnabled,
+			snapshot.Policy.ServiceFailureThreshold,
+			snapshot.Policy.ContainerRestartEnabled,
+			snapshot.Policy.ContainerExecutorConfigured,
+		)
+	}
 	fmt.Fprintf(&out, "targets: total=%d fullyReachable=%d fallbackCandidates=%d fallbackExecutable=%d runtimes=%d attention=%d controlActions=%d\n",
 		targets, fullyReachable, fallbackCandidates, fallbackExecutable, runtimeCount, runtimeAttention, controlActions)
 	for _, target := range snapshot.Targets {

--- a/cmd/bktrader-ctl/supervisor_test.go
+++ b/cmd/bktrader-ctl/supervisor_test.go
@@ -8,6 +8,12 @@ import (
 func TestBuildSupervisorStatusSummaryShowsFallbackReadiness(t *testing.T) {
 	payload := []byte(`{
 		"checkedAt":"2026-04-29T08:00:00Z",
+		"policy":{
+			"applicationRestartEnabled":true,
+			"serviceFailureThreshold":3,
+			"containerRestartEnabled":true,
+			"containerExecutorConfigured":false
+		},
 		"targets":[{
 			"name":"api",
 			"baseUrl":"http://127.0.0.1:8080",
@@ -48,6 +54,7 @@ func TestBuildSupervisorStatusSummaryShowsFallbackReadiness(t *testing.T) {
 	}
 	expected := []string{
 		"Runtime supervisor snapshot",
+		"policy: applicationRestartEnabled=true serviceFailureThreshold=3 containerRestartEnabled=true containerExecutorConfigured=false",
 		"targets: total=1 fullyReachable=0 fallbackCandidates=1 fallbackExecutable=0 runtimes=1 attention=1 controlActions=1",
 		"fallbackPlan: action=container-restart enabled=true executorConfigured=false executable=false blockedReason=container-executor-not-configured",
 		"lastFailure=healthz-unhealthy: http 503",
@@ -62,6 +69,12 @@ func TestBuildSupervisorStatusSummaryShowsFallbackReadiness(t *testing.T) {
 func TestBuildSupervisorStatusSummaryHandlesClearTarget(t *testing.T) {
 	payload := []byte(`{
 		"checkedAt":"2026-04-29T08:00:00Z",
+		"policy":{
+			"applicationRestartEnabled":false,
+			"serviceFailureThreshold":3,
+			"containerRestartEnabled":false,
+			"containerExecutorConfigured":false
+		},
 		"targets":[{
 			"name":"api",
 			"baseUrl":"http://127.0.0.1:8080",
@@ -77,6 +90,7 @@ func TestBuildSupervisorStatusSummaryHandlesClearTarget(t *testing.T) {
 		t.Fatalf("build supervisor summary failed: %v", err)
 	}
 	expected := []string{
+		"policy: applicationRestartEnabled=false serviceFailureThreshold=3 containerRestartEnabled=false containerExecutorConfigured=false",
 		"targets: total=1 fullyReachable=1 fallbackCandidates=0 fallbackExecutable=0 runtimes=0 attention=0 controlActions=0",
 		"serviceState: failures=0/3 fallback=clear",
 		"runtimes: total=0 attention=0 service=platform-api",

--- a/docs/runtime-supervisor.md
+++ b/docs/runtime-supervisor.md
@@ -322,8 +322,8 @@ func ClearRestartState(state map[string]any, keys []string)
 - `SUPERVISOR_SERVICE_FAILURE_THRESHOLD=3` 为默认值；supervisor 会按 target 记录连续服务级失败次数，并在达到阈值后把该 target 标记为容器兜底候选，但当前阶段只暴露状态，不执行 Docker/container restart。
 - `SUPERVISOR_CONTAINER_RESTART_ENABLED=false` 为默认值；未显式设为 `true` 时，容器兜底计划只会返回 `blockedReason=container-restart-disabled`，不会进入 executor 阶段。
 - 默认只采集 `/healthz` 和 `/api/v1/runtime/status`，不调用任何控制 API。
-- `GET /api/v1/supervisor/status` 返回最近一次 read-only supervisor 采集快照。
-- `bktrader-ctl runtime status --json` 和 `bktrader-ctl supervisor status --json` 提供 CLI 只读巡检入口；`bktrader-ctl supervisor status` 的人类可读输出会汇总 target reachability、runtime attention、control action 数量，以及 container fallback 的 `enabled` / `executorConfigured` / `executable` readiness。
+- `GET /api/v1/supervisor/status` 返回最近一次 read-only supervisor 采集快照，并在顶层 `policy` 中暴露 `applicationRestartEnabled`、`serviceFailureThreshold`、`containerRestartEnabled`、`containerExecutorConfigured`。这些字段只反映当前 supervisor policy，不代表已执行或允许执行容器 restart。
+- `bktrader-ctl runtime status --json` 和 `bktrader-ctl supervisor status --json` 提供 CLI 只读巡检入口；`bktrader-ctl supervisor status` 的人类可读输出会汇总 policy、target reachability、runtime attention、control action 数量，以及 container fallback 的 `enabled` / `executorConfigured` / `executable` readiness。
 - `SUPERVISOR_APPLICATION_RESTART_ENABLED=false` 为默认值；只有显式设为 `true` 时，supervisor 才会对满足全部条件的 signal runtime 提交应用内 `POST /api/v1/runtime/restart`：
   - 目标服务 `/healthz` 可达且成功。
   - `/api/v1/runtime/status` 可读。

--- a/internal/service/runtime_supervisor.go
+++ b/internal/service/runtime_supervisor.go
@@ -53,7 +53,15 @@ type RuntimeSupervisorTargetSnapshot struct {
 
 type RuntimeSupervisorSnapshot struct {
 	CheckedAt time.Time                         `json:"checkedAt"`
+	Policy    RuntimeSupervisorPolicy           `json:"policy"`
 	Targets   []RuntimeSupervisorTargetSnapshot `json:"targets"`
+}
+
+type RuntimeSupervisorPolicy struct {
+	ApplicationRestartEnabled   bool `json:"applicationRestartEnabled"`
+	ServiceFailureThreshold     int  `json:"serviceFailureThreshold"`
+	ContainerRestartEnabled     bool `json:"containerRestartEnabled"`
+	ContainerExecutorConfigured bool `json:"containerExecutorConfigured"`
 }
 
 type RuntimeSupervisorControlAction struct {
@@ -196,6 +204,7 @@ func (s *RuntimeSupervisor) Collect(ctx context.Context) RuntimeSupervisorSnapsh
 	now := time.Now().UTC()
 	snapshot := RuntimeSupervisorSnapshot{
 		CheckedAt: now,
+		Policy:    runtimeSupervisorPolicy(s.options),
 		Targets:   make([]RuntimeSupervisorTargetSnapshot, 0, len(s.targets)),
 	}
 	for _, target := range s.targets {
@@ -369,7 +378,7 @@ func runtimeSupervisorContainerFallbackPlan(state RuntimeSupervisorServiceState,
 	if !state.ContainerFallbackCandidate {
 		return nil
 	}
-	executorConfigured := false
+	executorConfigured := runtimeSupervisorContainerExecutorConfigured()
 	executable := options.EnableContainerFallback && executorConfigured
 	blockedReason := ""
 	if !options.EnableContainerFallback {
@@ -386,6 +395,20 @@ func runtimeSupervisorContainerFallbackPlan(state RuntimeSupervisorServiceState,
 		BlockedReason:      blockedReason,
 		Reason:             state.ContainerFallbackReason,
 	}
+}
+
+func runtimeSupervisorPolicy(options RuntimeSupervisorOptions) RuntimeSupervisorPolicy {
+	options = normalizeRuntimeSupervisorOptions(options)
+	return RuntimeSupervisorPolicy{
+		ApplicationRestartEnabled:   options.EnableApplicationRestart,
+		ServiceFailureThreshold:     options.ServiceFailureThreshold,
+		ContainerRestartEnabled:     options.EnableContainerFallback,
+		ContainerExecutorConfigured: runtimeSupervisorContainerExecutorConfigured(),
+	}
+}
+
+func runtimeSupervisorContainerExecutorConfigured() bool {
+	return false
 }
 
 func runtimeSupervisorServiceKey(target RuntimeSupervisorTarget) string {

--- a/internal/service/runtime_supervisor_test.go
+++ b/internal/service/runtime_supervisor_test.go
@@ -45,6 +45,12 @@ func TestRuntimeSupervisorCollectsHealthAndRuntimeStatus(t *testing.T) {
 		BaseURL: server.URL + "/",
 	}}, server.Client())
 	snapshot := supervisor.Collect(context.Background())
+	if snapshot.Policy.ApplicationRestartEnabled || snapshot.Policy.ContainerRestartEnabled || snapshot.Policy.ContainerExecutorConfigured {
+		t.Fatalf("expected default supervisor policy to stay read-only, got %+v", snapshot.Policy)
+	}
+	if snapshot.Policy.ServiceFailureThreshold != defaultRuntimeSupervisorServiceFailThresh {
+		t.Fatalf("expected default service failure threshold %d, got %+v", defaultRuntimeSupervisorServiceFailThresh, snapshot.Policy)
+	}
 	if len(snapshot.Targets) != 1 {
 		t.Fatalf("expected one target snapshot, got %#v", snapshot.Targets)
 	}
@@ -69,6 +75,47 @@ func TestRuntimeSupervisorCollectsHealthAndRuntimeStatus(t *testing.T) {
 	}
 	if requested["GET /healthz"] != 1 || requested["GET /api/v1/runtime/status"] != 1 {
 		t.Fatalf("expected one GET per read-only endpoint, got %#v", requested)
+	}
+}
+
+func TestRuntimeSupervisorSnapshotReportsPolicyWithoutFallbackCandidate(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/healthz":
+			writeRuntimeSupervisorTestJSON(t, w, map[string]any{"status": "ok"})
+		case "/api/v1/runtime/status":
+			writeRuntimeSupervisorTestJSON(t, w, RuntimeStatusSnapshot{Service: "platform-api"})
+		case "/api/v1/runtime/restart":
+			t.Errorf("policy reporting must not call control path %s", r.URL.Path)
+			w.WriteHeader(http.StatusForbidden)
+		default:
+			t.Errorf("unexpected request path %s", r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	supervisor := NewRuntimeSupervisorWithOptions(
+		[]RuntimeSupervisorTarget{{Name: "api", BaseURL: server.URL}},
+		server.Client(),
+		RuntimeSupervisorOptions{
+			EnableApplicationRestart: true,
+			ServiceFailureThreshold:  4,
+			EnableContainerFallback:  true,
+		},
+	)
+	snapshot := supervisor.Collect(context.Background())
+	if !snapshot.Policy.ApplicationRestartEnabled || !snapshot.Policy.ContainerRestartEnabled {
+		t.Fatalf("expected policy to expose enabled restart settings, got %+v", snapshot.Policy)
+	}
+	if snapshot.Policy.ContainerExecutorConfigured {
+		t.Fatalf("expected policy to expose missing container executor, got %+v", snapshot.Policy)
+	}
+	if snapshot.Policy.ServiceFailureThreshold != 4 {
+		t.Fatalf("expected service failure threshold 4, got %+v", snapshot.Policy)
+	}
+	if len(snapshot.Targets) != 1 || snapshot.Targets[0].ContainerFallbackPlan != nil {
+		t.Fatalf("expected policy without fallback candidate plan, got %+v", snapshot.Targets)
 	}
 }
 

--- a/web/console/src/types/domain.ts
+++ b/web/console/src/types/domain.ts
@@ -431,6 +431,13 @@ export type RuntimeSupervisorControlAction = {
   requestedAt: string;
 };
 
+export type RuntimeSupervisorPolicy = {
+  applicationRestartEnabled: boolean;
+  serviceFailureThreshold: number;
+  containerRestartEnabled: boolean;
+  containerExecutorConfigured: boolean;
+};
+
 export type RuntimeSupervisorTargetSnapshot = {
   name: string;
   baseUrl: string;
@@ -445,6 +452,7 @@ export type RuntimeSupervisorTargetSnapshot = {
 
 export type RuntimeSupervisorSnapshot = {
   checkedAt: string;
+  policy: RuntimeSupervisorPolicy;
   targets: RuntimeSupervisorTargetSnapshot[];
 };
 


### PR DESCRIPTION
## 目的
继续推进 #270 的 supervisor/control-plane 可观测面：`GET /api/v1/supervisor/status` 顶层新增只读 `policy`，暴露当前 supervisor 的策略开关和 executor readiness。

新增字段：
- `applicationRestartEnabled`
- `serviceFailureThreshold`
- `containerRestartEnabled`
- `containerExecutorConfigured`

同时：
- `bktrader-ctl supervisor status` 的人类可读摘要会展示 policy。
- 前端 `RuntimeSupervisorSnapshot` 类型对齐新 schema。
- 文档说明 policy 只反映当前配置/能力，不代表已执行或允许执行容器 restart。

本 PR 不新增配置、不修改默认值、不实现 Docker/container executor、不调用 Docker API、不改 deployments。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [x] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值无变化。
- [x] 不存在直接调用 `mainnet` 凭证或路由地址的硬编码。
- [x] 无 DB migration。
- [x] 未新增或修改配置字段。
- [x] 未调用 Docker API，未挂载 Docker socket，未修改 deployments，未执行容器 restart。

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

本地验证：
- `go test ./internal/service`
- `go test ./cmd/bktrader-ctl`
- `cd web/console && ./node_modules/.bin/tsc --noEmit src/pages/SupervisorStage.tsx --jsx react-jsx --esModuleInterop --target esnext --module esnext --moduleResolution Bundler --allowSyntheticDefaultImports`
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
- `go build ./cmd/bktrader-ctl`
- `cd web/console && npm run build`
- `git diff --check`
