### PR TITLE
[codex] fix zero-initial reentry guardrails

### DIFF
--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -5330,6 +5330,7 @@ func (p *Platform) resolveLiveSessionParameters(session domain.LiveSession, vers
 		"use_sma5_intraday_structure",
 		"reentry_min_stop_bps",
 		"reentry_atr_percentile_gte",
+		"signalDecisionMaxDeviationBps",
 	}
 	sessionParameterKeys = append(sessionParameterKeys, liveExecutionParameterOverrideKeys()...)
 	for _, key := range sessionParameterKeys {
@@ -5823,6 +5824,9 @@ func normalizeLiveSessionOverrides(overrides map[string]any) map[string]any {
 	}
 	if maxSpread := parseFloatValue(overrides["executionMaxSpreadBps"]); maxSpread > 0 {
 		normalized["executionMaxSpreadBps"] = maxSpread
+	}
+	if maxDeviation := parseFloatValue(overrides["signalDecisionMaxDeviationBps"]); maxDeviation > 0 {
+		normalized["signalDecisionMaxDeviationBps"] = maxDeviation
 	}
 	if maxAgeMs := parseFloatValue(overrides["executionEntryMaxBookAgeMs"]); maxAgeMs > 0 {
 		normalized["executionEntryMaxBookAgeMs"] = maxAgeMs

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -193,6 +193,88 @@ func TestEvaluateSignalBarGateAllowsLongAfterBreakoutAlignmentWithResearch(t *te
 	}
 }
 
+func TestEvaluateSignalUsesExecutionEntrySlippageAsDefaultDecisionDeviation(t *testing.T) {
+	engine := bkStrategyEngine{}
+	barStart := time.Date(2026, 4, 22, 3, 0, 0, 0, time.UTC)
+	signalStates := map[string]any{
+		signalBindingMatchKey("binance-kline", "signal", "BTCUSDT", map[string]any{"timeframe": "30m"}): map[string]any{
+			"symbol":    "BTCUSDT",
+			"timeframe": "30m",
+			"sma5":      99.0,
+			"atr14":     10.0,
+			"current": map[string]any{
+				"barStart": barStart.Format(time.RFC3339),
+				"close":    100.2,
+				"high":     100.2,
+				"low":      99.5,
+			},
+			"prevBar1": map[string]any{
+				"high": 99.0,
+				"low":  98.0,
+			},
+			"prevBar2": map[string]any{
+				"high": 100.0,
+				"low":  97.0,
+			},
+		},
+	}
+	evaluate := func(parameters map[string]any) StrategySignalDecision {
+		decision, err := engine.EvaluateSignal(StrategySignalEvaluationContext{
+			ExecutionContext: StrategyExecutionContext{
+				Symbol:          "BTCUSDT",
+				SignalTimeframe: "30m",
+				Parameters:      parameters,
+			},
+			TriggerSummary: map[string]any{
+				"role":   "trigger",
+				"symbol": "BTCUSDT",
+				"price":  100.2,
+			},
+			SourceStates: map[string]any{
+				"tick": map[string]any{
+					"streamType": "trade_tick",
+					"symbol":     "BTCUSDT",
+					"summary":    map[string]any{"price": 100.2},
+				},
+			},
+			SignalBarStates:   signalStates,
+			CurrentPosition:   map[string]any{},
+			SessionState:      map[string]any{},
+			EventTime:         barStart.Add(5 * time.Minute),
+			NextPlannedEvent:  barStart,
+			NextPlannedPrice:  100.0,
+			NextPlannedSide:   "BUY",
+			NextPlannedRole:   "entry",
+			NextPlannedReason: "Initial",
+		})
+		if err != nil {
+			t.Fatalf("evaluate signal failed: %v", err)
+		}
+		return decision
+	}
+
+	blocked := evaluate(map[string]any{
+		"executionEntryMaxSlippageBps": 8.0,
+	})
+	if blocked.Action != "wait" || blocked.Reason != "price-not-actionable" {
+		t.Fatalf("expected 8 bps inherited decision deviation to block 20 bps entry, got %+v", blocked)
+	}
+	if got := parseFloatValue(blocked.Metadata["maxDeviationBps"]); got != 8.0 {
+		t.Fatalf("expected maxDeviationBps to inherit executionEntryMaxSlippageBps=8, got %v", got)
+	}
+
+	allowed := evaluate(map[string]any{
+		"executionEntryMaxSlippageBps":  8.0,
+		"signalDecisionMaxDeviationBps": 25.0,
+	})
+	if allowed.Action != "advance-plan" {
+		t.Fatalf("expected explicit signalDecisionMaxDeviationBps to allow entry, got %+v", allowed)
+	}
+	if got := parseFloatValue(allowed.Metadata["maxDeviationBps"]); got != 25.0 {
+		t.Fatalf("expected explicit maxDeviationBps=25, got %v", got)
+	}
+}
+
 func TestEvaluateSignalBarGateUsesSMA5ForIntradayReentry(t *testing.T) {
 	gate := evaluateSignalBarGate(map[string]any{
 		"timeframe": "30m",
@@ -7331,10 +7413,11 @@ func TestEvaluateLiveSessionOnSignalKeepsReentryDispatchableWithoutInitialBreako
 	}
 
 	session, err := platform.CreateLiveSession("", "live-main", "strategy-bk-1d", map[string]any{
-		"symbol":              "BTCUSDT",
-		"signalTimeframe":     "1d",
-		"executionDataSource": "tick",
-		"dispatchMode":        "manual-review",
+		"symbol":                        "BTCUSDT",
+		"signalTimeframe":               "1d",
+		"executionDataSource":           "tick",
+		"dispatchMode":                  "manual-review",
+		"signalDecisionMaxDeviationBps": 25.0,
 	})
 	if err != nil {
 		t.Fatalf("create live session failed: %v", err)
@@ -7428,7 +7511,7 @@ func TestEvaluateLiveSessionOnSignalKeepsReentryDispatchableWithoutInitialBreako
 	}
 	proposal := mapValue(updated.State["lastExecutionProposal"])
 	if proposal == nil {
-		t.Fatal("expected lastExecutionProposal to be recorded")
+		t.Fatalf("expected lastExecutionProposal to be recorded; lastStrategyDecision=%+v", mapValue(updated.State["lastStrategyDecision"]))
 	}
 	if got := stringValue(proposal["status"]); got != "dispatchable" {
 		t.Fatalf("expected reentry proposal to remain dispatchable, got %s", got)
@@ -7485,12 +7568,13 @@ func TestEvaluateLiveSessionOnSignalUsesInjectedATRForVolatilitySizing(t *testin
 	}
 
 	session, err := platform.CreateLiveSession("", "live-main", "strategy-bk-1d", map[string]any{
-		"symbol":              "BTCUSDT",
-		"signalTimeframe":     "1d",
-		"executionDataSource": "tick",
-		"dispatchMode":        "manual-review",
-		"positionSizingMode":  "volatility_adjusted",
-		"targetRiskBps":       100.0,
+		"symbol":                        "BTCUSDT",
+		"signalTimeframe":               "1d",
+		"executionDataSource":           "tick",
+		"dispatchMode":                  "manual-review",
+		"positionSizingMode":            "volatility_adjusted",
+		"targetRiskBps":                 100.0,
+		"signalDecisionMaxDeviationBps": 25.0,
 	})
 	if err != nil {
 		t.Fatalf("create live session failed: %v", err)
@@ -7584,7 +7668,7 @@ func TestEvaluateLiveSessionOnSignalUsesInjectedATRForVolatilitySizing(t *testin
 	}
 	proposal := mapValue(updated.State["lastExecutionProposal"])
 	if proposal == nil {
-		t.Fatal("expected lastExecutionProposal to be recorded")
+		t.Fatalf("expected lastExecutionProposal to be recorded; lastStrategyDecision=%+v", mapValue(updated.State["lastStrategyDecision"]))
 	}
 	metadata := mapValue(proposal["metadata"])
 	if got := parseFloatValue(metadata["sizingATR14"]); got != 900.0 {

--- a/internal/service/live_zero_initial.go
+++ b/internal/service/live_zero_initial.go
@@ -127,6 +127,7 @@ func prepareLivePlanStepForSignalEvaluation(
 	if shortReady {
 		side = "SELL"
 	}
+	plannedReentryPrice := resolveLiveReentryPlanPrice(parameters, signalBarState, side)
 	pendingWindow := map[string]any{
 		"side":                      side,
 		"symbol":                    NormalizeSymbol(symbol),
@@ -136,8 +137,11 @@ func prepareLivePlanStepForSignalEvaluation(
 		"expiresAt":                 expiresAt.UTC().Format(time.RFC3339),
 		"breakoutBacked":            true,
 		"openReason":                liveZeroInitialWindowOpenReasonBreakoutLocked,
+		"breakoutSide":              side,
 		"breakoutPrice":             breakoutPrice,
 		"breakoutPriceSource":       strings.TrimSpace(breakoutPriceSource),
+		"plannedReentryPrice":       plannedReentryPrice,
+		"plannedReentryPriceSource": "zero-initial-window-armed",
 		"longStructureReady":        boolValue(gate["longStructureReady"]),
 		"shortStructureReady":       boolValue(gate["shortStructureReady"]),
 		"longBreakoutReady":         boolValue(gate["longBreakoutReady"]),
@@ -294,6 +298,9 @@ func livePendingZeroInitialWindowOpen(sessionState map[string]any, symbol, signa
 		return false
 	}
 	if !liveZeroInitialWindowHasBreakoutProof(pending) {
+		return false
+	}
+	if !liveZeroInitialWindowHasSideBreakoutProof(pending, side) {
 		return false
 	}
 	if pendingSide := strings.ToUpper(strings.TrimSpace(stringValue(pending["side"]))); pendingSide != "" &&
@@ -526,11 +533,15 @@ func liveZeroInitialWindowPlanStep(
 		delete(state, livePendingZeroInitialWindowStateKey)
 		return state, time.Time{}, 0, "", "", "", false
 	}
+	if !liveZeroInitialWindowHasSideBreakoutProof(pending, side) {
+		clearLivePendingZeroInitialWindow(state, eventTime, "zero-initial-window-side-breakout-proof-mismatch")
+		return state, time.Time{}, 0, "", "", "", false
+	}
 	signalBarState, _ := pickSignalBarState(signalBarStates, symbol, signalTimeframe)
 	if signalBarState == nil {
 		return state, time.Time{}, 0, "", "", "", false
 	}
-	price := resolveLiveReentryPlanPrice(parameters, signalBarState, side)
+	price := resolveLiveZeroInitialReentryPlanPrice(parameters, signalBarState, pending, side)
 	if price <= 0 {
 		return state, time.Time{}, 0, "", "", "", false
 	}
@@ -630,5 +641,53 @@ func resolveLiveReentryPlanPrice(parameters map[string]any, signalBarState map[s
 		return parseFloatValue(prevBar1["high"]) + parseFloatValue(firstNonNil(parameters["short_reentry_atr"], 0.0))*atr14
 	default:
 		return 0
+	}
+}
+
+func resolveLiveZeroInitialReentryPlanPrice(parameters map[string]any, signalBarState map[string]any, pending map[string]any, side string) float64 {
+	if liveZeroInitialWindowHasBreakoutProof(pending) {
+		if price := parseFloatValue(pending["plannedReentryPrice"]); price > 0 {
+			return price
+		}
+	}
+	return resolveLiveReentryPlanPrice(parameters, signalBarState, side)
+}
+
+func liveZeroInitialWindowHasSideBreakoutProof(pending map[string]any, side string) bool {
+	if !liveZeroInitialWindowHasBreakoutProof(pending) {
+		return false
+	}
+	normalizedSide := strings.ToUpper(strings.TrimSpace(side))
+	if breakoutSide := strings.ToUpper(strings.TrimSpace(stringValue(pending["breakoutSide"]))); breakoutSide != "" && breakoutSide != normalizedSide {
+		return false
+	}
+	hasSideProofFields := false
+	for _, key := range []string{
+		"longBreakoutReady",
+		"longBreakoutShapeReady",
+		"longBreakoutPriceReady",
+		"longBreakoutQualityReady",
+		"shortBreakoutReady",
+		"shortBreakoutShapeReady",
+		"shortBreakoutPriceReady",
+		"shortBreakoutQualityReady",
+	} {
+		if _, ok := pending[key]; ok {
+			hasSideProofFields = true
+			break
+		}
+	}
+	if !hasSideProofFields {
+		return true
+	}
+	switch normalizedSide {
+	case "BUY":
+		return boolValue(pending["longBreakoutReady"]) ||
+			(boolValue(pending["longBreakoutShapeReady"]) && boolValue(pending["longBreakoutPriceReady"]) && boolValue(pending["longBreakoutQualityReady"]))
+	case "SELL", "SHORT":
+		return boolValue(pending["shortBreakoutReady"]) ||
+			(boolValue(pending["shortBreakoutShapeReady"]) && boolValue(pending["shortBreakoutPriceReady"]) && boolValue(pending["shortBreakoutQualityReady"]))
+	default:
+		return false
 	}
 }

--- a/internal/service/live_zero_initial_test.go
+++ b/internal/service/live_zero_initial_test.go
@@ -142,6 +142,194 @@ func TestPrepareLivePlanStepForSignalEvaluationUsesSignalBarBoundaryForMillisBar
 	}
 }
 
+func TestPrepareLivePlanStepForSignalEvaluationSnapshotsZeroInitialReentryPriceAcrossBars(t *testing.T) {
+	armedBarStart := time.Date(2026, 4, 10, 0, 0, 0, 0, time.UTC)
+	parameters := map[string]any{
+		"dir2_zero_initial": true,
+		"zero_initial_mode": "reentry_window",
+		"long_reentry_atr":  0.1,
+	}
+	armedSignalStates := map[string]any{
+		signalBindingMatchKey("binance-kline", "signal", "BTCUSDT"): map[string]any{
+			"symbol":    "BTCUSDT",
+			"timeframe": "1d",
+			"sma5":      68050.0,
+			"atr14":     900.0,
+			"current": map[string]any{
+				"barStart": armedBarStart.Format(time.RFC3339),
+				"close":    68100.0,
+				"high":     69010.0,
+				"low":      67800.0,
+			},
+			"prevBar1": map[string]any{
+				"high": 68850.0,
+				"low":  67750.0,
+			},
+			"prevBar2": map[string]any{
+				"high": 69000.0,
+				"low":  67600.0,
+			},
+		},
+	}
+
+	state, _, gotPrice, gotSide, gotRole, gotReason := prepareLivePlanStepForSignalEvaluation(
+		map[string]any{},
+		parameters,
+		armedSignalStates,
+		"BTCUSDT",
+		"1d",
+		map[string]any{},
+		armedBarStart.Add(5*time.Minute),
+		69010.0,
+		"trigger.price",
+		armedBarStart.Add(-48*time.Hour),
+		75600.0,
+		"SELL",
+		"entry",
+		"SL-Reentry",
+	)
+	if gotRole != "entry" || gotReason != "Zero-Initial-Reentry" || gotSide != "BUY" {
+		t.Fatalf("expected armed BUY zero reentry, got side=%s role=%s reason=%s", gotSide, gotRole, gotReason)
+	}
+	if gotPrice != 67840.0 {
+		t.Fatalf("expected armed reentry price 67840.0, got %.2f", gotPrice)
+	}
+	pending := mapValue(state[livePendingZeroInitialWindowStateKey])
+	if got := parseFloatValue(pending["plannedReentryPrice"]); got != 67840.0 {
+		t.Fatalf("expected pending window to snapshot planned reentry price 67840.0, got %.2f", got)
+	}
+
+	nextBarStart := armedBarStart.Add(24 * time.Hour)
+	nextSignalStates := map[string]any{
+		signalBindingMatchKey("binance-kline", "signal", "BTCUSDT"): map[string]any{
+			"symbol":    "BTCUSDT",
+			"timeframe": "1d",
+			"sma5":      70000.0,
+			"atr14":     900.0,
+			"current": map[string]any{
+				"barStart": nextBarStart.Format(time.RFC3339),
+				"close":    71000.0,
+				"high":     71200.0,
+				"low":      70500.0,
+			},
+			"prevBar1": map[string]any{
+				"high": 71000.0,
+				"low":  70000.0,
+			},
+			"prevBar2": map[string]any{
+				"high": 69010.0,
+				"low":  67800.0,
+			},
+		},
+	}
+	_, gotEvent, gotPrice, gotSide, gotRole, gotReason := prepareLivePlanStepForSignalEvaluation(
+		state,
+		parameters,
+		nextSignalStates,
+		"BTCUSDT",
+		"1d",
+		map[string]any{},
+		nextBarStart.Add(8*time.Minute),
+		71050.0,
+		"trigger.price",
+		nextBarStart,
+		70090.0,
+		"BUY",
+		"entry",
+		"Initial",
+	)
+	if gotRole != "entry" || gotReason != "Zero-Initial-Reentry" || gotSide != "BUY" {
+		t.Fatalf("expected persisted zero reentry window, got side=%s role=%s reason=%s", gotSide, gotRole, gotReason)
+	}
+	if !gotEvent.Equal(nextBarStart) {
+		t.Fatalf("expected current bar planned event %s, got %s", nextBarStart, gotEvent)
+	}
+	if gotPrice != 67840.0 {
+		t.Fatalf("expected cross-bar zero reentry to keep armed price 67840.0, got %.2f", gotPrice)
+	}
+}
+
+func TestPrepareLivePlanStepForSignalEvaluationRejectsZeroWindowSideProofMismatch(t *testing.T) {
+	barStart := time.Date(2026, 4, 22, 3, 0, 0, 0, time.UTC)
+	state := map[string]any{
+		livePendingZeroInitialWindowStateKey: map[string]any{
+			"side":                      "SELL",
+			"symbol":                    "BTCUSDT",
+			"signalTimeframe":           "30m",
+			"armedAt":                   barStart.Add(-5 * time.Minute).Format(time.RFC3339),
+			"signalBarStart":            barStart.Format(time.RFC3339),
+			"expiresAt":                 barStart.Add(time.Hour).Format(time.RFC3339),
+			"breakoutBacked":            true,
+			"openReason":                liveZeroInitialWindowOpenReasonBreakoutLocked,
+			"breakoutSide":              "BUY",
+			"longBreakoutReady":         true,
+			"longBreakoutShapeReady":    true,
+			"longBreakoutPriceReady":    true,
+			"longBreakoutQualityReady":  true,
+			"shortBreakoutReady":        false,
+			"shortBreakoutShapeReady":   false,
+			"shortBreakoutPriceReady":   false,
+			"shortBreakoutQualityReady": true,
+		},
+	}
+	signalStates := map[string]any{
+		signalBindingMatchKey("binance-kline", "signal", "BTCUSDT", map[string]any{"timeframe": "30m"}): map[string]any{
+			"symbol":    "BTCUSDT",
+			"timeframe": "30m",
+			"sma5":      100.0,
+			"atr14":     10.0,
+			"current": map[string]any{
+				"barStart": barStart.Format(time.RFC3339),
+				"close":    98.0,
+				"high":     99.0,
+				"low":      97.0,
+			},
+			"prevBar1": map[string]any{
+				"high": 101.0,
+				"low":  98.0,
+			},
+			"prevBar2": map[string]any{
+				"high": 102.0,
+				"low":  97.0,
+			},
+		},
+	}
+
+	updated, _, _, gotSide, gotRole, gotReason := prepareLivePlanStepForSignalEvaluation(
+		state,
+		map[string]any{
+			"dir2_zero_initial": true,
+			"zero_initial_mode": "reentry_window",
+			"short_reentry_atr": 0.0,
+		},
+		signalStates,
+		"BTCUSDT",
+		"30m",
+		map[string]any{},
+		barStart.Add(5*time.Minute),
+		98.0,
+		"trigger.price",
+		barStart,
+		98.5,
+		"SELL",
+		"entry",
+		"Initial",
+	)
+	if gotRole != "entry" || gotReason != "Initial" || gotSide != "SELL" {
+		t.Fatalf("expected side-mismatched zero window to fall back to original plan, got side=%s role=%s reason=%s", gotSide, gotRole, gotReason)
+	}
+	if pending := mapValue(updated[livePendingZeroInitialWindowStateKey]); len(pending) != 0 {
+		t.Fatalf("expected side-mismatched zero window to be cleared, got %+v", pending)
+	}
+	timeline := metadataList(updated["timeline"])
+	if len(timeline) != 1 || stringValue(timeline[0]["title"]) != "zero-initial-window-consumed" {
+		t.Fatalf("expected one consume timeline event, got %+v", timeline)
+	}
+	if got := stringValue(mapValue(timeline[0]["metadata"])["reason"]); got != "zero-initial-window-side-breakout-proof-mismatch" {
+		t.Fatalf("expected side proof mismatch consume reason, got %s", got)
+	}
+}
+
 func TestPrepareLivePlanStepForSignalEvaluationConvertsNewZeroWindowAfterSameBarSLExit(t *testing.T) {
 	barStart := time.Date(2026, 4, 28, 11, 0, 0, 0, time.UTC)
 	eventTime := barStart.Add(22*time.Minute + 22*time.Second)

--- a/internal/service/strategy_registry.go
+++ b/internal/service/strategy_registry.go
@@ -276,7 +276,7 @@ func (e bkStrategyEngine) EvaluateSignal(context StrategySignalEvaluationContext
 		reason = "signal-filter-not-ready"
 	}
 	orderBookStats := extractOrderBookStats(trigger, sourceStates)
-	maxDeviationBps := firstPositive(parseFloatValue(context.ExecutionContext.Parameters["signalDecisionMaxDeviationBps"]), 50)
+	maxDeviationBps := resolveSignalDecisionMaxDeviationBps(context.ExecutionContext.Parameters)
 	maxSpreadBps := firstPositive(parseFloatValue(context.ExecutionContext.Parameters["signalDecisionMaxSpreadBps"]), 8)
 	effectivePlannedPrice := context.NextPlannedPrice
 	reasonTag := normalizeStrategyReasonTag(context.NextPlannedReason)
@@ -548,6 +548,13 @@ func isPlannedPriceActionable(side string, plannedPrice, marketPrice, maxDeviati
 	default:
 		return math.Abs(marketPrice/plannedPrice-1) <= tolerance
 	}
+}
+
+func resolveSignalDecisionMaxDeviationBps(parameters map[string]any) float64 {
+	return firstPositive(
+		parseFloatValue(parameters["signalDecisionMaxDeviationBps"]),
+		firstPositive(parseFloatValue(parameters["executionEntryMaxSlippageBps"]), 8),
+	)
 }
 
 func isReentryTriggerReached(side string, plannedPrice, triggerPrice float64) bool {

--- a/internal/service/telemetry.go
+++ b/internal/service/telemetry.go
@@ -533,10 +533,16 @@ func (p *Platform) recordLivePositionAccountSnapshot(session domain.LiveSession,
 	if orderID == "" {
 		orderID = stringValue(state["lastDispatchedOrderId"])
 	}
+	decisionEventID := stringValue(state["lastStrategyDecisionEventId"])
+	if orderID != "" {
+		if order, orderErr := p.GetOrder(orderID); orderErr == nil {
+			decisionEventID = firstNonEmpty(stringValue(order.Metadata["decisionEventId"]), decisionEventID)
+		}
+	}
 
 	snapshot := domain.PositionAccountSnapshot{
 		LiveSessionID:     session.ID,
-		DecisionEventID:   stringValue(state["lastStrategyDecisionEventId"]),
+		DecisionEventID:   decisionEventID,
 		OrderID:           orderID,
 		AccountID:         session.AccountID,
 		StrategyID:        session.StrategyID,

--- a/internal/service/telemetry_test.go
+++ b/internal/service/telemetry_test.go
@@ -477,6 +477,71 @@ func TestRefreshLiveSessionPositionContextPersistsPositionAccountSnapshot(t *tes
 	}
 }
 
+func TestRecordLivePositionAccountSnapshotUsesOrderDecisionEventID(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	account, err := platform.store.GetAccount("live-main")
+	if err != nil {
+		t.Fatalf("get account failed: %v", err)
+	}
+	account.Status = "READY"
+	account.Metadata = cloneMetadata(account.Metadata)
+	account.Metadata["liveSyncSnapshot"] = map[string]any{
+		"syncStatus": "SYNCED",
+	}
+	if _, err := platform.store.UpdateAccount(account); err != nil {
+		t.Fatalf("update account failed: %v", err)
+	}
+
+	session, err := platform.store.GetLiveSession("live-session-main")
+	if err != nil {
+		t.Fatalf("get live session failed: %v", err)
+	}
+	order, err := platform.store.CreateOrder(domain.Order{
+		AccountID:         session.AccountID,
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "BUY",
+		Type:              "LIMIT",
+		Quantity:          0.01,
+		Price:             100.0,
+		Metadata: map[string]any{
+			"decisionEventId": "decision-order-current",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create order failed: %v", err)
+	}
+	state := cloneMetadata(session.State)
+	state["symbol"] = "BTCUSDT"
+	state["lastStrategyDecisionEventId"] = "decision-stale-cancelled-entry"
+	state["lastDispatchedOrderId"] = order.ID
+	state["livePositionState"] = map[string]any{
+		"symbol":     "BTCUSDT",
+		"side":       "LONG",
+		"quantity":   0.01,
+		"entryPrice": 100.0,
+	}
+	session, err = platform.store.UpdateLiveSessionState(session.ID, state)
+	if err != nil {
+		t.Fatalf("update live session state failed: %v", err)
+	}
+
+	if err := platform.recordLivePositionAccountSnapshot(session, time.Date(2026, 4, 29, 15, 19, 41, 0, time.UTC), "live-order-sync", order.ID); err != nil {
+		t.Fatalf("record position/account snapshot failed: %v", err)
+	}
+	snapshots, err := platform.store.ListPositionAccountSnapshots(session.AccountID)
+	if err != nil {
+		t.Fatalf("list position/account snapshots failed: %v", err)
+	}
+	if len(snapshots) == 0 {
+		t.Fatal("expected at least one snapshot")
+	}
+	got := snapshots[len(snapshots)-1]
+	if got.DecisionEventID != "decision-order-current" {
+		t.Fatalf("expected snapshot to use order decision event id, got %s", got.DecisionEventID)
+	}
+}
+
 func prepareLiveDecisionTelemetryFixture(t *testing.T) (*Platform, domain.LiveSession, string, map[string]any, time.Time) {
 	t.Helper()
 


### PR DESCRIPTION
## 目的
修复 issue #341 相关的 zero-initial reentry window 跨 bar 存活后，入场参考价随新 bar 漂移并可能造成异常高位开仓的问题；同时收紧 signal decision 的默认价格偏离阈值，并修正生产排查中看到的 position/account snapshot 决策链 attribution 污染。

生产核对结论：`order-1777475288746567463` 本身最终状态为 `CANCELLED`，未看到该 BUY 入场单的成交；后续同决策链出现仓位/退出痕迹更像是 snapshot 记录使用 stale `lastStrategyDecisionEventId`，本 PR 将该问题作为独立 attribution 修复处理。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [x] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 改动摘要
- zero-initial window 开窗时记录 `breakoutSide` 与当时的 `plannedReentryPrice`，后续消费窗口时复用开窗价格，避免跨 bar 重新取 `prevBar1.low/high` 导致 reentry 基准漂移。
- 消费 zero-initial window 时校验方向 breakout proof，避免上破开窗被反向 entry 消费；方向 proof 不匹配会清理窗口。
- `signalDecisionMaxDeviationBps` 默认从 50bps 改为：显式配置优先，否则继承 `executionEntryMaxSlippageBps`，否则 8bps。
- live session override 支持 `signalDecisionMaxDeviationBps` 进入 normalize/resolve 参数链路。
- position/account snapshot 在有 orderID 时优先使用订单 metadata 的 `decisionEventId`，避免 stale session decision id 把后续仓位/退出痕迹挂到已取消入场决策链上。

## 风险点 checklist
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) - 未变化。
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？- 无新增。
- [x] DB migration 是否具备向下兼容幂等性？- 不涉及 migration。
- [x] 配置字段有没有无意被混改？- 有意新增 `signalDecisionMaxDeviationBps` live override 支持；默认阈值有意收紧。

## 验证方式与测试证据
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

本地验证：
- `go test ./internal/service`
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
- `git diff --check`

pre-push hook 验证：
- graphify rebuild 完成
- high risk defaults check passed
- env safety check passed
- backend changed-scope checks passed