### PR TITLE
Fix live trailing watermark refresh price

### DIFF
--- a/internal/service/live_recovery.go
+++ b/internal/service/live_recovery.go
@@ -187,7 +187,7 @@ func (p *Platform) refreshLiveSessionPositionContext(session domain.LiveSession,
 		}
 		return persistSnapshot(updated)
 	}
-	marketPrice := firstPositive(parseFloatValue(positionSnapshot["markPrice"]), parseFloatValue(mapValue(signalBarState["current"])["close"]))
+	marketPrice := resolveLivePositionContextMarketPrice(positionSnapshot, signalBarState, state)
 	livePositionState := evaluateLivePositionState(parameters, positionSnapshot, signalBarState, marketPrice, state)
 	if len(livePositionState) == 0 {
 		applyLivePositionReconcileGateState(state, reconcileGate)
@@ -289,6 +289,43 @@ func (p *Platform) refreshLiveSessionPositionContext(session domain.LiveSession,
 		return domain.LiveSession{}, updateErr
 	}
 	return persistSnapshot(updated)
+}
+
+func resolveLivePositionContextMarketPrice(positionSnapshot map[string]any, signalBarState map[string]any, sessionState map[string]any) float64 {
+	symbol := NormalizeSymbol(firstNonEmpty(
+		stringValue(positionSnapshot["symbol"]),
+		stringValue(sessionState["symbol"]),
+		stringValue(sessionState["lastSymbol"]),
+	))
+	sourceStates := cloneMetadata(mapValue(sessionState["lastStrategyEvaluationSourceStates"]))
+	if len(sourceStates) > 0 {
+		sourceStates = filterSourceStatesBySymbol(sourceStates, symbol)
+		if sourcePrice, _ := pickDecisionMarketPrice(map[string]any{"symbol": symbol}, sourceStates, livePositionExitSide(positionSnapshot)); sourcePrice > 0 {
+			return sourcePrice
+		}
+	}
+
+	decisionMetadata := mapValue(mapValue(sessionState["lastStrategyDecision"])["metadata"])
+	if decisionPrice := parseFloatValue(decisionMetadata["marketPrice"]); decisionPrice > 0 {
+		return decisionPrice
+	}
+
+	currentClose := parseFloatValue(mapValue(signalBarState["current"])["close"])
+	if currentClose > 0 {
+		return currentClose
+	}
+	return firstPositive(parseFloatValue(positionSnapshot["markPrice"]), parseFloatValue(positionSnapshot["entryPrice"]))
+}
+
+func livePositionExitSide(positionSnapshot map[string]any) string {
+	switch strings.ToUpper(strings.TrimSpace(stringValue(positionSnapshot["side"]))) {
+	case "LONG", "BUY":
+		return "SELL"
+	case "SHORT", "SELL":
+		return "BUY"
+	default:
+		return ""
+	}
 }
 
 func isProtectionOrder(order map[string]any) bool {

--- a/internal/service/live_recovery.go
+++ b/internal/service/live_recovery.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"math"
+	"sort"
 	"strings"
 	"time"
 
@@ -294,10 +295,11 @@ func (p *Platform) refreshLiveSessionPositionContext(session domain.LiveSession,
 }
 
 type livePositionContextPrice struct {
-	Price  float64
-	Source string
-	At     time.Time
-	Age    time.Duration
+	Price    float64
+	Source   string
+	StateKey string
+	At       time.Time
+	Age      time.Duration
 }
 
 func (p *Platform) resolveLivePositionContextMarketPrice(positionSnapshot map[string]any, signalBarState map[string]any, sessionState map[string]any, eventTime time.Time) livePositionContextPrice {
@@ -314,14 +316,8 @@ func (p *Platform) resolveLivePositionContextMarketPrice(positionSnapshot map[st
 	if len(sourceStates) > 0 {
 		sourceStates = filterSourceStatesBySymbol(sourceStates, symbol)
 		sourceStates = p.freshLivePositionContextSourceStates(sourceStates, sessionState, eventTime)
-		if sourcePrice, sourceName := pickDecisionMarketPrice(map[string]any{"symbol": symbol}, sourceStates, livePositionExitSide(positionSnapshot)); sourcePrice > 0 {
-			sourceAt := livePositionContextSourceEventAt(sourceStates, sourceName)
-			return livePositionContextPrice{
-				Price:  sourcePrice,
-				Source: sourceName,
-				At:     sourceAt,
-				Age:    nonNegativeDuration(eventTime.Sub(sourceAt)),
-			}
+		if sourcePrice, ok := pickLivePositionContextSourcePrice(sourceStates, livePositionExitSide(positionSnapshot), eventTime); ok {
+			return sourcePrice
 		}
 	}
 
@@ -335,18 +331,8 @@ func (p *Platform) resolveLivePositionContextMarketPrice(positionSnapshot map[st
 		}
 	}
 
-	currentClose := parseFloatValue(mapValue(signalBarState["current"])["close"])
-	if currentClose > 0 {
-		signalAt := parseOptionalRFC3339(firstNonEmpty(
-			stringValue(signalBarState["lastEventAt"]),
-			stringValue(mapValue(signalBarState["current"])["lastEventAt"]),
-		))
-		return livePositionContextPrice{
-			Price:  currentClose,
-			Source: "signal_bar.current.close",
-			At:     signalAt,
-			Age:    nonNegativeDuration(eventTime.Sub(signalAt)),
-		}
+	if signalPrice, ok := p.freshLivePositionSignalBarClose(signalBarState, sessionState, eventTime); ok {
+		return signalPrice
 	}
 	if markPrice := parseFloatValue(positionSnapshot["markPrice"]); markPrice > 0 {
 		return livePositionContextPrice{
@@ -357,6 +343,91 @@ func (p *Platform) resolveLivePositionContextMarketPrice(positionSnapshot map[st
 	return livePositionContextPrice{
 		Price:  parseFloatValue(positionSnapshot["entryPrice"]),
 		Source: "position.entryPrice",
+	}
+}
+
+func pickLivePositionContextSourcePrice(sourceStates map[string]any, side string, eventTime time.Time) (livePositionContextPrice, bool) {
+	type candidate struct {
+		price    float64
+		source   string
+		stateKey string
+		at       time.Time
+	}
+	var bestBid candidate
+	var bestAsk candidate
+	var trade candidate
+	keys := make([]string, 0, len(sourceStates))
+	for key := range sourceStates {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		entry := mapValue(sourceStates[key])
+		if entry == nil {
+			continue
+		}
+		sourceAt := parseOptionalRFC3339(stringValue(entry["lastEventAt"]))
+		summary := mapValue(entry["summary"])
+		switch strings.ToLower(strings.TrimSpace(stringValue(entry["streamType"]))) {
+		case "order_book":
+			if bestBid.price <= 0 {
+				bestBid = candidate{
+					price:    parseFloatValue(summary["bestBid"]),
+					source:   "order_book.bestBid",
+					stateKey: key,
+					at:       sourceAt,
+				}
+			}
+			if bestAsk.price <= 0 {
+				bestAsk = candidate{
+					price:    parseFloatValue(summary["bestAsk"]),
+					source:   "order_book.bestAsk",
+					stateKey: key,
+					at:       sourceAt,
+				}
+			}
+		case "trade_tick":
+			if trade.price <= 0 {
+				trade = candidate{
+					price:    parseFloatValue(summary["price"]),
+					source:   "trade_tick.price",
+					stateKey: key,
+					at:       sourceAt,
+				}
+			}
+		}
+	}
+	pick := func(value candidate) (livePositionContextPrice, bool) {
+		if value.price <= 0 {
+			return livePositionContextPrice{}, false
+		}
+		return livePositionContextPrice{
+			Price:    value.price,
+			Source:   value.source,
+			StateKey: value.stateKey,
+			At:       value.at,
+			Age:      nonNegativeDuration(eventTime.Sub(value.at)),
+		}, true
+	}
+	switch strings.ToUpper(strings.TrimSpace(side)) {
+	case "BUY":
+		if price, ok := pick(bestAsk); ok {
+			return price, true
+		}
+		if price, ok := pick(trade); ok {
+			return price, true
+		}
+		return pick(bestBid)
+	case "SELL", "SHORT":
+		if price, ok := pick(bestBid); ok {
+			return price, true
+		}
+		if price, ok := pick(trade); ok {
+			return price, true
+		}
+		return pick(bestAsk)
+	default:
+		return pick(trade)
 	}
 }
 
@@ -462,32 +533,63 @@ func (p *Platform) livePositionContextDecisionFreshnessWindow(source string) tim
 	}
 }
 
-func livePositionContextSourceEventAt(sourceStates map[string]any, source string) time.Time {
-	streamType := livePositionContextPriceSourceStreamType(source)
-	if streamType == "" {
-		return time.Time{}
+func (p *Platform) freshLivePositionSignalBarClose(signalBarState map[string]any, sessionState map[string]any, eventTime time.Time) (livePositionContextPrice, bool) {
+	current := mapValue(signalBarState["current"])
+	currentClose := parseFloatValue(current["close"])
+	if currentClose <= 0 {
+		return livePositionContextPrice{}, false
 	}
-	for _, raw := range sourceStates {
-		entry := mapValue(raw)
-		if entry == nil {
-			continue
-		}
-		if strings.EqualFold(strings.TrimSpace(stringValue(entry["streamType"])), streamType) {
-			return parseOptionalRFC3339(stringValue(entry["lastEventAt"]))
-		}
+	signalAt := livePositionSignalBarEventAt(signalBarState)
+	if signalAt.IsZero() {
+		return livePositionContextPrice{}, false
 	}
-	return time.Time{}
+	maxAge := p.livePositionContextSignalBarFreshnessWindow(signalBarState, sessionState)
+	if maxAge <= 0 {
+		return livePositionContextPrice{}, false
+	}
+	age := nonNegativeDuration(eventTime.Sub(signalAt))
+	if eventTime.Sub(signalAt) > maxAge {
+		return livePositionContextPrice{}, false
+	}
+	return livePositionContextPrice{
+		Price:  currentClose,
+		Source: "signal_bar.current.close",
+		At:     signalAt,
+		Age:    age,
+	}, true
 }
 
-func livePositionContextPriceSourceStreamType(source string) string {
-	switch {
-	case strings.HasPrefix(source, "order_book."):
-		return "order_book"
-	case strings.HasPrefix(source, "trade_tick."), source == "trigger.price":
-		return "trade_tick"
-	default:
-		return ""
+func (p *Platform) livePositionContextSignalBarFreshnessWindow(signalBarState map[string]any, sessionState map[string]any) time.Duration {
+	current := mapValue(signalBarState["current"])
+	options := map[string]any{}
+	if timeframe := firstNonEmpty(
+		stringValue(signalBarState["timeframe"]),
+		stringValue(current["timeframe"]),
+	); timeframe != "" {
+		options["timeframe"] = timeframe
 	}
+	return p.signalSourceFreshnessWindowWithOverride(domain.AccountSignalBinding{
+		SourceKey:  firstNonEmpty(stringValue(signalBarState["sourceKey"]), "binance-kline"),
+		Role:       firstNonEmpty(stringValue(signalBarState["role"]), "signal"),
+		StreamType: "signal_bar",
+		Symbol:     firstNonEmpty(stringValue(signalBarState["symbol"]), stringValue(current["symbol"])),
+		Options:    options,
+	}, sessionState)
+}
+
+func livePositionSignalBarEventAt(signalBarState map[string]any) time.Time {
+	current := mapValue(signalBarState["current"])
+	for _, raw := range []any{
+		signalBarState["lastEventAt"],
+		current["lastEventAt"],
+		current["updatedAt"],
+		signalBarState["updatedAt"],
+	} {
+		if parsed := parseOptionalRFC3339(stringValue(raw)); !parsed.IsZero() {
+			return parsed
+		}
+	}
+	return resolveBreakoutSignalTime(current["barStart"], time.Time{})
 }
 
 func applyLivePositionContextPriceMetadata(livePositionState map[string]any, price livePositionContextPrice) {
@@ -497,6 +599,9 @@ func applyLivePositionContextPriceMetadata(livePositionState map[string]any, pri
 	livePositionState["positionContextPrice"] = price.Price
 	if price.Source != "" {
 		livePositionState["positionContextPriceSource"] = price.Source
+	}
+	if price.StateKey != "" {
+		livePositionState["positionContextPriceStateKey"] = price.StateKey
 	}
 	if !price.At.IsZero() {
 		livePositionState["positionContextPriceAt"] = price.At.UTC().Format(time.RFC3339Nano)

--- a/internal/service/live_recovery.go
+++ b/internal/service/live_recovery.go
@@ -187,7 +187,8 @@ func (p *Platform) refreshLiveSessionPositionContext(session domain.LiveSession,
 		}
 		return persistSnapshot(updated)
 	}
-	marketPrice := resolveLivePositionContextMarketPrice(positionSnapshot, signalBarState, state)
+	priceContext := p.resolveLivePositionContextMarketPrice(positionSnapshot, signalBarState, state, eventTime)
+	marketPrice := priceContext.Price
 	livePositionState := evaluateLivePositionState(parameters, positionSnapshot, signalBarState, marketPrice, state)
 	if len(livePositionState) == 0 {
 		applyLivePositionReconcileGateState(state, reconcileGate)
@@ -199,6 +200,7 @@ func (p *Platform) refreshLiveSessionPositionContext(session domain.LiveSession,
 		}
 		return persistSnapshot(updated)
 	}
+	applyLivePositionContextPriceMetadata(livePositionState, priceContext)
 	state["livePositionState"] = livePositionState
 	state["lastLivePositionState"] = livePositionState
 	state["lastPositionContextRefreshAt"] = eventTime.UTC().Format(time.RFC3339)
@@ -291,7 +293,18 @@ func (p *Platform) refreshLiveSessionPositionContext(session domain.LiveSession,
 	return persistSnapshot(updated)
 }
 
-func resolveLivePositionContextMarketPrice(positionSnapshot map[string]any, signalBarState map[string]any, sessionState map[string]any) float64 {
+type livePositionContextPrice struct {
+	Price  float64
+	Source string
+	At     time.Time
+	Age    time.Duration
+}
+
+func (p *Platform) resolveLivePositionContextMarketPrice(positionSnapshot map[string]any, signalBarState map[string]any, sessionState map[string]any, eventTime time.Time) livePositionContextPrice {
+	if eventTime.IsZero() {
+		eventTime = time.Now().UTC()
+	}
+	eventTime = eventTime.UTC()
 	symbol := NormalizeSymbol(firstNonEmpty(
 		stringValue(positionSnapshot["symbol"]),
 		stringValue(sessionState["symbol"]),
@@ -300,21 +313,51 @@ func resolveLivePositionContextMarketPrice(positionSnapshot map[string]any, sign
 	sourceStates := cloneMetadata(mapValue(sessionState["lastStrategyEvaluationSourceStates"]))
 	if len(sourceStates) > 0 {
 		sourceStates = filterSourceStatesBySymbol(sourceStates, symbol)
-		if sourcePrice, _ := pickDecisionMarketPrice(map[string]any{"symbol": symbol}, sourceStates, livePositionExitSide(positionSnapshot)); sourcePrice > 0 {
-			return sourcePrice
+		sourceStates = p.freshLivePositionContextSourceStates(sourceStates, sessionState, eventTime)
+		if sourcePrice, sourceName := pickDecisionMarketPrice(map[string]any{"symbol": symbol}, sourceStates, livePositionExitSide(positionSnapshot)); sourcePrice > 0 {
+			sourceAt := livePositionContextSourceEventAt(sourceStates, sourceName)
+			return livePositionContextPrice{
+				Price:  sourcePrice,
+				Source: sourceName,
+				At:     sourceAt,
+				Age:    nonNegativeDuration(eventTime.Sub(sourceAt)),
+			}
 		}
 	}
 
 	decisionMetadata := mapValue(mapValue(sessionState["lastStrategyDecision"])["metadata"])
-	if decisionPrice := parseFloatValue(decisionMetadata["marketPrice"]); decisionPrice > 0 {
-		return decisionPrice
+	if decisionPrice, decisionSource, decisionAt, ok := p.freshLivePositionDecisionMarketPrice(decisionMetadata, sessionState, eventTime); ok {
+		return livePositionContextPrice{
+			Price:  decisionPrice,
+			Source: decisionSource,
+			At:     decisionAt,
+			Age:    nonNegativeDuration(eventTime.Sub(decisionAt)),
+		}
 	}
 
 	currentClose := parseFloatValue(mapValue(signalBarState["current"])["close"])
 	if currentClose > 0 {
-		return currentClose
+		signalAt := parseOptionalRFC3339(firstNonEmpty(
+			stringValue(signalBarState["lastEventAt"]),
+			stringValue(mapValue(signalBarState["current"])["lastEventAt"]),
+		))
+		return livePositionContextPrice{
+			Price:  currentClose,
+			Source: "signal_bar.current.close",
+			At:     signalAt,
+			Age:    nonNegativeDuration(eventTime.Sub(signalAt)),
+		}
 	}
-	return firstPositive(parseFloatValue(positionSnapshot["markPrice"]), parseFloatValue(positionSnapshot["entryPrice"]))
+	if markPrice := parseFloatValue(positionSnapshot["markPrice"]); markPrice > 0 {
+		return livePositionContextPrice{
+			Price:  markPrice,
+			Source: "position.markPrice",
+		}
+	}
+	return livePositionContextPrice{
+		Price:  parseFloatValue(positionSnapshot["entryPrice"]),
+		Source: "position.entryPrice",
+	}
 }
 
 func livePositionExitSide(positionSnapshot map[string]any) string {
@@ -326,6 +369,146 @@ func livePositionExitSide(positionSnapshot map[string]any) string {
 	default:
 		return ""
 	}
+}
+
+func (p *Platform) freshLivePositionContextSourceStates(sourceStates map[string]any, sessionState map[string]any, eventTime time.Time) map[string]any {
+	if len(sourceStates) == 0 {
+		return map[string]any{}
+	}
+	if sourceGate := mapValue(sessionState["lastStrategyEvaluationSourceGate"]); len(sourceGate) > 0 && !boolValue(sourceGate["ready"]) {
+		return map[string]any{}
+	}
+	fresh := make(map[string]any, len(sourceStates))
+	for key, raw := range sourceStates {
+		entry := cloneMetadata(mapValue(raw))
+		if len(entry) == 0 {
+			continue
+		}
+		if _, _, ok := p.livePositionContextSourceFreshness(entry, sessionState, eventTime); !ok {
+			continue
+		}
+		fresh[key] = entry
+	}
+	return fresh
+}
+
+func (p *Platform) livePositionContextSourceFreshness(entry map[string]any, sessionState map[string]any, eventTime time.Time) (time.Time, time.Duration, bool) {
+	lastEventAt := parseOptionalRFC3339(stringValue(entry["lastEventAt"]))
+	if lastEventAt.IsZero() {
+		return time.Time{}, 0, false
+	}
+	maxAge := p.livePositionContextSourceFreshnessWindow(entry, sessionState)
+	if maxAge <= 0 {
+		return lastEventAt, 0, false
+	}
+	age := nonNegativeDuration(eventTime.Sub(lastEventAt))
+	if eventTime.Sub(lastEventAt) > maxAge {
+		return lastEventAt, age, false
+	}
+	return lastEventAt, age, true
+}
+
+func (p *Platform) livePositionContextSourceFreshnessWindow(entry map[string]any, sessionState map[string]any) time.Duration {
+	options := cloneMetadata(mapValue(entry["options"]))
+	if timeframe := firstNonEmpty(
+		stringValue(entry["timeframe"]),
+		stringValue(mapValue(entry["summary"])["timeframe"]),
+	); timeframe != "" {
+		options["timeframe"] = timeframe
+	}
+	return p.signalSourceFreshnessWindowWithOverride(domain.AccountSignalBinding{
+		SourceKey:  stringValue(entry["sourceKey"]),
+		Role:       stringValue(entry["role"]),
+		StreamType: stringValue(entry["streamType"]),
+		Symbol:     stringValue(entry["symbol"]),
+		Options:    options,
+	}, sessionState)
+}
+
+func (p *Platform) freshLivePositionDecisionMarketPrice(decisionMetadata map[string]any, sessionState map[string]any, eventTime time.Time) (float64, string, time.Time, bool) {
+	price := parseFloatValue(decisionMetadata["marketPrice"])
+	if price <= 0 {
+		return 0, "", time.Time{}, false
+	}
+	source := strings.TrimSpace(stringValue(decisionMetadata["marketSource"]))
+	if source == "" {
+		return 0, "", time.Time{}, false
+	}
+	decisionAt := parseOptionalRFC3339(firstNonEmpty(
+		stringValue(decisionMetadata["eventTime"]),
+		stringValue(sessionState["lastStrategyEvaluationAt"]),
+	))
+	if decisionAt.IsZero() {
+		return 0, "", time.Time{}, false
+	}
+	maxAge := p.livePositionContextDecisionFreshnessWindow(source)
+	if maxAge <= 0 {
+		return 0, "", time.Time{}, false
+	}
+	if eventTime.Sub(decisionAt) > maxAge {
+		return 0, "", time.Time{}, false
+	}
+	return price, source, decisionAt, true
+}
+
+func (p *Platform) livePositionContextDecisionFreshnessWindow(source string) time.Duration {
+	switch {
+	case strings.HasPrefix(source, "order_book."):
+		return time.Duration(p.runtimePolicy.OrderBookFreshnessSeconds) * time.Second
+	case strings.HasPrefix(source, "trade_tick."), source == "trigger.price":
+		return time.Duration(p.runtimePolicy.TradeTickFreshnessSeconds) * time.Second
+	default:
+		return 0
+	}
+}
+
+func livePositionContextSourceEventAt(sourceStates map[string]any, source string) time.Time {
+	streamType := livePositionContextPriceSourceStreamType(source)
+	if streamType == "" {
+		return time.Time{}
+	}
+	for _, raw := range sourceStates {
+		entry := mapValue(raw)
+		if entry == nil {
+			continue
+		}
+		if strings.EqualFold(strings.TrimSpace(stringValue(entry["streamType"])), streamType) {
+			return parseOptionalRFC3339(stringValue(entry["lastEventAt"]))
+		}
+	}
+	return time.Time{}
+}
+
+func livePositionContextPriceSourceStreamType(source string) string {
+	switch {
+	case strings.HasPrefix(source, "order_book."):
+		return "order_book"
+	case strings.HasPrefix(source, "trade_tick."), source == "trigger.price":
+		return "trade_tick"
+	default:
+		return ""
+	}
+}
+
+func applyLivePositionContextPriceMetadata(livePositionState map[string]any, price livePositionContextPrice) {
+	if livePositionState == nil || price.Price <= 0 {
+		return
+	}
+	livePositionState["positionContextPrice"] = price.Price
+	if price.Source != "" {
+		livePositionState["positionContextPriceSource"] = price.Source
+	}
+	if !price.At.IsZero() {
+		livePositionState["positionContextPriceAt"] = price.At.UTC().Format(time.RFC3339Nano)
+		livePositionState["positionContextPriceAgeMs"] = int64(price.Age / time.Millisecond)
+	}
+}
+
+func nonNegativeDuration(value time.Duration) time.Duration {
+	if value < 0 {
+		return 0
+	}
+	return value
 }
 
 func isProtectionOrder(order map[string]any) bool {

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -7634,6 +7634,120 @@ func testLiveRecoverySignalBarStates(symbol string, closePrice float64) map[stri
 	}
 }
 
+func TestRefreshLiveSessionPositionContextPrefersRuntimePriceOverDivergentMarkPrice(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	account, err := platform.store.GetAccount("live-main")
+	if err != nil {
+		t.Fatalf("get account failed: %v", err)
+	}
+	account.Metadata = cloneMetadata(account.Metadata)
+	account.Metadata["liveSyncSnapshot"] = map[string]any{
+		"openOrders": []map[string]any{},
+	}
+	if _, err := platform.store.UpdateAccount(account); err != nil {
+		t.Fatalf("update account failed: %v", err)
+	}
+	if _, err := platform.store.SavePosition(domain.Position{
+		AccountID:         "live-main",
+		StrategyVersionID: "strategy-version-bk-btc-30m-enhanced-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "LONG",
+		Quantity:          0.0064,
+		EntryPrice:        77092.0,
+		MarkPrice:         77230.00949936,
+	}); err != nil {
+		t.Fatalf("save position failed: %v", err)
+	}
+
+	session, err := platform.CreateLiveSession("", "live-main", "strategy-bk-btc-30m-enhanced", map[string]any{
+		"symbol":          "BTCUSDT",
+		"signalTimeframe": "30m",
+	})
+	if err != nil {
+		t.Fatalf("create live session failed: %v", err)
+	}
+	state := cloneMetadata(session.State)
+	state["lastStrategyEvaluationSignalBarStates"] = map[string]any{
+		signalBindingMatchKey("binance-kline", "signal", "BTCUSDT", map[string]any{"timeframe": "30m"}): map[string]any{
+			"symbol":        "BTCUSDT",
+			"timeframe":     "30m",
+			"sma5":          77047.84,
+			"ma20":          76853.78,
+			"atr14":         160.5857142857172,
+			"atrPercentile": 34.39153439153439,
+			"current": map[string]any{
+				"barStart": time.Date(2026, 4, 29, 9, 30, 0, 0, time.UTC).Format(time.RFC3339),
+				"close":    77150.0,
+				"high":     77160.0,
+				"low":      77085.6,
+				"open":     77085.7,
+			},
+			"prevBar1": map[string]any{
+				"high": 77093.8,
+				"low":  76920.9,
+			},
+			"prevBar2": map[string]any{
+				"high": 77106.6,
+				"low":  76951.7,
+			},
+		},
+	}
+	state["lastStrategyEvaluationSourceStates"] = map[string]any{
+		signalBindingMatchKey("binance-order-book", "feature", "BTCUSDT"): map[string]any{
+			"sourceKey":  "binance-order-book",
+			"role":       "feature",
+			"symbol":     "BTCUSDT",
+			"streamType": "order_book",
+			"summary": map[string]any{
+				"bestBid":    77091.0,
+				"bestAsk":    77092.0,
+				"bestBidQty": 1.0,
+				"bestAskQty": 1.0,
+			},
+		},
+		signalBindingMatchKey("binance-trade-tick", "trigger", "BTCUSDT"): map[string]any{
+			"sourceKey":  "binance-trade-tick",
+			"role":       "trigger",
+			"symbol":     "BTCUSDT",
+			"streamType": "trade_tick",
+			"summary": map[string]any{
+				"price": 77091.0,
+			},
+		},
+	}
+	session, err = platform.store.UpdateLiveSessionState(session.ID, state)
+	if err != nil {
+		t.Fatalf("update live session state failed: %v", err)
+	}
+
+	updated, err := platform.refreshLiveSessionPositionContext(session, time.Date(2026, 4, 29, 9, 35, 35, 0, time.UTC), "test-refresh")
+	if err != nil {
+		t.Fatalf("refresh live session position context failed: %v", err)
+	}
+	liveState := mapValue(updated.State["livePositionState"])
+	if len(liveState) == 0 {
+		t.Fatal("expected live position state to be rebuilt")
+	}
+	if got := parseFloatValue(liveState["hwm"]); got != 77092.0 {
+		t.Fatalf("expected HWM to stay at entry using runtime bestBid instead of signal close or markPrice, got %v", got)
+	}
+	if got := parseFloatValue(liveState["lwm"]); got != 77091.0 {
+		t.Fatalf("expected LWM to follow runtime bestBid, got %v", got)
+	}
+	if got := parseFloatValue(liveState["markPrice"]); got != 0 {
+		t.Fatalf("expected live risk state not to persist divergent markPrice, got %v", got)
+	}
+	if boolValue(liveState["trailingStopActive"]) {
+		t.Fatalf("expected trailing stop to stay inactive without a real price advance, got %+v", liveState)
+	}
+	if got := stringValue(liveState["stopLossSource"]); got != "initial-stop" {
+		t.Fatalf("expected initial-stop source, got %s", got)
+	}
+	if got := parseFloatValue(liveState["stopLoss"]); got < 77043.8 || got > 77043.9 {
+		t.Fatalf("expected initial ATR stop around 77043.82, got %v", got)
+	}
+}
+
 func TestRefreshLiveSessionPositionContextRebuildsLivePositionState(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
 	account, err := platform.store.GetAccount("live-main")

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -7697,8 +7697,9 @@ func TestRefreshLiveSessionPositionContextPrefersRuntimePriceOverDivergentMarkPr
 	state["lastStrategyEvaluationSourceGate"] = map[string]any{
 		"ready": true,
 	}
+	orderBookStateKey := signalBindingMatchKey("binance-order-book", "feature", "BTCUSDT")
 	state["lastStrategyEvaluationSourceStates"] = map[string]any{
-		signalBindingMatchKey("binance-order-book", "feature", "BTCUSDT"): map[string]any{
+		orderBookStateKey: map[string]any{
 			"sourceKey":   "binance-order-book",
 			"role":        "feature",
 			"symbol":      "BTCUSDT",
@@ -7744,6 +7745,9 @@ func TestRefreshLiveSessionPositionContextPrefersRuntimePriceOverDivergentMarkPr
 	if got := stringValue(liveState["positionContextPriceSource"]); got != "order_book.bestBid" {
 		t.Fatalf("expected runtime order book price source, got %s", got)
 	}
+	if got := stringValue(liveState["positionContextPriceStateKey"]); got != orderBookStateKey {
+		t.Fatalf("expected runtime order book state key %s, got %s", orderBookStateKey, got)
+	}
 	if got := stringValue(liveState["positionContextPriceAt"]); got != sourceAt.Format(time.RFC3339Nano) {
 		t.Fatalf("expected runtime source timestamp %s, got %s", sourceAt.Format(time.RFC3339Nano), got)
 	}
@@ -7773,8 +7777,11 @@ func TestResolveLivePositionContextMarketPriceRequiresFreshRuntimePrice(t *testi
 		"markPrice":  77230.00949936,
 	}
 	signalBarState := map[string]any{
+		"symbol":    "BTCUSDT",
+		"timeframe": "30m",
 		"current": map[string]any{
-			"close": 77150.0,
+			"close":     77150.0,
+			"updatedAt": eventTime.Add(-time.Second).Format(time.RFC3339Nano),
 		},
 	}
 	bookState := func(lastEventAt string) map[string]any {
@@ -7830,6 +7837,19 @@ func TestResolveLivePositionContextMarketPriceRequiresFreshRuntimePrice(t *testi
 		t.Fatalf("expected stale runtime and decision prices to fall back to signal close, got %+v", staleRuntimeAndDecision)
 	}
 
+	staleSignalBarState := map[string]any{
+		"symbol":    "BTCUSDT",
+		"timeframe": "30m",
+		"current": map[string]any{
+			"close":     77150.0,
+			"updatedAt": eventTime.Add(-time.Minute).Format(time.RFC3339Nano),
+		},
+	}
+	staleRuntimeDecisionAndSignal := platform.resolveLivePositionContextMarketPrice(positionSnapshot, staleSignalBarState, stale, eventTime)
+	if staleRuntimeDecisionAndSignal.Price != 77230.00949936 || staleRuntimeDecisionAndSignal.Source != "position.markPrice" {
+		t.Fatalf("expected stale runtime, decision, and signal prices to fall back to markPrice, got %+v", staleRuntimeDecisionAndSignal)
+	}
+
 	freshDecisionState := bookState("")
 	freshDecisionState["lastStrategyEvaluationAt"] = eventTime.Add(-time.Second).Format(time.RFC3339Nano)
 	freshDecisionState["lastStrategyDecision"] = map[string]any{
@@ -7856,8 +7876,11 @@ func TestResolveLivePositionContextMarketPriceUsesShortExitAsk(t *testing.T) {
 		"markPrice":  76950.0,
 	}
 	signalBarState := map[string]any{
+		"symbol":    "BTCUSDT",
+		"timeframe": "30m",
 		"current": map[string]any{
-			"close": 77050.0,
+			"close":     77050.0,
+			"updatedAt": eventTime.Add(-time.Second).Format(time.RFC3339Nano),
 		},
 	}
 	sessionState := map[string]any{
@@ -7882,6 +7905,38 @@ func TestResolveLivePositionContextMarketPriceUsesShortExitAsk(t *testing.T) {
 	price := platform.resolveLivePositionContextMarketPrice(positionSnapshot, signalBarState, sessionState, eventTime)
 	if price.Price != 77092.0 || price.Source != "order_book.bestAsk" {
 		t.Fatalf("expected SHORT refresh to use exit bestAsk, got %+v", price)
+	}
+}
+
+func TestPickLivePositionContextSourcePriceReturnsSelectedStateKeyTimestamp(t *testing.T) {
+	eventTime := time.Date(2026, 4, 29, 9, 35, 35, 0, time.UTC)
+	selectedAt := eventTime.Add(-2 * time.Second)
+	otherAt := eventTime.Add(-1 * time.Second)
+	sourceStates := map[string]any{
+		"book-a": map[string]any{
+			"streamType":  "order_book",
+			"lastEventAt": selectedAt.Format(time.RFC3339Nano),
+			"summary": map[string]any{
+				"bestBid": 77091.0,
+				"bestAsk": 77092.0,
+			},
+		},
+		"book-z": map[string]any{
+			"streamType":  "order_book",
+			"lastEventAt": otherAt.Format(time.RFC3339Nano),
+			"summary": map[string]any{
+				"bestBid": 77080.0,
+				"bestAsk": 77081.0,
+			},
+		},
+	}
+
+	price, ok := pickLivePositionContextSourcePrice(sourceStates, "SELL", eventTime)
+	if !ok {
+		t.Fatal("expected source price")
+	}
+	if price.Price != 77091.0 || price.Source != "order_book.bestBid" || price.StateKey != "book-a" || !price.At.Equal(selectedAt) {
+		t.Fatalf("expected selected book-a timestamp to be returned, got %+v", price)
 	}
 }
 
@@ -8805,9 +8860,10 @@ func TestRefreshLiveSessionPositionContextRebuildsVirtualWatermarksFromVirtualPo
 			"timeframe": "1d",
 			"atr14":     900.0,
 			"current": map[string]any{
-				"close": 51000.0,
-				"high":  51100.0,
-				"low":   50500.0,
+				"close":     51000.0,
+				"high":      51100.0,
+				"low":       50500.0,
+				"updatedAt": time.Date(2026, 4, 10, 10, 0, 0, 0, time.UTC).Format(time.RFC3339Nano),
 			},
 			"prevBar1": map[string]any{
 				"high": 50800.0,

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -7636,6 +7636,8 @@ func testLiveRecoverySignalBarStates(symbol string, closePrice float64) map[stri
 
 func TestRefreshLiveSessionPositionContextPrefersRuntimePriceOverDivergentMarkPrice(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
+	refreshAt := time.Date(2026, 4, 29, 9, 35, 35, 0, time.UTC)
+	sourceAt := refreshAt.Add(-1 * time.Second)
 	account, err := platform.store.GetAccount("live-main")
 	if err != nil {
 		t.Fatalf("get account failed: %v", err)
@@ -7692,12 +7694,16 @@ func TestRefreshLiveSessionPositionContextPrefersRuntimePriceOverDivergentMarkPr
 			},
 		},
 	}
+	state["lastStrategyEvaluationSourceGate"] = map[string]any{
+		"ready": true,
+	}
 	state["lastStrategyEvaluationSourceStates"] = map[string]any{
 		signalBindingMatchKey("binance-order-book", "feature", "BTCUSDT"): map[string]any{
-			"sourceKey":  "binance-order-book",
-			"role":       "feature",
-			"symbol":     "BTCUSDT",
-			"streamType": "order_book",
+			"sourceKey":   "binance-order-book",
+			"role":        "feature",
+			"symbol":      "BTCUSDT",
+			"streamType":  "order_book",
+			"lastEventAt": sourceAt.Format(time.RFC3339Nano),
 			"summary": map[string]any{
 				"bestBid":    77091.0,
 				"bestAsk":    77092.0,
@@ -7706,10 +7712,11 @@ func TestRefreshLiveSessionPositionContextPrefersRuntimePriceOverDivergentMarkPr
 			},
 		},
 		signalBindingMatchKey("binance-trade-tick", "trigger", "BTCUSDT"): map[string]any{
-			"sourceKey":  "binance-trade-tick",
-			"role":       "trigger",
-			"symbol":     "BTCUSDT",
-			"streamType": "trade_tick",
+			"sourceKey":   "binance-trade-tick",
+			"role":        "trigger",
+			"symbol":      "BTCUSDT",
+			"streamType":  "trade_tick",
+			"lastEventAt": sourceAt.Format(time.RFC3339Nano),
 			"summary": map[string]any{
 				"price": 77091.0,
 			},
@@ -7720,7 +7727,7 @@ func TestRefreshLiveSessionPositionContextPrefersRuntimePriceOverDivergentMarkPr
 		t.Fatalf("update live session state failed: %v", err)
 	}
 
-	updated, err := platform.refreshLiveSessionPositionContext(session, time.Date(2026, 4, 29, 9, 35, 35, 0, time.UTC), "test-refresh")
+	updated, err := platform.refreshLiveSessionPositionContext(session, refreshAt, "test-refresh")
 	if err != nil {
 		t.Fatalf("refresh live session position context failed: %v", err)
 	}
@@ -7734,6 +7741,12 @@ func TestRefreshLiveSessionPositionContextPrefersRuntimePriceOverDivergentMarkPr
 	if got := parseFloatValue(liveState["lwm"]); got != 77091.0 {
 		t.Fatalf("expected LWM to follow runtime bestBid, got %v", got)
 	}
+	if got := stringValue(liveState["positionContextPriceSource"]); got != "order_book.bestBid" {
+		t.Fatalf("expected runtime order book price source, got %s", got)
+	}
+	if got := stringValue(liveState["positionContextPriceAt"]); got != sourceAt.Format(time.RFC3339Nano) {
+		t.Fatalf("expected runtime source timestamp %s, got %s", sourceAt.Format(time.RFC3339Nano), got)
+	}
 	if got := parseFloatValue(liveState["markPrice"]); got != 0 {
 		t.Fatalf("expected live risk state not to persist divergent markPrice, got %v", got)
 	}
@@ -7745,6 +7758,130 @@ func TestRefreshLiveSessionPositionContextPrefersRuntimePriceOverDivergentMarkPr
 	}
 	if got := parseFloatValue(liveState["stopLoss"]); got < 77043.8 || got > 77043.9 {
 		t.Fatalf("expected initial ATR stop around 77043.82, got %v", got)
+	}
+}
+
+func TestResolveLivePositionContextMarketPriceRequiresFreshRuntimePrice(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	eventTime := time.Date(2026, 4, 29, 9, 35, 35, 0, time.UTC)
+	positionSnapshot := map[string]any{
+		"found":      true,
+		"symbol":     "BTCUSDT",
+		"side":       "LONG",
+		"quantity":   0.0064,
+		"entryPrice": 77092.0,
+		"markPrice":  77230.00949936,
+	}
+	signalBarState := map[string]any{
+		"current": map[string]any{
+			"close": 77150.0,
+		},
+	}
+	bookState := func(lastEventAt string) map[string]any {
+		return map[string]any{
+			"lastStrategyEvaluationSourceGate": map[string]any{
+				"ready": true,
+			},
+			"lastStrategyEvaluationSourceStates": map[string]any{
+				signalBindingMatchKey("binance-order-book", "feature", "BTCUSDT"): map[string]any{
+					"sourceKey":   "binance-order-book",
+					"role":        "feature",
+					"symbol":      "BTCUSDT",
+					"streamType":  "order_book",
+					"lastEventAt": lastEventAt,
+					"summary": map[string]any{
+						"bestBid": 77091.0,
+						"bestAsk": 77092.0,
+					},
+				},
+			},
+		}
+	}
+
+	fresh := platform.resolveLivePositionContextMarketPrice(positionSnapshot, signalBarState, bookState(eventTime.Add(-time.Second).Format(time.RFC3339Nano)), eventTime)
+	if fresh.Price != 77091.0 || fresh.Source != "order_book.bestBid" {
+		t.Fatalf("expected fresh order book bestBid, got %+v", fresh)
+	}
+
+	gateBlockedState := bookState(eventTime.Add(-time.Second).Format(time.RFC3339Nano))
+	gateBlockedState["lastStrategyEvaluationSourceGate"] = map[string]any{
+		"ready": false,
+	}
+	gateBlocked := platform.resolveLivePositionContextMarketPrice(positionSnapshot, signalBarState, gateBlockedState, eventTime)
+	if gateBlocked.Price != 77150.0 || gateBlocked.Source != "signal_bar.current.close" {
+		t.Fatalf("expected blocked source gate to fall back to signal close, got %+v", gateBlocked)
+	}
+
+	missingTimestamp := platform.resolveLivePositionContextMarketPrice(positionSnapshot, signalBarState, bookState(""), eventTime)
+	if missingTimestamp.Price != 77150.0 || missingTimestamp.Source != "signal_bar.current.close" {
+		t.Fatalf("expected missing timestamp to fall back to signal close, got %+v", missingTimestamp)
+	}
+
+	stale := bookState(eventTime.Add(-time.Minute).Format(time.RFC3339Nano))
+	stale["lastStrategyEvaluationAt"] = eventTime.Add(-time.Minute).Format(time.RFC3339Nano)
+	stale["lastStrategyDecision"] = map[string]any{
+		"metadata": map[string]any{
+			"marketPrice":  77093.0,
+			"marketSource": "order_book.bestBid",
+		},
+	}
+	staleRuntimeAndDecision := platform.resolveLivePositionContextMarketPrice(positionSnapshot, signalBarState, stale, eventTime)
+	if staleRuntimeAndDecision.Price != 77150.0 || staleRuntimeAndDecision.Source != "signal_bar.current.close" {
+		t.Fatalf("expected stale runtime and decision prices to fall back to signal close, got %+v", staleRuntimeAndDecision)
+	}
+
+	freshDecisionState := bookState("")
+	freshDecisionState["lastStrategyEvaluationAt"] = eventTime.Add(-time.Second).Format(time.RFC3339Nano)
+	freshDecisionState["lastStrategyDecision"] = map[string]any{
+		"metadata": map[string]any{
+			"marketPrice":  77093.0,
+			"marketSource": "order_book.bestBid",
+		},
+	}
+	freshDecision := platform.resolveLivePositionContextMarketPrice(positionSnapshot, signalBarState, freshDecisionState, eventTime)
+	if freshDecision.Price != 77093.0 || freshDecision.Source != "order_book.bestBid" {
+		t.Fatalf("expected fresh decision market price after missing source timestamp, got %+v", freshDecision)
+	}
+}
+
+func TestResolveLivePositionContextMarketPriceUsesShortExitAsk(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	eventTime := time.Date(2026, 4, 29, 9, 35, 35, 0, time.UTC)
+	positionSnapshot := map[string]any{
+		"found":      true,
+		"symbol":     "BTCUSDT",
+		"side":       "SHORT",
+		"quantity":   0.0064,
+		"entryPrice": 77092.0,
+		"markPrice":  76950.0,
+	}
+	signalBarState := map[string]any{
+		"current": map[string]any{
+			"close": 77050.0,
+		},
+	}
+	sessionState := map[string]any{
+		"lastStrategyEvaluationSourceGate": map[string]any{
+			"ready": true,
+		},
+		"lastStrategyEvaluationSourceStates": map[string]any{
+			signalBindingMatchKey("binance-order-book", "feature", "BTCUSDT"): map[string]any{
+				"sourceKey":   "binance-order-book",
+				"role":        "feature",
+				"symbol":      "BTCUSDT",
+				"streamType":  "order_book",
+				"lastEventAt": eventTime.Add(-time.Second).Format(time.RFC3339Nano),
+				"summary": map[string]any{
+					"bestBid": 77091.0,
+					"bestAsk": 77092.0,
+				},
+			},
+		},
+	}
+
+	price := platform.resolveLivePositionContextMarketPrice(positionSnapshot, signalBarState, sessionState, eventTime)
+	if price.Price != 77092.0 || price.Source != "order_book.bestAsk" {
+		t.Fatalf("expected SHORT refresh to use exit bestAsk, got %+v", price)
 	}
 }
 


### PR DESCRIPTION
## 目的
修复 live position context refresh 在账户同步/恢复路径里优先使用 REST 仓位 `markPrice` 推进 HWM/LWM 的问题。

生产排查里 entry fill 附近盘口仍在 77091/77092，但账户快照 `markPrice` 曾到 77230，refresh 把 LONG HWM 推高后生成 trailing stop，随后用真实盘口 bestBid 判断 SL，导致开仓后很快触发 reduce-only exit。这个 PR 改为优先使用 session 最近一次 runtime `sourceStates` 的盘口/成交价：LONG 仓位按退出方向使用 bestBid，SHORT 仓位使用 bestAsk；再兜底到上次 strategy decision 的 marketPrice、signal bar current close，最后才用 REST markPrice。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [x] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) — 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？— 无
- [x] DB migration 是否具备向下兼容幂等性？— 不涉及 migration
- [x] 配置字段有没有无意被混改？— 无配置改动

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

验证已执行：
- `go test ./internal/service -run TestRefreshLiveSessionPositionContextPrefersRuntimePriceOverDivergentMarkPrice -count=1`
- `go test ./internal/service -count=1`
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
