### PR TITLE
[codex] Show supervisor policy on dashboard

### DIFF
--- a/docs/runtime-supervisor.md
+++ b/docs/runtime-supervisor.md
@@ -367,7 +367,7 @@ func ClearRestartState(state map[string]any, keys []string)
 
 ### Dashboard 视图
 
-前端 console 的 Runtime Supervisor 页面读取 `GET /api/v1/supervisor/status`，只展示 service target、runtime 状态、应用内控制动作和 `containerFallbackCandidate`。该页面不提交 runtime 或容器控制请求；真正执行容器级 restart 前仍需单独 PR 设计 executor、权限边界和部署安全审查。
+前端 console 的 Runtime Supervisor 页面读取 `GET /api/v1/supervisor/status`，只展示 supervisor policy、service target、runtime 状态、应用内控制动作和 `containerFallbackCandidate`。该页面不提交 runtime 或容器控制请求；真正执行容器级 restart 前仍需单独 PR 设计 executor、权限边界和部署安全审查。
 
 ## 7. 安全边界
 

--- a/web/console/src/pages/SupervisorStage.tsx
+++ b/web/console/src/pages/SupervisorStage.tsx
@@ -8,6 +8,7 @@ import {
   ServerCog,
   ShieldAlert,
   Signal,
+  SlidersHorizontal,
   XCircle,
 } from 'lucide-react';
 import { Badge } from '../components/ui/badge';
@@ -140,6 +141,10 @@ function runtimeNeedsAttention(runtime: RuntimeSupervisorRuntimeStatus) {
   return actual === 'ERROR' || ['error', 'suppressed', 'unreachable', 'stale'].includes(health);
 }
 
+function PolicyBadge({ enabled, enabledLabel, disabledLabel }: { enabled: boolean; enabledLabel: string; disabledLabel: string }) {
+  return <Badge variant={enabled ? 'secondary' : 'neutral'}>{enabled ? enabledLabel : disabledLabel}</Badge>;
+}
+
 export function SupervisorStage() {
   const [snapshot, setSnapshot] = useState<RuntimeSupervisorSnapshot | null>(null);
   const [loadState, setLoadState] = useState<LoadState>('idle');
@@ -192,6 +197,7 @@ export function SupervisorStage() {
   }, [snapshot]);
 
   const targets = snapshot?.targets ?? [];
+  const policy = snapshot?.policy;
   const isLoading = loadState === 'loading' || loadState === 'idle';
 
   return (
@@ -271,6 +277,51 @@ export function SupervisorStage() {
                 tone={controlActionRows.some((action) => action.error) ? 'danger' : 'neutral'}
               />
             </div>
+
+            {policy && (
+              <Card tone="bento" className="rounded-lg">
+                <CardHeader>
+                  <CardTitle>Supervisor Policy</CardTitle>
+                  <CardAction>
+                    <Badge variant={policy.containerExecutorConfigured ? 'success' : 'neutral'}>
+                      {policy.containerExecutorConfigured ? 'executor ready' : 'no executor'}
+                    </Badge>
+                  </CardAction>
+                </CardHeader>
+                <CardContent>
+                  <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+                    <div className="flex min-w-0 items-center justify-between gap-3 rounded-lg border border-[var(--bk-border)] bg-[var(--bk-surface-muted)] px-3 py-2">
+                      <div className="flex min-w-0 flex-col gap-1">
+                        <span className="text-xs font-medium uppercase text-[var(--bk-text-muted)]">Application Restart</span>
+                        <PolicyBadge enabled={policy.applicationRestartEnabled} enabledLabel="enabled" disabledLabel="disabled" />
+                      </div>
+                      <RotateCw className="size-4 shrink-0 text-[var(--bk-text-muted)]" />
+                    </div>
+                    <div className="flex min-w-0 items-center justify-between gap-3 rounded-lg border border-[var(--bk-border)] bg-[var(--bk-surface-muted)] px-3 py-2">
+                      <div className="flex min-w-0 flex-col gap-1">
+                        <span className="text-xs font-medium uppercase text-[var(--bk-text-muted)]">Failure Threshold</span>
+                        <Badge variant="neutral">{policy.serviceFailureThreshold}</Badge>
+                      </div>
+                      <SlidersHorizontal className="size-4 shrink-0 text-[var(--bk-text-muted)]" />
+                    </div>
+                    <div className="flex min-w-0 items-center justify-between gap-3 rounded-lg border border-[var(--bk-border)] bg-[var(--bk-surface-muted)] px-3 py-2">
+                      <div className="flex min-w-0 flex-col gap-1">
+                        <span className="text-xs font-medium uppercase text-[var(--bk-text-muted)]">Container Restart</span>
+                        <PolicyBadge enabled={policy.containerRestartEnabled} enabledLabel="opt-in" disabledLabel="disabled" />
+                      </div>
+                      <ShieldAlert className="size-4 shrink-0 text-[var(--bk-text-muted)]" />
+                    </div>
+                    <div className="flex min-w-0 items-center justify-between gap-3 rounded-lg border border-[var(--bk-border)] bg-[var(--bk-surface-muted)] px-3 py-2">
+                      <div className="flex min-w-0 flex-col gap-1">
+                        <span className="text-xs font-medium uppercase text-[var(--bk-text-muted)]">Container Executor</span>
+                        <PolicyBadge enabled={policy.containerExecutorConfigured} enabledLabel="ready" disabledLabel="not configured" />
+                      </div>
+                      <ServerCog className="size-4 shrink-0 text-[var(--bk-text-muted)]" />
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+            )}
 
             <Card tone="bento" className="rounded-lg">
               <CardHeader>


### PR DESCRIPTION
## 目的
继续推进 #270 的 Runtime Supervisor Dashboard 可观测面：把 #330 新增的顶层 `policy` 展示到前端 Runtime Supervisor 页面，便于直接看到 application restart、service failure threshold、container restart opt-in 和 container executor readiness。

本 PR 只增加只读展示，不新增按钮，不提交 runtime/container 控制请求，不实现 Docker/container executor。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [x] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值无变化。
- [x] 不存在直接调用 `mainnet` 凭证或路由地址的硬编码。
- [x] 不涉及 DB migration。
- [x] 配置字段没有被混改；仅消费已有 status payload 字段。

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

本地验证：
- `npx shadcn@latest docs badge card`
- `cd web/console && ./node_modules/.bin/tsc --noEmit src/pages/SupervisorStage.tsx --jsx react-jsx --esModuleInterop --target esnext --module esnext --moduleResolution Bundler --allowSyntheticDefaultImports`
- `cd web/console && npm run build`
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
- `go build ./cmd/bktrader-ctl`
- `git diff --check`

验证备注：`npm ci` 已成功，当前本机 Node `v20.6.1` 会对依赖 `validate-npm-package-name` 的 engine `^20.17.0 || >=22.9.0` 打 warning；另有既有的 5 个 moderate audit 提示。本 PR 未改依赖。
