### PR TITLE
[codex] Fix monitor runtime price sync

### DIFF
--- a/internal/service/dashboard_broker.go
+++ b/internal/service/dashboard_broker.go
@@ -145,6 +145,9 @@ func (b *DashboardBroker) StartPolling(ctx context.Context, cfg config.Config) {
 	startTicker(cfg.DashboardLiveSessionsPollMs, "live-sessions", func() (any, error) {
 		return b.platform.ListLiveSessionsSummary()
 	})
+	startTicker(cfg.DashboardLiveSessionsPollMs, "signal-runtime-sessions", func() (any, error) {
+		return b.platform.ListSignalRuntimeSessionsSummary(), nil
+	})
 	startTicker(cfg.DashboardPositionsPollMs, "positions", func() (any, error) {
 		return b.platform.ListPositions()
 	})
@@ -177,6 +180,9 @@ func (b *DashboardBroker) PushInitialSnapshot(id int) {
 	// Push latest state to new subscriber
 	// This ensures they don't have to wait for the next change
 	b.pushLatestIfAvailable("live-sessions", func() (any, error) { return b.platform.ListLiveSessionsSummary() }, ch)
+	b.pushLatestIfAvailable("signal-runtime-sessions", func() (any, error) {
+		return b.platform.ListSignalRuntimeSessionsSummary(), nil
+	}, ch)
 	b.pushLatestIfAvailable("positions", func() (any, error) { return b.platform.ListPositions() }, ch)
 	b.pushLatestIfAvailable("orders", func() (any, error) { return b.platform.ListOrdersWithLimit(50, 0) }, ch)
 	b.pushLatestIfAvailable("fills", func() (any, error) { return b.platform.ListFillsWithLimit(50, 0) }, ch)

--- a/internal/service/state_util.go
+++ b/internal/service/state_util.go
@@ -17,7 +17,17 @@ var sourceStateAllowedKeys = map[string]struct{}{
 	"symbol":      {},
 	"timeframe":   {},
 	"event":       {},
+	"price":       {},
+	"bestBid":     {},
+	"bestAsk":     {},
+	"summary":     {},
 	"lastEventAt": {},
+}
+
+var sourceStateSummaryAllowedKeys = map[string]struct{}{
+	"price":   {},
+	"bestBid": {},
+	"bestAsk": {},
 }
 
 var signalBarStateAllowedKeys = map[string]struct{}{
@@ -54,16 +64,16 @@ func stripHeavyState(state map[string]any) map[string]any {
 		case "breakoutHistory":
 			v = trimStateList(v, liveSessionSummaryBreakoutHistoryLimit)
 		case "sourceStates":
-			v = stripMapEntriesByWhitelist(v, sourceStateAllowedKeys)
+			v = stripMapEntriesByWhitelist(v, sourceStateAllowedKeys, true)
 		case "signalBarStates":
-			v = stripMapEntriesByWhitelist(v, signalBarStateAllowedKeys)
+			v = stripMapEntriesByWhitelist(v, signalBarStateAllowedKeys, false)
 		}
 		newState[k] = v
 	}
 	return newState
 }
 
-func stripMapEntriesByWhitelist(v any, whitelist map[string]struct{}) any {
+func stripMapEntriesByWhitelist(v any, whitelist map[string]struct{}, trimSourceSummary bool) any {
 	m, ok := v.(map[string]any)
 	if !ok {
 		return v
@@ -78,10 +88,27 @@ func stripMapEntriesByWhitelist(v any, whitelist map[string]struct{}) any {
 		newE := make(map[string]any, len(whitelist))
 		for ek, ev := range e {
 			if _, allowed := whitelist[ek]; allowed {
+				if ek == "summary" && trimSourceSummary {
+					ev = stripMapByWhitelist(ev, sourceStateSummaryAllowedKeys)
+				}
 				newE[ek] = ev
 			}
 		}
 		newM[k] = newE
+	}
+	return newM
+}
+
+func stripMapByWhitelist(v any, whitelist map[string]struct{}) any {
+	m, ok := v.(map[string]any)
+	if !ok {
+		return v
+	}
+	newM := make(map[string]any, len(whitelist))
+	for k, ev := range m {
+		if _, allowed := whitelist[k]; allowed {
+			newM[k] = ev
+		}
 	}
 	return newM
 }

--- a/internal/service/state_util_test.go
+++ b/internal/service/state_util_test.go
@@ -54,7 +54,24 @@ func TestStripHeavyState_Whitelist(t *testing.T) {
 				"streamType":  "trade_tick",
 				"lastEventAt": "2024-01-01T00:00:00Z",
 				"bars":        []any{1, 2, 3},
-				"summary":     map[string]any{"price": "100"},
+				"price":       "100",
+				"summary": map[string]any{
+					"price":   "100",
+					"bestBid": "99",
+					"bestAsk": "101",
+					"volume":  "1000",
+				},
+			},
+			"s2": map[string]any{
+				"streamType":  "order_book",
+				"lastEventAt": "2024-01-01T00:00:01Z",
+				"bestBid":     "99",
+				"bestAsk":     "101",
+				"summary": map[string]any{
+					"bestBid": "99",
+					"bestAsk": "101",
+					"bids":    []any{1, 2, 3},
+				},
 			},
 		},
 		"signalBarStates": map[string]any{
@@ -72,8 +89,23 @@ func TestStripHeavyState_Whitelist(t *testing.T) {
 	if s1["streamType"] != "trade_tick" || s1["lastEventAt"] != "2024-01-01T00:00:00Z" {
 		t.Error("missing allowed source metadata")
 	}
-	if s1["bars"] != nil || s1["summary"] != nil {
+	if s1["price"] != "100" {
+		t.Error("missing allowed trade price")
+	}
+	s1Summary := s1["summary"].(map[string]any)
+	if s1Summary["price"] != "100" || s1Summary["bestBid"] != "99" || s1Summary["bestAsk"] != "101" {
+		t.Error("missing allowed source summary market fields")
+	}
+	if s1["bars"] != nil || s1Summary["volume"] != nil {
 		t.Error("failed to strip disallowed source metadata")
+	}
+	s2 := output["sourceStates"].(map[string]any)["s2"].(map[string]any)
+	s2Summary := s2["summary"].(map[string]any)
+	if s2["bestBid"] != "99" || s2["bestAsk"] != "101" || s2Summary["bestBid"] != "99" || s2Summary["bestAsk"] != "101" {
+		t.Error("missing allowed order book fields")
+	}
+	if s2Summary["bids"] != nil {
+		t.Error("failed to strip heavy order book summary fields")
 	}
 
 	b1 := output["signalBarStates"].(map[string]any)["b1"].(map[string]any)

--- a/web/console/src/hooks/useDashboardRealtime.ts
+++ b/web/console/src/hooks/useDashboardRealtime.ts
@@ -4,7 +4,7 @@ import { useTradingStore } from '../store/useTradingStore';
 import { fetchJSON } from '../utils/api';
 import { writeStoredAuthSession } from '../utils/auth';
 import { 
-  LiveSession, Position, Order, Fill, PlatformAlert, 
+  LiveSession, Position, Order, Fill, PlatformAlert, SignalRuntimeSession,
   PlatformNotification, PlatformHealthSnapshot
 } from '../types/domain';
 import { useDashboardStream } from './useDashboardStream';
@@ -99,6 +99,7 @@ export function useDashboardRealtime() {
   const authSession = useUIStore(s => s.authSession);
 
   const setLiveSessions = useTradingStore(s => s.setLiveSessions);
+  const setSignalRuntimeSessions = useTradingStore(s => s.setSignalRuntimeSessions);
   const setPositions = useTradingStore(s => s.setPositions);
   const setOrders = useTradingStore(s => s.setOrders);
   const setFills = useTradingStore(s => s.setFills);
@@ -116,6 +117,7 @@ export function useDashboardRealtime() {
   async function loadRealtime() {
     const [
       liveSessionData,
+      signalRuntimeSessionData,
       positionsData,
       ordersData,
       fillsData,
@@ -124,6 +126,7 @@ export function useDashboardRealtime() {
       monitorHealthData,
     ] = await Promise.all([
       fetchJSON<LiveSession[]>("/api/v1/live/sessions?view=summary"),
+      fetchJSON<SignalRuntimeSession[]>("/api/v1/signal-runtime/sessions?view=summary"),
       fetchJSON<Position[]>("/api/v1/positions"),
       fetchJSON<Order[]>("/api/v1/orders?limit=50"),
       fetchJSON<Fill[]>("/api/v1/fills?limit=50"),
@@ -133,6 +136,7 @@ export function useDashboardRealtime() {
     ]);
 
     const normalizedLiveSessions = Array.isArray(liveSessionData) ? liveSessionData : [];
+    const normalizedSignalRuntimeSessions = Array.isArray(signalRuntimeSessionData) ? signalRuntimeSessionData : [];
     const normalizedPositions = Array.isArray(positionsData) ? positionsData : [];
     const normalizedOrders = Array.isArray(ordersData) ? ordersData : [];
     const normalizedFills = Array.isArray(fillsData) ? fillsData : [];
@@ -142,6 +146,7 @@ export function useDashboardRealtime() {
     const mergedLiveSessions = mergeLiveSessionSnapshot(useTradingStore.getState().liveSessions, normalizedLiveSessions);
     notifyLiveSessionControlTransitions(liveSessionControlRef.current, mergedLiveSessions, setNotification);
     setLiveSessions(mergedLiveSessions);
+    setSignalRuntimeSessions(normalizedSignalRuntimeSessions);
     setPositions(normalizedPositions);
     setOrders(normalizedOrders);
     setFills(normalizedFills);

--- a/web/console/src/hooks/useDashboardStream.ts
+++ b/web/console/src/hooks/useDashboardStream.ts
@@ -10,6 +10,7 @@ export function useDashboardStream(enabled: boolean) {
   const authSession = useUIStore(s => s.authSession);
 
   const setLiveSessions = useTradingStore(s => s.setLiveSessions);
+  const setSignalRuntimeSessions = useTradingStore(s => s.setSignalRuntimeSessions);
   const setPositions = useTradingStore(s => s.setPositions);
   const setOrders = useTradingStore(s => s.setOrders);
   const setFills = useTradingStore(s => s.setFills);
@@ -123,6 +124,7 @@ export function useDashboardStream(enabled: boolean) {
         const snapshot = Array.isArray(data) ? data : [];
         setLiveSessions((current) => mergeLiveSessionSnapshot(current, snapshot));
       }));
+      es.addEventListener('signal-runtime-sessions', handleEvent('signal-runtime-sessions', setSignalRuntimeSessions));
       es.addEventListener('positions', handleEvent('positions', setPositions));
       es.addEventListener('orders', handleEvent('orders', setOrders));
       es.addEventListener('fills', handleEvent('fills', setFills));

--- a/web/console/src/pages/MonitorStage.tsx
+++ b/web/console/src/pages/MonitorStage.tsx
@@ -326,9 +326,9 @@ export function MonitorStage({ syncLiveOrder, dockTab, onDockTabChange, dockCont
         mergeSignalBars(fallbackMonitorBars, monitorBars),
         monitorMarket.tradePrice,
         fallbackResolution,
-        monitorSourceSummary.latestEventAt
+        monitorMarket.tradePriceAt
       ),
-    [fallbackMonitorBars, fallbackResolution, monitorBars, monitorMarket.tradePrice, monitorSourceSummary.latestEventAt]
+    [fallbackMonitorBars, fallbackResolution, monitorBars, monitorMarket.tradePrice, monitorMarket.tradePriceAt]
   );
 
   useEffect(() => {

--- a/web/console/src/pages/MonitorStage.tsx
+++ b/web/console/src/pages/MonitorStage.tsx
@@ -19,10 +19,11 @@ import {
   deriveHighlightedLiveSession,
   deriveLiveDispatchPreview,
   deriveLiveSessionFlow,
-  deriveRuntimeReadiness,
   deriveRuntimeSourceSummary,
+  deriveRuntimeReadiness,
   deriveLiveSessionExecutionSummary,
   deriveLiveSessionHealth,
+  mergeLivePriceIntoSignalBars,
   buildTimelineNotes,
   liveSessionHealthTone,
   getNumber,
@@ -309,9 +310,25 @@ export function MonitorStage({ syncLiveOrder, dockTab, onDockTabChange, dockCont
     () => mapChartCandlesToSignalBarCandles(monitorCandles, fallbackResolution),
     [monitorCandles, fallbackResolution]
   );
+  const monitorMarket = deriveRuntimeMarketSnapshot(
+    getRecord(monitorRuntimeState.sourceStates),
+    getRecord(monitorRuntimeState.lastEventSummary),
+    monitorSymbol
+  );
+  const monitorSourceSummary = deriveRuntimeSourceSummary(
+    getRecord(monitorRuntimeState.sourceStates),
+    runtimePolicy,
+    monitorSymbol
+  );
   const displayMonitorBars = useMemo(
-    () => mergeSignalBars(fallbackMonitorBars, monitorBars),
-    [fallbackMonitorBars, monitorBars]
+    () =>
+      mergeLivePriceIntoSignalBars(
+        mergeSignalBars(fallbackMonitorBars, monitorBars),
+        monitorMarket.tradePrice,
+        fallbackResolution,
+        monitorSourceSummary.latestEventAt
+      ),
+    [fallbackMonitorBars, fallbackResolution, monitorBars, monitorMarket.tradePrice, monitorSourceSummary.latestEventAt]
   );
 
   useEffect(() => {
@@ -453,11 +470,6 @@ export function MonitorStage({ syncLiveOrder, dockTab, onDockTabChange, dockCont
     [expandMonitorCandles]
   );
 
-  const monitorMarket = deriveRuntimeMarketSnapshot(
-    getRecord(monitorRuntimeState.sourceStates),
-    getRecord(monitorRuntimeState.lastEventSummary),
-    monitorSymbol
-  );
   const monitorSummary =
     monitorSession ? summaries.find((item) => item.accountId === monitorSession.accountId) ?? null : null;
   const monitorMarkers = deriveSessionMarkers(monitorSession, orders, fills);
@@ -489,7 +501,7 @@ export function MonitorStage({ syncLiveOrder, dockTab, onDockTabChange, dockCont
     : [];
   const monitorRuntimeReadiness = deriveRuntimeReadiness(
     highlightedLiveRuntimeState,
-    deriveRuntimeSourceSummary(getRecord(highlightedLiveRuntimeState.sourceStates), runtimePolicy, monitorSymbol),
+    monitorSourceSummary,
     { requireTick: true, requireOrderBook: false }
   );
   const monitorIntent = getRecord(monitorSession?.state?.lastStrategyIntent);

--- a/web/console/src/types/domain.ts
+++ b/web/console/src/types/domain.ts
@@ -511,8 +511,11 @@ export type SelectableSample = SelectedSample & {
 
 export type RuntimeMarketSnapshot = {
   tradePrice?: number;
+  tradePriceAt?: string;
   bestBid?: number;
+  bestBidAt?: string;
   bestAsk?: number;
+  bestAskAt?: string;
   spreadBps?: number;
 };
 

--- a/web/console/src/utils/derivation.test.ts
+++ b/web/console/src/utils/derivation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { deriveSessionMarkers, deriveSignalMonitorDecorations, markerText } from "./derivation";
+import { deriveSessionMarkers, deriveSignalMonitorDecorations, markerText, mergeLivePriceIntoSignalBars } from "./derivation";
 import { ChartAnnotation, Order, Position, SignalBarCandle } from "../types/domain";
 
 describe("monitor chart marker labels", () => {
@@ -73,6 +73,43 @@ describe("monitor chart marker labels", () => {
     } satisfies ChartAnnotation;
 
     expect(markerText(annotation)).toBe("平多 TP");
+  });
+});
+
+describe("live monitor candles", () => {
+  it("updates the active bar with the latest runtime trade price", () => {
+    const candles: SignalBarCandle[] = [
+      { ...candle("2026-04-24T00:00:00Z"), high: 101, low: 99, close: 100, timeframe: "5" },
+    ];
+
+    const merged = mergeLivePriceIntoSignalBars(candles, 105, "5", "2026-04-24T00:03:10Z");
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0]).toMatchObject({
+      time: "2026-04-24T00:00:00Z",
+      high: 105,
+      low: 99,
+      close: 105,
+      isClosed: false,
+    });
+  });
+
+  it("appends a current bar when REST candles are behind runtime trade data", () => {
+    const candles: SignalBarCandle[] = [
+      { ...candle("2026-04-24T00:00:00Z"), close: 76000, timeframe: "5" },
+    ];
+
+    const merged = mergeLivePriceIntoSignalBars(candles, 77100, "5", "2026-04-24T00:05:02Z");
+
+    expect(merged).toHaveLength(2);
+    expect(merged[1]).toMatchObject({
+      time: "2026-04-24T00:05:00.000Z",
+      open: 76000,
+      high: 77100,
+      low: 76000,
+      close: 77100,
+      isClosed: false,
+    });
   });
 });
 

--- a/web/console/src/utils/derivation.test.ts
+++ b/web/console/src/utils/derivation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { deriveSessionMarkers, deriveSignalMonitorDecorations, markerText, mergeLivePriceIntoSignalBars } from "./derivation";
+import { deriveRuntimeMarketSnapshot, deriveSessionMarkers, deriveSignalMonitorDecorations, markerText, mergeLivePriceIntoSignalBars } from "./derivation";
 import { ChartAnnotation, Order, Position, SignalBarCandle } from "../types/domain";
 
 describe("monitor chart marker labels", () => {
@@ -110,6 +110,64 @@ describe("live monitor candles", () => {
       close: 77100,
       isClosed: false,
     });
+  });
+
+  it("keeps trade price paired with its own source timestamp when order book is newer", () => {
+    const market = deriveRuntimeMarketSnapshot(
+      {
+        trade: {
+          streamType: "trade_tick",
+          symbol: "BTCUSDT",
+          summary: { price: "77100" },
+          lastEventAt: "2026-04-24T00:00:10Z",
+        },
+        book: {
+          streamType: "order_book",
+          symbol: "BTCUSDT",
+          summary: { bestBid: "77090", bestAsk: "77110" },
+          lastEventAt: "2026-04-24T00:05:10Z",
+        },
+      },
+      { event: "depth", bestBid: "77090", bestAsk: "77110" },
+      "BTCUSDT"
+    );
+    const candles: SignalBarCandle[] = [
+      { ...candle("2026-04-24T00:00:00Z"), close: 76000, timeframe: "5" },
+    ];
+
+    const merged = mergeLivePriceIntoSignalBars(candles, market.tradePrice, "5", market.tradePriceAt);
+
+    expect(market).toMatchObject({
+      tradePrice: 77100,
+      tradePriceAt: "2026-04-24T00:00:10Z",
+      bestBid: 77090,
+      bestBidAt: "2026-04-24T00:05:10Z",
+      bestAsk: 77110,
+      bestAskAt: "2026-04-24T00:05:10Z",
+    });
+    expect(merged).toHaveLength(1);
+    expect(merged[0]).toMatchObject({
+      time: "2026-04-24T00:00:00Z",
+      close: 77100,
+    });
+  });
+
+  it("reads trade price from source summary when last event summary is not a trade", () => {
+    const market = deriveRuntimeMarketSnapshot(
+      {
+        trade: {
+          streamType: "trade_tick",
+          symbol: "BTCUSDT",
+          summary: { price: "77100" },
+          lastEventAt: "2026-04-24T00:00:10Z",
+        },
+      },
+      { event: "depth", bestBid: "77090", bestAsk: "77110" },
+      "BTCUSDT"
+    );
+
+    expect(market.tradePrice).toBe(77100);
+    expect(market.tradePriceAt).toBe("2026-04-24T00:00:10Z");
   });
 });
 

--- a/web/console/src/utils/derivation.ts
+++ b/web/console/src/utils/derivation.ts
@@ -406,6 +406,15 @@ export function getList(value: unknown): Array<Record<string, unknown>> {
   return value.filter((item): item is Record<string, unknown> => !!item && typeof item === "object" && !Array.isArray(item));
 }
 
+function sourceStateNumber(state: Record<string, unknown>, key: string) {
+  return getNumber(state[key]) ?? getNumber(getRecord(state.summary)[key]);
+}
+
+function sourceStateTime(state: Record<string, unknown>) {
+  const value = String(state.lastEventAt ?? getRecord(state.summary).lastEventAt ?? "").trim();
+  return Number.isFinite(Date.parse(value)) ? value : undefined;
+}
+
 export function deriveRuntimeMarketSnapshot(
   sourceStates: Record<string, unknown>,
   summary: Record<string, unknown>,
@@ -424,20 +433,50 @@ export function deriveRuntimeMarketSnapshot(
     });
 
   for (const state of states) {
-    if (snapshot.tradePrice == null) {
-      snapshot.tradePrice = getNumber(state.price);
+    const streamType = String(state.streamType ?? "").trim().toLowerCase();
+    const lastEventAt = sourceStateTime(state);
+    if (streamType === "trade_tick" && snapshot.tradePrice == null) {
+      snapshot.tradePrice = sourceStateNumber(state, "price");
+      snapshot.tradePriceAt = snapshot.tradePrice != null ? lastEventAt : undefined;
     }
-    if (snapshot.bestBid == null) {
-      snapshot.bestBid = getNumber(state.bestBid);
+    if (streamType === "order_book" && snapshot.bestBid == null) {
+      snapshot.bestBid = sourceStateNumber(state, "bestBid");
+      snapshot.bestBidAt = snapshot.bestBid != null ? lastEventAt : undefined;
     }
-    if (snapshot.bestAsk == null) {
-      snapshot.bestAsk = getNumber(state.bestAsk);
+    if (streamType === "order_book" && snapshot.bestAsk == null) {
+      snapshot.bestAsk = sourceStateNumber(state, "bestAsk");
+      snapshot.bestAskAt = snapshot.bestAsk != null ? lastEventAt : undefined;
     }
   }
 
-  snapshot.tradePrice ??= getNumber(summary.price);
-  snapshot.bestBid ??= getNumber(summary.bestBid);
-  snapshot.bestAsk ??= getNumber(summary.bestAsk);
+  for (const state of states) {
+    const lastEventAt = sourceStateTime(state);
+    if (snapshot.tradePrice == null) {
+      snapshot.tradePrice = sourceStateNumber(state, "price");
+      snapshot.tradePriceAt = snapshot.tradePrice != null ? lastEventAt : undefined;
+    }
+    if (snapshot.bestBid == null) {
+      snapshot.bestBid = sourceStateNumber(state, "bestBid");
+      snapshot.bestBidAt = snapshot.bestBid != null ? lastEventAt : undefined;
+    }
+    if (snapshot.bestAsk == null) {
+      snapshot.bestAsk = sourceStateNumber(state, "bestAsk");
+      snapshot.bestAskAt = snapshot.bestAsk != null ? lastEventAt : undefined;
+    }
+  }
+
+  if (snapshot.tradePrice == null) {
+    snapshot.tradePrice = getNumber(summary.price);
+    snapshot.tradePriceAt = snapshot.tradePrice != null ? sourceStateTime(summary) : undefined;
+  }
+  if (snapshot.bestBid == null) {
+    snapshot.bestBid = getNumber(summary.bestBid);
+    snapshot.bestBidAt = snapshot.bestBid != null ? sourceStateTime(summary) : undefined;
+  }
+  if (snapshot.bestAsk == null) {
+    snapshot.bestAsk = getNumber(summary.bestAsk);
+    snapshot.bestAskAt = snapshot.bestAsk != null ? sourceStateTime(summary) : undefined;
+  }
 
   if (snapshot.bestBid != null && snapshot.bestAsk != null && snapshot.bestBid > 0 && snapshot.bestAsk >= snapshot.bestBid) {
     const mid = (snapshot.bestBid + snapshot.bestAsk) / 2;
@@ -678,7 +717,10 @@ export function mergeLivePriceIntoSignalBars(
   if (price == null || !Number.isFinite(price) || price <= 0) {
     return candles;
   }
-  const eventMs = eventTime ? Date.parse(eventTime) : Date.now();
+  if (!eventTime) {
+    return candles;
+  }
+  const eventMs = Date.parse(eventTime);
   if (!Number.isFinite(eventMs)) {
     return candles;
   }

--- a/web/console/src/utils/derivation.ts
+++ b/web/console/src/utils/derivation.ts
@@ -660,6 +660,71 @@ export function mapChartCandlesToSignalBarCandles(candles: ChartCandle[], timefr
   }));
 }
 
+function signalBarResolutionSeconds(timeframe: string) {
+  const normalized = String(timeframe ?? "").trim().toUpperCase();
+  if (normalized === "1D") {
+    return 24 * 60 * 60;
+  }
+  const minutes = Number.parseInt(normalized, 10);
+  return Number.isFinite(minutes) && minutes > 0 ? minutes * 60 : 5 * 60;
+}
+
+export function mergeLivePriceIntoSignalBars(
+  candles: SignalBarCandle[],
+  price: number | null | undefined,
+  timeframe: string,
+  eventTime?: string
+): SignalBarCandle[] {
+  if (price == null || !Number.isFinite(price) || price <= 0) {
+    return candles;
+  }
+  const eventMs = eventTime ? Date.parse(eventTime) : Date.now();
+  if (!Number.isFinite(eventMs)) {
+    return candles;
+  }
+
+  const stepMs = signalBarResolutionSeconds(timeframe) * 1000;
+  const currentStartMs = Math.floor(eventMs / stepMs) * stepMs;
+  const currentStartISO = new Date(currentStartMs).toISOString();
+  const sorted = [...candles].sort((a, b) => Date.parse(a.time) - Date.parse(b.time));
+  const latestMs = sorted.length > 0 ? Date.parse(sorted[sorted.length - 1].time) : NaN;
+  if (Number.isFinite(latestMs) && latestMs > currentStartMs) {
+    return sorted;
+  }
+
+  let matched = false;
+  const updated = sorted.map((item) => {
+    const itemMs = Date.parse(item.time);
+    if (itemMs !== currentStartMs) {
+      return item;
+    }
+    matched = true;
+    return {
+      ...item,
+      high: Math.max(item.high, price),
+      low: Math.min(item.low, price),
+      close: price,
+      isClosed: false,
+    };
+  });
+
+  if (!matched) {
+    const previous = sorted.length > 0 ? sorted[sorted.length - 1] : null;
+    const open = previous && Number.isFinite(latestMs) && latestMs < currentStartMs ? previous.close : price;
+    updated.push({
+      time: currentStartISO,
+      open,
+      high: Math.max(open, price),
+      low: Math.min(open, price),
+      close: price,
+      timeframe,
+      isClosed: false,
+    });
+  }
+
+  return updated.sort((a, b) => Date.parse(a.time) - Date.parse(b.time));
+}
+
 export function applyDefaultChartWindow(chart: ReturnType<typeof createChart>, candleCount: number, preferredBars: number) {
   if (candleCount <= 0) {
     return;


### PR DESCRIPTION
## 目的
修复主监控 K 线显示与实时执行价格明显脱节的问题。此前监控图主要依赖 REST fallback K 线，而 signal runtime 最新行情摘要没有进入实时刷新/SSE 推送链路，导致图上仍显示 7.6 万附近时，订单/成交/仓位执行数据已经进入 7.7 万以上。

本次改动让 signal runtime sessions 进入 dashboard 实时同步，并在主监控图里用最新 runtime trade price 合成/更新当前 K 线 bar，使监控图价格更贴近实际执行数据。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [x] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) — 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？— 无
- [x] DB migration 是否具备向下兼容幂等性？— 无 DB migration
- [x] 配置字段有没有无意被混改？— 无配置字段变更

## 变更摘要
- Dashboard SSE broker 增加 `signal-runtime-sessions` 初始快照和轮询推送。
- 非 SSE 实时轮询也同步刷新 `/api/v1/signal-runtime/sessions?view=summary`。
- 前端 stream 订阅 runtime session snapshot。
- 主监控图把最新 runtime trade price 合成到当前 signal bar，REST K 线落后时追加当前 bar。
- 增加 derivation 单测覆盖当前 bar 更新与 REST K 线落后追加 bar。

## 验证方式与测试证据
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

本地验证：
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
- `cd web/console && npm test -- --run src/utils/derivation.test.ts`
- `cd web/console && ./node_modules/.bin/tsc --noEmit src/pages/MonitorStage.tsx --jsx react-jsx --esModuleInterop --target esnext --module esnext --moduleResolution Bundler --allowSyntheticDefaultImports`
- `cd web/console && npm run build`

Pre-push harness：
- graphify rebuilt successfully
- high risk defaults check passed
- env safety check passed
- backend changed-scope checks passed
- frontend changed-scope build passed

Vite build 仍有既有的大 chunk warning，不影响本次构建通过。