### PR TITLE
[codex] Fix live SL reentry window consumption

### DIFF
--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -4086,6 +4086,8 @@ func liveSessionNonRegressiveFactKeys() []string {
 		"lastSLExitReentryConsumedOrderId",
 		"lastSLExitReentryConsumedAt",
 		"lastSLExitReentryConsumedReason",
+		"lastSLExitReentryConsumedEntryOrderId",
+		"lastSLExitReentryConsumedEntryStatus",
 	}
 }
 

--- a/internal/service/live_execution.go
+++ b/internal/service/live_execution.go
@@ -987,6 +987,7 @@ func (p *Platform) dispatchLiveSessionIntent(session domain.LiveSession) (domain
 	state["lastDispatchedOrderStatus"] = created.Status
 	state["lastExecutionDispatch"] = executionDispatchSummary(proposalMap, created, false)
 	updateExecutionEventStats(state, proposalMap, mapValue(state["lastExecutionDispatch"]))
+	maybeConsumeLiveSLReentryWindowForEntryOrder(state, proposalMap, created.ID, created.Status, dispatchedAt, "sl-reentry-dispatched")
 	if isTerminalOrderStatus(created.Status) {
 		state["lastSyncedOrderId"] = created.ID
 		state["lastSyncedOrderStatus"] = created.Status
@@ -1656,6 +1657,8 @@ func maybeIncrementLiveSessionReentryCount(state map[string]any, proposalMap map
 	}
 	if reasonTag == "zero-initial-reentry" {
 		clearLivePendingZeroInitialWindow(state, eventTime, "zero-initial-reentry-filled")
+	} else if reasonTag == "sl-reentry" {
+		maybeConsumeLiveSLReentryWindowForEntryOrder(state, proposalMap, orderID, status, eventTime, "sl-reentry-filled")
 	}
 	if orderID != "" && stringValue(state["lastCountedReentryOrderId"]) == orderID {
 		return
@@ -1673,6 +1676,33 @@ func maybeIncrementLiveSessionReentryCount(state map[string]any, proposalMap map
 	state["sessionReentryCount"] = reentryCount
 	if orderID != "" {
 		state["lastCountedReentryOrderId"] = orderID
+	}
+}
+
+func maybeConsumeLiveSLReentryWindowForEntryOrder(state map[string]any, proposalMap map[string]any, orderID, status string, eventTime time.Time, reason string) {
+	if state == nil || len(proposalMap) == 0 {
+		return
+	}
+	if strings.TrimSpace(stringValue(state["lastSLExitOrderId"])) == "" || liveSLReentryWindowConsumed(state) {
+		return
+	}
+	if !strings.EqualFold(strings.TrimSpace(stringValue(proposalMap["role"])), "entry") {
+		return
+	}
+	if normalizeStrategyReasonTag(stringValue(proposalMap["reason"])) != "sl-reentry" {
+		return
+	}
+	switch strings.ToUpper(strings.TrimSpace(status)) {
+	case "NEW", "ACCEPTED", "PARTIALLY_FILLED", "FILLED":
+	default:
+		return
+	}
+	consumeLiveSLReentryWindow(state, eventTime, reason)
+	if strings.TrimSpace(orderID) != "" {
+		state["lastSLExitReentryConsumedEntryOrderId"] = orderID
+	}
+	if strings.TrimSpace(status) != "" {
+		state["lastSLExitReentryConsumedEntryStatus"] = strings.ToUpper(strings.TrimSpace(status))
 	}
 }
 
@@ -1700,6 +1730,8 @@ func recordLiveSessionStopLossExitFill(state map[string]any, proposalMap map[str
 	delete(state, "lastSLExitReentryConsumedOrderId")
 	delete(state, "lastSLExitReentryConsumedAt")
 	delete(state, "lastSLExitReentryConsumedReason")
+	delete(state, "lastSLExitReentryConsumedEntryOrderId")
+	delete(state, "lastSLExitReentryConsumedEntryStatus")
 	if side := liveEntrySideAfterExitSide(stringValue(proposalMap["side"])); side != "" {
 		state["lastSLExitReentrySide"] = side
 	}

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -5005,6 +5005,62 @@ func TestMaybeIncrementLiveSessionReentryCountCountsZeroInitialWindowEntry(t *te
 	}
 }
 
+func TestMaybeConsumeLiveSLReentryWindowForEntryOrderConsumesOnDispatch(t *testing.T) {
+	eventTime := time.Date(2026, 4, 22, 3, 5, 10, 0, time.UTC)
+	state := map[string]any{
+		"lastSLExitOrderId":     "order-sl-1",
+		"lastSLExitReentrySide": "BUY",
+	}
+	proposal := map[string]any{
+		"role":   "entry",
+		"reason": "SL-Reentry",
+	}
+	maybeConsumeLiveSLReentryWindowForEntryOrder(state, proposal, "order-reentry-1", "NEW", eventTime, "sl-reentry-dispatched")
+	if got := stringValue(state["lastSLExitReentryConsumedOrderId"]); got != "order-sl-1" {
+		t.Fatalf("expected SL reentry dispatch to consume order-sl-1, got %q", got)
+	}
+	if got := stringValue(state["lastSLExitReentryConsumedEntryOrderId"]); got != "order-reentry-1" {
+		t.Fatalf("expected consumed entry order id order-reentry-1, got %q", got)
+	}
+	if got := stringValue(state["lastSLExitReentryConsumedEntryStatus"]); got != "NEW" {
+		t.Fatalf("expected consumed entry status NEW, got %q", got)
+	}
+	if got := stringValue(state["lastSLExitReentryConsumedReason"]); got != "sl-reentry-dispatched" {
+		t.Fatalf("expected sl-reentry-dispatched consume reason, got %q", got)
+	}
+	if got := stringValue(state["lastSLExitReentrySide"]); got != "" {
+		t.Fatalf("expected consumed SL reentry side to be cleared, got %q", got)
+	}
+}
+
+func TestMaybeConsumeLiveSLReentryWindowForEntryOrderSkipsNonSLReentry(t *testing.T) {
+	eventTime := time.Date(2026, 4, 22, 3, 5, 10, 0, time.UTC)
+	state := map[string]any{
+		"lastSLExitOrderId":     "order-sl-1",
+		"lastSLExitReentrySide": "BUY",
+	}
+	proposal := map[string]any{
+		"role":   "entry",
+		"reason": "Zero-Initial-Reentry",
+	}
+	maybeConsumeLiveSLReentryWindowForEntryOrder(state, proposal, "order-zero-1", "NEW", eventTime, "zero-initial-dispatched")
+	if got := stringValue(state["lastSLExitReentryConsumedOrderId"]); got != "" {
+		t.Fatalf("expected zero-initial entry not to consume SL reentry window, got %q", got)
+	}
+	if got := stringValue(state["lastSLExitReentrySide"]); got != "BUY" {
+		t.Fatalf("expected non-SL entry to leave SL reentry side armed, got %q", got)
+	}
+
+	proposal["reason"] = "SL-Reentry"
+	maybeConsumeLiveSLReentryWindowForEntryOrder(state, proposal, "order-reentry-1", "CANCELLED", eventTime, "sl-reentry-dispatched")
+	if got := stringValue(state["lastSLExitReentryConsumedOrderId"]); got != "" {
+		t.Fatalf("expected cancelled SL reentry order not to consume window, got %q", got)
+	}
+	if got := stringValue(state["lastSLExitReentrySide"]); got != "BUY" {
+		t.Fatalf("expected cancelled SL reentry order to leave side armed, got %q", got)
+	}
+}
+
 func TestMaybeIncrementLiveSessionReentryCountUsesPerBarIdentity(t *testing.T) {
 	eventTime := time.Date(2026, 4, 22, 3, 30, 10, 0, time.UTC)
 	state := map[string]any{

--- a/internal/service/live_zero_initial.go
+++ b/internal/service/live_zero_initial.go
@@ -178,6 +178,10 @@ func prepareLivePlanStepForSignalEvaluation(
 	}
 	appendTimelineEvent(updatedState, "strategy", eventTime, "zero-initial-window-armed", timelineMetadata)
 	updatedState, alignedEvent, alignedPrice, alignedSide, alignedRole, alignedReason, _ = liveZeroInitialWindowPlanStep(updatedState, parameters, signalBarStates, symbol, signalTimeframe, eventTime)
+	if livePendingZeroInitialWindowShouldYieldSLReentry(updatedState, signalBarStates, symbol, signalTimeframe, eventTime) {
+		clearLivePendingZeroInitialWindow(updatedState, eventTime, "sl-exit-reentry-priority")
+		return updatedState, alignedEvent, alignedPrice, alignedSide, alignedRole, "SL-Reentry"
+	}
 	return updatedState, alignedEvent, alignedPrice, alignedSide, alignedRole, alignedReason
 }
 
@@ -573,7 +577,6 @@ func liveSLReentryWindowPlanStep(
 	if price <= 0 {
 		return state, time.Time{}, 0, "", "", "", false
 	}
-	consumeLiveSLReentryWindow(state, eventTime, "consumed-on-derive")
 	return state, liveCurrentSignalBarStart(signalBarState, eventTime), price, side, "entry", "SL-Reentry", true
 }
 
@@ -591,11 +594,11 @@ func livePendingZeroInitialWindowShouldYieldSLReentry(
 	if parseFloatValue(sessionState["sessionReentryCount"]) <= 0 {
 		return false
 	}
-	lastSLExitAt := parseOptionalRFC3339(stringValue(sessionState["lastSLExitFilledAt"]))
-	if lastSLExitAt.IsZero() || lastSLExitAt.UTC().After(eventTime.UTC()) {
+	if liveSLReentryWindowConsumed(sessionState) {
 		return false
 	}
-	if armedAt := parseOptionalRFC3339(stringValue(pending["armedAt"])); !armedAt.IsZero() && lastSLExitAt.UTC().Before(armedAt.UTC()) {
+	lastSLExitAt := parseOptionalRFC3339(stringValue(sessionState["lastSLExitFilledAt"]))
+	if lastSLExitAt.IsZero() || lastSLExitAt.UTC().After(eventTime.UTC()) {
 		return false
 	}
 	if pendingSymbol := NormalizeSymbol(stringValue(pending["symbol"])); pendingSymbol != "" && pendingSymbol != NormalizeSymbol(symbol) {

--- a/internal/service/live_zero_initial_test.go
+++ b/internal/service/live_zero_initial_test.go
@@ -142,6 +142,80 @@ func TestPrepareLivePlanStepForSignalEvaluationUsesSignalBarBoundaryForMillisBar
 	}
 }
 
+func TestPrepareLivePlanStepForSignalEvaluationConvertsNewZeroWindowAfterSameBarSLExit(t *testing.T) {
+	barStart := time.Date(2026, 4, 28, 11, 0, 0, 0, time.UTC)
+	eventTime := barStart.Add(22*time.Minute + 22*time.Second)
+	barKey := "BTCUSDT|30m|" + barStart.Format(time.RFC3339)
+	signalStates := map[string]any{
+		signalBindingMatchKey("binance-kline", "signal", "BTCUSDT", map[string]any{"timeframe": "30m"}): map[string]any{
+			"symbol":    "BTCUSDT",
+			"timeframe": "30m",
+			"sma5":      76561.0,
+			"atr14":     230.0,
+			"current": map[string]any{
+				"barStart": strconv.FormatInt(barStart.UnixMilli(), 10),
+				"close":    76440.0,
+				"high":     76483.7,
+				"low":      76440.0,
+			},
+			"prevBar1": map[string]any{
+				"high": 76564.2,
+				"low":  76470.2,
+			},
+			"prevBar2": map[string]any{
+				"high": 76565.7,
+				"low":  76444.6,
+			},
+		},
+	}
+	state := map[string]any{
+		"sessionReentryCount":         1.0,
+		"lastSLExitFilledAt":          barStart.Add(19*time.Minute + 49*time.Second).Format(time.RFC3339),
+		"lastSLExitOrderId":           "order-sl",
+		"lastSLExitSignalBarStateKey": barKey,
+	}
+
+	updated, _, _, gotSide, gotRole, gotReason := prepareLivePlanStepForSignalEvaluation(
+		state,
+		map[string]any{
+			"dir2_zero_initial": true,
+			"zero_initial_mode": "reentry_window",
+			"short_reentry_atr": 0.0,
+		},
+		signalStates,
+		"BTCUSDT",
+		"30m",
+		map[string]any{},
+		eventTime,
+		76444.5,
+		"trigger.price",
+		barStart.Add(-2*time.Hour),
+		76444.6,
+		"SELL",
+		"entry",
+		"Initial",
+	)
+	if gotRole != "entry" || gotReason != "SL-Reentry" || gotSide != "SELL" {
+		t.Fatalf("expected same-bar SL exit to convert newly armed zero window to SL-Reentry, got side=%s role=%s reason=%s", gotSide, gotRole, gotReason)
+	}
+	if pending := mapValue(updated[livePendingZeroInitialWindowStateKey]); len(pending) != 0 {
+		t.Fatalf("expected converted zero window to be consumed, got %+v", pending)
+	}
+	timeline := metadataList(updated["timeline"])
+	if len(timeline) != 2 {
+		t.Fatalf("expected arm and consume timeline events, got %+v", timeline)
+	}
+	if got := stringValue(timeline[0]["title"]); got != "zero-initial-window-armed" {
+		t.Fatalf("expected first timeline event to arm zero window, got %s", got)
+	}
+	if got := stringValue(timeline[1]["title"]); got != "zero-initial-window-consumed" {
+		t.Fatalf("expected second timeline event to consume zero window, got %s", got)
+	}
+	if got := stringValue(mapValue(timeline[1]["metadata"])["reason"]); got != "sl-exit-reentry-priority" {
+		t.Fatalf("expected sl-exit-reentry-priority consume reason, got %s", got)
+	}
+}
+
 func TestRefreshLiveZeroInitialWindowStateExpiresLegacyEventTimeWindowAtBarBoundary(t *testing.T) {
 	barStart := time.Date(2026, 4, 28, 11, 0, 0, 0, time.UTC)
 	eventTime := barStart.Add(time.Hour + 7*time.Second)
@@ -476,18 +550,15 @@ func TestPrepareLivePlanStepForSignalEvaluationUsesRecordedSLReentryWindow(t *te
 	if pending := mapValue(updated[livePendingZeroInitialWindowStateKey]); len(pending) != 0 {
 		t.Fatalf("expected no pending zero window for recorded SL reentry, got %+v", pending)
 	}
-	if got := stringValue(updated["lastSLExitReentryConsumedOrderId"]); got != "order-sl" {
-		t.Fatalf("expected recorded SL reentry to consume order-sl, got %q", got)
+	if got := stringValue(updated["lastSLExitReentryConsumedOrderId"]); got != "" {
+		t.Fatalf("expected recorded SL reentry not to consume order-sl before dispatch, got %q", got)
 	}
-	if got := stringValue(updated["lastSLExitReentryConsumedReason"]); got != "consumed-on-derive" {
-		t.Fatalf("expected consumed-on-derive reason, got %q", got)
-	}
-	if got := stringValue(updated["lastSLExitReentrySide"]); got != "" {
-		t.Fatalf("expected derived SL reentry to clear armed side, got %q", got)
+	if got := stringValue(updated["lastSLExitReentrySide"]); got != "SELL" {
+		t.Fatalf("expected derived SL reentry to keep armed side until dispatch, got %q", got)
 	}
 }
 
-func TestPrepareLivePlanStepForSignalEvaluationConsumesRecordedSLReentryWindowOnce(t *testing.T) {
+func TestPrepareLivePlanStepForSignalEvaluationKeepsRecordedSLReentryWindowUntilDispatch(t *testing.T) {
 	slBarStart := time.Date(2026, 4, 28, 11, 30, 0, 0, time.UTC)
 	currentBarStart := slBarStart.Add(30 * time.Minute)
 	eventTime, state, signalStates := recordedSLReentryWindowFixture(slBarStart, currentBarStart)
@@ -515,8 +586,8 @@ func TestPrepareLivePlanStepForSignalEvaluationConsumesRecordedSLReentryWindowOn
 	if gotRole != "entry" || gotReason != "SL-Reentry" {
 		t.Fatalf("expected first evaluation to derive SL-Reentry, got role=%s reason=%s", gotRole, gotReason)
 	}
-	if got := stringValue(updated["lastSLExitReentryConsumedOrderId"]); got != "order-sl" {
-		t.Fatalf("expected consumed order id order-sl after first derive, got %q", got)
+	if got := stringValue(updated["lastSLExitReentryConsumedOrderId"]); got != "" {
+		t.Fatalf("expected first derive not to consume order-sl before dispatch, got %q", got)
 	}
 
 	second, _, _, _, gotRole, gotReason := prepareLivePlanStepForSignalEvaluation(
@@ -539,14 +610,14 @@ func TestPrepareLivePlanStepForSignalEvaluationConsumesRecordedSLReentryWindowOn
 		"entry",
 		"Initial",
 	)
-	if gotReason == "SL-Reentry" {
-		t.Fatalf("expected consumed SL fill not to derive SL-Reentry again, got role=%s reason=%s", gotRole, gotReason)
+	if gotRole != "entry" || gotReason != "SL-Reentry" {
+		t.Fatalf("expected unconsumed SL fill to keep deriving SL-Reentry, got role=%s reason=%s", gotRole, gotReason)
 	}
-	if got := stringValue(second["lastSLExitReentryConsumedOrderId"]); got != "order-sl" {
-		t.Fatalf("expected consumed order id to remain order-sl, got %q", got)
+	if got := stringValue(second["lastSLExitReentryConsumedOrderId"]); got != "" {
+		t.Fatalf("expected second derive not to consume order-sl before dispatch, got %q", got)
 	}
-	if got := stringValue(second["lastSLExitReentrySide"]); got != "" {
-		t.Fatalf("expected consumed SL reentry side to stay cleared, got %q", got)
+	if got := stringValue(second["lastSLExitReentrySide"]); got != "SELL" {
+		t.Fatalf("expected unconsumed SL reentry side to remain armed, got %q", got)
 	}
 }
 


### PR DESCRIPTION
## 目的
修复生产中观察到的两类 live reentry 语义问题：

- SL 后的同一根 signal bar 内，后续再入场不应继续标识为 `Zero-Initial-Reentry`。
- `SL-Reentry` 窗口不应在 plan derive 阶段被空耗；应等真实 reentry 订单进入执行链路后再消费。

本 PR 由 Codex 协助生成并已人工式逐行检查差异。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [x] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
- [x] `dispatchMode` 默认值无变化
- [x] 无直接调用 `mainnet` 凭证或路由地址的硬编码
- [x] 无 DB migration
- [x] 配置字段没有无意混改

## 变更摘要
- `liveSLReentryWindowPlanStep` 不再在 derive 时调用 `consumeLiveSLReentryWindow`。
- 新增 `maybeConsumeLiveSLReentryWindowForEntryOrder`，在 SL reentry 订单 `NEW/ACCEPTED/PARTIALLY_FILLED/FILLED` 后消费 SL reentry 窗口，并记录实际消费 entry order。
- 同一 signal bar 内有 SL exit 时，新 arm 出来的 zero-initial window 会让位给 `SL-Reentry`，避免止损后继续显示为初始 reentry。
- 新 SL exit 会清掉旧的 SL reentry consumption entry metadata。

## 验证方式与测试证据
- [x] `go test ./internal/service -run 'TestPrepareLivePlanStepForSignalEvaluation(UsesRecordedSLReentryWindow|KeepsRecordedSLReentryWindowUntilDispatch|ExpiresRecordedSLReentryWindowAfterNextBar|ConvertsNewZeroWindowAfterSameBarSLExit)|TestMaybeConsumeLiveSLReentryWindowForEntryOrder|TestMaybeIncrementLiveSessionReentryCount|TestRecordLiveSessionStopLossExitFill' -count=1`
- [x] `go test ./internal/service -count=1`
- [x] `go test ./...`
- [x] `go build ./cmd/platform-api && go build ./cmd/db-migrate`
- [x] `bash scripts/check_high_risk_defaults.sh && bash scripts/check_env_safety.sh`
- [x] pre-push harness checks passed
