### PR TITLE
[codex] Remove t3 breakout from enhanced strategy

### DIFF
--- a/db/migrations/029_btc_30m_t2_only_breakout.sql
+++ b/db/migrations/029_btc_30m_t2_only_breakout.sql
@@ -1,0 +1,34 @@
+update strategies
+set name = 'BK BTCUSDT 30m T2-only 0.5bps',
+    description = 'BTCUSDT 30m live intrabar SMA5 original T2 breakout with 0.5 bps tolerance.'
+where id = 'strategy-bk-btc-30m-enhanced';
+
+update strategy_versions
+set parameters = (
+    parameters
+    || '{
+        "strategyEngine": "bk-live-intrabar-sma5-t2-only-0p5bps",
+        "breakout_shape": "original_t2",
+        "breakout_shape_tolerance_bps": 0.5,
+        "use_sma5_intraday_structure": true
+    }'::jsonb
+) - 't3_min_sma_atr_separation'
+where id = 'strategy-version-bk-btc-30m-enhanced-v010'
+  and strategy_id = 'strategy-bk-btc-30m-enhanced';
+
+update live_sessions
+set state = (
+    state
+    || '{
+        "strategyEngine": "bk-live-intrabar-sma5-t2-only-0p5bps",
+        "breakout_shape": "original_t2",
+        "breakout_shape_tolerance_bps": 0.5,
+        "use_sma5_intraday_structure": true
+    }'::jsonb
+) - 't3_min_sma_atr_separation'
+where strategy_id = 'strategy-bk-btc-30m-enhanced'
+  and (
+    state->>'launchTemplateKey' = 'binance-testnet-btc-30m-enhanced'
+    or state->>'strategyEngine' = 'bk-live-intrabar-sma5-t3-sep'
+    or state->>'strategyEngine' = 'bk-live-intrabar-sma5-t2-only-0p5bps'
+  );

--- a/docs/30m-enhanced-filter-research.md
+++ b/docs/30m-enhanced-filter-research.md
@@ -10,7 +10,7 @@ Template key: `binance-testnet-btc-30m-enhanced`
 Strategy/version:
 
 - `strategy-bk-btc-30m-enhanced`
-- `strategyEngine=bk-live-intrabar-sma5-t3-sep`
+- `strategyEngine=bk-live-intrabar-sma5-t2-only-0p5bps`
 - `signalTimeframe=30m`
 - `executionDataSource=tick`
 
@@ -31,8 +31,8 @@ Sizing/risk baseline:
 Signal filters:
 
 - `use_sma5_intraday_structure=true`: intraday entries use the current 30m bar close vs SMA5 as the hard structure filter. Long entries need close above SMA5; short entries need close below SMA5.
-- `breakout_shape=baseline_plus_t3`: the original T2 breakout remains enabled, and the T3 swing breakout is added.
-- `t3_min_sma_atr_separation=0.25`: T3 swing breakout must be at least `0.25 * ATR14` away from SMA5. This filter applies to `t3_swing` only; it does not block `original_t2`.
+- `breakout_shape=original_t2`: only the T2 breakout shape is enabled; T3 swing breakout is disabled.
+- `breakout_shape_tolerance_bps=0.5`: the T2 high/low comparison may miss by up to 0.5 bps, while the breakout level still locks to T2 high/low.
 - `reentry_min_stop_bps=6.0`: reentry entries require `stop_loss_atr * ATR14 / reentry_price * 10000 >= 6`.
 - `reentry_atr_percentile_gte=25.0`: reentry entries require the current ATR14 percentile to be at least 25 over the rolling ATR sample.
 
@@ -60,8 +60,9 @@ Replay setup:
 - Full Binance trade archive, continuous 1s execution bars
 - Signal timeframe `30m`
 - Replay mode `live_intrabar_sma5`
-- `breakout_shape=baseline_plus_t3`
-- `t3_min_sma_atr_separation=0.25`
+- Current live breakout shape: `original_t2`
+- Current live T2 tolerance: `breakout_shape_tolerance_bps=0.5`
+- Historical sweep baseline before this change used `breakout_shape=baseline_plus_t3` with `t3_min_sma_atr_separation=0.25`.
 - BTC live-like risk profile: `stop_loss_atr=0.3`, `trailing_stop_atr=0.3`, `delayed_trailing_activation=0.5`
 
 Low-volatility reentry gate sweep:
@@ -103,8 +104,8 @@ The ETH low-volatility gate was evaluated on the ETH research baseline:
 - `stop_loss_atr=0.05`
 - `trailing_stop_atr=0.3`
 - `delayed_trailing_activation=0.5`
-- `breakout_shape=baseline_plus_t3`
-- `t3_min_sma_atr_separation=0.25`
+- Historical ETH low-volatility gate sweep used `breakout_shape=baseline_plus_t3` with `t3_min_sma_atr_separation=0.25`.
+- T2-only follow-up research preference: `breakout_shape=original_t2`, `breakout_shape_tolerance_bps=0.5`.
 
 ETH stop-distance distribution under `stop_loss_atr=0.05`:
 

--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -5326,7 +5326,7 @@ func (p *Platform) resolveLiveSessionParameters(session domain.LiveSession, vers
 		"zero_initial_mode",
 		"sl_reentry_min_delay_seconds",
 		"breakout_shape",
-		"t3_min_sma_atr_separation",
+		"breakout_shape_tolerance_bps",
 		"use_sma5_intraday_structure",
 		"reentry_min_stop_bps",
 		"reentry_atr_percentile_gte",
@@ -5855,8 +5855,11 @@ func normalizeLiveSessionOverrides(overrides map[string]any) map[string]any {
 	if shape := strings.ToLower(strings.TrimSpace(stringValue(overrides["breakout_shape"]))); shape != "" {
 		normalized["breakout_shape"] = shape
 	}
-	if separation := parseFloatValue(overrides["t3_min_sma_atr_separation"]); separation > 0 {
-		normalized["t3_min_sma_atr_separation"] = separation
+	if _, ok := overrides["breakout_shape_tolerance_bps"]; ok {
+		toleranceBps := parseFloatValue(overrides["breakout_shape_tolerance_bps"])
+		if toleranceBps >= 0 && !math.IsInf(toleranceBps, 0) {
+			normalized["breakout_shape_tolerance_bps"] = sanitizeBreakoutShapeToleranceBps(toleranceBps)
+		}
 	}
 	if _, ok := overrides["use_sma5_intraday_structure"]; ok {
 		normalized["use_sma5_intraday_structure"] = boolValue(overrides["use_sma5_intraday_structure"])

--- a/internal/service/live_launch_flow_template_test.go
+++ b/internal/service/live_launch_flow_template_test.go
@@ -232,14 +232,17 @@ func TestLaunchLiveFlowEnhancedTemplateUsesEnhancedStrategyAndEngine(t *testing.
 	if result.RuntimeSession.StrategyID != "strategy-bk-btc-30m-enhanced" {
 		t.Fatalf("expected enhanced runtime strategy, got %s", result.RuntimeSession.StrategyID)
 	}
-	if got := stringValue(result.LiveSession.State["strategyEngine"]); got != "bk-live-intrabar-sma5-t3-sep" {
+	if got := stringValue(result.LiveSession.State["strategyEngine"]); got != bkLiveIntrabarSMA5T2Only0p5BpsEngineKey {
 		t.Fatalf("expected enhanced strategy engine, got %s", got)
 	}
-	if got := stringValue(result.LiveSession.State["breakout_shape"]); got != "baseline_plus_t3" {
-		t.Fatalf("expected baseline_plus_t3 breakout shape, got %s", got)
+	if got := stringValue(result.LiveSession.State["breakout_shape"]); got != "original_t2" {
+		t.Fatalf("expected original_t2 breakout shape, got %s", got)
 	}
-	if got := parseFloatValue(result.LiveSession.State["t3_min_sma_atr_separation"]); got != 0.25 {
-		t.Fatalf("expected t3 sep_0p25, got %v", got)
+	if got := parseFloatValue(result.LiveSession.State["breakout_shape_tolerance_bps"]); got != 0.5 {
+		t.Fatalf("expected T2 breakout tolerance 0.5 bps, got %v", got)
+	}
+	if _, ok := result.LiveSession.State["t3_min_sma_atr_separation"]; ok {
+		t.Fatalf("expected enhanced live session to omit t3 sep override, got %#v", result.LiveSession.State)
 	}
 	if got := maxIntValue(result.LiveSession.State["sl_reentry_min_delay_seconds"], 0); got != 60 {
 		t.Fatalf("expected enhanced live session SL-Reentry delay 60s, got %d", got)

--- a/internal/service/live_launch_templates.go
+++ b/internal/service/live_launch_templates.go
@@ -189,8 +189,8 @@ func (p *Platform) LiveLaunchTemplates() ([]LiveLaunchTemplate, error) {
 	buildEnhancedTemplate := func() LiveLaunchTemplate {
 		item := buildTemplate("BTCUSDT", "30m", 0.002, false)
 		item.Key = "binance-testnet-btc-30m-enhanced"
-		item.Name = "Binance Testnet BTCUSDT 30m Enhanced"
-		item.Description = "BTCUSDT 30m 增强策略：live_intrabar_sma5_baseline_plus_t3_breakout + t3 sep_0p25。"
+		item.Name = "Binance Testnet BTCUSDT 30m T2-only 0.5bps"
+		item.Description = "BTCUSDT 30m 增强策略：live_intrabar_sma5_original_t2_breakout_tol_0p5bps。"
 		item.StrategyID = enhancedStrategyID
 		item.StrategyName = enhancedStrategyName
 		item.StrategyVersionID = enhancedStrategyVersionID
@@ -201,8 +201,8 @@ func (p *Platform) LiveLaunchTemplates() ([]LiveLaunchTemplate, error) {
 		item.LaunchPayload.LaunchTemplateKey = item.Key
 		item.LaunchPayload.LaunchTemplateName = item.Name
 		item.Notes = append([]string{
-			fmt.Sprintf("增强模板单独使用 %s（strategyEngine=%s），不改变原 BTCUSDT 30m 模板。", enhancedStrategyName, "bk-live-intrabar-sma5-t3-sep"),
-			"策略口径对齐 research `live_intrabar_sma5_baseline_plus_t3_breakout+sep_0p25`：SMA5 intrabar hard filter + original_t2/t3_swing breakout，其中 sep_0p25 只过滤 t3_swing。",
+			fmt.Sprintf("增强模板单独使用 %s（strategyEngine=%s，历史 key %s 保留兼容），不改变原 BTCUSDT 30m 模板。", enhancedStrategyName, bkLiveIntrabarSMA5T2Only0p5BpsEngineKey, bkLiveIntrabarSMA5LegacyT3SepEngineKey),
+			"策略口径：SMA5 intrabar hard filter + original_t2 breakout + T2 shape tolerance 0.5 bps；t3_swing breakout 已摘除。",
 			"低波动 reentry gate 固化为 reentry_min_stop_bps=6 与 reentry_atr_percentile_gte=25，仅过滤 Zero-Initial/SL/PT reentry 开仓，不过滤止损出场。",
 			"模板仍保持 dispatchMode 由前端提交前选择，默认展示为 manual-review。",
 		}, item.Notes...)
@@ -269,12 +269,12 @@ func liveIntradayResearchBaselineOverrides(strategyEngine string) map[string]any
 }
 
 func liveBTC30mEnhancedOverrides() map[string]any {
-	overrides := liveIntradayResearchBaselineOverrides("bk-live-intrabar-sma5-t3-sep")
+	overrides := liveIntradayResearchBaselineOverrides(bkLiveIntrabarSMA5T2Only0p5BpsEngineKey)
 	overrides["max_trades_per_bar"] = domain.ResearchBaselineMaxTradesPerBar
 	overrides["stop_loss_atr"] = 0.3
 	overrides["sl_reentry_min_delay_seconds"] = 60
-	overrides["breakout_shape"] = "baseline_plus_t3"
-	overrides["t3_min_sma_atr_separation"] = 0.25
+	overrides["breakout_shape"] = "original_t2"
+	overrides["breakout_shape_tolerance_bps"] = defaultT2BreakoutShapeToleranceBps
 	overrides["use_sma5_intraday_structure"] = true
 	overrides["reentry_min_stop_bps"] = 6.0
 	overrides["reentry_atr_percentile_gte"] = 25.0

--- a/internal/service/live_launch_templates_test.go
+++ b/internal/service/live_launch_templates_test.go
@@ -186,14 +186,17 @@ func TestLiveLaunchTemplatesExposeBinanceTestnetVariants(t *testing.T) {
 				t.Fatalf("expected reentry_size_schedule [0.20, 0.10] for %s, got %#v", item.Key, item.LaunchPayload.LiveSessionOverrides["reentry_size_schedule"])
 			}
 			if want.enhanced {
-				if got := stringValue(item.LaunchPayload.LiveSessionOverrides["strategyEngine"]); got != "bk-live-intrabar-sma5-t3-sep" {
+				if got := stringValue(item.LaunchPayload.LiveSessionOverrides["strategyEngine"]); got != bkLiveIntrabarSMA5T2Only0p5BpsEngineKey {
 					t.Fatalf("expected enhanced strategy engine, got %s", got)
 				}
-				if got := stringValue(item.LaunchPayload.LiveSessionOverrides["breakout_shape"]); got != "baseline_plus_t3" {
-					t.Fatalf("expected baseline_plus_t3 breakout shape, got %s", got)
+				if got := stringValue(item.LaunchPayload.LiveSessionOverrides["breakout_shape"]); got != "original_t2" {
+					t.Fatalf("expected original_t2 breakout shape, got %s", got)
 				}
-				if got := parseFloatValue(item.LaunchPayload.LiveSessionOverrides["t3_min_sma_atr_separation"]); got != 0.25 {
-					t.Fatalf("expected t3 sep 0.25, got %v", got)
+				if got := parseFloatValue(item.LaunchPayload.LiveSessionOverrides["breakout_shape_tolerance_bps"]); got != 0.5 {
+					t.Fatalf("expected T2 breakout tolerance 0.5 bps, got %v", got)
+				}
+				if _, ok := item.LaunchPayload.LiveSessionOverrides["t3_min_sma_atr_separation"]; ok {
+					t.Fatalf("expected enhanced template to omit t3 sep override, got %#v", item.LaunchPayload.LiveSessionOverrides)
 				}
 				if got := maxIntValue(item.LaunchPayload.LiveSessionOverrides["sl_reentry_min_delay_seconds"], 0); got != 60 {
 					t.Fatalf("expected enhanced template SL-Reentry delay 60s, got %d", got)

--- a/internal/service/live_market_data.go
+++ b/internal/service/live_market_data.go
@@ -555,7 +555,7 @@ func (p *Platform) buildLiveExecutionPlanFromMarketData(
 
 	var result map[string]any
 	switch normalized := normalizeStrategyEngineKey(engineKey); normalized {
-	case "bk-default", "bk-live-intrabar-sma5-t3-sep":
+	case "bk-default", bkLiveIntrabarSMA5T2Only0p5BpsEngineKey:
 		result, err = runStrategyReplayOnMinuteBars(cfg, signals, minuteBars)
 	default:
 		result, err = engine.Run(context)

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -783,7 +783,13 @@ func TestEvaluateSignalBarGateAllowsBreakoutBoundaryEquality(t *testing.T) {
 	}
 }
 
-func TestEvaluateSignalBarGateAllowsT3BreakoutWithSeparation(t *testing.T) {
+func TestNormalizeStrategyEngineKeyMapsLegacyT3SepToT2Only(t *testing.T) {
+	if got := normalizeStrategyEngineKey(bkLiveIntrabarSMA5LegacyT3SepEngineKey); got != bkLiveIntrabarSMA5T2Only0p5BpsEngineKey {
+		t.Fatalf("expected legacy enhanced engine key to normalize to %s, got %s", bkLiveIntrabarSMA5T2Only0p5BpsEngineKey, got)
+	}
+}
+
+func TestEvaluateSignalBarGateAllowsT2BreakoutTolerance(t *testing.T) {
 	gate := evaluateSignalBarGate(map[string]any{
 		"timeframe": "30m",
 		"sma5":      68200.0,
@@ -791,25 +797,28 @@ func TestEvaluateSignalBarGateAllowsT3BreakoutWithSeparation(t *testing.T) {
 		"atr14":     800.0,
 		"current": map[string]any{
 			"close": 68600.0,
-			"high":  69050.0,
+			"high":  68998.0,
 			"low":   68100.0,
 		},
-		"prevBar1": map[string]any{"high": 68800.0, "low": 68100.0},
-		"prevBar2": map[string]any{"high": 68600.0, "low": 68000.0},
-		"prevBar3": map[string]any{"high": 69000.0, "low": 67900.0},
-	}, "BUY", "entry", "", 69010.0, "trade_tick.price", signalBarGateOptions{
-		BreakoutShape:         "baseline_plus_t3",
-		T3MinSMAATRSeparation: 0.25,
+		"prevBar1": map[string]any{"high": 69000.0, "low": 68100.0},
+		"prevBar2": map[string]any{"high": 68997.0, "low": 68000.0},
+		"prevBar3": map[string]any{"high": 68700.0, "low": 67900.0},
+	}, "BUY", "entry", "", 68997.0, "trade_tick.price", signalBarGateOptions{
+		BreakoutShape:             "original_t2",
+		BreakoutShapeToleranceBps: 0.5,
 	})
 	if !boolValue(gate["longBreakoutPatternReady"]) || !boolValue(gate["longReady"]) {
-		t.Fatalf("expected t3 breakout with sep_0p25 to pass, got %#v", gate)
+		t.Fatalf("expected original_t2 breakout within 0.5 bps tolerance to pass, got %#v", gate)
 	}
-	if got := stringValue(gate["longBreakoutShapeName"]); got != "t3_swing" {
-		t.Fatalf("expected t3_swing shape, got %s in %#v", got, gate)
+	if got := stringValue(gate["longBreakoutShapeName"]); got != "original_t2" {
+		t.Fatalf("expected original_t2 shape, got %s in %#v", got, gate)
+	}
+	if got := parseFloatValue(gate["longBreakoutLevel"]); got != 68997.0 {
+		t.Fatalf("expected original_t2 level to remain T2 high, got %v in %#v", got, gate)
 	}
 }
 
-func TestEvaluateSignalBarGateKeepsOriginalT2WhenT3Enabled(t *testing.T) {
+func TestEvaluateSignalBarGateKeepsOriginalT2WithLegacyBreakoutShape(t *testing.T) {
 	gate := evaluateSignalBarGate(map[string]any{
 		"timeframe": "30m",
 		"sma5":      68200.0,
@@ -824,18 +833,18 @@ func TestEvaluateSignalBarGateKeepsOriginalT2WhenT3Enabled(t *testing.T) {
 		"prevBar2": map[string]any{"high": 69000.0, "low": 68000.0},
 		"prevBar3": map[string]any{"high": 68700.0, "low": 67900.0},
 	}, "BUY", "entry", "", 69000.0, "trade_tick.price", signalBarGateOptions{
-		BreakoutShape:         "baseline_plus_t3",
-		T3MinSMAATRSeparation: 0.25,
+		BreakoutShape:             "baseline_plus_t3",
+		BreakoutShapeToleranceBps: 0.5,
 	})
 	if !boolValue(gate["longBreakoutPatternReady"]) || !boolValue(gate["longReady"]) {
-		t.Fatalf("expected original_t2 breakout to pass with t3 enabled, got %#v", gate)
+		t.Fatalf("expected original_t2 breakout to pass with legacy breakout shape configured, got %#v", gate)
 	}
 	if got := stringValue(gate["longBreakoutShapeName"]); got != "original_t2" {
 		t.Fatalf("expected original_t2 to remain selected, got %s in %#v", got, gate)
 	}
 }
 
-func TestEvaluateSignalBarGateBlocksT3BreakoutInsideSeparation(t *testing.T) {
+func TestEvaluateSignalBarGateIgnoresT3OnlyBreakoutShape(t *testing.T) {
 	gate := evaluateSignalBarGate(map[string]any{
 		"timeframe": "30m",
 		"sma5":      68850.0,
@@ -850,14 +859,14 @@ func TestEvaluateSignalBarGateBlocksT3BreakoutInsideSeparation(t *testing.T) {
 		"prevBar2": map[string]any{"high": 68600.0, "low": 68000.0},
 		"prevBar3": map[string]any{"high": 69000.0, "low": 67900.0},
 	}, "BUY", "entry", "", 69010.0, "trade_tick.price", signalBarGateOptions{
-		BreakoutShape:         "baseline_plus_t3",
-		T3MinSMAATRSeparation: 0.25,
+		BreakoutShape:             "baseline_plus_t3",
+		BreakoutShapeToleranceBps: 0.5,
 	})
 	if boolValue(gate["longBreakoutPatternReady"]) || boolValue(gate["longReady"]) {
-		t.Fatalf("expected t3 breakout inside sep_0p25 to be blocked, got %#v", gate)
+		t.Fatalf("expected t3-only breakout shape to be ignored, got %#v", gate)
 	}
-	if boolValue(gate["longBreakoutQualityReady"]) {
-		t.Fatalf("expected t3 quality gate to fail, got %#v", gate)
+	if got := stringValue(gate["longBreakoutShapeName"]); got != "" {
+		t.Fatalf("expected no breakout shape, got %s in %#v", got, gate)
 	}
 }
 
@@ -1554,7 +1563,7 @@ func TestBuildLiveExecutionPlanFromMarketDataUsesLiveSnapshotForEnhanced30m(t *t
 	if err != nil {
 		t.Fatalf("resolve strategy engine failed: %v", err)
 	}
-	if got := normalizeStrategyEngineKey(engineKey); got != "bk-live-intrabar-sma5-t3-sep" {
+	if got := normalizeStrategyEngineKey(engineKey); got != bkLiveIntrabarSMA5T2Only0p5BpsEngineKey {
 		t.Fatalf("expected enhanced engine, got %s", got)
 	}
 
@@ -4343,20 +4352,20 @@ func TestNormalizeLiveSessionOverridesIncludesZeroInitialControls(t *testing.T) 
 	}
 }
 
-func TestNormalizeLiveSessionOverridesIncludesT3BreakoutControls(t *testing.T) {
+func TestNormalizeLiveSessionOverridesIncludesT2BreakoutTolerance(t *testing.T) {
 	overrides := normalizeLiveSessionOverrides(map[string]any{
-		"breakout_shape":                    "baseline_plus_t3",
-		"t3_min_sma_atr_separation":         0.25,
-		"use_sma5_intraday_structure":       true,
-		"reentry_min_stop_bps":              6.0,
-		"reentry_atr_percentile_gte":        25.0,
-		"ignored_t3_min_sma_atr_separation": 0.50,
+		"breakout_shape":                       "ORIGINAL_T2",
+		"breakout_shape_tolerance_bps":         0.5,
+		"use_sma5_intraday_structure":          true,
+		"reentry_min_stop_bps":                 6.0,
+		"reentry_atr_percentile_gte":           25.0,
+		"ignored_breakout_shape_tolerance_bps": 1.0,
 	})
-	if got := stringValue(overrides["breakout_shape"]); got != "baseline_plus_t3" {
-		t.Fatalf("expected breakout_shape=baseline_plus_t3, got %s", got)
+	if got := stringValue(overrides["breakout_shape"]); got != "original_t2" {
+		t.Fatalf("expected breakout_shape=original_t2, got %s", got)
 	}
-	if got := parseFloatValue(overrides["t3_min_sma_atr_separation"]); got != 0.25 {
-		t.Fatalf("expected t3_min_sma_atr_separation=0.25, got %v", got)
+	if got := parseFloatValue(overrides["breakout_shape_tolerance_bps"]); got != 0.5 {
+		t.Fatalf("expected breakout_shape_tolerance_bps=0.5, got %v", got)
 	}
 	if !boolValue(overrides["use_sma5_intraday_structure"]) {
 		t.Fatal("expected use_sma5_intraday_structure override")
@@ -4367,13 +4376,25 @@ func TestNormalizeLiveSessionOverridesIncludesT3BreakoutControls(t *testing.T) {
 	if got := parseFloatValue(overrides["reentry_atr_percentile_gte"]); got != 25.0 {
 		t.Fatalf("expected reentry_atr_percentile_gte=25, got %v", got)
 	}
-	if _, ok := overrides["ignored_t3_min_sma_atr_separation"]; ok {
-		t.Fatalf("expected unknown t3 override key to be dropped, got %#v", overrides)
+	if _, ok := overrides["ignored_breakout_shape_tolerance_bps"]; ok {
+		t.Fatalf("expected unknown breakout tolerance override key to be dropped, got %#v", overrides)
 	}
 }
 
 func TestLiveBTC30mEnhancedOverridesEnableReentryGuards(t *testing.T) {
 	overrides := liveBTC30mEnhancedOverrides()
+	if got := stringValue(overrides["strategyEngine"]); got != bkLiveIntrabarSMA5T2Only0p5BpsEngineKey {
+		t.Fatalf("expected BTC 30m enhanced template to use T2-only engine, got %s", got)
+	}
+	if got := stringValue(overrides["breakout_shape"]); got != "original_t2" {
+		t.Fatalf("expected BTC 30m enhanced template to use original_t2 breakout, got %s", got)
+	}
+	if got := parseFloatValue(overrides["breakout_shape_tolerance_bps"]); got != 0.5 {
+		t.Fatalf("expected BTC 30m enhanced template to use T2 tolerance 0.5 bps, got %v", got)
+	}
+	if _, ok := overrides["t3_min_sma_atr_separation"]; ok {
+		t.Fatalf("expected BTC 30m enhanced template to omit t3 sep override, got %#v", overrides)
+	}
 	if got := maxIntValue(overrides["sl_reentry_min_delay_seconds"], 0); got != 60 {
 		t.Fatalf("expected BTC 30m enhanced template to require 60s SL-Reentry delay, got %d", got)
 	}

--- a/internal/service/strategy.go
+++ b/internal/service/strategy.go
@@ -611,6 +611,8 @@ func applyBacktestParameterAliases(parameters map[string]any) {
 		"delayedTrailingActivationATR": "delayed_trailing_activation_atr",
 		"longReentryATR":               "long_reentry_atr",
 		"shortReentryATR":              "short_reentry_atr",
+		"breakoutShape":                "breakout_shape",
+		"breakoutShapeToleranceBps":    "breakout_shape_tolerance_bps",
 		"reentryMinStopBps":            "reentry_min_stop_bps",
 		"reentryATRPercentileGTE":      "reentry_atr_percentile_gte",
 		"minStopBps":                   "min_stop_bps",

--- a/internal/service/strategy_registry.go
+++ b/internal/service/strategy_registry.go
@@ -97,10 +97,19 @@ func defaultExecutionSemantics(mode ExecutionMode, parameters map[string]any) St
 	return semantics
 }
 
+const (
+	bkLiveIntrabarSMA5T2Only0p5BpsEngineKey = "bk-live-intrabar-sma5-t2-only-0p5bps"
+	bkLiveIntrabarSMA5LegacyT3SepEngineKey  = "bk-live-intrabar-sma5-t3-sep"
+	defaultT2BreakoutShapeToleranceBps      = 0.5
+)
+
 func normalizeStrategyEngineKey(raw string) string {
 	value := strings.TrimSpace(strings.ToLower(raw))
 	if value == "" {
 		return "bk-default"
+	}
+	if value == bkLiveIntrabarSMA5LegacyT3SepEngineKey {
+		return bkLiveIntrabarSMA5T2Only0p5BpsEngineKey
 	}
 	return value
 }
@@ -117,7 +126,7 @@ func (p *Platform) registerStrategyEngine(engine StrategyEngine) {
 
 func (p *Platform) registerBuiltInStrategyEngines() {
 	p.registerStrategyEngine(bkStrategyEngine{platform: p})
-	p.registerStrategyEngine(bkLiveIntrabarSMA5T3SepEngine{platform: p})
+	p.registerStrategyEngine(bkLiveIntrabarSMA5T2Only0p5BpsEngine{platform: p})
 }
 
 func (p *Platform) resolveStrategyEngine(strategyVersionID string, parameters map[string]any) (StrategyEngine, string, error) {
@@ -180,46 +189,46 @@ func (e bkStrategyEngine) Run(context StrategyExecutionContext) (map[string]any,
 	return e.platform.runStrategyReplay(context)
 }
 
-type bkLiveIntrabarSMA5T3SepEngine struct {
+type bkLiveIntrabarSMA5T2Only0p5BpsEngine struct {
 	platform *Platform
 }
 
-func (e bkLiveIntrabarSMA5T3SepEngine) Key() string {
-	return "bk-live-intrabar-sma5-t3-sep"
+func (e bkLiveIntrabarSMA5T2Only0p5BpsEngine) Key() string {
+	return bkLiveIntrabarSMA5T2Only0p5BpsEngineKey
 }
 
-func (e bkLiveIntrabarSMA5T3SepEngine) Describe() map[string]any {
+func (e bkLiveIntrabarSMA5T2Only0p5BpsEngine) Describe() map[string]any {
 	return map[string]any{
 		"key":                  e.Key(),
-		"name":                 "BK Live Intrabar SMA5 T3 Sep",
+		"name":                 "BK Live Intrabar SMA5 T2-only 0.5bps",
 		"supportedSignalBars":  []string{"30m"},
 		"supportedExecutions":  []string{"tick", "1min"},
-		"runtimeConsistency":   "live-intrabar-sma5-baseline-plus-t3-breakout-sep-0p25",
+		"runtimeConsistency":   "live-intrabar-sma5-original-t2-breakout-tol-0p5bps",
 		"backtestSlippageOnly": true,
 	}
 }
 
-func (e bkLiveIntrabarSMA5T3SepEngine) Run(context StrategyExecutionContext) (map[string]any, error) {
+func (e bkLiveIntrabarSMA5T2Only0p5BpsEngine) Run(context StrategyExecutionContext) (map[string]any, error) {
 	return e.platform.runStrategyReplay(context)
 }
 
-func (e bkLiveIntrabarSMA5T3SepEngine) EvaluateSignal(context StrategySignalEvaluationContext) (StrategySignalDecision, error) {
+func (e bkLiveIntrabarSMA5T2Only0p5BpsEngine) EvaluateSignal(context StrategySignalEvaluationContext) (StrategySignalDecision, error) {
 	return bkStrategyEngine{platform: e.platform}.EvaluateSignal(context)
 }
 
 type signalBarGateOptions struct {
-	BreakoutShape           string
-	T3MinSMAATRSeparation   float64
-	ReentryMinStopBps       float64
-	ReentryATRPercentileGTE float64
+	BreakoutShape             string
+	BreakoutShapeToleranceBps float64
+	ReentryMinStopBps         float64
+	ReentryATRPercentileGTE   float64
 }
 
 func signalBarGateOptionsFromParameters(parameters map[string]any) signalBarGateOptions {
 	return signalBarGateOptions{
-		BreakoutShape:           strings.ToLower(strings.TrimSpace(stringValue(parameters["breakout_shape"]))),
-		T3MinSMAATRSeparation:   parseFloatValue(parameters["t3_min_sma_atr_separation"]),
-		ReentryMinStopBps:       firstPositive(parseFloatValue(parameters["reentry_min_stop_bps"]), parseFloatValue(parameters["min_stop_bps"])),
-		ReentryATRPercentileGTE: firstPositive(parseFloatValue(parameters["reentry_atr_percentile_gte"]), parseFloatValue(parameters["atr_pct_gte"])),
+		BreakoutShape:             strings.ToLower(strings.TrimSpace(stringValue(parameters["breakout_shape"]))),
+		BreakoutShapeToleranceBps: parseFloatValue(parameters["breakout_shape_tolerance_bps"]),
+		ReentryMinStopBps:         firstPositive(parseFloatValue(parameters["reentry_min_stop_bps"]), parseFloatValue(parameters["min_stop_bps"])),
+		ReentryATRPercentileGTE:   firstPositive(parseFloatValue(parameters["reentry_atr_percentile_gte"]), parseFloatValue(parameters["atr_pct_gte"])),
 	}
 }
 
@@ -817,7 +826,6 @@ func evaluateSignalBarGate(signalBarState map[string]any, nextSide, nextRole, ne
 	current := mapValue(signalBarState["current"])
 	prevBar1 := mapValue(signalBarState["prevBar1"])
 	prevBar2 := mapValue(signalBarState["prevBar2"])
-	prevBar3 := mapValue(signalBarState["prevBar3"])
 	ma20 := parseFloatValue(signalBarState["ma20"])
 	sma5 := parseFloatValue(signalBarState["sma5"])
 	atr14 := parseFloatValue(signalBarState["atr14"])
@@ -829,10 +837,8 @@ func evaluateSignalBarGate(signalBarState map[string]any, nextSide, nextRole, ne
 	closePrice := parseFloatValue(current["close"])
 	prevHigh1 := parseFloatValue(prevBar1["high"])
 	prevHigh2 := parseFloatValue(prevBar2["high"])
-	prevHigh3 := parseFloatValue(prevBar3["high"])
 	prevLow1 := parseFloatValue(prevBar1["low"])
 	prevLow2 := parseFloatValue(prevBar2["low"])
-	prevLow3 := parseFloatValue(prevBar3["low"])
 	longStructureReady := false
 	shortStructureReady := false
 	longEarlyReversalReady := false
@@ -879,32 +885,22 @@ func evaluateSignalBarGate(signalBarState map[string]any, nextSide, nextRole, ne
 	}
 	longBreakoutShapeName := ""
 	longBreakoutLevel := 0.0
-	if prevHigh2 > prevHigh1 && prevHigh2 > 0 {
+	if t2LongBreakoutShapeReady(prevHigh2, prevHigh1, gateOptions.BreakoutShapeToleranceBps) {
 		longBreakoutShapeName = "original_t2"
 		longBreakoutLevel = prevHigh2
 	}
-	if gateOptions.BreakoutShape == "baseline_plus_t3" &&
-		prevHigh3 > prevHigh2 && prevHigh3 > prevHigh1 && prevHigh1 > prevHigh2 && prevHigh3 > 0 {
-		longBreakoutShapeName = "t3_swing"
-		longBreakoutLevel = prevHigh3
-	}
 	shortBreakoutShapeName := ""
 	shortBreakoutLevel := 0.0
-	if prevLow2 < prevLow1 && prevLow2 > 0 {
+	if t2ShortBreakoutShapeReady(prevLow2, prevLow1, gateOptions.BreakoutShapeToleranceBps) {
 		shortBreakoutShapeName = "original_t2"
 		shortBreakoutLevel = prevLow2
-	}
-	if gateOptions.BreakoutShape == "baseline_plus_t3" &&
-		prevLow3 < prevLow2 && prevLow3 < prevLow1 && prevLow1 < prevLow2 && prevLow3 > 0 {
-		shortBreakoutShapeName = "t3_swing"
-		shortBreakoutLevel = prevLow3
 	}
 	longBreakoutShapeReady := longBreakoutShapeName != "" && longBreakoutLevel > 0
 	shortBreakoutShapeReady := shortBreakoutShapeName != "" && shortBreakoutLevel > 0
 	longBreakoutPriceReady := breakoutPrice >= longBreakoutLevel && longBreakoutLevel > 0
 	shortBreakoutPriceReady := breakoutPrice <= shortBreakoutLevel && shortBreakoutLevel > 0
-	longBreakoutQualityReady := breakoutQualityReady(longBreakoutShapeName, longBreakoutLevel, sma5, atr14, gateOptions)
-	shortBreakoutQualityReady := breakoutQualityReady(shortBreakoutShapeName, shortBreakoutLevel, sma5, atr14, gateOptions)
+	longBreakoutQualityReady := true
+	shortBreakoutQualityReady := true
 	longBreakoutReady := longBreakoutShapeReady && longBreakoutPriceReady && longBreakoutQualityReady
 	shortBreakoutReady := shortBreakoutShapeReady && shortBreakoutPriceReady && shortBreakoutQualityReady
 	longReady := longStructureReady && longBreakoutReady
@@ -1021,14 +1017,33 @@ func evaluateReentryEntryQualityGate(parameters map[string]any, signalBarState m
 	return result
 }
 
-func breakoutQualityReady(shapeName string, breakoutLevel, sma5, atr14 float64, options signalBarGateOptions) bool {
-	if shapeName != "t3_swing" || options.T3MinSMAATRSeparation <= 0 {
-		return true
-	}
-	if breakoutLevel <= 0 || sma5 <= 0 || atr14 <= 0 {
+func t2LongBreakoutShapeReady(prevHigh2, prevHigh1, toleranceBps float64) bool {
+	if prevHigh2 <= 0 || prevHigh1 <= 0 {
 		return false
 	}
-	return math.Abs(breakoutLevel-sma5) >= options.T3MinSMAATRSeparation*atr14
+	toleranceBps = sanitizeBreakoutShapeToleranceBps(toleranceBps)
+	if toleranceBps <= 0 {
+		return prevHigh2 > prevHigh1
+	}
+	return prevHigh2 >= prevHigh1*(1-toleranceBps/10000)
+}
+
+func t2ShortBreakoutShapeReady(prevLow2, prevLow1, toleranceBps float64) bool {
+	if prevLow2 <= 0 || prevLow1 <= 0 {
+		return false
+	}
+	toleranceBps = sanitizeBreakoutShapeToleranceBps(toleranceBps)
+	if toleranceBps <= 0 {
+		return prevLow2 < prevLow1
+	}
+	return prevLow2 <= prevLow1*(1+toleranceBps/10000)
+}
+
+func sanitizeBreakoutShapeToleranceBps(toleranceBps float64) float64 {
+	if toleranceBps <= 0 || math.IsNaN(toleranceBps) || math.IsInf(toleranceBps, 0) {
+		return 0
+	}
+	return toleranceBps
 }
 
 func isFavorableBiasForPlan(nextRole, nextReason, liquidityBias string) bool {

--- a/internal/service/strategy_replay.go
+++ b/internal/service/strategy_replay.go
@@ -55,31 +55,31 @@ type strategyPosition struct {
 }
 
 type strategyReplayConfig struct {
-	SignalTimeframe          string
-	ExecutionDataSource      string
-	Symbol                   string
-	From                     time.Time
-	To                       time.Time
-	InitialBalance           float64
-	Dir1ReentryConfirm       bool
-	Dir2ZeroInitial          bool
-	ZeroInitialMode          string
-	FixedSlippage            float64
-	StopLossATR              float64
-	MaxTradesPerBar          int
-	ReentrySizeSchedule      []float64
-	LongReentryATR           float64
-	ShortReentryATR          float64
-	StopMode                 string
-	ProfitProtectATR         float64
-	TrailingStopATR          float64
-	DelayedTrailingATR       float64
-	TradingFeeRate           float64
-	FundingRate              float64
-	FundingIntervalHours     int
-	BreakoutShape            string
-	T3MinSMAATRSeparation    float64
-	UseSMA5IntradayStructure bool
+	SignalTimeframe           string
+	ExecutionDataSource       string
+	Symbol                    string
+	From                      time.Time
+	To                        time.Time
+	InitialBalance            float64
+	Dir1ReentryConfirm        bool
+	Dir2ZeroInitial           bool
+	ZeroInitialMode           string
+	FixedSlippage             float64
+	StopLossATR               float64
+	MaxTradesPerBar           int
+	ReentrySizeSchedule       []float64
+	LongReentryATR            float64
+	ShortReentryATR           float64
+	StopMode                  string
+	ProfitProtectATR          float64
+	TrailingStopATR           float64
+	DelayedTrailingATR        float64
+	TradingFeeRate            float64
+	FundingRate               float64
+	FundingIntervalHours      int
+	BreakoutShape             string
+	BreakoutShapeToleranceBps float64
+	UseSMA5IntradayStructure  bool
 }
 
 func (p *Platform) runStrategyReplay(context StrategyExecutionContext) (map[string]any, error) {
@@ -1049,31 +1049,31 @@ func buildStrategyReplayConfig(context StrategyExecutionContext) strategyReplayC
 		stopLossATR = 0.05
 	}
 	return strategyReplayConfig{
-		SignalTimeframe:          normalizeSignalBarInterval(context.SignalTimeframe),
-		ExecutionDataSource:      strings.ToLower(context.ExecutionDataSource),
-		Symbol:                   normalizeBacktestSymbol(context.Symbol),
-		From:                     context.From,
-		To:                       context.To,
-		InitialBalance:           100000.0,
-		Dir1ReentryConfirm:       false,
-		Dir2ZeroInitial:          dir2ZeroInitial,
-		ZeroInitialMode:          resolveStrategyZeroInitialMode(dir2ZeroInitial, parameters["zero_initial_mode"]),
-		FixedSlippage:            strategyReplaySlippage(context, parameters),
-		StopLossATR:              stopLossATR,
-		MaxTradesPerBar:          maxIntValue(parameters["max_trades_per_bar"], domain.ResearchBaselineMaxTradesPerBar),
-		ReentrySizeSchedule:      reentrySizes,
-		LongReentryATR:           parseFloatValue(firstNonNil(parameters["long_reentry_atr"], 0.1)),
-		ShortReentryATR:          parseFloatValue(firstNonNil(parameters["short_reentry_atr"], 0.0)),
-		StopMode:                 stopMode,
-		ProfitProtectATR:         firstPositive(parseFloatValue(parameters["profit_protect_atr"]), 1.0),
-		TrailingStopATR:          parseFloatValue(parameters["trailing_stop_atr"]),
-		DelayedTrailingATR:       parseFloatValue(parameters["delayed_trailing_activation_atr"]),
-		TradingFeeRate:           context.Semantics.TradingFeeBps / 10000.0,
-		FundingRate:              context.Semantics.FundingRateBps / 10000.0,
-		FundingIntervalHours:     maxIntValue(context.Semantics.FundingIntervalHours, 8),
-		BreakoutShape:            strings.ToLower(strings.TrimSpace(stringValue(parameters["breakout_shape"]))),
-		T3MinSMAATRSeparation:    parseFloatValue(parameters["t3_min_sma_atr_separation"]),
-		UseSMA5IntradayStructure: boolValue(parameters["use_sma5_intraday_structure"]),
+		SignalTimeframe:           normalizeSignalBarInterval(context.SignalTimeframe),
+		ExecutionDataSource:       strings.ToLower(context.ExecutionDataSource),
+		Symbol:                    normalizeBacktestSymbol(context.Symbol),
+		From:                      context.From,
+		To:                        context.To,
+		InitialBalance:            100000.0,
+		Dir1ReentryConfirm:        false,
+		Dir2ZeroInitial:           dir2ZeroInitial,
+		ZeroInitialMode:           resolveStrategyZeroInitialMode(dir2ZeroInitial, parameters["zero_initial_mode"]),
+		FixedSlippage:             strategyReplaySlippage(context, parameters),
+		StopLossATR:               stopLossATR,
+		MaxTradesPerBar:           maxIntValue(parameters["max_trades_per_bar"], domain.ResearchBaselineMaxTradesPerBar),
+		ReentrySizeSchedule:       reentrySizes,
+		LongReentryATR:            parseFloatValue(firstNonNil(parameters["long_reentry_atr"], 0.1)),
+		ShortReentryATR:           parseFloatValue(firstNonNil(parameters["short_reentry_atr"], 0.0)),
+		StopMode:                  stopMode,
+		ProfitProtectATR:          firstPositive(parseFloatValue(parameters["profit_protect_atr"]), 1.0),
+		TrailingStopATR:           parseFloatValue(parameters["trailing_stop_atr"]),
+		DelayedTrailingATR:        parseFloatValue(parameters["delayed_trailing_activation_atr"]),
+		TradingFeeRate:            context.Semantics.TradingFeeBps / 10000.0,
+		FundingRate:               context.Semantics.FundingRateBps / 10000.0,
+		FundingIntervalHours:      maxIntValue(context.Semantics.FundingIntervalHours, 8),
+		BreakoutShape:             strings.ToLower(strings.TrimSpace(stringValue(parameters["breakout_shape"]))),
+		BreakoutShapeToleranceBps: parseFloatValue(parameters["breakout_shape_tolerance_bps"]),
+		UseSMA5IntradayStructure:  boolValue(parameters["use_sma5_intraday_structure"]),
 	}
 }
 
@@ -1185,37 +1185,15 @@ type replayInitialBreakout struct {
 func resolveReplayInitialBreakout(sig strategySignalBar, side string, observedPrice float64, cfg strategyReplayConfig) replayInitialBreakout {
 	switch strings.ToLower(strings.TrimSpace(side)) {
 	case "long":
-		if sig.PrevHigh2 > sig.PrevHigh1 && sig.PrevHigh2 > 0 && observedPrice >= sig.PrevHigh2 {
+		if t2LongBreakoutShapeReady(sig.PrevHigh2, sig.PrevHigh1, cfg.BreakoutShapeToleranceBps) && observedPrice >= sig.PrevHigh2 {
 			return replayInitialBreakout{Ready: true, Level: sig.PrevHigh2, Shape: "original_t2"}
 		}
-		if cfg.BreakoutShape == "baseline_plus_t3" &&
-			sig.PrevHigh3 > sig.PrevHigh2 && sig.PrevHigh3 > sig.PrevHigh1 && sig.PrevHigh1 > sig.PrevHigh2 &&
-			sig.PrevHigh3 > 0 && observedPrice >= sig.PrevHigh3 &&
-			replayT3BreakoutQualityReady(sig.PrevHigh3, sig, cfg) {
-			return replayInitialBreakout{Ready: true, Level: sig.PrevHigh3, Shape: "t3_swing"}
-		}
 	case "short":
-		if sig.PrevLow2 < sig.PrevLow1 && sig.PrevLow2 > 0 && observedPrice <= sig.PrevLow2 {
+		if t2ShortBreakoutShapeReady(sig.PrevLow2, sig.PrevLow1, cfg.BreakoutShapeToleranceBps) && observedPrice <= sig.PrevLow2 {
 			return replayInitialBreakout{Ready: true, Level: sig.PrevLow2, Shape: "original_t2"}
-		}
-		if cfg.BreakoutShape == "baseline_plus_t3" &&
-			sig.PrevLow3 < sig.PrevLow2 && sig.PrevLow3 < sig.PrevLow1 && sig.PrevLow1 < sig.PrevLow2 &&
-			sig.PrevLow3 > 0 && observedPrice <= sig.PrevLow3 &&
-			replayT3BreakoutQualityReady(sig.PrevLow3, sig, cfg) {
-			return replayInitialBreakout{Ready: true, Level: sig.PrevLow3, Shape: "t3_swing"}
 		}
 	}
 	return replayInitialBreakout{}
-}
-
-func replayT3BreakoutQualityReady(level float64, sig strategySignalBar, cfg strategyReplayConfig) bool {
-	if cfg.T3MinSMAATRSeparation <= 0 {
-		return true
-	}
-	if level <= 0 || sig.MA5 <= 0 || sig.ATR <= 0 || math.IsNaN(sig.MA5) || math.IsNaN(sig.ATR) {
-		return false
-	}
-	return math.Abs(level-sig.MA5) >= cfg.T3MinSMAATRSeparation*sig.ATR
 }
 
 func strategySignalRegimeReady(sig strategySignalBar, timeframe string, useSMA5Intraday ...bool) (bool, bool) {

--- a/internal/service/strategy_replay_test.go
+++ b/internal/service/strategy_replay_test.go
@@ -176,31 +176,31 @@ func TestBuildStrategyReplayConfigUsesUpdatedBaselineDefaults(t *testing.T) {
 	}
 }
 
-func TestResolveReplayInitialBreakoutAllowsT3WithSep(t *testing.T) {
+func TestResolveReplayInitialBreakoutAllowsT2Tolerance(t *testing.T) {
 	cfg := strategyReplayConfig{
-		BreakoutShape:         "baseline_plus_t3",
-		T3MinSMAATRSeparation: 0.25,
+		BreakoutShape:             "original_t2",
+		BreakoutShapeToleranceBps: 0.5,
 	}
 	sig := strategySignalBar{
 		MA5:       68200,
 		ATR:       800,
-		PrevHigh1: 68800,
-		PrevHigh2: 68600,
-		PrevHigh3: 69000,
+		PrevHigh1: 69000,
+		PrevHigh2: 68997,
+		PrevHigh3: 68700,
 		PrevLow1:  68100,
 		PrevLow2:  68000,
 		PrevLow3:  67900,
 	}
-	breakout := resolveReplayInitialBreakout(sig, "long", 69010, cfg)
-	if !breakout.Ready || breakout.Level != 69000 || breakout.Shape != "t3_swing" {
-		t.Fatalf("expected t3 breakout to pass sep filter, got %#v", breakout)
+	breakout := resolveReplayInitialBreakout(sig, "long", 68997, cfg)
+	if !breakout.Ready || breakout.Level != 68997 || breakout.Shape != "original_t2" {
+		t.Fatalf("expected original_t2 breakout within 0.5 bps tolerance, got %#v", breakout)
 	}
 }
 
-func TestResolveReplayInitialBreakoutBlocksT3InsideSep(t *testing.T) {
+func TestResolveReplayInitialBreakoutIgnoresT3OnlyShape(t *testing.T) {
 	cfg := strategyReplayConfig{
-		BreakoutShape:         "baseline_plus_t3",
-		T3MinSMAATRSeparation: 0.25,
+		BreakoutShape:             "baseline_plus_t3",
+		BreakoutShapeToleranceBps: 0.5,
 	}
 	sig := strategySignalBar{
 		MA5:       68850,
@@ -211,7 +211,7 @@ func TestResolveReplayInitialBreakoutBlocksT3InsideSep(t *testing.T) {
 	}
 	breakout := resolveReplayInitialBreakout(sig, "long", 69010, cfg)
 	if breakout.Ready {
-		t.Fatalf("expected t3 breakout inside sep filter to be blocked, got %#v", breakout)
+		t.Fatalf("expected t3-only breakout shape to be ignored, got %#v", breakout)
 	}
 }
 

--- a/internal/store/memory/store.go
+++ b/internal/store/memory/store.go
@@ -129,9 +129,9 @@ func NewStore() *Store {
 
 	enhancedStrategy := domain.Strategy{
 		ID:          "strategy-bk-btc-30m-enhanced",
-		Name:        "BK BTCUSDT 30m Enhanced",
+		Name:        "BK BTCUSDT 30m T2-only 0.5bps",
 		Status:      "ACTIVE",
-		Description: "BTCUSDT 30m live intrabar SMA5 baseline plus t3 breakout with sep_0p25.",
+		Description: "BTCUSDT 30m live intrabar SMA5 original T2 breakout with 0.5 bps tolerance.",
 		CreatedAt:   now,
 	}
 	enhancedVersion := domain.StrategyVersion{
@@ -141,7 +141,7 @@ func NewStore() *Store {
 		SignalTimeframe:    "30m",
 		ExecutionTimeframe: "tick",
 		Parameters: map[string]any{
-			"strategyEngine":                  "bk-live-intrabar-sma5-t3-sep",
+			"strategyEngine":                  "bk-live-intrabar-sma5-t2-only-0p5bps",
 			"symbol":                          "BTCUSDT",
 			"signalTimeframe":                 "30m",
 			"executionDataSource":             "tick",
@@ -150,8 +150,8 @@ func NewStore() *Store {
 			"zero_initial_mode":               domain.ResearchBaselineZeroInitialMode,
 			"max_trades_per_bar":              domain.ResearchBaselineMaxTradesPerBar,
 			"reentry_size_schedule":           domain.ResearchBaselineReentrySizeSchedule(),
-			"breakout_shape":                  "baseline_plus_t3",
-			"t3_min_sma_atr_separation":       0.25,
+			"breakout_shape":                  "original_t2",
+			"breakout_shape_tolerance_bps":    0.5,
 			"use_sma5_intraday_structure":     true,
 			"reentry_min_stop_bps":            6.0,
 			"reentry_atr_percentile_gte":      25.0,


### PR DESCRIPTION
## 目的
- 摘除 BTCUSDT 30m enhanced 策略里的 `t3_swing` breakout 派生入口，live gate 与 replay 都只保留 `original_t2`。
- 更新策略/engine/template 命名为 T2-only 0.5bps，并加入 `breakout_shape_tolerance_bps=0.5`，对应之前研究里的 T2-only 0.5 bps 方案。
- 增加 migration 更新生产策略名、strategy version 参数和匹配的 live session state：切到新 engine key、`breakout_shape=original_t2`、写入 0.5 bps 容差，并移除旧 `t3_min_sma_atr_separation`。
- 旧 `bk-live-intrabar-sma5-t3-sep` engine key 仍 normalize 到新 key，避免历史配置解析失败。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [x] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) - 无变化。
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？- 无。
- [x] DB migration 是否具备向下兼容幂等性？- migration 固定覆盖目标策略/会话字段；旧 engine key 保留 normalize 兼容。
- [x] 配置字段有没有无意被混改？- 有意变更 enhanced 策略的 `strategyEngine`、`breakout_shape`、`breakout_shape_tolerance_bps`，并移除旧 t3 sep 参数。

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

Validation:
- `go test ./internal/service`
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
- pre-push harness passed: high risk defaults check, env safety check, migration safety sensor, backend checks.
