### PR TITLE
[codex] Force live SL exits to market

### DIFF
--- a/internal/service/execution_strategy.go
+++ b/internal/service/execution_strategy.go
@@ -262,33 +262,27 @@ func (bookAwareExecutionStrategy) BuildProposal(ctx ExecutionPlanningContext) (E
 	}
 	if profile.ReduceOnly && reasonTag == "sl" {
 		slMaxSlippageBps := firstPositive(profile.SLMaxSlippageBps, 8)
+		proposal.Type = "MARKET"
+		proposal.LimitPrice = 0
+		proposal.TimeInForce = ""
+		proposal.PostOnly = false
 		if spreadBps > 0 && slMaxSlippageBps > 0 && spreadBps > slMaxSlippageBps {
 			slProtection := resolveAggressiveSLProtectionDecision(intent.Side, proposal.Quantity, bestBid, bestAsk, bestBidQty, bestAskQty, priceHint, slMaxSlippageBps)
-			cappedPrice := slProtection.Price
-			proposal.Type = "LIMIT"
-			proposal.LimitPrice = cappedPrice
-			proposal.TimeInForce = "GTC"
-			proposal.PostOnly = false
-			timeoutSeconds := profile.RestingTimeoutSeconds
-			if timeoutSeconds <= 0 {
-				timeoutSeconds = 5
-			}
-			proposal.Metadata["executionExpiresAt"] = ctx.EventTime.UTC().Add(time.Duration(timeoutSeconds) * time.Second).Format(time.RFC3339)
-			proposal.Metadata["executionRestingTimeoutSeconds"] = timeoutSeconds
-			proposal.Metadata["slProtectionActive"] = true
-			proposal.Metadata["slCappedPrice"] = cappedPrice
+			proposal.Metadata["slProtectionObserved"] = true
+			proposal.Metadata["slCappedPrice"] = slProtection.Price
 			proposal.Metadata["slOriginalSpreadBps"] = spreadBps
 			proposal.Metadata["slMaxSlippageBps"] = slMaxSlippageBps
 			proposal.Metadata["topDepthNotional"] = slProtection.TopDepthNotional
 			proposal.Metadata["expectedFillCoverage"] = slProtection.ExpectedCoverage
 			proposal.Metadata["quoteGapBps"] = slProtection.QuoteGapBps
 			proposal.Metadata["slProtectionDepthMode"] = slProtection.DepthMode
-			proposal.Metadata["executionDecision"] = "sl-slippage-protected"
+			proposal.Metadata["executionDecision"] = "direct-dispatch"
 			proposal.Metadata["executionDecisionContext"] = mergeExecutionDecisionContext(
 				mapValue(proposal.Metadata["executionDecisionContext"]),
 				map[string]any{
 					"slProtectionBranch":    true,
-					"slProtectionMode":      "spread-capped-limit",
+					"slProtectionMode":      "market-dispatch",
+					"slProtectionObserved":  true,
 					"slMaxSlippageBps":      slMaxSlippageBps,
 					"slProtectionDepthMode": slProtection.DepthMode,
 					"topDepthQty":           slProtection.TopDepthQty,

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -2787,7 +2787,7 @@ func TestBookAwareExecutionStrategyUsesTightZeroInitialReentryMakerFallback(t *t
 	}
 }
 
-func TestBookAwareExecutionStrategySetsExpiryForSLProtectionWhenConfigured(t *testing.T) {
+func TestBookAwareExecutionStrategyKeepsMarketSLWhenSlippageProtectionConfigured(t *testing.T) {
 	strategy := bookAwareExecutionStrategy{}
 	eventTime := time.Date(2026, 4, 7, 8, 0, 0, 0, time.UTC)
 	proposal, err := strategy.BuildProposal(ExecutionPlanningContext{
@@ -2795,6 +2795,8 @@ func TestBookAwareExecutionStrategySetsExpiryForSLProtectionWhenConfigured(t *te
 		Execution: StrategyExecutionContext{
 			Parameters: map[string]any{
 				"executionMaxSpreadBps":                5.0,
+				"executionSLExitOrderType":             "LIMIT",
+				"executionSLExitPostOnly":              true,
 				"executionSLExitRestingTimeoutSeconds": 15,
 				"executionSLMaxSlippageBps":            20.0,
 			},
@@ -2819,27 +2821,39 @@ func TestBookAwareExecutionStrategySetsExpiryForSLProtectionWhenConfigured(t *te
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if got := proposal.Type; got != "LIMIT" {
-		t.Fatalf("expected LIMIT SL protection order, got %s", got)
+	if got := proposal.Type; got != "MARKET" {
+		t.Fatalf("expected SL to remain MARKET despite wide spread, got %s", got)
 	}
-	if got := stringValue(proposal.Metadata["executionDecision"]); got != "sl-slippage-protected" {
-		t.Fatalf("expected sl-slippage-protected, got %s", got)
+	if proposal.LimitPrice != 0 || proposal.TimeInForce != "" || proposal.PostOnly {
+		t.Fatalf("expected unbounded market SL, got limit=%v tif=%s postOnly=%v", proposal.LimitPrice, proposal.TimeInForce, proposal.PostOnly)
 	}
-	if got := proposal.LimitPrice; got != 68013.85 {
-		t.Fatalf("expected spread-capped SL protection price 68013.85, got %v", got)
+	if !proposal.ReduceOnly {
+		t.Fatal("expected SL proposal to stay reduceOnly")
 	}
-	if got := stringValue(proposal.Metadata["executionExpiresAt"]); got != eventTime.Add(15*time.Second).Format(time.RFC3339) {
-		t.Fatalf("expected configured SL expiry, got %s", got)
+	if got := stringValue(proposal.Metadata["executionDecision"]); got != "direct-dispatch" {
+		t.Fatalf("expected direct-dispatch for market SL, got %s", got)
+	}
+	if got := stringValue(proposal.Metadata["executionExpiresAt"]); got != "" {
+		t.Fatalf("expected market SL to avoid resting expiry, got %s", got)
+	}
+	if got := parseFloatValue(proposal.Metadata["slCappedPrice"]); got != 68013.85 {
+		t.Fatalf("expected telemetry capped price 68013.85, got %v", got)
+	}
+	if !boolValue(proposal.Metadata["slProtectionObserved"]) {
+		t.Fatal("expected wide-spread SL telemetry to be recorded")
 	}
 	if !boolValue(mapValue(proposal.Metadata["executionDecisionContext"])["slProtectionBranch"]) {
-		t.Fatal("expected explicit SL protection branch marker")
+		t.Fatal("expected explicit SL slippage branch marker")
+	}
+	if got := stringValue(mapValue(proposal.Metadata["executionDecisionContext"])["slProtectionMode"]); got != "market-dispatch" {
+		t.Fatalf("expected SL protection mode market-dispatch, got %s", got)
 	}
 	if got := stringValue(mapValue(proposal.Metadata["executionDecisionContext"])["slProtectionDepthMode"]); got != "spread-capped-fallback" {
 		t.Fatalf("expected fallback SL depth mode without qty data, got %s", got)
 	}
 }
 
-func TestBookAwareExecutionStrategyUsesTightDefaultForSLProtection(t *testing.T) {
+func TestBookAwareExecutionStrategyKeepsMarketSLWithDefaultSlippageTelemetry(t *testing.T) {
 	strategy := bookAwareExecutionStrategy{}
 	eventTime := time.Date(2026, 4, 24, 9, 22, 46, 0, time.UTC)
 	proposal, err := strategy.BuildProposal(ExecutionPlanningContext{
@@ -2867,15 +2881,24 @@ func TestBookAwareExecutionStrategyUsesTightDefaultForSLProtection(t *testing.T)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if got := proposal.Type; got != "LIMIT" {
-		t.Fatalf("expected default SL protection to switch to LIMIT on 20bps spread, got %s", got)
+	if got := proposal.Type; got != "MARKET" {
+		t.Fatalf("expected default SL to remain MARKET on 20bps spread, got %s", got)
 	}
-	if got := stringValue(proposal.Metadata["executionDecision"]); got != "sl-slippage-protected" {
-		t.Fatalf("expected sl-slippage-protected, got %s", got)
+	if proposal.LimitPrice != 0 || proposal.TimeInForce != "" || proposal.PostOnly {
+		t.Fatalf("expected unbounded market SL, got limit=%v tif=%s postOnly=%v", proposal.LimitPrice, proposal.TimeInForce, proposal.PostOnly)
+	}
+	if got := stringValue(proposal.Metadata["executionDecision"]); got != "direct-dispatch" {
+		t.Fatalf("expected direct-dispatch for market SL, got %s", got)
+	}
+	if !boolValue(proposal.Metadata["slProtectionObserved"]) {
+		t.Fatal("expected wide-spread SL telemetry to be recorded")
 	}
 	context := mapValue(proposal.Metadata["executionDecisionContext"])
 	if got := parseFloatValue(context["slMaxSlippageBps"]); got != 8 {
 		t.Fatalf("expected default slMaxSlippageBps=8, got %v", got)
+	}
+	if got := stringValue(context["slProtectionMode"]); got != "market-dispatch" {
+		t.Fatalf("expected market-dispatch SL mode, got %s", got)
 	}
 }
 


### PR DESCRIPTION
## 目的
修复 Live SL exit 在宽点差场景下被 `book-aware-v1` 的 slippage protection 从 `MARKET` 改写成 `LIMIT` 的问题。

根因是 `BuildProposal` 在 `reasonTag == "sl"` 且 `spreadBps > executionSLMaxSlippageBps` 时走了 `sl-slippage-protected` 分支，把 reduce-only SL 单改成了限价单。该行为和 `docs/live-safety-invariants.md` 中“SL exits must be unconditional MARKET orders”的安全约束冲突，也会造成止损退出不再是无条件退出。

本次改动将 SL reduce-only exit 强制保持为 `MARKET`，清空 limit/TIF/post-only 字段；宽点差保护仅保留为 telemetry / context，不再改变最终订单类型。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [x] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main)
  - 无变化。
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？
  - 无。
- [x] DB migration 是否具备向下兼容幂等性？
  - 不涉及 DB migration。
- [x] 配置字段有没有无意被混改？
  - 无配置字段变更；仅修正 SL 执行策略在宽点差时的订单类型处理。

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

已执行：
- `go test ./internal/service -run 'TestBookAwareExecutionStrategyKeepsMarketSL|TestBookAwareExecutionStrategyUsesAggressiveReduceOnlyProfileForSLExit|TestRefreshLiveSessionPositionContext.*Watchdog|TestRefreshLiveSessionPositionContextGenerates.*Fallback'`
- `go test ./internal/service`
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
- `git diff --check`
- pre-push harness：graphify rebuild、高风险默认值检查、env safety check、backend checks 均通过。