### PR TITLE
[codex] Add BTC enhanced reentry volatility gates

### DIFF
--- a/db/migrations/026_btc_30m_enhanced_strategy.sql
+++ b/db/migrations/026_btc_30m_enhanced_strategy.sql
@@ -36,6 +36,8 @@ values (
         "breakout_shape": "baseline_plus_t3",
         "t3_min_sma_atr_separation": 0.25,
         "use_sma5_intraday_structure": true,
+        "reentry_min_stop_bps": 6.0,
+        "reentry_atr_percentile_gte": 25.0,
         "stop_mode": "atr",
         "stop_loss_atr": 0.3,
         "profit_protect_atr": 1.0,

--- a/db/migrations/028_btc_30m_enhanced_low_vol_entry_gates.sql
+++ b/db/migrations/028_btc_30m_enhanced_low_vol_entry_gates.sql
@@ -1,0 +1,22 @@
+update strategy_versions
+set parameters = jsonb_set(
+    jsonb_set(parameters, '{reentry_min_stop_bps}', '6.0'::jsonb, true),
+    '{reentry_atr_percentile_gte}',
+    '25.0'::jsonb,
+    true
+)
+where id = 'strategy-version-bk-btc-30m-enhanced-v010'
+  and strategy_id = 'strategy-bk-btc-30m-enhanced';
+
+update live_sessions
+set state = jsonb_set(
+    jsonb_set(state, '{reentry_min_stop_bps}', '6.0'::jsonb, true),
+    '{reentry_atr_percentile_gte}',
+    '25.0'::jsonb,
+    true
+)
+where strategy_id = 'strategy-bk-btc-30m-enhanced'
+  and (
+    state->>'launchTemplateKey' = 'binance-testnet-btc-30m-enhanced'
+    or state->>'strategyEngine' = 'bk-live-intrabar-sma5-t3-sep'
+  );

--- a/docs/30m-enhanced-filter-research.md
+++ b/docs/30m-enhanced-filter-research.md
@@ -150,6 +150,39 @@ Read:
 - `stop_loss_atr=0.3` is reasonable for ETH 30m in Q1 and had the best return in this sweep.
 - If ETH 30m moves from `stop_loss_atr=0.05` to `0.3`, the bps gate must be recalibrated. The current `reentry_min_stop_bps=2.0` recommendation is tied to the `0.05` stop profile.
 
+## Follow-up: Unified Entry Quality Report
+
+The current BTC live template wires the low-volatility checks into the reentry entry path only. A follow-up PR should consolidate entry eligibility checks into one report schema instead of adding more isolated conditionals over time.
+
+Suggested gate result shape:
+
+```go
+type EntryQualityGateResult struct {
+	Name       string         `json:"name"`
+	Applied    bool           `json:"applied"`
+	Ready      bool           `json:"ready"`
+	Reason     string         `json:"reason,omitempty"`
+	Metrics    map[string]any `json:"metrics,omitempty"`
+	Thresholds map[string]any `json:"thresholds,omitempty"`
+}
+
+type EntryQualityReport struct {
+	Ready       bool                     `json:"ready"`
+	Reason      string                   `json:"reason,omitempty"`
+	GateResults []EntryQualityGateResult `json:"gates"`
+}
+```
+
+Candidate gates to migrate into this report:
+
+- signal bar readiness: SMA5, breakout shape, T3 separation.
+- reentry trigger readiness: planned price versus trigger price.
+- low-volatility reentry quality: stop-distance bps and ATR percentile.
+- execution quality: spread, source divergence, book bias, book freshness, top-book coverage.
+- delay controls: SL reentry cooldown.
+
+The report should explicitly carry scope such as `entry-only`, `reentry-only`, or `exit-never` so protective SL exits cannot be blocked by entry-quality filters.
+
 ## Source Reports
 
 - `research/20260429_btc_q1_30min_low_vol_entry_filters.md`

--- a/docs/30m-enhanced-filter-research.md
+++ b/docs/30m-enhanced-filter-research.md
@@ -1,0 +1,160 @@
+# BTC/ETH 30m Enhanced Filter Notes
+
+This document records the live BTCUSDT 30m enhanced template filters and the
+Q1 2026 research runs used to choose the current low-volatility reentry gate.
+
+## Live BTCUSDT 30m Enhanced Template
+
+Template key: `binance-testnet-btc-30m-enhanced`
+
+Strategy/version:
+
+- `strategy-bk-btc-30m-enhanced`
+- `strategyEngine=bk-live-intrabar-sma5-t3-sep`
+- `signalTimeframe=30m`
+- `executionDataSource=tick`
+
+Sizing/risk baseline:
+
+- `dir2_zero_initial=true`
+- `zero_initial_mode=reentry_window`
+- `reentry_size_schedule=[0.20, 0.10]`
+- `max_trades_per_bar=2`
+- `stop_mode=atr`
+- `stop_loss_atr=0.3`
+- `profit_protect_atr=1.0`
+- `trailing_stop_atr=0.3`
+- `delayed_trailing_activation_atr=0.5`
+- `long_reentry_atr=0.1`
+- `short_reentry_atr=0.0`
+
+Signal filters:
+
+- `use_sma5_intraday_structure=true`: intraday entries use the current 30m bar close vs SMA5 as the hard structure filter. Long entries need close above SMA5; short entries need close below SMA5.
+- `breakout_shape=baseline_plus_t3`: the original T2 breakout remains enabled, and the T3 swing breakout is added.
+- `t3_min_sma_atr_separation=0.25`: T3 swing breakout must be at least `0.25 * ATR14` away from SMA5. This filter applies to `t3_swing` only; it does not block `original_t2`.
+- `reentry_min_stop_bps=6.0`: reentry entries require `stop_loss_atr * ATR14 / reentry_price * 10000 >= 6`.
+- `reentry_atr_percentile_gte=25.0`: reentry entries require the current ATR14 percentile to be at least 25 over the rolling ATR sample.
+
+Reentry-specific behavior:
+
+- The low-volatility gate applies only to reentry entries: `Zero-Initial-Reentry`, `SL-Reentry`, and `PT-Reentry`.
+- It does not filter stop-loss exits. SL remains a hard risk boundary.
+- Live ATR percentile is derived from signal-bar history with the research-compatible rule: ATR14 rolling mean, then percentile rank of the latest ATR over a 240-bar window with at least 50 valid ATR values. Runtime signal-bar history keeps 260 bars so the 240-bar percentile can be computed after ATR warmup.
+
+Execution and liquidity filters:
+
+- Entry planning uses `book-aware-v1`.
+- Entry max spread/slippage/source divergence are capped at 8 bps.
+- Entry order book must be fresh within 500 ms and have top-book coverage at least 0.5.
+- Wide entry spread mode is `limit-maker`, with 15s resting timeout and MARKET fallback.
+- PT exit is post-only LIMIT/GTX with MARKET fallback.
+- SL exit remains MARKET, with max spread/slippage caps of 8 bps.
+- Live signal decision also gates entries on actionable price, order-book spread, and liquidity bias. For SL reentry, neutral book bias is not considered actionable.
+- `sl_reentry_min_delay_seconds=60` blocks immediate SL reentry churn for the enhanced template.
+
+## BTCUSDT Q1 2026 30m Results
+
+Replay setup:
+
+- Full Binance trade archive, continuous 1s execution bars
+- Signal timeframe `30m`
+- Replay mode `live_intrabar_sma5`
+- `breakout_shape=baseline_plus_t3`
+- `t3_min_sma_atr_separation=0.25`
+- BTC live-like risk profile: `stop_loss_atr=0.3`, `trailing_stop_atr=0.3`, `delayed_trailing_activation=0.5`
+
+Low-volatility reentry gate sweep:
+
+| Variant | Return | Max DD | Trades | Win Rate | Sharpe | Delta vs Baseline |
+|---|---:|---:|---:|---:|---:|---:|
+| `baseline` | 127.45% | -3.03% | 3177 | 76.46% | 13.23 | 0.00 pp |
+| `min_stop_bps_6` | 140.32% | -1.27% | 2967 | 80.49% | 13.91 | +12.87 pp |
+| `min_stop_bps_8` | 151.38% | -0.66% | 2748 | 83.08% | 14.56 | +23.93 pp |
+| `atr_pct_gte_25` | 137.25% | -1.27% | 2334 | 82.73% | 14.47 | +9.80 pp |
+| `atr_pct_gte_35` | 127.15% | -1.13% | 2017 | 84.04% | 14.74 | -0.30 pp |
+| `min_stop_bps_6 + atr_pct_gte_25` | 138.08% | -1.27% | 2318 | 83.09% | 14.54 | +10.63 pp |
+| `min_stop_bps_6 + atr_pct_gte_35` | 127.15% | -1.13% | 2017 | 84.04% | 14.74 | -0.30 pp |
+
+Read:
+
+- `min_stop_bps_8` had the best raw Q1 return and drawdown in this sweep.
+- `min_stop_bps_6 + atr_pct_gte_25` is more conservative and combines an absolute stop-distance check with a relative volatility-regime check. It is the parameter set currently wired into the live BTC 30m enhanced template.
+- `atr_pct_gte_35` overfilters BTC Q1. Combining it with `min_stop_bps_6` produced the same headline metrics as `atr_pct_gte_35` alone.
+
+Breakout confirmation sweep:
+
+| Variant | Return | Max DD | Trades | Win Rate | Sharpe |
+|---|---:|---:|---:|---:|---:|
+| `baseline_single_observation` | 127.45% | -3.03% | 3177 | 76.46% | 13.23 |
+| `margin_0p02atr` | 127.79% | -2.89% | 3111 | 76.73% | 13.36 |
+| `confirm_2x_1s` | 126.80% | -2.85% | 3126 | 76.52% | 13.22 |
+| `confirm_3x_1s` | 127.61% | -2.86% | 3079 | 76.78% | 13.30 |
+
+Read:
+
+- Multi-tick confirmation is not the primary recommendation for BTC 30m. It reduces some trades, but the return improvement is weak or negative.
+- The low-volatility reentry gate better targets the observed issue: entries with very thin ATR-derived stop distance.
+
+## ETHUSDT 30m Recommendation
+
+The ETH low-volatility gate was evaluated on the ETH research baseline:
+
+- `stop_loss_atr=0.05`
+- `trailing_stop_atr=0.3`
+- `delayed_trailing_activation=0.5`
+- `breakout_shape=baseline_plus_t3`
+- `t3_min_sma_atr_separation=0.25`
+
+ETH stop-distance distribution under `stop_loss_atr=0.05`:
+
+| Count | Min | P05 | P10 | P25 | P50 | P75 | P90 | P95 | Max |
+|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| 4307 | 0.6144 | 1.2044 | 1.5776 | 2.3642 | 3.4132 | 4.6035 | 5.9251 | 7.2042 | 15.9955 |
+
+ETH low-volatility reentry gate sweep:
+
+| Variant | Return | Max DD | Trades | Win Rate | Sharpe | Delta vs Baseline |
+|---|---:|---:|---:|---:|---:|---:|
+| `baseline` | 436.11% | -2.04% | 3226 | 80.60% | 13.49 | 0.00 pp |
+| `min_stop_bps_2` | 477.67% | -0.38% | 2622 | 86.84% | 15.18 | +41.56 pp |
+| `min_stop_bps_4` | 288.53% | -0.21% | 1185 | 91.39% | 17.71 | -147.58 pp |
+| `min_stop_bps_6` | 92.49% | -0.17% | 307 | 92.83% | 18.79 | -343.62 pp |
+| `min_stop_bps_8` | 41.72% | -0.17% | 133 | 90.23% | 18.49 | -394.39 pp |
+| `atr_pct_gte_25` | 386.72% | -0.34% | 2297 | 85.46% | 14.66 | -49.39 pp |
+| `min_stop_bps_4 + atr_pct_gte_25` | 264.45% | -0.21% | 1101 | 91.37% | 17.55 | -171.66 pp |
+
+Recommended ETH 30m filter parameters for the current ETH research profile:
+
+- `reentry_min_stop_bps=2.0`
+- `reentry_atr_percentile_gte=0` or unset
+
+Read:
+
+- ETH should not inherit BTC's 6 or 8 bps threshold under `stop_loss_atr=0.05`; both overfilter.
+- `min_stop_bps_2` is the strongest ETH Q1 candidate in this profile.
+- ATR percentile is useful as a defensive risk-off overlay but reduced return in Q1.
+
+ETH stop-loss ATR sweep:
+
+| stop_loss_atr | Return | Max DD | Trades | Win Rate | Sharpe |
+|---:|---:|---:|---:|---:|---:|
+| 0.05 | 436.11% | -2.04% | 3226 | 80.60% | 13.49 |
+| 0.10 | 434.50% | -2.12% | 3259 | 80.95% | 13.40 |
+| 0.20 | 437.39% | -2.01% | 3229 | 82.41% | 13.40 |
+| 0.30 | 451.20% | -1.86% | 3190 | 84.23% | 13.61 |
+| 0.40 | 441.23% | -1.63% | 3136 | 85.36% | 13.72 |
+
+Read:
+
+- `stop_loss_atr=0.3` is reasonable for ETH 30m in Q1 and had the best return in this sweep.
+- If ETH 30m moves from `stop_loss_atr=0.05` to `0.3`, the bps gate must be recalibrated. The current `reentry_min_stop_bps=2.0` recommendation is tied to the `0.05` stop profile.
+
+## Source Reports
+
+- `research/20260429_btc_q1_30min_low_vol_entry_filters.md`
+- `research/20260429_btc_q1_30min_low_vol_entry_filters_combo35.md`
+- `research/20260429_btc_q1_30min_breakout_confirmation_filters.md`
+- `research/20260429_eth_q1_30min_low_vol_entry_filters.md`
+- `research/20260429_eth_q1_30min_stop_loss_atr_sweep.md`
+- `research/20260427_eth_q1_30min_t3_sma5_sep_0p25_marginal.md`

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,6 +49,7 @@
 
 ### 投研
 - [量化交易与CTA扩展说明.md](量化交易与CTA扩展说明.md) — 量化交易扩展说明
+- [30m-enhanced-filter-research.md](30m-enhanced-filter-research.md) — BTC/ETH 30m enhanced 过滤器、模板参数与 Q1 2026 回测结论
 
 ---
 

--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -5326,6 +5326,8 @@ func (p *Platform) resolveLiveSessionParameters(session domain.LiveSession, vers
 		"breakout_shape",
 		"t3_min_sma_atr_separation",
 		"use_sma5_intraday_structure",
+		"reentry_min_stop_bps",
+		"reentry_atr_percentile_gte",
 	}
 	sessionParameterKeys = append(sessionParameterKeys, liveExecutionParameterOverrideKeys()...)
 	for _, key := range sessionParameterKeys {
@@ -5560,6 +5562,7 @@ func deriveLiveSignalIntent(decision StrategySignalDecision, symbol string) *Sig
 	spreadBps := parseFloatValue(meta["spreadBps"])
 	ma20 := parseFloatValue(signalBarDecision["ma20"])
 	atr14 := parseFloatValue(signalBarDecision["atr14"])
+	atrPercentile := parseFloatValue(signalBarDecision["atrPercentile"])
 	liquidityBias := stringValue(meta["liquidityBias"])
 	biasActionable := boolValue(meta["biasActionable"])
 	bestBid := parseFloatValue(meta["bestBid"])
@@ -5595,6 +5598,7 @@ func deriveLiveSignalIntent(decision StrategySignalDecision, symbol string) *Sig
 			"spreadBps":                     spreadBps,
 			"ma20":                          ma20,
 			"atr14":                         atr14,
+			"atrPercentile":                 atrPercentile,
 			"liquidityBias":                 liquidityBias,
 			"biasActionable":                biasActionable,
 			"bestBid":                       bestBid,
@@ -5850,6 +5854,12 @@ func normalizeLiveSessionOverrides(overrides map[string]any) map[string]any {
 	}
 	if _, ok := overrides["use_sma5_intraday_structure"]; ok {
 		normalized["use_sma5_intraday_structure"] = boolValue(overrides["use_sma5_intraday_structure"])
+	}
+	if minStopBps := parseFloatValue(overrides["reentry_min_stop_bps"]); minStopBps > 0 {
+		normalized["reentry_min_stop_bps"] = minStopBps
+	}
+	if atrPercentileGTE := parseFloatValue(overrides["reentry_atr_percentile_gte"]); atrPercentileGTE > 0 {
+		normalized["reentry_atr_percentile_gte"] = atrPercentileGTE
 	}
 	return normalized
 }

--- a/internal/service/live_launch_flow_template_test.go
+++ b/internal/service/live_launch_flow_template_test.go
@@ -244,6 +244,12 @@ func TestLaunchLiveFlowEnhancedTemplateUsesEnhancedStrategyAndEngine(t *testing.
 	if got := maxIntValue(result.LiveSession.State["sl_reentry_min_delay_seconds"], 0); got != 60 {
 		t.Fatalf("expected enhanced live session SL-Reentry delay 60s, got %d", got)
 	}
+	if got := parseFloatValue(result.LiveSession.State["reentry_min_stop_bps"]); got != 6.0 {
+		t.Fatalf("expected enhanced live session reentry_min_stop_bps=6, got %v", got)
+	}
+	if got := parseFloatValue(result.LiveSession.State["reentry_atr_percentile_gte"]); got != 25.0 {
+		t.Fatalf("expected enhanced live session reentry_atr_percentile_gte=25, got %v", got)
+	}
 
 	bindings, err := platform.ListStrategySignalBindings("strategy-bk-btc-30m-enhanced")
 	if err != nil {

--- a/internal/service/live_launch_templates.go
+++ b/internal/service/live_launch_templates.go
@@ -203,6 +203,7 @@ func (p *Platform) LiveLaunchTemplates() ([]LiveLaunchTemplate, error) {
 		item.Notes = append([]string{
 			fmt.Sprintf("增强模板单独使用 %s（strategyEngine=%s），不改变原 BTCUSDT 30m 模板。", enhancedStrategyName, "bk-live-intrabar-sma5-t3-sep"),
 			"策略口径对齐 research `live_intrabar_sma5_baseline_plus_t3_breakout+sep_0p25`：SMA5 intrabar hard filter + original_t2/t3_swing breakout，其中 sep_0p25 只过滤 t3_swing。",
+			"低波动 reentry gate 固化为 reentry_min_stop_bps=6 与 reentry_atr_percentile_gte=25，仅过滤 Zero-Initial/SL/PT reentry 开仓，不过滤止损出场。",
 			"模板仍保持 dispatchMode 由前端提交前选择，默认展示为 manual-review。",
 		}, item.Notes...)
 		return item
@@ -275,6 +276,8 @@ func liveBTC30mEnhancedOverrides() map[string]any {
 	overrides["breakout_shape"] = "baseline_plus_t3"
 	overrides["t3_min_sma_atr_separation"] = 0.25
 	overrides["use_sma5_intraday_structure"] = true
+	overrides["reentry_min_stop_bps"] = 6.0
+	overrides["reentry_atr_percentile_gte"] = 25.0
 	return overrides
 }
 

--- a/internal/service/live_launch_templates_test.go
+++ b/internal/service/live_launch_templates_test.go
@@ -198,6 +198,12 @@ func TestLiveLaunchTemplatesExposeBinanceTestnetVariants(t *testing.T) {
 				if got := maxIntValue(item.LaunchPayload.LiveSessionOverrides["sl_reentry_min_delay_seconds"], 0); got != 60 {
 					t.Fatalf("expected enhanced template SL-Reentry delay 60s, got %d", got)
 				}
+				if got := parseFloatValue(item.LaunchPayload.LiveSessionOverrides["reentry_min_stop_bps"]); got != 6.0 {
+					t.Fatalf("expected enhanced template reentry_min_stop_bps=6, got %v", got)
+				}
+				if got := parseFloatValue(item.LaunchPayload.LiveSessionOverrides["reentry_atr_percentile_gte"]); got != 25.0 {
+					t.Fatalf("expected enhanced template reentry_atr_percentile_gte=25, got %v", got)
+				}
 				if !boolValue(item.LaunchPayload.LiveSessionOverrides["use_sma5_intraday_structure"]) {
 					t.Fatalf("expected enhanced template to use SMA5 intraday structure")
 				}

--- a/internal/service/live_market_data.go
+++ b/internal/service/live_market_data.go
@@ -238,6 +238,9 @@ func (p *Platform) liveSignalBarStates(symbol, timeframe string) (map[string]any
 		"atr14":     current.ATR,
 		"current":   strategySignalBarToStateEntry(current, symbol, timeframe),
 	}
+	if atrPercentile := finiteSignalBarIndicator(current.ATRPercentile); atrPercentile != nil {
+		entry["atrPercentile"] = *atrPercentile
+	}
 	if index >= 1 {
 		entry["prevBar1"] = strategySignalBarToStateEntry(bars[index-1], symbol, timeframe)
 	}
@@ -415,6 +418,7 @@ func buildStrategySignalBarsFromCandles(bars []candleBar) ([]strategySignalBar, 
 		signals[i].MA5 = rollingMean(closes, i, 5)
 		signals[i].MA20 = rollingMean(closes, i, 20)
 		signals[i].ATR = rollingMean(trueRanges, i, 14)
+		signals[i].ATRPercentile = rollingLastPercentileFromSeries(trueRanges, i, 14, 240, 50)
 		if i >= 1 {
 			signals[i].PrevHigh1 = bars[i-1].High
 			signals[i].PrevLow1 = bars[i-1].Low

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -375,6 +375,110 @@ func TestEvaluateSignalRequiresReentryTriggerWithinOpenWindow(t *testing.T) {
 	}
 }
 
+func TestEvaluateSignalAppliesReentryLowVolatilityGate(t *testing.T) {
+	engine := bkStrategyEngine{}
+	barStart := time.Date(2026, 4, 22, 3, 0, 0, 0, time.UTC)
+	baseSignalState := func(atr14, atrPercentile float64) map[string]any {
+		return map[string]any{
+			"symbol":        "BTCUSDT",
+			"timeframe":     "30m",
+			"sma5":          49500.0,
+			"atr14":         atr14,
+			"atrPercentile": atrPercentile,
+			"current": map[string]any{
+				"barStart": barStart.Format(time.RFC3339),
+				"close":    50100.0,
+				"high":     50120.0,
+				"low":      49980.0,
+			},
+			"prevBar1": map[string]any{
+				"high": 50200.0,
+				"low":  49800.0,
+			},
+			"prevBar2": map[string]any{
+				"high": 50300.0,
+				"low":  49700.0,
+			},
+		}
+	}
+	sessionState := map[string]any{
+		livePendingZeroInitialWindowStateKey: map[string]any{
+			"side":            "BUY",
+			"symbol":          "BTCUSDT",
+			"signalTimeframe": "30m",
+			"armedAt":         barStart.Add(-5 * time.Minute).Format(time.RFC3339),
+			"signalBarStart":  barStart.Format(time.RFC3339),
+			"expiresAt":       barStart.Add(30 * time.Minute).Format(time.RFC3339),
+			"breakoutBacked":  true,
+			"openReason":      liveZeroInitialWindowOpenReasonBreakoutLocked,
+		},
+	}
+	evaluate := func(atr14, atrPercentile float64) StrategySignalDecision {
+		decision, err := engine.EvaluateSignal(StrategySignalEvaluationContext{
+			ExecutionContext: StrategyExecutionContext{
+				Symbol:          "BTCUSDT",
+				SignalTimeframe: "30m",
+				Parameters: map[string]any{
+					"symbol":                     "BTCUSDT",
+					"signalTimeframe":            "30m",
+					"stop_loss_atr":              0.3,
+					"reentry_min_stop_bps":       6.0,
+					"reentry_atr_percentile_gte": 25.0,
+					"signalDecisionMaxSpreadBps": 8.0,
+				},
+			},
+			TriggerSummary: map[string]any{
+				"role":   "trigger",
+				"symbol": "BTCUSDT",
+				"price":  50010.0,
+			},
+			SourceStates: map[string]any{
+				"tick": map[string]any{
+					"streamType": "trade_tick",
+					"symbol":     "BTCUSDT",
+					"summary":    map[string]any{"price": 50010.0},
+				},
+			},
+			SignalBarStates: map[string]any{
+				signalBindingMatchKey("binance-kline", "signal", "BTCUSDT", map[string]any{"timeframe": "30m"}): baseSignalState(atr14, atrPercentile),
+			},
+			CurrentPosition:   map[string]any{},
+			SessionState:      cloneMetadata(sessionState),
+			EventTime:         barStart.Add(5 * time.Minute),
+			NextPlannedEvent:  barStart,
+			NextPlannedPrice:  50000.0,
+			NextPlannedSide:   "BUY",
+			NextPlannedRole:   "entry",
+			NextPlannedReason: "Zero-Initial-Reentry",
+		})
+		if err != nil {
+			t.Fatalf("evaluate signal failed: %v", err)
+		}
+		return decision
+	}
+
+	thinStop := evaluate(90.0, 30.0)
+	if thinStop.Action != "wait" || thinStop.Reason != "reentry-stop-distance-too-small" {
+		t.Fatalf("expected min stop bps gate to block thin stop, got %+v", thinStop)
+	}
+	if got := parseFloatValue(mapValue(thinStop.Metadata["reentryEntryQuality"])["stopBps"]); got >= 6.0 {
+		t.Fatalf("expected stop bps below 6, got %v", got)
+	}
+
+	lowPercentile := evaluate(110.0, 20.0)
+	if lowPercentile.Action != "wait" || lowPercentile.Reason != "reentry-atr-percentile-too-low" {
+		t.Fatalf("expected ATR percentile gate to block low percentile, got %+v", lowPercentile)
+	}
+
+	ready := evaluate(110.0, 30.0)
+	if ready.Action != "advance-plan" {
+		t.Fatalf("expected reentry to pass low-volatility gate, got %+v", ready)
+	}
+	if !boolValue(mapValue(ready.Metadata["reentryEntryQuality"])["ready"]) {
+		t.Fatalf("expected reentry entry quality metadata to be ready, got %+v", ready.Metadata["reentryEntryQuality"])
+	}
+}
+
 func TestEvaluateSignalRejectsZeroInitialWindowWithoutBreakoutProof(t *testing.T) {
 	engine := bkStrategyEngine{}
 	barStart := time.Date(2026, 4, 22, 6, 0, 0, 0, time.UTC)
@@ -3926,6 +4030,8 @@ func TestNormalizeLiveSessionOverridesIncludesExecutionControls(t *testing.T) {
 		"executionSLExitMaxSpreadBps":          999.0,
 		"executionSLMaxSlippageBps":            8.0,
 		"sl_reentry_min_delay_seconds":         60,
+		"reentry_min_stop_bps":                 6.0,
+		"reentry_atr_percentile_gte":           25.0,
 	})
 	if got := stringValue(overrides["executionStrategy"]); got != "book-aware-v1" {
 		t.Fatalf("expected execution strategy override, got %s", got)
@@ -3987,6 +4093,12 @@ func TestNormalizeLiveSessionOverridesIncludesExecutionControls(t *testing.T) {
 	if got := maxIntValue(overrides["sl_reentry_min_delay_seconds"], 0); got != 60 {
 		t.Fatalf("expected SL-Reentry delay override, got %d", got)
 	}
+	if got := parseFloatValue(overrides["reentry_min_stop_bps"]); got != 6.0 {
+		t.Fatalf("expected reentry_min_stop_bps override, got %v", got)
+	}
+	if got := parseFloatValue(overrides["reentry_atr_percentile_gte"]); got != 25.0 {
+		t.Fatalf("expected reentry_atr_percentile_gte override, got %v", got)
+	}
 }
 
 func TestNormalizeLiveSessionOverridesIncludesPositionSizing(t *testing.T) {
@@ -4042,6 +4154,8 @@ func TestNormalizeLiveSessionOverridesIncludesT3BreakoutControls(t *testing.T) {
 		"breakout_shape":                    "baseline_plus_t3",
 		"t3_min_sma_atr_separation":         0.25,
 		"use_sma5_intraday_structure":       true,
+		"reentry_min_stop_bps":              6.0,
+		"reentry_atr_percentile_gte":        25.0,
 		"ignored_t3_min_sma_atr_separation": 0.50,
 	})
 	if got := stringValue(overrides["breakout_shape"]); got != "baseline_plus_t3" {
@@ -4053,15 +4167,27 @@ func TestNormalizeLiveSessionOverridesIncludesT3BreakoutControls(t *testing.T) {
 	if !boolValue(overrides["use_sma5_intraday_structure"]) {
 		t.Fatal("expected use_sma5_intraday_structure override")
 	}
+	if got := parseFloatValue(overrides["reentry_min_stop_bps"]); got != 6.0 {
+		t.Fatalf("expected reentry_min_stop_bps=6, got %v", got)
+	}
+	if got := parseFloatValue(overrides["reentry_atr_percentile_gte"]); got != 25.0 {
+		t.Fatalf("expected reentry_atr_percentile_gte=25, got %v", got)
+	}
 	if _, ok := overrides["ignored_t3_min_sma_atr_separation"]; ok {
 		t.Fatalf("expected unknown t3 override key to be dropped, got %#v", overrides)
 	}
 }
 
-func TestLiveBTC30mEnhancedOverridesEnableSLReentryDelay(t *testing.T) {
+func TestLiveBTC30mEnhancedOverridesEnableReentryGuards(t *testing.T) {
 	overrides := liveBTC30mEnhancedOverrides()
 	if got := maxIntValue(overrides["sl_reentry_min_delay_seconds"], 0); got != 60 {
 		t.Fatalf("expected BTC 30m enhanced template to require 60s SL-Reentry delay, got %d", got)
+	}
+	if got := parseFloatValue(overrides["reentry_min_stop_bps"]); got != 6.0 {
+		t.Fatalf("expected BTC 30m enhanced template to require reentry_min_stop_bps=6, got %v", got)
+	}
+	if got := parseFloatValue(overrides["reentry_atr_percentile_gte"]); got != 25.0 {
+		t.Fatalf("expected BTC 30m enhanced template to require reentry_atr_percentile_gte=25, got %v", got)
 	}
 }
 

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -378,13 +378,15 @@ func TestEvaluateSignalRequiresReentryTriggerWithinOpenWindow(t *testing.T) {
 func TestEvaluateSignalAppliesReentryLowVolatilityGate(t *testing.T) {
 	engine := bkStrategyEngine{}
 	barStart := time.Date(2026, 4, 22, 3, 0, 0, 0, time.UTC)
-	baseSignalState := func(atr14, atrPercentile float64) map[string]any {
-		return map[string]any{
-			"symbol":        "BTCUSDT",
-			"timeframe":     "30m",
-			"sma5":          49500.0,
-			"atr14":         atr14,
-			"atrPercentile": atrPercentile,
+	floatPtr := func(value float64) *float64 {
+		return &value
+	}
+	baseSignalState := func(atr14 float64, atrPercentile *float64) map[string]any {
+		state := map[string]any{
+			"symbol":    "BTCUSDT",
+			"timeframe": "30m",
+			"sma5":      49500.0,
+			"atr14":     atr14,
 			"current": map[string]any{
 				"barStart": barStart.Format(time.RFC3339),
 				"close":    50100.0,
@@ -400,6 +402,10 @@ func TestEvaluateSignalAppliesReentryLowVolatilityGate(t *testing.T) {
 				"low":  49700.0,
 			},
 		}
+		if atrPercentile != nil {
+			state["atrPercentile"] = *atrPercentile
+		}
+		return state
 	}
 	sessionState := map[string]any{
 		livePendingZeroInitialWindowStateKey: map[string]any{
@@ -413,7 +419,7 @@ func TestEvaluateSignalAppliesReentryLowVolatilityGate(t *testing.T) {
 			"openReason":      liveZeroInitialWindowOpenReasonBreakoutLocked,
 		},
 	}
-	evaluate := func(atr14, atrPercentile float64) StrategySignalDecision {
+	evaluate := func(atr14 float64, atrPercentile *float64) StrategySignalDecision {
 		decision, err := engine.EvaluateSignal(StrategySignalEvaluationContext{
 			ExecutionContext: StrategyExecutionContext{
 				Symbol:          "BTCUSDT",
@@ -457,7 +463,7 @@ func TestEvaluateSignalAppliesReentryLowVolatilityGate(t *testing.T) {
 		return decision
 	}
 
-	thinStop := evaluate(90.0, 30.0)
+	thinStop := evaluate(90.0, floatPtr(30.0))
 	if thinStop.Action != "wait" || thinStop.Reason != "reentry-stop-distance-too-small" {
 		t.Fatalf("expected min stop bps gate to block thin stop, got %+v", thinStop)
 	}
@@ -465,17 +471,100 @@ func TestEvaluateSignalAppliesReentryLowVolatilityGate(t *testing.T) {
 		t.Fatalf("expected stop bps below 6, got %v", got)
 	}
 
-	lowPercentile := evaluate(110.0, 20.0)
+	lowPercentile := evaluate(110.0, floatPtr(20.0))
 	if lowPercentile.Action != "wait" || lowPercentile.Reason != "reentry-atr-percentile-too-low" {
 		t.Fatalf("expected ATR percentile gate to block low percentile, got %+v", lowPercentile)
 	}
 
-	ready := evaluate(110.0, 30.0)
+	missingPercentile := evaluate(110.0, nil)
+	if missingPercentile.Action != "wait" || missingPercentile.Reason != "reentry-atr-percentile-too-low" {
+		t.Fatalf("expected missing ATR percentile to block conservatively, got %+v", missingPercentile)
+	}
+
+	ready := evaluate(110.0, floatPtr(30.0))
 	if ready.Action != "advance-plan" {
 		t.Fatalf("expected reentry to pass low-volatility gate, got %+v", ready)
 	}
 	if !boolValue(mapValue(ready.Metadata["reentryEntryQuality"])["ready"]) {
 		t.Fatalf("expected reentry entry quality metadata to be ready, got %+v", ready.Metadata["reentryEntryQuality"])
+	}
+}
+
+func TestEvaluateSignalDoesNotApplyReentryLowVolatilityGateToSLExit(t *testing.T) {
+	engine := bkStrategyEngine{}
+	barStart := time.Date(2026, 4, 22, 3, 0, 0, 0, time.UTC)
+	signalState := map[string]any{
+		"symbol":    "BTCUSDT",
+		"timeframe": "30m",
+		"sma5":      50000.0,
+		"atr14":     100.0,
+		"current": map[string]any{
+			"barStart": barStart.Format(time.RFC3339),
+			"close":    49960.0,
+			"high":     50100.0,
+			"low":      49950.0,
+		},
+		"prevBar1": map[string]any{
+			"high": 50200.0,
+			"low":  49900.0,
+		},
+		"prevBar2": map[string]any{
+			"high": 50300.0,
+			"low":  49800.0,
+		},
+	}
+	decision, err := engine.EvaluateSignal(StrategySignalEvaluationContext{
+		ExecutionContext: StrategyExecutionContext{
+			Symbol:          "BTCUSDT",
+			SignalTimeframe: "30m",
+			Parameters: map[string]any{
+				"symbol":                     "BTCUSDT",
+				"signalTimeframe":            "30m",
+				"stop_loss_atr":              0.3,
+				"reentry_min_stop_bps":       6.0,
+				"reentry_atr_percentile_gte": 25.0,
+				"signalDecisionMaxSpreadBps": 8.0,
+			},
+		},
+		TriggerSummary: map[string]any{
+			"role":   "trigger",
+			"symbol": "BTCUSDT",
+			"price":  49960.0,
+		},
+		SourceStates: map[string]any{
+			"tick": map[string]any{
+				"streamType": "trade_tick",
+				"symbol":     "BTCUSDT",
+				"summary":    map[string]any{"price": 49960.0},
+			},
+		},
+		SignalBarStates: map[string]any{
+			signalBindingMatchKey("binance-kline", "signal", "BTCUSDT", map[string]any{"timeframe": "30m"}): signalState,
+		},
+		CurrentPosition: map[string]any{
+			"found":      true,
+			"symbol":     "BTCUSDT",
+			"side":       "LONG",
+			"entryPrice": 50000.0,
+			"quantity":   0.01,
+		},
+		SessionState:      map[string]any{},
+		EventTime:         barStart.Add(5 * time.Minute),
+		NextPlannedEvent:  barStart,
+		NextPlannedPrice:  49970.0,
+		NextPlannedSide:   "SELL",
+		NextPlannedRole:   "exit",
+		NextPlannedReason: "SL",
+	})
+	if err != nil {
+		t.Fatalf("evaluate signal failed: %v", err)
+	}
+	if decision.Action != "advance-plan" {
+		t.Fatalf("expected SL exit to bypass reentry entry gate, got %+v", decision)
+	}
+	reentryEntryQuality := mapValue(decision.Metadata["reentryEntryQuality"])
+	if boolValue(reentryEntryQuality["applied"]) || !boolValue(reentryEntryQuality["ready"]) {
+		t.Fatalf("expected reentry entry gate to be unapplied and ready for exit, got %+v", reentryEntryQuality)
 	}
 }
 

--- a/internal/service/signal_runtime_sessions.go
+++ b/internal/service/signal_runtime_sessions.go
@@ -580,7 +580,7 @@ func (p *Platform) bootstrapSignalRuntimeSourceStates(subscriptions []map[string
 				"timeframe":  timeframe,
 				"streamType": stringValue(subscription["streamType"]),
 			},
-			"bars": strategySignalBarsToRuntimeHistory(bars, symbol, timeframe, 200),
+			"bars": strategySignalBarsToRuntimeHistory(bars, symbol, timeframe, liveSignalBarHistoryLimit),
 		}
 	}
 	return out

--- a/internal/service/signal_runtime_ws.go
+++ b/internal/service/signal_runtime_ws.go
@@ -115,6 +115,7 @@ const (
 	signalRuntimeWSHandshakeTimeout   = 5 * time.Second
 	signalRuntimeWSPingInterval       = 10 * time.Second
 	signalRuntimeWSPingWriteTimeout   = 3 * time.Second
+	liveSignalBarHistoryLimit         = 260
 )
 
 type signalRuntimeWSProfile struct {
@@ -1111,7 +1112,7 @@ func mergeSignalSourceState(existing any, summary map[string]any, eventTime time
 	}
 	if strings.EqualFold(stringValue(summary["streamType"]), "signal_bar") {
 		entry := cloneMetadata(mapValue(stateMap[key]))
-		entry["bars"] = mergeSignalBarHistory(existingEntry["bars"], summary, eventTime, 200)
+		entry["bars"] = mergeSignalBarHistory(existingEntry["bars"], summary, eventTime, liveSignalBarHistoryLimit)
 		stateMap[key] = entry
 	}
 	return stateMap
@@ -1223,6 +1224,9 @@ func deriveSignalBarStates(sourceStates map[string]any) map[string]any {
 		}
 		if atr14 := finiteSignalBarIndicator(rollingMean(trueRanges, len(indicatorBars)-1, 14)); atr14 != nil {
 			entry["atr14"] = *atr14
+		}
+		if atrPercentile := finiteSignalBarIndicator(rollingLastPercentileFromSeries(trueRanges, len(indicatorBars)-1, 14, 240, 50)); atrPercentile != nil {
+			entry["atrPercentile"] = *atrPercentile
 		}
 		if len(previousClosed) >= 1 {
 			entry["prevBar1"] = cloneMetadata(previousClosed[len(previousClosed)-1])

--- a/internal/service/signal_runtime_ws_test.go
+++ b/internal/service/signal_runtime_ws_test.go
@@ -719,6 +719,45 @@ func TestDeriveSignalBarStatesDedupesCanonicalBarHistory(t *testing.T) {
 	}
 }
 
+func TestDeriveSignalBarStatesIncludesATRPercentile(t *testing.T) {
+	key := signalBindingMatchKey("binance-kline", "signal", "BTCUSDT", map[string]any{"timeframe": "30m"})
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	bars := make([]any, 0, 70)
+	for i := 0; i < 70; i++ {
+		closePrice := 50000.0 + float64(i)*10
+		rangeSize := 100.0 + float64(i)
+		bars = append(bars, map[string]any{
+			"symbol":    "BTCUSDT",
+			"timeframe": "30m",
+			"barStart":  base.Add(time.Duration(i) * 30 * time.Minute).Format(time.RFC3339),
+			"open":      closePrice - 5,
+			"high":      closePrice + rangeSize/2,
+			"low":       closePrice - rangeSize/2,
+			"close":     closePrice,
+			"volume":    1000.0,
+			"isClosed":  true,
+		})
+	}
+
+	states := deriveSignalBarStates(map[string]any{
+		key: map[string]any{
+			"sourceKey":  "binance-kline",
+			"role":       "signal",
+			"streamType": "signal_bar",
+			"symbol":     "BTCUSDT",
+			"timeframe":  "30m",
+			"bars":       bars,
+		},
+	})
+	state := mapValue(states[key])
+	if state == nil {
+		t.Fatalf("expected signal bar state, got %#v", states)
+	}
+	if got := parseFloatValue(state["atrPercentile"]); got <= 0 || got > 100 {
+		t.Fatalf("expected ATR percentile in (0, 100], got %v from %#v", got, state)
+	}
+}
+
 func TestBootstrapSignalRuntimeSourceStatesUsesWarmMarketCache(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
 	signalBars := make([]strategySignalBar, 0, 4)

--- a/internal/service/state_util.go
+++ b/internal/service/state_util.go
@@ -29,9 +29,11 @@ var signalBarStateAllowedKeys = map[string]struct{}{
 	"current":        {},
 	"prevBar1":       {},
 	"prevBar2":       {},
+	"prevBar3":       {},
 	"sma5":           {},
 	"ma20":           {},
 	"atr14":          {},
+	"atrPercentile":  {},
 }
 
 // stripHeavyState removes large objects from a session state map to reduce the

--- a/internal/service/strategy.go
+++ b/internal/service/strategy.go
@@ -611,6 +611,10 @@ func applyBacktestParameterAliases(parameters map[string]any) {
 		"delayedTrailingActivationATR": "delayed_trailing_activation_atr",
 		"longReentryATR":               "long_reentry_atr",
 		"shortReentryATR":              "short_reentry_atr",
+		"reentryMinStopBps":            "reentry_min_stop_bps",
+		"reentryATRPercentileGTE":      "reentry_atr_percentile_gte",
+		"minStopBps":                   "min_stop_bps",
+		"atrPctGTE":                    "atr_pct_gte",
 	}
 	for from, to := range aliases {
 		if _, ok := parameters[to]; ok {

--- a/internal/service/strategy_registry.go
+++ b/internal/service/strategy_registry.go
@@ -208,14 +208,18 @@ func (e bkLiveIntrabarSMA5T3SepEngine) EvaluateSignal(context StrategySignalEval
 }
 
 type signalBarGateOptions struct {
-	BreakoutShape         string
-	T3MinSMAATRSeparation float64
+	BreakoutShape           string
+	T3MinSMAATRSeparation   float64
+	ReentryMinStopBps       float64
+	ReentryATRPercentileGTE float64
 }
 
 func signalBarGateOptionsFromParameters(parameters map[string]any) signalBarGateOptions {
 	return signalBarGateOptions{
-		BreakoutShape:         strings.ToLower(strings.TrimSpace(stringValue(parameters["breakout_shape"]))),
-		T3MinSMAATRSeparation: parseFloatValue(parameters["t3_min_sma_atr_separation"]),
+		BreakoutShape:           strings.ToLower(strings.TrimSpace(stringValue(parameters["breakout_shape"]))),
+		T3MinSMAATRSeparation:   parseFloatValue(parameters["t3_min_sma_atr_separation"]),
+		ReentryMinStopBps:       firstPositive(parseFloatValue(parameters["reentry_min_stop_bps"]), parseFloatValue(parameters["min_stop_bps"])),
+		ReentryATRPercentileGTE: firstPositive(parseFloatValue(parameters["reentry_atr_percentile_gte"]), parseFloatValue(parameters["atr_pct_gte"])),
 	}
 }
 
@@ -330,6 +334,19 @@ func (e bkStrategyEngine) EvaluateSignal(context StrategySignalEvaluationContext
 			reason = "reentry-trigger-not-reached"
 		}
 	}
+	reentryEntryQuality := evaluateReentryEntryQualityGate(
+		context.ExecutionContext.Parameters,
+		signalBarState,
+		context.NextPlannedSide,
+		context.NextPlannedRole,
+		context.NextPlannedReason,
+		effectivePlannedPrice,
+		marketPrice,
+	)
+	if action == "advance-plan" && !boolValue(reentryEntryQuality["ready"]) {
+		action = "wait"
+		reason = firstNonEmpty(stringValue(reentryEntryQuality["reason"]), "reentry-entry-quality-not-ready")
+	}
 	deviationBps := 0.0
 	positionPnLBps := computePositionPnLBps(currentPosition, marketPrice)
 	if action == "advance-plan" && effectivePlannedPrice > 0 && marketPrice > 0 {
@@ -384,6 +401,7 @@ func (e bkStrategyEngine) EvaluateSignal(context StrategySignalEvaluationContext
 			"reentryTriggerPrice":           reentryTriggerPrice,
 			"reentryTriggerPriceSource":     reentryTriggerPriceSource,
 			"reentryTriggerReady":           reentryTriggerReady,
+			"reentryEntryQuality":           reentryEntryQuality,
 			"bestBid":                       orderBookStats.bestBid,
 			"bestAsk":                       orderBookStats.bestAsk,
 			"bestBidQty":                    orderBookStats.bestBidQty,
@@ -574,6 +592,8 @@ func classifyStrategyDecisionState(action, reason, nextRole string) string {
 		return "waiting-price"
 	case "reentry-trigger-not-reached":
 		return "waiting-price"
+	case "reentry-stop-distance-too-small", "reentry-atr-percentile-too-low", "reentry-entry-quality-not-ready":
+		return "waiting-signal-filter"
 	case "spread-too-wide":
 		return "waiting-liquidity"
 	case "bias-unfavorable":
@@ -773,18 +793,19 @@ func evaluateSignalBarGate(signalBarState map[string]any, nextSide, nextRole, ne
 		timeframe = strings.ToLower(strings.TrimSpace(stringValue(mapValue(signalBarState["current"])["timeframe"])))
 	}
 	result := map[string]any{
-		"ready":     true,
-		"reason":    "signal-bar-ready",
-		"side":      strings.ToUpper(strings.TrimSpace(nextSide)),
-		"role":      role,
-		"timeframe": timeframe,
-		"sma5":      parseFloatValue(signalBarState["sma5"]),
-		"ma20":      parseFloatValue(signalBarState["ma20"]),
-		"atr14":     parseFloatValue(signalBarState["atr14"]),
-		"current":   cloneMetadata(mapValue(signalBarState["current"])),
-		"prevBar1":  cloneMetadata(mapValue(signalBarState["prevBar1"])),
-		"prevBar2":  cloneMetadata(mapValue(signalBarState["prevBar2"])),
-		"prevBar3":  cloneMetadata(mapValue(signalBarState["prevBar3"])),
+		"ready":         true,
+		"reason":        "signal-bar-ready",
+		"side":          strings.ToUpper(strings.TrimSpace(nextSide)),
+		"role":          role,
+		"timeframe":     timeframe,
+		"sma5":          parseFloatValue(signalBarState["sma5"]),
+		"ma20":          parseFloatValue(signalBarState["ma20"]),
+		"atr14":         parseFloatValue(signalBarState["atr14"]),
+		"atrPercentile": parseFloatValue(signalBarState["atrPercentile"]),
+		"current":       cloneMetadata(mapValue(signalBarState["current"])),
+		"prevBar1":      cloneMetadata(mapValue(signalBarState["prevBar1"])),
+		"prevBar2":      cloneMetadata(mapValue(signalBarState["prevBar2"])),
+		"prevBar3":      cloneMetadata(mapValue(signalBarState["prevBar3"])),
 	}
 	current := mapValue(signalBarState["current"])
 	prevBar1 := mapValue(signalBarState["prevBar1"])
@@ -921,6 +942,74 @@ func evaluateSignalBarGate(signalBarState map[string]any, nextSide, nextRole, ne
 			result["ready"] = false
 			result["reason"] = "short-signal-not-ready"
 		}
+	}
+	return result
+}
+
+func evaluateReentryEntryQualityGate(parameters map[string]any, signalBarState map[string]any, nextSide, nextRole, nextReason string, plannedPrice, marketPrice float64) map[string]any {
+	options := signalBarGateOptionsFromParameters(parameters)
+	result := map[string]any{
+		"ready":            true,
+		"reason":           "reentry-entry-quality-ready",
+		"side":             strings.ToUpper(strings.TrimSpace(nextSide)),
+		"role":             strings.ToLower(strings.TrimSpace(nextRole)),
+		"reasonTag":        normalizeStrategyReasonTag(nextReason),
+		"minStopBps":       options.ReentryMinStopBps,
+		"atrPercentileGTE": options.ReentryATRPercentileGTE,
+	}
+	reasonTag := stringValue(result["reasonTag"])
+	if result["role"] != "entry" || (reasonTag != "zero-initial-reentry" && reasonTag != "sl-reentry" && reasonTag != "pt-reentry") {
+		result["applied"] = false
+		return result
+	}
+	if options.ReentryMinStopBps <= 0 && options.ReentryATRPercentileGTE <= 0 {
+		result["applied"] = false
+		return result
+	}
+	result["applied"] = true
+
+	atr14 := parseFloatValue(mapValue(signalBarState)["atr14"])
+	atrPercentile := parseFloatValue(mapValue(signalBarState)["atrPercentile"])
+	stopLossATR := parseFloatValue(parameters["stop_loss_atr"])
+	if stopLossATR <= 0 {
+		stopLossATR = 0.05
+	}
+	priceRef := plannedPrice
+	if priceRef <= 0 {
+		priceRef = marketPrice
+	}
+	if priceRef <= 0 {
+		priceRef = parseFloatValue(mapValue(mapValue(signalBarState)["current"])["close"])
+	}
+	stopBps := 0.0
+	if atr14 > 0 && priceRef > 0 {
+		stopBps = stopLossATR * atr14 / priceRef * 10000.0
+	}
+	result["stopLossATR"] = stopLossATR
+	result["atr14"] = atr14
+	result["atrPercentile"] = atrPercentile
+	result["priceRef"] = priceRef
+	result["stopBps"] = stopBps
+
+	rejectReasons := []string{}
+	if options.ReentryMinStopBps > 0 && (stopBps <= 0 || stopBps < options.ReentryMinStopBps) {
+		rejectReasons = append(rejectReasons, "min_stop_bps")
+	}
+	if options.ReentryATRPercentileGTE > 0 && (atrPercentile <= 0 || atrPercentile < options.ReentryATRPercentileGTE) {
+		rejectReasons = append(rejectReasons, "atr_percentile")
+	}
+	if len(rejectReasons) == 0 {
+		return result
+	}
+	result["ready"] = false
+	result["rejectReasons"] = rejectReasons
+	switch rejectReasons[0] {
+	case "min_stop_bps":
+		result["reason"] = "reentry-stop-distance-too-small"
+	case "atr_percentile":
+		result["reason"] = "reentry-atr-percentile-too-low"
+	default:
+		result["reason"] = "reentry-entry-quality-not-ready"
 	}
 	return result
 }

--- a/internal/service/strategy_replay.go
+++ b/internal/service/strategy_replay.go
@@ -15,21 +15,22 @@ import (
 )
 
 type strategySignalBar struct {
-	Time      time.Time
-	Open      float64
-	High      float64
-	Low       float64
-	Close     float64
-	Volume    float64
-	MA5       float64
-	MA20      float64
-	ATR       float64
-	PrevHigh1 float64
-	PrevHigh2 float64
-	PrevHigh3 float64
-	PrevLow1  float64
-	PrevLow2  float64
-	PrevLow3  float64
+	Time          time.Time
+	Open          float64
+	High          float64
+	Low           float64
+	Close         float64
+	Volume        float64
+	MA5           float64
+	MA20          float64
+	ATR           float64
+	ATRPercentile float64
+	PrevHigh1     float64
+	PrevHigh2     float64
+	PrevHigh3     float64
+	PrevLow1      float64
+	PrevLow2      float64
+	PrevLow3      float64
 }
 
 type executionBar struct {
@@ -1149,6 +1150,7 @@ func buildSignalBars(minuteBars []candleBar, timeframe string) ([]strategySignal
 		signals[i].MA5 = rollingMean(closes, i, 5)
 		signals[i].MA20 = rollingMean(closes, i, 20)
 		signals[i].ATR = rollingMean(trueRanges, i, 14)
+		signals[i].ATRPercentile = rollingLastPercentileFromSeries(trueRanges, i, 14, 240, 50)
 		if i >= 1 {
 			signals[i].PrevHigh1 = aggregated[i-1].High
 			signals[i].PrevLow1 = aggregated[i-1].Low
@@ -1597,6 +1599,43 @@ func rollingMean(values []float64, end, window int) float64 {
 		sum += values[i]
 	}
 	return sum / float64(window)
+}
+
+func rollingLastPercentile(values []float64, end, window, minPeriods int) float64 {
+	if end < 0 || end >= len(values) {
+		return math.NaN()
+	}
+	start := end - window + 1
+	if start < 0 {
+		start = 0
+	}
+	clean := make([]float64, 0, end-start+1)
+	for i := start; i <= end; i++ {
+		value := values[i]
+		if math.IsNaN(value) || math.IsInf(value, 0) {
+			continue
+		}
+		clean = append(clean, value)
+	}
+	if len(clean) < minPeriods {
+		return math.NaN()
+	}
+	last := clean[len(clean)-1]
+	lessOrEqual := 0
+	for _, value := range clean {
+		if value <= last {
+			lessOrEqual++
+		}
+	}
+	return float64(lessOrEqual) / float64(len(clean)) * 100.0
+}
+
+func rollingLastPercentileFromSeries(values []float64, end, sourceWindow, percentileWindow, minPeriods int) float64 {
+	rolled := make([]float64, end+1)
+	for i := 0; i <= end; i++ {
+		rolled[i] = rollingMean(values, i, sourceWindow)
+	}
+	return rollingLastPercentile(rolled, end, percentileWindow, minPeriods)
 }
 
 func firstPositive(value, fallback float64) float64 {

--- a/internal/service/strategy_replay.go
+++ b/internal/service/strategy_replay.go
@@ -1591,7 +1591,11 @@ func replayTrailingActive(side string, entryPrice, hwm, lwm, atr, delayedActivat
 }
 
 func rollingMean(values []float64, end, window int) float64 {
-	if end+1 < window {
+	return rollingMeanOrNaN(values, end, window)
+}
+
+func rollingMeanOrNaN(values []float64, end, window int) float64 {
+	if window <= 0 || end < 0 || end >= len(values) || end-window+1 < 0 {
 		return math.NaN()
 	}
 	sum := 0.0
@@ -1633,7 +1637,7 @@ func rollingLastPercentile(values []float64, end, window, minPeriods int) float6
 func rollingLastPercentileFromSeries(values []float64, end, sourceWindow, percentileWindow, minPeriods int) float64 {
 	rolled := make([]float64, end+1)
 	for i := 0; i <= end; i++ {
-		rolled[i] = rollingMean(values, i, sourceWindow)
+		rolled[i] = rollingMeanOrNaN(values, i, sourceWindow)
 	}
 	return rollingLastPercentile(rolled, end, percentileWindow, minPeriods)
 }

--- a/internal/service/strategy_replay_test.go
+++ b/internal/service/strategy_replay_test.go
@@ -128,6 +128,23 @@ func TestBuildSignalBarsSupportsFiveMinuteAggregation(t *testing.T) {
 	}
 }
 
+func TestRollingLastPercentileFromSeriesIgnoresSourceWarmup(t *testing.T) {
+	trueRanges := make([]float64, 63)
+	for i := range trueRanges {
+		trueRanges[i] = 100.0
+	}
+
+	if got := rollingLastPercentileFromSeries(trueRanges, 49, 14, 240, 50); !math.IsNaN(got) {
+		t.Fatalf("expected percentile to stay NaN before 50 real ATR14 samples, got %v", got)
+	}
+	if got := rollingLastPercentileFromSeries(trueRanges, 50, 14, 240, 50); !math.IsNaN(got) {
+		t.Fatalf("expected percentile to stay NaN near the warmup boundary, got %v", got)
+	}
+	if got := rollingLastPercentileFromSeries(trueRanges, 62, 14, 240, 50); got != 100.0 {
+		t.Fatalf("expected percentile after 50 real ATR14 samples to be 100, got %v", got)
+	}
+}
+
 func TestBuildStrategyReplayConfigUsesUpdatedBaselineDefaults(t *testing.T) {
 	cfg := buildStrategyReplayConfig(StrategyExecutionContext{
 		SignalTimeframe:     "1d",

--- a/internal/store/memory/store.go
+++ b/internal/store/memory/store.go
@@ -153,6 +153,8 @@ func NewStore() *Store {
 			"breakout_shape":                  "baseline_plus_t3",
 			"t3_min_sma_atr_separation":       0.25,
 			"use_sma5_intraday_structure":     true,
+			"reentry_min_stop_bps":            6.0,
+			"reentry_atr_percentile_gte":      25.0,
 			"stop_mode":                       "atr",
 			"stop_loss_atr":                   0.3,
 			"profit_protect_atr":              1.0,

--- a/research/20260429_btc_q1_30min_breakout_confirmation_filters.md
+++ b/research/20260429_btc_q1_30min_breakout_confirmation_filters.md
@@ -1,0 +1,50 @@
+# BTC Q1 2026 30min Breakout Confirmation Filters
+
+Scope: research-only Python replay. No live or execution path is changed by this report.
+
+## Setup
+
+- Symbol/window: `BTCUSDT`, `2026-01-01T00:00:00+00:00` to `2026-03-31T23:59:59+00:00`
+- Execution bars: continuous `1s` bars rebuilt from Binance trade archives
+- Signal timeframe: `30min`
+- Replay mode: `live_intrabar_sma5`, breakout shape `baseline_plus_t3`, t3 SMA/ATR separation `0.25`
+- Sizing: `dir2_zero_initial=true`, `zero_initial_mode=reentry_window`, `reentry_size_schedule=[0.20, 0.10]`, `max_trades_per_bar=2`
+- Risk params use the BTC 30m enhanced/live-like research profile: `stop_loss_atr=0.3`, `trailing_stop_atr=0.3`, `delayed_trailing_activation=0.5`
+- `confirm_2x_1s` / `confirm_3x_1s` are multi-tick proxies: they require consecutive 1s observations to cross the same breakout level.
+
+## Results
+
+| Variant | Final Balance | Return | Max DD | Trades | Win Rate | Sharpe | Entry Mix | Filter Rejects |
+|---|---:|---:|---:|---:|---:|---:|---|---|
+| `baseline_single_observation` | 227,449.41 | 127.45% | -3.03% | 3177 | 76.46% | 13.23 | `SL-Reentry:2137, Zero-Initial-Reentry:1040` | `margin L/S 0/0; confirm L/S 0/0` |
+| `margin_0p02atr` | 227,787.82 | 127.79% | -2.89% | 3111 | 76.73% | 13.36 | `SL-Reentry:2092, Zero-Initial-Reentry:1019` | `margin L/S 6648/7380; confirm L/S 0/0` |
+| `confirm_2x_1s` | 226,802.02 | 126.80% | -2.85% | 3126 | 76.52% | 13.22 | `SL-Reentry:2101, Zero-Initial-Reentry:1025` | `margin L/S 0/0; confirm L/S 1502/1490` |
+| `confirm_3x_1s` | 227,609.94 | 127.61% | -2.86% | 3079 | 76.78% | 13.30 | `SL-Reentry:2071, Zero-Initial-Reentry:1008` | `margin L/S 0/0; confirm L/S 2877/2907` |
+
+## Delta vs Baseline
+
+| Variant | Final Balance Delta | Return Delta | Max DD Delta | Trades Delta | Win Rate Delta | Sharpe Delta |
+|---|---:|---:|---:|---:|---:|---:|
+| `margin_0p02atr` | 338.41 | 0.34 pp | 0.14 pp | -66 | 0.27 pp | 0.13 |
+| `confirm_2x_1s` | -647.39 | -0.65 pp | 0.18 pp | -51 | 0.06 pp | -0.01 |
+| `confirm_3x_1s` | 160.53 | 0.16 pp | 0.17 pp | -98 | 0.32 pp | 0.07 |
+
+## Breakout Attribution
+
+| Variant | Shape | Trades | Win Rate | Avg PnL | Net PnL | Worst PnL | Profit Factor |
+|---|---|---:|---:|---:|---:|---:|---:|
+| `baseline_single_observation` | `original_t2` | 2441 | 89.47% | 0.3705% | 209,920.87 | -0.7003% | 21.2922 |
+| `baseline_single_observation` | `t3_swing` | 736 | 90.35% | 0.3802% | 66,030.95 | -0.6977% | 24.3702 |
+| `margin_0p02atr` | `original_t2` | 2383 | 89.55% | 0.3743% | 207,343.76 | -0.7003% | 21.7115 |
+| `margin_0p02atr` | `t3_swing` | 728 | 90.52% | 0.3832% | 65,741.71 | -0.6977% | 25.1944 |
+| `confirm_2x_1s` | `original_t2` | 2399 | 89.41% | 0.3726% | 206,785.14 | -0.7003% | 21.0589 |
+| `confirm_2x_1s` | `t3_swing` | 727 | 90.37% | 0.3827% | 65,491.28 | -0.6977% | 24.4563 |
+| `confirm_3x_1s` | `original_t2` | 2357 | 89.56% | 0.3753% | 204,943.75 | -0.7003% | 22.0497 |
+| `confirm_3x_1s` | `t3_swing` | 722 | 90.44% | 0.3860% | 65,641.31 | -0.6977% | 25.2337 |
+
+## Variants
+
+- `baseline_single_observation`: Current research behavior: one 1s high/low crossing can lock the zero-initial window.
+- `margin_0p02atr`: Require breakout probe to clear the level by at least 0.02 ATR.
+- `confirm_2x_1s`: Require two consecutive 1s observations crossing the same breakout level.
+- `confirm_3x_1s`: Require three consecutive 1s observations crossing the same breakout level.

--- a/research/20260429_btc_q1_30min_low_vol_entry_filters.md
+++ b/research/20260429_btc_q1_30min_low_vol_entry_filters.md
@@ -1,0 +1,42 @@
+# BTCUSDT Q1 2026 30min Low-Volatility Entry Gates
+
+Scope: research-only Python replay. No live or execution path is changed by this report.
+
+## Setup
+
+- Symbol/window: `BTCUSDT`, `2026-01-01T00:00:00+00:00` to `2026-03-31T23:59:59+00:00`
+- Execution bars: continuous `1s` bars rebuilt from Binance trade archives
+- Signal timeframe: `30min`
+- Replay mode: `live_intrabar_sma5`, breakout shape `baseline_plus_t3`, t3 SMA/ATR separation `0.25`
+- Sizing: `dir2_zero_initial=true`, `zero_initial_mode=reentry_window`, `reentry_size_schedule=[0.20, 0.10]`, `max_trades_per_bar=2`
+- Gate point: reentry price resolution, so the gate blocks both Zero-Initial-Reentry and SL-Reentry entries. Stop-loss exits are not filtered.
+
+## Results
+
+| Variant | Final Balance | Return | Max DD | Trades | Win Rate | Sharpe | Avg Loss | Worst Loss | Entry Mix | Gate Reject Calls |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---|---:|
+| `baseline` | 227,449.41 | 127.45% | -3.03% | 3177 | 76.46% | 13.23 | -0.1659% | -0.7003% | `SL-Reentry:2137, Zero-Initial-Reentry:1040` | 0 |
+| `min_stop_bps_6` | 240,319.34 | 140.32% | -1.27% | 2967 | 80.49% | 13.91 | -0.1977% | -0.7003% | `SL-Reentry:1996, Zero-Initial-Reentry:971` | 205782 |
+| `min_stop_bps_8` | 251,377.98 | 151.38% | -0.66% | 2748 | 83.08% | 14.56 | -0.2130% | -0.7003% | `SL-Reentry:1847, Zero-Initial-Reentry:901` | 443571 |
+| `atr_pct_gte_25` | 237,251.08 | 137.25% | -1.27% | 2334 | 82.73% | 14.47 | -0.2117% | -0.7003% | `SL-Reentry:1558, Zero-Initial-Reentry:776` | 826574 |
+| `atr_pct_gte_35` | 227,154.89 | 127.15% | -1.13% | 2017 | 84.04% | 14.74 | -0.2218% | -0.7003% | `SL-Reentry:1344, Zero-Initial-Reentry:673` | 1146020 |
+| `min_stop_bps_6_atr_pct_gte_25` | 238,079.98 | 138.08% | -1.27% | 2318 | 83.09% | 14.54 | -0.2146% | -0.7003% | `SL-Reentry:1549, Zero-Initial-Reentry:769` | 843709 |
+
+## Delta vs Baseline
+
+| Variant | Final Delta | Return Delta | Max DD Delta | Trades Delta | Win Delta | Sharpe Delta |
+|---|---:|---:|---:|---:|---:|---:|
+| `min_stop_bps_6` | 12,869.93 | 12.87 pp | 1.76 pp | -210 | 4.03 pp | 0.68 |
+| `min_stop_bps_8` | 23,928.57 | 23.93 pp | 2.37 pp | -429 | 6.62 pp | 1.33 |
+| `atr_pct_gte_25` | 9,801.67 | 9.80 pp | 1.76 pp | -843 | 6.27 pp | 1.24 |
+| `atr_pct_gte_35` | -294.52 | -0.30 pp | 1.90 pp | -1160 | 7.58 pp | 1.51 |
+| `min_stop_bps_6_atr_pct_gte_25` | 10,630.57 | 10.63 pp | 1.76 pp | -859 | 6.63 pp | 1.31 |
+
+## Variants
+
+- `baseline`: No low-volatility entry gate.
+- `min_stop_bps_6`: Require stop_loss_atr * ATR to be at least 6 bps of entry reference price.
+- `min_stop_bps_8`: Require stop_loss_atr * ATR to be at least 8 bps of entry reference price.
+- `atr_pct_gte_25`: Require signal ATR percentile over the rolling 240 signal bars to be at least 25.
+- `atr_pct_gte_35`: Require signal ATR percentile over the rolling 240 signal bars to be at least 35.
+- `min_stop_bps_6_atr_pct_gte_25`: Require both min stop distance of 6 bps and ATR percentile at least 25.

--- a/research/20260429_btc_q1_30min_low_vol_entry_filters_combo35.md
+++ b/research/20260429_btc_q1_30min_low_vol_entry_filters_combo35.md
@@ -1,0 +1,27 @@
+# BTCUSDT Q1 2026 30min Low-Volatility Entry Gates
+
+Scope: research-only Python replay. No live or execution path is changed by this report.
+
+## Setup
+
+- Symbol/window: `BTCUSDT`, `2026-01-01T00:00:00+00:00` to `2026-03-31T23:59:59+00:00`
+- Execution bars: continuous `1s` bars rebuilt from Binance trade archives
+- Signal timeframe: `30min`
+- Replay mode: `live_intrabar_sma5`, breakout shape `baseline_plus_t3`, t3 SMA/ATR separation `0.25`
+- Sizing: `dir2_zero_initial=true`, `zero_initial_mode=reentry_window`, `reentry_size_schedule=[0.20, 0.10]`, `max_trades_per_bar=2`
+- Gate point: reentry price resolution, so the gate blocks both Zero-Initial-Reentry and SL-Reentry entries. Stop-loss exits are not filtered.
+
+## Results
+
+| Variant | Final Balance | Return | Max DD | Trades | Win Rate | Sharpe | Avg Loss | Worst Loss | Entry Mix | Gate Reject Calls |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---|---:|
+| `min_stop_bps_6_atr_pct_gte_35` | 227,154.89 | 127.15% | -1.13% | 2017 | 84.04% | 14.74 | -0.2218% | -0.7003% | `SL-Reentry:1344, Zero-Initial-Reentry:673` | 1146020 |
+
+## Delta vs Baseline
+
+| Variant | Final Delta | Return Delta | Max DD Delta | Trades Delta | Win Delta | Sharpe Delta |
+|---|---:|---:|---:|---:|---:|---:|
+
+## Variants
+
+- `min_stop_bps_6_atr_pct_gte_35`: Require both min stop distance of 6 bps and ATR percentile at least 35.

--- a/research/20260429_eth_q1_30min_breakout_confirmation_filters.md
+++ b/research/20260429_eth_q1_30min_breakout_confirmation_filters.md
@@ -1,0 +1,51 @@
+# ETHUSDT Q1 2026 30min Breakout Confirmation Filters
+
+Scope: research-only Python replay. No live or execution path is changed by this report.
+
+## Setup
+
+- Symbol/window: `ETHUSDT`, `2026-01-01T00:00:00+00:00` to `2026-03-31T23:59:59+00:00`
+- Execution bars: continuous `1s` bars rebuilt from Binance trade archives
+- Signal timeframe: `30min`
+- Replay mode: `live_intrabar_sma5`, breakout shape `baseline_plus_t3`, t3 SMA/ATR separation `0.25`
+- Sizing: `dir2_zero_initial=true`, `zero_initial_mode=reentry_window`, `reentry_size_schedule=[0.20, 0.10]`, `max_trades_per_bar=2`
+- Replay profile: `eth_research`
+- Risk params: `stop_loss_atr=0.05`, `trailing_stop_atr=0.3`, `delayed_trailing_activation=0.5`
+- `confirm_2x_1s` / `confirm_3x_1s` are multi-tick proxies: they require consecutive 1s observations to cross the same breakout level.
+
+## Results
+
+| Variant | Final Balance | Return | Max DD | Trades | Win Rate | Sharpe | Entry Mix | Filter Rejects |
+|---|---:|---:|---:|---:|---:|---:|---|---|
+| `baseline_single_observation` | 536,109.15 | 436.11% | -2.04% | 3226 | 80.60% | 13.49 | `SL-Reentry:2086, Zero-Initial-Reentry:1140` | `margin L/S 0/0; confirm L/S 0/0` |
+| `margin_0p02atr` | 517,226.25 | 417.23% | -1.97% | 3162 | 80.80% | 13.68 | `SL-Reentry:2047, Zero-Initial-Reentry:1115` | `margin L/S 7450/7523; confirm L/S 0/0` |
+| `confirm_2x_1s` | 524,591.79 | 424.59% | -2.04% | 3158 | 80.65% | 13.53 | `SL-Reentry:2042, Zero-Initial-Reentry:1116` | `margin L/S 0/0; confirm L/S 1660/1723` |
+| `confirm_3x_1s` | 523,434.32 | 423.43% | -2.04% | 3109 | 80.60% | 12.97 | `SL-Reentry:2011, Zero-Initial-Reentry:1098` | `margin L/S 0/0; confirm L/S 3190/3307` |
+
+## Delta vs Baseline
+
+| Variant | Final Balance Delta | Return Delta | Max DD Delta | Trades Delta | Win Rate Delta | Sharpe Delta |
+|---|---:|---:|---:|---:|---:|---:|
+| `margin_0p02atr` | -18,882.90 | -18.88 pp | 0.07 pp | -64 | 0.20 pp | 0.19 |
+| `confirm_2x_1s` | -11,517.36 | -11.52 pp | 0.00 pp | -68 | 0.05 pp | 0.04 |
+| `confirm_3x_1s` | -12,674.83 | -12.68 pp | 0.00 pp | -117 | 0.00 pp | -0.52 |
+
+## Breakout Attribution
+
+| Variant | Shape | Trades | Win Rate | Avg PnL | Net PnL | Worst PnL | Profit Factor |
+|---|---|---:|---:|---:|---:|---:|---:|
+| `baseline_single_observation` | `original_t2` | 2575 | 87.96% | 0.5409% | 555,845.31 | -0.1811% | 61.861 |
+| `baseline_single_observation` | `t3_swing` | 651 | 87.10% | 0.5355% | 137,520.44 | -0.1188% | 64.946 |
+| `margin_0p02atr` | `original_t2` | 2519 | 88.29% | 0.5395% | 529,207.28 | -0.1811% | 63.2888 |
+| `margin_0p02atr` | `t3_swing` | 643 | 86.94% | 0.5408% | 133,188.86 | -0.1365% | 61.3525 |
+| `confirm_2x_1s` | `original_t2` | 2514 | 87.87% | 0.5435% | 537,196.84 | -0.1811% | 61.4108 |
+| `confirm_2x_1s` | `t3_swing` | 644 | 86.80% | 0.5388% | 134,426.18 | -0.1188% | 63.4185 |
+| `confirm_3x_1s` | `original_t2` | 2471 | 88.06% | 0.5493% | 535,262.98 | -0.1811% | 63.557 |
+| `confirm_3x_1s` | `t3_swing` | 638 | 86.21% | 0.5438% | 132,784.43 | -0.1365% | 59.399 |
+
+## Variants
+
+- `baseline_single_observation`: Current research behavior: one 1s high/low crossing can lock the zero-initial window.
+- `margin_0p02atr`: Require breakout probe to clear the level by at least 0.02 ATR.
+- `confirm_2x_1s`: Require two consecutive 1s observations crossing the same breakout level.
+- `confirm_3x_1s`: Require three consecutive 1s observations crossing the same breakout level.

--- a/research/20260429_eth_q1_30min_low_vol_entry_filters.md
+++ b/research/20260429_eth_q1_30min_low_vol_entry_filters.md
@@ -1,0 +1,52 @@
+# ETHUSDT Q1 2026 30min Low-Volatility Entry Gates
+
+Scope: research-only Python replay. No live or execution path is changed by this report.
+
+## Setup
+
+- Symbol/window: `ETHUSDT`, `2026-01-01T00:00:00+00:00` to `2026-03-31T23:59:59+00:00`
+- Execution bars: continuous `1s` bars rebuilt from Binance trade archives
+- Signal timeframe: `30min`
+- Replay mode: `live_intrabar_sma5`, breakout shape `baseline_plus_t3`, t3 SMA/ATR separation `0.25`
+- Sizing: `dir2_zero_initial=true`, `zero_initial_mode=reentry_window`, `reentry_size_schedule=[0.20, 0.10]`, `max_trades_per_bar=2`
+- Risk profile: `stop_loss_atr=0.05`, `trailing_stop_atr=0.3`, `delayed_trailing_activation=0.5`
+- Gate point: reentry price resolution, so the gate blocks both Zero-Initial-Reentry and SL-Reentry entries. Stop-loss exits are not filtered.
+
+## Stop Distance Distribution
+
+| Count | Min | P05 | P10 | P25 | P50 | P75 | P90 | P95 | Max |
+|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| 4307 | 0.6144 | 1.2044 | 1.5776 | 2.3642 | 3.4132 | 4.6035 | 5.9251 | 7.2042 | 15.9955 |
+
+## Results
+
+| Variant | Final Balance | Return | Max DD | Trades | Win Rate | Sharpe | Avg Loss | Worst Loss | Entry Mix | Gate Reject Calls |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---|---:|
+| `baseline` | 536,109.15 | 436.11% | -2.04% | 3226 | 80.60% | 13.49 | -0.0798% | -0.1811% | `SL-Reentry:2086, Zero-Initial-Reentry:1140` | 0 |
+| `min_stop_bps_2` | 577,665.51 | 477.67% | -0.38% | 2622 | 86.84% | 15.18 | -0.0887% | -0.1811% | `SL-Reentry:1681, Zero-Initial-Reentry:941` | 560979 |
+| `min_stop_bps_4` | 388,532.61 | 288.53% | -0.21% | 1185 | 91.39% | 17.71 | -0.1055% | -0.1811% | `SL-Reentry:739, Zero-Initial-Reentry:446` | 1950049 |
+| `min_stop_bps_6` | 192,490.09 | 92.49% | -0.17% | 307 | 92.83% | 18.79 | -0.1368% | -0.1811% | `SL-Reentry:190, Zero-Initial-Reentry:117` | 2741898 |
+| `min_stop_bps_8` | 141,721.63 | 41.72% | -0.17% | 133 | 90.23% | 18.49 | -0.1490% | -0.1811% | `SL-Reentry:83, Zero-Initial-Reentry:50` | 2901698 |
+| `atr_pct_gte_25` | 486,720.09 | 386.72% | -0.34% | 2297 | 85.46% | 14.66 | -0.0884% | -0.1811% | `SL-Reentry:1471, Zero-Initial-Reentry:826` | 855849 |
+| `min_stop_bps_4_atr_pct_gte_25` | 364,445.73 | 264.45% | -0.21% | 1101 | 91.37% | 17.55 | -0.1064% | -0.1811% | `SL-Reentry:686, Zero-Initial-Reentry:415` | 2025929 |
+
+## Delta vs Baseline
+
+| Variant | Final Delta | Return Delta | Max DD Delta | Trades Delta | Win Delta | Sharpe Delta |
+|---|---:|---:|---:|---:|---:|---:|
+| `min_stop_bps_2` | 41,556.36 | 41.56 pp | 1.66 pp | -604 | 6.24 pp | 1.69 |
+| `min_stop_bps_4` | -147,576.54 | -147.58 pp | 1.83 pp | -2041 | 10.79 pp | 4.22 |
+| `min_stop_bps_6` | -343,619.06 | -343.62 pp | 1.87 pp | -2919 | 12.23 pp | 5.30 |
+| `min_stop_bps_8` | -394,387.52 | -394.39 pp | 1.87 pp | -3093 | 9.63 pp | 5.00 |
+| `atr_pct_gte_25` | -49,389.06 | -49.39 pp | 1.70 pp | -929 | 4.86 pp | 1.17 |
+| `min_stop_bps_4_atr_pct_gte_25` | -171,663.42 | -171.66 pp | 1.83 pp | -2125 | 10.77 pp | 4.06 |
+
+## Variants
+
+- `baseline`: No low-volatility entry gate.
+- `min_stop_bps_2`: Require stop_loss_atr * ATR to be at least 2 bps of entry reference price.
+- `min_stop_bps_4`: Require stop_loss_atr * ATR to be at least 4 bps of entry reference price.
+- `min_stop_bps_6`: Require stop_loss_atr * ATR to be at least 6 bps of entry reference price.
+- `min_stop_bps_8`: Require stop_loss_atr * ATR to be at least 8 bps of entry reference price.
+- `atr_pct_gte_25`: Require signal ATR percentile over the rolling 240 signal bars to be at least 25.
+- `min_stop_bps_4_atr_pct_gte_25`: Require both min stop distance of 4 bps and ATR percentile at least 25.

--- a/research/20260429_eth_q1_30min_stop_loss_atr_sweep.md
+++ b/research/20260429_eth_q1_30min_stop_loss_atr_sweep.md
@@ -1,0 +1,31 @@
+# ETHUSDT Q1 2026 30min Stop-Loss ATR Sweep
+
+Scope: research-only Python replay. No live or execution path is changed by this report.
+
+## Setup
+
+- Symbol/window: `ETHUSDT`, `2026-01-01T00:00:00+00:00` to `2026-03-31T23:59:59+00:00`
+- Execution bars: continuous `1s` bars rebuilt from Binance trade archives
+- Signal timeframe: `30min`
+- Replay mode: `live_intrabar_sma5`, breakout shape `baseline_plus_t3`, t3 SMA/ATR separation `0.25`
+- Sizing: `dir2_zero_initial=true`, `zero_initial_mode=reentry_window`, `reentry_size_schedule=[0.20, 0.10]`, `max_trades_per_bar=2`
+- Sweep changes only `stop_loss_atr`; `trailing_stop_atr=0.3` and `delayed_trailing_activation=0.5` stay fixed.
+
+## Results
+
+| stop_loss_atr | Final Balance | Return | Max DD | Trades | Win Rate | Sharpe | Avg Loss | Worst Loss | Profit Factor | Median Hold |
+|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| 0.05 | 536,109.15 | 436.11% | -2.04% | 3226 | 80.60% | 13.49 | -0.0798% | -0.1811% | 62.449 | 258s |
+| 0.10 | 534,500.90 | 434.50% | -2.12% | 3259 | 80.95% | 13.40 | -0.1103% | -0.3123% | 46.5882 | 271s |
+| 0.20 | 537,386.59 | 437.39% | -2.01% | 3229 | 82.41% | 13.40 | -0.1701% | -0.5745% | 33.4078 | 296s |
+| 0.30 | 551,198.83 | 451.20% | -1.86% | 3190 | 84.23% | 13.61 | -0.2248% | -0.8368% | 31.3064 | 307s |
+| 0.40 | 541,234.86 | 441.23% | -1.63% | 3136 | 85.36% | 13.72 | -0.2729% | -1.0990% | 29.286 | 308s |
+
+## Delta vs 0.05 ATR
+
+| stop_loss_atr | Final Delta | Return Delta | Max DD Delta | Trades Delta | Win Delta | Sharpe Delta |
+|---:|---:|---:|---:|---:|---:|---:|
+| 0.10 | -1,608.25 | -1.61 pp | -0.08 pp | 33 | 0.35 pp | -0.09 |
+| 0.20 | 1,277.44 | 1.28 pp | 0.03 pp | 3 | 1.81 pp | -0.09 |
+| 0.30 | 15,089.68 | 15.09 pp | 0.18 pp | -36 | 3.63 pp | 0.12 |
+| 0.40 | 5,125.71 | 5.12 pp | 0.41 pp | -90 | 4.76 pp | 0.23 |

--- a/research/btc_2026_q1_30min_breakout_confirmation_filters_summary.json
+++ b/research/btc_2026_q1_30min_breakout_confirmation_filters_summary.json
@@ -1,0 +1,610 @@
+{
+  "symbol": "BTCUSDT",
+  "start": "2026-01-01T00:00:00+00:00",
+  "end": "2026-03-31T23:59:59+00:00",
+  "build_stats": {
+    "raw_tick_rows": 448247191,
+    "kept_tick_rows": 448247183,
+    "sparse_second_rows": 7451463,
+    "continuous_second_rows": 7776000,
+    "first_second": "2026-01-01T00:00:00+00:00",
+    "last_second": "2026-03-31T23:59:59+00:00"
+  },
+  "signal_stats": {
+    "signal_rows": 4320,
+    "signal_start": "2026-01-01T00:00:00+00:00",
+    "signal_end": "2026-03-31T23:30:00+00:00",
+    "valid_sma5_rows": 4316,
+    "valid_atr_rows": 4307
+  },
+  "replay_kwargs": {
+    "dir2_zero_initial": true,
+    "zero_initial_mode": "reentry_window",
+    "fixed_slippage": 0.0005,
+    "stop_loss_atr": 0.3,
+    "stop_mode": "atr",
+    "max_trades_per_bar": 2,
+    "reentry_size_schedule": [
+      0.2,
+      0.1
+    ],
+    "long_reentry_atr": 0.1,
+    "short_reentry_atr": 0.0,
+    "profit_protect_atr": 1.0,
+    "trailing_stop_atr": 0.3,
+    "delayed_trailing_activation": 0.5,
+    "reentry_anchor_levels": "wick",
+    "reentry_trigger_mode": "reclaim"
+  },
+  "selected_variants": [
+    {
+      "name": "baseline_single_observation",
+      "description": "Current research behavior: one 1s high/low crossing can lock the zero-initial window."
+    },
+    {
+      "name": "margin_0p02atr",
+      "description": "Require breakout probe to clear the level by at least 0.02 ATR.",
+      "margin_atr": 0.02
+    },
+    {
+      "name": "confirm_2x_1s",
+      "description": "Require two consecutive 1s observations crossing the same breakout level.",
+      "confirm_observations": 2
+    },
+    {
+      "name": "confirm_3x_1s",
+      "description": "Require three consecutive 1s observations crossing the same breakout level.",
+      "confirm_observations": 3
+    }
+  ],
+  "results": [
+    {
+      "variant": "baseline_single_observation",
+      "description": "Current research behavior: one 1s high/low crossing can lock the zero-initial window.",
+      "params": {
+        "name": "baseline_single_observation",
+        "description": "Current research behavior: one 1s high/low crossing can lock the zero-initial window."
+      },
+      "summary": {
+        "final_balance": 227449.41,
+        "return_pct": 127.45,
+        "max_dd_pct": -3.03,
+        "trades": 3177,
+        "win_rate_pct": 76.46,
+        "sharpe": 13.23,
+        "first_entry": "2026-01-01T07:11:33+00:00",
+        "last_exit": "2026-03-31T23:59:59+00:00",
+        "entry_reasons": {
+          "SL-Reentry": 2137,
+          "Zero-Initial-Reentry": 1040
+        },
+        "exit_reasons": {
+          "SL": 3176,
+          "FinalMarkToMarket": 1
+        },
+        "entry_types": {
+          "SHORT": 1595,
+          "BUY": 1582
+        },
+        "integrity": {
+          "rows": 6354,
+          "entries": 3177,
+          "exits": 3177,
+          "zero_notional_entries": 0
+        }
+      },
+      "attribution": {
+        "original_t2": {
+          "trades": 2441,
+          "win_rate_pct": 89.47,
+          "avg_pnl_pct": 0.3705,
+          "median_pnl_pct": 0.2763,
+          "pnl_std_pct": 0.4355,
+          "worst_pnl_pct": -0.7003,
+          "net_pnl_value": 209920.87,
+          "max_pnl_drawdown": -285.47,
+          "profit_factor": 21.2922,
+          "entry_types": {
+            "SHORT": 1255,
+            "BUY": 1186
+          },
+          "entry_reasons": {
+            "SL-Reentry": 1638,
+            "Zero-Initial-Reentry": 803
+          },
+          "exit_reasons": {
+            "SL": 2440,
+            "FinalMarkToMarket": 1
+          }
+        },
+        "t3_swing": {
+          "trades": 736,
+          "win_rate_pct": 90.35,
+          "avg_pnl_pct": 0.3802,
+          "median_pnl_pct": 0.2807,
+          "pnl_std_pct": 0.4841,
+          "worst_pnl_pct": -0.6977,
+          "net_pnl_value": 66030.95,
+          "max_pnl_drawdown": -174.03,
+          "profit_factor": 24.3702,
+          "entry_types": {
+            "BUY": 396,
+            "SHORT": 340
+          },
+          "entry_reasons": {
+            "SL-Reentry": 499,
+            "Zero-Initial-Reentry": 237
+          },
+          "exit_reasons": {
+            "SL": 736
+          }
+        }
+      },
+      "diagnostics": {
+        "filters": {
+          "margin_rejects": {
+            "long": 0,
+            "short": 0
+          },
+          "confirm_rejects": {
+            "long": 0,
+            "short": 0
+          },
+          "margin_reject_distance_sum": {
+            "long": 0.0,
+            "short": 0.0
+          },
+          "margin_required": 0.0,
+          "max_confirm_count": {
+            "long": 1565,
+            "short": 1706
+          }
+        },
+        "replay": {
+          "breakout_locks": {
+            "long": {
+              "original_t2": 393,
+              "t3_swing": 124
+            },
+            "short": {
+              "original_t2": 434,
+              "t3_swing": 115
+            }
+          },
+          "t3_cooldown_skips": {
+            "long": 0,
+            "short": 0
+          },
+          "t3_quality_rejects": {
+            "long": {
+              "sma_atr_separation": 7
+            },
+            "short": {
+              "sma_atr_separation": 5
+            }
+          }
+        }
+      },
+      "elapsed_seconds": 230.76,
+      "ledger_path": "research/tmp_btc_2026_q1_30min_1s_breakout_confirmation_baseline_single_observation_ledger.csv"
+    },
+    {
+      "variant": "margin_0p02atr",
+      "description": "Require breakout probe to clear the level by at least 0.02 ATR.",
+      "params": {
+        "name": "margin_0p02atr",
+        "description": "Require breakout probe to clear the level by at least 0.02 ATR.",
+        "margin_atr": 0.02
+      },
+      "summary": {
+        "final_balance": 227787.82,
+        "return_pct": 127.79,
+        "max_dd_pct": -2.89,
+        "trades": 3111,
+        "win_rate_pct": 76.73,
+        "sharpe": 13.36,
+        "first_entry": "2026-01-01T07:11:33+00:00",
+        "last_exit": "2026-03-31T23:59:59+00:00",
+        "entry_reasons": {
+          "SL-Reentry": 2092,
+          "Zero-Initial-Reentry": 1019
+        },
+        "exit_reasons": {
+          "SL": 3110,
+          "FinalMarkToMarket": 1
+        },
+        "entry_types": {
+          "BUY": 1562,
+          "SHORT": 1549
+        },
+        "integrity": {
+          "rows": 6222,
+          "entries": 3111,
+          "exits": 3111,
+          "zero_notional_entries": 0
+        }
+      },
+      "attribution": {
+        "original_t2": {
+          "trades": 2383,
+          "win_rate_pct": 89.55,
+          "avg_pnl_pct": 0.3743,
+          "median_pnl_pct": 0.2831,
+          "pnl_std_pct": 0.4349,
+          "worst_pnl_pct": -0.7003,
+          "net_pnl_value": 207343.76,
+          "max_pnl_drawdown": -285.84,
+          "profit_factor": 21.7115,
+          "entry_types": {
+            "SHORT": 1214,
+            "BUY": 1169
+          },
+          "entry_reasons": {
+            "SL-Reentry": 1598,
+            "Zero-Initial-Reentry": 785
+          },
+          "exit_reasons": {
+            "SL": 2382,
+            "FinalMarkToMarket": 1
+          }
+        },
+        "t3_swing": {
+          "trades": 728,
+          "win_rate_pct": 90.52,
+          "avg_pnl_pct": 0.3832,
+          "median_pnl_pct": 0.2816,
+          "pnl_std_pct": 0.4856,
+          "worst_pnl_pct": -0.6977,
+          "net_pnl_value": 65741.71,
+          "max_pnl_drawdown": -174.49,
+          "profit_factor": 25.1944,
+          "entry_types": {
+            "BUY": 393,
+            "SHORT": 335
+          },
+          "entry_reasons": {
+            "SL-Reentry": 494,
+            "Zero-Initial-Reentry": 234
+          },
+          "exit_reasons": {
+            "SL": 728
+          }
+        }
+      },
+      "diagnostics": {
+        "filters": {
+          "margin_rejects": {
+            "long": 6648,
+            "short": 7380
+          },
+          "confirm_rejects": {
+            "long": 0,
+            "short": 0
+          },
+          "margin_reject_distance_sum": {
+            "long": 24227.05859375,
+            "short": 24948.82421875
+          },
+          "margin_required": 8.916122448979593,
+          "max_confirm_count": {
+            "long": 1565,
+            "short": 1706
+          }
+        },
+        "replay": {
+          "breakout_locks": {
+            "long": {
+              "original_t2": 387,
+              "t3_swing": 122
+            },
+            "short": {
+              "original_t2": 423,
+              "t3_swing": 114
+            }
+          },
+          "t3_cooldown_skips": {
+            "long": 0,
+            "short": 0
+          },
+          "t3_quality_rejects": {
+            "long": {
+              "sma_atr_separation": 8
+            },
+            "short": {
+              "sma_atr_separation": 5
+            }
+          }
+        }
+      },
+      "elapsed_seconds": 231.32,
+      "ledger_path": "research/tmp_btc_2026_q1_30min_1s_breakout_confirmation_margin_0p02atr_ledger.csv",
+      "delta_vs_baseline": {
+        "final_balance_delta": 338.41,
+        "return_pct_delta": 0.34,
+        "max_dd_pct_delta": 0.14,
+        "trades_delta": -66,
+        "win_rate_pct_delta": 0.27,
+        "sharpe_delta": 0.13
+      }
+    },
+    {
+      "variant": "confirm_2x_1s",
+      "description": "Require two consecutive 1s observations crossing the same breakout level.",
+      "params": {
+        "name": "confirm_2x_1s",
+        "description": "Require two consecutive 1s observations crossing the same breakout level.",
+        "confirm_observations": 2
+      },
+      "summary": {
+        "final_balance": 226802.02,
+        "return_pct": 126.8,
+        "max_dd_pct": -2.85,
+        "trades": 3126,
+        "win_rate_pct": 76.52,
+        "sharpe": 13.22,
+        "first_entry": "2026-01-01T07:11:34+00:00",
+        "last_exit": "2026-03-31T23:59:59+00:00",
+        "entry_reasons": {
+          "SL-Reentry": 2101,
+          "Zero-Initial-Reentry": 1025
+        },
+        "exit_reasons": {
+          "SL": 3125,
+          "FinalMarkToMarket": 1
+        },
+        "entry_types": {
+          "SHORT": 1583,
+          "BUY": 1543
+        },
+        "integrity": {
+          "rows": 6252,
+          "entries": 3126,
+          "exits": 3126,
+          "zero_notional_entries": 0
+        }
+      },
+      "attribution": {
+        "original_t2": {
+          "trades": 2399,
+          "win_rate_pct": 89.41,
+          "avg_pnl_pct": 0.3726,
+          "median_pnl_pct": 0.2786,
+          "pnl_std_pct": 0.4387,
+          "worst_pnl_pct": -0.7003,
+          "net_pnl_value": 206785.14,
+          "max_pnl_drawdown": -284.63,
+          "profit_factor": 21.0589,
+          "entry_types": {
+            "SHORT": 1247,
+            "BUY": 1152
+          },
+          "entry_reasons": {
+            "SL-Reentry": 1609,
+            "Zero-Initial-Reentry": 790
+          },
+          "exit_reasons": {
+            "SL": 2398,
+            "FinalMarkToMarket": 1
+          }
+        },
+        "t3_swing": {
+          "trades": 727,
+          "win_rate_pct": 90.37,
+          "avg_pnl_pct": 0.3827,
+          "median_pnl_pct": 0.2811,
+          "pnl_std_pct": 0.4861,
+          "worst_pnl_pct": -0.6977,
+          "net_pnl_value": 65491.28,
+          "max_pnl_drawdown": -173.98,
+          "profit_factor": 24.4563,
+          "entry_types": {
+            "BUY": 391,
+            "SHORT": 336
+          },
+          "entry_reasons": {
+            "SL-Reentry": 492,
+            "Zero-Initial-Reentry": 235
+          },
+          "exit_reasons": {
+            "SL": 727
+          }
+        }
+      },
+      "diagnostics": {
+        "filters": {
+          "margin_rejects": {
+            "long": 0,
+            "short": 0
+          },
+          "confirm_rejects": {
+            "long": 1502,
+            "short": 1490
+          },
+          "margin_reject_distance_sum": {
+            "long": 0.0,
+            "short": 0.0
+          },
+          "margin_required": 0.0,
+          "max_confirm_count": {
+            "long": 1566,
+            "short": 1706
+          }
+        },
+        "replay": {
+          "breakout_locks": {
+            "long": {
+              "original_t2": 368,
+              "t3_swing": 122
+            },
+            "short": {
+              "original_t2": 422,
+              "t3_swing": 113
+            }
+          },
+          "t3_cooldown_skips": {
+            "long": 0,
+            "short": 0
+          },
+          "t3_quality_rejects": {
+            "long": {
+              "sma_atr_separation": 7
+            },
+            "short": {
+              "sma_atr_separation": 5
+            }
+          }
+        }
+      },
+      "elapsed_seconds": 230.3,
+      "ledger_path": "research/tmp_btc_2026_q1_30min_1s_breakout_confirmation_confirm_2x_1s_ledger.csv",
+      "delta_vs_baseline": {
+        "final_balance_delta": -647.39,
+        "return_pct_delta": -0.65,
+        "max_dd_pct_delta": 0.18,
+        "trades_delta": -51,
+        "win_rate_pct_delta": 0.06,
+        "sharpe_delta": -0.01
+      }
+    },
+    {
+      "variant": "confirm_3x_1s",
+      "description": "Require three consecutive 1s observations crossing the same breakout level.",
+      "params": {
+        "name": "confirm_3x_1s",
+        "description": "Require three consecutive 1s observations crossing the same breakout level.",
+        "confirm_observations": 3
+      },
+      "summary": {
+        "final_balance": 227609.94,
+        "return_pct": 127.61,
+        "max_dd_pct": -2.86,
+        "trades": 3079,
+        "win_rate_pct": 76.78,
+        "sharpe": 13.3,
+        "first_entry": "2026-01-01T07:11:35+00:00",
+        "last_exit": "2026-03-31T23:59:59+00:00",
+        "entry_reasons": {
+          "SL-Reentry": 2071,
+          "Zero-Initial-Reentry": 1008
+        },
+        "exit_reasons": {
+          "SL": 3078,
+          "FinalMarkToMarket": 1
+        },
+        "entry_types": {
+          "BUY": 1541,
+          "SHORT": 1538
+        },
+        "integrity": {
+          "rows": 6158,
+          "entries": 3079,
+          "exits": 3079,
+          "zero_notional_entries": 0
+        }
+      },
+      "attribution": {
+        "original_t2": {
+          "trades": 2357,
+          "win_rate_pct": 89.56,
+          "avg_pnl_pct": 0.3753,
+          "median_pnl_pct": 0.2794,
+          "pnl_std_pct": 0.4389,
+          "worst_pnl_pct": -0.7003,
+          "net_pnl_value": 204943.75,
+          "max_pnl_drawdown": -285.08,
+          "profit_factor": 22.0497,
+          "entry_types": {
+            "SHORT": 1207,
+            "BUY": 1150
+          },
+          "entry_reasons": {
+            "SL-Reentry": 1582,
+            "Zero-Initial-Reentry": 775
+          },
+          "exit_reasons": {
+            "SL": 2356,
+            "FinalMarkToMarket": 1
+          }
+        },
+        "t3_swing": {
+          "trades": 722,
+          "win_rate_pct": 90.44,
+          "avg_pnl_pct": 0.386,
+          "median_pnl_pct": 0.2832,
+          "pnl_std_pct": 0.4873,
+          "worst_pnl_pct": -0.6977,
+          "net_pnl_value": 65641.31,
+          "max_pnl_drawdown": -173.42,
+          "profit_factor": 25.2337,
+          "entry_types": {
+            "BUY": 391,
+            "SHORT": 331
+          },
+          "entry_reasons": {
+            "SL-Reentry": 489,
+            "Zero-Initial-Reentry": 233
+          },
+          "exit_reasons": {
+            "SL": 722
+          }
+        }
+      },
+      "diagnostics": {
+        "filters": {
+          "margin_rejects": {
+            "long": 0,
+            "short": 0
+          },
+          "confirm_rejects": {
+            "long": 2877,
+            "short": 2907
+          },
+          "margin_reject_distance_sum": {
+            "long": 0.0,
+            "short": 0.0
+          },
+          "margin_required": 0.0,
+          "max_confirm_count": {
+            "long": 1567,
+            "short": 1706
+          }
+        },
+        "replay": {
+          "breakout_locks": {
+            "long": {
+              "original_t2": 365,
+              "t3_swing": 122
+            },
+            "short": {
+              "original_t2": 410,
+              "t3_swing": 111
+            }
+          },
+          "t3_cooldown_skips": {
+            "long": 0,
+            "short": 0
+          },
+          "t3_quality_rejects": {
+            "long": {
+              "sma_atr_separation": 7
+            },
+            "short": {
+              "sma_atr_separation": 5
+            }
+          }
+        }
+      },
+      "elapsed_seconds": 231.15,
+      "ledger_path": "research/tmp_btc_2026_q1_30min_1s_breakout_confirmation_confirm_3x_1s_ledger.csv",
+      "delta_vs_baseline": {
+        "final_balance_delta": 160.53,
+        "return_pct_delta": 0.16,
+        "max_dd_pct_delta": 0.17,
+        "trades_delta": -98,
+        "win_rate_pct_delta": 0.32,
+        "sharpe_delta": 0.07
+      }
+    }
+  ],
+  "note": "Research-only comparison. Consecutive 1s confirmation is used as a multi-tick proxy because this research replay operates on rebuilt 1s bars."
+}

--- a/research/btc_2026_q1_30min_low_vol_entry_filters_combo35_summary.json
+++ b/research/btc_2026_q1_30min_low_vol_entry_filters_combo35_summary.json
@@ -1,0 +1,194 @@
+{
+  "symbol": "BTCUSDT",
+  "start": "2026-01-01T00:00:00+00:00",
+  "end": "2026-03-31T23:59:59+00:00",
+  "build_stats": {
+    "raw_tick_rows": 448247191,
+    "kept_tick_rows": 448247183,
+    "sparse_second_rows": 7451463,
+    "continuous_second_rows": 7776000,
+    "first_second": "2026-01-01T00:00:00+00:00",
+    "last_second": "2026-03-31T23:59:59+00:00"
+  },
+  "signal_stats": {
+    "signal_rows": 4320,
+    "signal_start": "2026-01-01T00:00:00+00:00",
+    "signal_end": "2026-03-31T23:30:00+00:00",
+    "valid_sma5_rows": 4316,
+    "valid_atr_rows": 4307,
+    "valid_atr_percentile_rows": 4258
+  },
+  "replay_kwargs": {
+    "dir2_zero_initial": true,
+    "zero_initial_mode": "reentry_window",
+    "fixed_slippage": 0.0005,
+    "stop_loss_atr": 0.3,
+    "stop_mode": "atr",
+    "max_trades_per_bar": 2,
+    "reentry_size_schedule": [
+      0.2,
+      0.1
+    ],
+    "long_reentry_atr": 0.1,
+    "short_reentry_atr": 0.0,
+    "profit_protect_atr": 1.0,
+    "trailing_stop_atr": 0.3,
+    "delayed_trailing_activation": 0.5,
+    "reentry_anchor_levels": "wick",
+    "reentry_trigger_mode": "reclaim"
+  },
+  "selected_variants": [
+    {
+      "name": "min_stop_bps_6_atr_pct_gte_35",
+      "description": "Require both min stop distance of 6 bps and ATR percentile at least 35.",
+      "min_stop_bps": 6.0,
+      "atr_percentile_gte": 35.0
+    }
+  ],
+  "results": [
+    {
+      "variant": "min_stop_bps_6_atr_pct_gte_35",
+      "description": "Require both min stop distance of 6 bps and ATR percentile at least 35.",
+      "params": {
+        "name": "min_stop_bps_6_atr_pct_gte_35",
+        "description": "Require both min stop distance of 6 bps and ATR percentile at least 35.",
+        "min_stop_bps": 6.0,
+        "atr_percentile_gte": 35.0
+      },
+      "summary": {
+        "final_balance": 227154.89,
+        "return_pct": 127.15,
+        "max_dd_pct": -1.13,
+        "trades": 2017,
+        "win_rate_pct": 84.04,
+        "sharpe": 14.74,
+        "first_entry": "2026-01-02T08:13:12+00:00",
+        "last_exit": "2026-03-31T23:59:59+00:00",
+        "entry_reasons": {
+          "SL-Reentry": 1344,
+          "Zero-Initial-Reentry": 673
+        },
+        "exit_reasons": {
+          "SL": 2016,
+          "FinalMarkToMarket": 1
+        },
+        "entry_types": {
+          "SHORT": 1028,
+          "BUY": 989
+        },
+        "integrity": {
+          "rows": 4034,
+          "entries": 2017,
+          "exits": 2017,
+          "zero_notional_entries": 0
+        }
+      },
+      "pair_diagnostics": {
+        "paired_trades": 2017,
+        "avg_loss_pct": -0.2218,
+        "worst_loss_pct": -0.7003,
+        "avg_win_pct": 0.5277,
+        "profit_factor": 26.6453,
+        "median_hold_seconds": 381.0,
+        "avg_hold_seconds": 627.53,
+        "entry_reasons": {
+          "SL-Reentry": 1344,
+          "Zero-Initial-Reentry": 673
+        },
+        "exit_reasons": {
+          "SL": 2016,
+          "FinalMarkToMarket": 1
+        }
+      },
+      "attribution": {
+        "original_t2": {
+          "trades": 1579,
+          "win_rate_pct": 91.77,
+          "avg_pnl_pct": 0.4636,
+          "median_pnl_pct": 0.3555,
+          "pnl_std_pct": 0.4897,
+          "worst_pnl_pct": -0.7003,
+          "net_pnl_value": 171544.7,
+          "max_pnl_drawdown": -287.02,
+          "profit_factor": 25.5313,
+          "entry_types": {
+            "SHORT": 827,
+            "BUY": 752
+          },
+          "entry_reasons": {
+            "SL-Reentry": 1052,
+            "Zero-Initial-Reentry": 527
+          },
+          "exit_reasons": {
+            "SL": 1578,
+            "FinalMarkToMarket": 1
+          }
+        },
+        "t3_swing": {
+          "trades": 438,
+          "win_rate_pct": 93.61,
+          "avg_pnl_pct": 0.4882,
+          "median_pnl_pct": 0.373,
+          "pnl_std_pct": 0.5562,
+          "worst_pnl_pct": -0.6977,
+          "net_pnl_value": 50247.96,
+          "max_pnl_drawdown": -185.71,
+          "profit_factor": 31.3507,
+          "entry_types": {
+            "BUY": 237,
+            "SHORT": 201
+          },
+          "entry_reasons": {
+            "SL-Reentry": 292,
+            "Zero-Initial-Reentry": 146
+          },
+          "exit_reasons": {
+            "SL": 438
+          }
+        }
+      },
+      "diagnostics": {
+        "entry_gate": {
+          "calls": 1162009,
+          "allowed_calls": 15989,
+          "rejected_calls": 1146020,
+          "reject_reasons": {
+            "min_stop_bps": 203385,
+            "atr_percentile": 1146020
+          },
+          "min_observed_stop_bps": 2.221071936201564,
+          "max_observed_stop_bps": 80.18742827110815,
+          "min_observed_atr_percentile": 0.4166666666666667,
+          "max_observed_atr_percentile": 100.0
+        },
+        "replay": {
+          "breakout_locks": {
+            "long": {
+              "original_t2": 423,
+              "t3_swing": 129
+            },
+            "short": {
+              "original_t2": 454,
+              "t3_swing": 119
+            }
+          },
+          "t3_cooldown_skips": {
+            "long": 0,
+            "short": 0
+          },
+          "t3_quality_rejects": {
+            "long": {
+              "sma_atr_separation": 18
+            },
+            "short": {
+              "sma_atr_separation": 19
+            }
+          }
+        }
+      },
+      "elapsed_seconds": 194.21,
+      "ledger_path": "research/tmp_btc_2026_q1_30min_1s_low_vol_entry_filter_combo35_min_stop_bps_6_atr_pct_gte_35_ledger.csv"
+    }
+  ],
+  "note": "Research-only comparison. Entry gates patch reentry price resolution and do not alter stop-loss exit behavior."
+}

--- a/research/btc_2026_q1_30min_low_vol_entry_filters_summary.json
+++ b/research/btc_2026_q1_30min_low_vol_entry_filters_summary.json
@@ -1,0 +1,960 @@
+{
+  "symbol": "BTCUSDT",
+  "start": "2026-01-01T00:00:00+00:00",
+  "end": "2026-03-31T23:59:59+00:00",
+  "build_stats": {
+    "raw_tick_rows": 448247191,
+    "kept_tick_rows": 448247183,
+    "sparse_second_rows": 7451463,
+    "continuous_second_rows": 7776000,
+    "first_second": "2026-01-01T00:00:00+00:00",
+    "last_second": "2026-03-31T23:59:59+00:00"
+  },
+  "signal_stats": {
+    "signal_rows": 4320,
+    "signal_start": "2026-01-01T00:00:00+00:00",
+    "signal_end": "2026-03-31T23:30:00+00:00",
+    "valid_sma5_rows": 4316,
+    "valid_atr_rows": 4307,
+    "valid_atr_percentile_rows": 4258
+  },
+  "replay_kwargs": {
+    "dir2_zero_initial": true,
+    "zero_initial_mode": "reentry_window",
+    "fixed_slippage": 0.0005,
+    "stop_loss_atr": 0.3,
+    "stop_mode": "atr",
+    "max_trades_per_bar": 2,
+    "reentry_size_schedule": [
+      0.2,
+      0.1
+    ],
+    "long_reentry_atr": 0.1,
+    "short_reentry_atr": 0.0,
+    "profit_protect_atr": 1.0,
+    "trailing_stop_atr": 0.3,
+    "delayed_trailing_activation": 0.5,
+    "reentry_anchor_levels": "wick",
+    "reentry_trigger_mode": "reclaim"
+  },
+  "selected_variants": [
+    {
+      "name": "baseline",
+      "description": "No low-volatility entry gate."
+    },
+    {
+      "name": "min_stop_bps_6",
+      "description": "Require stop_loss_atr * ATR to be at least 6 bps of entry reference price.",
+      "min_stop_bps": 6.0
+    },
+    {
+      "name": "min_stop_bps_8",
+      "description": "Require stop_loss_atr * ATR to be at least 8 bps of entry reference price.",
+      "min_stop_bps": 8.0
+    },
+    {
+      "name": "atr_pct_gte_25",
+      "description": "Require signal ATR percentile over the rolling 240 signal bars to be at least 25.",
+      "atr_percentile_gte": 25.0
+    },
+    {
+      "name": "atr_pct_gte_35",
+      "description": "Require signal ATR percentile over the rolling 240 signal bars to be at least 35.",
+      "atr_percentile_gte": 35.0
+    },
+    {
+      "name": "min_stop_bps_6_atr_pct_gte_25",
+      "description": "Require both min stop distance of 6 bps and ATR percentile at least 25.",
+      "min_stop_bps": 6.0,
+      "atr_percentile_gte": 25.0
+    }
+  ],
+  "results": [
+    {
+      "variant": "baseline",
+      "description": "No low-volatility entry gate.",
+      "params": {
+        "name": "baseline",
+        "description": "No low-volatility entry gate."
+      },
+      "summary": {
+        "final_balance": 227449.41,
+        "return_pct": 127.45,
+        "max_dd_pct": -3.03,
+        "trades": 3177,
+        "win_rate_pct": 76.46,
+        "sharpe": 13.23,
+        "first_entry": "2026-01-01T07:11:33+00:00",
+        "last_exit": "2026-03-31T23:59:59+00:00",
+        "entry_reasons": {
+          "SL-Reentry": 2137,
+          "Zero-Initial-Reentry": 1040
+        },
+        "exit_reasons": {
+          "SL": 3176,
+          "FinalMarkToMarket": 1
+        },
+        "entry_types": {
+          "SHORT": 1595,
+          "BUY": 1582
+        },
+        "integrity": {
+          "rows": 6354,
+          "entries": 3177,
+          "exits": 3177,
+          "zero_notional_entries": 0
+        }
+      },
+      "pair_diagnostics": {
+        "paired_trades": 3177,
+        "avg_loss_pct": -0.1659,
+        "worst_loss_pct": -0.7003,
+        "avg_win_pct": 0.4348,
+        "profit_factor": 21.9525,
+        "median_hold_seconds": 355.0,
+        "avg_hold_seconds": 600.92,
+        "entry_reasons": {
+          "SL-Reentry": 2137,
+          "Zero-Initial-Reentry": 1040
+        },
+        "exit_reasons": {
+          "SL": 3176,
+          "FinalMarkToMarket": 1
+        }
+      },
+      "attribution": {
+        "original_t2": {
+          "trades": 2441,
+          "win_rate_pct": 89.47,
+          "avg_pnl_pct": 0.3705,
+          "median_pnl_pct": 0.2763,
+          "pnl_std_pct": 0.4355,
+          "worst_pnl_pct": -0.7003,
+          "net_pnl_value": 209920.87,
+          "max_pnl_drawdown": -285.47,
+          "profit_factor": 21.2922,
+          "entry_types": {
+            "SHORT": 1255,
+            "BUY": 1186
+          },
+          "entry_reasons": {
+            "SL-Reentry": 1638,
+            "Zero-Initial-Reentry": 803
+          },
+          "exit_reasons": {
+            "SL": 2440,
+            "FinalMarkToMarket": 1
+          }
+        },
+        "t3_swing": {
+          "trades": 736,
+          "win_rate_pct": 90.35,
+          "avg_pnl_pct": 0.3802,
+          "median_pnl_pct": 0.2807,
+          "pnl_std_pct": 0.4841,
+          "worst_pnl_pct": -0.6977,
+          "net_pnl_value": 66030.95,
+          "max_pnl_drawdown": -174.03,
+          "profit_factor": 24.3702,
+          "entry_types": {
+            "BUY": 396,
+            "SHORT": 340
+          },
+          "entry_reasons": {
+            "SL-Reentry": 499,
+            "Zero-Initial-Reentry": 237
+          },
+          "exit_reasons": {
+            "SL": 736
+          }
+        }
+      },
+      "diagnostics": {
+        "entry_gate": {
+          "calls": 24366,
+          "allowed_calls": 24366,
+          "rejected_calls": 0,
+          "reject_reasons": {},
+          "min_observed_stop_bps": 2.244589406582735,
+          "max_observed_stop_bps": 80.18742827110815,
+          "min_observed_atr_percentile": 0.4166666666666667,
+          "max_observed_atr_percentile": 100.0
+        },
+        "replay": {
+          "breakout_locks": {
+            "long": {
+              "original_t2": 393,
+              "t3_swing": 124
+            },
+            "short": {
+              "original_t2": 434,
+              "t3_swing": 115
+            }
+          },
+          "t3_cooldown_skips": {
+            "long": 0,
+            "short": 0
+          },
+          "t3_quality_rejects": {
+            "long": {
+              "sma_atr_separation": 7
+            },
+            "short": {
+              "sma_atr_separation": 5
+            }
+          }
+        }
+      },
+      "elapsed_seconds": 230.18,
+      "ledger_path": "research/tmp_btc_2026_q1_30min_1s_low_vol_entry_filter_baseline_ledger.csv"
+    },
+    {
+      "variant": "min_stop_bps_6",
+      "description": "Require stop_loss_atr * ATR to be at least 6 bps of entry reference price.",
+      "params": {
+        "name": "min_stop_bps_6",
+        "description": "Require stop_loss_atr * ATR to be at least 6 bps of entry reference price.",
+        "min_stop_bps": 6.0
+      },
+      "summary": {
+        "final_balance": 240319.34,
+        "return_pct": 140.32,
+        "max_dd_pct": -1.27,
+        "trades": 2967,
+        "win_rate_pct": 80.49,
+        "sharpe": 13.91,
+        "first_entry": "2026-01-01T19:39:10+00:00",
+        "last_exit": "2026-03-31T23:59:59+00:00",
+        "entry_reasons": {
+          "SL-Reentry": 1996,
+          "Zero-Initial-Reentry": 971
+        },
+        "exit_reasons": {
+          "SL": 2966,
+          "FinalMarkToMarket": 1
+        },
+        "entry_types": {
+          "SHORT": 1494,
+          "BUY": 1473
+        },
+        "integrity": {
+          "rows": 5934,
+          "entries": 2967,
+          "exits": 2967,
+          "zero_notional_entries": 0
+        }
+      },
+      "pair_diagnostics": {
+        "paired_trades": 2967,
+        "avg_loss_pct": -0.1977,
+        "worst_loss_pct": -0.7003,
+        "avg_win_pct": 0.4521,
+        "profit_factor": 23.0636,
+        "median_hold_seconds": 355.0,
+        "avg_hold_seconds": 598.51,
+        "entry_reasons": {
+          "SL-Reentry": 1996,
+          "Zero-Initial-Reentry": 971
+        },
+        "exit_reasons": {
+          "SL": 2966,
+          "FinalMarkToMarket": 1
+        }
+      },
+      "attribution": {
+        "original_t2": {
+          "trades": 2285,
+          "win_rate_pct": 91.25,
+          "avg_pnl_pct": 0.3935,
+          "median_pnl_pct": 0.2977,
+          "pnl_std_pct": 0.44,
+          "worst_pnl_pct": -0.7003,
+          "net_pnl_value": 219765.74,
+          "max_pnl_drawdown": -301.27,
+          "profit_factor": 22.3802,
+          "entry_types": {
+            "SHORT": 1179,
+            "BUY": 1106
+          },
+          "entry_reasons": {
+            "SL-Reentry": 1532,
+            "Zero-Initial-Reentry": 753
+          },
+          "exit_reasons": {
+            "SL": 2284,
+            "FinalMarkToMarket": 1
+          }
+        },
+        "t3_swing": {
+          "trades": 682,
+          "win_rate_pct": 92.23,
+          "avg_pnl_pct": 0.4074,
+          "median_pnl_pct": 0.3034,
+          "pnl_std_pct": 0.4921,
+          "worst_pnl_pct": -0.6977,
+          "net_pnl_value": 69035.19,
+          "max_pnl_drawdown": -183.44,
+          "profit_factor": 25.5633,
+          "entry_types": {
+            "BUY": 367,
+            "SHORT": 315
+          },
+          "entry_reasons": {
+            "SL-Reentry": 464,
+            "Zero-Initial-Reentry": 218
+          },
+          "exit_reasons": {
+            "SL": 682
+          }
+        }
+      },
+      "diagnostics": {
+        "entry_gate": {
+          "calls": 227998,
+          "allowed_calls": 22216,
+          "rejected_calls": 205782,
+          "reject_reasons": {
+            "min_stop_bps": 205782
+          },
+          "min_observed_stop_bps": 2.221071936201564,
+          "max_observed_stop_bps": 80.18742827110815,
+          "min_observed_atr_percentile": 0.4166666666666667,
+          "max_observed_atr_percentile": 100.0
+        },
+        "replay": {
+          "breakout_locks": {
+            "long": {
+              "original_t2": 397,
+              "t3_swing": 125
+            },
+            "short": {
+              "original_t2": 436,
+              "t3_swing": 115
+            }
+          },
+          "t3_cooldown_skips": {
+            "long": 0,
+            "short": 0
+          },
+          "t3_quality_rejects": {
+            "long": {
+              "sma_atr_separation": 10
+            },
+            "short": {
+              "sma_atr_separation": 7
+            }
+          }
+        }
+      },
+      "elapsed_seconds": 233.94,
+      "ledger_path": "research/tmp_btc_2026_q1_30min_1s_low_vol_entry_filter_min_stop_bps_6_ledger.csv",
+      "delta_vs_baseline": {
+        "final_balance_delta": 12869.93,
+        "return_pct_delta": 12.87,
+        "max_dd_pct_delta": 1.76,
+        "trades_delta": -210,
+        "win_rate_pct_delta": 4.03,
+        "sharpe_delta": 0.68
+      }
+    },
+    {
+      "variant": "min_stop_bps_8",
+      "description": "Require stop_loss_atr * ATR to be at least 8 bps of entry reference price.",
+      "params": {
+        "name": "min_stop_bps_8",
+        "description": "Require stop_loss_atr * ATR to be at least 8 bps of entry reference price.",
+        "min_stop_bps": 8.0
+      },
+      "summary": {
+        "final_balance": 251377.98,
+        "return_pct": 151.38,
+        "max_dd_pct": -0.66,
+        "trades": 2748,
+        "win_rate_pct": 83.08,
+        "sharpe": 14.56,
+        "first_entry": "2026-01-02T03:07:26+00:00",
+        "last_exit": "2026-03-31T23:59:59+00:00",
+        "entry_reasons": {
+          "SL-Reentry": 1847,
+          "Zero-Initial-Reentry": 901
+        },
+        "exit_reasons": {
+          "SL": 2747,
+          "FinalMarkToMarket": 1
+        },
+        "entry_types": {
+          "BUY": 1375,
+          "SHORT": 1373
+        },
+        "integrity": {
+          "rows": 5496,
+          "entries": 2748,
+          "exits": 2748,
+          "zero_notional_entries": 0
+        }
+      },
+      "pair_diagnostics": {
+        "paired_trades": 2748,
+        "avg_loss_pct": -0.213,
+        "worst_loss_pct": -0.7003,
+        "avg_win_pct": 0.4769,
+        "profit_factor": 24.5632,
+        "median_hold_seconds": 353.0,
+        "avg_hold_seconds": 603.15,
+        "entry_reasons": {
+          "SL-Reentry": 1847,
+          "Zero-Initial-Reentry": 901
+        },
+        "exit_reasons": {
+          "SL": 2747,
+          "FinalMarkToMarket": 1
+        }
+      },
+      "attribution": {
+        "original_t2": {
+          "trades": 2101,
+          "win_rate_pct": 91.77,
+          "avg_pnl_pct": 0.4205,
+          "median_pnl_pct": 0.327,
+          "pnl_std_pct": 0.4485,
+          "worst_pnl_pct": -0.7003,
+          "net_pnl_value": 224392.21,
+          "max_pnl_drawdown": -313.99,
+          "profit_factor": 23.7211,
+          "entry_types": {
+            "SHORT": 1071,
+            "BUY": 1030
+          },
+          "entry_reasons": {
+            "SL-Reentry": 1407,
+            "Zero-Initial-Reentry": 694
+          },
+          "exit_reasons": {
+            "SL": 2100,
+            "FinalMarkToMarket": 1
+          }
+        },
+        "t3_swing": {
+          "trades": 647,
+          "win_rate_pct": 93.2,
+          "avg_pnl_pct": 0.4288,
+          "median_pnl_pct": 0.329,
+          "pnl_std_pct": 0.4969,
+          "worst_pnl_pct": -0.6977,
+          "net_pnl_value": 71279.65,
+          "max_pnl_drawdown": -188.84,
+          "profit_factor": 27.6756,
+          "entry_types": {
+            "BUY": 345,
+            "SHORT": 302
+          },
+          "entry_reasons": {
+            "SL-Reentry": 440,
+            "Zero-Initial-Reentry": 207
+          },
+          "exit_reasons": {
+            "SL": 647
+          }
+        }
+      },
+      "diagnostics": {
+        "entry_gate": {
+          "calls": 462831,
+          "allowed_calls": 19260,
+          "rejected_calls": 443571,
+          "reject_reasons": {
+            "min_stop_bps": 443571
+          },
+          "min_observed_stop_bps": 2.221071936201564,
+          "max_observed_stop_bps": 80.18742827110815,
+          "min_observed_atr_percentile": 0.4166666666666667,
+          "max_observed_atr_percentile": 100.0
+        },
+        "replay": {
+          "breakout_locks": {
+            "long": {
+              "original_t2": 401,
+              "t3_swing": 125
+            },
+            "short": {
+              "original_t2": 437,
+              "t3_swing": 117
+            }
+          },
+          "t3_cooldown_skips": {
+            "long": 0,
+            "short": 0
+          },
+          "t3_quality_rejects": {
+            "long": {
+              "sma_atr_separation": 11
+            },
+            "short": {
+              "sma_atr_separation": 7
+            }
+          }
+        }
+      },
+      "elapsed_seconds": 231.76,
+      "ledger_path": "research/tmp_btc_2026_q1_30min_1s_low_vol_entry_filter_min_stop_bps_8_ledger.csv",
+      "delta_vs_baseline": {
+        "final_balance_delta": 23928.57,
+        "return_pct_delta": 23.93,
+        "max_dd_pct_delta": 2.37,
+        "trades_delta": -429,
+        "win_rate_pct_delta": 6.62,
+        "sharpe_delta": 1.33
+      }
+    },
+    {
+      "variant": "atr_pct_gte_25",
+      "description": "Require signal ATR percentile over the rolling 240 signal bars to be at least 25.",
+      "params": {
+        "name": "atr_pct_gte_25",
+        "description": "Require signal ATR percentile over the rolling 240 signal bars to be at least 25.",
+        "atr_percentile_gte": 25.0
+      },
+      "summary": {
+        "final_balance": 237251.08,
+        "return_pct": 137.25,
+        "max_dd_pct": -1.27,
+        "trades": 2334,
+        "win_rate_pct": 82.73,
+        "sharpe": 14.47,
+        "first_entry": "2026-01-02T08:13:12+00:00",
+        "last_exit": "2026-03-31T23:59:59+00:00",
+        "entry_reasons": {
+          "SL-Reentry": 1558,
+          "Zero-Initial-Reentry": 776
+        },
+        "exit_reasons": {
+          "SL": 2333,
+          "FinalMarkToMarket": 1
+        },
+        "entry_types": {
+          "SHORT": 1184,
+          "BUY": 1150
+        },
+        "integrity": {
+          "rows": 4668,
+          "entries": 2334,
+          "exits": 2334,
+          "zero_notional_entries": 0
+        }
+      },
+      "pair_diagnostics": {
+        "paired_trades": 2334,
+        "avg_loss_pct": -0.2117,
+        "worst_loss_pct": -0.7003,
+        "avg_win_pct": 0.5048,
+        "profit_factor": 25.1441,
+        "median_hold_seconds": 368.0,
+        "avg_hold_seconds": 610.36,
+        "entry_reasons": {
+          "SL-Reentry": 1558,
+          "Zero-Initial-Reentry": 776
+        },
+        "exit_reasons": {
+          "SL": 2333,
+          "FinalMarkToMarket": 1
+        }
+      },
+      "attribution": {
+        "original_t2": {
+          "trades": 1804,
+          "win_rate_pct": 91.57,
+          "avg_pnl_pct": 0.4408,
+          "median_pnl_pct": 0.3411,
+          "pnl_std_pct": 0.4735,
+          "worst_pnl_pct": -0.7003,
+          "net_pnl_value": 190391.63,
+          "max_pnl_drawdown": -296.92,
+          "profit_factor": 24.4523,
+          "entry_types": {
+            "SHORT": 936,
+            "BUY": 868
+          },
+          "entry_reasons": {
+            "SL-Reentry": 1203,
+            "Zero-Initial-Reentry": 601
+          },
+          "exit_reasons": {
+            "SL": 1803,
+            "FinalMarkToMarket": 1
+          }
+        },
+        "t3_swing": {
+          "trades": 530,
+          "win_rate_pct": 92.26,
+          "avg_pnl_pct": 0.4617,
+          "median_pnl_pct": 0.3525,
+          "pnl_std_pct": 0.5367,
+          "worst_pnl_pct": -0.6977,
+          "net_pnl_value": 58953.11,
+          "max_pnl_drawdown": -183.62,
+          "profit_factor": 27.6861,
+          "entry_types": {
+            "BUY": 282,
+            "SHORT": 248
+          },
+          "entry_reasons": {
+            "SL-Reentry": 355,
+            "Zero-Initial-Reentry": 175
+          },
+          "exit_reasons": {
+            "SL": 530
+          }
+        }
+      },
+      "diagnostics": {
+        "entry_gate": {
+          "calls": 845230,
+          "allowed_calls": 18656,
+          "rejected_calls": 826574,
+          "reject_reasons": {
+            "atr_percentile": 826574
+          },
+          "min_observed_stop_bps": 2.221071936201564,
+          "max_observed_stop_bps": 80.18742827110815,
+          "min_observed_atr_percentile": 0.4166666666666667,
+          "max_observed_atr_percentile": 100.0
+        },
+        "replay": {
+          "breakout_locks": {
+            "long": {
+              "original_t2": 413,
+              "t3_swing": 127
+            },
+            "short": {
+              "original_t2": 448,
+              "t3_swing": 117
+            }
+          },
+          "t3_cooldown_skips": {
+            "long": 0,
+            "short": 0
+          },
+          "t3_quality_rejects": {
+            "long": {
+              "sma_atr_separation": 16
+            },
+            "short": {
+              "sma_atr_separation": 17
+            }
+          }
+        }
+      },
+      "elapsed_seconds": 236.09,
+      "ledger_path": "research/tmp_btc_2026_q1_30min_1s_low_vol_entry_filter_atr_pct_gte_25_ledger.csv",
+      "delta_vs_baseline": {
+        "final_balance_delta": 9801.67,
+        "return_pct_delta": 9.8,
+        "max_dd_pct_delta": 1.76,
+        "trades_delta": -843,
+        "win_rate_pct_delta": 6.27,
+        "sharpe_delta": 1.24
+      }
+    },
+    {
+      "variant": "atr_pct_gte_35",
+      "description": "Require signal ATR percentile over the rolling 240 signal bars to be at least 35.",
+      "params": {
+        "name": "atr_pct_gte_35",
+        "description": "Require signal ATR percentile over the rolling 240 signal bars to be at least 35.",
+        "atr_percentile_gte": 35.0
+      },
+      "summary": {
+        "final_balance": 227154.89,
+        "return_pct": 127.15,
+        "max_dd_pct": -1.13,
+        "trades": 2017,
+        "win_rate_pct": 84.04,
+        "sharpe": 14.74,
+        "first_entry": "2026-01-02T08:13:12+00:00",
+        "last_exit": "2026-03-31T23:59:59+00:00",
+        "entry_reasons": {
+          "SL-Reentry": 1344,
+          "Zero-Initial-Reentry": 673
+        },
+        "exit_reasons": {
+          "SL": 2016,
+          "FinalMarkToMarket": 1
+        },
+        "entry_types": {
+          "SHORT": 1028,
+          "BUY": 989
+        },
+        "integrity": {
+          "rows": 4034,
+          "entries": 2017,
+          "exits": 2017,
+          "zero_notional_entries": 0
+        }
+      },
+      "pair_diagnostics": {
+        "paired_trades": 2017,
+        "avg_loss_pct": -0.2218,
+        "worst_loss_pct": -0.7003,
+        "avg_win_pct": 0.5277,
+        "profit_factor": 26.6453,
+        "median_hold_seconds": 381.0,
+        "avg_hold_seconds": 627.53,
+        "entry_reasons": {
+          "SL-Reentry": 1344,
+          "Zero-Initial-Reentry": 673
+        },
+        "exit_reasons": {
+          "SL": 2016,
+          "FinalMarkToMarket": 1
+        }
+      },
+      "attribution": {
+        "original_t2": {
+          "trades": 1579,
+          "win_rate_pct": 91.77,
+          "avg_pnl_pct": 0.4636,
+          "median_pnl_pct": 0.3555,
+          "pnl_std_pct": 0.4897,
+          "worst_pnl_pct": -0.7003,
+          "net_pnl_value": 171544.7,
+          "max_pnl_drawdown": -287.02,
+          "profit_factor": 25.5313,
+          "entry_types": {
+            "SHORT": 827,
+            "BUY": 752
+          },
+          "entry_reasons": {
+            "SL-Reentry": 1052,
+            "Zero-Initial-Reentry": 527
+          },
+          "exit_reasons": {
+            "SL": 1578,
+            "FinalMarkToMarket": 1
+          }
+        },
+        "t3_swing": {
+          "trades": 438,
+          "win_rate_pct": 93.61,
+          "avg_pnl_pct": 0.4882,
+          "median_pnl_pct": 0.373,
+          "pnl_std_pct": 0.5562,
+          "worst_pnl_pct": -0.6977,
+          "net_pnl_value": 50247.96,
+          "max_pnl_drawdown": -185.71,
+          "profit_factor": 31.3507,
+          "entry_types": {
+            "BUY": 237,
+            "SHORT": 201
+          },
+          "entry_reasons": {
+            "SL-Reentry": 292,
+            "Zero-Initial-Reentry": 146
+          },
+          "exit_reasons": {
+            "SL": 438
+          }
+        }
+      },
+      "diagnostics": {
+        "entry_gate": {
+          "calls": 1162009,
+          "allowed_calls": 15989,
+          "rejected_calls": 1146020,
+          "reject_reasons": {
+            "atr_percentile": 1146020
+          },
+          "min_observed_stop_bps": 2.221071936201564,
+          "max_observed_stop_bps": 80.18742827110815,
+          "min_observed_atr_percentile": 0.4166666666666667,
+          "max_observed_atr_percentile": 100.0
+        },
+        "replay": {
+          "breakout_locks": {
+            "long": {
+              "original_t2": 423,
+              "t3_swing": 129
+            },
+            "short": {
+              "original_t2": 454,
+              "t3_swing": 119
+            }
+          },
+          "t3_cooldown_skips": {
+            "long": 0,
+            "short": 0
+          },
+          "t3_quality_rejects": {
+            "long": {
+              "sma_atr_separation": 18
+            },
+            "short": {
+              "sma_atr_separation": 19
+            }
+          }
+        }
+      },
+      "elapsed_seconds": 239.02,
+      "ledger_path": "research/tmp_btc_2026_q1_30min_1s_low_vol_entry_filter_atr_pct_gte_35_ledger.csv",
+      "delta_vs_baseline": {
+        "final_balance_delta": -294.52,
+        "return_pct_delta": -0.3,
+        "max_dd_pct_delta": 1.9,
+        "trades_delta": -1160,
+        "win_rate_pct_delta": 7.58,
+        "sharpe_delta": 1.51
+      }
+    },
+    {
+      "variant": "min_stop_bps_6_atr_pct_gte_25",
+      "description": "Require both min stop distance of 6 bps and ATR percentile at least 25.",
+      "params": {
+        "name": "min_stop_bps_6_atr_pct_gte_25",
+        "description": "Require both min stop distance of 6 bps and ATR percentile at least 25.",
+        "min_stop_bps": 6.0,
+        "atr_percentile_gte": 25.0
+      },
+      "summary": {
+        "final_balance": 238079.98,
+        "return_pct": 138.08,
+        "max_dd_pct": -1.27,
+        "trades": 2318,
+        "win_rate_pct": 83.09,
+        "sharpe": 14.54,
+        "first_entry": "2026-01-02T08:13:12+00:00",
+        "last_exit": "2026-03-31T23:59:59+00:00",
+        "entry_reasons": {
+          "SL-Reentry": 1549,
+          "Zero-Initial-Reentry": 769
+        },
+        "exit_reasons": {
+          "SL": 2317,
+          "FinalMarkToMarket": 1
+        },
+        "entry_types": {
+          "SHORT": 1178,
+          "BUY": 1140
+        },
+        "integrity": {
+          "rows": 4636,
+          "entries": 2318,
+          "exits": 2318,
+          "zero_notional_entries": 0
+        }
+      },
+      "pair_diagnostics": {
+        "paired_trades": 2318,
+        "avg_loss_pct": -0.2146,
+        "worst_loss_pct": -0.7003,
+        "avg_win_pct": 0.507,
+        "profit_factor": 25.2584,
+        "median_hold_seconds": 368.5,
+        "avg_hold_seconds": 611.28,
+        "entry_reasons": {
+          "SL-Reentry": 1549,
+          "Zero-Initial-Reentry": 769
+        },
+        "exit_reasons": {
+          "SL": 2317,
+          "FinalMarkToMarket": 1
+        }
+      },
+      "attribution": {
+        "original_t2": {
+          "trades": 1795,
+          "win_rate_pct": 91.7,
+          "avg_pnl_pct": 0.4429,
+          "median_pnl_pct": 0.3425,
+          "pnl_std_pct": 0.4737,
+          "worst_pnl_pct": -0.7003,
+          "net_pnl_value": 190980.34,
+          "max_pnl_drawdown": -297.96,
+          "profit_factor": 24.5511,
+          "entry_types": {
+            "SHORT": 934,
+            "BUY": 861
+          },
+          "entry_reasons": {
+            "SL-Reentry": 1197,
+            "Zero-Initial-Reentry": 598
+          },
+          "exit_reasons": {
+            "SL": 1794,
+            "FinalMarkToMarket": 1
+          }
+        },
+        "t3_swing": {
+          "trades": 523,
+          "win_rate_pct": 92.35,
+          "avg_pnl_pct": 0.4662,
+          "median_pnl_pct": 0.3591,
+          "pnl_std_pct": 0.5386,
+          "worst_pnl_pct": -0.6977,
+          "net_pnl_value": 59009.71,
+          "max_pnl_drawdown": -184.26,
+          "profit_factor": 27.8699,
+          "entry_types": {
+            "BUY": 279,
+            "SHORT": 244
+          },
+          "entry_reasons": {
+            "SL-Reentry": 352,
+            "Zero-Initial-Reentry": 171
+          },
+          "exit_reasons": {
+            "SL": 523
+          }
+        }
+      },
+      "diagnostics": {
+        "entry_gate": {
+          "calls": 861992,
+          "allowed_calls": 18283,
+          "rejected_calls": 843709,
+          "reject_reasons": {
+            "min_stop_bps": 202666,
+            "atr_percentile": 826574
+          },
+          "min_observed_stop_bps": 2.221071936201564,
+          "max_observed_stop_bps": 80.18742827110815,
+          "min_observed_atr_percentile": 0.4166666666666667,
+          "max_observed_atr_percentile": 100.0
+        },
+        "replay": {
+          "breakout_locks": {
+            "long": {
+              "original_t2": 413,
+              "t3_swing": 127
+            },
+            "short": {
+              "original_t2": 448,
+              "t3_swing": 117
+            }
+          },
+          "t3_cooldown_skips": {
+            "long": 0,
+            "short": 0
+          },
+          "t3_quality_rejects": {
+            "long": {
+              "sma_atr_separation": 16
+            },
+            "short": {
+              "sma_atr_separation": 17
+            }
+          }
+        }
+      },
+      "elapsed_seconds": 235.56,
+      "ledger_path": "research/tmp_btc_2026_q1_30min_1s_low_vol_entry_filter_min_stop_bps_6_atr_pct_gte_25_ledger.csv",
+      "delta_vs_baseline": {
+        "final_balance_delta": 10630.57,
+        "return_pct_delta": 10.63,
+        "max_dd_pct_delta": 1.76,
+        "trades_delta": -859,
+        "win_rate_pct_delta": 6.63,
+        "sharpe_delta": 1.31
+      }
+    }
+  ],
+  "note": "Research-only comparison. Entry gates patch reentry price resolution and do not alter stop-loss exit behavior."
+}

--- a/research/btc_2026_q1_breakout_confirmation_filters.py
+++ b/research/btc_2026_q1_breakout_confirmation_filters.py
@@ -1,0 +1,383 @@
+#!/usr/bin/env python3
+"""BTC Q1 2026 30min breakout confirmation filters, 1s research replay.
+
+Research-only script. It reuses the existing Python 1s replay engine and
+temporarily wraps breakout detection to compare:
+- baseline single-observation breakout lock
+- ATR-distance breakout threshold
+- consecutive 1s breakout confirmation as a multi-tick proxy
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from contextlib import contextmanager
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+import eth_q1_breakout_t3_shape_compare as replay
+
+
+DEFAULT_TICK_FILES = [
+    "dataset/archive/BTCUSDT-trades-2026-01/BTCUSDT-trades-2026-01.csv",
+    "dataset/archive/BTCUSDT-trades-2026-02/BTCUSDT-trades-2026-02.csv",
+    "dataset/archive/BTCUSDT-trades-2026-03/BTCUSDT-trades-2026-03.csv",
+]
+
+PRODUCTION_LIKE_REPLAY_KWARGS = {
+    "dir2_zero_initial": True,
+    "zero_initial_mode": "reentry_window",
+    "fixed_slippage": 0.0005,
+    "stop_loss_atr": 0.3,
+    "stop_mode": "atr",
+    "max_trades_per_bar": 2,
+    "reentry_size_schedule": [0.20, 0.10],
+    "long_reentry_atr": 0.1,
+    "short_reentry_atr": 0.0,
+    "profit_protect_atr": 1.0,
+    "trailing_stop_atr": 0.3,
+    "delayed_trailing_activation": 0.5,
+    "reentry_anchor_levels": "wick",
+    "reentry_trigger_mode": "reclaim",
+}
+
+REPLAY_PROFILES = {
+    "btc_live_like": PRODUCTION_LIKE_REPLAY_KWARGS,
+    "eth_research": dict(replay.COMMON_REPLAY_KWARGS),
+}
+
+VARIANTS = [
+    {
+        "name": "baseline_single_observation",
+        "description": "Current research behavior: one 1s high/low crossing can lock the zero-initial window.",
+    },
+    {
+        "name": "margin_0p01atr",
+        "description": "Require breakout probe to clear the level by at least 0.01 ATR.",
+        "margin_atr": 0.01,
+    },
+    {
+        "name": "margin_0p02atr",
+        "description": "Require breakout probe to clear the level by at least 0.02 ATR.",
+        "margin_atr": 0.02,
+    },
+    {
+        "name": "margin_0p03atr",
+        "description": "Require breakout probe to clear the level by at least 0.03 ATR.",
+        "margin_atr": 0.03,
+    },
+    {
+        "name": "confirm_2x_1s",
+        "description": "Require two consecutive 1s observations crossing the same breakout level.",
+        "confirm_observations": 2,
+    },
+    {
+        "name": "confirm_3x_1s",
+        "description": "Require three consecutive 1s observations crossing the same breakout level.",
+        "confirm_observations": 3,
+    },
+    {
+        "name": "confirm_2x_1s_margin_0p01atr",
+        "description": "Require two consecutive 1s observations and 0.01 ATR clearance.",
+        "confirm_observations": 2,
+        "margin_atr": 0.01,
+    },
+]
+
+
+def _shape_key(side: str, shape_name: str, level: float) -> str:
+    if not shape_name or pd.isna(level):
+        return ""
+    return f"{side}|{shape_name}|{float(level):.8f}"
+
+
+def _passes_margin(side: str, probe_price: float, level: float, atr: float, margin_atr: float) -> tuple[bool, float, float]:
+    if margin_atr <= 0:
+        distance = float(probe_price) - float(level)
+        if side == "short":
+            distance = float(level) - float(probe_price)
+        return True, distance, 0.0
+    if not np.isfinite(probe_price) or not np.isfinite(level) or not np.isfinite(atr) or atr <= 0:
+        return False, 0.0, 0.0
+    distance = float(probe_price) - float(level)
+    if side == "short":
+        distance = float(level) - float(probe_price)
+    required = float(margin_atr) * float(atr)
+    return distance >= required, distance, required
+
+
+def _confirm_state(sig: dict, side: str) -> dict:
+    key = f"_breakout_confirm_{side}"
+    state = sig.get(key)
+    if not isinstance(state, dict):
+        state = {"key": "", "count": 0}
+        sig[key] = state
+    return state
+
+
+def _reset_confirm_state(sig: dict, side: str) -> None:
+    if isinstance(sig, dict):
+        sig[f"_breakout_confirm_{side}"] = {"key": "", "count": 0}
+
+
+@contextmanager
+def patched_breakout_filters(variant: dict, diagnostics: dict):
+    original_long = replay._long_breakout
+    original_short = replay._short_breakout
+    margin_atr = float(variant.get("margin_atr", 0.0) or 0.0)
+    confirm_observations = int(variant.get("confirm_observations", 1) or 1)
+
+    def long_breakout(sig, current_high: float, breakout_shape: str):
+        triggered, level, shape_name = original_long(sig, current_high, breakout_shape)
+        if not triggered:
+            _reset_confirm_state(sig, "long")
+            return triggered, level, shape_name
+
+        atr = float(sig.get("atr", np.nan))
+        margin_ok, distance, required = _passes_margin("long", current_high, level, atr, margin_atr)
+        if not margin_ok:
+            diagnostics["margin_rejects"]["long"] += 1
+            diagnostics["margin_reject_distance_sum"]["long"] += float(distance)
+            diagnostics["margin_required"] = float(required)
+            _reset_confirm_state(sig, "long")
+            return False, np.nan, ""
+
+        key = _shape_key("long", shape_name, level)
+        state = _confirm_state(sig, "long")
+        state["count"] = int(state["count"]) + 1 if state.get("key") == key else 1
+        state["key"] = key
+        diagnostics["max_confirm_count"]["long"] = max(diagnostics["max_confirm_count"]["long"], int(state["count"]))
+        if state["count"] < confirm_observations:
+            diagnostics["confirm_rejects"]["long"] += 1
+            return False, np.nan, ""
+        return triggered, level, shape_name
+
+    def short_breakout(sig, current_low: float, breakout_shape: str):
+        triggered, level, shape_name = original_short(sig, current_low, breakout_shape)
+        if not triggered:
+            _reset_confirm_state(sig, "short")
+            return triggered, level, shape_name
+
+        atr = float(sig.get("atr", np.nan))
+        margin_ok, distance, required = _passes_margin("short", current_low, level, atr, margin_atr)
+        if not margin_ok:
+            diagnostics["margin_rejects"]["short"] += 1
+            diagnostics["margin_reject_distance_sum"]["short"] += float(distance)
+            diagnostics["margin_required"] = float(required)
+            _reset_confirm_state(sig, "short")
+            return False, np.nan, ""
+
+        key = _shape_key("short", shape_name, level)
+        state = _confirm_state(sig, "short")
+        state["count"] = int(state["count"]) + 1 if state.get("key") == key else 1
+        state["key"] = key
+        diagnostics["max_confirm_count"]["short"] = max(diagnostics["max_confirm_count"]["short"], int(state["count"]))
+        if state["count"] < confirm_observations:
+            diagnostics["confirm_rejects"]["short"] += 1
+            return False, np.nan, ""
+        return triggered, level, shape_name
+
+    replay._long_breakout = long_breakout
+    replay._short_breakout = short_breakout
+    try:
+        yield
+    finally:
+        replay._long_breakout = original_long
+        replay._short_breakout = original_short
+
+
+def _empty_filter_diagnostics() -> dict:
+    return {
+        "margin_rejects": {"long": 0, "short": 0},
+        "confirm_rejects": {"long": 0, "short": 0},
+        "margin_reject_distance_sum": {"long": 0.0, "short": 0.0},
+        "margin_required": 0.0,
+        "max_confirm_count": {"long": 0, "short": 0},
+    }
+
+
+def _delta(base: dict, current: dict) -> dict:
+    return {
+        "final_balance_delta": round(current["final_balance"] - base["final_balance"], 2),
+        "return_pct_delta": round(current["return_pct"] - base["return_pct"], 2),
+        "max_dd_pct_delta": round(current["max_dd_pct"] - base["max_dd_pct"], 2),
+        "trades_delta": int(current["trades"] - base["trades"]),
+        "win_rate_pct_delta": round(current["win_rate_pct"] - base["win_rate_pct"], 2),
+        "sharpe_delta": round(current["sharpe"] - base["sharpe"], 2),
+    }
+
+
+def run_variant(second_bars: pd.DataFrame, signal: pd.DataFrame, variant: dict, initial_balance: float):
+    filter_diagnostics = _empty_filter_diagnostics()
+    started = time.time()
+    with patched_breakout_filters(variant, filter_diagnostics):
+        ledger, replay_diagnostics = replay.run_second_bar_replay(
+            second_bars,
+            signal,
+            initial_balance=initial_balance,
+            breakout_shape="baseline_plus_t3",
+            replay_mode="live_intrabar_sma5",
+            t3_reentry_size_schedule=[0.20, 0.10],
+            t3_cooldown_bars=0,
+            t3_quality_filters={"min_sma_atr_separation": 0.25},
+            quality_filter_shapes=["t3_swing"],
+        )
+    return {
+        "variant": variant["name"],
+        "description": variant["description"],
+        "params": variant,
+        "summary": replay.summarize_run(ledger, initial_balance),
+        "attribution": replay.summarize_breakout_attribution(ledger),
+        "diagnostics": {
+            "filters": filter_diagnostics,
+            "replay": replay_diagnostics,
+        },
+        "elapsed_seconds": round(time.time() - started, 2),
+        "ledger": ledger,
+    }
+
+
+def write_markdown(summary: dict, output_path: Path) -> None:
+    lines = [
+        f"# {summary['symbol']} Q1 2026 30min Breakout Confirmation Filters",
+        "",
+        "Scope: research-only Python replay. No live or execution path is changed by this report.",
+        "",
+        "## Setup",
+        "",
+        f"- Symbol/window: `{summary['symbol']}`, `{summary['start']}` to `{summary['end']}`",
+        "- Execution bars: continuous `1s` bars rebuilt from Binance trade archives",
+        "- Signal timeframe: `30min`",
+        "- Replay mode: `live_intrabar_sma5`, breakout shape `baseline_plus_t3`, t3 SMA/ATR separation `0.25`",
+        "- Sizing: `dir2_zero_initial=true`, `zero_initial_mode=reentry_window`, `reentry_size_schedule=[0.20, 0.10]`, `max_trades_per_bar=2`",
+        f"- Replay profile: `{summary['profile']}`",
+        f"- Risk params: `stop_loss_atr={summary['replay_kwargs']['stop_loss_atr']}`, "
+        f"`trailing_stop_atr={summary['replay_kwargs']['trailing_stop_atr']}`, "
+        f"`delayed_trailing_activation={summary['replay_kwargs']['delayed_trailing_activation']}`",
+        "- `confirm_2x_1s` / `confirm_3x_1s` are multi-tick proxies: they require consecutive 1s observations to cross the same breakout level.",
+        "",
+        "## Results",
+        "",
+        "| Variant | Final Balance | Return | Max DD | Trades | Win Rate | Sharpe | Entry Mix | Filter Rejects |",
+        "|---|---:|---:|---:|---:|---:|---:|---|---|",
+    ]
+    for result in summary["results"]:
+        s = result["summary"]
+        filters = result["diagnostics"]["filters"]
+        entry_mix = ", ".join(f"{k}:{v}" for k, v in s["entry_reasons"].items())
+        rejects = (
+            f"margin L/S {filters['margin_rejects']['long']}/{filters['margin_rejects']['short']}; "
+            f"confirm L/S {filters['confirm_rejects']['long']}/{filters['confirm_rejects']['short']}"
+        )
+        lines.append(
+            f"| `{result['variant']}` | {s['final_balance']:,.2f} | {s['return_pct']:.2f}% | "
+            f"{s['max_dd_pct']:.2f}% | {s['trades']} | {s['win_rate_pct']:.2f}% | "
+            f"{s['sharpe']:.2f} | `{entry_mix}` | `{rejects}` |"
+        )
+
+    lines.extend(["", "## Delta vs Baseline", ""])
+    lines.append("| Variant | Final Balance Delta | Return Delta | Max DD Delta | Trades Delta | Win Rate Delta | Sharpe Delta |")
+    lines.append("|---|---:|---:|---:|---:|---:|---:|")
+    for result in summary["results"][1:]:
+        d = result["delta_vs_baseline"]
+        lines.append(
+            f"| `{result['variant']}` | {d['final_balance_delta']:,.2f} | {d['return_pct_delta']:.2f} pp | "
+            f"{d['max_dd_pct_delta']:.2f} pp | {d['trades_delta']} | {d['win_rate_pct_delta']:.2f} pp | "
+            f"{d['sharpe_delta']:.2f} |"
+        )
+
+    lines.extend(["", "## Breakout Attribution", ""])
+    lines.append("| Variant | Shape | Trades | Win Rate | Avg PnL | Net PnL | Worst PnL | Profit Factor |")
+    lines.append("|---|---|---:|---:|---:|---:|---:|---:|")
+    for result in summary["results"]:
+        for shape_name, item in result.get("attribution", {}).items():
+            lines.append(
+                f"| `{result['variant']}` | `{shape_name}` | {item['trades']} | {item['win_rate_pct']:.2f}% | "
+                f"{item['avg_pnl_pct']:.4f}% | {item['net_pnl_value']:,.2f} | "
+                f"{item['worst_pnl_pct']:.4f}% | {item['profit_factor']} |"
+            )
+
+    lines.extend(["", "## Variants", ""])
+    for variant in summary.get("selected_variants", VARIANTS):
+        lines.append(f"- `{variant['name']}`: {variant['description']}")
+    lines.append("")
+    output_path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="BTC Q1 2026 30min breakout confirmation filters")
+    parser.add_argument("--symbol", default="BTCUSDT")
+    parser.add_argument("--profile", choices=sorted(REPLAY_PROFILES), default="btc_live_like")
+    parser.add_argument("--tick-files", nargs="+", default=DEFAULT_TICK_FILES)
+    parser.add_argument("--start", default="2026-01-01T00:00:00Z")
+    parser.add_argument("--end", default="2026-03-31T23:59:59Z")
+    parser.add_argument("--initial-balance", type=float, default=100000.0)
+    parser.add_argument("--chunksize", type=int, default=2_000_000)
+    parser.add_argument("--summary-json", default="research/btc_2026_q1_30min_breakout_confirmation_filters_summary.json")
+    parser.add_argument("--markdown", default="research/20260429_btc_q1_30min_breakout_confirmation_filters.md")
+    parser.add_argument("--ledger-prefix", default="research/tmp_btc_2026_q1_30min_1s_breakout_confirmation")
+    parser.add_argument("--variants", nargs="+", default=[item["name"] for item in VARIANTS])
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    replay_kwargs = dict(REPLAY_PROFILES[args.profile])
+    replay.COMMON_REPLAY_KWARGS.clear()
+    replay.COMMON_REPLAY_KWARGS.update(replay_kwargs)
+    start = replay._as_utc_timestamp(args.start)
+    end = replay._as_utc_timestamp(args.end)
+    second_bars, build_stats = replay.build_continuous_second_bars(args.tick_files, start, end, args.chunksize)
+    _, signal = replay.build_signal_frame(second_bars, "30min")
+
+    selected_variants = [item for item in VARIANTS if item["name"] in set(args.variants)]
+    if not selected_variants:
+        raise ValueError(f"no variants selected from {args.variants}")
+
+    results = []
+    for variant in selected_variants:
+        result = run_variant(second_bars, signal, variant, args.initial_balance)
+        ledger_path = Path(f"{args.ledger_prefix}_{variant['name']}_ledger.csv")
+        result["ledger"].to_csv(ledger_path, index=False)
+        del result["ledger"]
+        result["ledger_path"] = str(ledger_path)
+        results.append(result)
+        s = result["summary"]
+        print(
+            f"{variant['name']}: return={s['return_pct']:.2f}% trades={s['trades']} "
+            f"win={s['win_rate_pct']:.2f}% elapsed={result['elapsed_seconds']}s",
+            flush=True,
+        )
+
+    base_summary = results[0]["summary"]
+    for result in results[1:]:
+        result["delta_vs_baseline"] = _delta(base_summary, result["summary"])
+
+    summary = {
+        "symbol": args.symbol,
+        "profile": args.profile,
+        "start": start.isoformat(),
+        "end": end.isoformat(),
+        "build_stats": build_stats,
+        "signal_stats": {
+            "signal_rows": int(len(signal)),
+            "signal_start": signal.index[0].isoformat() if not signal.empty else "",
+            "signal_end": signal.index[-1].isoformat() if not signal.empty else "",
+            "valid_sma5_rows": int(signal["sma5"].notna().sum()),
+            "valid_atr_rows": int(signal["atr"].notna().sum()),
+        },
+        "replay_kwargs": replay_kwargs,
+        "selected_variants": selected_variants,
+        "results": results,
+        "note": "Research-only comparison. Consecutive 1s confirmation is used as a multi-tick proxy because this research replay operates on rebuilt 1s bars.",
+    }
+    Path(args.summary_json).write_text(json.dumps(summary, indent=2, ensure_ascii=False), encoding="utf-8")
+    write_markdown(summary, Path(args.markdown))
+
+
+if __name__ == "__main__":
+    main()

--- a/research/btc_q1_30min_low_vol_entry_filters.py
+++ b/research/btc_q1_30min_low_vol_entry_filters.py
@@ -1,0 +1,383 @@
+#!/usr/bin/env python3
+"""BTC Q1 2026 30min low-volatility entry gate research replay.
+
+Research-only script. It evaluates gates that block reentry-window entries
+when the ATR-derived stop is too small in bps, or when the signal ATR is in a
+low rolling percentile. It does not filter stop-loss exits.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from contextlib import contextmanager
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+import eth_q1_breakout_t3_shape_compare as replay
+
+
+DEFAULT_TICK_FILES = [
+    "dataset/archive/BTCUSDT-trades-2026-01/BTCUSDT-trades-2026-01.csv",
+    "dataset/archive/BTCUSDT-trades-2026-02/BTCUSDT-trades-2026-02.csv",
+    "dataset/archive/BTCUSDT-trades-2026-03/BTCUSDT-trades-2026-03.csv",
+]
+
+BTC_LIVE_LIKE_REPLAY_KWARGS = {
+    "dir2_zero_initial": True,
+    "zero_initial_mode": "reentry_window",
+    "fixed_slippage": 0.0005,
+    "stop_loss_atr": 0.3,
+    "stop_mode": "atr",
+    "max_trades_per_bar": 2,
+    "reentry_size_schedule": [0.20, 0.10],
+    "long_reentry_atr": 0.1,
+    "short_reentry_atr": 0.0,
+    "profit_protect_atr": 1.0,
+    "trailing_stop_atr": 0.3,
+    "delayed_trailing_activation": 0.5,
+    "reentry_anchor_levels": "wick",
+    "reentry_trigger_mode": "reclaim",
+}
+
+VARIANTS = [
+    {
+        "name": "baseline",
+        "description": "No low-volatility entry gate.",
+    },
+    {
+        "name": "min_stop_bps_6",
+        "description": "Require stop_loss_atr * ATR to be at least 6 bps of entry reference price.",
+        "min_stop_bps": 6.0,
+    },
+    {
+        "name": "min_stop_bps_8",
+        "description": "Require stop_loss_atr * ATR to be at least 8 bps of entry reference price.",
+        "min_stop_bps": 8.0,
+    },
+    {
+        "name": "atr_pct_gte_25",
+        "description": "Require signal ATR percentile over the rolling 240 signal bars to be at least 25.",
+        "atr_percentile_gte": 25.0,
+    },
+    {
+        "name": "atr_pct_gte_35",
+        "description": "Require signal ATR percentile over the rolling 240 signal bars to be at least 35.",
+        "atr_percentile_gte": 35.0,
+    },
+    {
+        "name": "min_stop_bps_6_atr_pct_gte_25",
+        "description": "Require both min stop distance of 6 bps and ATR percentile at least 25.",
+        "min_stop_bps": 6.0,
+        "atr_percentile_gte": 25.0,
+    },
+    {
+        "name": "min_stop_bps_6_atr_pct_gte_35",
+        "description": "Require both min stop distance of 6 bps and ATR percentile at least 35.",
+        "min_stop_bps": 6.0,
+        "atr_percentile_gte": 35.0,
+    },
+]
+
+
+def _paired_trades(ledger: pd.DataFrame) -> pd.DataFrame:
+    rows = []
+    open_entry = None
+    for _, row in ledger.iterrows():
+        if row["type"] in {"BUY", "SHORT"}:
+            open_entry = row
+            continue
+        if row["type"] != "EXIT" or open_entry is None:
+            continue
+        entry_time = pd.Timestamp(open_entry["time"])
+        exit_time = pd.Timestamp(row["time"])
+        side_mult = 1.0 if open_entry["type"] == "BUY" else -1.0
+        entry_price = float(open_entry["price"])
+        exit_price = float(row["price"])
+        notional = float(open_entry["notional"])
+        pnl_pct = side_mult * (exit_price - entry_price) / entry_price if entry_price > 0 else 0.0
+        rows.append(
+            {
+                "entry_time": entry_time,
+                "exit_time": exit_time,
+                "entry_type": str(open_entry["type"]),
+                "entry_reason": str(open_entry["reason"]),
+                "exit_reason": str(row["reason"]),
+                "breakout_shape_name": str(open_entry.get("breakout_shape_name", "")),
+                "entry_price": entry_price,
+                "exit_price": exit_price,
+                "notional": notional,
+                "pnl_pct": pnl_pct,
+                "pnl_value": pnl_pct * notional,
+                "hold_seconds": float((exit_time - entry_time).total_seconds()),
+            }
+        )
+        open_entry = None
+    return pd.DataFrame(rows)
+
+
+def _pair_diagnostics(pairs: pd.DataFrame) -> dict:
+    if pairs.empty:
+        return {
+            "paired_trades": 0,
+            "avg_loss_pct": 0.0,
+            "worst_loss_pct": 0.0,
+            "avg_win_pct": 0.0,
+            "profit_factor": None,
+            "median_hold_seconds": 0.0,
+            "avg_hold_seconds": 0.0,
+            "entry_reasons": {},
+            "exit_reasons": {},
+        }
+    pnl_pct = pairs["pnl_pct"].astype("float64")
+    pnl_value = pairs["pnl_value"].astype("float64")
+    losses = pnl_pct[pnl_pct < 0]
+    wins = pnl_pct[pnl_pct > 0]
+    gross_profit = float(pnl_value[pnl_value > 0].sum())
+    gross_loss = abs(float(pnl_value[pnl_value < 0].sum()))
+    return {
+        "paired_trades": int(len(pairs)),
+        "avg_loss_pct": round(float(losses.mean()) * 100, 4) if not losses.empty else 0.0,
+        "worst_loss_pct": round(float(losses.min()) * 100, 4) if not losses.empty else 0.0,
+        "avg_win_pct": round(float(wins.mean()) * 100, 4) if not wins.empty else 0.0,
+        "profit_factor": round(gross_profit / gross_loss, 4) if gross_loss > 0 else None,
+        "median_hold_seconds": round(float(pairs["hold_seconds"].median()), 2),
+        "avg_hold_seconds": round(float(pairs["hold_seconds"].mean()), 2),
+        "entry_reasons": {str(k): int(v) for k, v in pairs["entry_reason"].value_counts().items()},
+        "exit_reasons": {str(k): int(v) for k, v in pairs["exit_reason"].value_counts().items()},
+    }
+
+
+def _delta(base: dict, current: dict) -> dict:
+    return {
+        "final_balance_delta": round(current["final_balance"] - base["final_balance"], 2),
+        "return_pct_delta": round(current["return_pct"] - base["return_pct"], 2),
+        "max_dd_pct_delta": round(current["max_dd_pct"] - base["max_dd_pct"], 2),
+        "trades_delta": int(current["trades"] - base["trades"]),
+        "win_rate_pct_delta": round(current["win_rate_pct"] - base["win_rate_pct"], 2),
+        "sharpe_delta": round(current["sharpe"] - base["sharpe"], 2),
+    }
+
+
+def _empty_gate_diagnostics() -> dict:
+    return {
+        "calls": 0,
+        "allowed_calls": 0,
+        "rejected_calls": 0,
+        "reject_reasons": {},
+        "min_observed_stop_bps": None,
+        "max_observed_stop_bps": None,
+        "min_observed_atr_percentile": None,
+        "max_observed_atr_percentile": None,
+    }
+
+
+def _record_range(diagnostics: dict, key_min: str, key_max: str, value: float) -> None:
+    if not np.isfinite(value):
+        return
+    diagnostics[key_min] = value if diagnostics[key_min] is None else min(diagnostics[key_min], value)
+    diagnostics[key_max] = value if diagnostics[key_max] is None else max(diagnostics[key_max], value)
+
+
+@contextmanager
+def patched_entry_gate(variant: dict, diagnostics: dict):
+    original_resolve_reentry_price = replay._resolve_reentry_price
+    min_stop_bps = variant.get("min_stop_bps")
+    atr_percentile_gte = variant.get("atr_percentile_gte")
+
+    def resolve_reentry_price(sig, side: str, reentry_anchor_levels: str, reentry_atr: float):
+        reentry_price = original_resolve_reentry_price(sig, side, reentry_anchor_levels, reentry_atr)
+        diagnostics["calls"] += 1
+
+        atr = float(sig.get("atr", np.nan))
+        price_ref = float(reentry_price)
+        if not np.isfinite(price_ref) or price_ref <= 0:
+            price_ref = float(sig.get("close", np.nan))
+        stop_loss_atr = float(replay.COMMON_REPLAY_KWARGS["stop_loss_atr"])
+        stop_bps = stop_loss_atr * atr / price_ref * 10000.0 if np.isfinite(atr) and atr > 0 and price_ref > 0 else np.nan
+        atr_percentile = float(sig.get("atr_percentile", np.nan))
+        _record_range(diagnostics, "min_observed_stop_bps", "max_observed_stop_bps", stop_bps)
+        _record_range(diagnostics, "min_observed_atr_percentile", "max_observed_atr_percentile", atr_percentile)
+
+        reject_reasons = []
+        if min_stop_bps is not None and (not np.isfinite(stop_bps) or stop_bps < float(min_stop_bps)):
+            reject_reasons.append("min_stop_bps")
+        if atr_percentile_gte is not None and (
+            not np.isfinite(atr_percentile) or atr_percentile < float(atr_percentile_gte)
+        ):
+            reject_reasons.append("atr_percentile")
+
+        if reject_reasons:
+            diagnostics["rejected_calls"] += 1
+            for reason in reject_reasons:
+                diagnostics["reject_reasons"][reason] = diagnostics["reject_reasons"].get(reason, 0) + 1
+            return np.inf if side == "long" else -np.inf
+
+        diagnostics["allowed_calls"] += 1
+        return reentry_price
+
+    replay._resolve_reentry_price = resolve_reentry_price
+    try:
+        yield
+    finally:
+        replay._resolve_reentry_price = original_resolve_reentry_price
+
+
+def run_variant(second_bars: pd.DataFrame, signal: pd.DataFrame, variant: dict, initial_balance: float):
+    gate_diagnostics = _empty_gate_diagnostics()
+    started = time.time()
+    with patched_entry_gate(variant, gate_diagnostics):
+        ledger, replay_diagnostics = replay.run_second_bar_replay(
+            second_bars,
+            signal,
+            initial_balance=initial_balance,
+            breakout_shape="baseline_plus_t3",
+            replay_mode="live_intrabar_sma5",
+            t3_reentry_size_schedule=[0.20, 0.10],
+            t3_cooldown_bars=0,
+            t3_quality_filters={"min_sma_atr_separation": 0.25},
+            quality_filter_shapes=["t3_swing"],
+        )
+    pairs = _paired_trades(ledger)
+    return {
+        "variant": variant["name"],
+        "description": variant["description"],
+        "params": variant,
+        "summary": replay.summarize_run(ledger, initial_balance),
+        "pair_diagnostics": _pair_diagnostics(pairs),
+        "attribution": replay.summarize_breakout_attribution(ledger),
+        "diagnostics": {
+            "entry_gate": gate_diagnostics,
+            "replay": replay_diagnostics,
+        },
+        "elapsed_seconds": round(time.time() - started, 2),
+        "ledger": ledger,
+    }
+
+
+def write_markdown(summary: dict, output_path: Path) -> None:
+    lines = [
+        "# BTCUSDT Q1 2026 30min Low-Volatility Entry Gates",
+        "",
+        "Scope: research-only Python replay. No live or execution path is changed by this report.",
+        "",
+        "## Setup",
+        "",
+        f"- Symbol/window: `{summary['symbol']}`, `{summary['start']}` to `{summary['end']}`",
+        "- Execution bars: continuous `1s` bars rebuilt from Binance trade archives",
+        "- Signal timeframe: `30min`",
+        "- Replay mode: `live_intrabar_sma5`, breakout shape `baseline_plus_t3`, t3 SMA/ATR separation `0.25`",
+        "- Sizing: `dir2_zero_initial=true`, `zero_initial_mode=reentry_window`, `reentry_size_schedule=[0.20, 0.10]`, `max_trades_per_bar=2`",
+        "- Gate point: reentry price resolution, so the gate blocks both Zero-Initial-Reentry and SL-Reentry entries. Stop-loss exits are not filtered.",
+        "",
+        "## Results",
+        "",
+        "| Variant | Final Balance | Return | Max DD | Trades | Win Rate | Sharpe | Avg Loss | Worst Loss | Entry Mix | Gate Reject Calls |",
+        "|---|---:|---:|---:|---:|---:|---:|---:|---:|---|---:|",
+    ]
+    for result in summary["results"]:
+        s = result["summary"]
+        d = result["pair_diagnostics"]
+        gate = result["diagnostics"]["entry_gate"]
+        entry_mix = ", ".join(f"{k}:{v}" for k, v in s["entry_reasons"].items())
+        lines.append(
+            f"| `{result['variant']}` | {s['final_balance']:,.2f} | {s['return_pct']:.2f}% | "
+            f"{s['max_dd_pct']:.2f}% | {s['trades']} | {s['win_rate_pct']:.2f}% | {s['sharpe']:.2f} | "
+            f"{d['avg_loss_pct']:.4f}% | {d['worst_loss_pct']:.4f}% | `{entry_mix}` | "
+            f"{gate['rejected_calls']} |"
+        )
+
+    lines.extend(["", "## Delta vs Baseline", ""])
+    lines.append("| Variant | Final Delta | Return Delta | Max DD Delta | Trades Delta | Win Delta | Sharpe Delta |")
+    lines.append("|---|---:|---:|---:|---:|---:|---:|")
+    for result in summary["results"][1:]:
+        delta = result["delta_vs_baseline"]
+        lines.append(
+            f"| `{result['variant']}` | {delta['final_balance_delta']:,.2f} | "
+            f"{delta['return_pct_delta']:.2f} pp | {delta['max_dd_pct_delta']:.2f} pp | "
+            f"{delta['trades_delta']} | {delta['win_rate_pct_delta']:.2f} pp | {delta['sharpe_delta']:.2f} |"
+        )
+
+    lines.extend(["", "## Variants", ""])
+    for variant in summary["selected_variants"]:
+        lines.append(f"- `{variant['name']}`: {variant['description']}")
+    lines.append("")
+    output_path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="BTC Q1 2026 30min low-volatility entry gate replay")
+    parser.add_argument("--tick-files", nargs="+", default=DEFAULT_TICK_FILES)
+    parser.add_argument("--start", default="2026-01-01T00:00:00Z")
+    parser.add_argument("--end", default="2026-03-31T23:59:59Z")
+    parser.add_argument("--initial-balance", type=float, default=100000.0)
+    parser.add_argument("--chunksize", type=int, default=2_000_000)
+    parser.add_argument("--variants", nargs="+", default=[item["name"] for item in VARIANTS])
+    parser.add_argument("--summary-json", default="research/btc_2026_q1_30min_low_vol_entry_filters_summary.json")
+    parser.add_argument("--markdown", default="research/20260429_btc_q1_30min_low_vol_entry_filters.md")
+    parser.add_argument("--ledger-prefix", default="research/tmp_btc_2026_q1_30min_1s_low_vol_entry_filter")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    replay.COMMON_REPLAY_KWARGS.clear()
+    replay.COMMON_REPLAY_KWARGS.update(BTC_LIVE_LIKE_REPLAY_KWARGS)
+    start = replay._as_utc_timestamp(args.start)
+    end = replay._as_utc_timestamp(args.end)
+    second_bars, build_stats = replay.build_continuous_second_bars(args.tick_files, start, end, args.chunksize)
+    _, signal = replay.build_signal_frame(second_bars, "30min")
+
+    selected_names = set(args.variants)
+    selected_variants = [item for item in VARIANTS if item["name"] in selected_names]
+    if not selected_variants:
+        raise ValueError(f"no variants selected from {args.variants}")
+
+    results = []
+    for variant in selected_variants:
+        result = run_variant(second_bars, signal, variant, args.initial_balance)
+        ledger_path = Path(f"{args.ledger_prefix}_{variant['name']}_ledger.csv")
+        result["ledger"].to_csv(ledger_path, index=False)
+        del result["ledger"]
+        result["ledger_path"] = str(ledger_path)
+        results.append(result)
+        s = result["summary"]
+        gate = result["diagnostics"]["entry_gate"]
+        print(
+            f"{variant['name']}: return={s['return_pct']:.2f}% trades={s['trades']} "
+            f"win={s['win_rate_pct']:.2f}% max_dd={s['max_dd_pct']:.2f}% "
+            f"gate_reject_calls={gate['rejected_calls']} elapsed={result['elapsed_seconds']}s",
+            flush=True,
+        )
+
+    base_summary = results[0]["summary"]
+    for result in results[1:]:
+        result["delta_vs_baseline"] = _delta(base_summary, result["summary"])
+
+    output = {
+        "symbol": "BTCUSDT",
+        "start": start.isoformat(),
+        "end": end.isoformat(),
+        "build_stats": build_stats,
+        "signal_stats": {
+            "signal_rows": int(len(signal)),
+            "signal_start": signal.index[0].isoformat() if not signal.empty else "",
+            "signal_end": signal.index[-1].isoformat() if not signal.empty else "",
+            "valid_sma5_rows": int(signal["sma5"].notna().sum()),
+            "valid_atr_rows": int(signal["atr"].notna().sum()),
+            "valid_atr_percentile_rows": int(signal["atr_percentile"].notna().sum()),
+        },
+        "replay_kwargs": dict(BTC_LIVE_LIKE_REPLAY_KWARGS),
+        "selected_variants": selected_variants,
+        "results": results,
+        "note": "Research-only comparison. Entry gates patch reentry price resolution and do not alter stop-loss exit behavior.",
+    }
+    Path(args.summary_json).write_text(json.dumps(output, indent=2, ensure_ascii=False), encoding="utf-8")
+    write_markdown(output, Path(args.markdown))
+
+
+if __name__ == "__main__":
+    main()

--- a/research/eth_2026_q1_30min_breakout_confirmation_filters_summary.json
+++ b/research/eth_2026_q1_30min_breakout_confirmation_filters_summary.json
@@ -1,0 +1,611 @@
+{
+  "symbol": "ETHUSDT",
+  "profile": "eth_research",
+  "start": "2026-01-01T00:00:00+00:00",
+  "end": "2026-03-31T23:59:59+00:00",
+  "build_stats": {
+    "raw_tick_rows": 748747244,
+    "kept_tick_rows": 748747172,
+    "sparse_second_rows": 7596268,
+    "continuous_second_rows": 7776000,
+    "first_second": "2026-01-01T00:00:00+00:00",
+    "last_second": "2026-03-31T23:59:59+00:00"
+  },
+  "signal_stats": {
+    "signal_rows": 4320,
+    "signal_start": "2026-01-01T00:00:00+00:00",
+    "signal_end": "2026-03-31T23:30:00+00:00",
+    "valid_sma5_rows": 4316,
+    "valid_atr_rows": 4307
+  },
+  "replay_kwargs": {
+    "dir2_zero_initial": true,
+    "zero_initial_mode": "reentry_window",
+    "fixed_slippage": 0.0005,
+    "stop_loss_atr": 0.05,
+    "stop_mode": "atr",
+    "max_trades_per_bar": 2,
+    "reentry_size_schedule": [
+      0.2,
+      0.1
+    ],
+    "long_reentry_atr": 0.1,
+    "short_reentry_atr": 0.0,
+    "profit_protect_atr": 1.0,
+    "trailing_stop_atr": 0.3,
+    "delayed_trailing_activation": 0.5,
+    "reentry_anchor_levels": "wick",
+    "reentry_trigger_mode": "reclaim"
+  },
+  "selected_variants": [
+    {
+      "name": "baseline_single_observation",
+      "description": "Current research behavior: one 1s high/low crossing can lock the zero-initial window."
+    },
+    {
+      "name": "margin_0p02atr",
+      "description": "Require breakout probe to clear the level by at least 0.02 ATR.",
+      "margin_atr": 0.02
+    },
+    {
+      "name": "confirm_2x_1s",
+      "description": "Require two consecutive 1s observations crossing the same breakout level.",
+      "confirm_observations": 2
+    },
+    {
+      "name": "confirm_3x_1s",
+      "description": "Require three consecutive 1s observations crossing the same breakout level.",
+      "confirm_observations": 3
+    }
+  ],
+  "results": [
+    {
+      "variant": "baseline_single_observation",
+      "description": "Current research behavior: one 1s high/low crossing can lock the zero-initial window.",
+      "params": {
+        "name": "baseline_single_observation",
+        "description": "Current research behavior: one 1s high/low crossing can lock the zero-initial window."
+      },
+      "summary": {
+        "final_balance": 536109.15,
+        "return_pct": 436.11,
+        "max_dd_pct": -2.04,
+        "trades": 3226,
+        "win_rate_pct": 80.6,
+        "sharpe": 13.49,
+        "first_entry": "2026-01-01T10:22:41+00:00",
+        "last_exit": "2026-03-31T23:59:59+00:00",
+        "entry_reasons": {
+          "SL-Reentry": 2086,
+          "Zero-Initial-Reentry": 1140
+        },
+        "exit_reasons": {
+          "SL": 3225,
+          "FinalMarkToMarket": 1
+        },
+        "entry_types": {
+          "BUY": 1632,
+          "SHORT": 1594
+        },
+        "integrity": {
+          "rows": 6452,
+          "entries": 3226,
+          "exits": 3226,
+          "zero_notional_entries": 0
+        }
+      },
+      "attribution": {
+        "original_t2": {
+          "trades": 2575,
+          "win_rate_pct": 87.96,
+          "avg_pnl_pct": 0.5409,
+          "median_pnl_pct": 0.4009,
+          "pnl_std_pct": 0.6352,
+          "worst_pnl_pct": -0.1811,
+          "net_pnl_value": 555845.31,
+          "max_pnl_drawdown": -221.0,
+          "profit_factor": 61.861,
+          "entry_types": {
+            "SHORT": 1298,
+            "BUY": 1277
+          },
+          "entry_reasons": {
+            "SL-Reentry": 1663,
+            "Zero-Initial-Reentry": 912
+          },
+          "exit_reasons": {
+            "SL": 2574,
+            "FinalMarkToMarket": 1
+          }
+        },
+        "t3_swing": {
+          "trades": 651,
+          "win_rate_pct": 87.1,
+          "avg_pnl_pct": 0.5355,
+          "median_pnl_pct": 0.3717,
+          "pnl_std_pct": 0.6343,
+          "worst_pnl_pct": -0.1188,
+          "net_pnl_value": 137520.44,
+          "max_pnl_drawdown": -217.37,
+          "profit_factor": 64.946,
+          "entry_types": {
+            "BUY": 355,
+            "SHORT": 296
+          },
+          "entry_reasons": {
+            "SL-Reentry": 423,
+            "Zero-Initial-Reentry": 228
+          },
+          "exit_reasons": {
+            "SL": 651
+          }
+        }
+      },
+      "diagnostics": {
+        "filters": {
+          "margin_rejects": {
+            "long": 0,
+            "short": 0
+          },
+          "confirm_rejects": {
+            "long": 0,
+            "short": 0
+          },
+          "margin_reject_distance_sum": {
+            "long": 0.0,
+            "short": 0.0
+          },
+          "margin_required": 0.0,
+          "max_confirm_count": {
+            "long": 1745,
+            "short": 1742
+          }
+        },
+        "replay": {
+          "breakout_locks": {
+            "long": {
+              "original_t2": 449,
+              "t3_swing": 119
+            },
+            "short": {
+              "original_t2": 470,
+              "t3_swing": 109
+            }
+          },
+          "t3_cooldown_skips": {
+            "long": 0,
+            "short": 0
+          },
+          "t3_quality_rejects": {
+            "long": {
+              "sma_atr_separation": 9
+            },
+            "short": {
+              "sma_atr_separation": 5
+            }
+          }
+        }
+      },
+      "elapsed_seconds": 221.87,
+      "ledger_path": "research/tmp_eth_2026_q1_30min_1s_breakout_confirmation_baseline_single_observation_ledger.csv"
+    },
+    {
+      "variant": "margin_0p02atr",
+      "description": "Require breakout probe to clear the level by at least 0.02 ATR.",
+      "params": {
+        "name": "margin_0p02atr",
+        "description": "Require breakout probe to clear the level by at least 0.02 ATR.",
+        "margin_atr": 0.02
+      },
+      "summary": {
+        "final_balance": 517226.25,
+        "return_pct": 417.23,
+        "max_dd_pct": -1.97,
+        "trades": 3162,
+        "win_rate_pct": 80.8,
+        "sharpe": 13.68,
+        "first_entry": "2026-01-01T10:23:37+00:00",
+        "last_exit": "2026-03-31T23:59:59+00:00",
+        "entry_reasons": {
+          "SL-Reentry": 2047,
+          "Zero-Initial-Reentry": 1115
+        },
+        "exit_reasons": {
+          "SL": 3161,
+          "FinalMarkToMarket": 1
+        },
+        "entry_types": {
+          "BUY": 1583,
+          "SHORT": 1579
+        },
+        "integrity": {
+          "rows": 6324,
+          "entries": 3162,
+          "exits": 3162,
+          "zero_notional_entries": 0
+        }
+      },
+      "attribution": {
+        "original_t2": {
+          "trades": 2519,
+          "win_rate_pct": 88.29,
+          "avg_pnl_pct": 0.5395,
+          "median_pnl_pct": 0.4068,
+          "pnl_std_pct": 0.6223,
+          "worst_pnl_pct": -0.1811,
+          "net_pnl_value": 529207.28,
+          "max_pnl_drawdown": -212.5,
+          "profit_factor": 63.2888,
+          "entry_types": {
+            "SHORT": 1284,
+            "BUY": 1235
+          },
+          "entry_reasons": {
+            "SL-Reentry": 1627,
+            "Zero-Initial-Reentry": 892
+          },
+          "exit_reasons": {
+            "SL": 2518,
+            "FinalMarkToMarket": 1
+          }
+        },
+        "t3_swing": {
+          "trades": 643,
+          "win_rate_pct": 86.94,
+          "avg_pnl_pct": 0.5408,
+          "median_pnl_pct": 0.3717,
+          "pnl_std_pct": 0.6426,
+          "worst_pnl_pct": -0.1365,
+          "net_pnl_value": 133188.86,
+          "max_pnl_drawdown": -209.24,
+          "profit_factor": 61.3525,
+          "entry_types": {
+            "BUY": 348,
+            "SHORT": 295
+          },
+          "entry_reasons": {
+            "SL-Reentry": 420,
+            "Zero-Initial-Reentry": 223
+          },
+          "exit_reasons": {
+            "SL": 643
+          }
+        }
+      },
+      "diagnostics": {
+        "filters": {
+          "margin_rejects": {
+            "long": 7450,
+            "short": 7523
+          },
+          "confirm_rejects": {
+            "long": 0,
+            "short": 0
+          },
+          "margin_reject_distance_sum": {
+            "long": 1162.638427734375,
+            "short": 1146.71826171875
+          },
+          "margin_required": 0.3353866390306122,
+          "max_confirm_count": {
+            "long": 1798,
+            "short": 1742
+          }
+        },
+        "replay": {
+          "breakout_locks": {
+            "long": {
+              "original_t2": 436,
+              "t3_swing": 118
+            },
+            "short": {
+              "original_t2": 463,
+              "t3_swing": 105
+            }
+          },
+          "t3_cooldown_skips": {
+            "long": 0,
+            "short": 0
+          },
+          "t3_quality_rejects": {
+            "long": {
+              "sma_atr_separation": 9
+            },
+            "short": {
+              "sma_atr_separation": 5
+            }
+          }
+        }
+      },
+      "elapsed_seconds": 222.0,
+      "ledger_path": "research/tmp_eth_2026_q1_30min_1s_breakout_confirmation_margin_0p02atr_ledger.csv",
+      "delta_vs_baseline": {
+        "final_balance_delta": -18882.9,
+        "return_pct_delta": -18.88,
+        "max_dd_pct_delta": 0.07,
+        "trades_delta": -64,
+        "win_rate_pct_delta": 0.2,
+        "sharpe_delta": 0.19
+      }
+    },
+    {
+      "variant": "confirm_2x_1s",
+      "description": "Require two consecutive 1s observations crossing the same breakout level.",
+      "params": {
+        "name": "confirm_2x_1s",
+        "description": "Require two consecutive 1s observations crossing the same breakout level.",
+        "confirm_observations": 2
+      },
+      "summary": {
+        "final_balance": 524591.79,
+        "return_pct": 424.59,
+        "max_dd_pct": -2.04,
+        "trades": 3158,
+        "win_rate_pct": 80.65,
+        "sharpe": 13.53,
+        "first_entry": "2026-01-01T10:22:42+00:00",
+        "last_exit": "2026-03-31T23:59:59+00:00",
+        "entry_reasons": {
+          "SL-Reentry": 2042,
+          "Zero-Initial-Reentry": 1116
+        },
+        "exit_reasons": {
+          "SL": 3157,
+          "FinalMarkToMarket": 1
+        },
+        "entry_types": {
+          "BUY": 1595,
+          "SHORT": 1563
+        },
+        "integrity": {
+          "rows": 6316,
+          "entries": 3158,
+          "exits": 3158,
+          "zero_notional_entries": 0
+        }
+      },
+      "attribution": {
+        "original_t2": {
+          "trades": 2514,
+          "win_rate_pct": 87.87,
+          "avg_pnl_pct": 0.5435,
+          "median_pnl_pct": 0.4077,
+          "pnl_std_pct": 0.6355,
+          "worst_pnl_pct": -0.1811,
+          "net_pnl_value": 537196.84,
+          "max_pnl_drawdown": -216.85,
+          "profit_factor": 61.4108,
+          "entry_types": {
+            "SHORT": 1271,
+            "BUY": 1243
+          },
+          "entry_reasons": {
+            "SL-Reentry": 1624,
+            "Zero-Initial-Reentry": 890
+          },
+          "exit_reasons": {
+            "SL": 2513,
+            "FinalMarkToMarket": 1
+          }
+        },
+        "t3_swing": {
+          "trades": 644,
+          "win_rate_pct": 86.8,
+          "avg_pnl_pct": 0.5388,
+          "median_pnl_pct": 0.371,
+          "pnl_std_pct": 0.6407,
+          "worst_pnl_pct": -0.1188,
+          "net_pnl_value": 134426.18,
+          "max_pnl_drawdown": -213.22,
+          "profit_factor": 63.4185,
+          "entry_types": {
+            "BUY": 352,
+            "SHORT": 292
+          },
+          "entry_reasons": {
+            "SL-Reentry": 418,
+            "Zero-Initial-Reentry": 226
+          },
+          "exit_reasons": {
+            "SL": 644
+          }
+        }
+      },
+      "diagnostics": {
+        "filters": {
+          "margin_rejects": {
+            "long": 0,
+            "short": 0
+          },
+          "confirm_rejects": {
+            "long": 1660,
+            "short": 1723
+          },
+          "margin_reject_distance_sum": {
+            "long": 0.0,
+            "short": 0.0
+          },
+          "margin_required": 0.0,
+          "max_confirm_count": {
+            "long": 1801,
+            "short": 1743
+          }
+        },
+        "replay": {
+          "breakout_locks": {
+            "long": {
+              "original_t2": 435,
+              "t3_swing": 119
+            },
+            "short": {
+              "original_t2": 455,
+              "t3_swing": 107
+            }
+          },
+          "t3_cooldown_skips": {
+            "long": 0,
+            "short": 0
+          },
+          "t3_quality_rejects": {
+            "long": {
+              "sma_atr_separation": 9
+            },
+            "short": {
+              "sma_atr_separation": 7
+            }
+          }
+        }
+      },
+      "elapsed_seconds": 220.7,
+      "ledger_path": "research/tmp_eth_2026_q1_30min_1s_breakout_confirmation_confirm_2x_1s_ledger.csv",
+      "delta_vs_baseline": {
+        "final_balance_delta": -11517.36,
+        "return_pct_delta": -11.52,
+        "max_dd_pct_delta": 0.0,
+        "trades_delta": -68,
+        "win_rate_pct_delta": 0.05,
+        "sharpe_delta": 0.04
+      }
+    },
+    {
+      "variant": "confirm_3x_1s",
+      "description": "Require three consecutive 1s observations crossing the same breakout level.",
+      "params": {
+        "name": "confirm_3x_1s",
+        "description": "Require three consecutive 1s observations crossing the same breakout level.",
+        "confirm_observations": 3
+      },
+      "summary": {
+        "final_balance": 523434.32,
+        "return_pct": 423.43,
+        "max_dd_pct": -2.04,
+        "trades": 3109,
+        "win_rate_pct": 80.6,
+        "sharpe": 12.97,
+        "first_entry": "2026-01-01T10:22:43+00:00",
+        "last_exit": "2026-03-31T23:59:59+00:00",
+        "entry_reasons": {
+          "SL-Reentry": 2011,
+          "Zero-Initial-Reentry": 1098
+        },
+        "exit_reasons": {
+          "SL": 3108,
+          "FinalMarkToMarket": 1
+        },
+        "entry_types": {
+          "BUY": 1556,
+          "SHORT": 1553
+        },
+        "integrity": {
+          "rows": 6218,
+          "entries": 3109,
+          "exits": 3109,
+          "zero_notional_entries": 0
+        }
+      },
+      "attribution": {
+        "original_t2": {
+          "trades": 2471,
+          "win_rate_pct": 88.06,
+          "avg_pnl_pct": 0.5493,
+          "median_pnl_pct": 0.4081,
+          "pnl_std_pct": 0.6632,
+          "worst_pnl_pct": -0.1811,
+          "net_pnl_value": 535262.98,
+          "max_pnl_drawdown": -217.62,
+          "profit_factor": 63.557,
+          "entry_types": {
+            "SHORT": 1254,
+            "BUY": 1217
+          },
+          "entry_reasons": {
+            "SL-Reentry": 1594,
+            "Zero-Initial-Reentry": 877
+          },
+          "exit_reasons": {
+            "SL": 2470,
+            "FinalMarkToMarket": 1
+          }
+        },
+        "t3_swing": {
+          "trades": 638,
+          "win_rate_pct": 86.21,
+          "avg_pnl_pct": 0.5438,
+          "median_pnl_pct": 0.3684,
+          "pnl_std_pct": 0.6991,
+          "worst_pnl_pct": -0.1365,
+          "net_pnl_value": 132784.43,
+          "max_pnl_drawdown": -214.85,
+          "profit_factor": 59.399,
+          "entry_types": {
+            "BUY": 339,
+            "SHORT": 299
+          },
+          "entry_reasons": {
+            "SL-Reentry": 417,
+            "Zero-Initial-Reentry": 221
+          },
+          "exit_reasons": {
+            "SL": 638
+          }
+        }
+      },
+      "diagnostics": {
+        "filters": {
+          "margin_rejects": {
+            "long": 0,
+            "short": 0
+          },
+          "confirm_rejects": {
+            "long": 3190,
+            "short": 3307
+          },
+          "margin_reject_distance_sum": {
+            "long": 0.0,
+            "short": 0.0
+          },
+          "margin_required": 0.0,
+          "max_confirm_count": {
+            "long": 1801,
+            "short": 1744
+          }
+        },
+        "replay": {
+          "breakout_locks": {
+            "long": {
+              "original_t2": 426,
+              "t3_swing": 114
+            },
+            "short": {
+              "original_t2": 451,
+              "t3_swing": 107
+            }
+          },
+          "t3_cooldown_skips": {
+            "long": 0,
+            "short": 0
+          },
+          "t3_quality_rejects": {
+            "long": {
+              "sma_atr_separation": 11
+            },
+            "short": {
+              "sma_atr_separation": 7
+            }
+          }
+        }
+      },
+      "elapsed_seconds": 220.38,
+      "ledger_path": "research/tmp_eth_2026_q1_30min_1s_breakout_confirmation_confirm_3x_1s_ledger.csv",
+      "delta_vs_baseline": {
+        "final_balance_delta": -12674.83,
+        "return_pct_delta": -12.68,
+        "max_dd_pct_delta": 0.0,
+        "trades_delta": -117,
+        "win_rate_pct_delta": 0.0,
+        "sharpe_delta": -0.52
+      }
+    }
+  ],
+  "note": "Research-only comparison. Consecutive 1s confirmation is used as a multi-tick proxy because this research replay operates on rebuilt 1s bars."
+}

--- a/research/eth_2026_q1_30min_low_vol_entry_filters_summary.json
+++ b/research/eth_2026_q1_30min_low_vol_entry_filters_summary.json
@@ -1,0 +1,1121 @@
+{
+  "symbol": "ETHUSDT",
+  "start": "2026-01-01T00:00:00+00:00",
+  "end": "2026-03-31T23:59:59+00:00",
+  "build_stats": {
+    "raw_tick_rows": 748747244,
+    "kept_tick_rows": 748747172,
+    "sparse_second_rows": 7596268,
+    "continuous_second_rows": 7776000,
+    "first_second": "2026-01-01T00:00:00+00:00",
+    "last_second": "2026-03-31T23:59:59+00:00"
+  },
+  "signal_stats": {
+    "signal_rows": 4320,
+    "signal_start": "2026-01-01T00:00:00+00:00",
+    "signal_end": "2026-03-31T23:30:00+00:00",
+    "valid_sma5_rows": 4316,
+    "valid_atr_rows": 4307,
+    "valid_atr_percentile_rows": 4258
+  },
+  "signal_stop_bps_stats": {
+    "count": 4307,
+    "min": 0.6144,
+    "p05": 1.2044,
+    "p10": 1.5776,
+    "p25": 2.3642,
+    "p50": 3.4132,
+    "p75": 4.6035,
+    "p90": 5.9251,
+    "p95": 7.2042,
+    "max": 15.9955
+  },
+  "replay_kwargs": {
+    "dir2_zero_initial": true,
+    "zero_initial_mode": "reentry_window",
+    "fixed_slippage": 0.0005,
+    "stop_loss_atr": 0.05,
+    "stop_mode": "atr",
+    "max_trades_per_bar": 2,
+    "reentry_size_schedule": [
+      0.2,
+      0.1
+    ],
+    "long_reentry_atr": 0.1,
+    "short_reentry_atr": 0.0,
+    "profit_protect_atr": 1.0,
+    "trailing_stop_atr": 0.3,
+    "delayed_trailing_activation": 0.5,
+    "reentry_anchor_levels": "wick",
+    "reentry_trigger_mode": "reclaim"
+  },
+  "selected_variants": [
+    {
+      "name": "baseline",
+      "description": "No low-volatility entry gate."
+    },
+    {
+      "name": "min_stop_bps_2",
+      "description": "Require stop_loss_atr * ATR to be at least 2 bps of entry reference price.",
+      "min_stop_bps": 2.0
+    },
+    {
+      "name": "min_stop_bps_4",
+      "description": "Require stop_loss_atr * ATR to be at least 4 bps of entry reference price.",
+      "min_stop_bps": 4.0
+    },
+    {
+      "name": "min_stop_bps_6",
+      "description": "Require stop_loss_atr * ATR to be at least 6 bps of entry reference price.",
+      "min_stop_bps": 6.0
+    },
+    {
+      "name": "min_stop_bps_8",
+      "description": "Require stop_loss_atr * ATR to be at least 8 bps of entry reference price.",
+      "min_stop_bps": 8.0
+    },
+    {
+      "name": "atr_pct_gte_25",
+      "description": "Require signal ATR percentile over the rolling 240 signal bars to be at least 25.",
+      "atr_percentile_gte": 25.0
+    },
+    {
+      "name": "min_stop_bps_4_atr_pct_gte_25",
+      "description": "Require both min stop distance of 4 bps and ATR percentile at least 25.",
+      "min_stop_bps": 4.0,
+      "atr_percentile_gte": 25.0
+    }
+  ],
+  "results": [
+    {
+      "variant": "baseline",
+      "description": "No low-volatility entry gate.",
+      "params": {
+        "name": "baseline",
+        "description": "No low-volatility entry gate."
+      },
+      "summary": {
+        "final_balance": 536109.15,
+        "return_pct": 436.11,
+        "max_dd_pct": -2.04,
+        "trades": 3226,
+        "win_rate_pct": 80.6,
+        "sharpe": 13.49,
+        "first_entry": "2026-01-01T10:22:41+00:00",
+        "last_exit": "2026-03-31T23:59:59+00:00",
+        "entry_reasons": {
+          "SL-Reentry": 2086,
+          "Zero-Initial-Reentry": 1140
+        },
+        "exit_reasons": {
+          "SL": 3225,
+          "FinalMarkToMarket": 1
+        },
+        "entry_types": {
+          "BUY": 1632,
+          "SHORT": 1594
+        },
+        "integrity": {
+          "rows": 6452,
+          "entries": 3226,
+          "exits": 3226,
+          "zero_notional_entries": 0
+        }
+      },
+      "pair_diagnostics": {
+        "paired_trades": 3226,
+        "avg_loss_pct": -0.0798,
+        "worst_loss_pct": -0.1811,
+        "avg_win_pct": 0.626,
+        "profit_factor": 62.449,
+        "median_hold_seconds": 258.0,
+        "avg_hold_seconds": 434.8,
+        "entry_reasons": {
+          "SL-Reentry": 2086,
+          "Zero-Initial-Reentry": 1140
+        },
+        "exit_reasons": {
+          "SL": 3225,
+          "FinalMarkToMarket": 1
+        }
+      },
+      "attribution": {
+        "original_t2": {
+          "trades": 2575,
+          "win_rate_pct": 87.96,
+          "avg_pnl_pct": 0.5409,
+          "median_pnl_pct": 0.4009,
+          "pnl_std_pct": 0.6352,
+          "worst_pnl_pct": -0.1811,
+          "net_pnl_value": 555845.31,
+          "max_pnl_drawdown": -221.0,
+          "profit_factor": 61.861,
+          "entry_types": {
+            "SHORT": 1298,
+            "BUY": 1277
+          },
+          "entry_reasons": {
+            "SL-Reentry": 1663,
+            "Zero-Initial-Reentry": 912
+          },
+          "exit_reasons": {
+            "SL": 2574,
+            "FinalMarkToMarket": 1
+          }
+        },
+        "t3_swing": {
+          "trades": 651,
+          "win_rate_pct": 87.1,
+          "avg_pnl_pct": 0.5355,
+          "median_pnl_pct": 0.3717,
+          "pnl_std_pct": 0.6343,
+          "worst_pnl_pct": -0.1188,
+          "net_pnl_value": 137520.44,
+          "max_pnl_drawdown": -217.37,
+          "profit_factor": 64.946,
+          "entry_types": {
+            "BUY": 355,
+            "SHORT": 296
+          },
+          "entry_reasons": {
+            "SL-Reentry": 423,
+            "Zero-Initial-Reentry": 228
+          },
+          "exit_reasons": {
+            "SL": 651
+          }
+        }
+      },
+      "diagnostics": {
+        "entry_gate": {
+          "calls": 9574,
+          "allowed_calls": 9574,
+          "rejected_calls": 0,
+          "reject_reasons": {},
+          "min_observed_stop_bps": 0.5842958745784826,
+          "max_observed_stop_bps": 17.687825241430826,
+          "min_observed_atr_percentile": 0.4166666666666667,
+          "max_observed_atr_percentile": 100.0
+        },
+        "replay": {
+          "breakout_locks": {
+            "long": {
+              "original_t2": 449,
+              "t3_swing": 119
+            },
+            "short": {
+              "original_t2": 470,
+              "t3_swing": 109
+            }
+          },
+          "t3_cooldown_skips": {
+            "long": 0,
+            "short": 0
+          },
+          "t3_quality_rejects": {
+            "long": {
+              "sma_atr_separation": 9
+            },
+            "short": {
+              "sma_atr_separation": 5
+            }
+          }
+        }
+      },
+      "elapsed_seconds": 221.36,
+      "ledger_path": "research/tmp_eth_2026_q1_30min_1s_low_vol_entry_filter_baseline_ledger.csv"
+    },
+    {
+      "variant": "min_stop_bps_2",
+      "description": "Require stop_loss_atr * ATR to be at least 2 bps of entry reference price.",
+      "params": {
+        "name": "min_stop_bps_2",
+        "description": "Require stop_loss_atr * ATR to be at least 2 bps of entry reference price.",
+        "min_stop_bps": 2.0
+      },
+      "summary": {
+        "final_balance": 577665.51,
+        "return_pct": 477.67,
+        "max_dd_pct": -0.38,
+        "trades": 2622,
+        "win_rate_pct": 86.84,
+        "sharpe": 15.18,
+        "first_entry": "2026-01-02T06:40:34+00:00",
+        "last_exit": "2026-03-31T23:59:59+00:00",
+        "entry_reasons": {
+          "SL-Reentry": 1681,
+          "Zero-Initial-Reentry": 941
+        },
+        "exit_reasons": {
+          "SL": 2621,
+          "FinalMarkToMarket": 1
+        },
+        "entry_types": {
+          "BUY": 1321,
+          "SHORT": 1301
+        },
+        "integrity": {
+          "rows": 5244,
+          "entries": 2622,
+          "exits": 2622,
+          "zero_notional_entries": 0
+        }
+      },
+      "pair_diagnostics": {
+        "paired_trades": 2622,
+        "avg_loss_pct": -0.0887,
+        "worst_loss_pct": -0.1811,
+        "avg_win_pct": 0.7217,
+        "profit_factor": 72.2996,
+        "median_hold_seconds": 256.0,
+        "avg_hold_seconds": 437.42,
+        "entry_reasons": {
+          "SL-Reentry": 1681,
+          "Zero-Initial-Reentry": 941
+        },
+        "exit_reasons": {
+          "SL": 2621,
+          "FinalMarkToMarket": 1
+        }
+      },
+      "attribution": {
+        "original_t2": {
+          "trades": 2121,
+          "win_rate_pct": 89.67,
+          "avg_pnl_pct": 0.6321,
+          "median_pnl_pct": 0.5051,
+          "pnl_std_pct": 0.6631,
+          "worst_pnl_pct": -0.1811,
+          "net_pnl_value": 571780.78,
+          "max_pnl_drawdown": -235.23,
+          "profit_factor": 71.3364,
+          "entry_types": {
+            "SHORT": 1073,
+            "BUY": 1048
+          },
+          "entry_reasons": {
+            "SL-Reentry": 1359,
+            "Zero-Initial-Reentry": 762
+          },
+          "exit_reasons": {
+            "SL": 2120,
+            "FinalMarkToMarket": 1
+          }
+        },
+        "t3_swing": {
+          "trades": 501,
+          "win_rate_pct": 88.62,
+          "avg_pnl_pct": 0.6545,
+          "median_pnl_pct": 0.48,
+          "pnl_std_pct": 0.6748,
+          "worst_pnl_pct": -0.1188,
+          "net_pnl_value": 139867.22,
+          "max_pnl_drawdown": -231.11,
+          "profit_factor": 76.5278,
+          "entry_types": {
+            "BUY": 273,
+            "SHORT": 228
+          },
+          "entry_reasons": {
+            "SL-Reentry": 322,
+            "Zero-Initial-Reentry": 179
+          },
+          "exit_reasons": {
+            "SL": 501
+          }
+        }
+      },
+      "diagnostics": {
+        "entry_gate": {
+          "calls": 569014,
+          "allowed_calls": 8035,
+          "rejected_calls": 560979,
+          "reject_reasons": {
+            "min_stop_bps": 560979
+          },
+          "min_observed_stop_bps": 0.5698575061303605,
+          "max_observed_stop_bps": 17.687825241430826,
+          "min_observed_atr_percentile": 0.4166666666666667,
+          "max_observed_atr_percentile": 100.0
+        },
+        "replay": {
+          "breakout_locks": {
+            "long": {
+              "original_t2": 453,
+              "t3_swing": 120
+            },
+            "short": {
+              "original_t2": 480,
+              "t3_swing": 110
+            }
+          },
+          "t3_cooldown_skips": {
+            "long": 0,
+            "short": 0
+          },
+          "t3_quality_rejects": {
+            "long": {
+              "sma_atr_separation": 17
+            },
+            "short": {
+              "sma_atr_separation": 12
+            }
+          }
+        }
+      },
+      "elapsed_seconds": 190.26,
+      "ledger_path": "research/tmp_eth_2026_q1_30min_1s_low_vol_entry_filter_min_stop_bps_2_ledger.csv",
+      "delta_vs_baseline": {
+        "final_balance_delta": 41556.36,
+        "return_pct_delta": 41.56,
+        "max_dd_pct_delta": 1.66,
+        "trades_delta": -604,
+        "win_rate_pct_delta": 6.24,
+        "sharpe_delta": 1.69
+      }
+    },
+    {
+      "variant": "min_stop_bps_4",
+      "description": "Require stop_loss_atr * ATR to be at least 4 bps of entry reference price.",
+      "params": {
+        "name": "min_stop_bps_4",
+        "description": "Require stop_loss_atr * ATR to be at least 4 bps of entry reference price.",
+        "min_stop_bps": 4.0
+      },
+      "summary": {
+        "final_balance": 388532.61,
+        "return_pct": 288.53,
+        "max_dd_pct": -0.21,
+        "trades": 1185,
+        "win_rate_pct": 91.39,
+        "sharpe": 17.71,
+        "first_entry": "2026-01-02T14:48:09+00:00",
+        "last_exit": "2026-03-31T23:59:59+00:00",
+        "entry_reasons": {
+          "SL-Reentry": 739,
+          "Zero-Initial-Reentry": 446
+        },
+        "exit_reasons": {
+          "SL": 1184,
+          "FinalMarkToMarket": 1
+        },
+        "entry_types": {
+          "BUY": 635,
+          "SHORT": 550
+        },
+        "integrity": {
+          "rows": 2370,
+          "entries": 1185,
+          "exits": 1185,
+          "zero_notional_entries": 0
+        }
+      },
+      "pair_diagnostics": {
+        "paired_trades": 1185,
+        "avg_loss_pct": -0.1055,
+        "worst_loss_pct": -0.1811,
+        "avg_win_pct": 1.0468,
+        "profit_factor": 101.1325,
+        "median_hold_seconds": 266.0,
+        "avg_hold_seconds": 470.66,
+        "entry_reasons": {
+          "SL-Reentry": 739,
+          "Zero-Initial-Reentry": 446
+        },
+        "exit_reasons": {
+          "SL": 1184,
+          "FinalMarkToMarket": 1
+        }
+      },
+      "attribution": {
+        "original_t2": {
+          "trades": 937,
+          "win_rate_pct": 92.0,
+          "avg_pnl_pct": 0.9438,
+          "median_pnl_pct": 0.7864,
+          "pnl_std_pct": 0.8501,
+          "worst_pnl_pct": -0.1811,
+          "net_pnl_value": 291401.6,
+          "max_pnl_drawdown": -121.56,
+          "profit_factor": 108.9222,
+          "entry_types": {
+            "BUY": 507,
+            "SHORT": 430
+          },
+          "entry_reasons": {
+            "SL-Reentry": 582,
+            "Zero-Initial-Reentry": 355
+          },
+          "exit_reasons": {
+            "SL": 936,
+            "FinalMarkToMarket": 1
+          }
+        },
+        "t3_swing": {
+          "trades": 248,
+          "win_rate_pct": 89.11,
+          "avg_pnl_pct": 0.9623,
+          "median_pnl_pct": 0.7963,
+          "pnl_std_pct": 0.8461,
+          "worst_pnl_pct": -0.1188,
+          "net_pnl_value": 80593.02,
+          "max_pnl_drawdown": -185.44,
+          "profit_factor": 80.4086,
+          "entry_types": {
+            "BUY": 128,
+            "SHORT": 120
+          },
+          "entry_reasons": {
+            "SL-Reentry": 157,
+            "Zero-Initial-Reentry": 91
+          },
+          "exit_reasons": {
+            "SL": 248
+          }
+        }
+      },
+      "diagnostics": {
+        "entry_gate": {
+          "calls": 1955541,
+          "allowed_calls": 5492,
+          "rejected_calls": 1950049,
+          "reject_reasons": {
+            "min_stop_bps": 1950049
+          },
+          "min_observed_stop_bps": 0.5698575061303605,
+          "max_observed_stop_bps": 17.687825241430826,
+          "min_observed_atr_percentile": 0.4166666666666667,
+          "max_observed_atr_percentile": 100.0
+        },
+        "replay": {
+          "breakout_locks": {
+            "long": {
+              "original_t2": 474,
+              "t3_swing": 123
+            },
+            "short": {
+              "original_t2": 497,
+              "t3_swing": 111
+            }
+          },
+          "t3_cooldown_skips": {
+            "long": 0,
+            "short": 0
+          },
+          "t3_quality_rejects": {
+            "long": {
+              "sma_atr_separation": 31
+            },
+            "short": {
+              "sma_atr_separation": 21
+            }
+          }
+        }
+      },
+      "elapsed_seconds": 175.53,
+      "ledger_path": "research/tmp_eth_2026_q1_30min_1s_low_vol_entry_filter_min_stop_bps_4_ledger.csv",
+      "delta_vs_baseline": {
+        "final_balance_delta": -147576.54,
+        "return_pct_delta": -147.58,
+        "max_dd_pct_delta": 1.83,
+        "trades_delta": -2041,
+        "win_rate_pct_delta": 10.79,
+        "sharpe_delta": 4.22
+      }
+    },
+    {
+      "variant": "min_stop_bps_6",
+      "description": "Require stop_loss_atr * ATR to be at least 6 bps of entry reference price.",
+      "params": {
+        "name": "min_stop_bps_6",
+        "description": "Require stop_loss_atr * ATR to be at least 6 bps of entry reference price.",
+        "min_stop_bps": 6.0
+      },
+      "summary": {
+        "final_balance": 192490.09,
+        "return_pct": 92.49,
+        "max_dd_pct": -0.17,
+        "trades": 307,
+        "win_rate_pct": 92.83,
+        "sharpe": 18.79,
+        "first_entry": "2026-01-13T22:10:33+00:00",
+        "last_exit": "2026-03-31T17:25:40+00:00",
+        "entry_reasons": {
+          "SL-Reentry": 190,
+          "Zero-Initial-Reentry": 117
+        },
+        "exit_reasons": {
+          "SL": 307
+        },
+        "entry_types": {
+          "BUY": 173,
+          "SHORT": 134
+        },
+        "integrity": {
+          "rows": 614,
+          "entries": 307,
+          "exits": 307,
+          "zero_notional_entries": 0
+        }
+      },
+      "pair_diagnostics": {
+        "paired_trades": 307,
+        "avg_loss_pct": -0.1368,
+        "worst_loss_pct": -0.1811,
+        "avg_win_pct": 1.7162,
+        "profit_factor": 166.2014,
+        "median_hold_seconds": 288.0,
+        "avg_hold_seconds": 467.36,
+        "entry_reasons": {
+          "SL-Reentry": 190,
+          "Zero-Initial-Reentry": 117
+        },
+        "exit_reasons": {
+          "SL": 307
+        }
+      },
+      "attribution": {
+        "original_t2": {
+          "trades": 259,
+          "win_rate_pct": 92.28,
+          "avg_pnl_pct": 1.5513,
+          "median_pnl_pct": 1.2569,
+          "pnl_std_pct": 1.3597,
+          "worst_pnl_pct": -0.1811,
+          "net_pnl_value": 87950.98,
+          "max_pnl_drawdown": -106.08,
+          "profit_factor": 150.5533,
+          "entry_types": {
+            "BUY": 148,
+            "SHORT": 111
+          },
+          "entry_reasons": {
+            "SL-Reentry": 164,
+            "Zero-Initial-Reentry": 95
+          },
+          "exit_reasons": {
+            "SL": 259
+          }
+        },
+        "t3_swing": {
+          "trades": 48,
+          "win_rate_pct": 95.83,
+          "avg_pnl_pct": 1.757,
+          "median_pnl_pct": 1.4594,
+          "pnl_std_pct": 1.1826,
+          "worst_pnl_pct": -0.1188,
+          "net_pnl_value": 18198.33,
+          "max_pnl_drawdown": -54.45,
+          "profit_factor": 335.1978,
+          "entry_types": {
+            "BUY": 25,
+            "SHORT": 23
+          },
+          "entry_reasons": {
+            "SL-Reentry": 26,
+            "Zero-Initial-Reentry": 22
+          },
+          "exit_reasons": {
+            "SL": 48
+          }
+        }
+      },
+      "diagnostics": {
+        "entry_gate": {
+          "calls": 2742833,
+          "allowed_calls": 935,
+          "rejected_calls": 2741898,
+          "reject_reasons": {
+            "min_stop_bps": 2741898
+          },
+          "min_observed_stop_bps": 0.5698575061303605,
+          "max_observed_stop_bps": 17.687825241430826,
+          "min_observed_atr_percentile": 0.4166666666666667,
+          "max_observed_atr_percentile": 100.0
+        },
+        "replay": {
+          "breakout_locks": {
+            "long": {
+              "original_t2": 478,
+              "t3_swing": 126
+            },
+            "short": {
+              "original_t2": 508,
+              "t3_swing": 113
+            }
+          },
+          "t3_cooldown_skips": {
+            "long": 0,
+            "short": 0
+          },
+          "t3_quality_rejects": {
+            "long": {
+              "sma_atr_separation": 39
+            },
+            "short": {
+              "sma_atr_separation": 27
+            }
+          }
+        }
+      },
+      "elapsed_seconds": 181.51,
+      "ledger_path": "research/tmp_eth_2026_q1_30min_1s_low_vol_entry_filter_min_stop_bps_6_ledger.csv",
+      "delta_vs_baseline": {
+        "final_balance_delta": -343619.06,
+        "return_pct_delta": -343.62,
+        "max_dd_pct_delta": 1.87,
+        "trades_delta": -2919,
+        "win_rate_pct_delta": 12.23,
+        "sharpe_delta": 5.3
+      }
+    },
+    {
+      "variant": "min_stop_bps_8",
+      "description": "Require stop_loss_atr * ATR to be at least 8 bps of entry reference price.",
+      "params": {
+        "name": "min_stop_bps_8",
+        "description": "Require stop_loss_atr * ATR to be at least 8 bps of entry reference price.",
+        "min_stop_bps": 8.0
+      },
+      "summary": {
+        "final_balance": 141721.63,
+        "return_pct": 41.72,
+        "max_dd_pct": -0.17,
+        "trades": 133,
+        "win_rate_pct": 90.23,
+        "sharpe": 18.49,
+        "first_entry": "2026-01-31T18:38:32+00:00",
+        "last_exit": "2026-03-23T18:07:27+00:00",
+        "entry_reasons": {
+          "SL-Reentry": 83,
+          "Zero-Initial-Reentry": 50
+        },
+        "exit_reasons": {
+          "SL": 133
+        },
+        "entry_types": {
+          "BUY": 69,
+          "SHORT": 64
+        },
+        "integrity": {
+          "rows": 266,
+          "entries": 133,
+          "exits": 133,
+          "zero_notional_entries": 0
+        }
+      },
+      "pair_diagnostics": {
+        "paired_trades": 133,
+        "avg_loss_pct": -0.149,
+        "worst_loss_pct": -0.1811,
+        "avg_win_pct": 2.1005,
+        "profit_factor": 125.0517,
+        "median_hold_seconds": 247.0,
+        "avg_hold_seconds": 454.2,
+        "entry_reasons": {
+          "SL-Reentry": 83,
+          "Zero-Initial-Reentry": 50
+        },
+        "exit_reasons": {
+          "SL": 133
+        }
+      },
+      "attribution": {
+        "original_t2": {
+          "trades": 113,
+          "win_rate_pct": 88.5,
+          "avg_pnl_pct": 1.7295,
+          "median_pnl_pct": 1.5319,
+          "pnl_std_pct": 1.6516,
+          "worst_pnl_pct": -0.1811,
+          "net_pnl_value": 37247.09,
+          "max_pnl_drawdown": -92.68,
+          "profit_factor": 100.0263,
+          "entry_types": {
+            "BUY": 59,
+            "SHORT": 54
+          },
+          "entry_reasons": {
+            "SL-Reentry": 73,
+            "Zero-Initial-Reentry": 40
+          },
+          "exit_reasons": {
+            "SL": 113
+          }
+        },
+        "t3_swing": {
+          "trades": 20,
+          "win_rate_pct": 100.0,
+          "avg_pnl_pct": 2.7341,
+          "median_pnl_pct": 2.7748,
+          "pnl_std_pct": 0.9675,
+          "worst_pnl_pct": 1.3019,
+          "net_pnl_value": 9412.88,
+          "max_pnl_drawdown": 0.0,
+          "profit_factor": null,
+          "entry_types": {
+            "SHORT": 10,
+            "BUY": 10
+          },
+          "entry_reasons": {
+            "Zero-Initial-Reentry": 10,
+            "SL-Reentry": 10
+          },
+          "exit_reasons": {
+            "SL": 20
+          }
+        }
+      },
+      "diagnostics": {
+        "entry_gate": {
+          "calls": 2902277,
+          "allowed_calls": 579,
+          "rejected_calls": 2901698,
+          "reject_reasons": {
+            "min_stop_bps": 2901698
+          },
+          "min_observed_stop_bps": 0.5698575061303605,
+          "max_observed_stop_bps": 17.687825241430826,
+          "min_observed_atr_percentile": 0.4166666666666667,
+          "max_observed_atr_percentile": 100.0
+        },
+        "replay": {
+          "breakout_locks": {
+            "long": {
+              "original_t2": 479,
+              "t3_swing": 126
+            },
+            "short": {
+              "original_t2": 509,
+              "t3_swing": 113
+            }
+          },
+          "t3_cooldown_skips": {
+            "long": 0,
+            "short": 0
+          },
+          "t3_quality_rejects": {
+            "long": {
+              "sma_atr_separation": 39
+            },
+            "short": {
+              "sma_atr_separation": 28
+            }
+          }
+        }
+      },
+      "elapsed_seconds": 193.87,
+      "ledger_path": "research/tmp_eth_2026_q1_30min_1s_low_vol_entry_filter_min_stop_bps_8_ledger.csv",
+      "delta_vs_baseline": {
+        "final_balance_delta": -394387.52,
+        "return_pct_delta": -394.39,
+        "max_dd_pct_delta": 1.87,
+        "trades_delta": -3093,
+        "win_rate_pct_delta": 9.63,
+        "sharpe_delta": 5.0
+      }
+    },
+    {
+      "variant": "atr_pct_gte_25",
+      "description": "Require signal ATR percentile over the rolling 240 signal bars to be at least 25.",
+      "params": {
+        "name": "atr_pct_gte_25",
+        "description": "Require signal ATR percentile over the rolling 240 signal bars to be at least 25.",
+        "atr_percentile_gte": 25.0
+      },
+      "summary": {
+        "final_balance": 486720.09,
+        "return_pct": 386.72,
+        "max_dd_pct": -0.34,
+        "trades": 2297,
+        "win_rate_pct": 85.46,
+        "sharpe": 14.66,
+        "first_entry": "2026-01-02T08:53:06+00:00",
+        "last_exit": "2026-03-31T23:59:59+00:00",
+        "entry_reasons": {
+          "SL-Reentry": 1471,
+          "Zero-Initial-Reentry": 826
+        },
+        "exit_reasons": {
+          "SL": 2296,
+          "FinalMarkToMarket": 1
+        },
+        "entry_types": {
+          "BUY": 1171,
+          "SHORT": 1126
+        },
+        "integrity": {
+          "rows": 4594,
+          "entries": 2297,
+          "exits": 2297,
+          "zero_notional_entries": 0
+        }
+      },
+      "pair_diagnostics": {
+        "paired_trades": 2297,
+        "avg_loss_pct": -0.0884,
+        "worst_loss_pct": -0.1811,
+        "avg_win_pct": 0.7451,
+        "profit_factor": 71.1611,
+        "median_hold_seconds": 258.0,
+        "avg_hold_seconds": 445.31,
+        "entry_reasons": {
+          "SL-Reentry": 1471,
+          "Zero-Initial-Reentry": 826
+        },
+        "exit_reasons": {
+          "SL": 2296,
+          "FinalMarkToMarket": 1
+        }
+      },
+      "attribution": {
+        "original_t2": {
+          "trades": 1826,
+          "win_rate_pct": 88.83,
+          "avg_pnl_pct": 0.6509,
+          "median_pnl_pct": 0.5133,
+          "pnl_std_pct": 0.703,
+          "worst_pnl_pct": -0.1811,
+          "net_pnl_value": 444944.62,
+          "max_pnl_drawdown": -203.98,
+          "profit_factor": 71.1168,
+          "entry_types": {
+            "SHORT": 913,
+            "BUY": 913
+          },
+          "entry_reasons": {
+            "SL-Reentry": 1163,
+            "Zero-Initial-Reentry": 663
+          },
+          "exit_reasons": {
+            "SL": 1825,
+            "FinalMarkToMarket": 1
+          }
+        },
+        "t3_swing": {
+          "trades": 471,
+          "win_rate_pct": 87.47,
+          "avg_pnl_pct": 0.6448,
+          "median_pnl_pct": 0.4664,
+          "pnl_std_pct": 0.7041,
+          "worst_pnl_pct": -0.1188,
+          "net_pnl_value": 112363.46,
+          "max_pnl_drawdown": -203.23,
+          "profit_factor": 71.3372,
+          "entry_types": {
+            "BUY": 258,
+            "SHORT": 213
+          },
+          "entry_reasons": {
+            "SL-Reentry": 308,
+            "Zero-Initial-Reentry": 163
+          },
+          "exit_reasons": {
+            "SL": 471
+          }
+        }
+      },
+      "diagnostics": {
+        "entry_gate": {
+          "calls": 863405,
+          "allowed_calls": 7556,
+          "rejected_calls": 855849,
+          "reject_reasons": {
+            "atr_percentile": 855849
+          },
+          "min_observed_stop_bps": 0.5698575061303605,
+          "max_observed_stop_bps": 17.687825241430826,
+          "min_observed_atr_percentile": 0.4166666666666667,
+          "max_observed_atr_percentile": 100.0
+        },
+        "replay": {
+          "breakout_locks": {
+            "long": {
+              "original_t2": 457,
+              "t3_swing": 121
+            },
+            "short": {
+              "original_t2": 481,
+              "t3_swing": 111
+            }
+          },
+          "t3_cooldown_skips": {
+            "long": 0,
+            "short": 0
+          },
+          "t3_quality_rejects": {
+            "long": {
+              "sma_atr_separation": 19
+            },
+            "short": {
+              "sma_atr_separation": 16
+            }
+          }
+        }
+      },
+      "elapsed_seconds": 181.47,
+      "ledger_path": "research/tmp_eth_2026_q1_30min_1s_low_vol_entry_filter_atr_pct_gte_25_ledger.csv",
+      "delta_vs_baseline": {
+        "final_balance_delta": -49389.06,
+        "return_pct_delta": -49.39,
+        "max_dd_pct_delta": 1.7,
+        "trades_delta": -929,
+        "win_rate_pct_delta": 4.86,
+        "sharpe_delta": 1.17
+      }
+    },
+    {
+      "variant": "min_stop_bps_4_atr_pct_gte_25",
+      "description": "Require both min stop distance of 4 bps and ATR percentile at least 25.",
+      "params": {
+        "name": "min_stop_bps_4_atr_pct_gte_25",
+        "description": "Require both min stop distance of 4 bps and ATR percentile at least 25.",
+        "min_stop_bps": 4.0,
+        "atr_percentile_gte": 25.0
+      },
+      "summary": {
+        "final_balance": 364445.73,
+        "return_pct": 264.45,
+        "max_dd_pct": -0.21,
+        "trades": 1101,
+        "win_rate_pct": 91.37,
+        "sharpe": 17.55,
+        "first_entry": "2026-01-02T14:48:09+00:00",
+        "last_exit": "2026-03-31T23:59:59+00:00",
+        "entry_reasons": {
+          "SL-Reentry": 686,
+          "Zero-Initial-Reentry": 415
+        },
+        "exit_reasons": {
+          "SL": 1100,
+          "FinalMarkToMarket": 1
+        },
+        "entry_types": {
+          "BUY": 588,
+          "SHORT": 513
+        },
+        "integrity": {
+          "rows": 2202,
+          "entries": 1101,
+          "exits": 1101,
+          "zero_notional_entries": 0
+        }
+      },
+      "pair_diagnostics": {
+        "paired_trades": 1101,
+        "avg_loss_pct": -0.1064,
+        "worst_loss_pct": -0.1811,
+        "avg_win_pct": 1.0671,
+        "profit_factor": 102.5939,
+        "median_hold_seconds": 266.0,
+        "avg_hold_seconds": 478.97,
+        "entry_reasons": {
+          "SL-Reentry": 686,
+          "Zero-Initial-Reentry": 415
+        },
+        "exit_reasons": {
+          "SL": 1100,
+          "FinalMarkToMarket": 1
+        }
+      },
+      "attribution": {
+        "original_t2": {
+          "trades": 863,
+          "win_rate_pct": 92.0,
+          "avg_pnl_pct": 0.9623,
+          "median_pnl_pct": 0.795,
+          "pnl_std_pct": 0.8774,
+          "worst_pnl_pct": -0.1811,
+          "net_pnl_value": 263514.95,
+          "max_pnl_drawdown": -120.4,
+          "profit_factor": 110.4867,
+          "entry_types": {
+            "BUY": 465,
+            "SHORT": 398
+          },
+          "entry_reasons": {
+            "SL-Reentry": 535,
+            "Zero-Initial-Reentry": 328
+          },
+          "exit_reasons": {
+            "SL": 862,
+            "FinalMarkToMarket": 1
+          }
+        },
+        "t3_swing": {
+          "trades": 238,
+          "win_rate_pct": 89.08,
+          "avg_pnl_pct": 0.9789,
+          "median_pnl_pct": 0.8076,
+          "pnl_std_pct": 0.8576,
+          "worst_pnl_pct": -0.1188,
+          "net_pnl_value": 75506.86,
+          "max_pnl_drawdown": -172.46,
+          "profit_factor": 82.1721,
+          "entry_types": {
+            "BUY": 123,
+            "SHORT": 115
+          },
+          "entry_reasons": {
+            "SL-Reentry": 151,
+            "Zero-Initial-Reentry": 87
+          },
+          "exit_reasons": {
+            "SL": 238
+          }
+        }
+      },
+      "diagnostics": {
+        "entry_gate": {
+          "calls": 2031259,
+          "allowed_calls": 5330,
+          "rejected_calls": 2025929,
+          "reject_reasons": {
+            "min_stop_bps": 1950034,
+            "atr_percentile": 859599
+          },
+          "min_observed_stop_bps": 0.5698575061303605,
+          "max_observed_stop_bps": 17.687825241430826,
+          "min_observed_atr_percentile": 0.4166666666666667,
+          "max_observed_atr_percentile": 100.0
+        },
+        "replay": {
+          "breakout_locks": {
+            "long": {
+              "original_t2": 474,
+              "t3_swing": 123
+            },
+            "short": {
+              "original_t2": 497,
+              "t3_swing": 112
+            }
+          },
+          "t3_cooldown_skips": {
+            "long": 0,
+            "short": 0
+          },
+          "t3_quality_rejects": {
+            "long": {
+              "sma_atr_separation": 32
+            },
+            "short": {
+              "sma_atr_separation": 22
+            }
+          }
+        }
+      },
+      "elapsed_seconds": 190.22,
+      "ledger_path": "research/tmp_eth_2026_q1_30min_1s_low_vol_entry_filter_min_stop_bps_4_atr_pct_gte_25_ledger.csv",
+      "delta_vs_baseline": {
+        "final_balance_delta": -171663.42,
+        "return_pct_delta": -171.66,
+        "max_dd_pct_delta": 1.83,
+        "trades_delta": -2125,
+        "win_rate_pct_delta": 10.77,
+        "sharpe_delta": 4.06
+      }
+    }
+  ],
+  "elapsed_at": "2026-04-29T15:39:23+0800",
+  "note": "Research-only comparison. Entry gates patch reentry price resolution and do not alter stop-loss exit behavior."
+}

--- a/research/eth_2026_q1_30min_stop_loss_atr_sweep_summary.json
+++ b/research/eth_2026_q1_30min_stop_loss_atr_sweep_summary.json
@@ -1,0 +1,915 @@
+{
+  "symbol": "ETHUSDT",
+  "start": "2026-01-01T00:00:00+00:00",
+  "end": "2026-03-31T23:59:59+00:00",
+  "build_stats": {
+    "raw_tick_rows": 748747244,
+    "kept_tick_rows": 748747172,
+    "sparse_second_rows": 7596268,
+    "continuous_second_rows": 7776000,
+    "first_second": "2026-01-01T00:00:00+00:00",
+    "last_second": "2026-03-31T23:59:59+00:00"
+  },
+  "signal_stats": {
+    "signal_rows": 4320,
+    "signal_start": "2026-01-01T00:00:00+00:00",
+    "signal_end": "2026-03-31T23:30:00+00:00",
+    "valid_sma5_rows": 4316,
+    "valid_atr_rows": 4307
+  },
+  "results": [
+    {
+      "stop_loss_atr": 0.05,
+      "summary": {
+        "final_balance": 536109.15,
+        "return_pct": 436.11,
+        "max_dd_pct": -2.04,
+        "trades": 3226,
+        "win_rate_pct": 80.6,
+        "sharpe": 13.49,
+        "first_entry": "2026-01-01T10:22:41+00:00",
+        "last_exit": "2026-03-31T23:59:59+00:00",
+        "entry_reasons": {
+          "SL-Reentry": 2086,
+          "Zero-Initial-Reentry": 1140
+        },
+        "exit_reasons": {
+          "SL": 3225,
+          "FinalMarkToMarket": 1
+        },
+        "entry_types": {
+          "BUY": 1632,
+          "SHORT": 1594
+        },
+        "integrity": {
+          "rows": 6452,
+          "entries": 3226,
+          "exits": 3226,
+          "zero_notional_entries": 0
+        }
+      },
+      "pair_diagnostics": {
+        "paired_trades": 3226,
+        "avg_loss_pct": -0.0798,
+        "worst_loss_pct": -0.1811,
+        "avg_win_pct": 0.626,
+        "profit_factor": 62.449,
+        "median_hold_seconds": 258.0,
+        "avg_hold_seconds": 434.8,
+        "exit_reasons": {
+          "SL": 3225,
+          "FinalMarkToMarket": 1
+        },
+        "entry_reasons": {
+          "SL-Reentry": 2086,
+          "Zero-Initial-Reentry": 1140
+        }
+      },
+      "monthly": [
+        {
+          "month": "2026-01",
+          "trades": 1118,
+          "win_rate_pct": 83.27,
+          "net_pnl_value": 71005.07,
+          "avg_pnl_pct": 0.367,
+          "avg_loss_pct": -0.0699,
+          "worst_loss_pct": -0.1747,
+          "profit_factor": 34.3591
+        },
+        {
+          "month": "2026-02",
+          "trades": 1000,
+          "win_rate_pct": 89.8,
+          "net_pnl_value": 248992.0,
+          "avg_pnl_pct": 0.7494,
+          "avg_loss_pct": -0.0953,
+          "worst_loss_pct": -0.1811,
+          "profit_factor": 74.3561
+        },
+        {
+          "month": "2026-03",
+          "trades": 1108,
+          "win_rate_pct": 90.52,
+          "net_pnl_value": 373368.69,
+          "avg_pnl_pct": 0.525,
+          "avg_loss_pct": -0.0821,
+          "worst_loss_pct": -0.1087,
+          "profit_factor": 65.812
+        }
+      ],
+      "breakout_attribution": {
+        "original_t2": {
+          "trades": 2575,
+          "win_rate_pct": 87.96,
+          "avg_pnl_pct": 0.5409,
+          "median_pnl_pct": 0.4009,
+          "pnl_std_pct": 0.6352,
+          "worst_pnl_pct": -0.1811,
+          "net_pnl_value": 555845.31,
+          "max_pnl_drawdown": -221.0,
+          "profit_factor": 61.861,
+          "entry_types": {
+            "SHORT": 1298,
+            "BUY": 1277
+          },
+          "entry_reasons": {
+            "SL-Reentry": 1663,
+            "Zero-Initial-Reentry": 912
+          },
+          "exit_reasons": {
+            "SL": 2574,
+            "FinalMarkToMarket": 1
+          }
+        },
+        "t3_swing": {
+          "trades": 651,
+          "win_rate_pct": 87.1,
+          "avg_pnl_pct": 0.5355,
+          "median_pnl_pct": 0.3717,
+          "pnl_std_pct": 0.6343,
+          "worst_pnl_pct": -0.1188,
+          "net_pnl_value": 137520.44,
+          "max_pnl_drawdown": -217.37,
+          "profit_factor": 64.946,
+          "entry_types": {
+            "BUY": 355,
+            "SHORT": 296
+          },
+          "entry_reasons": {
+            "SL-Reentry": 423,
+            "Zero-Initial-Reentry": 228
+          },
+          "exit_reasons": {
+            "SL": 651
+          }
+        }
+      },
+      "diagnostics": {
+        "breakout_locks": {
+          "long": {
+            "original_t2": 449,
+            "t3_swing": 119
+          },
+          "short": {
+            "original_t2": 470,
+            "t3_swing": 109
+          }
+        },
+        "t3_cooldown_skips": {
+          "long": 0,
+          "short": 0
+        },
+        "t3_quality_rejects": {
+          "long": {
+            "sma_atr_separation": 9
+          },
+          "short": {
+            "sma_atr_separation": 5
+          }
+        }
+      },
+      "ledger_path": "research/tmp_eth_2026_q1_30min_1s_stop_loss_atr_sweep_0p05_ledger.csv",
+      "elapsed_seconds": 223.01,
+      "replay_kwargs": {
+        "dir2_zero_initial": true,
+        "zero_initial_mode": "reentry_window",
+        "fixed_slippage": 0.0005,
+        "stop_loss_atr": 0.05,
+        "stop_mode": "atr",
+        "max_trades_per_bar": 2,
+        "reentry_size_schedule": [
+          0.2,
+          0.1
+        ],
+        "long_reentry_atr": 0.1,
+        "short_reentry_atr": 0.0,
+        "profit_protect_atr": 1.0,
+        "trailing_stop_atr": 0.3,
+        "delayed_trailing_activation": 0.5,
+        "reentry_anchor_levels": "wick",
+        "reentry_trigger_mode": "reclaim"
+      }
+    },
+    {
+      "stop_loss_atr": 0.1,
+      "summary": {
+        "final_balance": 534500.9,
+        "return_pct": 434.5,
+        "max_dd_pct": -2.12,
+        "trades": 3259,
+        "win_rate_pct": 80.95,
+        "sharpe": 13.4,
+        "first_entry": "2026-01-01T10:22:41+00:00",
+        "last_exit": "2026-03-31T23:59:59+00:00",
+        "entry_reasons": {
+          "SL-Reentry": 2131,
+          "Zero-Initial-Reentry": 1128
+        },
+        "exit_reasons": {
+          "SL": 3258,
+          "FinalMarkToMarket": 1
+        },
+        "entry_types": {
+          "BUY": 1651,
+          "SHORT": 1608
+        },
+        "integrity": {
+          "rows": 6518,
+          "entries": 3259,
+          "exits": 3259,
+          "zero_notional_entries": 0
+        }
+      },
+      "pair_diagnostics": {
+        "paired_trades": 3259,
+        "avg_loss_pct": -0.1103,
+        "worst_loss_pct": -0.3123,
+        "avg_win_pct": 0.6203,
+        "profit_factor": 46.5882,
+        "median_hold_seconds": 271.0,
+        "avg_hold_seconds": 464.11,
+        "exit_reasons": {
+          "SL": 3258,
+          "FinalMarkToMarket": 1
+        },
+        "entry_reasons": {
+          "SL-Reentry": 2131,
+          "Zero-Initial-Reentry": 1128
+        }
+      },
+      "monthly": [
+        {
+          "month": "2026-01",
+          "trades": 1126,
+          "win_rate_pct": 83.93,
+          "net_pnl_value": 70588.0,
+          "avg_pnl_pct": 0.3637,
+          "avg_loss_pct": -0.0911,
+          "worst_loss_pct": -0.2993,
+          "profit_factor": 26.8071
+        },
+        {
+          "month": "2026-02",
+          "trades": 1016,
+          "win_rate_pct": 91.34,
+          "net_pnl_value": 252036.8,
+          "avg_pnl_pct": 0.7473,
+          "avg_loss_pct": -0.1467,
+          "worst_loss_pct": -0.3123,
+          "profit_factor": 55.7455
+        },
+        {
+          "month": "2026-03",
+          "trades": 1117,
+          "win_rate_pct": 90.78,
+          "net_pnl_value": 372091.06,
+          "avg_pnl_pct": 0.5202,
+          "avg_loss_pct": -0.1129,
+          "worst_loss_pct": -0.1663,
+          "profit_factor": 48.1006
+        }
+      ],
+      "breakout_attribution": {
+        "original_t2": {
+          "trades": 2601,
+          "win_rate_pct": 88.77,
+          "avg_pnl_pct": 0.5379,
+          "median_pnl_pct": 0.3984,
+          "pnl_std_pct": 0.636,
+          "worst_pnl_pct": -0.3123,
+          "net_pnl_value": 556182.22,
+          "max_pnl_drawdown": -316.46,
+          "profit_factor": 46.0147,
+          "entry_types": {
+            "SHORT": 1313,
+            "BUY": 1288
+          },
+          "entry_reasons": {
+            "SL-Reentry": 1700,
+            "Zero-Initial-Reentry": 901
+          },
+          "exit_reasons": {
+            "SL": 2600,
+            "FinalMarkToMarket": 1
+          }
+        },
+        "t3_swing": {
+          "trades": 658,
+          "win_rate_pct": 87.84,
+          "avg_pnl_pct": 0.5333,
+          "median_pnl_pct": 0.3685,
+          "pnl_std_pct": 0.6368,
+          "worst_pnl_pct": -0.1876,
+          "net_pnl_value": 138533.64,
+          "max_pnl_drawdown": -272.97,
+          "profit_factor": 49.0458,
+          "entry_types": {
+            "BUY": 363,
+            "SHORT": 295
+          },
+          "entry_reasons": {
+            "SL-Reentry": 431,
+            "Zero-Initial-Reentry": 227
+          },
+          "exit_reasons": {
+            "SL": 658
+          }
+        }
+      },
+      "diagnostics": {
+        "breakout_locks": {
+          "long": {
+            "original_t2": 444,
+            "t3_swing": 118
+          },
+          "short": {
+            "original_t2": 467,
+            "t3_swing": 109
+          }
+        },
+        "t3_cooldown_skips": {
+          "long": 0,
+          "short": 0
+        },
+        "t3_quality_rejects": {
+          "long": {
+            "sma_atr_separation": 9
+          },
+          "short": {
+            "sma_atr_separation": 5
+          }
+        }
+      },
+      "ledger_path": "research/tmp_eth_2026_q1_30min_1s_stop_loss_atr_sweep_0p1_ledger.csv",
+      "elapsed_seconds": 229.85,
+      "replay_kwargs": {
+        "dir2_zero_initial": true,
+        "zero_initial_mode": "reentry_window",
+        "fixed_slippage": 0.0005,
+        "stop_loss_atr": 0.1,
+        "stop_mode": "atr",
+        "max_trades_per_bar": 2,
+        "reentry_size_schedule": [
+          0.2,
+          0.1
+        ],
+        "long_reentry_atr": 0.1,
+        "short_reentry_atr": 0.0,
+        "profit_protect_atr": 1.0,
+        "trailing_stop_atr": 0.3,
+        "delayed_trailing_activation": 0.5,
+        "reentry_anchor_levels": "wick",
+        "reentry_trigger_mode": "reclaim"
+      },
+      "delta_vs_0p05": {
+        "final_balance_delta": -1608.25,
+        "return_pct_delta": -1.61,
+        "max_dd_pct_delta": -0.08,
+        "trades_delta": 33,
+        "win_rate_pct_delta": 0.35,
+        "sharpe_delta": -0.09
+      }
+    },
+    {
+      "stop_loss_atr": 0.2,
+      "summary": {
+        "final_balance": 537386.59,
+        "return_pct": 437.39,
+        "max_dd_pct": -2.01,
+        "trades": 3229,
+        "win_rate_pct": 82.41,
+        "sharpe": 13.4,
+        "first_entry": "2026-01-01T10:22:41+00:00",
+        "last_exit": "2026-03-31T23:59:59+00:00",
+        "entry_reasons": {
+          "SL-Reentry": 2119,
+          "Zero-Initial-Reentry": 1110
+        },
+        "exit_reasons": {
+          "SL": 3228,
+          "FinalMarkToMarket": 1
+        },
+        "entry_types": {
+          "BUY": 1646,
+          "SHORT": 1583
+        },
+        "integrity": {
+          "rows": 6458,
+          "entries": 3229,
+          "exits": 3229,
+          "zero_notional_entries": 0
+        }
+      },
+      "pair_diagnostics": {
+        "paired_trades": 3229,
+        "avg_loss_pct": -0.1701,
+        "worst_loss_pct": -0.5745,
+        "avg_win_pct": 0.6202,
+        "profit_factor": 33.4078,
+        "median_hold_seconds": 296.0,
+        "avg_hold_seconds": 505.62,
+        "exit_reasons": {
+          "SL": 3228,
+          "FinalMarkToMarket": 1
+        },
+        "entry_reasons": {
+          "SL-Reentry": 2119,
+          "Zero-Initial-Reentry": 1110
+        }
+      },
+      "monthly": [
+        {
+          "month": "2026-01",
+          "trades": 1106,
+          "win_rate_pct": 86.44,
+          "net_pnl_value": 71655.75,
+          "avg_pnl_pct": 0.3753,
+          "avg_loss_pct": -0.1307,
+          "worst_loss_pct": -0.5486,
+          "profit_factor": 21.6012
+        },
+        {
+          "month": "2026-02",
+          "trades": 999,
+          "win_rate_pct": 92.89,
+          "net_pnl_value": 251867.95,
+          "avg_pnl_pct": 0.7555,
+          "avg_loss_pct": -0.2427,
+          "worst_loss_pct": -0.5745,
+          "profit_factor": 41.4678
+        },
+        {
+          "month": "2026-03",
+          "trades": 1124,
+          "win_rate_pct": 91.55,
+          "net_pnl_value": 375755.47,
+          "avg_pnl_pct": 0.5188,
+          "avg_loss_pct": -0.1781,
+          "worst_loss_pct": -0.2826,
+          "profit_factor": 32.6417
+        }
+      ],
+      "breakout_attribution": {
+        "original_t2": {
+          "trades": 2583,
+          "win_rate_pct": 90.17,
+          "avg_pnl_pct": 0.5407,
+          "median_pnl_pct": 0.4081,
+          "pnl_std_pct": 0.6433,
+          "worst_pnl_pct": -0.5745,
+          "net_pnl_value": 557315.9,
+          "max_pnl_drawdown": -800.51,
+          "profit_factor": 31.883,
+          "entry_types": {
+            "SHORT": 1297,
+            "BUY": 1286
+          },
+          "entry_reasons": {
+            "SL-Reentry": 1693,
+            "Zero-Initial-Reentry": 890
+          },
+          "exit_reasons": {
+            "SL": 2582,
+            "FinalMarkToMarket": 1
+          }
+        },
+        "t3_swing": {
+          "trades": 646,
+          "win_rate_pct": 90.4,
+          "avg_pnl_pct": 0.5515,
+          "median_pnl_pct": 0.3864,
+          "pnl_std_pct": 0.6416,
+          "worst_pnl_pct": -0.3189,
+          "net_pnl_value": 141963.26,
+          "max_pnl_drawdown": -331.9,
+          "profit_factor": 41.1998,
+          "entry_types": {
+            "BUY": 360,
+            "SHORT": 286
+          },
+          "entry_reasons": {
+            "SL-Reentry": 426,
+            "Zero-Initial-Reentry": 220
+          },
+          "exit_reasons": {
+            "SL": 646
+          }
+        }
+      },
+      "diagnostics": {
+        "breakout_locks": {
+          "long": {
+            "original_t2": 441,
+            "t3_swing": 117
+          },
+          "short": {
+            "original_t2": 463,
+            "t3_swing": 105
+          }
+        },
+        "t3_cooldown_skips": {
+          "long": 0,
+          "short": 0
+        },
+        "t3_quality_rejects": {
+          "long": {
+            "sma_atr_separation": 8
+          },
+          "short": {
+            "sma_atr_separation": 5
+          }
+        }
+      },
+      "ledger_path": "research/tmp_eth_2026_q1_30min_1s_stop_loss_atr_sweep_0p2_ledger.csv",
+      "elapsed_seconds": 222.27,
+      "replay_kwargs": {
+        "dir2_zero_initial": true,
+        "zero_initial_mode": "reentry_window",
+        "fixed_slippage": 0.0005,
+        "stop_loss_atr": 0.2,
+        "stop_mode": "atr",
+        "max_trades_per_bar": 2,
+        "reentry_size_schedule": [
+          0.2,
+          0.1
+        ],
+        "long_reentry_atr": 0.1,
+        "short_reentry_atr": 0.0,
+        "profit_protect_atr": 1.0,
+        "trailing_stop_atr": 0.3,
+        "delayed_trailing_activation": 0.5,
+        "reentry_anchor_levels": "wick",
+        "reentry_trigger_mode": "reclaim"
+      },
+      "delta_vs_0p05": {
+        "final_balance_delta": 1277.44,
+        "return_pct_delta": 1.28,
+        "max_dd_pct_delta": 0.03,
+        "trades_delta": 3,
+        "win_rate_pct_delta": 1.81,
+        "sharpe_delta": -0.09
+      }
+    },
+    {
+      "stop_loss_atr": 0.3,
+      "summary": {
+        "final_balance": 551198.83,
+        "return_pct": 451.2,
+        "max_dd_pct": -1.86,
+        "trades": 3190,
+        "win_rate_pct": 84.23,
+        "sharpe": 13.61,
+        "first_entry": "2026-01-01T10:22:41+00:00",
+        "last_exit": "2026-03-31T23:59:59+00:00",
+        "entry_reasons": {
+          "SL-Reentry": 2095,
+          "Zero-Initial-Reentry": 1095
+        },
+        "exit_reasons": {
+          "SL": 3189,
+          "FinalMarkToMarket": 1
+        },
+        "entry_types": {
+          "SHORT": 1595,
+          "BUY": 1595
+        },
+        "integrity": {
+          "rows": 6380,
+          "entries": 3190,
+          "exits": 3190,
+          "zero_notional_entries": 0
+        }
+      },
+      "pair_diagnostics": {
+        "paired_trades": 3190,
+        "avg_loss_pct": -0.2248,
+        "worst_loss_pct": -0.8368,
+        "avg_win_pct": 0.6176,
+        "profit_factor": 31.3064,
+        "median_hold_seconds": 307.0,
+        "avg_hold_seconds": 540.15,
+        "exit_reasons": {
+          "SL": 3189,
+          "FinalMarkToMarket": 1
+        },
+        "entry_reasons": {
+          "SL-Reentry": 2095,
+          "Zero-Initial-Reentry": 1095
+        }
+      },
+      "monthly": [
+        {
+          "month": "2026-01",
+          "trades": 1086,
+          "win_rate_pct": 89.13,
+          "net_pnl_value": 72881.28,
+          "avg_pnl_pct": 0.3857,
+          "avg_loss_pct": -0.1661,
+          "worst_loss_pct": -0.7979,
+          "profit_factor": 21.1181
+        },
+        {
+          "month": "2026-02",
+          "trades": 987,
+          "win_rate_pct": 94.53,
+          "net_pnl_value": 257029.99,
+          "avg_pnl_pct": 0.7675,
+          "avg_loss_pct": -0.3275,
+          "worst_loss_pct": -0.8368,
+          "profit_factor": 39.3682
+        },
+        {
+          "month": "2026-03",
+          "trades": 1117,
+          "win_rate_pct": 93.29,
+          "net_pnl_value": 386068.47,
+          "avg_pnl_pct": 0.5244,
+          "avg_loss_pct": -0.2432,
+          "worst_loss_pct": -0.399,
+          "profit_factor": 30.0212
+        }
+      ],
+      "breakout_attribution": {
+        "original_t2": {
+          "trades": 2553,
+          "win_rate_pct": 92.28,
+          "avg_pnl_pct": 0.5511,
+          "median_pnl_pct": 0.4193,
+          "pnl_std_pct": 0.6444,
+          "worst_pnl_pct": -0.8368,
+          "net_pnl_value": 573461.08,
+          "max_pnl_drawdown": -946.29,
+          "profit_factor": 30.817,
+          "entry_types": {
+            "SHORT": 1311,
+            "BUY": 1242
+          },
+          "entry_reasons": {
+            "SL-Reentry": 1677,
+            "Zero-Initial-Reentry": 876
+          },
+          "exit_reasons": {
+            "SL": 2552,
+            "FinalMarkToMarket": 1
+          }
+        },
+        "t3_swing": {
+          "trades": 637,
+          "win_rate_pct": 92.15,
+          "avg_pnl_pct": 0.5576,
+          "median_pnl_pct": 0.3915,
+          "pnl_std_pct": 0.6437,
+          "worst_pnl_pct": -0.4533,
+          "net_pnl_value": 142518.66,
+          "max_pnl_drawdown": -472.95,
+          "profit_factor": 33.4495,
+          "entry_types": {
+            "BUY": 353,
+            "SHORT": 284
+          },
+          "entry_reasons": {
+            "SL-Reentry": 418,
+            "Zero-Initial-Reentry": 219
+          },
+          "exit_reasons": {
+            "SL": 637
+          }
+        }
+      },
+      "diagnostics": {
+        "breakout_locks": {
+          "long": {
+            "original_t2": 432,
+            "t3_swing": 115
+          },
+          "short": {
+            "original_t2": 461,
+            "t3_swing": 106
+          }
+        },
+        "t3_cooldown_skips": {
+          "long": 0,
+          "short": 0
+        },
+        "t3_quality_rejects": {
+          "long": {
+            "sma_atr_separation": 7
+          },
+          "short": {
+            "sma_atr_separation": 5
+          }
+        }
+      },
+      "ledger_path": "research/tmp_eth_2026_q1_30min_1s_stop_loss_atr_sweep_0p3_ledger.csv",
+      "elapsed_seconds": 222.37,
+      "replay_kwargs": {
+        "dir2_zero_initial": true,
+        "zero_initial_mode": "reentry_window",
+        "fixed_slippage": 0.0005,
+        "stop_loss_atr": 0.3,
+        "stop_mode": "atr",
+        "max_trades_per_bar": 2,
+        "reentry_size_schedule": [
+          0.2,
+          0.1
+        ],
+        "long_reentry_atr": 0.1,
+        "short_reentry_atr": 0.0,
+        "profit_protect_atr": 1.0,
+        "trailing_stop_atr": 0.3,
+        "delayed_trailing_activation": 0.5,
+        "reentry_anchor_levels": "wick",
+        "reentry_trigger_mode": "reclaim"
+      },
+      "delta_vs_0p05": {
+        "final_balance_delta": 15089.68,
+        "return_pct_delta": 15.09,
+        "max_dd_pct_delta": 0.18,
+        "trades_delta": -36,
+        "win_rate_pct_delta": 3.63,
+        "sharpe_delta": 0.12
+      }
+    },
+    {
+      "stop_loss_atr": 0.4,
+      "summary": {
+        "final_balance": 541234.86,
+        "return_pct": 441.23,
+        "max_dd_pct": -1.63,
+        "trades": 3136,
+        "win_rate_pct": 85.36,
+        "sharpe": 13.72,
+        "first_entry": "2026-01-01T10:22:41+00:00",
+        "last_exit": "2026-03-31T23:59:59+00:00",
+        "entry_reasons": {
+          "SL-Reentry": 2062,
+          "Zero-Initial-Reentry": 1074
+        },
+        "exit_reasons": {
+          "SL": 3135,
+          "FinalMarkToMarket": 1
+        },
+        "entry_types": {
+          "BUY": 1593,
+          "SHORT": 1543
+        },
+        "integrity": {
+          "rows": 6272,
+          "entries": 3136,
+          "exits": 3136,
+          "zero_notional_entries": 0
+        }
+      },
+      "pair_diagnostics": {
+        "paired_trades": 3136,
+        "avg_loss_pct": -0.2729,
+        "worst_loss_pct": -1.099,
+        "avg_win_pct": 0.6151,
+        "profit_factor": 29.286,
+        "median_hold_seconds": 308.0,
+        "avg_hold_seconds": 574.2,
+        "exit_reasons": {
+          "SL": 3135,
+          "FinalMarkToMarket": 1
+        },
+        "entry_reasons": {
+          "SL-Reentry": 2062,
+          "Zero-Initial-Reentry": 1074
+        }
+      },
+      "monthly": [
+        {
+          "month": "2026-01",
+          "trades": 1064,
+          "win_rate_pct": 90.32,
+          "net_pnl_value": 70729.24,
+          "avg_pnl_pct": 0.3851,
+          "avg_loss_pct": -0.1961,
+          "worst_loss_pct": -1.0472,
+          "profit_factor": 19.1012
+        },
+        {
+          "month": "2026-02",
+          "trades": 967,
+          "win_rate_pct": 95.97,
+          "net_pnl_value": 250960.66,
+          "avg_pnl_pct": 0.7785,
+          "avg_loss_pct": -0.4281,
+          "worst_loss_pct": -1.099,
+          "profit_factor": 40.6077
+        },
+        {
+          "month": "2026-03",
+          "trades": 1105,
+          "win_rate_pct": 94.12,
+          "net_pnl_value": 376641.46,
+          "avg_pnl_pct": 0.5273,
+          "avg_loss_pct": -0.3016,
+          "worst_loss_pct": -0.5153,
+          "profit_factor": 27.0748
+        }
+      ],
+      "breakout_attribution": {
+        "original_t2": {
+          "trades": 2493,
+          "win_rate_pct": 93.42,
+          "avg_pnl_pct": 0.5568,
+          "median_pnl_pct": 0.4248,
+          "pnl_std_pct": 0.6446,
+          "worst_pnl_pct": -1.099,
+          "net_pnl_value": 556847.93,
+          "max_pnl_drawdown": -905.27,
+          "profit_factor": 27.9093,
+          "entry_types": {
+            "SHORT": 1262,
+            "BUY": 1231
+          },
+          "entry_reasons": {
+            "SL-Reentry": 1637,
+            "Zero-Initial-Reentry": 856
+          },
+          "exit_reasons": {
+            "SL": 2492,
+            "FinalMarkToMarket": 1
+          }
+        },
+        "t3_swing": {
+          "trades": 643,
+          "win_rate_pct": 93.31,
+          "avg_pnl_pct": 0.5555,
+          "median_pnl_pct": 0.3854,
+          "pnl_std_pct": 0.642,
+          "worst_pnl_pct": -0.5877,
+          "net_pnl_value": 141483.43,
+          "max_pnl_drawdown": -436.52,
+          "profit_factor": 36.4179,
+          "entry_types": {
+            "BUY": 362,
+            "SHORT": 281
+          },
+          "entry_reasons": {
+            "SL-Reentry": 425,
+            "Zero-Initial-Reentry": 218
+          },
+          "exit_reasons": {
+            "SL": 643
+          }
+        }
+      },
+      "diagnostics": {
+        "breakout_locks": {
+          "long": {
+            "original_t2": 421,
+            "t3_swing": 115
+          },
+          "short": {
+            "original_t2": 453,
+            "t3_swing": 106
+          }
+        },
+        "t3_cooldown_skips": {
+          "long": 0,
+          "short": 0
+        },
+        "t3_quality_rejects": {
+          "long": {
+            "sma_atr_separation": 7
+          },
+          "short": {
+            "sma_atr_separation": 5
+          }
+        }
+      },
+      "ledger_path": "research/tmp_eth_2026_q1_30min_1s_stop_loss_atr_sweep_0p4_ledger.csv",
+      "elapsed_seconds": 220.54,
+      "replay_kwargs": {
+        "dir2_zero_initial": true,
+        "zero_initial_mode": "reentry_window",
+        "fixed_slippage": 0.0005,
+        "stop_loss_atr": 0.4,
+        "stop_mode": "atr",
+        "max_trades_per_bar": 2,
+        "reentry_size_schedule": [
+          0.2,
+          0.1
+        ],
+        "long_reentry_atr": 0.1,
+        "short_reentry_atr": 0.0,
+        "profit_protect_atr": 1.0,
+        "trailing_stop_atr": 0.3,
+        "delayed_trailing_activation": 0.5,
+        "reentry_anchor_levels": "wick",
+        "reentry_trigger_mode": "reclaim"
+      },
+      "delta_vs_0p05": {
+        "final_balance_delta": 5125.71,
+        "return_pct_delta": 5.12,
+        "max_dd_pct_delta": 0.41,
+        "trades_delta": -90,
+        "win_rate_pct_delta": 4.76,
+        "sharpe_delta": 0.23
+      }
+    }
+  ],
+  "note": "Research-only exact-semantics sweep for the ETH Q1 breakout-filter replay path."
+}

--- a/research/eth_q1_30min_low_vol_entry_filters.py
+++ b/research/eth_q1_30min_low_vol_entry_filters.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""ETH Q1 2026 30min low-volatility entry gate research replay.
+
+Research-only script. It evaluates bps/ATR-percentile entry gates on the ETH
+Q1 30min replay path. The gate is applied at reentry price resolution, so it
+can block Zero-Initial-Reentry and SL-Reentry entries without filtering
+stop-loss exits.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from pathlib import Path
+
+import numpy as np
+
+import btc_q1_30min_low_vol_entry_filters as low_vol
+import eth_q1_breakout_t3_shape_compare as replay
+
+
+BASE_REPLAY_KWARGS = dict(replay.COMMON_REPLAY_KWARGS)
+
+VARIANTS = [
+    {
+        "name": "baseline",
+        "description": "No low-volatility entry gate.",
+    },
+    {
+        "name": "min_stop_bps_2",
+        "description": "Require stop_loss_atr * ATR to be at least 2 bps of entry reference price.",
+        "min_stop_bps": 2.0,
+    },
+    {
+        "name": "min_stop_bps_4",
+        "description": "Require stop_loss_atr * ATR to be at least 4 bps of entry reference price.",
+        "min_stop_bps": 4.0,
+    },
+    {
+        "name": "min_stop_bps_6",
+        "description": "Require stop_loss_atr * ATR to be at least 6 bps of entry reference price.",
+        "min_stop_bps": 6.0,
+    },
+    {
+        "name": "min_stop_bps_8",
+        "description": "Require stop_loss_atr * ATR to be at least 8 bps of entry reference price.",
+        "min_stop_bps": 8.0,
+    },
+    {
+        "name": "atr_pct_gte_25",
+        "description": "Require signal ATR percentile over the rolling 240 signal bars to be at least 25.",
+        "atr_percentile_gte": 25.0,
+    },
+    {
+        "name": "min_stop_bps_4_atr_pct_gte_25",
+        "description": "Require both min stop distance of 4 bps and ATR percentile at least 25.",
+        "min_stop_bps": 4.0,
+        "atr_percentile_gte": 25.0,
+    },
+]
+
+
+def _stop_bps_stats(signal, stop_loss_atr: float) -> dict:
+    stop_bps = stop_loss_atr * signal["atr"].astype("float64") / signal["close"].astype("float64") * 10000.0
+    stop_bps = stop_bps.replace([np.inf, -np.inf], np.nan).dropna()
+    if stop_bps.empty:
+        return {}
+    return {
+        "count": int(len(stop_bps)),
+        "min": round(float(stop_bps.min()), 4),
+        "p05": round(float(stop_bps.quantile(0.05)), 4),
+        "p10": round(float(stop_bps.quantile(0.10)), 4),
+        "p25": round(float(stop_bps.quantile(0.25)), 4),
+        "p50": round(float(stop_bps.quantile(0.50)), 4),
+        "p75": round(float(stop_bps.quantile(0.75)), 4),
+        "p90": round(float(stop_bps.quantile(0.90)), 4),
+        "p95": round(float(stop_bps.quantile(0.95)), 4),
+        "max": round(float(stop_bps.max()), 4),
+    }
+
+
+def _write_markdown(output: dict, path: Path) -> None:
+    lines = [
+        "# ETHUSDT Q1 2026 30min Low-Volatility Entry Gates",
+        "",
+        "Scope: research-only Python replay. No live or execution path is changed by this report.",
+        "",
+        "## Setup",
+        "",
+        f"- Symbol/window: `{output['symbol']}`, `{output['start']}` to `{output['end']}`",
+        "- Execution bars: continuous `1s` bars rebuilt from Binance trade archives",
+        "- Signal timeframe: `30min`",
+        "- Replay mode: `live_intrabar_sma5`, breakout shape `baseline_plus_t3`, t3 SMA/ATR separation `0.25`",
+        "- Sizing: `dir2_zero_initial=true`, `zero_initial_mode=reentry_window`, `reentry_size_schedule=[0.20, 0.10]`, `max_trades_per_bar=2`",
+        f"- Risk profile: `stop_loss_atr={output['replay_kwargs']['stop_loss_atr']}`, `trailing_stop_atr={output['replay_kwargs']['trailing_stop_atr']}`, `delayed_trailing_activation={output['replay_kwargs']['delayed_trailing_activation']}`",
+        "- Gate point: reentry price resolution, so the gate blocks both Zero-Initial-Reentry and SL-Reentry entries. Stop-loss exits are not filtered.",
+        "",
+        "## Stop Distance Distribution",
+        "",
+        "| Count | Min | P05 | P10 | P25 | P50 | P75 | P90 | P95 | Max |",
+        "|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|",
+    ]
+    bps = output["signal_stop_bps_stats"]
+    lines.append(
+        f"| {bps.get('count', 0)} | {bps.get('min', 0):.4f} | {bps.get('p05', 0):.4f} | "
+        f"{bps.get('p10', 0):.4f} | {bps.get('p25', 0):.4f} | {bps.get('p50', 0):.4f} | "
+        f"{bps.get('p75', 0):.4f} | {bps.get('p90', 0):.4f} | {bps.get('p95', 0):.4f} | "
+        f"{bps.get('max', 0):.4f} |"
+    )
+
+    lines.extend(
+        [
+            "",
+            "## Results",
+            "",
+            "| Variant | Final Balance | Return | Max DD | Trades | Win Rate | Sharpe | Avg Loss | Worst Loss | Entry Mix | Gate Reject Calls |",
+            "|---|---:|---:|---:|---:|---:|---:|---:|---:|---|---:|",
+        ]
+    )
+    for result in output["results"]:
+        s = result["summary"]
+        d = result["pair_diagnostics"]
+        gate = result["diagnostics"]["entry_gate"]
+        entry_mix = ", ".join(f"{k}:{v}" for k, v in s["entry_reasons"].items())
+        lines.append(
+            f"| `{result['variant']}` | {s['final_balance']:,.2f} | {s['return_pct']:.2f}% | "
+            f"{s['max_dd_pct']:.2f}% | {s['trades']} | {s['win_rate_pct']:.2f}% | {s['sharpe']:.2f} | "
+            f"{d['avg_loss_pct']:.4f}% | {d['worst_loss_pct']:.4f}% | `{entry_mix}` | "
+            f"{gate['rejected_calls']} |"
+        )
+
+    lines.extend(["", "## Delta vs Baseline", ""])
+    lines.append("| Variant | Final Delta | Return Delta | Max DD Delta | Trades Delta | Win Delta | Sharpe Delta |")
+    lines.append("|---|---:|---:|---:|---:|---:|---:|")
+    for result in output["results"][1:]:
+        delta = result["delta_vs_baseline"]
+        lines.append(
+            f"| `{result['variant']}` | {delta['final_balance_delta']:,.2f} | "
+            f"{delta['return_pct_delta']:.2f} pp | {delta['max_dd_pct_delta']:.2f} pp | "
+            f"{delta['trades_delta']} | {delta['win_rate_pct_delta']:.2f} pp | {delta['sharpe_delta']:.2f} |"
+        )
+
+    lines.extend(["", "## Variants", ""])
+    for variant in output["selected_variants"]:
+        lines.append(f"- `{variant['name']}`: {variant['description']}")
+    lines.append("")
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="ETH Q1 2026 30min low-volatility entry gate replay")
+    parser.add_argument("--tick-files", nargs="+", default=replay.DEFAULT_TICK_FILES)
+    parser.add_argument("--start", default="2026-01-01T00:00:00Z")
+    parser.add_argument("--end", default="2026-03-31T23:59:59Z")
+    parser.add_argument("--initial-balance", type=float, default=100000.0)
+    parser.add_argument("--chunksize", type=int, default=2_000_000)
+    parser.add_argument("--stop-loss-atr", type=float, default=BASE_REPLAY_KWARGS["stop_loss_atr"])
+    parser.add_argument("--variants", nargs="+", default=[item["name"] for item in VARIANTS])
+    parser.add_argument("--summary-json", default="research/eth_2026_q1_30min_low_vol_entry_filters_summary.json")
+    parser.add_argument("--markdown", default="research/20260429_eth_q1_30min_low_vol_entry_filters.md")
+    parser.add_argument("--ledger-prefix", default="research/tmp_eth_2026_q1_30min_1s_low_vol_entry_filter")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    replay_kwargs = dict(BASE_REPLAY_KWARGS)
+    replay_kwargs["stop_loss_atr"] = float(args.stop_loss_atr)
+    replay.COMMON_REPLAY_KWARGS.clear()
+    replay.COMMON_REPLAY_KWARGS.update(replay_kwargs)
+
+    start = replay._as_utc_timestamp(args.start)
+    end = replay._as_utc_timestamp(args.end)
+    second_bars, build_stats = replay.build_continuous_second_bars(args.tick_files, start, end, args.chunksize)
+    _, signal = replay.build_signal_frame(second_bars, "30min")
+
+    selected_names = set(args.variants)
+    selected_variants = [item for item in VARIANTS if item["name"] in selected_names]
+    if not selected_variants:
+        raise ValueError(f"no variants selected from {args.variants}")
+
+    results = []
+    for variant in selected_variants:
+        result = low_vol.run_variant(second_bars, signal, variant, args.initial_balance)
+        ledger_path = Path(f"{args.ledger_prefix}_{variant['name']}_ledger.csv")
+        result["ledger"].to_csv(ledger_path, index=False)
+        del result["ledger"]
+        result["ledger_path"] = str(ledger_path)
+        results.append(result)
+        s = result["summary"]
+        gate = result["diagnostics"]["entry_gate"]
+        print(
+            f"{variant['name']}: return={s['return_pct']:.2f}% trades={s['trades']} "
+            f"win={s['win_rate_pct']:.2f}% max_dd={s['max_dd_pct']:.2f}% "
+            f"gate_reject_calls={gate['rejected_calls']} elapsed={result['elapsed_seconds']}s",
+            flush=True,
+        )
+
+    base_summary = results[0]["summary"]
+    for result in results[1:]:
+        result["delta_vs_baseline"] = low_vol._delta(base_summary, result["summary"])
+
+    output = {
+        "symbol": "ETHUSDT",
+        "start": start.isoformat(),
+        "end": end.isoformat(),
+        "build_stats": build_stats,
+        "signal_stats": {
+            "signal_rows": int(len(signal)),
+            "signal_start": signal.index[0].isoformat() if not signal.empty else "",
+            "signal_end": signal.index[-1].isoformat() if not signal.empty else "",
+            "valid_sma5_rows": int(signal["sma5"].notna().sum()),
+            "valid_atr_rows": int(signal["atr"].notna().sum()),
+            "valid_atr_percentile_rows": int(signal["atr_percentile"].notna().sum()),
+        },
+        "signal_stop_bps_stats": _stop_bps_stats(signal, replay_kwargs["stop_loss_atr"]),
+        "replay_kwargs": replay_kwargs,
+        "selected_variants": selected_variants,
+        "results": results,
+        "elapsed_at": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+        "note": "Research-only comparison. Entry gates patch reentry price resolution and do not alter stop-loss exit behavior.",
+    }
+    Path(args.summary_json).write_text(json.dumps(output, indent=2, ensure_ascii=False), encoding="utf-8")
+    _write_markdown(output, Path(args.markdown))
+
+
+if __name__ == "__main__":
+    main()

--- a/research/eth_q1_30min_stop_loss_atr_sweep.py
+++ b/research/eth_q1_30min_stop_loss_atr_sweep.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""ETH Q1 2026 30min stop-loss ATR sweep on the current 1s replay path.
+
+Research-only script. It keeps the same replay setup used by
+btc_2026_q1_breakout_confirmation_filters.py for the ETH Q1 breakout-filter
+run, and changes only stop_loss_atr.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from pathlib import Path
+
+import pandas as pd
+
+import eth_q1_breakout_t3_shape_compare as replay
+
+
+BASE_REPLAY_KWARGS = dict(replay.COMMON_REPLAY_KWARGS)
+
+
+def _delta(base: dict, current: dict) -> dict:
+    return {
+        "final_balance_delta": round(current["final_balance"] - base["final_balance"], 2),
+        "return_pct_delta": round(current["return_pct"] - base["return_pct"], 2),
+        "max_dd_pct_delta": round(current["max_dd_pct"] - base["max_dd_pct"], 2),
+        "trades_delta": int(current["trades"] - base["trades"]),
+        "win_rate_pct_delta": round(current["win_rate_pct"] - base["win_rate_pct"], 2),
+        "sharpe_delta": round(current["sharpe"] - base["sharpe"], 2),
+    }
+
+
+def _paired_trades(ledger: pd.DataFrame) -> pd.DataFrame:
+    rows = []
+    open_entry = None
+    for _, row in ledger.iterrows():
+        if row["type"] in {"BUY", "SHORT"}:
+            open_entry = row
+            continue
+        if row["type"] != "EXIT" or open_entry is None:
+            continue
+
+        entry_time = pd.Timestamp(open_entry["time"])
+        exit_time = pd.Timestamp(row["time"])
+        side_mult = 1.0 if open_entry["type"] == "BUY" else -1.0
+        entry_price = float(open_entry["price"])
+        exit_price = float(row["price"])
+        notional = float(open_entry["notional"])
+        pnl_pct = side_mult * (exit_price - entry_price) / entry_price if entry_price > 0 else 0.0
+        rows.append(
+            {
+                "entry_time": entry_time,
+                "exit_time": exit_time,
+                "entry_type": str(open_entry["type"]),
+                "entry_reason": str(open_entry["reason"]),
+                "exit_reason": str(row["reason"]),
+                "breakout_shape_name": str(open_entry.get("breakout_shape_name", "")),
+                "entry_price": entry_price,
+                "exit_price": exit_price,
+                "notional": notional,
+                "pnl_pct": pnl_pct,
+                "pnl_value": pnl_pct * notional,
+                "hold_seconds": float((exit_time - entry_time).total_seconds()),
+            }
+        )
+        open_entry = None
+    return pd.DataFrame(rows)
+
+
+def _pair_diagnostics(pairs: pd.DataFrame) -> dict:
+    if pairs.empty:
+        return {
+            "paired_trades": 0,
+            "avg_loss_pct": 0.0,
+            "worst_loss_pct": 0.0,
+            "avg_win_pct": 0.0,
+            "profit_factor": None,
+            "median_hold_seconds": 0.0,
+            "avg_hold_seconds": 0.0,
+            "exit_reasons": {},
+            "entry_reasons": {},
+        }
+
+    pnl_pct = pairs["pnl_pct"].astype("float64")
+    pnl_value = pairs["pnl_value"].astype("float64")
+    losses = pnl_pct[pnl_pct < 0]
+    wins = pnl_pct[pnl_pct > 0]
+    gross_profit = float(pnl_value[pnl_value > 0].sum())
+    gross_loss = abs(float(pnl_value[pnl_value < 0].sum()))
+    return {
+        "paired_trades": int(len(pairs)),
+        "avg_loss_pct": round(float(losses.mean()) * 100, 4) if not losses.empty else 0.0,
+        "worst_loss_pct": round(float(losses.min()) * 100, 4) if not losses.empty else 0.0,
+        "avg_win_pct": round(float(wins.mean()) * 100, 4) if not wins.empty else 0.0,
+        "profit_factor": round(gross_profit / gross_loss, 4) if gross_loss > 0 else None,
+        "median_hold_seconds": round(float(pairs["hold_seconds"].median()), 2),
+        "avg_hold_seconds": round(float(pairs["hold_seconds"].mean()), 2),
+        "exit_reasons": {str(k): int(v) for k, v in pairs["exit_reason"].value_counts().items()},
+        "entry_reasons": {str(k): int(v) for k, v in pairs["entry_reason"].value_counts().items()},
+    }
+
+
+def _monthly_summary(pairs: pd.DataFrame) -> list[dict]:
+    if pairs.empty:
+        return []
+    rows = []
+    work = pairs.copy()
+    work["month"] = work["exit_time"].dt.strftime("%Y-%m")
+    for month, group in work.groupby("month", sort=True):
+        pnl_value = group["pnl_value"].astype("float64")
+        pnl_pct = group["pnl_pct"].astype("float64")
+        losses = pnl_pct[pnl_pct < 0]
+        gross_profit = float(pnl_value[pnl_value > 0].sum())
+        gross_loss = abs(float(pnl_value[pnl_value < 0].sum()))
+        rows.append(
+            {
+                "month": str(month),
+                "trades": int(len(group)),
+                "win_rate_pct": round(float((pnl_value > 0).mean()) * 100, 2),
+                "net_pnl_value": round(float(pnl_value.sum()), 2),
+                "avg_pnl_pct": round(float(pnl_pct.mean()) * 100, 4),
+                "avg_loss_pct": round(float(losses.mean()) * 100, 4) if not losses.empty else 0.0,
+                "worst_loss_pct": round(float(losses.min()) * 100, 4) if not losses.empty else 0.0,
+                "profit_factor": round(gross_profit / gross_loss, 4) if gross_loss > 0 else None,
+            }
+        )
+    return rows
+
+
+def _write_markdown(output: dict, path: Path) -> None:
+    lines = [
+        "# ETHUSDT Q1 2026 30min Stop-Loss ATR Sweep",
+        "",
+        "Scope: research-only Python replay. No live or execution path is changed by this report.",
+        "",
+        "## Setup",
+        "",
+        f"- Symbol/window: `{output['symbol']}`, `{output['start']}` to `{output['end']}`",
+        "- Execution bars: continuous `1s` bars rebuilt from Binance trade archives",
+        "- Signal timeframe: `30min`",
+        "- Replay mode: `live_intrabar_sma5`, breakout shape `baseline_plus_t3`, t3 SMA/ATR separation `0.25`",
+        "- Sizing: `dir2_zero_initial=true`, `zero_initial_mode=reentry_window`, `reentry_size_schedule=[0.20, 0.10]`, `max_trades_per_bar=2`",
+        "- Sweep changes only `stop_loss_atr`; `trailing_stop_atr=0.3` and `delayed_trailing_activation=0.5` stay fixed.",
+        "",
+        "## Results",
+        "",
+        "| stop_loss_atr | Final Balance | Return | Max DD | Trades | Win Rate | Sharpe | Avg Loss | Worst Loss | Profit Factor | Median Hold |",
+        "|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|",
+    ]
+    for result in output["results"]:
+        s = result["summary"]
+        d = result["pair_diagnostics"]
+        lines.append(
+            f"| {result['stop_loss_atr']:.2f} | {s['final_balance']:,.2f} | {s['return_pct']:.2f}% | "
+            f"{s['max_dd_pct']:.2f}% | {s['trades']} | {s['win_rate_pct']:.2f}% | {s['sharpe']:.2f} | "
+            f"{d['avg_loss_pct']:.4f}% | {d['worst_loss_pct']:.4f}% | {d['profit_factor']} | "
+            f"{d['median_hold_seconds']:.0f}s |"
+        )
+
+    lines.extend(["", "## Delta vs 0.05 ATR", ""])
+    lines.append("| stop_loss_atr | Final Delta | Return Delta | Max DD Delta | Trades Delta | Win Delta | Sharpe Delta |")
+    lines.append("|---:|---:|---:|---:|---:|---:|---:|")
+    for result in output["results"][1:]:
+        d = result["delta_vs_0p05"]
+        lines.append(
+            f"| {result['stop_loss_atr']:.2f} | {d['final_balance_delta']:,.2f} | "
+            f"{d['return_pct_delta']:.2f} pp | {d['max_dd_pct_delta']:.2f} pp | "
+            f"{d['trades_delta']} | {d['win_rate_pct_delta']:.2f} pp | {d['sharpe_delta']:.2f} |"
+        )
+    lines.append("")
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="ETH Q1 2026 30min stop-loss ATR sweep")
+    parser.add_argument("--tick-files", nargs="+", default=replay.DEFAULT_TICK_FILES)
+    parser.add_argument("--start", default="2026-01-01T00:00:00Z")
+    parser.add_argument("--end", default="2026-03-31T23:59:59Z")
+    parser.add_argument("--initial-balance", type=float, default=100000.0)
+    parser.add_argument("--chunksize", type=int, default=2_000_000)
+    parser.add_argument("--stop-loss-atrs", nargs="+", type=float, default=[0.05, 0.10, 0.20, 0.30, 0.40])
+    parser.add_argument("--summary-json", default="research/eth_2026_q1_30min_stop_loss_atr_sweep_summary.json")
+    parser.add_argument("--markdown", default="research/20260429_eth_q1_30min_stop_loss_atr_sweep.md")
+    parser.add_argument("--ledger-prefix", default="research/tmp_eth_2026_q1_30min_1s_stop_loss_atr_sweep")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    start = replay._as_utc_timestamp(args.start)
+    end = replay._as_utc_timestamp(args.end)
+    second_bars, build_stats = replay.build_continuous_second_bars(args.tick_files, start, end, args.chunksize)
+    _, signal = replay.build_signal_frame(second_bars, "30min")
+
+    results = []
+    for stop_loss_atr in args.stop_loss_atrs:
+        replay_kwargs = dict(BASE_REPLAY_KWARGS)
+        replay_kwargs["stop_loss_atr"] = float(stop_loss_atr)
+        replay.COMMON_REPLAY_KWARGS.clear()
+        replay.COMMON_REPLAY_KWARGS.update(replay_kwargs)
+
+        started = time.time()
+        ledger, diagnostics = replay.run_second_bar_replay(
+            second_bars,
+            signal,
+            initial_balance=args.initial_balance,
+            breakout_shape="baseline_plus_t3",
+            replay_mode="live_intrabar_sma5",
+            t3_reentry_size_schedule=[0.20, 0.10],
+            t3_cooldown_bars=0,
+            t3_quality_filters={"min_sma_atr_separation": 0.25},
+            quality_filter_shapes=["t3_swing"],
+        )
+        elapsed = round(time.time() - started, 2)
+        label = str(stop_loss_atr).replace(".", "p")
+        ledger_path = Path(f"{args.ledger_prefix}_{label}_ledger.csv")
+        ledger.to_csv(ledger_path, index=False)
+        pairs = _paired_trades(ledger)
+        result = {
+            "stop_loss_atr": float(stop_loss_atr),
+            "summary": replay.summarize_run(ledger, args.initial_balance),
+            "pair_diagnostics": _pair_diagnostics(pairs),
+            "monthly": _monthly_summary(pairs),
+            "breakout_attribution": replay.summarize_breakout_attribution(ledger),
+            "diagnostics": diagnostics,
+            "ledger_path": str(ledger_path),
+            "elapsed_seconds": elapsed,
+            "replay_kwargs": replay_kwargs,
+        }
+        results.append(result)
+        s = result["summary"]
+        d = result["pair_diagnostics"]
+        print(
+            f"stop_loss_atr={stop_loss_atr:.2f}: return={s['return_pct']:.2f}% "
+            f"trades={s['trades']} win={s['win_rate_pct']:.2f}% "
+            f"max_dd={s['max_dd_pct']:.2f}% worst_loss={d['worst_loss_pct']:.4f}% "
+            f"elapsed={elapsed}s",
+            flush=True,
+        )
+
+    base_summary = results[0]["summary"]
+    for result in results[1:]:
+        result["delta_vs_0p05"] = _delta(base_summary, result["summary"])
+
+    output = {
+        "symbol": "ETHUSDT",
+        "start": start.isoformat(),
+        "end": end.isoformat(),
+        "build_stats": build_stats,
+        "signal_stats": {
+            "signal_rows": int(len(signal)),
+            "signal_start": signal.index[0].isoformat() if not signal.empty else "",
+            "signal_end": signal.index[-1].isoformat() if not signal.empty else "",
+            "valid_sma5_rows": int(signal["sma5"].notna().sum()),
+            "valid_atr_rows": int(signal["atr"].notna().sum()),
+        },
+        "results": results,
+        "note": "Research-only exact-semantics sweep for the ETH Q1 breakout-filter replay path.",
+    }
+    Path(args.summary_json).write_text(json.dumps(output, indent=2, ensure_ascii=False), encoding="utf-8")
+    _write_markdown(output, Path(args.markdown))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 目的
实现 BTCUSDT 30m Enhanced 模板的低波动 reentry gate：`reentry_min_stop_bps=6.0` + `reentry_atr_percentile_gte=25.0`，用于过滤薄止损距离/低 ATR regime 下的 Zero-Initial/SL/PT reentry 开仓，同时保留 SL 出场为硬风险边界。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [x] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) — 无变化，模板仍默认 `manual-review`
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？— 无
- [x] DB migration 是否具备向下兼容幂等性？— 是，针对既有 enhanced strategy/version/live session 做 jsonb_set
- [x] 配置字段有没有无意被混改？— 新增字段限定为 `reentry_min_stop_bps` / `reentry_atr_percentile_gte`

## 改动摘要
- 新增 live reentry entry quality gate，仅作用于 `Zero-Initial-Reentry` / `SL-Reentry` / `PT-Reentry` 开仓，不过滤止损出场。
- signal-bar state 增加 `atrPercentile`，使用 research-compatible ATR14 rolling percentile 口径；runtime signal history 提升到 260 bars。
- BTC 30m Enhanced memory seed、PG migration、launch template 均固化 `reentry_min_stop_bps=6.0` 和 `reentry_atr_percentile_gte=25.0`。
- 新增 `docs/30m-enhanced-filter-research.md`，记录 BTC enhanced 现有过滤器、本次新增过滤器、BTC/ETH Q1 2026 回测结果和 ETH 30m 建议参数。
- 纳入相关 research 脚本、markdown 报告和 summary JSON，保证文档证据可复查。

## 验证方式与测试证据
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

本地验证：
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
- `git diff --check`

Push 前 pre-push harness：
- graphify rebuild completed
- high risk defaults check passed
- env safety check passed
- migration safety check passed
- changed-scope backend checks passed
