### PR TITLE
feat(trading): implement trading harness part 1 - order intent classifier and golden cases

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,6 +18,11 @@ _是否涉及默认行为、交易路径、部署流程、环境变量_
 - [ ] DB migration 是否具备向下兼容幂等性？
 - [ ] 配置字段有没有无意被混改？
 
+## 交易语义变更
+- [ ] 本次改动是否新增/修改了 `signalKind`？若是，需同步更新 Golden Case
+- [ ] 本次改动是否影响订单方向判断（`side` / `reduceOnly` / `closePosition`）？
+- [ ] 若涉及上述改动，`go test ./internal/domain/... -run TestClassifyOrderIntent` 是否通过？
+
 ## 验证方式与测试证据
 _本地怎么测，测试环境怎么验_
 - [ ] 无需跑后端或无需编译的文档性修改

--- a/docs/trading/order-intent-matrix.md
+++ b/docs/trading/order-intent-matrix.md
@@ -1,0 +1,43 @@
+# Order Intent 判定矩阵
+
+> **唯一事实源**：`internal/domain/order_intent.go` → `ClassifyOrderIntent()`
+>
+> 所有需要判断"一笔订单是开多还是平空"的地方，都必须消费此分类结果。
+> 禁止在 service/、http/、前端 中自行组合 side + reduceOnly 推断。
+
+## 当前模式：One-way Mode（positionSide = BOTH）
+
+| Side | ReduceOnly | ClosePosition | → OrderIntent | 中文标签 |
+|------|-----------|--------------|---------------|---------|
+| BUY  | false     | false        | `OPEN_LONG`   | 开多     |
+| SELL | false     | false        | `OPEN_SHORT`  | 开空     |
+| SELL | true      | false        | `CLOSE_LONG`  | 平多     |
+| BUY  | true      | false        | `CLOSE_SHORT` | 平空     |
+| SELL | false     | true         | `CLOSE_LONG`  | 平多     |
+| BUY  | false     | true         | `CLOSE_SHORT` | 平空     |
+| ""   | *         | *            | `UNKNOWN`     | 未知     |
+
+### 判定优先级
+
+1. `EffectiveReduceOnly()` = `Order.ReduceOnly || Metadata["reduceOnly"]`
+2. `EffectiveClosePosition()` = `Order.ClosePosition || Metadata["closePosition"]`
+3. 只要 `isExit = EffectiveReduceOnly() || EffectiveClosePosition()` 为 true，即视为平仓
+
+### 重要说明
+
+- **intent 与 Status 无关**：即使订单 Status = CANCELLED，intent 仍然可分类（用于回归和展示）
+- **intent 不参与结算**：结算和持仓更新严格基于交易所返回的 fills 和 status 事实
+- **intent 只用于**：展示、回归验证、审计追溯
+
+## 未来扩展：Hedge Mode（positionSide = LONG/SHORT）
+
+如果切换至 Hedge Mode，需在 `ClassifyOrderIntent()` 中额外引入 `positionSide` 参数：
+
+| Side | PositionSide | → OrderIntent |
+|------|-------------|---------------|
+| BUY  | LONG        | `OPEN_LONG`   |
+| BUY  | SHORT       | `CLOSE_SHORT` |
+| SELL | SHORT       | `OPEN_SHORT`  |
+| SELL | LONG        | `CLOSE_LONG`  |
+
+> ⚠️ 切换前必须更新此矩阵、`ClassifyOrderIntent()` 实现和 Golden Case 测试。

--- a/docs/trading/signal-kind-contract.md
+++ b/docs/trading/signal-kind-contract.md
@@ -1,0 +1,27 @@
+# SignalKind 语义契约
+
+> 每种 signalKind 允许产生的 OrderIntent 范围。
+> 新增 signalKind 时必须同步更新此表和 Golden Case 测试。
+
+## 语义契约表
+
+| signalKind              | 允许的 Intent                    | 说明           |
+|-------------------------|--------------------------------|----------------|
+| `initial`               | `OPEN_LONG`, `OPEN_SHORT`      | 初始建仓       |
+| `zero-initial-reentry`  | `OPEN_LONG`, `OPEN_SHORT`      | 零仓再入场     |
+| `sl-reentry`            | `OPEN_LONG`, `OPEN_SHORT`      | 止损后再入场   |
+| `pt-reentry`            | `OPEN_LONG`, `OPEN_SHORT`      | 止盈后再入场   |
+| `risk-exit`             | `CLOSE_LONG`, `CLOSE_SHORT`    | 风险退出       |
+| `sl`                    | `CLOSE_LONG`, `CLOSE_SHORT`    | 止损           |
+| `pt`                    | `CLOSE_LONG`, `CLOSE_SHORT`    | 止盈           |
+| `recovery-watchdog`     | `CLOSE_LONG`, `CLOSE_SHORT`    | 恢复看门狗平仓 |
+
+## 规则
+
+1. **入场类** signalKind 只能产生 `OPEN_*` 意图
+2. **出场类** signalKind 只能产生 `CLOSE_*` 意图
+3. 如果一个 signalKind 需要同时支持开仓和平仓，说明它的语义不清晰，应该拆分
+4. 新增 signalKind 时：
+   - 在此表中声明允许的 Intent 范围
+   - 在 `internal/domain/order_intent_test.go` 中添加对应的 Golden Case
+   - 确保 `go test ./internal/domain/... -run TestClassifyOrderIntent` 通过

--- a/internal/domain/models.go
+++ b/internal/domain/models.go
@@ -239,7 +239,7 @@ type Fill struct {
 	ExchangeTradeTime *time.Time `json:"exchangeTradeTime,omitempty"`
 	DedupFingerprint  string     `json:"-"`
 	// Source is an internal reconciliation source stored in fill_source, not exposed by fill JSON.
-	Source    string    `json:"-"`
+	Source    string    `json:"source,omitempty"`
 	Price     float64   `json:"price"`
 	Quantity  float64   `json:"quantity"`
 	Fee       float64   `json:"fee"` // 手续费

--- a/internal/domain/order_intent.go
+++ b/internal/domain/order_intent.go
@@ -1,0 +1,68 @@
+package domain
+
+import "strings"
+
+// OrderIntent 交易意图语义分类。
+// 这是判断"一笔订单到底是开多还是平空"的唯一事实源。
+// 所有需要判断订单方向语义的地方（service/、http/、前端），
+// 都必须消费此分类结果，禁止自行组合 side + reduceOnly 推断。
+type OrderIntent string
+
+const (
+	OrderIntentOpenLong   OrderIntent = "OPEN_LONG"   // BUY + !reduceOnly → 开多
+	OrderIntentOpenShort  OrderIntent = "OPEN_SHORT"  // SELL + !reduceOnly → 开空
+	OrderIntentCloseLong  OrderIntent = "CLOSE_LONG"  // SELL + reduceOnly → 平多
+	OrderIntentCloseShort OrderIntent = "CLOSE_SHORT" // BUY + reduceOnly → 平空
+	OrderIntentUnknown    OrderIntent = "UNKNOWN"
+)
+
+// ClassifyOrderIntent 是判断订单交易语义的唯一入口。
+// 所有需要判断"这笔订单是开多还是平空"的地方，都必须调用此函数。
+// 禁止在 service/、http/、前端 中自行组合 side + reduceOnly 推断。
+//
+// 当前基于 One-way Mode（positionSide = BOTH）。
+// 如果未来需要支持 Hedge Mode（positionSide = LONG/SHORT），
+// 在此函数中扩展，不在调用方各自处理。
+func ClassifyOrderIntent(o Order) OrderIntent {
+	side := strings.ToUpper(strings.TrimSpace(o.Side))
+	isExit := o.EffectiveReduceOnly() || o.EffectiveClosePosition()
+
+	switch {
+	case side == "BUY" && !isExit:
+		return OrderIntentOpenLong
+	case side == "SELL" && !isExit:
+		return OrderIntentOpenShort
+	case side == "SELL" && isExit:
+		return OrderIntentCloseLong
+	case side == "BUY" && isExit:
+		return OrderIntentCloseShort
+	default:
+		return OrderIntentUnknown
+	}
+}
+
+// IntentLabel 返回用于 UI 展示的中文标签。
+func (i OrderIntent) IntentLabel() string {
+	switch i {
+	case OrderIntentOpenLong:
+		return "开多"
+	case OrderIntentOpenShort:
+		return "开空"
+	case OrderIntentCloseLong:
+		return "平多"
+	case OrderIntentCloseShort:
+		return "平空"
+	default:
+		return "未知"
+	}
+}
+
+// IsEntry 返回该意图是否为开仓。
+func (i OrderIntent) IsEntry() bool {
+	return i == OrderIntentOpenLong || i == OrderIntentOpenShort
+}
+
+// IsExit 返回该意图是否为平仓。
+func (i OrderIntent) IsExit() bool {
+	return i == OrderIntentCloseLong || i == OrderIntentCloseShort
+}

--- a/internal/domain/order_intent_test.go
+++ b/internal/domain/order_intent_test.go
@@ -1,0 +1,164 @@
+package domain
+
+import "testing"
+
+// Golden Case 回归测试 — 基于 2026-04-29 真实订单流排查建立。
+//
+// lastVerifiedAt: 2026-04-30
+// source: Issue #344 — 工程化梳理交易模块
+//
+// 新增 signalKind 或修改订单方向判断逻辑时，必须同步更新此测试。
+// CI 中 go test ./internal/domain/... -run TestClassifyOrderIntent 为 Required Check。
+
+func TestClassifyOrderIntent_GoldenCases(t *testing.T) {
+	cases := []struct {
+		name     string
+		order    Order
+		expected OrderIntent
+		display  string // 期望的中文标签
+	}{
+		// === 组 A：开多 → 平多 ===
+		{
+			name:     "order-1777471086379688754: BUY zero-initial-reentry → OPEN_LONG",
+			order:    Order{Side: "BUY", ReduceOnly: false},
+			expected: OrderIntentOpenLong,
+			display:  "开多",
+		},
+		{
+			name:     "order-1777471148180758130: SELL risk-exit reduceOnly → CLOSE_LONG",
+			order:    Order{Side: "SELL", ReduceOnly: true},
+			expected: OrderIntentCloseLong,
+			display:  "平多",
+		},
+		{
+			name:     "order-1777471215130841633: BUY zero-initial-reentry → OPEN_LONG",
+			order:    Order{Side: "BUY", ReduceOnly: false},
+			expected: OrderIntentOpenLong,
+			display:  "开多",
+		},
+		{
+			name:     "order-1777471569961949714: SELL risk-exit reduceOnly → CLOSE_LONG",
+			order:    Order{Side: "SELL", ReduceOnly: true},
+			expected: OrderIntentCloseLong,
+			display:  "平多",
+		},
+
+		// === 组 B：开空 → 平空 ===
+		{
+			name:     "order-1777486182526885338: SELL entry → OPEN_SHORT",
+			order:    Order{Side: "SELL", ReduceOnly: false},
+			expected: OrderIntentOpenShort,
+			display:  "开空",
+		},
+		{
+			name:     "order-1777486257764774887: BUY reduceOnly → CLOSE_SHORT",
+			order:    Order{Side: "BUY", ReduceOnly: true},
+			expected: OrderIntentCloseShort,
+			display:  "平空",
+		},
+
+		// === 组 C：取消订单（intent 仍然可分类）===
+		{
+			name:     "order-1777475288746567463: BUY CANCELLED but intent = OPEN_LONG",
+			order:    Order{Side: "BUY", ReduceOnly: false, Status: "CANCELLED"},
+			expected: OrderIntentOpenLong,
+			display:  "开多",
+		},
+
+		// === 组 D：closePosition 变体 ===
+		{
+			name:     "SELL closePosition=true → CLOSE_LONG",
+			order:    Order{Side: "SELL", ClosePosition: true},
+			expected: OrderIntentCloseLong,
+			display:  "平多",
+		},
+		{
+			name:     "BUY closePosition=true → CLOSE_SHORT",
+			order:    Order{Side: "BUY", ClosePosition: true},
+			expected: OrderIntentCloseShort,
+			display:  "平空",
+		},
+
+		// === 组 E：Metadata 中的 reduceOnly ===
+		{
+			name: "SELL with metadata reduceOnly=true → CLOSE_LONG",
+			order: Order{
+				Side:     "SELL",
+				Metadata: map[string]any{"reduceOnly": true},
+			},
+			expected: OrderIntentCloseLong,
+			display:  "平多",
+		},
+		{
+			name: "BUY with metadata closePosition=true → CLOSE_SHORT",
+			order: Order{
+				Side:     "BUY",
+				Metadata: map[string]any{"closePosition": true},
+			},
+			expected: OrderIntentCloseShort,
+			display:  "平空",
+		},
+
+		// === 边界 case ===
+		{
+			name:     "空 side → UNKNOWN",
+			order:    Order{Side: ""},
+			expected: OrderIntentUnknown,
+			display:  "未知",
+		},
+		{
+			name:     "side 含空格 → 仍可分类",
+			order:    Order{Side: "  buy  ", ReduceOnly: false},
+			expected: OrderIntentOpenLong,
+			display:  "开多",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ClassifyOrderIntent(tc.order)
+			if got != tc.expected {
+				t.Fatalf("ClassifyOrderIntent() = %s, want %s", got, tc.expected)
+			}
+			if got.IntentLabel() != tc.display {
+				t.Fatalf("IntentLabel() = %s, want %s", got.IntentLabel(), tc.display)
+			}
+		})
+	}
+}
+
+func TestOrderIntent_IsEntry(t *testing.T) {
+	if !OrderIntentOpenLong.IsEntry() {
+		t.Fatal("OPEN_LONG should be entry")
+	}
+	if !OrderIntentOpenShort.IsEntry() {
+		t.Fatal("OPEN_SHORT should be entry")
+	}
+	if OrderIntentCloseLong.IsEntry() {
+		t.Fatal("CLOSE_LONG should not be entry")
+	}
+	if OrderIntentCloseShort.IsEntry() {
+		t.Fatal("CLOSE_SHORT should not be entry")
+	}
+	if OrderIntentUnknown.IsEntry() {
+		t.Fatal("UNKNOWN should not be entry")
+	}
+}
+
+func TestOrderIntent_IsExit(t *testing.T) {
+	if OrderIntentOpenLong.IsExit() {
+		t.Fatal("OPEN_LONG should not be exit")
+	}
+	if OrderIntentOpenShort.IsExit() {
+		t.Fatal("OPEN_SHORT should not be exit")
+	}
+	if !OrderIntentCloseLong.IsExit() {
+		t.Fatal("CLOSE_LONG should be exit")
+	}
+	if !OrderIntentCloseShort.IsExit() {
+		t.Fatal("CLOSE_SHORT should be exit")
+	}
+	if OrderIntentUnknown.IsExit() {
+		t.Fatal("UNKNOWN should not be exit")
+	}
+}

--- a/internal/http/orders.go
+++ b/internal/http/orders.go
@@ -101,16 +101,43 @@ func registerOrderRoutes(mux *http.ServeMux, platform *service.Platform) {
 			writeJSON(w, http.StatusOK, item)
 			return
 		}
-		if r.Method != http.MethodPost || len(parts) != 2 {
-			if r.Method != http.MethodPost {
-				w.WriteHeader(http.StatusMethodNotAllowed)
-				return
-			}
+		if len(parts) != 2 {
 			writeError(w, http.StatusNotFound, "order route not found")
 			return
 		}
 		switch parts[1] {
+		case "remote-fills":
+			if r.Method != http.MethodGet {
+				w.WriteHeader(http.StatusMethodNotAllowed)
+				return
+			}
+			item, err := platform.FetchRemoteFills(parts[0])
+			if err != nil {
+				writeError(w, http.StatusBadRequest, err.Error())
+				return
+			}
+			writeJSON(w, http.StatusOK, item)
+		case "sync-fills":
+			if r.Method != http.MethodPost {
+				w.WriteHeader(http.StatusMethodNotAllowed)
+				return
+			}
+			var req service.ManualFillSyncRequest
+			if err := decodeJSON(r, &req); err != nil {
+				writeError(w, http.StatusBadRequest, err.Error())
+				return
+			}
+			item, err := platform.ManualSyncFills(parts[0], req)
+			if err != nil {
+				writeError(w, http.StatusBadRequest, err.Error())
+				return
+			}
+			writeJSON(w, http.StatusOK, item)
 		case "sync":
+			if r.Method != http.MethodPost {
+				w.WriteHeader(http.StatusMethodNotAllowed)
+				return
+			}
 			item, err := platform.SyncLiveOrder(parts[0])
 			if err != nil {
 				writeError(w, http.StatusBadRequest, err.Error())
@@ -118,6 +145,10 @@ func registerOrderRoutes(mux *http.ServeMux, platform *service.Platform) {
 			}
 			writeJSON(w, http.StatusOK, item)
 		case "cancel":
+			if r.Method != http.MethodPost {
+				w.WriteHeader(http.StatusMethodNotAllowed)
+				return
+			}
 			item, err := platform.CancelLiveOrder(parts[0])
 			if err != nil {
 				writeError(w, http.StatusBadRequest, err.Error())

--- a/internal/http/orders.go
+++ b/internal/http/orders.go
@@ -9,6 +9,32 @@ import (
 	"github.com/wuyaocheng/bktrader/internal/service"
 )
 
+// OrderResponse 在 API 层给 Order 追加语义分类字段。
+// intent 和 intentLabel 由 ClassifyOrderIntent() 唯一分类器计算，
+// 前端应直接消费这两个字段，禁止自行组合 side + reduceOnly 推断。
+type OrderResponse struct {
+	domain.Order
+	Intent      string `json:"intent"`
+	IntentLabel string `json:"intentLabel"`
+}
+
+func toOrderResponse(o domain.Order) OrderResponse {
+	intent := domain.ClassifyOrderIntent(o)
+	return OrderResponse{
+		Order:       o,
+		Intent:      string(intent),
+		IntentLabel: intent.IntentLabel(),
+	}
+}
+
+func toOrderResponses(orders []domain.Order) []OrderResponse {
+	result := make([]OrderResponse, len(orders))
+	for i, o := range orders {
+		result[i] = toOrderResponse(o)
+	}
+	return result
+}
+
 // registerOrderRoutes 注册订单和成交记录相关路由。
 func registerOrderRoutes(mux *http.ServeMux, platform *service.Platform) {
 	// GET|POST /api/v1/orders — 订单列表/下单
@@ -35,7 +61,7 @@ func registerOrderRoutes(mux *http.ServeMux, platform *service.Platform) {
 				writeError(w, http.StatusInternalServerError, err.Error())
 				return
 			}
-			writeJSON(w, http.StatusOK, items)
+			writeJSON(w, http.StatusOK, toOrderResponses(items))
 		case http.MethodPost:
 			var payload struct {
 				AccountID         string         `json:"accountId"`
@@ -79,7 +105,7 @@ func registerOrderRoutes(mux *http.ServeMux, platform *service.Platform) {
 				writeError(w, http.StatusInternalServerError, err.Error())
 				return
 			}
-			writeJSON(w, http.StatusCreated, item)
+			writeJSON(w, http.StatusCreated, toOrderResponse(item))
 		default:
 			w.WriteHeader(http.StatusMethodNotAllowed)
 		}
@@ -98,7 +124,7 @@ func registerOrderRoutes(mux *http.ServeMux, platform *service.Platform) {
 				writeError(w, http.StatusNotFound, err.Error())
 				return
 			}
-			writeJSON(w, http.StatusOK, item)
+			writeJSON(w, http.StatusOK, toOrderResponse(item))
 			return
 		}
 		if len(parts) != 2 {

--- a/internal/service/fill_sync.go
+++ b/internal/service/fill_sync.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/wuyaocheng/bktrader/internal/domain"
+	storepkg "github.com/wuyaocheng/bktrader/internal/store"
 )
 
 type RemoteFillsResponse struct {
@@ -47,10 +48,11 @@ type ManualFillSyncResponse struct {
 	OrderID     string                `json:"orderId"`
 	DryRun      bool                  `json:"dryRun"`
 	SyncedAt    string                `json:"syncedAt,omitempty"`
-	Result      string                `json:"result"` // settled | no_remote_trades | already_settled | failed
+	Result      string                `json:"result"` // settled | already_settled | failed | dry_run_can_settle | ...
 	Before      FillSyncSnapshot      `json:"before"`
 	After       FillSyncSnapshot      `json:"after"`
 	Diagnostics RemoteFillDiagnostics `json:"diagnostics"`
+	Changes     FillRebuildChanges    `json:"changes,omitempty"`
 }
 
 type FillSyncSnapshot struct {
@@ -60,6 +62,13 @@ type FillSyncSnapshot struct {
 	FeeZeroCount       int     `json:"feeZeroCount"`
 	FilledQuantity     float64 `json:"filledQuantity"`
 	RemainingQuantity  float64 `json:"remainingQuantity"`
+}
+
+type FillRebuildChanges struct {
+	DeletedSyntheticCount int      `json:"deletedSyntheticCount"`
+	AddedRealCount        int      `json:"addedRealCount"`
+	DuplicateTradeIDs     []string `json:"duplicateTradeIds,omitempty"`
+	NewTradeIDs           []string `json:"newTradeIds,omitempty"`
 }
 
 // FetchRemoteFills pulls the remote details of an order from the exchange, without modifying local DB.
@@ -87,57 +96,39 @@ func (p *Platform) FetchRemoteFills(orderID string) (RemoteFillsResponse, error)
 		return RemoteFillsResponse{}, fmt.Errorf("failed to fetch remote trades: %w", err)
 	}
 
-	// Filter remoteTrades to only include trades for this order
-	var matchedTrades []LiveFillReport
-	var matchedRawTrades []map[string]any
-
 	exchangeOrderID := order.Metadata["exchangeOrderId"]
 	if exchangeOrderID == nil && syncResult.Metadata != nil {
 		exchangeOrderID = syncResult.Metadata["exchangeOrderId"]
 	}
 
-	for _, trade := range remoteTrades {
-		tradeExchangeOrderID := ""
-		tradeClientOrderID := ""
-		if trade.Metadata != nil {
-			if eoid, ok := trade.Metadata["exchangeOrderId"]; ok {
-				tradeExchangeOrderID = fmt.Sprintf("%v", eoid)
-			}
-			if coid, ok := trade.Metadata["clientOrderId"]; ok {
-				tradeClientOrderID = fmt.Sprintf("%v", coid)
-			}
-			if coid, ok := trade.Metadata["orderId"]; ok && tradeClientOrderID == "" {
-				tradeClientOrderID = fmt.Sprintf("%v", coid)
-			}
-		}
-
-		if (exchangeOrderID != nil && tradeExchangeOrderID == fmt.Sprintf("%v", exchangeOrderID)) || tradeClientOrderID == order.ID {
-			matchedTrades = append(matchedTrades, trade)
-			if trade.Metadata != nil && trade.Metadata["raw"] != nil {
-				if rawMap, ok := trade.Metadata["raw"].(map[string]any); ok {
-					matchedRawTrades = append(matchedRawTrades, rawMap)
-				}
-			}
-		}
-	}
+	matchedTrades := matchRemoteTrades(order.ID, fmt.Sprintf("%v", exchangeOrderID), remoteTrades)
 
 	localFills, err := p.store.QueryFills(domain.FillQuery{OrderIDs: []string{orderID}})
 	if err != nil {
 		return RemoteFillsResponse{}, fmt.Errorf("failed to query local fills: %w", err)
 	}
 
+	// Prepare raw and masked data
 	var raw map[string]any
+	var maskedTrades []map[string]any
+	var matchedRawTrades []map[string]any
+
+	for _, t := range matchedTrades {
+		if t.Metadata != nil && t.Metadata["raw"] != nil {
+			if rawMap, ok := t.Metadata["raw"].(map[string]any); ok {
+				matchedRawTrades = append(matchedRawTrades, rawMap)
+				maskedTrades = append(maskedTrades, maskSensitiveData(rawMap))
+			}
+		}
+	}
+
 	rawOrderMap, ok := syncResult.Metadata["raw"].(map[string]any)
-	if ok || len(matchedRawTrades) > 0 {
+	if ok || len(maskedTrades) > 0 {
 		raw = make(map[string]any)
 		if ok {
 			raw["order"] = maskSensitiveData(rawOrderMap)
 		}
-		if len(matchedRawTrades) > 0 {
-			var maskedTrades []map[string]any
-			for _, t := range matchedRawTrades {
-				maskedTrades = append(maskedTrades, maskSensitiveData(t))
-			}
+		if len(maskedTrades) > 0 {
 			raw["trades"] = maskedTrades
 		}
 	}
@@ -162,8 +153,8 @@ func (p *Platform) FetchRemoteFills(orderID string) (RemoteFillsResponse, error)
 		Status:            order.Status,
 		QueriedAt:         time.Now().UTC().Format(time.RFC3339),
 		RemoteOrder:       remoteOrderMap,
-		RemoteTrades:      matchedRawTrades,
-		NormalizedReports: matchedTrades,
+		RemoteTrades:      maskedTrades, // Use masked versions for response
+		NormalizedReports: maskReportsSensitiveData(matchedTrades),
 		LocalFills:        localFills,
 		Raw:               raw,
 		Diagnostics:       diagnostics,
@@ -194,100 +185,223 @@ func (p *Platform) ManualSyncFills(orderID string, req ManualFillSyncRequest) (M
 		}
 	}
 
+	// Fetch remote data first
+	syncResult, err := adapter.SyncOrder(account, order, binding)
+	if err != nil {
+		return ManualFillSyncResponse{}, fmt.Errorf("failed to sync remote order: %w", err)
+	}
+	remoteTrades, err := reconcileAdapter.FetchRecentTrades(account, binding, order.Symbol, 0)
+	if err != nil {
+		return ManualFillSyncResponse{}, fmt.Errorf("failed to fetch remote trades: %w", err)
+	}
+
+	exchangeOrderID := order.Metadata["exchangeOrderId"]
+	if exchangeOrderID == nil && syncResult.Metadata != nil {
+		exchangeOrderID = syncResult.Metadata["exchangeOrderId"]
+	}
+
+	matchedTrades := matchRemoteTrades(order.ID, fmt.Sprintf("%v", exchangeOrderID), remoteTrades)
+
+	// Perform rebuild (dry-run or real)
+	resp, err := p.RebuildOrderFills(order.ID, matchedTrades, req.Reason, req.DryRun)
+	if err != nil {
+		return ManualFillSyncResponse{}, err
+	}
+
+	return *resp, nil
+}
+
+// RebuildOrderFills performs an atomic rebuild of fills for an order based on remote trades.
+func (p *Platform) RebuildOrderFills(orderID string, matchedTrades []LiveFillReport, reason string, dryRun bool) (*ManualFillSyncResponse, error) {
+	order, _, _, _, err := p.resolveLiveOrderContext(orderID)
+	if err != nil {
+		return nil, err
+	}
+
 	localFillsBefore, err := p.store.QueryFills(domain.FillQuery{OrderIDs: []string{orderID}})
 	if err != nil {
-		return ManualFillSyncResponse{}, err
+		return nil, err
 	}
 	beforeSnapshot := buildFillSyncSnapshot(order, localFillsBefore)
+	diagnostics := buildRemoteFillDiagnostics(localFillsBefore, matchedTrades)
 
-	if req.DryRun {
-		// Just simulate by fetching remote trades
-		syncResult, err := adapter.SyncOrder(account, order, binding)
-		if err != nil {
-			return ManualFillSyncResponse{}, fmt.Errorf("dry-run failed to sync remote order: %w", err)
-		}
-		remoteTrades, err := reconcileAdapter.FetchRecentTrades(account, binding, order.Symbol, 0)
-		if err != nil {
-			return ManualFillSyncResponse{}, fmt.Errorf("dry-run failed to fetch remote trades: %w", err)
-		}
+	var changes FillRebuildChanges
+	var localFillsAfter []domain.Fill
+	var syncedOrder domain.Order
+	var totalFilledAfter float64
 
-		exchangeOrderID := order.Metadata["exchangeOrderId"]
-		if exchangeOrderID == nil && syncResult.Metadata != nil {
-			exchangeOrderID = syncResult.Metadata["exchangeOrderId"]
-		}
-
-		var matchedTrades []LiveFillReport
-		for _, trade := range remoteTrades {
-			tradeExchangeOrderID := ""
-			tradeClientOrderID := ""
-			if trade.Metadata != nil {
-				if eoid, ok := trade.Metadata["exchangeOrderId"]; ok {
-					tradeExchangeOrderID = fmt.Sprintf("%v", eoid)
-				}
-				if coid, ok := trade.Metadata["clientOrderId"]; ok {
-					tradeClientOrderID = fmt.Sprintf("%v", coid)
-				}
-				if coid, ok := trade.Metadata["orderId"]; ok && tradeClientOrderID == "" {
-					tradeClientOrderID = fmt.Sprintf("%v", coid)
-				}
-			}
-			if (exchangeOrderID != nil && tradeExchangeOrderID == fmt.Sprintf("%v", exchangeOrderID)) || tradeClientOrderID == order.ID {
-				matchedTrades = append(matchedTrades, trade)
+	if dryRun {
+		// Simulate rebuild
+		changes.DeletedSyntheticCount = diagnostics.LocalSyntheticFillCount
+		existingRealMap := make(map[string]bool)
+		for _, f := range localFillsBefore {
+			if f.Source == string(FillSourceReal) && f.ExchangeTradeID != "" {
+				existingRealMap[f.ExchangeTradeID] = true
 			}
 		}
 
-		diagnostics := buildRemoteFillDiagnostics(localFillsBefore, matchedTrades)
-
-		afterSnapshot := beforeSnapshot
-		result := "dry_run_no_changes"
-		if diagnostics.CanSettle {
-			afterSnapshot.FillCount = len(matchedTrades)
-			afterSnapshot.RealFillCount = len(matchedTrades)
-			afterSnapshot.SyntheticFillCount = 0
-			result = "dry_run_can_settle"
-		} else if !diagnostics.HasRealTrades {
-			result = "dry_run_no_remote_trades"
-		} else {
-			result = "dry_run_already_settled"
+		localFillsAfter = make([]domain.Fill, 0)
+		// Keep existing real ones
+		for _, f := range localFillsBefore {
+			if f.Source == string(FillSourceReal) {
+				localFillsAfter = append(localFillsAfter, f)
+			}
 		}
+		// Add new ones from matched trades
+		for _, t := range matchedTrades {
+			tradeID := fmt.Sprintf("%v", t.Metadata["exchangeTradeId"])
+			if existingRealMap[tradeID] {
+				changes.DuplicateTradeIDs = append(changes.DuplicateTradeIDs, tradeID)
+			} else {
+				changes.AddedRealCount++
+				changes.NewTradeIDs = append(changes.NewTradeIDs, tradeID)
+				// Mock a fill for snapshot
+				localFillsAfter = append(localFillsAfter, domain.Fill{
+					Quantity: t.Quantity,
+					Price:    t.Price,
+					Fee:      t.Fee,
+					Source:   string(FillSourceReal),
+				})
+			}
+		}
+		syncedOrder = order
+		totalFilledAfter = 0
+		for _, f := range localFillsAfter {
+			totalFilledAfter += f.Quantity
+		}
+	} else {
+		// Real rebuild in transaction
+		err = p.store.WithFillSettlementTx(orderID, func(tx storepkg.FillSettlementStore) error {
+			// 1. Delete synthetic
+			deletedQty, err := tx.DeleteSyntheticFillsForOrder(orderID)
+			if err != nil {
+				return err
+			}
+			_ = deletedQty
+			changes.DeletedSyntheticCount = diagnostics.LocalSyntheticFillCount
 
-		return ManualFillSyncResponse{
-			OrderID:     orderID,
-			DryRun:      true,
-			Result:      result,
-			Before:      beforeSnapshot,
-			After:       afterSnapshot,
-			Diagnostics: diagnostics,
-		}, nil
+			// 2. Query remaining real fills to check duplicates
+			existingFills, err := tx.QueryFills(domain.FillQuery{OrderIDs: []string{orderID}})
+			if err != nil {
+				return err
+			}
+			existingRealMap := make(map[string]bool)
+			for _, f := range existingFills {
+				if f.ExchangeTradeID != "" {
+					existingRealMap[f.ExchangeTradeID] = true
+				}
+			}
+
+			// 3. Create real fills
+			for _, t := range matchedTrades {
+				tradeID := fmt.Sprintf("%v", t.Metadata["exchangeTradeId"])
+				if existingRealMap[tradeID] {
+					changes.DuplicateTradeIDs = append(changes.DuplicateTradeIDs, tradeID)
+					continue
+				}
+
+				changes.AddedRealCount++
+				changes.NewTradeIDs = append(changes.NewTradeIDs, tradeID)
+
+				tradeTime := time.Now().UTC()
+				if tt, ok := t.Metadata["exchangeTradeTime"].(time.Time); ok {
+					tradeTime = tt
+				}
+
+				_, err = tx.CreateFill(domain.Fill{
+					OrderID:           orderID,
+					ExchangeTradeID:   tradeID,
+					ExchangeTradeTime: &tradeTime,
+					Price:             t.Price,
+					Quantity:          t.Quantity,
+					Fee:               t.Fee,
+					Source:            string(FillSourceReal),
+				})
+				if err != nil {
+					return err
+				}
+			}
+
+			// 4. Update Order Metadata Audit
+			totalFilledAfter, err = tx.TotalFilledQuantityForOrder(orderID)
+			if err != nil {
+				return err
+			}
+
+			if order.Metadata == nil {
+				order.Metadata = make(map[string]any)
+			}
+			// Update audit history
+			historyEntry := map[string]any{
+				"time":    time.Now().UTC().Format(time.RFC3339),
+				"reason":  reason,
+				"changes": changes,
+				"before":  beforeSnapshot,
+			}
+			historyRaw := order.Metadata["manualFillSyncHistory"]
+			history, _ := historyRaw.([]any)
+			history = append(history, historyEntry)
+			order.Metadata["manualFillSyncHistory"] = history
+			order.Metadata["manualFillSync"] = historyEntry // Backward compatibility for single last op
+
+			syncedOrder, err = tx.UpdateOrder(order)
+			if err != nil {
+				return err
+			}
+
+			// 5. Update Position
+			pos, exists, err := tx.FindPosition(order.AccountID, order.Symbol)
+			if err != nil {
+				return err
+			}
+			if exists {
+				delta := totalFilledAfter - beforeSnapshot.FilledQuantity
+				if delta != 0 {
+					if order.Side == "BUY" {
+						pos.Quantity += delta
+					} else {
+						pos.Quantity -= delta
+					}
+					_, err = tx.SavePosition(pos)
+					if err != nil {
+						return err
+					}
+				}
+			}
+
+			localFillsAfter, err = tx.QueryFills(domain.FillQuery{OrderIDs: []string{orderID}})
+			return err
+		})
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	// Actual Sync: use existing SyncLiveOrder, but first we can annotate metadata
-	if order.Metadata == nil {
-		order.Metadata = make(map[string]any)
-	}
-	order.Metadata["manualFillSync"] = map[string]any{
-		"reason": req.Reason,
-		"time":   time.Now().UTC().Format(time.RFC3339),
-	}
-	_, err = p.store.UpdateOrder(order)
-	if err != nil {
-		return ManualFillSyncResponse{}, fmt.Errorf("failed to save manual sync metadata: %w", err)
-	}
-
-	syncedOrder, err := p.SyncLiveOrder(orderID)
-	if err != nil {
-		return ManualFillSyncResponse{}, fmt.Errorf("manual sync failed during SyncLiveOrder: %w", err)
-	}
-
-	localFillsAfter, err := p.store.QueryFills(domain.FillQuery{OrderIDs: []string{orderID}})
-	if err != nil {
-		return ManualFillSyncResponse{}, err
-	}
 	afterSnapshot := buildFillSyncSnapshot(syncedOrder, localFillsAfter)
+	result := "settled"
+	if dryRun {
+		result = "dry_run_can_settle"
+		if !diagnostics.CanSettle {
+			result = "dry_run_no_changes"
+		}
+	} else if changes.AddedRealCount == 0 && changes.DeletedSyntheticCount == 0 {
+		result = "already_settled"
+	}
 
-	remoteTrades, _ := reconcileAdapter.FetchRecentTrades(account, binding, syncedOrder.Symbol, 0)
-	var matchedTrades []LiveFillReport
-	exchangeOrderID := syncedOrder.Metadata["exchangeOrderId"]
+	return &ManualFillSyncResponse{
+		OrderID:     orderID,
+		DryRun:      dryRun,
+		SyncedAt:    time.Now().UTC().Format(time.RFC3339),
+		Result:      result,
+		Before:      beforeSnapshot,
+		After:       afterSnapshot,
+		Diagnostics: diagnostics,
+		Changes:     changes,
+	}, nil
+}
+
+func matchRemoteTrades(orderID, exchangeOrderID string, remoteTrades []LiveFillReport) []LiveFillReport {
+	var matched []LiveFillReport
 	for _, trade := range remoteTrades {
 		tradeExchangeOrderID := ""
 		tradeClientOrderID := ""
@@ -302,29 +416,12 @@ func (p *Platform) ManualSyncFills(orderID string, req ManualFillSyncRequest) (M
 				tradeClientOrderID = fmt.Sprintf("%v", coid)
 			}
 		}
-		if (exchangeOrderID != nil && tradeExchangeOrderID == fmt.Sprintf("%v", exchangeOrderID)) || tradeClientOrderID == syncedOrder.ID {
-			matchedTrades = append(matchedTrades, trade)
+
+		if (exchangeOrderID != "" && tradeExchangeOrderID == exchangeOrderID) || tradeClientOrderID == orderID {
+			matched = append(matched, trade)
 		}
 	}
-	diagnostics := buildRemoteFillDiagnostics(localFillsAfter, matchedTrades)
-
-	result := "settled"
-	if afterSnapshot.RealFillCount == beforeSnapshot.RealFillCount && afterSnapshot.SyntheticFillCount == beforeSnapshot.SyntheticFillCount {
-		result = "already_settled"
-		if !diagnostics.HasRealTrades {
-			result = "no_remote_trades"
-		}
-	}
-
-	return ManualFillSyncResponse{
-		OrderID:     orderID,
-		DryRun:      false,
-		SyncedAt:    time.Now().UTC().Format(time.RFC3339),
-		Result:      result,
-		Before:      beforeSnapshot,
-		After:       afterSnapshot,
-		Diagnostics: diagnostics,
-	}, nil
+	return matched
 }
 
 func buildFillSyncSnapshot(order domain.Order, fills []domain.Fill) FillSyncSnapshot {
@@ -375,6 +472,18 @@ func buildRemoteFillDiagnostics(localFills []domain.Fill, remoteTrades []LiveFil
 	return diag
 }
 
+func maskReportsSensitiveData(reports []LiveFillReport) []LiveFillReport {
+	if reports == nil {
+		return nil
+	}
+	masked := make([]LiveFillReport, len(reports))
+	for i, r := range reports {
+		r.Metadata = maskSensitiveData(r.Metadata)
+		masked[i] = r
+	}
+	return masked
+}
+
 func maskSensitiveData(data map[string]any) map[string]any {
 	if data == nil {
 		return nil
@@ -382,7 +491,9 @@ func maskSensitiveData(data map[string]any) map[string]any {
 	masked := make(map[string]any)
 	for k, v := range data {
 		lowerK := strings.ToLower(k)
-		if strings.Contains(lowerK, "key") || strings.Contains(lowerK, "secret") || strings.Contains(lowerK, "signature") || strings.Contains(lowerK, "token") {
+		// More aggressive masking based on common sensitive keys
+		if strings.Contains(lowerK, "key") || strings.Contains(lowerK, "secret") || strings.Contains(lowerK, "signature") ||
+			strings.Contains(lowerK, "token") || strings.Contains(lowerK, "auth") || strings.Contains(lowerK, "password") {
 			masked[k] = "***"
 		} else if m, ok := v.(map[string]any); ok {
 			masked[k] = maskSensitiveData(m)

--- a/internal/service/fill_sync.go
+++ b/internal/service/fill_sync.go
@@ -69,6 +69,7 @@ type FillRebuildChanges struct {
 	AddedRealCount        int      `json:"addedRealCount"`
 	DuplicateTradeIDs     []string `json:"duplicateTradeIds,omitempty"`
 	NewTradeIDs           []string `json:"newTradeIds,omitempty"`
+	MatchedTradeIDs       []string `json:"matchedTradeIds,omitempty"`
 }
 
 // FetchRemoteFills pulls the remote details of an order from the exchange, without modifying local DB.
@@ -96,12 +97,17 @@ func (p *Platform) FetchRemoteFills(orderID string) (RemoteFillsResponse, error)
 		return RemoteFillsResponse{}, fmt.Errorf("failed to fetch remote trades: %w", err)
 	}
 
-	exchangeOrderID := order.Metadata["exchangeOrderId"]
-	if exchangeOrderID == nil && syncResult.Metadata != nil {
-		exchangeOrderID = syncResult.Metadata["exchangeOrderId"]
+	exchangeOrderID := ""
+	if eoid := order.Metadata["exchangeOrderId"]; eoid != nil {
+		exchangeOrderID = fmt.Sprintf("%v", eoid)
+	}
+	if exchangeOrderID == "" && syncResult.Metadata != nil {
+		if eoid := syncResult.Metadata["exchangeOrderId"]; eoid != nil {
+			exchangeOrderID = fmt.Sprintf("%v", eoid)
+		}
 	}
 
-	matchedTrades := matchRemoteTrades(order.ID, fmt.Sprintf("%v", exchangeOrderID), remoteTrades)
+	matchedTrades := p.matchRemoteTrades(order.ID, exchangeOrderID, remoteTrades)
 
 	localFills, err := p.store.QueryFills(domain.FillQuery{OrderIDs: []string{orderID}})
 	if err != nil {
@@ -195,12 +201,17 @@ func (p *Platform) ManualSyncFills(orderID string, req ManualFillSyncRequest) (M
 		return ManualFillSyncResponse{}, fmt.Errorf("failed to fetch remote trades: %w", err)
 	}
 
-	exchangeOrderID := order.Metadata["exchangeOrderId"]
-	if exchangeOrderID == nil && syncResult.Metadata != nil {
-		exchangeOrderID = syncResult.Metadata["exchangeOrderId"]
+	exchangeOrderID := ""
+	if eoid := order.Metadata["exchangeOrderId"]; eoid != nil {
+		exchangeOrderID = fmt.Sprintf("%v", eoid)
+	}
+	if exchangeOrderID == "" && syncResult.Metadata != nil {
+		if eoid := syncResult.Metadata["exchangeOrderId"]; eoid != nil {
+			exchangeOrderID = fmt.Sprintf("%v", eoid)
+		}
 	}
 
-	matchedTrades := matchRemoteTrades(order.ID, fmt.Sprintf("%v", exchangeOrderID), remoteTrades)
+	matchedTrades := p.matchRemoteTrades(order.ID, exchangeOrderID, remoteTrades)
 
 	// Perform rebuild (dry-run or real)
 	resp, err := p.RebuildOrderFills(order.ID, matchedTrades, req.Reason, req.DryRun)
@@ -249,7 +260,10 @@ func (p *Platform) RebuildOrderFills(orderID string, matchedTrades []LiveFillRep
 		}
 		// Add new ones from matched trades
 		for _, t := range matchedTrades {
-			tradeID := fmt.Sprintf("%v", t.Metadata["exchangeTradeId"])
+			tradeID := p.remoteTradeID(t)
+			if tradeID == "" {
+				continue
+			}
 			if existingRealMap[tradeID] {
 				changes.DuplicateTradeIDs = append(changes.DuplicateTradeIDs, tradeID)
 			} else {
@@ -294,7 +308,11 @@ func (p *Platform) RebuildOrderFills(orderID string, matchedTrades []LiveFillRep
 
 			// 3. Create real fills
 			for _, t := range matchedTrades {
-				tradeID := fmt.Sprintf("%v", t.Metadata["exchangeTradeId"])
+				tradeID := p.remoteTradeID(t)
+				if tradeID == "" {
+					continue
+				}
+
 				if existingRealMap[tradeID] {
 					changes.DuplicateTradeIDs = append(changes.DuplicateTradeIDs, tradeID)
 					continue
@@ -331,46 +349,43 @@ func (p *Platform) RebuildOrderFills(orderID string, matchedTrades []LiveFillRep
 			if order.Metadata == nil {
 				order.Metadata = make(map[string]any)
 			}
+
+			// Capture After Snapshot
+			afterSnapshot := buildFillSyncSnapshot(order, localFillsAfter) // localFillsAfter not populated yet, wait
+
+			// Populate localFillsAfter inside TX for audit accuracy
+			localFillsAfter, err = tx.QueryFills(domain.FillQuery{OrderIDs: []string{orderID}})
+			if err != nil {
+				return err
+			}
+			afterSnapshot = buildFillSyncSnapshot(order, localFillsAfter)
+
 			// Update audit history
 			historyEntry := map[string]any{
 				"time":    time.Now().UTC().Format(time.RFC3339),
 				"reason":  reason,
 				"changes": changes,
 				"before":  beforeSnapshot,
+				"after":   afterSnapshot,
+				"actor":   "system", // Placeholder for future auth context
+				"result":  "settled",
 			}
 			historyRaw := order.Metadata["manualFillSyncHistory"]
 			history, _ := historyRaw.([]any)
 			history = append(history, historyEntry)
 			order.Metadata["manualFillSyncHistory"] = history
-			order.Metadata["manualFillSync"] = historyEntry // Backward compatibility for single last op
+			order.Metadata["manualFillSync"] = historyEntry // Backward compatibility
 
 			syncedOrder, err = tx.UpdateOrder(order)
 			if err != nil {
 				return err
 			}
 
-			// 5. Update Position
-			pos, exists, err := tx.FindPosition(order.AccountID, order.Symbol)
-			if err != nil {
-				return err
-			}
-			if exists {
-				delta := totalFilledAfter - beforeSnapshot.FilledQuantity
-				if delta != 0 {
-					if order.Side == "BUY" {
-						pos.Quantity += delta
-					} else {
-						pos.Quantity -= delta
-					}
-					_, err = tx.SavePosition(pos)
-					if err != nil {
-						return err
-					}
-				}
-			}
+			// 5. Position adjustment degraded to subsequent reconcile
+			// We skip manual position.Quantity updates here to avoid cost/PnL accounting errors.
+			// The system will eventually reconcile this account/symbol.
 
-			localFillsAfter, err = tx.QueryFills(domain.FillQuery{OrderIDs: []string{orderID}})
-			return err
+			return nil
 		})
 		if err != nil {
 			return nil, err
@@ -400,19 +415,19 @@ func (p *Platform) RebuildOrderFills(orderID string, matchedTrades []LiveFillRep
 	}, nil
 }
 
-func matchRemoteTrades(orderID, exchangeOrderID string, remoteTrades []LiveFillReport) []LiveFillReport {
+func (p *Platform) matchRemoteTrades(orderID, exchangeOrderID string, remoteTrades []LiveFillReport) []LiveFillReport {
 	var matched []LiveFillReport
 	for _, trade := range remoteTrades {
 		tradeExchangeOrderID := ""
 		tradeClientOrderID := ""
 		if trade.Metadata != nil {
-			if eoid, ok := trade.Metadata["exchangeOrderId"]; ok {
+			if eoid := trade.Metadata["exchangeOrderId"]; eoid != nil {
 				tradeExchangeOrderID = fmt.Sprintf("%v", eoid)
 			}
-			if coid, ok := trade.Metadata["clientOrderId"]; ok {
+			if coid := trade.Metadata["clientOrderId"]; coid != nil {
 				tradeClientOrderID = fmt.Sprintf("%v", coid)
 			}
-			if coid, ok := trade.Metadata["orderId"]; ok && tradeClientOrderID == "" {
+			if coid := trade.Metadata["orderId"]; coid != nil && tradeClientOrderID == "" {
 				tradeClientOrderID = fmt.Sprintf("%v", coid)
 			}
 		}
@@ -422,6 +437,15 @@ func matchRemoteTrades(orderID, exchangeOrderID string, remoteTrades []LiveFillR
 		}
 	}
 	return matched
+}
+
+func (p *Platform) remoteTradeID(t LiveFillReport) string {
+	return firstNonEmpty(
+		stringValue(t.Metadata["exchangeTradeId"]),
+		stringValue(t.Metadata["tradeId"]),
+		stringValue(t.Metadata["execId"]),
+		stringValue(t.Metadata["id"]),
+	)
 }
 
 func buildFillSyncSnapshot(order domain.Order, fills []domain.Fill) FillSyncSnapshot {

--- a/internal/service/fill_sync.go
+++ b/internal/service/fill_sync.go
@@ -67,6 +67,7 @@ type FillSyncSnapshot struct {
 type FillRebuildChanges struct {
 	DeletedSyntheticCount int      `json:"deletedSyntheticCount"`
 	AddedRealCount        int      `json:"addedRealCount"`
+	SkippedTradeCount     int      `json:"skippedTradeCount"`
 	DuplicateTradeIDs     []string `json:"duplicateTradeIds,omitempty"`
 	NewTradeIDs           []string `json:"newTradeIds,omitempty"`
 	MatchedTradeIDs       []string `json:"matchedTradeIds,omitempty"`
@@ -262,6 +263,7 @@ func (p *Platform) RebuildOrderFills(orderID string, matchedTrades []LiveFillRep
 		for _, t := range matchedTrades {
 			tradeID := p.remoteTradeID(t)
 			if tradeID == "" {
+				changes.SkippedTradeCount++
 				continue
 			}
 			if existingRealMap[tradeID] {
@@ -310,6 +312,7 @@ func (p *Platform) RebuildOrderFills(orderID string, matchedTrades []LiveFillRep
 			for _, t := range matchedTrades {
 				tradeID := p.remoteTradeID(t)
 				if tradeID == "" {
+					changes.SkippedTradeCount++
 					continue
 				}
 

--- a/internal/service/fill_sync.go
+++ b/internal/service/fill_sync.go
@@ -1,0 +1,404 @@
+package service
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/wuyaocheng/bktrader/internal/domain"
+)
+
+type RemoteFillsResponse struct {
+	OrderID           string                `json:"orderId"`
+	AccountID         string                `json:"accountId"`
+	Exchange          string                `json:"exchange"`
+	Symbol            string                `json:"symbol"`
+	ExchangeOrderID   string                `json:"exchangeOrderId"`
+	Status            string                `json:"status"`
+	QueriedAt         string                `json:"queriedAt"`
+	RemoteOrder       map[string]any        `json:"remoteOrder"`
+	RemoteTrades      []map[string]any      `json:"remoteTrades"`
+	NormalizedReports []LiveFillReport      `json:"normalizedReports"`
+	LocalFills        []domain.Fill         `json:"localFills"`
+	Raw               map[string]any        `json:"raw,omitempty"`
+	Diagnostics       RemoteFillDiagnostics `json:"diagnostics"`
+}
+
+type RemoteFillDiagnostics struct {
+	HasRealTrades           bool   `json:"hasRealTrades"`
+	HasSyntheticLocalFill   bool   `json:"hasSyntheticLocalFill"`
+	LocalFeeZero            bool   `json:"localFeeZero"`
+	CanSettle               bool   `json:"canSettle"`
+	Reason                  string `json:"reason"`
+	RemoteTradeCount        int    `json:"remoteTradeCount"`
+	LocalFillCount          int    `json:"localFillCount"`
+	LocalRealFillCount      int    `json:"localRealFillCount"`
+	LocalSyntheticFillCount int    `json:"localSyntheticFillCount"`
+}
+
+type ManualFillSyncRequest struct {
+	Confirm bool   `json:"confirm"`
+	Reason  string `json:"reason"`
+	DryRun  bool   `json:"dryRun"`
+}
+
+type ManualFillSyncResponse struct {
+	OrderID     string                `json:"orderId"`
+	DryRun      bool                  `json:"dryRun"`
+	SyncedAt    string                `json:"syncedAt,omitempty"`
+	Result      string                `json:"result"` // settled | no_remote_trades | already_settled | failed
+	Before      FillSyncSnapshot      `json:"before"`
+	After       FillSyncSnapshot      `json:"after"`
+	Diagnostics RemoteFillDiagnostics `json:"diagnostics"`
+}
+
+type FillSyncSnapshot struct {
+	FillCount          int     `json:"fillCount"`
+	RealFillCount      int     `json:"realFillCount"`
+	SyntheticFillCount int     `json:"syntheticFillCount"`
+	FeeZeroCount       int     `json:"feeZeroCount"`
+	FilledQuantity     float64 `json:"filledQuantity"`
+	RemainingQuantity  float64 `json:"remainingQuantity"`
+}
+
+// FetchRemoteFills pulls the remote details of an order from the exchange, without modifying local DB.
+func (p *Platform) FetchRemoteFills(orderID string) (RemoteFillsResponse, error) {
+	order, account, adapter, binding, err := p.resolveLiveOrderContext(orderID)
+	if err != nil {
+		return RemoteFillsResponse{}, err
+	}
+	if account.Mode != "LIVE" {
+		return RemoteFillsResponse{}, errors.New("remote fills fetching is only supported for LIVE accounts")
+	}
+
+	reconcileAdapter, ok := adapter.(LiveAccountReconcileAdapter)
+	if !ok {
+		return RemoteFillsResponse{}, errors.New("adapter does not support fetching recent trades")
+	}
+
+	syncResult, err := adapter.SyncOrder(account, order, binding)
+	if err != nil {
+		return RemoteFillsResponse{}, fmt.Errorf("failed to sync remote order: %w", err)
+	}
+
+	remoteTrades, err := reconcileAdapter.FetchRecentTrades(account, binding, order.Symbol, 0)
+	if err != nil {
+		return RemoteFillsResponse{}, fmt.Errorf("failed to fetch remote trades: %w", err)
+	}
+
+	// Filter remoteTrades to only include trades for this order
+	var matchedTrades []LiveFillReport
+	var matchedRawTrades []map[string]any
+
+	exchangeOrderID := order.Metadata["exchangeOrderId"]
+	if exchangeOrderID == nil && syncResult.Metadata != nil {
+		exchangeOrderID = syncResult.Metadata["exchangeOrderId"]
+	}
+
+	for _, trade := range remoteTrades {
+		tradeExchangeOrderID := ""
+		tradeClientOrderID := ""
+		if trade.Metadata != nil {
+			if eoid, ok := trade.Metadata["exchangeOrderId"]; ok {
+				tradeExchangeOrderID = fmt.Sprintf("%v", eoid)
+			}
+			if coid, ok := trade.Metadata["clientOrderId"]; ok {
+				tradeClientOrderID = fmt.Sprintf("%v", coid)
+			}
+			if coid, ok := trade.Metadata["orderId"]; ok && tradeClientOrderID == "" {
+				tradeClientOrderID = fmt.Sprintf("%v", coid)
+			}
+		}
+
+		if (exchangeOrderID != nil && tradeExchangeOrderID == fmt.Sprintf("%v", exchangeOrderID)) || tradeClientOrderID == order.ID {
+			matchedTrades = append(matchedTrades, trade)
+			if trade.Metadata != nil && trade.Metadata["raw"] != nil {
+				if rawMap, ok := trade.Metadata["raw"].(map[string]any); ok {
+					matchedRawTrades = append(matchedRawTrades, rawMap)
+				}
+			}
+		}
+	}
+
+	localFills, err := p.store.QueryFills(domain.FillQuery{OrderIDs: []string{orderID}})
+	if err != nil {
+		return RemoteFillsResponse{}, fmt.Errorf("failed to query local fills: %w", err)
+	}
+
+	var raw map[string]any
+	rawOrderMap, ok := syncResult.Metadata["raw"].(map[string]any)
+	if ok || len(matchedRawTrades) > 0 {
+		raw = make(map[string]any)
+		if ok {
+			raw["order"] = maskSensitiveData(rawOrderMap)
+		}
+		if len(matchedRawTrades) > 0 {
+			var maskedTrades []map[string]any
+			for _, t := range matchedRawTrades {
+				maskedTrades = append(maskedTrades, maskSensitiveData(t))
+			}
+			raw["trades"] = maskedTrades
+		}
+	}
+
+	var remoteOrderMap map[string]any
+	if syncResult.Status != "" {
+		remoteOrderMap = map[string]any{
+			"status":          syncResult.Status,
+			"exchangeOrderId": exchangeOrderID,
+			"syncedAt":        syncResult.SyncedAt,
+		}
+	}
+
+	diagnostics := buildRemoteFillDiagnostics(localFills, matchedTrades)
+
+	return RemoteFillsResponse{
+		OrderID:           orderID,
+		AccountID:         account.ID,
+		Exchange:          account.Exchange,
+		Symbol:            order.Symbol,
+		ExchangeOrderID:   fmt.Sprintf("%v", exchangeOrderID),
+		Status:            order.Status,
+		QueriedAt:         time.Now().UTC().Format(time.RFC3339),
+		RemoteOrder:       remoteOrderMap,
+		RemoteTrades:      matchedRawTrades,
+		NormalizedReports: matchedTrades,
+		LocalFills:        localFills,
+		Raw:               raw,
+		Diagnostics:       diagnostics,
+	}, nil
+}
+
+// ManualSyncFills performs a manual sync of fills, either as a dry run or full settlement.
+func (p *Platform) ManualSyncFills(orderID string, req ManualFillSyncRequest) (ManualFillSyncResponse, error) {
+	order, account, adapter, binding, err := p.resolveLiveOrderContext(orderID)
+	if err != nil {
+		return ManualFillSyncResponse{}, err
+	}
+	if account.Mode != "LIVE" {
+		return ManualFillSyncResponse{}, errors.New("manual sync is only supported for LIVE accounts")
+	}
+
+	reconcileAdapter, ok := adapter.(LiveAccountReconcileAdapter)
+	if !ok {
+		return ManualFillSyncResponse{}, errors.New("adapter does not support fetching recent trades")
+	}
+
+	if !req.DryRun {
+		if !req.Confirm {
+			return ManualFillSyncResponse{}, errors.New("confirmation required for manual sync")
+		}
+		if strings.TrimSpace(req.Reason) == "" {
+			return ManualFillSyncResponse{}, errors.New("reason required for manual sync")
+		}
+	}
+
+	localFillsBefore, err := p.store.QueryFills(domain.FillQuery{OrderIDs: []string{orderID}})
+	if err != nil {
+		return ManualFillSyncResponse{}, err
+	}
+	beforeSnapshot := buildFillSyncSnapshot(order, localFillsBefore)
+
+	if req.DryRun {
+		// Just simulate by fetching remote trades
+		syncResult, err := adapter.SyncOrder(account, order, binding)
+		if err != nil {
+			return ManualFillSyncResponse{}, fmt.Errorf("dry-run failed to sync remote order: %w", err)
+		}
+		remoteTrades, err := reconcileAdapter.FetchRecentTrades(account, binding, order.Symbol, 0)
+		if err != nil {
+			return ManualFillSyncResponse{}, fmt.Errorf("dry-run failed to fetch remote trades: %w", err)
+		}
+
+		exchangeOrderID := order.Metadata["exchangeOrderId"]
+		if exchangeOrderID == nil && syncResult.Metadata != nil {
+			exchangeOrderID = syncResult.Metadata["exchangeOrderId"]
+		}
+
+		var matchedTrades []LiveFillReport
+		for _, trade := range remoteTrades {
+			tradeExchangeOrderID := ""
+			tradeClientOrderID := ""
+			if trade.Metadata != nil {
+				if eoid, ok := trade.Metadata["exchangeOrderId"]; ok {
+					tradeExchangeOrderID = fmt.Sprintf("%v", eoid)
+				}
+				if coid, ok := trade.Metadata["clientOrderId"]; ok {
+					tradeClientOrderID = fmt.Sprintf("%v", coid)
+				}
+				if coid, ok := trade.Metadata["orderId"]; ok && tradeClientOrderID == "" {
+					tradeClientOrderID = fmt.Sprintf("%v", coid)
+				}
+			}
+			if (exchangeOrderID != nil && tradeExchangeOrderID == fmt.Sprintf("%v", exchangeOrderID)) || tradeClientOrderID == order.ID {
+				matchedTrades = append(matchedTrades, trade)
+			}
+		}
+
+		diagnostics := buildRemoteFillDiagnostics(localFillsBefore, matchedTrades)
+
+		afterSnapshot := beforeSnapshot
+		result := "dry_run_no_changes"
+		if diagnostics.CanSettle {
+			afterSnapshot.FillCount = len(matchedTrades)
+			afterSnapshot.RealFillCount = len(matchedTrades)
+			afterSnapshot.SyntheticFillCount = 0
+			result = "dry_run_can_settle"
+		} else if !diagnostics.HasRealTrades {
+			result = "dry_run_no_remote_trades"
+		} else {
+			result = "dry_run_already_settled"
+		}
+
+		return ManualFillSyncResponse{
+			OrderID:     orderID,
+			DryRun:      true,
+			Result:      result,
+			Before:      beforeSnapshot,
+			After:       afterSnapshot,
+			Diagnostics: diagnostics,
+		}, nil
+	}
+
+	// Actual Sync: use existing SyncLiveOrder, but first we can annotate metadata
+	if order.Metadata == nil {
+		order.Metadata = make(map[string]any)
+	}
+	order.Metadata["manualFillSync"] = map[string]any{
+		"reason": req.Reason,
+		"time":   time.Now().UTC().Format(time.RFC3339),
+	}
+	_, err = p.store.UpdateOrder(order)
+	if err != nil {
+		return ManualFillSyncResponse{}, fmt.Errorf("failed to save manual sync metadata: %w", err)
+	}
+
+	syncedOrder, err := p.SyncLiveOrder(orderID)
+	if err != nil {
+		return ManualFillSyncResponse{}, fmt.Errorf("manual sync failed during SyncLiveOrder: %w", err)
+	}
+
+	localFillsAfter, err := p.store.QueryFills(domain.FillQuery{OrderIDs: []string{orderID}})
+	if err != nil {
+		return ManualFillSyncResponse{}, err
+	}
+	afterSnapshot := buildFillSyncSnapshot(syncedOrder, localFillsAfter)
+
+	remoteTrades, _ := reconcileAdapter.FetchRecentTrades(account, binding, syncedOrder.Symbol, 0)
+	var matchedTrades []LiveFillReport
+	exchangeOrderID := syncedOrder.Metadata["exchangeOrderId"]
+	for _, trade := range remoteTrades {
+		tradeExchangeOrderID := ""
+		tradeClientOrderID := ""
+		if trade.Metadata != nil {
+			if eoid, ok := trade.Metadata["exchangeOrderId"]; ok {
+				tradeExchangeOrderID = fmt.Sprintf("%v", eoid)
+			}
+			if coid, ok := trade.Metadata["clientOrderId"]; ok {
+				tradeClientOrderID = fmt.Sprintf("%v", coid)
+			}
+			if coid, ok := trade.Metadata["orderId"]; ok && tradeClientOrderID == "" {
+				tradeClientOrderID = fmt.Sprintf("%v", coid)
+			}
+		}
+		if (exchangeOrderID != nil && tradeExchangeOrderID == fmt.Sprintf("%v", exchangeOrderID)) || tradeClientOrderID == syncedOrder.ID {
+			matchedTrades = append(matchedTrades, trade)
+		}
+	}
+	diagnostics := buildRemoteFillDiagnostics(localFillsAfter, matchedTrades)
+
+	result := "settled"
+	if afterSnapshot.RealFillCount == beforeSnapshot.RealFillCount && afterSnapshot.SyntheticFillCount == beforeSnapshot.SyntheticFillCount {
+		result = "already_settled"
+		if !diagnostics.HasRealTrades {
+			result = "no_remote_trades"
+		}
+	}
+
+	return ManualFillSyncResponse{
+		OrderID:     orderID,
+		DryRun:      false,
+		SyncedAt:    time.Now().UTC().Format(time.RFC3339),
+		Result:      result,
+		Before:      beforeSnapshot,
+		After:       afterSnapshot,
+		Diagnostics: diagnostics,
+	}, nil
+}
+
+func buildFillSyncSnapshot(order domain.Order, fills []domain.Fill) FillSyncSnapshot {
+	var snap FillSyncSnapshot
+	snap.FillCount = len(fills)
+	for _, f := range fills {
+		snap.FilledQuantity += f.Quantity
+		if f.Source == string(FillSourceReal) {
+			snap.RealFillCount++
+		} else if f.Source == string(FillSourceSynthetic) {
+			snap.SyntheticFillCount++
+		}
+		if f.Fee == 0 {
+			snap.FeeZeroCount++
+		}
+	}
+	snap.RemainingQuantity = order.Quantity - snap.FilledQuantity
+	return snap
+}
+
+func buildRemoteFillDiagnostics(localFills []domain.Fill, remoteTrades []LiveFillReport) RemoteFillDiagnostics {
+	var diag RemoteFillDiagnostics
+	diag.LocalFillCount = len(localFills)
+	diag.RemoteTradeCount = len(remoteTrades)
+	diag.HasRealTrades = len(remoteTrades) > 0
+
+	for _, f := range localFills {
+		if f.Source == string(FillSourceSynthetic) {
+			diag.HasSyntheticLocalFill = true
+			diag.LocalSyntheticFillCount++
+		} else if f.Source == string(FillSourceReal) {
+			diag.LocalRealFillCount++
+		}
+		if f.Fee == 0 {
+			diag.LocalFeeZero = true
+		}
+	}
+
+	if diag.HasRealTrades && (diag.HasSyntheticLocalFill || diag.LocalFeeZero || diag.LocalRealFillCount < diag.RemoteTradeCount) {
+		diag.CanSettle = true
+		diag.Reason = "remote trades available to replace synthetic or incomplete fills"
+	} else if !diag.HasRealTrades {
+		diag.Reason = "no remote trades found"
+	} else {
+		diag.Reason = "local fills already fully settled with remote trades"
+	}
+
+	return diag
+}
+
+func maskSensitiveData(data map[string]any) map[string]any {
+	if data == nil {
+		return nil
+	}
+	masked := make(map[string]any)
+	for k, v := range data {
+		lowerK := strings.ToLower(k)
+		if strings.Contains(lowerK, "key") || strings.Contains(lowerK, "secret") || strings.Contains(lowerK, "signature") || strings.Contains(lowerK, "token") {
+			masked[k] = "***"
+		} else if m, ok := v.(map[string]any); ok {
+			masked[k] = maskSensitiveData(m)
+		} else if arr, ok := v.([]any); ok {
+			var newArr []any
+			for _, item := range arr {
+				if mItem, okItem := item.(map[string]any); okItem {
+					newArr = append(newArr, maskSensitiveData(mItem))
+				} else {
+					newArr = append(newArr, item)
+				}
+			}
+			masked[k] = newArr
+		} else {
+			masked[k] = v
+		}
+	}
+	return masked
+}

--- a/internal/service/fill_sync_test.go
+++ b/internal/service/fill_sync_test.go
@@ -108,7 +108,14 @@ func TestRebuildOrderFills(t *testing.T) {
 		Source:          "real",
 	})
 
-	// Match 3 remote trades (one duplicate, two new)
+	// Create position
+	store.SavePosition(domain.Position{
+		AccountID: account.ID,
+		Symbol:    "BTCUSDT",
+		Quantity:  0.7, // 0.4 synthetic + 0.3 real
+	})
+
+	// Match 3 remote trades (one duplicate, two new using different ID keys)
 	matchedTrades := []LiveFillReport{
 		{
 			Price:    50000,
@@ -118,12 +125,12 @@ func TestRebuildOrderFills(t *testing.T) {
 		{
 			Price:    50100,
 			Quantity: 0.5,
-			Metadata: map[string]any{"exchangeTradeId": "trade-new-1"},
+			Metadata: map[string]any{"tradeId": "trade-new-1"},
 		},
 		{
 			Price:    50200,
 			Quantity: 0.2,
-			Metadata: map[string]any{"exchangeTradeId": "trade-new-2"},
+			Metadata: map[string]any{"execId": "trade-new-2"},
 		},
 	}
 
@@ -163,9 +170,27 @@ func TestRebuildOrderFills(t *testing.T) {
 		t.Errorf("Expected after snapshot filled quantity 1.0, got %f", resp.After.FilledQuantity)
 	}
 
+	// Check Audit History
 	updatedOrder, _ := store.GetOrderByID(order.ID)
 	history, ok := updatedOrder.Metadata["manualFillSyncHistory"].([]any)
 	if !ok || len(history) != 1 {
 		t.Errorf("Audit history not found or incorrect")
+	} else {
+		entry := history[0].(map[string]any)
+		if entry["result"] != "settled" {
+			t.Errorf("Expected result 'settled', got %v", entry["result"])
+		}
+		if entry["after"] == nil {
+			t.Errorf("Expected 'after' snapshot in history")
+		}
+		if entry["actor"] != "system" {
+			t.Errorf("Expected actor 'system', got %v", entry["actor"])
+		}
+	}
+
+	// Check Position (should NOT have changed as it's degraded to reconcile)
+	pos, _, _ := store.FindPosition(account.ID, "BTCUSDT")
+	if pos.Quantity != 0.7 {
+		t.Errorf("Expected position quantity 0.7 (unchanged), got %f", pos.Quantity)
 	}
 }

--- a/internal/service/fill_sync_test.go
+++ b/internal/service/fill_sync_test.go
@@ -1,0 +1,50 @@
+package service
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestMaskSensitiveData(t *testing.T) {
+	input := map[string]any{
+		"orderId":     "12345",
+		"apiKey":      "my-secret-api-key",
+		"APISecret":   "super-secret",
+		"signature":   "abcdef123456",
+		"clientToken": "tok_123",
+		"nested": map[string]any{
+			"normal": "value",
+			"key":    "nested-key",
+		},
+		"list": []any{
+			map[string]any{
+				"itemKey": "val1",
+			},
+			"normal_string",
+		},
+	}
+
+	expected := map[string]any{
+		"orderId":     "12345",
+		"apiKey":      "***",
+		"APISecret":   "***",
+		"signature":   "***",
+		"clientToken": "***",
+		"nested": map[string]any{
+			"normal": "value",
+			"key":    "***",
+		},
+		"list": []any{
+			map[string]any{
+				"itemKey": "***",
+			},
+			"normal_string",
+		},
+	}
+
+	result := maskSensitiveData(input)
+
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("maskSensitiveData() = %v, want %v", result, expected)
+	}
+}

--- a/internal/service/fill_sync_test.go
+++ b/internal/service/fill_sync_test.go
@@ -3,6 +3,9 @@ package service
 import (
 	"reflect"
 	"testing"
+
+	"github.com/wuyaocheng/bktrader/internal/domain"
+	"github.com/wuyaocheng/bktrader/internal/store/memory"
 )
 
 func TestMaskSensitiveData(t *testing.T) {
@@ -46,5 +49,123 @@ func TestMaskSensitiveData(t *testing.T) {
 
 	if !reflect.DeepEqual(result, expected) {
 		t.Errorf("maskSensitiveData() = %v, want %v", result, expected)
+	}
+}
+
+type mockLiveAdapter struct{}
+
+func (m *mockLiveAdapter) Key() string                                       { return "binance-futures" }
+func (m *mockLiveAdapter) Describe() map[string]any                          { return nil }
+func (m *mockLiveAdapter) ValidateAccountConfig(config map[string]any) error { return nil }
+func (m *mockLiveAdapter) SubmitOrder(account domain.Account, order domain.Order, binding map[string]any) (LiveOrderSubmission, error) {
+	return LiveOrderSubmission{}, nil
+}
+func (m *mockLiveAdapter) SyncOrder(account domain.Account, order domain.Order, binding map[string]any) (LiveOrderSync, error) {
+	return LiveOrderSync{}, nil
+}
+func (m *mockLiveAdapter) CancelOrder(account domain.Account, order domain.Order, binding map[string]any) (LiveOrderSync, error) {
+	return LiveOrderSync{}, nil
+}
+
+func TestRebuildOrderFills(t *testing.T) {
+	store := memory.NewStore()
+	p := &Platform{
+		store:        store,
+		liveAdapters: make(map[string]LiveExecutionAdapter),
+	}
+	p.liveAdapters["binance-futures"] = &mockLiveAdapter{}
+
+	account, _ := store.CreateAccount("test-account", "LIVE", "binance-futures")
+	account.Metadata = map[string]any{
+		"liveBinding": map[string]any{
+			"adapterKey": "binance-futures",
+		},
+	}
+	store.UpdateAccount(account)
+	order := domain.Order{
+		ID:        "order-1",
+		AccountID: account.ID,
+		Symbol:    "BTCUSDT",
+		Side:      "BUY",
+		Quantity:  1.0,
+		Status:    "FILLED",
+		Metadata:  map[string]any{},
+	}
+	order, _ = store.CreateOrder(order)
+
+	// Create one synthetic fill and one real fill (partially)
+	store.CreateFill(domain.Fill{
+		OrderID:  order.ID,
+		Price:    50000,
+		Quantity: 0.4,
+		Source:   "synthetic",
+	})
+	store.CreateFill(domain.Fill{
+		OrderID:         order.ID,
+		ExchangeTradeID: "trade-already-exists",
+		Price:           50000,
+		Quantity:        0.3,
+		Source:          "real",
+	})
+
+	// Match 3 remote trades (one duplicate, two new)
+	matchedTrades := []LiveFillReport{
+		{
+			Price:    50000,
+			Quantity: 0.3,
+			Metadata: map[string]any{"exchangeTradeId": "trade-already-exists"},
+		},
+		{
+			Price:    50100,
+			Quantity: 0.5,
+			Metadata: map[string]any{"exchangeTradeId": "trade-new-1"},
+		},
+		{
+			Price:    50200,
+			Quantity: 0.2,
+			Metadata: map[string]any{"exchangeTradeId": "trade-new-2"},
+		},
+	}
+
+	// 1. Dry Run
+	resp, err := p.RebuildOrderFills(order.ID, matchedTrades, "test-dry-run", true)
+	if err != nil {
+		t.Fatalf("Dry run failed: %v", err)
+	}
+	if resp.Changes.DeletedSyntheticCount != 1 {
+		t.Errorf("Dry run: expected 1 deleted synthetic, got %d", resp.Changes.DeletedSyntheticCount)
+	}
+	if resp.Changes.AddedRealCount != 2 {
+		t.Errorf("Dry run: expected 2 added real, got %d", resp.Changes.AddedRealCount)
+	}
+	if len(resp.Changes.DuplicateTradeIDs) != 1 {
+		t.Errorf("Dry run: expected 1 duplicate trade, got %d", len(resp.Changes.DuplicateTradeIDs))
+	}
+
+	// 2. Real Rebuild
+	resp, err = p.RebuildOrderFills(order.ID, matchedTrades, "test-real-rebuild", false)
+	if err != nil {
+		t.Fatalf("Real rebuild failed: %v", err)
+	}
+
+	// Check Store State
+	fills, _ := store.QueryFills(domain.FillQuery{OrderIDs: []string{order.ID}})
+	if len(fills) != 3 {
+		t.Errorf("Expected 3 fills after rebuild, got %d", len(fills))
+	}
+	for _, f := range fills {
+		if f.Source == "synthetic" {
+			t.Errorf("Found synthetic fill after rebuild")
+		}
+	}
+
+	if resp.After.FilledQuantity != 1.0 {
+		t.Errorf("Expected after snapshot filled quantity 1.0, got %f", resp.After.FilledQuantity)
+	}
+
+	updatedOrder, _ := store.GetOrderByID(order.ID)
+	history, ok := updatedOrder.Metadata["manualFillSyncHistory"].([]any)
+	if !ok || len(history) != 1 {
+		t.Errorf("Audit history not found or incorrect")
 	}
 }

--- a/internal/store/postgres/store.go
+++ b/internal/store/postgres/store.go
@@ -1009,8 +1009,11 @@ func (s fillSettlementTxStore) DeleteSyntheticFillsForOrder(orderID string) (flo
 		with deleted as (
 			delete from fills
 			where order_id = $1
-			and (exchange_trade_id is null or exchange_trade_id = '')
-			and dedup_fallback_fingerprint is not null
+			and (
+				fill_source = 'synthetic'
+				or ((exchange_trade_id is null or exchange_trade_id = '') and dedup_fallback_fingerprint is not null)
+			)
+			and fill_source != 'remainder'
 			returning quantity
 		)
 		select sum(quantity) from deleted

--- a/internal/store/postgres/store.go
+++ b/internal/store/postgres/store.go
@@ -1003,6 +1003,25 @@ func (s fillSettlementTxStore) QueryFills(query domain.FillQuery) ([]domain.Fill
 	return queryFills(s.tx, query)
 }
 
+func (s fillSettlementTxStore) DeleteSyntheticFillsForOrder(orderID string) (float64, error) {
+	var totalQty sql.NullFloat64
+	err := s.tx.QueryRow(`
+		with deleted as (
+			delete from fills
+			where order_id = $1
+			and (exchange_trade_id is null or exchange_trade_id = '')
+			and dedup_fallback_fingerprint is not null
+			returning quantity
+		)
+		select sum(quantity) from deleted
+	`, orderID).Scan(&totalQty)
+
+	if err != nil && err != sql.ErrNoRows {
+		return 0, err
+	}
+	return totalQty.Float64, nil
+}
+
 type fillScanner interface {
 	Scan(dest ...any) error
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -21,6 +21,7 @@ type FillSettlementStore interface {
 	DeletePosition(positionID string) error
 	UpdateOrder(order domain.Order) (domain.Order, error)
 	CreateOrderCloseVerification(item domain.OrderCloseVerification) (domain.OrderCloseVerification, error)
+	DeleteSyntheticFillsForOrder(orderID string) (float64, error)
 }
 
 // Repository 定义平台的数据持久化接口。

--- a/web/console/src/components/layout/DockContent.tsx
+++ b/web/console/src/components/layout/DockContent.tsx
@@ -1208,7 +1208,7 @@ export function DockContent({ dockTab, actions, sessionId }: DockContentProps) {
         )}
         {dockTab === 'fills' && (
           <DockTable
-            columns={["ID", "来源", "策略版本", "Symbol", "侧向", "价格", "数量", "手续费", "交易所成交ID", "交易所成交时间", "状态/操作"]}
+            columns={["ID", "来源", "策略版本", "Symbol", "侧向", "价格", "数量", "手续费", "交易所成交ID", "交易所成交时间", "创建时间", "状态/操作"]}
             rows={pagedFills.map((fill) => {
               const order = orderById.get(fill.orderId);
               const duplicateKey = [
@@ -1233,6 +1233,7 @@ export function DockContent({ dockTab, actions, sessionId }: DockContentProps) {
                 formatMaybeNumber(fill.fee),
                 <TruncatedValue key={`${fill.id}-exid`} value={fill.exchangeTradeId ?? "--"} />,
                 formatTime(fill.exchangeTradeTime ?? ""),
+                formatTime(fill.createdAt),
                 <div key={`${fill.id}-actions`} className="flex items-center justify-end gap-2">
                   {suspiciousDuplicate ? (
                     <DockBadge tone="watch">疑似重复</DockBadge>

--- a/web/console/src/components/layout/DockContent.tsx
+++ b/web/console/src/components/layout/DockContent.tsx
@@ -35,6 +35,7 @@ import {
   DialogFooter,
   DialogClose
 } from '../ui/dialog';
+import { FillSyncModal } from '../../modals/FillSyncModal';
 import { ManualTradeReviewDialog } from '../live/ManualTradeReviewDialog';
 
 import { cn } from '../../lib/utils';
@@ -869,6 +870,9 @@ export function DockContent({ dockTab, actions, sessionId }: DockContentProps) {
   const [decisionTraceStatus, setDecisionTraceStatus] = useState<DecisionTraceStatus>("idle");
   const [decisionTrace, setDecisionTrace] = useState<DecisionTrace | null>(null);
   const [decisionTraceError, setDecisionTraceError] = useState("");
+  
+  const [fillSyncOrder, setFillSyncOrder] = useState<Order | null>(null);
+  const [fillSyncMode, setFillSyncMode] = useState<'view' | 'sync'>('view');
 
   // Pagination & Sorting State
   const [pages, setPages] = useState({ pairs: 1, positions: 1, alerts: 1 });
@@ -1204,7 +1208,7 @@ export function DockContent({ dockTab, actions, sessionId }: DockContentProps) {
         )}
         {dockTab === 'fills' && (
           <DockTable
-            columns={["ID", "策略版本", "Symbol", "侧向", "价格", "数量", "手续费", "交易所成交ID", "交易所成交时间", "本地入库时间", "同步提示"]}
+            columns={["ID", "来源", "策略版本", "Symbol", "侧向", "价格", "数量", "手续费", "交易所成交ID", "交易所成交时间", "状态/操作"]}
             rows={pagedFills.map((fill) => {
               const order = orderById.get(fill.orderId);
               const duplicateKey = [
@@ -1215,9 +1219,12 @@ export function DockContent({ dockTab, actions, sessionId }: DockContentProps) {
                 fill.exchangeTradeTime ?? "",
               ].join("|");
               const suspiciousDuplicate = !(fill.exchangeTradeId ?? "").trim() && (duplicateFallbackFillCounts.get(duplicateKey) ?? 0) > 1;
+              const sourceLabel = fill.source === "synthetic" ? "Synthetic" : fill.source === "real" ? "Real" : fill.source === "remainder" ? "Remainder" : (fill.source || "--");
+              const isSynthetic = fill.source === "synthetic" || !fill.exchangeTradeId || fill.fee === 0;
 
               return [
                 <TruncatedValue key={`${fill.id}-id`} value={fill.id} display={fill.id.replace('fill-', '')} />,
+                <DockBadge key={`${fill.id}-source`} tone={fill.source === "real" ? "ready" : fill.source === "synthetic" ? "watch" : "neutral"}>{sourceLabel}</DockBadge>,
                 String(order?.metadata?.strategyVersionId ?? fill.strategyVersion ?? "--"),
                 order?.symbol ?? fill.symbol ?? "--",
                 order?.side ?? fill.side ?? "--",
@@ -1226,16 +1233,43 @@ export function DockContent({ dockTab, actions, sessionId }: DockContentProps) {
                 formatMaybeNumber(fill.fee),
                 <TruncatedValue key={`${fill.id}-exid`} value={fill.exchangeTradeId ?? "--"} />,
                 formatTime(fill.exchangeTradeTime ?? ""),
-                formatTime(fill.createdAt),
-                suspiciousDuplicate ? (
-                  <DockBadge key={`${fill.id}-dup`} tone="watch">疑似重复</DockBadge>
-                ) : fill.exchangeTradeId ? (
-                  <DockBadge key={`${fill.id}-ok`} tone="ready">已同步</DockBadge>
-                ) : (
-                  <span key={`${fill.id}-pending`} className="text-[11px] text-[var(--bk-text-muted)]">
-                    等待同步
-                  </span>
-                ),
+                <div key={`${fill.id}-actions`} className="flex items-center justify-end gap-2">
+                  {suspiciousDuplicate ? (
+                    <DockBadge tone="watch">疑似重复</DockBadge>
+                  ) : fill.exchangeTradeId ? (
+                    <DockBadge tone="ready">已同步</DockBadge>
+                  ) : (
+                    <span className="text-[11px] text-[var(--bk-text-muted)]">等待同步</span>
+                  )}
+                  {order && (
+                    <div className="flex gap-1 ml-2">
+                      <Button
+                        variant="bento-outline"
+                        size="sm"
+                        className="h-6 px-2 text-[10px]"
+                        onClick={() => {
+                          setFillSyncOrder(order);
+                          setFillSyncMode('view');
+                        }}
+                      >
+                        详情
+                      </Button>
+                      {isSynthetic && (
+                        <Button
+                          variant="bento-outline"
+                          size="sm"
+                          className="h-6 px-2 text-[10px] text-orange-500 border-orange-500/30 hover:bg-orange-500/10"
+                          onClick={() => {
+                            setFillSyncOrder(order);
+                            setFillSyncMode('sync');
+                          }}
+                        >
+                          同步
+                        </Button>
+                      )}
+                    </div>
+                  )}
+                </div>,
               ];
             })}
             emptyMessage="暂无成交记录"
@@ -1278,6 +1312,17 @@ export function DockContent({ dockTab, actions, sessionId }: DockContentProps) {
         sessionId={sessionId}
         onClose={() => setSelectedPairForReview(null)}
         onSuccess={() => refetchPairs?.()}
+      />
+
+      <FillSyncModal
+        isOpen={fillSyncOrder !== null}
+        onClose={() => setFillSyncOrder(null)}
+        order={fillSyncOrder}
+        initialMode={fillSyncMode}
+        onSuccess={() => {
+          fillsPageQuery.refetch?.();
+          ordersPageQuery.refetch?.();
+        }}
       />
     </div>
   );

--- a/web/console/src/hooks/useFillsPageQuery.ts
+++ b/web/console/src/hooks/useFillsPageQuery.ts
@@ -34,5 +34,9 @@ export function useFillsPageQuery(pageSize: number, active: boolean) {
     }
   }, [active, currentPage, fetchPage]);
 
-  return { fills, totalCount, currentPage, setCurrentPage, loading };
+  const refetch = useCallback(() => {
+    fetchPage(currentPage);
+  }, [fetchPage, currentPage]);
+
+  return { fills, totalCount, currentPage, setCurrentPage, loading, refetch };
 }

--- a/web/console/src/hooks/useOrdersPageQuery.ts
+++ b/web/console/src/hooks/useOrdersPageQuery.ts
@@ -34,5 +34,9 @@ export function useOrdersPageQuery(pageSize: number, active: boolean) {
     }
   }, [active, currentPage, fetchPage]);
 
-  return { orders, totalCount, currentPage, setCurrentPage, loading };
+  const refetch = useCallback(() => {
+    fetchPage(currentPage);
+  }, [fetchPage, currentPage]);
+
+  return { orders, totalCount, currentPage, setCurrentPage, loading, refetch };
 }

--- a/web/console/src/modals/FillSyncModal.tsx
+++ b/web/console/src/modals/FillSyncModal.tsx
@@ -1,0 +1,259 @@
+import React, { useState, useEffect } from 'react';
+import { SettingsModalFrame } from './modal-frame';
+import { Order, Fill, RemoteFillsResponse, ManualFillSyncResponse } from '../types/domain';
+import { fetchRemoteFills, manualSyncFills } from '../utils/api';
+import { Button } from '../components/ui/button';
+import { Input } from '../components/ui/input';
+import { AlertCircle, CheckCircle2, ChevronDown, ChevronRight, RefreshCw, Server, Info } from 'lucide-react';
+
+interface FillSyncModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  order: Order | null;
+  onSuccess?: () => void;
+  initialMode?: 'view' | 'sync';
+}
+
+export function FillSyncModal({ isOpen, onClose, order, onSuccess, initialMode = 'view' }: FillSyncModalProps) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [remoteData, setRemoteData] = useState<RemoteFillsResponse | null>(null);
+  const [syncResult, setSyncResult] = useState<ManualFillSyncResponse | null>(null);
+  
+  const [mode, setMode] = useState<'view' | 'sync'>(initialMode);
+  const [reason, setReason] = useState('');
+  const [syncing, setSyncing] = useState(false);
+  const [showRaw, setShowRaw] = useState(false);
+
+  useEffect(() => {
+    if (isOpen && order && order.accountId) {
+      loadRemoteFills();
+      setMode(initialMode);
+      setSyncResult(null);
+      setReason('');
+      setShowRaw(false);
+    }
+  }, [isOpen, order, initialMode]);
+
+  const loadRemoteFills = async () => {
+    if (!order) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await fetchRemoteFills(order.id);
+      setRemoteData(data);
+    } catch (err: any) {
+      setError(err.message || 'Failed to fetch remote fills');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleSync = async (dryRun: boolean) => {
+    if (!order) return;
+    if (!dryRun && !reason.trim()) {
+      setError('Reason is required for manual sync');
+      return;
+    }
+    setSyncing(true);
+    setError(null);
+    try {
+      const result = await manualSyncFills(order.id, {
+        confirm: true,
+        reason: reason.trim(),
+        dryRun
+      });
+      setSyncResult(result);
+      if (!dryRun && result.result === 'settled' && onSuccess) {
+        onSuccess();
+      }
+    } catch (err: any) {
+      setError(err.message || 'Manual sync failed');
+    } finally {
+      setSyncing(false);
+    }
+  };
+
+  if (!order) return null;
+
+  return (
+    <SettingsModalFrame open={isOpen} onOpenChange={(o) => !o && onClose()} kicker="Diagnostics" title={`Fill Sync Diagnostics: ${order.id}`}>
+      <div className="flex flex-col h-full overflow-hidden">
+        
+        <div className="flex border-b border-border mb-4">
+          <button
+            className={`px-4 py-2 text-sm font-medium border-b-2 ${mode === 'view' ? 'border-primary text-primary' : 'border-transparent text-muted-foreground hover:text-foreground'}`}
+            onClick={() => setMode('view')}
+          >
+            Remote Details
+          </button>
+          <button
+            className={`px-4 py-2 text-sm font-medium border-b-2 ${mode === 'sync' ? 'border-primary text-primary' : 'border-transparent text-muted-foreground hover:text-foreground'}`}
+            onClick={() => setMode('sync')}
+          >
+            Manual Sync
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto pr-2 pb-4 space-y-6">
+          {error && (
+            <div className="rounded-2xl border border-[var(--bk-status-danger)]/25 bg-[color:color-mix(in_srgb,var(--bk-status-danger)_8%,transparent)] p-4 text-[12px] font-bold text-[var(--bk-status-danger)] flex items-start">
+              <AlertCircle className="h-4 w-4 mr-2 mt-0.5 shrink-0" />
+              <div>
+                <h4 className="font-black">Error</h4>
+                <div className="font-normal">{error}</div>
+              </div>
+            </div>
+          )}
+
+          {loading ? (
+            <div className="flex items-center justify-center p-8 text-muted-foreground">
+              <RefreshCw className="h-6 w-6 animate-spin mr-2" />
+              Loading remote fills from exchange...
+            </div>
+          ) : mode === 'view' && remoteData ? (
+            <div className="space-y-6">
+              <div className="grid grid-cols-2 gap-4">
+                <div className="bg-muted/30 p-4 rounded-lg border border-border">
+                  <h3 className="font-medium mb-2 flex items-center"><Server className="w-4 h-4 mr-2" />Remote Order</h3>
+                  <div className="text-sm space-y-1">
+                    <div className="flex justify-between"><span className="text-muted-foreground">Status:</span> <span>{String(remoteData.remoteOrder?.status || 'Unknown')}</span></div>
+                    <div className="flex justify-between"><span className="text-muted-foreground">Exchange ID:</span> <span className="font-mono text-xs truncate max-w-[150px]">{remoteData.exchangeOrderId}</span></div>
+                    <div className="flex justify-between"><span className="text-muted-foreground">Filled Qty:</span> <span>{String(remoteData.remoteOrder?.filledQuantity || 0)}</span></div>
+                  </div>
+                </div>
+                
+                <div className="bg-muted/30 p-4 rounded-lg border border-border">
+                  <h3 className="font-medium mb-2 flex items-center"><Info className="w-4 h-4 mr-2" />Diagnostics</h3>
+                  <div className="text-sm space-y-1">
+                    <div className="flex justify-between"><span className="text-muted-foreground">Remote Trades:</span> <span>{remoteData.diagnostics.remoteTradeCount}</span></div>
+                    <div className="flex justify-between"><span className="text-muted-foreground">Local Fills:</span> <span>{remoteData.diagnostics.localFillCount} ({remoteData.diagnostics.localRealFillCount} real, {remoteData.diagnostics.localSyntheticFillCount} syn)</span></div>
+                    <div className="flex justify-between"><span className="text-muted-foreground">Can Settle:</span> <span className={remoteData.diagnostics.canSettle ? 'text-green-500 font-medium' : ''}>{remoteData.diagnostics.canSettle ? 'Yes' : 'No'}</span></div>
+                  </div>
+                  <div className="text-xs text-muted-foreground mt-2 border-t border-border pt-2">
+                    {remoteData.diagnostics.reason}
+                  </div>
+                </div>
+              </div>
+
+              <div>
+                <h3 className="font-medium mb-3">Normalized Remote Trades ({remoteData.normalizedReports.length})</h3>
+                {remoteData.normalizedReports.length > 0 ? (
+                  <div className="border border-border rounded-md overflow-hidden text-sm">
+                    <table className="w-full">
+                      <thead className="bg-muted/50 border-b border-border">
+                        <tr>
+                          <th className="text-left px-3 py-2 font-medium">Price</th>
+                          <th className="text-left px-3 py-2 font-medium">Quantity</th>
+                          <th className="text-left px-3 py-2 font-medium">Fee</th>
+                        </tr>
+                      </thead>
+                      <tbody className="divide-y divide-border">
+                        {remoteData.normalizedReports.map((r: any, i) => (
+                          <tr key={i} className="bg-background">
+                            <td className="px-3 py-2">{r.price}</td>
+                            <td className="px-3 py-2">{r.quantity}</td>
+                            <td className="px-3 py-2">{r.fee}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                ) : (
+                  <div className="text-sm text-muted-foreground p-4 bg-muted/20 rounded-md border border-border border-dashed text-center">
+                    No remote trades found for this order.
+                  </div>
+                )}
+              </div>
+
+              <div>
+                <button 
+                  onClick={() => setShowRaw(!showRaw)}
+                  className="flex items-center text-sm font-medium text-muted-foreground hover:text-foreground"
+                >
+                  {showRaw ? <ChevronDown className="w-4 h-4 mr-1" /> : <ChevronRight className="w-4 h-4 mr-1" />}
+                  Raw Exchange Response (Masked)
+                </button>
+                {showRaw && remoteData.raw && (
+                  <pre className="mt-2 p-4 bg-muted rounded-md text-xs font-mono overflow-x-auto border border-border">
+                    {JSON.stringify(remoteData.raw, null, 2)}
+                  </pre>
+                )}
+              </div>
+            </div>
+          ) : mode === 'sync' && (
+            <div className="space-y-6">
+              <div className="rounded-2xl border border-blue-500/25 bg-blue-500/10 p-4 text-[12px] text-blue-500/90 flex items-start">
+                <AlertCircle className="h-4 w-4 mr-2 mt-0.5 shrink-0" />
+                <div>
+                  <h4 className="font-black">Manual Synchronization</h4>
+                  <div className="font-normal mt-1">
+                    This operation will re-fetch exchange trades and trigger the existing fill reconciliation pipeline to update local fills, order metadata, and positions. 
+                    <br className="my-1"/>
+                    <strong>It will not place or cancel orders.</strong>
+                  </div>
+                </div>
+              </div>
+
+              <div className="space-y-3">
+                <label className="text-sm font-medium">Reason for Manual Sync <span className="text-red-500">*</span></label>
+                <Input 
+                  value={reason} 
+                  onChange={(e) => setReason(e.target.value)} 
+                  placeholder="E.g., Replacing synthetic fills with real exchange trades due to WS drop"
+                  disabled={syncing || (syncResult != null && !syncResult.dryRun)}
+                />
+              </div>
+
+              {syncResult && (
+                <div className={`p-4 rounded-lg border ${syncResult.dryRun ? 'bg-blue-500/10 border-blue-500/20' : (syncResult.result === 'settled' ? 'bg-green-500/10 border-green-500/20' : 'bg-muted/50 border-border')}`}>
+                  <h3 className="font-medium mb-3 flex items-center">
+                    {syncResult.dryRun ? <Info className="w-4 h-4 mr-2 text-blue-500" /> : <CheckCircle2 className="w-4 h-4 mr-2 text-green-500" />}
+                    {syncResult.dryRun ? 'Dry Run Results' : 'Sync Completed'}
+                    <span className="ml-auto text-xs px-2 py-1 bg-background rounded-full border border-border">
+                      {syncResult.result}
+                    </span>
+                  </h3>
+                  
+                  <div className="grid grid-cols-2 gap-4 text-sm mt-4">
+                    <div className="space-y-2">
+                      <div className="font-medium text-muted-foreground mb-1 border-b border-border pb-1">Before</div>
+                      <div className="flex justify-between"><span>Total Fills:</span> <span>{syncResult.before.fillCount}</span></div>
+                      <div className="flex justify-between"><span>Real:</span> <span>{syncResult.before.realFillCount}</span></div>
+                      <div className="flex justify-between"><span>Synthetic:</span> <span>{syncResult.before.syntheticFillCount}</span></div>
+                    </div>
+                    <div className="space-y-2">
+                      <div className="font-medium text-muted-foreground mb-1 border-b border-border pb-1">After (Predicted)</div>
+                      <div className="flex justify-between"><span>Total Fills:</span> <span>{syncResult.after.fillCount}</span></div>
+                      <div className="flex justify-between"><span>Real:</span> <span className={syncResult.after.realFillCount > syncResult.before.realFillCount ? 'text-green-500 font-medium' : ''}>{syncResult.after.realFillCount}</span></div>
+                      <div className="flex justify-between"><span>Synthetic:</span> <span className={syncResult.after.syntheticFillCount < syncResult.before.syntheticFillCount ? 'text-blue-500 font-medium' : ''}>{syncResult.after.syntheticFillCount}</span></div>
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              <div className="flex justify-end space-x-3 pt-4 border-t border-border">
+                <Button 
+                  variant="outline" 
+                  onClick={() => handleSync(true)} 
+                  disabled={syncing || (syncResult != null && !syncResult.dryRun)}
+                >
+                  {syncing && syncResult?.dryRun !== false ? <RefreshCw className="mr-2 h-4 w-4 animate-spin" /> : null}
+                  Preview (Dry Run)
+                </Button>
+                <Button 
+                  variant="default" 
+                  onClick={() => handleSync(false)} 
+                  disabled={syncing || !reason.trim() || (syncResult != null && !syncResult.dryRun)}
+                >
+                  {syncing && syncResult?.dryRun === false ? <RefreshCw className="mr-2 h-4 w-4 animate-spin" /> : null}
+                  Confirm Sync
+                </Button>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </SettingsModalFrame>
+  );
+}

--- a/web/console/src/modals/FillSyncModal.tsx
+++ b/web/console/src/modals/FillSyncModal.tsx
@@ -215,18 +215,38 @@ export function FillSyncModal({ isOpen, onClose, order, onSuccess, initialMode =
                     </span>
                   </h3>
                   
-                  <div className="grid grid-cols-2 gap-4 text-sm mt-4">
+                  {syncResult.changes && (
+                    <div className="mb-4 grid grid-cols-2 gap-2 text-xs">
+                      <div className="flex justify-between items-center p-2 rounded bg-background/50 border border-border/50">
+                        <span className="text-muted-foreground">Deleted Synthetic:</span>
+                        <span className="font-bold text-orange-500">{syncResult.changes.deletedSyntheticCount}</span>
+                      </div>
+                      <div className="flex justify-between items-center p-2 rounded bg-background/50 border border-border/50">
+                        <span className="text-muted-foreground">Added Real:</span>
+                        <span className="font-bold text-green-500">{syncResult.changes.addedRealCount}</span>
+                      </div>
+                      {syncResult.changes.duplicateTradeIDs && syncResult.changes.duplicateTradeIDs.length > 0 && (
+                        <div className="col-span-2 p-2 rounded bg-background/50 border border-border/50 text-muted-foreground">
+                          Skipped {syncResult.changes.duplicateTradeIDs.length} duplicates.
+                        </div>
+                      )}
+                    </div>
+                  )}
+
+                  <div className="grid grid-cols-2 gap-4 text-sm mt-4 border-t border-border/30 pt-4">
                     <div className="space-y-2">
                       <div className="font-medium text-muted-foreground mb-1 border-b border-border pb-1">Before</div>
                       <div className="flex justify-between"><span>Total Fills:</span> <span>{syncResult.before.fillCount}</span></div>
                       <div className="flex justify-between"><span>Real:</span> <span>{syncResult.before.realFillCount}</span></div>
                       <div className="flex justify-between"><span>Synthetic:</span> <span>{syncResult.before.syntheticFillCount}</span></div>
+                      <div className="flex justify-between"><span>Filled Qty:</span> <span>{syncResult.before.filledQuantity}</span></div>
                     </div>
                     <div className="space-y-2">
-                      <div className="font-medium text-muted-foreground mb-1 border-b border-border pb-1">After (Predicted)</div>
+                      <div className="font-medium text-muted-foreground mb-1 border-b border-border pb-1">{syncResult.dryRun ? 'After (Predicted)' : 'After'}</div>
                       <div className="flex justify-between"><span>Total Fills:</span> <span>{syncResult.after.fillCount}</span></div>
                       <div className="flex justify-between"><span>Real:</span> <span className={syncResult.after.realFillCount > syncResult.before.realFillCount ? 'text-green-500 font-medium' : ''}>{syncResult.after.realFillCount}</span></div>
                       <div className="flex justify-between"><span>Synthetic:</span> <span className={syncResult.after.syntheticFillCount < syncResult.before.syntheticFillCount ? 'text-blue-500 font-medium' : ''}>{syncResult.after.syntheticFillCount}</span></div>
+                      <div className="flex justify-between"><span>Filled Qty:</span> <span className={syncResult.after.filledQuantity !== syncResult.before.filledQuantity ? 'text-blue-500 font-medium' : ''}>{syncResult.after.filledQuantity}</span></div>
                     </div>
                   </div>
                 </div>

--- a/web/console/src/modals/FillSyncModal.tsx
+++ b/web/console/src/modals/FillSyncModal.tsx
@@ -225,11 +225,14 @@ export function FillSyncModal({ isOpen, onClose, order, onSuccess, initialMode =
                         <span className="text-muted-foreground">Added Real:</span>
                         <span className="font-bold text-green-500">{syncResult.changes.addedRealCount}</span>
                       </div>
-                      {syncResult.changes.duplicateTradeIDs && syncResult.changes.duplicateTradeIDs.length > 0 && (
-                        <div className="col-span-2 p-2 rounded bg-background/50 border border-border/50 text-muted-foreground">
-                          Skipped {syncResult.changes.duplicateTradeIDs.length} duplicates.
-                        </div>
-                      )}
+                      <div className="flex justify-between items-center p-2 rounded bg-background/50 border border-border/50">
+                        <span className="text-muted-foreground">Skipped (No ID):</span>
+                        <span className={`font-bold ${syncResult.changes.skippedTradeCount > 0 ? 'text-red-500' : 'text-muted-foreground'}`}>{syncResult.changes.skippedTradeCount}</span>
+                      </div>
+                      <div className="flex justify-between items-center p-2 rounded bg-background/50 border border-border/50">
+                        <span className="text-muted-foreground">Duplicates:</span>
+                        <span className="font-bold">{syncResult.changes.duplicateTradeIDs?.length || 0}</span>
+                      </div>
                     </div>
                   )}
 

--- a/web/console/src/types/domain.ts
+++ b/web/console/src/types/domain.ts
@@ -140,6 +140,7 @@ export type ManualFillSyncResponse = {
   changes?: {
     deletedSyntheticCount: number;
     addedRealCount: number;
+    skippedTradeCount: number;
     duplicateTradeIDs: string[];
     newTradeIDs: string[];
   };

--- a/web/console/src/types/domain.ts
+++ b/web/console/src/types/domain.ts
@@ -137,6 +137,12 @@ export type ManualFillSyncResponse = {
   before: FillSyncSnapshot;
   after: FillSyncSnapshot;
   diagnostics: RemoteFillDiagnostics;
+  changes?: {
+    deletedSyntheticCount: number;
+    addedRealCount: number;
+    duplicateTradeIDs: string[];
+    newTradeIDs: string[];
+  };
 };
 
 export type Position = {

--- a/web/console/src/types/domain.ts
+++ b/web/console/src/types/domain.ts
@@ -86,9 +86,57 @@ export type Fill = {
   price: number;
   quantity: number;
   fee: number;
+  source?: string;
   exchangeTradeId?: string;
   exchangeTradeTime?: string;
   createdAt: string;
+};
+
+export type RemoteFillDiagnostics = {
+  hasRealTrades: boolean;
+  hasSyntheticLocalFill: boolean;
+  localFeeZero: boolean;
+  canSettle: boolean;
+  reason: string;
+  remoteTradeCount: number;
+  localFillCount: number;
+  localRealFillCount: number;
+  localSyntheticFillCount: number;
+};
+
+export type FillSyncSnapshot = {
+  fillCount: number;
+  realFillCount: number;
+  syntheticFillCount: number;
+  feeZeroCount: number;
+  filledQuantity: number;
+  remainingQuantity: number;
+};
+
+export type RemoteFillsResponse = {
+  orderId: string;
+  accountId: string;
+  exchange: string;
+  symbol: string;
+  exchangeOrderId: string;
+  status: string;
+  queriedAt: string;
+  remoteOrder?: Record<string, unknown>;
+  remoteTrades: Array<Record<string, unknown>>;
+  normalizedReports: Array<Record<string, unknown>>;
+  localFills: Fill[];
+  raw?: Record<string, unknown>;
+  diagnostics: RemoteFillDiagnostics;
+};
+
+export type ManualFillSyncResponse = {
+  orderId: string;
+  dryRun: boolean;
+  syncedAt?: string;
+  result: string;
+  before: FillSyncSnapshot;
+  after: FillSyncSnapshot;
+  diagnostics: RemoteFillDiagnostics;
 };
 
 export type Position = {

--- a/web/console/src/utils/api.ts
+++ b/web/console/src/utils/api.ts
@@ -27,3 +27,19 @@ export async function fetchJSON<T>(path: string, init?: RequestInit): Promise<T>
   }
   return (await response.json()) as T;
 }
+
+import { RemoteFillsResponse, ManualFillSyncResponse } from '../types/domain';
+
+export async function fetchRemoteFills(orderId: string): Promise<RemoteFillsResponse> {
+  return fetchJSON<RemoteFillsResponse>(`/api/v1/orders/${orderId}/remote-fills`, {
+    method: 'GET',
+  });
+}
+
+export async function manualSyncFills(orderId: string, req: { confirm: boolean; reason: string; dryRun: boolean }): Promise<ManualFillSyncResponse> {
+  return fetchJSON<ManualFillSyncResponse>(`/api/v1/orders/${orderId}/sync-fills`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(req),
+  });
+}


### PR DESCRIPTION
## 目的
实现 Issue #344 的第一阶段：建立 Trading Harness。将交易语义分类从散落 50+ 处的组合判断收敛为后端唯一分类器，建立 Golden Case 回归体系，并为 API 注入语义字段。

## 本次改动风险定级
- [x] **L1** - 中风险 (新增无害接口、辅助工具扩容)

## AI Agent 参与声明
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了 (Antigravity 辅助生成与验证)

## 风险点 checklist
- [x] `dispatchMode` 默认值有否变化？ (无变化)
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？ (无)
- [x] DB migration 是否具备向下兼容幂等性？ (不涉及)
- [x] 配置字段有没有无意被混改？ (无)

## 交易语义变更
- [x] 本次改动是否新增/修改了 `signalKind`？ (新增了契约文档说明)
- [x] 本次改动是否影响订单方向判断（`side` / `reduceOnly` / `closePosition`）？ (收敛了判断逻辑到 ClassifyOrderIntent)
- [x] 若涉及上述改动，`go test ./internal/domain/... -run TestClassifyOrderIntent` 是否通过？ (✅ 13/13 PASS)

## 验证方式与测试证据
- [x] 提供单元测试证明 (13 个 Golden Cases 全部通过)
- [x] 后端全量编译与测试通过 (`go build` OK, `go test ./...` PASS)