### PR TITLE
[codex] Expose supervisor fallback audit state

### DIFF
--- a/cmd/bktrader-ctl/supervisor.go
+++ b/cmd/bktrader-ctl/supervisor.go
@@ -63,11 +63,16 @@ type supervisorProbe struct {
 }
 
 type supervisorServiceState struct {
-	ConsecutiveFailures        int    `json:"consecutiveFailures"`
-	FailureThreshold           int    `json:"failureThreshold"`
-	LastFailureReason          string `json:"lastFailureReason,omitempty"`
-	ContainerFallbackCandidate bool   `json:"containerFallbackCandidate"`
-	ContainerFallbackReason    string `json:"containerFallbackReason,omitempty"`
+	ConsecutiveFailures                 int    `json:"consecutiveFailures"`
+	FailureThreshold                    int    `json:"failureThreshold"`
+	LastFailureReason                   string `json:"lastFailureReason,omitempty"`
+	ContainerFallbackCandidate          bool   `json:"containerFallbackCandidate"`
+	ContainerFallbackReason             string `json:"containerFallbackReason,omitempty"`
+	ContainerFallbackSuppressed         bool   `json:"containerFallbackSuppressed"`
+	ContainerFallbackBackoffUntil       string `json:"containerFallbackBackoffUntil,omitempty"`
+	ContainerFallbackAttemptCount       int    `json:"containerFallbackAttemptCount"`
+	LastContainerFallbackDecisionAt     string `json:"lastContainerFallbackDecisionAt,omitempty"`
+	LastContainerFallbackDecisionReason string `json:"lastContainerFallbackDecisionReason,omitempty"`
 }
 
 type supervisorContainerFallbackPlan struct {
@@ -168,13 +173,22 @@ func buildSupervisorStatusSummary(data []byte) (string, error) {
 	for _, target := range snapshot.Targets {
 		fmt.Fprintf(&out, "\n- %s %s\n", firstNonEmpty(target.Name, "--"), firstNonEmpty(target.BaseURL, "--"))
 		fmt.Fprintf(&out, "  probes: healthz=%s runtimeStatus=%s\n", supervisorProbeText(target.Healthz), supervisorProbeText(target.RuntimeStatus))
-		fmt.Fprintf(&out, "  serviceState: failures=%d/%d fallback=%s\n",
+		fmt.Fprintf(&out, "  serviceState: failures=%d/%d fallback=%s attempts=%d suppressed=%t backoffUntil=%s\n",
 			target.ServiceState.ConsecutiveFailures,
 			target.ServiceState.FailureThreshold,
 			supervisorFallbackStateText(target.ServiceState),
+			target.ServiceState.ContainerFallbackAttemptCount,
+			target.ServiceState.ContainerFallbackSuppressed,
+			firstNonEmpty(target.ServiceState.ContainerFallbackBackoffUntil, "--"),
 		)
 		if strings.TrimSpace(target.ServiceState.LastFailureReason) != "" {
 			fmt.Fprintf(&out, "  lastFailure=%s\n", target.ServiceState.LastFailureReason)
+		}
+		if strings.TrimSpace(target.ServiceState.LastContainerFallbackDecisionReason) != "" {
+			fmt.Fprintf(&out, "  lastFallbackDecision=%s at=%s\n",
+				target.ServiceState.LastContainerFallbackDecisionReason,
+				firstNonEmpty(target.ServiceState.LastContainerFallbackDecisionAt, "--"),
+			)
 		}
 		if target.ContainerFallbackPlan != nil {
 			plan := target.ContainerFallbackPlan

--- a/cmd/bktrader-ctl/supervisor_test.go
+++ b/cmd/bktrader-ctl/supervisor_test.go
@@ -24,7 +24,11 @@ func TestBuildSupervisorStatusSummaryShowsFallbackReadiness(t *testing.T) {
 				"failureThreshold":3,
 				"lastFailureReason":"healthz-unhealthy: http 503",
 				"containerFallbackCandidate":true,
-				"containerFallbackReason":"service probes failed 3/3"
+				"containerFallbackReason":"service probes failed 3/3",
+				"containerFallbackAttemptCount":2,
+				"containerFallbackSuppressed":false,
+				"lastContainerFallbackDecisionAt":"2026-04-29T08:00:00Z",
+				"lastContainerFallbackDecisionReason":"container-executor-not-configured"
 			},
 			"containerFallbackPlan":{
 				"action":"container-restart",
@@ -60,6 +64,8 @@ func TestBuildSupervisorStatusSummaryShowsFallbackReadiness(t *testing.T) {
 		"Runtime supervisor snapshot",
 		"policy: applicationRestartEnabled=true serviceFailureThreshold=3 containerRestartEnabled=true containerExecutorConfigured=false",
 		"targets: total=1 fullyReachable=0 fallbackCandidates=1 fallbackExecutable=0 runtimes=1 attention=1 controlActions=1",
+		"serviceState: failures=3/3 fallback=candidate attempts=2 suppressed=false backoffUntil=--",
+		"lastFallbackDecision=container-executor-not-configured at=2026-04-29T08:00:00Z",
 		"fallbackPlan: action=container-restart decision=blocked enabled=true executorConfigured=false executable=false suppressed=false backoffActive=false safetyGateOk=true blockedReason=container-executor-not-configured eligibleReason=--",
 		"lastFailure=healthz-unhealthy: http 503",
 	}
@@ -96,7 +102,7 @@ func TestBuildSupervisorStatusSummaryHandlesClearTarget(t *testing.T) {
 	expected := []string{
 		"policy: applicationRestartEnabled=false serviceFailureThreshold=3 containerRestartEnabled=false containerExecutorConfigured=false",
 		"targets: total=1 fullyReachable=1 fallbackCandidates=0 fallbackExecutable=0 runtimes=0 attention=0 controlActions=0",
-		"serviceState: failures=0/3 fallback=clear",
+		"serviceState: failures=0/3 fallback=clear attempts=0 suppressed=false backoffUntil=--",
 		"runtimes: total=0 attention=0 service=platform-api",
 	}
 	for _, want := range expected {

--- a/docs/runtime-supervisor.md
+++ b/docs/runtime-supervisor.md
@@ -323,7 +323,7 @@ func ClearRestartState(state map[string]any, keys []string)
 - `SUPERVISOR_CONTAINER_RESTART_ENABLED=false` 为默认值；未显式设为 `true` 时，容器兜底计划只会返回 `blockedReason=container-restart-disabled`，不会进入 executor 阶段。
 - 默认只采集 `/healthz` 和 `/api/v1/runtime/status`，不调用任何控制 API。
 - `GET /api/v1/supervisor/status` 返回最近一次 read-only supervisor 采集快照，并在顶层 `policy` 中暴露 `applicationRestartEnabled`、`serviceFailureThreshold`、`containerRestartEnabled`、`containerExecutorConfigured`。这些字段只反映当前 supervisor policy，不代表已执行或允许执行容器 restart。
-- `bktrader-ctl runtime status --json` 和 `bktrader-ctl supervisor status --json` 提供 CLI 只读巡检入口；`bktrader-ctl supervisor status` 的人类可读输出会汇总 policy、target reachability、runtime attention、control action 数量，以及 container fallback 的 `decision`、`enabled` / `executorConfigured` / `executable` readiness 和 dry-run gates。
+- `bktrader-ctl runtime status --json` 和 `bktrader-ctl supervisor status --json` 提供 CLI 只读巡检入口；`bktrader-ctl supervisor status` 的人类可读输出会汇总 policy、target reachability、runtime attention、control action 数量，以及 container fallback 的 `decision`、`enabled` / `executorConfigured` / `executable` readiness、dry-run gates 和当前失败 episode 的 decision audit。
 - `SUPERVISOR_APPLICATION_RESTART_ENABLED=false` 为默认值；只有显式设为 `true` 时，supervisor 才会对满足全部条件的 signal runtime 提交应用内 `POST /api/v1/runtime/restart`：
   - 目标服务 `/healthz` 可达且成功。
   - `/api/v1/runtime/status` 可读。
@@ -359,7 +359,7 @@ func ClearRestartState(state map[string]any, keys []string)
 
 当前只读候选状态：
 
-- `GET /api/v1/supervisor/status` 的每个 target 会返回 `serviceState`，包含连续失败次数、失败阈值、最近失败/恢复时间，以及是否已成为 `containerFallbackCandidate`。
+- `GET /api/v1/supervisor/status` 的每个 target 会返回 `serviceState`，包含连续失败次数、失败阈值、最近失败/恢复时间、是否已成为 `containerFallbackCandidate`，以及 dry-run decision audit：`containerFallbackSuppressed`、`containerFallbackBackoffUntil`、`containerFallbackAttemptCount`、`lastContainerFallbackDecisionAt`、`lastContainerFallbackDecisionReason`。当前 `containerFallbackAttemptCount` 表示当前连续失败 episode 内进入容器兜底决策层的次数，健康恢复后清零；它不是 Docker restart 执行次数。
 - 当 target 已成为容器兜底候选时，状态中会额外返回 `containerFallbackPlan`；当前 `action=container-restart` 只是计划语义。该计划显式返回 `decision=blocked|eligible`、`enabled`、`executorConfigured`、`executable` 以及 dry-run gates：`suppressed`、`backoffActive`、`safetyGateOk`。当前完整执行语义被固定为 `candidate && enabled && executorConfigured && !suppressed && !backoffActive && safetyGateOk`；默认 `enabled=false`、`executorConfigured=false`、`executable=false`、`decision=blocked`，并返回 `blockedReason=container-restart-disabled`；即使 `SUPERVISOR_CONTAINER_RESTART_ENABLED=true`，在 executor 尚未配置前也只会返回 `enabled=true`、`executorConfigured=false`、`executable=false`、`decision=blocked`、`blockedReason=container-executor-not-configured`，用于明确“候选”不等于“已允许执行”。
 - 当前 service fallback 只把 `/healthz` 不可达或非 2xx、`/api/v1/runtime/status` 连接不可达视为服务级失败；`/runtime/status` JSON decode 失败不会触发容器兜底候选，避免把业务状态或响应格式问题误判成需要重启容器。
 - 达到 `SUPERVISOR_SERVICE_FAILURE_THRESHOLD` 后只记录 `containerFallbackCandidate=true` 和原因，不调用 Docker API，不挂载 Docker socket，不执行容器 restart。
@@ -367,7 +367,7 @@ func ClearRestartState(state map[string]any, keys []string)
 
 ### Dashboard 视图
 
-前端 console 的 Runtime Supervisor 页面读取 `GET /api/v1/supervisor/status`，只展示 supervisor policy、service target、runtime 状态、应用内控制动作、`containerFallbackCandidate` 和 fallback `decision`。该页面不提交 runtime 或容器控制请求；真正执行容器级 restart 前仍需单独 PR 设计 executor、权限边界和部署安全审查。
+前端 console 的 Runtime Supervisor 页面读取 `GET /api/v1/supervisor/status`，只展示 supervisor policy、service target、runtime 状态、应用内控制动作、`containerFallbackCandidate`、fallback `decision` 和 dry-run audit 摘要。该页面不提交 runtime 或容器控制请求；真正执行容器级 restart 前仍需单独 PR 设计 executor、权限边界和部署安全审查。
 
 ## 7. 安全边界
 

--- a/internal/service/runtime_supervisor.go
+++ b/internal/service/runtime_supervisor.go
@@ -80,13 +80,18 @@ type RuntimeSupervisorControlAction struct {
 }
 
 type RuntimeSupervisorServiceState struct {
-	ConsecutiveFailures        int        `json:"consecutiveFailures"`
-	FailureThreshold           int        `json:"failureThreshold"`
-	LastFailureReason          string     `json:"lastFailureReason,omitempty"`
-	LastFailureAt              *time.Time `json:"lastFailureAt,omitempty"`
-	LastHealthyAt              *time.Time `json:"lastHealthyAt,omitempty"`
-	ContainerFallbackCandidate bool       `json:"containerFallbackCandidate"`
-	ContainerFallbackReason    string     `json:"containerFallbackReason,omitempty"`
+	ConsecutiveFailures                 int        `json:"consecutiveFailures"`
+	FailureThreshold                    int        `json:"failureThreshold"`
+	LastFailureReason                   string     `json:"lastFailureReason,omitempty"`
+	LastFailureAt                       *time.Time `json:"lastFailureAt,omitempty"`
+	LastHealthyAt                       *time.Time `json:"lastHealthyAt,omitempty"`
+	ContainerFallbackCandidate          bool       `json:"containerFallbackCandidate"`
+	ContainerFallbackReason             string     `json:"containerFallbackReason,omitempty"`
+	ContainerFallbackSuppressed         bool       `json:"containerFallbackSuppressed"`
+	ContainerFallbackBackoffUntil       *time.Time `json:"containerFallbackBackoffUntil,omitempty"`
+	ContainerFallbackAttemptCount       int        `json:"containerFallbackAttemptCount"`
+	LastContainerFallbackDecisionAt     *time.Time `json:"lastContainerFallbackDecisionAt,omitempty"`
+	LastContainerFallbackDecisionReason string     `json:"lastContainerFallbackDecisionReason,omitempty"`
 }
 
 type RuntimeSupervisorContainerFallbackPlan struct {
@@ -105,10 +110,15 @@ type RuntimeSupervisorContainerFallbackPlan struct {
 }
 
 type runtimeSupervisorServiceState struct {
-	ConsecutiveFailures int
-	LastFailureReason   string
-	LastFailureAt       time.Time
-	LastHealthyAt       time.Time
+	ConsecutiveFailures                 int
+	LastFailureReason                   string
+	LastFailureAt                       time.Time
+	LastHealthyAt                       time.Time
+	ContainerFallbackSuppressed         bool
+	ContainerFallbackBackoffUntil       time.Time
+	ContainerFallbackAttemptCount       int
+	LastContainerFallbackDecisionAt     time.Time
+	LastContainerFallbackDecisionReason string
 }
 
 type runtimeSupervisorContainerFallbackDecisionInput struct {
@@ -244,7 +254,7 @@ func (s *RuntimeSupervisor) Collect(ctx context.Context) RuntimeSupervisorSnapsh
 		var status RuntimeStatusSnapshot
 		targetSnapshot.RuntimeStatus = s.fetchJSON(ctx, target, "/api/v1/runtime/status", &status)
 		targetSnapshot.ServiceState = s.updateServiceState(target, targetSnapshot.Healthz, targetSnapshot.RuntimeStatus, now)
-		targetSnapshot.ContainerFallbackPlan = runtimeSupervisorContainerFallbackPlan(targetSnapshot.ServiceState, s.options)
+		targetSnapshot.ContainerFallbackPlan, targetSnapshot.ServiceState = s.updateContainerFallbackPlan(target, targetSnapshot.ServiceState, now)
 		if targetSnapshot.RuntimeStatus.Error == "" && targetSnapshot.RuntimeStatus.Reachable {
 			targetSnapshot.Status = &status
 			targetSnapshot.ControlActions = s.submitApplicationRestarts(ctx, target, status, targetSnapshot.Healthz, now)
@@ -348,6 +358,10 @@ func (s *RuntimeSupervisor) updateServiceState(target RuntimeSupervisorTarget, h
 		state.ConsecutiveFailures = 0
 		state.LastFailureReason = ""
 		state.LastHealthyAt = now
+		state.ContainerFallbackAttemptCount = 0
+		state.ContainerFallbackBackoffUntil = time.Time{}
+		state.LastContainerFallbackDecisionAt = time.Time{}
+		state.LastContainerFallbackDecisionReason = ""
 	}
 	s.serviceStates[key] = state
 	return runtimeSupervisorServiceStateSnapshot(state, s.options.ServiceFailureThreshold)
@@ -379,9 +393,12 @@ func runtimeSupervisorServiceStateSnapshot(state runtimeSupervisorServiceState, 
 		threshold = defaultRuntimeSupervisorServiceFailThresh
 	}
 	out := RuntimeSupervisorServiceState{
-		ConsecutiveFailures: state.ConsecutiveFailures,
-		FailureThreshold:    threshold,
-		LastFailureReason:   state.LastFailureReason,
+		ConsecutiveFailures:                 state.ConsecutiveFailures,
+		FailureThreshold:                    threshold,
+		LastFailureReason:                   state.LastFailureReason,
+		ContainerFallbackSuppressed:         state.ContainerFallbackSuppressed,
+		ContainerFallbackAttemptCount:       state.ContainerFallbackAttemptCount,
+		LastContainerFallbackDecisionReason: state.LastContainerFallbackDecisionReason,
 	}
 	if !state.LastFailureAt.IsZero() {
 		lastFailureAt := state.LastFailureAt.UTC()
@@ -391,6 +408,14 @@ func runtimeSupervisorServiceStateSnapshot(state runtimeSupervisorServiceState, 
 		lastHealthyAt := state.LastHealthyAt.UTC()
 		out.LastHealthyAt = &lastHealthyAt
 	}
+	if !state.ContainerFallbackBackoffUntil.IsZero() {
+		backoffUntil := state.ContainerFallbackBackoffUntil.UTC()
+		out.ContainerFallbackBackoffUntil = &backoffUntil
+	}
+	if !state.LastContainerFallbackDecisionAt.IsZero() {
+		lastDecisionAt := state.LastContainerFallbackDecisionAt.UTC()
+		out.LastContainerFallbackDecisionAt = &lastDecisionAt
+	}
 	if state.ConsecutiveFailures >= threshold && state.LastFailureReason != "" {
 		out.ContainerFallbackCandidate = true
 		out.ContainerFallbackReason = fmt.Sprintf("service probes failed %d/%d: %s", state.ConsecutiveFailures, threshold, state.LastFailureReason)
@@ -398,13 +423,39 @@ func runtimeSupervisorServiceStateSnapshot(state runtimeSupervisorServiceState, 
 	return out
 }
 
-func runtimeSupervisorContainerFallbackPlan(state RuntimeSupervisorServiceState, options RuntimeSupervisorOptions) *RuntimeSupervisorContainerFallbackPlan {
+func (s *RuntimeSupervisor) updateContainerFallbackPlan(target RuntimeSupervisorTarget, state RuntimeSupervisorServiceState, now time.Time) (*RuntimeSupervisorContainerFallbackPlan, RuntimeSupervisorServiceState) {
+	if s == nil || !state.ContainerFallbackCandidate {
+		return nil, state
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	now = now.UTC()
+	key := runtimeSupervisorServiceKey(target)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.serviceStates == nil {
+		s.serviceStates = make(map[string]runtimeSupervisorServiceState)
+	}
+	stored := s.serviceStates[key]
+	stored.ContainerFallbackAttemptCount++
+	state = runtimeSupervisorServiceStateSnapshot(stored, s.options.ServiceFailureThreshold)
+	plan := runtimeSupervisorContainerFallbackPlan(state, s.options, now)
+	decisionReason := runtimeSupervisorContainerFallbackDecisionReason(plan)
+	stored.LastContainerFallbackDecisionAt = now
+	stored.LastContainerFallbackDecisionReason = decisionReason
+	s.serviceStates[key] = stored
+	state = runtimeSupervisorServiceStateSnapshot(stored, s.options.ServiceFailureThreshold)
+	return plan, state
+}
+
+func runtimeSupervisorContainerFallbackPlan(state RuntimeSupervisorServiceState, options RuntimeSupervisorOptions, now time.Time) *RuntimeSupervisorContainerFallbackPlan {
 	if !state.ContainerFallbackCandidate {
 		return nil
 	}
 	executorConfigured := runtimeSupervisorContainerExecutorConfigured()
-	suppressed := false
-	backoffActive := false
+	suppressed := state.ContainerFallbackSuppressed
+	backoffActive := runtimeSupervisorContainerFallbackBackoffActive(state.ContainerFallbackBackoffUntil, now)
 	safetyGateOK := strings.TrimSpace(state.ContainerFallbackReason) != ""
 	decision := evaluateRuntimeSupervisorContainerFallbackDecision(runtimeSupervisorContainerFallbackDecisionInput{
 		Candidate:          state.ContainerFallbackCandidate,
@@ -428,6 +479,26 @@ func runtimeSupervisorContainerFallbackPlan(state RuntimeSupervisorServiceState,
 		EligibleReason:     decision.EligibleReason,
 		Reason:             state.ContainerFallbackReason,
 	}
+}
+
+func runtimeSupervisorContainerFallbackBackoffActive(backoffUntil *time.Time, now time.Time) bool {
+	if backoffUntil == nil || backoffUntil.IsZero() {
+		return false
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	return backoffUntil.UTC().After(now.UTC())
+}
+
+func runtimeSupervisorContainerFallbackDecisionReason(plan *RuntimeSupervisorContainerFallbackPlan) string {
+	if plan == nil {
+		return ""
+	}
+	if strings.TrimSpace(plan.BlockedReason) != "" {
+		return strings.TrimSpace(plan.BlockedReason)
+	}
+	return strings.TrimSpace(plan.EligibleReason)
 }
 
 func evaluateRuntimeSupervisorContainerFallbackDecision(input runtimeSupervisorContainerFallbackDecisionInput) runtimeSupervisorContainerFallbackDecisionResult {
@@ -458,7 +529,7 @@ func evaluateRuntimeSupervisorContainerFallbackDecision(input runtimeSupervisorC
 	return runtimeSupervisorContainerFallbackDecisionResult{
 		Decision:       runtimeSupervisorContainerFallbackDecisionEligible,
 		Executable:     true,
-		EligibleReason: "container fallback eligible",
+		EligibleReason: "container-fallback-eligible",
 	}
 }
 

--- a/internal/service/runtime_supervisor_test.go
+++ b/internal/service/runtime_supervisor_test.go
@@ -210,6 +210,9 @@ func TestRuntimeSupervisorMarksContainerFallbackCandidateAfterServiceFailures(t 
 	if second.ServiceState.ContainerFallbackReason == "" || second.ServiceState.LastFailureReason == "" || second.ServiceState.LastFailureAt == nil {
 		t.Fatalf("expected fallback reason and failure metadata, got %+v", second.ServiceState)
 	}
+	if second.ServiceState.ContainerFallbackAttemptCount != 1 || second.ServiceState.LastContainerFallbackDecisionAt == nil || second.ServiceState.LastContainerFallbackDecisionReason != "container-restart-disabled" {
+		t.Fatalf("expected first fallback decision audit, got %+v", second.ServiceState)
+	}
 	if second.ContainerFallbackPlan == nil {
 		t.Fatalf("expected fallback plan for candidate, got %+v", second)
 	}
@@ -235,6 +238,11 @@ func TestRuntimeSupervisorMarksContainerFallbackCandidateAfterServiceFailures(t 
 		t.Fatalf("expected no control action for service fallback candidate, got %#v", requested)
 	}
 
+	third := supervisor.Collect(context.Background()).Targets[0]
+	if third.ServiceState.ContainerFallbackAttemptCount != 2 || third.ServiceState.LastContainerFallbackDecisionReason != "container-restart-disabled" {
+		t.Fatalf("expected fallback decision audit to advance while candidate remains active, got %+v", third.ServiceState)
+	}
+
 	healthy = true
 	recovered := supervisor.Collect(context.Background()).Targets[0]
 	if recovered.ServiceState.ConsecutiveFailures != 0 || recovered.ServiceState.ContainerFallbackCandidate {
@@ -245,6 +253,9 @@ func TestRuntimeSupervisorMarksContainerFallbackCandidateAfterServiceFailures(t 
 	}
 	if recovered.ServiceState.LastHealthyAt == nil {
 		t.Fatalf("expected healthy probe to record last healthy time, got %+v", recovered.ServiceState)
+	}
+	if recovered.ServiceState.ContainerFallbackAttemptCount != 0 || recovered.ServiceState.LastContainerFallbackDecisionAt != nil || recovered.ServiceState.LastContainerFallbackDecisionReason != "" {
+		t.Fatalf("expected healthy probe to clear fallback decision audit, got %+v", recovered.ServiceState)
 	}
 }
 
@@ -283,6 +294,9 @@ func TestRuntimeSupervisorContainerFallbackOptInStillRequiresExecutor(t *testing
 	if target.ContainerFallbackPlan.Decision != runtimeSupervisorContainerFallbackDecisionBlocked {
 		t.Fatalf("expected opt-in plan to report blocked decision, got %+v", target.ContainerFallbackPlan)
 	}
+	if target.ServiceState.ContainerFallbackAttemptCount != 1 || target.ServiceState.LastContainerFallbackDecisionReason != "container-executor-not-configured" {
+		t.Fatalf("expected opt-in plan to audit executor blocker, got %+v", target.ServiceState)
+	}
 	if !target.ContainerFallbackPlan.Enabled || target.ContainerFallbackPlan.ExecutorConfigured {
 		t.Fatalf("expected opt-in readiness to show enabled/no executor, got %+v", target.ContainerFallbackPlan)
 	}
@@ -301,6 +315,7 @@ func TestRuntimeSupervisorContainerFallbackDecisionContract(t *testing.T) {
 		wantDecision    string
 		wantExecutable  bool
 		wantBlocked     string
+		wantEligible    string
 		wantEligibleSet bool
 	}{
 		{
@@ -356,6 +371,8 @@ func TestRuntimeSupervisorContainerFallbackDecisionContract(t *testing.T) {
 			input:           base,
 			wantDecision:    runtimeSupervisorContainerFallbackDecisionEligible,
 			wantExecutable:  true,
+			wantBlocked:     "",
+			wantEligible:    "container-fallback-eligible",
 			wantEligibleSet: true,
 		},
 	}
@@ -368,10 +385,28 @@ func TestRuntimeSupervisorContainerFallbackDecisionContract(t *testing.T) {
 			if tt.wantEligibleSet && got.EligibleReason == "" {
 				t.Fatalf("expected eligible reason, got %+v", got)
 			}
+			if tt.wantEligible != "" && got.EligibleReason != tt.wantEligible {
+				t.Fatalf("unexpected eligible reason: got %+v want %s", got, tt.wantEligible)
+			}
 			if !tt.wantEligibleSet && got.EligibleReason != "" {
 				t.Fatalf("did not expect eligible reason, got %+v", got)
 			}
 		})
+	}
+}
+
+func TestRuntimeSupervisorContainerFallbackBackoffActive(t *testing.T) {
+	now := time.Date(2026, 4, 29, 8, 55, 0, 0, time.UTC)
+	future := now.Add(time.Minute)
+	if !runtimeSupervisorContainerFallbackBackoffActive(&future, now) {
+		t.Fatal("expected future backoff to be active")
+	}
+	past := now.Add(-time.Minute)
+	if runtimeSupervisorContainerFallbackBackoffActive(&past, now) {
+		t.Fatal("expected past backoff to be inactive")
+	}
+	if runtimeSupervisorContainerFallbackBackoffActive(nil, now) {
+		t.Fatal("expected missing backoff to be inactive")
 	}
 }
 

--- a/web/console/src/pages/SupervisorStage.tsx
+++ b/web/console/src/pages/SupervisorStage.tsx
@@ -354,9 +354,11 @@ export function SupervisorStage() {
                         const runtimeErrors = target.status?.runtimes.filter(runtimeNeedsAttention).length ?? 0;
                         const fallbackPlan = target.containerFallbackPlan;
                         const fallbackDecision = fallbackPlan?.decision || (fallbackPlan?.executable ? 'eligible' : 'blocked');
+                        const fallbackAttemptCount = target.serviceState.containerFallbackAttemptCount ?? 0;
                         const fallbackDetail =
                           fallbackPlan?.blockedReason ||
                           fallbackPlan?.eligibleReason ||
+                          target.serviceState.lastContainerFallbackDecisionReason ||
                           fallbackPlan?.reason ||
                           target.serviceState.containerFallbackReason;
                         return (
@@ -407,6 +409,17 @@ export function SupervisorStage() {
                                     <Badge variant={fallbackPlan.executorConfigured ? 'success' : 'neutral'}>
                                       {fallbackPlan.executorConfigured ? 'executor ready' : 'no executor'}
                                     </Badge>
+                                  )}
+                                  {fallbackAttemptCount > 0 && (
+                                    <Badge variant="neutral">
+                                      attempts {fallbackAttemptCount}
+                                    </Badge>
+                                  )}
+                                  {target.serviceState.containerFallbackSuppressed && (
+                                    <Badge variant="destructive">suppressed</Badge>
+                                  )}
+                                  {fallbackPlan?.backoffActive && (
+                                    <Badge variant="secondary">backoff</Badge>
                                   )}
                                 </div>
                                 {fallbackDetail && (

--- a/web/console/src/types/domain.ts
+++ b/web/console/src/types/domain.ts
@@ -407,6 +407,11 @@ export type RuntimeSupervisorServiceState = {
   lastHealthyAt?: string;
   containerFallbackCandidate: boolean;
   containerFallbackReason?: string;
+  containerFallbackSuppressed?: boolean;
+  containerFallbackBackoffUntil?: string;
+  containerFallbackAttemptCount?: number;
+  lastContainerFallbackDecisionAt?: string;
+  lastContainerFallbackDecisionReason?: string;
 };
 
 export type RuntimeSupervisorContainerFallbackPlan = {


### PR DESCRIPTION
## 目的
继续推进 #270 的容器兜底 dry-run 阶段，并接上 #332 / #333 review comment 里的下一步建议：先暴露 suppression / backoff / audit 状态，仍不接 Docker executor。

本 PR 为 `GET /api/v1/supervisor/status` 的 target `serviceState` 增加：

- `containerFallbackSuppressed`
- `containerFallbackBackoffUntil`
- `containerFallbackAttemptCount`
- `lastContainerFallbackDecisionAt`
- `lastContainerFallbackDecisionReason`

其中 `containerFallbackAttemptCount` 表示当前连续失败 episode 内进入容器兜底 dry-run 决策层的次数，健康恢复后清零；它不是 Docker restart 执行次数。本 PR 还把 #333 review 里提到的 eligible reason 统一为 kebab-case：`container-fallback-eligible`。

当前仍不配置 executor、不调用 Docker、不挂载 docker.sock、不执行容器 restart；默认计划保持 `decision=blocked` / `executable=false`。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [x] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值无变化。
- [x] 不存在直接调用 `mainnet` 凭证或路由地址的硬编码。
- [x] 不涉及 DB migration。
- [x] 不修改部署、Docker socket、GitHub Actions 或 executor 权限边界。
- [x] 不新增 runtime/container 控制请求；container fallback 仍为 dry-run status/plan。

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

本地验证：
- `go test ./internal/service ./cmd/bktrader-ctl`
- `npx shadcn@latest docs badge`
- `cd web/console && ./node_modules/.bin/tsc --noEmit src/pages/SupervisorStage.tsx --jsx react-jsx --esModuleInterop --target esnext --module esnext --moduleResolution Bundler --allowSyntheticDefaultImports`
- `cd web/console && npm run build`
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
- `go build ./cmd/bktrader-ctl`
- `git diff --check`

验证备注：`npm ci` 已成功；当前本机 Node `v20.6.1` 会对依赖 `validate-npm-package-name` 的 engine `^20.17.0 || >=22.9.0` 打 warning，另有既有的 5 个 moderate audit 提示。本 PR 未改依赖。
