### PR TITLE
[codex] Fix live monitor signal-bar display

### DIFF
--- a/web/console/src/App.tsx
+++ b/web/console/src/App.tsx
@@ -11,7 +11,7 @@ import { useTradingStore } from './store/useTradingStore';
 import { useDashboard } from './hooks/useDashboard';
 import { useTradingActions } from './hooks/useTradingActions';
 import { fetchJSON } from './utils/api';
-import { deriveHighlightedLiveSession } from './utils/derivation';
+import { deriveSelectedOrHighlightedLiveSession } from './utils/derivation';
 
 // Layout Components
 import { HeaderMetrics } from './components/layout/HeaderMetrics';
@@ -93,17 +93,7 @@ export default function App() {
 
   const selectedSignalRuntimeId = useTradingStore(s => s.selectedSignalRuntimeId);
   const monitorSessionId = useMemo(() => {
-    if (selectedSignalRuntimeId) {
-      const sessionWithRuntime = liveSessions.find(s => 
-        s.id === selectedSignalRuntimeId || 
-        String(s.state?.signalRuntimeSessionId) === selectedSignalRuntimeId
-      );
-      if (sessionWithRuntime) {
-        const highlighted = deriveHighlightedLiveSession([sessionWithRuntime], orders, fills, positions);
-        return highlighted?.session.id || null;
-      }
-    }
-    const highlighted = deriveHighlightedLiveSession(liveSessions, orders, fills, positions);
+    const highlighted = deriveSelectedOrHighlightedLiveSession(liveSessions, selectedSignalRuntimeId, orders, fills, positions);
     return highlighted?.session.id || null;
   }, [liveSessions, orders, fills, positions, selectedSignalRuntimeId]);
 

--- a/web/console/src/pages/MonitorStage.tsx
+++ b/web/console/src/pages/MonitorStage.tsx
@@ -10,13 +10,14 @@ import {
   resolveChartAnchor,
   buildTimeRange,
   deriveSignalBarCandles,
+  deriveSignalBarStateCandles,
   mapChartCandlesToSignalBarCandles,
   derivePrimarySignalBarState, 
   deriveRuntimeMarketSnapshot, 
   deriveSessionMarkers,
   deriveSignalMonitorDecorations,
   derivePaperSessionExecutionSummary,
-  deriveHighlightedLiveSession,
+  deriveSelectedOrHighlightedLiveSession,
   deriveLiveDispatchPreview,
   deriveLiveSessionFlow,
   deriveRuntimeSourceSummary,
@@ -169,18 +170,7 @@ export function MonitorStage({ syncLiveOrder, dockTab, onDockTabChange, dockCont
 
   // 1. 高亮会话选择逻辑
   const highlightedLiveSession = useMemo(
-    () => {
-      if (selectedSignalRuntimeId) {
-        const sessionWithRuntime = liveSessions.find(s => 
-          s.id === selectedSignalRuntimeId || 
-          String(s.state?.signalRuntimeSessionId) === selectedSignalRuntimeId
-        );
-        if (sessionWithRuntime) {
-          return deriveHighlightedLiveSession([sessionWithRuntime], orders, fills, positions);
-        }
-      }
-      return deriveHighlightedLiveSession(liveSessions, orders, fills, positions);
-    },
+    () => deriveSelectedOrHighlightedLiveSession(liveSessions, selectedSignalRuntimeId, orders, fills, positions),
     [liveSessions, orders, fills, positions, selectedSignalRuntimeId]
   );
 
@@ -295,12 +285,24 @@ export function MonitorStage({ syncLiveOrder, dockTab, onDockTabChange, dockCont
   const monitorSymbol = monitorSignalSymbol || sessionSymbol;
 
   const monitorBars = useMemo(() => {
-    return deriveSignalBarCandles(getRecord(highlightedLiveRuntimeState.sourceStates), {
+    const sourceBars = deriveSignalBarCandles(getRecord(highlightedLiveRuntimeState.sourceStates), {
       targetSymbol: monitorSymbol,
       targetTimeframe: monitorSignalTimeframe,
       targetStateKey: monitorSignalBarStateKey,
     });
-  }, [highlightedLiveRuntimeState.sourceStates, monitorSymbol, monitorSignalTimeframe, monitorSignalBarStateKey]);
+    const stateBars = deriveSignalBarStateCandles(getRecord(highlightedLiveRuntimeState.signalBarStates), {
+      targetSymbol: monitorSymbol,
+      targetTimeframe: monitorSignalTimeframe,
+      targetStateKey: monitorSignalBarStateKey,
+    });
+    return mergeSignalBars(sourceBars, stateBars);
+  }, [
+    highlightedLiveRuntimeState.sourceStates,
+    highlightedLiveRuntimeState.signalBarStates,
+    monitorSymbol,
+    monitorSignalTimeframe,
+    monitorSignalBarStateKey,
+  ]);
 
   const fallbackResolution = useMemo(
     () => resolveMonitorFallbackResolution(monitorSignalTimeframe),
@@ -390,7 +392,10 @@ export function MonitorStage({ syncLiveOrder, dockTab, onDockTabChange, dockCont
           return;
         }
         console.warn("Failed to load monitor fallback candles", error);
-        fallbackRequestKeyRef.current = "";
+        candleCacheRef.current[requestKey] = {
+          candles: [],
+          fetchedAt: Date.now(),
+        };
         setMonitorCandles([]);
       });
 

--- a/web/console/src/utils/derivation.test.ts
+++ b/web/console/src/utils/derivation.test.ts
@@ -50,6 +50,27 @@ describe("monitor chart marker labels", () => {
     expect(markers[0].text).toBe("平多 SL 75948.80");
   });
 
+  it("reads signal bar keys from execution proposal top-level metadata", () => {
+    const session = { id: "live-1", strategyId: "strategy-1" } as any;
+    const orders: Order[] = [
+      order(
+        "o1",
+        "BUY",
+        75897.5,
+        false,
+        "2026-04-30T00:33:51Z",
+        "",
+        "BTCUSDT|30m|2026-04-30T00:30:00Z",
+        "proposalTopLevel"
+      ),
+    ];
+
+    const markers = deriveSessionMarkers(session, orders, []);
+
+    expect(markers[0].time).toBe("2026-04-30T00:30:00.000Z");
+    expect(markers[0].text).toBe("开多 75897.50");
+  });
+
   it("draws execution price overlays across the owning signal bar", () => {
     const candles: SignalBarCandle[] = [
       candle("2026-04-30T00:00:00Z"),
@@ -157,7 +178,6 @@ describe("live monitor candles", () => {
             high: "76387.00",
             low: "76213.70",
             close: "76263.10",
-            isClosed: true,
           },
           current: {
             barStart: "1777514400000",
@@ -165,7 +185,6 @@ describe("live monitor candles", () => {
             high: "76317.10",
             low: "76218.90",
             close: "76236.30",
-            isClosed: false,
           },
         },
       },
@@ -202,7 +221,7 @@ describe("live monitor candles", () => {
           accountId: "live-main",
           strategyId: "strategy-bk-1d",
           status: "READY",
-          state: { dispatchMode: "manual-review" },
+          state: { dispatchMode: "manual-review", symbol: "BTCUSDT" },
           createdAt: "2026-04-30T01:57:39Z",
         } as any,
         {
@@ -328,8 +347,32 @@ function order(
   reduceOnly: boolean,
   createdAt: string,
   reason = "",
-  signalBarTradeLimitKey = ""
+  signalBarTradeLimitKey = "",
+  signalBarTradeLimitKeyPlacement: "proposalMetadata" | "proposalTopLevel" | "intentMetadata" | "orderMetadata" = "proposalMetadata"
 ): Order {
+  const executionProposal: Record<string, unknown> = {
+    role: reduceOnly ? "exit" : "entry",
+    reason,
+    reduceOnly,
+  };
+  const intent: Record<string, unknown> = {};
+  const metadata: Record<string, unknown> = {
+    liveSessionId: "live-1",
+    reduceOnly,
+    executionProposal,
+  };
+  if (signalBarTradeLimitKey) {
+    if (signalBarTradeLimitKeyPlacement === "proposalTopLevel") {
+      executionProposal.signalBarTradeLimitKey = signalBarTradeLimitKey;
+    } else if (signalBarTradeLimitKeyPlacement === "intentMetadata") {
+      intent.metadata = { signalBarTradeLimitKey };
+      metadata.intent = intent;
+    } else if (signalBarTradeLimitKeyPlacement === "orderMetadata") {
+      metadata.signalBarTradeLimitKey = signalBarTradeLimitKey;
+    } else {
+      executionProposal.metadata = { signalBarTradeLimitKey };
+    }
+  }
   return {
     id,
     accountId: "account-1",
@@ -340,16 +383,7 @@ function order(
     quantity: 0.01,
     price,
     reduceOnly,
-    metadata: {
-      liveSessionId: "live-1",
-      reduceOnly,
-      executionProposal: {
-        role: reduceOnly ? "exit" : "entry",
-        reason,
-        reduceOnly,
-        metadata: signalBarTradeLimitKey ? { signalBarTradeLimitKey } : undefined,
-      },
-    },
+    metadata,
     createdAt,
   };
 }

--- a/web/console/src/utils/derivation.test.ts
+++ b/web/console/src/utils/derivation.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from "vitest";
-import { deriveRuntimeMarketSnapshot, deriveSessionMarkers, deriveSignalMonitorDecorations, markerText, mergeLivePriceIntoSignalBars } from "./derivation";
-import { ChartAnnotation, Order, Position, SignalBarCandle } from "../types/domain";
+import {
+  deriveRuntimeMarketSnapshot,
+  deriveSelectedOrHighlightedLiveSession,
+  deriveSessionMarkers,
+  deriveSignalBarStateCandles,
+  deriveSignalMonitorDecorations,
+  markerText,
+  mergeLivePriceIntoSignalBars,
+} from "./derivation";
+import { ChartAnnotation, Fill, Order, Position, SignalBarCandle } from "../types/domain";
 
 describe("monitor chart marker labels", () => {
   it("distinguishes long and short entry/exit order markers", () => {
@@ -20,6 +28,66 @@ describe("monitor chart marker labels", () => {
       "平多 SL 102.00",
       "平空 TP 103.00",
     ]);
+  });
+
+  it("anchors order markers to the signal bar trade limit key", () => {
+    const session = { id: "live-1", strategyId: "strategy-1" } as any;
+    const orders: Order[] = [
+      order(
+        "o1",
+        "SELL",
+        75948.8,
+        true,
+        "2026-04-30T00:41:02Z",
+        "SL",
+        "BTCUSDT|30m|2026-04-30T00:30:00Z"
+      ),
+    ];
+
+    const markers = deriveSessionMarkers(session, orders, []);
+
+    expect(markers[0].time).toBe("2026-04-30T00:30:00.000Z");
+    expect(markers[0].text).toBe("平多 SL 75948.80");
+  });
+
+  it("draws execution price overlays across the owning signal bar", () => {
+    const candles: SignalBarCandle[] = [
+      candle("2026-04-30T00:00:00Z"),
+      candle("2026-04-30T00:30:00Z"),
+      candle("2026-04-30T01:00:00Z"),
+    ];
+    const session = { id: "live-1", strategyId: "strategy-1", state: {} } as any;
+    const orders: Order[] = [
+      order(
+        "o1",
+        "SELL",
+        75948.8,
+        true,
+        "2026-04-30T00:41:02Z",
+        "SL",
+        "BTCUSDT|30m|2026-04-30T00:30:00Z"
+      ),
+    ];
+    const fills: Fill[] = [
+      {
+        id: "f1",
+        orderId: "o1",
+        price: 75948.8,
+        quantity: 0.0065,
+        fee: 0,
+        createdAt: "2026-04-30T00:41:03Z",
+      },
+    ];
+
+    const { overlays } = deriveSignalMonitorDecorations(session, candles, null, orders, fills);
+
+    expect(overlays).toContainEqual({
+      startTime: "2026-04-30T00:30:00.000Z",
+      endTime: "2026-04-30T01:00:00Z",
+      price: 75948.8,
+      color: "#b04a37",
+      lineStyle: "solid",
+    });
   });
 
   it("adds direction to breakout and stop monitor decorations", () => {
@@ -77,6 +145,88 @@ describe("monitor chart marker labels", () => {
 });
 
 describe("live monitor candles", () => {
+  it("derives candles from runtime signal bar state snapshots", () => {
+    const candles = deriveSignalBarStateCandles(
+      {
+        "binance-kline|signal|BTCUSDT|30m": {
+          symbol: "BTCUSDT",
+          timeframe: "30m",
+          prevBar1: {
+            barStart: "1777512600000",
+            open: "76298.80",
+            high: "76387.00",
+            low: "76213.70",
+            close: "76263.10",
+            isClosed: true,
+          },
+          current: {
+            barStart: "1777514400000",
+            open: "76303.00",
+            high: "76317.10",
+            low: "76218.90",
+            close: "76236.30",
+            isClosed: false,
+          },
+        },
+      },
+      { targetSymbol: "BTCUSDT", targetTimeframe: "30m" }
+    );
+
+    expect(candles).toEqual([
+      {
+        time: "2026-04-30T01:30:00.000Z",
+        open: 76298.8,
+        high: 76387,
+        low: 76213.7,
+        close: 76263.1,
+        timeframe: "30m",
+        isClosed: true,
+      },
+      {
+        time: "2026-04-30T02:00:00.000Z",
+        open: 76303,
+        high: 76317.1,
+        low: 76218.9,
+        close: 76236.3,
+        timeframe: "30m",
+        isClosed: false,
+      },
+    ]);
+  });
+
+  it("auto-promotes away from an empty seed session when an active runtime session exists", () => {
+    const selected = deriveSelectedOrHighlightedLiveSession(
+      [
+        {
+          id: "live-session-main",
+          accountId: "live-main",
+          strategyId: "strategy-bk-1d",
+          status: "READY",
+          state: { dispatchMode: "manual-review" },
+          createdAt: "2026-04-30T01:57:39Z",
+        } as any,
+        {
+          id: "live-session-1",
+          accountId: "live-main",
+          strategyId: "strategy-bk-btc-30m-enhanced",
+          status: "RUNNING",
+          state: {
+            symbol: "BTCUSDT",
+            signalRuntimeSessionId: "signal-runtime-1",
+            signalRuntimeStatus: "RUNNING",
+          },
+          createdAt: "2026-04-30T01:59:07Z",
+        } as any,
+      ],
+      "live-session-main",
+      [],
+      [],
+      []
+    );
+
+    expect(selected?.session.id).toBe("live-session-1");
+  });
+
   it("updates the active bar with the latest runtime trade price", () => {
     const candles: SignalBarCandle[] = [
       { ...candle("2026-04-24T00:00:00Z"), high: 101, low: 99, close: 100, timeframe: "5" },
@@ -171,7 +321,15 @@ describe("live monitor candles", () => {
   });
 });
 
-function order(id: string, side: string, price: number, reduceOnly: boolean, createdAt: string, reason = ""): Order {
+function order(
+  id: string,
+  side: string,
+  price: number,
+  reduceOnly: boolean,
+  createdAt: string,
+  reason = "",
+  signalBarTradeLimitKey = ""
+): Order {
   return {
     id,
     accountId: "account-1",
@@ -189,6 +347,7 @@ function order(id: string, side: string, price: number, reduceOnly: boolean, cre
         role: reduceOnly ? "exit" : "entry",
         reason,
         reduceOnly,
+        metadata: signalBarTradeLimitKey ? { signalBarTradeLimitKey } : undefined,
       },
     },
     createdAt,

--- a/web/console/src/utils/derivation.ts
+++ b/web/console/src/utils/derivation.ts
@@ -765,16 +765,18 @@ export function deriveSignalBarStateCandles(
       continue;
     }
 
-    const bars = Array.isArray(state.bars) ? (state.bars as Array<Record<string, unknown>>) : [];
+    const bars = Array.isArray(state.bars)
+      ? (state.bars as Array<Record<string, unknown>>).map((bar) => ({ bar, fallbackClosed: false }))
+      : [];
     const namedBars = ["prevBar4", "prevBar3", "prevBar2", "prevBar1", "current"]
-      .map((key) => getRecord(state[key]))
-      .filter((bar) => Object.keys(bar).length > 0);
-    for (const bar of [...bars, ...namedBars]) {
+      .map((key) => ({ bar: getRecord(state[key]), fallbackClosed: key !== "current" }))
+      .filter((item) => Object.keys(item.bar).length > 0);
+    for (const { bar, fallbackClosed } of [...bars, ...namedBars]) {
       const candle = signalBarStateCandleFromRecord(
         bar,
         stateSymbol,
         stateTimeframe,
-        false,
+        fallbackClosed,
         targetSymbol,
         targetTimeframe
       );
@@ -1298,17 +1300,28 @@ export function deriveSessionMarkers(session: LiveSession | PaperSession | null,
   });
 }
 
-function executionOrderMetadata(order: Order): Record<string, unknown> {
+function executionOrderSignalBarTradeLimitKey(order: Order): string {
   const metadata = getRecord(order.metadata);
-  const proposalMetadata = getRecord(getRecord(metadata.executionProposal).metadata);
-  if (Object.keys(proposalMetadata).length > 0) {
-    return proposalMetadata;
+  const proposal = getRecord(metadata.executionProposal);
+  const intent = getRecord(metadata.intent);
+  const candidates = [
+    metadata.signalBarTradeLimitKey,
+    proposal.signalBarTradeLimitKey,
+    getRecord(proposal.metadata).signalBarTradeLimitKey,
+    intent.signalBarTradeLimitKey,
+    getRecord(intent.metadata).signalBarTradeLimitKey,
+  ];
+  for (const candidate of candidates) {
+    const value = String(candidate ?? "").trim();
+    if (value) {
+      return value;
+    }
   }
-  return getRecord(getRecord(metadata.intent).metadata);
+  return "";
 }
 
 function resolveExecutionOrderSignalBarTime(order: Order): string {
-  const key = String(executionOrderMetadata(order).signalBarTradeLimitKey ?? "").trim();
+  const key = executionOrderSignalBarTradeLimitKey(order);
   const parts = key.split("|");
   const candidate = parts.length >= 3 ? parts.slice(2).join("|") : "";
   if (!candidate) {
@@ -1670,13 +1683,29 @@ export function deriveSelectedOrHighlightedLiveSession(
     return selected;
   }
 
+  const selectedState = getRecord(selected.session.state);
+  const selectedHasRuntimeData = !!String(
+    selectedState.signalRuntimeSessionId ??
+      selectedState.lastSignalRuntimeSessionId ??
+      selectedState.signalRuntimeStatus ??
+      selectedState.lastSignalRuntimeEventAt ??
+      ""
+  ).trim();
+  const selectedHasStrategyActivity =
+    Object.keys(getRecord(selectedState.lastStrategyIntent)).length > 0 ||
+    !!String(
+      selectedState.lastStrategyEvaluationStatus ??
+        selectedState.lastStrategyDecisionAt ??
+        selectedState.lastStrategyTriggerErrorAt ??
+        ""
+    ).trim();
   const selectedIsEmptySeed =
     liveSessionHealthPriority(selected.health.status) === 0 &&
     selected.execution.orderCount === 0 &&
     selected.execution.fillCount === 0 &&
     !selected.execution.position &&
-    !String(selected.session.state?.symbol ?? "").trim() &&
-    !String(selected.session.state?.signalRuntimeSessionId ?? "").trim();
+    !selectedHasRuntimeData &&
+    !selectedHasStrategyActivity;
   if (selectedIsEmptySeed && liveSessionHealthPriority(highlighted.health.status) > liveSessionHealthPriority(selected.health.status)) {
     return highlighted;
   }

--- a/web/console/src/utils/derivation.ts
+++ b/web/console/src/utils/derivation.ts
@@ -687,6 +687,115 @@ export function deriveSignalBarCandles(
   return candles.slice(-120);
 }
 
+function normalizeSignalBarStart(value: unknown): string {
+  if (value == null || value === "") {
+    return "";
+  }
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+  const raw = String(value).trim();
+  const parsed = Number(raw);
+  if (Number.isFinite(parsed) && parsed > 0) {
+    const millis = parsed > 10_000_000_000 ? parsed : parsed * 1000;
+    return new Date(millis).toISOString();
+  }
+  const timestamp = Date.parse(raw);
+  return Number.isFinite(timestamp) ? new Date(timestamp).toISOString() : "";
+}
+
+function signalBarStateCandleFromRecord(
+  bar: Record<string, unknown>,
+  fallbackSymbol: string,
+  fallbackTimeframe: string,
+  fallbackClosed: boolean,
+  targetSymbol: string,
+  targetTimeframe: string
+): SignalBarCandle | null {
+  const barSymbol = normalizeSignalSymbol(bar.symbol ?? fallbackSymbol);
+  const barTimeframe = normalizeSignalTimeframe(bar.timeframe ?? fallbackTimeframe);
+  if (targetSymbol && barSymbol && barSymbol !== targetSymbol) {
+    return null;
+  }
+  if (targetTimeframe && barTimeframe && barTimeframe !== targetTimeframe) {
+    return null;
+  }
+  const time = normalizeSignalBarStart(bar.barStart ?? bar.time ?? bar.openTime ?? bar.startTime);
+  const open = getNumber(bar.open);
+  const high = getNumber(bar.high);
+  const low = getNumber(bar.low);
+  const close = getNumber(bar.close);
+  if (!time || open == null || high == null || low == null || close == null) {
+    return null;
+  }
+  return {
+    time,
+    open,
+    high,
+    low,
+    close,
+    timeframe: String(bar.timeframe ?? fallbackTimeframe ?? "--"),
+    isClosed: bar.isClosed == null ? fallbackClosed : Boolean(bar.isClosed),
+  };
+}
+
+export function deriveSignalBarStateCandles(
+  signalBarStates: Record<string, unknown>,
+  options?: Omit<SignalBarSelectionOptions, "fallbackStates">
+): SignalBarCandle[] {
+  const targetStateKey = String(options?.targetStateKey ?? "").trim();
+  const targetSymbol = normalizeSignalSymbol(options?.targetSymbol);
+  const targetTimeframe = normalizeSignalTimeframe(options?.targetTimeframe);
+  const candidateEntries = targetStateKey
+    ? Object.entries(signalBarStates).filter(([key]) => key === targetStateKey)
+    : Object.entries(signalBarStates);
+  const byTime = new Map<string, SignalBarCandle>();
+
+  for (const [, value] of candidateEntries) {
+    const state = getRecord(value);
+    if (Object.keys(state).length === 0) {
+      continue;
+    }
+    const stateSymbol = normalizeSignalSymbol(state.symbol ?? getRecord(state.current).symbol);
+    const stateTimeframe = normalizeSignalTimeframe(state.timeframe ?? getRecord(state.current).timeframe);
+    if (targetSymbol && stateSymbol && stateSymbol !== targetSymbol) {
+      continue;
+    }
+    if (targetTimeframe && stateTimeframe && stateTimeframe !== targetTimeframe) {
+      continue;
+    }
+
+    const bars = Array.isArray(state.bars) ? (state.bars as Array<Record<string, unknown>>) : [];
+    const namedBars = ["prevBar4", "prevBar3", "prevBar2", "prevBar1", "current"]
+      .map((key) => getRecord(state[key]))
+      .filter((bar) => Object.keys(bar).length > 0);
+    for (const bar of [...bars, ...namedBars]) {
+      const candle = signalBarStateCandleFromRecord(
+        bar,
+        stateSymbol,
+        stateTimeframe,
+        false,
+        targetSymbol,
+        targetTimeframe
+      );
+      if (candle) {
+        byTime.set(candle.time, candle);
+      }
+    }
+  }
+
+  if (byTime.size === 0 && targetStateKey) {
+    return deriveSignalBarStateCandles(signalBarStates, {
+      targetSymbol: options?.targetSymbol,
+      targetTimeframe: options?.targetTimeframe,
+    });
+  }
+
+  return Array.from(byTime.values())
+    .sort((a, b) => Date.parse(a.time) - Date.parse(b.time))
+    .slice(-120);
+}
+
 export function mapChartCandlesToSignalBarCandles(candles: ChartCandle[], timeframe: string): SignalBarCandle[] {
   return candles.map((item) => ({
     time: item.time,
@@ -1180,13 +1289,33 @@ export function deriveSessionMarkers(session: LiveSession | PaperSession | null,
     const isBuy = side === "BUY";
     const markerText = executionOrderMarkerText(order);
     return {
-      time: fill?.createdAt || order.createdAt,
+      time: resolveExecutionOrderSignalBarTime(order) || fill?.createdAt || order.createdAt,
       position: isBuy ? "belowBar" : "aboveBar",
       color: isBuy ? "#0e6d60" : "#b04a37",
       shape: isBuy ? "arrowUp" : "arrowDown",
       text: `${markerText} ${formatMaybeNumber(order.price)}`,
     };
   });
+}
+
+function executionOrderMetadata(order: Order): Record<string, unknown> {
+  const metadata = getRecord(order.metadata);
+  const proposalMetadata = getRecord(getRecord(metadata.executionProposal).metadata);
+  if (Object.keys(proposalMetadata).length > 0) {
+    return proposalMetadata;
+  }
+  return getRecord(getRecord(metadata.intent).metadata);
+}
+
+function resolveExecutionOrderSignalBarTime(order: Order): string {
+  const key = String(executionOrderMetadata(order).signalBarTradeLimitKey ?? "").trim();
+  const parts = key.split("|");
+  const candidate = parts.length >= 3 ? parts.slice(2).join("|") : "";
+  if (!candidate) {
+    return "";
+  }
+  const parsed = Date.parse(candidate);
+  return Number.isFinite(parsed) ? new Date(parsed).toISOString() : "";
 }
 
 function executionOrderMarkerText(order: Order): string {
@@ -1236,6 +1365,10 @@ function executionOrderPositionSide(side: string, isExit: boolean): "LONG" | "SH
 
 function normalizeExecutionReasonTag(reason: string): string {
   return reason.trim().toLowerCase().replace(/_/g, "-");
+}
+
+function executionOrderMarkerColor(order: Order): string {
+  return String(order.side ?? "").trim().toUpperCase() === "BUY" ? "#0e6d60" : "#b04a37";
 }
 
 function compactExecutionReasonLabel(reason: string): string {
@@ -1347,6 +1480,33 @@ export function deriveSignalMonitorDecorations(
     });
   }
 
+  const sessionOrders = resolveSessionOrders(session, orders);
+  const fillByOrderId = new Map(fills.map((fill) => [fill.orderId, fill] as const));
+  for (const order of sessionOrders.slice(-24)) {
+    const price = getNumber(fillByOrderId.get(order.id)?.price) ?? getNumber(order.price);
+    if (price == null || price <= 0) {
+      continue;
+    }
+    const orderTime = clampAnnotationTime(
+      resolveExecutionOrderSignalBarTime(order) || fillByOrderId.get(order.id)?.createdAt || order.createdAt,
+      visibleStart,
+      visibleEnd
+    );
+    if (!orderTime) {
+      continue;
+    }
+    const nextCandleTime =
+      candles.find((item) => Date.parse(item.time) > Date.parse(orderTime))?.time ??
+      new Date(Date.parse(orderTime) + signalBarResolutionSeconds(candles[0]?.timeframe ?? "") * 1000).toISOString();
+    overlays.push({
+      startTime: orderTime,
+      endTime: nextCandleTime,
+      price,
+      color: executionOrderMarkerColor(order),
+      lineStyle: isExitOrderMarker(order) ? "solid" : "dotted",
+    });
+  }
+
   if (!position || Math.abs(Number(position.quantity ?? 0)) <= 0 || !visibleEnd) {
     return { markers, overlays };
   }
@@ -1360,8 +1520,6 @@ export function deriveSignalMonitorDecorations(
     return { markers, overlays };
   }
 
-  const sessionOrders = resolveSessionOrders(session, orders);
-  const fillByOrderId = new Map(fills.map((fill) => [fill.orderId, fill] as const));
   const normalizedSide = String(position.side ?? livePositionState.side ?? "").trim().toUpperCase();
   const entrySide = normalizedSide === "SHORT" ? "SELL" : "BUY";
   const entryOrder = [...sessionOrders]
@@ -1487,6 +1645,43 @@ export function deriveHighlightedLiveSession(
     })
     .sort((left, right) => right.priority - left.priority || Date.parse(right.session.createdAt) - Date.parse(left.session.createdAt));
   return ranked[0] ?? null;
+}
+
+export function deriveSelectedOrHighlightedLiveSession(
+  sessions: LiveSession[],
+  selectedSessionOrRuntimeId: string | null | undefined,
+  orders: Order[],
+  fills: Fill[],
+  positions: Position[]
+): HighlightedLiveSession {
+  const highlighted = deriveHighlightedLiveSession(sessions, orders, fills, positions);
+  const selectedID = String(selectedSessionOrRuntimeId ?? "").trim();
+  if (!selectedID) {
+    return highlighted;
+  }
+  const selectedSession = sessions.find(
+    (session) => session.id === selectedID || String(session.state?.signalRuntimeSessionId ?? "") === selectedID
+  );
+  if (!selectedSession) {
+    return highlighted;
+  }
+  const selected = deriveHighlightedLiveSession([selectedSession], orders, fills, positions);
+  if (!selected || !highlighted || selected.session.id === highlighted.session.id) {
+    return selected;
+  }
+
+  const selectedIsEmptySeed =
+    liveSessionHealthPriority(selected.health.status) === 0 &&
+    selected.execution.orderCount === 0 &&
+    selected.execution.fillCount === 0 &&
+    !selected.execution.position &&
+    !String(selected.session.state?.symbol ?? "").trim() &&
+    !String(selected.session.state?.signalRuntimeSessionId ?? "").trim();
+  if (selectedIsEmptySeed && liveSessionHealthPriority(highlighted.health.status) > liveSessionHealthPriority(selected.health.status)) {
+    return highlighted;
+  }
+
+  return selected;
 }
 
 export function deriveLiveSessionFlow(session: LiveSession, summary: LiveSessionExecutionSummary): LiveSessionFlowStep[] {


### PR DESCRIPTION
## 目的
修复主监控在本轮生产排查中暴露的显示问题：

- 订单 marker 和执行价线优先锚定到所属 signal bar，而不是简单使用 fill/order created time。
- 当历史 K 线 REST fallback 不可用、或 runtime `sourceStates` 只有 summary 没有 bars 时，主监控直接使用 runtime `signalBarStates.current/prevBar*` 绘制 K 线。
- 当本地/seed 的空 `live-session-main` 被持久选中时，主监控会自动切到真正有 runtime 数据的 live session，避免页面看起来像“无数据”。
- 同一个历史 K 线 fallback 请求失败后短暂缓存为空，避免监控页每轮 poll 都刷相同 warning。

Root cause 摘要：主监控之前优先保留已选中的空 seed session，同时 runtime K 线只读 `sourceStates.bars` / REST fallback；当历史 K 线接口失败或 source summary 不含 bars 时，页面会显示“等待实盘数据输入”。订单显示问题则来自 marker 使用 fill/order 时间，没有优先使用 execution proposal 的 `signalBarTradeLimitKey`。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [x] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

说明：本 PR 只改 console monitor 展示/派生逻辑，不改后端 live execution、dispatch、配置默认值或 DB migration。

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值未变化
- [x] 未新增直接调用 `mainnet` 凭证或路由地址的硬编码
- [x] 无 DB migration
- [x] 配置字段未无意混改

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

验证已跑：

```bash
go test ./internal/service
go test ./internal/store/...
go test ./...
go build ./cmd/platform-api
go build ./cmd/db-migrate
cd web/console && npm test -- --run src/utils/derivation.test.ts
cd web/console && ./node_modules/.bin/tsc --noEmit src/pages/MonitorStage.tsx --jsx react-jsx --esModuleInterop --target esnext --module esnext --moduleResolution Bundler --allowSyntheticDefaultImports
cd web/console && ./node_modules/.bin/tsc --noEmit src/pages/AccountStage.tsx --jsx react-jsx --esModuleInterop --target esnext --module esnext --moduleResolution Bundler --allowSyntheticDefaultImports
cd web/console && npm run build
```

pre-push hook also passed changed-scope checks and rebuilt graphify before pushing.