### PR TITLE
[codex] Define supervisor fallback decision contract

### DIFF
--- a/cmd/bktrader-ctl/supervisor.go
+++ b/cmd/bktrader-ctl/supervisor.go
@@ -76,7 +76,12 @@ type supervisorContainerFallbackPlan struct {
 	Enabled            bool   `json:"enabled"`
 	ExecutorConfigured bool   `json:"executorConfigured"`
 	Executable         bool   `json:"executable"`
+	Decision           string `json:"decision"`
+	Suppressed         bool   `json:"suppressed"`
+	BackoffActive      bool   `json:"backoffActive"`
+	SafetyGateOK       bool   `json:"safetyGateOk"`
 	BlockedReason      string `json:"blockedReason,omitempty"`
+	EligibleReason     string `json:"eligibleReason,omitempty"`
 	Reason             string `json:"reason,omitempty"`
 }
 
@@ -173,12 +178,17 @@ func buildSupervisorStatusSummary(data []byte) (string, error) {
 		}
 		if target.ContainerFallbackPlan != nil {
 			plan := target.ContainerFallbackPlan
-			fmt.Fprintf(&out, "  fallbackPlan: action=%s enabled=%t executorConfigured=%t executable=%t blockedReason=%s\n",
+			fmt.Fprintf(&out, "  fallbackPlan: action=%s decision=%s enabled=%t executorConfigured=%t executable=%t suppressed=%t backoffActive=%t safetyGateOk=%t blockedReason=%s eligibleReason=%s\n",
 				firstNonEmpty(plan.Action, "--"),
+				firstNonEmpty(plan.Decision, "--"),
 				plan.Enabled,
 				plan.ExecutorConfigured,
 				plan.Executable,
+				plan.Suppressed,
+				plan.BackoffActive,
+				plan.SafetyGateOK,
 				firstNonEmpty(plan.BlockedReason, "--"),
+				firstNonEmpty(plan.EligibleReason, "--"),
 			)
 		}
 		if target.Status != nil {

--- a/cmd/bktrader-ctl/supervisor_test.go
+++ b/cmd/bktrader-ctl/supervisor_test.go
@@ -32,6 +32,10 @@ func TestBuildSupervisorStatusSummaryShowsFallbackReadiness(t *testing.T) {
 				"enabled":true,
 				"executorConfigured":false,
 				"executable":false,
+				"decision":"blocked",
+				"suppressed":false,
+				"backoffActive":false,
+				"safetyGateOk":true,
 				"blockedReason":"container-executor-not-configured"
 			},
 			"status":{
@@ -56,7 +60,7 @@ func TestBuildSupervisorStatusSummaryShowsFallbackReadiness(t *testing.T) {
 		"Runtime supervisor snapshot",
 		"policy: applicationRestartEnabled=true serviceFailureThreshold=3 containerRestartEnabled=true containerExecutorConfigured=false",
 		"targets: total=1 fullyReachable=0 fallbackCandidates=1 fallbackExecutable=0 runtimes=1 attention=1 controlActions=1",
-		"fallbackPlan: action=container-restart enabled=true executorConfigured=false executable=false blockedReason=container-executor-not-configured",
+		"fallbackPlan: action=container-restart decision=blocked enabled=true executorConfigured=false executable=false suppressed=false backoffActive=false safetyGateOk=true blockedReason=container-executor-not-configured eligibleReason=--",
 		"lastFailure=healthz-unhealthy: http 503",
 	}
 	for _, want := range expected {

--- a/docs/runtime-supervisor.md
+++ b/docs/runtime-supervisor.md
@@ -323,7 +323,7 @@ func ClearRestartState(state map[string]any, keys []string)
 - `SUPERVISOR_CONTAINER_RESTART_ENABLED=false` 为默认值；未显式设为 `true` 时，容器兜底计划只会返回 `blockedReason=container-restart-disabled`，不会进入 executor 阶段。
 - 默认只采集 `/healthz` 和 `/api/v1/runtime/status`，不调用任何控制 API。
 - `GET /api/v1/supervisor/status` 返回最近一次 read-only supervisor 采集快照，并在顶层 `policy` 中暴露 `applicationRestartEnabled`、`serviceFailureThreshold`、`containerRestartEnabled`、`containerExecutorConfigured`。这些字段只反映当前 supervisor policy，不代表已执行或允许执行容器 restart。
-- `bktrader-ctl runtime status --json` 和 `bktrader-ctl supervisor status --json` 提供 CLI 只读巡检入口；`bktrader-ctl supervisor status` 的人类可读输出会汇总 policy、target reachability、runtime attention、control action 数量，以及 container fallback 的 `enabled` / `executorConfigured` / `executable` readiness。
+- `bktrader-ctl runtime status --json` 和 `bktrader-ctl supervisor status --json` 提供 CLI 只读巡检入口；`bktrader-ctl supervisor status` 的人类可读输出会汇总 policy、target reachability、runtime attention、control action 数量，以及 container fallback 的 `decision`、`enabled` / `executorConfigured` / `executable` readiness 和 dry-run gates。
 - `SUPERVISOR_APPLICATION_RESTART_ENABLED=false` 为默认值；只有显式设为 `true` 时，supervisor 才会对满足全部条件的 signal runtime 提交应用内 `POST /api/v1/runtime/restart`：
   - 目标服务 `/healthz` 可达且成功。
   - `/api/v1/runtime/status` 可读。
@@ -360,14 +360,14 @@ func ClearRestartState(state map[string]any, keys []string)
 当前只读候选状态：
 
 - `GET /api/v1/supervisor/status` 的每个 target 会返回 `serviceState`，包含连续失败次数、失败阈值、最近失败/恢复时间，以及是否已成为 `containerFallbackCandidate`。
-- 当 target 已成为容器兜底候选时，状态中会额外返回 `containerFallbackPlan`；当前 `action=container-restart` 只是计划语义。该计划显式返回 `enabled`、`executorConfigured`、`executable` 三个 readiness 字段：默认 `enabled=false`、`executorConfigured=false`、`executable=false`，并返回 `blockedReason=container-restart-disabled`；即使 `SUPERVISOR_CONTAINER_RESTART_ENABLED=true`，在 executor 尚未配置前也只会返回 `enabled=true`、`executorConfigured=false`、`executable=false`、`blockedReason=container-executor-not-configured`，用于明确“候选”不等于“已允许执行”。
+- 当 target 已成为容器兜底候选时，状态中会额外返回 `containerFallbackPlan`；当前 `action=container-restart` 只是计划语义。该计划显式返回 `decision=blocked|eligible`、`enabled`、`executorConfigured`、`executable` 以及 dry-run gates：`suppressed`、`backoffActive`、`safetyGateOk`。当前完整执行语义被固定为 `candidate && enabled && executorConfigured && !suppressed && !backoffActive && safetyGateOk`；默认 `enabled=false`、`executorConfigured=false`、`executable=false`、`decision=blocked`，并返回 `blockedReason=container-restart-disabled`；即使 `SUPERVISOR_CONTAINER_RESTART_ENABLED=true`，在 executor 尚未配置前也只会返回 `enabled=true`、`executorConfigured=false`、`executable=false`、`decision=blocked`、`blockedReason=container-executor-not-configured`，用于明确“候选”不等于“已允许执行”。
 - 当前 service fallback 只把 `/healthz` 不可达或非 2xx、`/api/v1/runtime/status` 连接不可达视为服务级失败；`/runtime/status` JSON decode 失败不会触发容器兜底候选，避免把业务状态或响应格式问题误判成需要重启容器。
 - 达到 `SUPERVISOR_SERVICE_FAILURE_THRESHOLD` 后只记录 `containerFallbackCandidate=true` 和原因，不调用 Docker API，不挂载 Docker socket，不执行容器 restart。
 - 后续真正执行容器级 restart 前，仍需单独设计 executor、backoff、人工抑制、权限边界和部署安全审查。
 
 ### Dashboard 视图
 
-前端 console 的 Runtime Supervisor 页面读取 `GET /api/v1/supervisor/status`，只展示 supervisor policy、service target、runtime 状态、应用内控制动作和 `containerFallbackCandidate`。该页面不提交 runtime 或容器控制请求；真正执行容器级 restart 前仍需单独 PR 设计 executor、权限边界和部署安全审查。
+前端 console 的 Runtime Supervisor 页面读取 `GET /api/v1/supervisor/status`，只展示 supervisor policy、service target、runtime 状态、应用内控制动作、`containerFallbackCandidate` 和 fallback `decision`。该页面不提交 runtime 或容器控制请求；真正执行容器级 restart 前仍需单独 PR 设计 executor、权限边界和部署安全审查。
 
 ## 7. 安全边界
 

--- a/internal/service/runtime_supervisor.go
+++ b/internal/service/runtime_supervisor.go
@@ -17,6 +17,9 @@ import (
 const (
 	defaultRuntimeSupervisorHTTPTimeout       = 5 * time.Second
 	defaultRuntimeSupervisorServiceFailThresh = 3
+
+	runtimeSupervisorContainerFallbackDecisionBlocked  = "blocked"
+	runtimeSupervisorContainerFallbackDecisionEligible = "eligible"
 )
 
 type RuntimeSupervisorOptions struct {
@@ -92,7 +95,12 @@ type RuntimeSupervisorContainerFallbackPlan struct {
 	Enabled            bool   `json:"enabled"`
 	ExecutorConfigured bool   `json:"executorConfigured"`
 	Executable         bool   `json:"executable"`
+	Decision           string `json:"decision"`
+	Suppressed         bool   `json:"suppressed"`
+	BackoffActive      bool   `json:"backoffActive"`
+	SafetyGateOK       bool   `json:"safetyGateOk"`
 	BlockedReason      string `json:"blockedReason,omitempty"`
+	EligibleReason     string `json:"eligibleReason,omitempty"`
 	Reason             string `json:"reason,omitempty"`
 }
 
@@ -101,6 +109,22 @@ type runtimeSupervisorServiceState struct {
 	LastFailureReason   string
 	LastFailureAt       time.Time
 	LastHealthyAt       time.Time
+}
+
+type runtimeSupervisorContainerFallbackDecisionInput struct {
+	Candidate          bool
+	Enabled            bool
+	ExecutorConfigured bool
+	Suppressed         bool
+	BackoffActive      bool
+	SafetyGateOK       bool
+}
+
+type runtimeSupervisorContainerFallbackDecisionResult struct {
+	Decision       string
+	Executable     bool
+	BlockedReason  string
+	EligibleReason string
 }
 
 type RuntimeSupervisor struct {
@@ -379,21 +403,62 @@ func runtimeSupervisorContainerFallbackPlan(state RuntimeSupervisorServiceState,
 		return nil
 	}
 	executorConfigured := runtimeSupervisorContainerExecutorConfigured()
-	executable := options.EnableContainerFallback && executorConfigured
-	blockedReason := ""
-	if !options.EnableContainerFallback {
-		blockedReason = "container-restart-disabled"
-	} else if !executorConfigured {
-		blockedReason = "container-executor-not-configured"
-	}
+	suppressed := false
+	backoffActive := false
+	safetyGateOK := strings.TrimSpace(state.ContainerFallbackReason) != ""
+	decision := evaluateRuntimeSupervisorContainerFallbackDecision(runtimeSupervisorContainerFallbackDecisionInput{
+		Candidate:          state.ContainerFallbackCandidate,
+		Enabled:            options.EnableContainerFallback,
+		ExecutorConfigured: executorConfigured,
+		Suppressed:         suppressed,
+		BackoffActive:      backoffActive,
+		SafetyGateOK:       safetyGateOK,
+	})
 	return &RuntimeSupervisorContainerFallbackPlan{
 		Action:             "container-restart",
 		Candidate:          true,
 		Enabled:            options.EnableContainerFallback,
 		ExecutorConfigured: executorConfigured,
-		Executable:         executable,
-		BlockedReason:      blockedReason,
+		Executable:         decision.Executable,
+		Decision:           decision.Decision,
+		Suppressed:         suppressed,
+		BackoffActive:      backoffActive,
+		SafetyGateOK:       safetyGateOK,
+		BlockedReason:      decision.BlockedReason,
+		EligibleReason:     decision.EligibleReason,
 		Reason:             state.ContainerFallbackReason,
+	}
+}
+
+func evaluateRuntimeSupervisorContainerFallbackDecision(input runtimeSupervisorContainerFallbackDecisionInput) runtimeSupervisorContainerFallbackDecisionResult {
+	blocked := func(reason string) runtimeSupervisorContainerFallbackDecisionResult {
+		return runtimeSupervisorContainerFallbackDecisionResult{
+			Decision:      runtimeSupervisorContainerFallbackDecisionBlocked,
+			BlockedReason: reason,
+		}
+	}
+	if !input.Candidate {
+		return blocked("container-fallback-not-candidate")
+	}
+	if !input.Enabled {
+		return blocked("container-restart-disabled")
+	}
+	if !input.ExecutorConfigured {
+		return blocked("container-executor-not-configured")
+	}
+	if input.Suppressed {
+		return blocked("container-fallback-suppressed")
+	}
+	if input.BackoffActive {
+		return blocked("container-fallback-backoff-active")
+	}
+	if !input.SafetyGateOK {
+		return blocked("container-fallback-safety-gate-blocked")
+	}
+	return runtimeSupervisorContainerFallbackDecisionResult{
+		Decision:       runtimeSupervisorContainerFallbackDecisionEligible,
+		Executable:     true,
+		EligibleReason: "container fallback eligible",
 	}
 }
 

--- a/internal/service/runtime_supervisor_test.go
+++ b/internal/service/runtime_supervisor_test.go
@@ -219,6 +219,12 @@ func TestRuntimeSupervisorMarksContainerFallbackCandidateAfterServiceFailures(t 
 	if second.ContainerFallbackPlan.Executable || second.ContainerFallbackPlan.BlockedReason != "container-restart-disabled" {
 		t.Fatalf("expected fallback plan to stay blocked without explicit opt-in, got %+v", second.ContainerFallbackPlan)
 	}
+	if second.ContainerFallbackPlan.Decision != runtimeSupervisorContainerFallbackDecisionBlocked {
+		t.Fatalf("expected blocked fallback decision, got %+v", second.ContainerFallbackPlan)
+	}
+	if second.ContainerFallbackPlan.Suppressed || second.ContainerFallbackPlan.BackoffActive || !second.ContainerFallbackPlan.SafetyGateOK {
+		t.Fatalf("expected dry-run gates to be clear with safety gate ok, got %+v", second.ContainerFallbackPlan)
+	}
 	if second.ContainerFallbackPlan.Enabled || second.ContainerFallbackPlan.ExecutorConfigured {
 		t.Fatalf("expected fallback readiness to show disabled/no executor, got %+v", second.ContainerFallbackPlan)
 	}
@@ -274,8 +280,98 @@ func TestRuntimeSupervisorContainerFallbackOptInStillRequiresExecutor(t *testing
 	if target.ContainerFallbackPlan.Executable || target.ContainerFallbackPlan.BlockedReason != "container-executor-not-configured" {
 		t.Fatalf("expected opt-in plan to stay blocked without executor, got %+v", target.ContainerFallbackPlan)
 	}
+	if target.ContainerFallbackPlan.Decision != runtimeSupervisorContainerFallbackDecisionBlocked {
+		t.Fatalf("expected opt-in plan to report blocked decision, got %+v", target.ContainerFallbackPlan)
+	}
 	if !target.ContainerFallbackPlan.Enabled || target.ContainerFallbackPlan.ExecutorConfigured {
 		t.Fatalf("expected opt-in readiness to show enabled/no executor, got %+v", target.ContainerFallbackPlan)
+	}
+}
+
+func TestRuntimeSupervisorContainerFallbackDecisionContract(t *testing.T) {
+	base := runtimeSupervisorContainerFallbackDecisionInput{
+		Candidate:          true,
+		Enabled:            true,
+		ExecutorConfigured: true,
+		SafetyGateOK:       true,
+	}
+	tests := []struct {
+		name            string
+		input           runtimeSupervisorContainerFallbackDecisionInput
+		wantDecision    string
+		wantExecutable  bool
+		wantBlocked     string
+		wantEligibleSet bool
+	}{
+		{
+			name:         "not candidate",
+			input:        runtimeSupervisorContainerFallbackDecisionInput{},
+			wantDecision: runtimeSupervisorContainerFallbackDecisionBlocked,
+			wantBlocked:  "container-fallback-not-candidate",
+		},
+		{
+			name:         "disabled",
+			input:        runtimeSupervisorContainerFallbackDecisionInput{Candidate: true, ExecutorConfigured: true, SafetyGateOK: true},
+			wantDecision: runtimeSupervisorContainerFallbackDecisionBlocked,
+			wantBlocked:  "container-restart-disabled",
+		},
+		{
+			name:         "executor missing",
+			input:        runtimeSupervisorContainerFallbackDecisionInput{Candidate: true, Enabled: true, SafetyGateOK: true},
+			wantDecision: runtimeSupervisorContainerFallbackDecisionBlocked,
+			wantBlocked:  "container-executor-not-configured",
+		},
+		{
+			name: "suppressed",
+			input: runtimeSupervisorContainerFallbackDecisionInput{
+				Candidate:          true,
+				Enabled:            true,
+				ExecutorConfigured: true,
+				Suppressed:         true,
+				SafetyGateOK:       true,
+			},
+			wantDecision: runtimeSupervisorContainerFallbackDecisionBlocked,
+			wantBlocked:  "container-fallback-suppressed",
+		},
+		{
+			name: "backoff active",
+			input: runtimeSupervisorContainerFallbackDecisionInput{
+				Candidate:          true,
+				Enabled:            true,
+				ExecutorConfigured: true,
+				BackoffActive:      true,
+				SafetyGateOK:       true,
+			},
+			wantDecision: runtimeSupervisorContainerFallbackDecisionBlocked,
+			wantBlocked:  "container-fallback-backoff-active",
+		},
+		{
+			name:         "safety gate blocked",
+			input:        runtimeSupervisorContainerFallbackDecisionInput{Candidate: true, Enabled: true, ExecutorConfigured: true},
+			wantDecision: runtimeSupervisorContainerFallbackDecisionBlocked,
+			wantBlocked:  "container-fallback-safety-gate-blocked",
+		},
+		{
+			name:            "eligible",
+			input:           base,
+			wantDecision:    runtimeSupervisorContainerFallbackDecisionEligible,
+			wantExecutable:  true,
+			wantEligibleSet: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := evaluateRuntimeSupervisorContainerFallbackDecision(tt.input)
+			if got.Decision != tt.wantDecision || got.Executable != tt.wantExecutable || got.BlockedReason != tt.wantBlocked {
+				t.Fatalf("unexpected decision: got %+v want decision=%s executable=%t blocked=%s", got, tt.wantDecision, tt.wantExecutable, tt.wantBlocked)
+			}
+			if tt.wantEligibleSet && got.EligibleReason == "" {
+				t.Fatalf("expected eligible reason, got %+v", got)
+			}
+			if !tt.wantEligibleSet && got.EligibleReason != "" {
+				t.Fatalf("did not expect eligible reason, got %+v", got)
+			}
+		})
 	}
 }
 

--- a/web/console/src/pages/SupervisorStage.tsx
+++ b/web/console/src/pages/SupervisorStage.tsx
@@ -352,11 +352,13 @@ export function SupervisorStage() {
                       {targets.map((target) => {
                         const runtimeCount = target.status?.runtimes.length ?? 0;
                         const runtimeErrors = target.status?.runtimes.filter(runtimeNeedsAttention).length ?? 0;
-                        const fallbackDetail =
-                          target.containerFallbackPlan?.blockedReason ||
-                          target.containerFallbackPlan?.reason ||
-                          target.serviceState.containerFallbackReason;
                         const fallbackPlan = target.containerFallbackPlan;
+                        const fallbackDecision = fallbackPlan?.decision || (fallbackPlan?.executable ? 'eligible' : 'blocked');
+                        const fallbackDetail =
+                          fallbackPlan?.blockedReason ||
+                          fallbackPlan?.eligibleReason ||
+                          fallbackPlan?.reason ||
+                          target.serviceState.containerFallbackReason;
                         return (
                           <TableRow key={`${target.name}:${target.baseUrl}`}>
                             <TableCell>
@@ -391,6 +393,11 @@ export function SupervisorStage() {
                                   <Badge variant={target.serviceState.containerFallbackCandidate ? 'destructive' : 'neutral'}>
                                     {target.serviceState.containerFallbackCandidate ? 'candidate' : 'clear'}
                                   </Badge>
+                                  {fallbackPlan && (
+                                    <Badge variant={fallbackDecision === 'eligible' ? 'success' : 'neutral'}>
+                                      {fallbackDecision}
+                                    </Badge>
+                                  )}
                                   {fallbackPlan && (
                                     <Badge variant={fallbackPlan.enabled ? 'secondary' : 'neutral'}>
                                       {fallbackPlan.enabled ? 'opt-in' : 'disabled'}

--- a/web/console/src/types/domain.ts
+++ b/web/console/src/types/domain.ts
@@ -415,7 +415,12 @@ export type RuntimeSupervisorContainerFallbackPlan = {
   enabled: boolean;
   executorConfigured: boolean;
   executable: boolean;
+  decision?: 'blocked' | 'eligible' | string;
+  suppressed: boolean;
+  backoffActive: boolean;
+  safetyGateOk: boolean;
   blockedReason?: string;
+  eligibleReason?: string;
   reason?: string;
 };
 


### PR DESCRIPTION
## 目的
继续推进 #270，并落实 #332 code review comment 里的下一阶段建议：先定义 Container Fallback Decision Contract，而不是直接接 Docker API 或把 `executable=false` 改成 true。

本 PR 将 `containerFallbackPlan` 从单纯 readiness 展示扩展为显式 dry-run 决策：

```text
candidate + enabled + executorConfigured + !suppressed + !backoffActive + safetyGateOk
  -> decision: blocked / eligible
  -> blockedReason / eligibleReason
```

当前仍不配置 executor、不调用 Docker、不挂载 docker.sock、不执行容器 restart；默认计划保持 `decision=blocked` / `executable=false`。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [x] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值无变化。
- [x] 不存在直接调用 `mainnet` 凭证或路由地址的硬编码。
- [x] 不涉及 DB migration。
- [x] 不修改部署、Docker socket、GitHub Actions 或 executor 权限边界。
- [x] 不新增 runtime/container 控制请求；container fallback 仍为 dry-run status/plan。

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

本地验证：
- `go test ./internal/service ./cmd/bktrader-ctl`
- `npx shadcn@latest docs badge`
- `cd web/console && ./node_modules/.bin/tsc --noEmit src/pages/SupervisorStage.tsx --jsx react-jsx --esModuleInterop --target esnext --module esnext --moduleResolution Bundler --allowSyntheticDefaultImports`
- `cd web/console && npm run build`
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
- `go build ./cmd/bktrader-ctl`
- `git diff --check`

验证备注：`npm ci` 已成功；当前本机 Node `v20.6.1` 会对依赖 `validate-npm-package-name` 的 engine `^20.17.0 || >=22.9.0` 打 warning，另有既有的 5 个 moderate audit 提示。本 PR 未改依赖。
