### PR TITLE
[codex] Expose supervisor app restart plans

### DIFF
--- a/cmd/bktrader-ctl/supervisor.go
+++ b/cmd/bktrader-ctl/supervisor.go
@@ -100,12 +100,25 @@ type supervisorRuntimeStatusSnapshot struct {
 }
 
 type supervisorRuntimeStatus struct {
-	RuntimeID             string `json:"runtimeId"`
-	RuntimeKind           string `json:"runtimeKind"`
-	DesiredStatus         string `json:"desiredStatus"`
-	ActualStatus          string `json:"actualStatus"`
-	Health                string `json:"health"`
-	AutoRestartSuppressed bool   `json:"autoRestartSuppressed"`
+	RuntimeID              string                            `json:"runtimeId"`
+	RuntimeKind            string                            `json:"runtimeKind"`
+	DesiredStatus          string                            `json:"desiredStatus"`
+	ActualStatus           string                            `json:"actualStatus"`
+	Health                 string                            `json:"health"`
+	AutoRestartSuppressed  bool                              `json:"autoRestartSuppressed"`
+	ApplicationRestartPlan *supervisorApplicationRestartPlan `json:"applicationRestartPlan,omitempty"`
+}
+
+type supervisorApplicationRestartPlan struct {
+	Candidate      bool   `json:"candidate"`
+	Enabled        bool   `json:"enabled"`
+	HealthzOK      bool   `json:"healthzOk"`
+	Supported      bool   `json:"supported"`
+	Due            bool   `json:"due"`
+	Duplicate      bool   `json:"duplicate"`
+	Decision       string `json:"decision"`
+	BlockedReason  string `json:"blockedReason,omitempty"`
+	EligibleReason string `json:"eligibleReason,omitempty"`
 }
 
 type supervisorControlAction struct {
@@ -219,12 +232,24 @@ func buildSupervisorStatusSummary(data []byte) (string, error) {
 		}
 		if target.Status != nil {
 			attention := 0
+			restartPlans := 0
+			restartEligible := 0
 			for _, runtime := range target.Status.Runtimes {
 				if supervisorRuntimeNeedsAttention(runtime) {
 					attention++
 				}
+				if runtime.ApplicationRestartPlan != nil {
+					restartPlans++
+					if runtime.ApplicationRestartPlan.Decision == "eligible" {
+						restartEligible++
+					}
+				}
 			}
-			fmt.Fprintf(&out, "  runtimes: total=%d attention=%d service=%s\n", len(target.Status.Runtimes), attention, firstNonEmpty(target.Status.Service, "--"))
+			if restartPlans > 0 {
+				fmt.Fprintf(&out, "  runtimes: total=%d attention=%d restartPlans=%d restartEligible=%d service=%s\n", len(target.Status.Runtimes), attention, restartPlans, restartEligible, firstNonEmpty(target.Status.Service, "--"))
+			} else {
+				fmt.Fprintf(&out, "  runtimes: total=%d attention=%d service=%s\n", len(target.Status.Runtimes), attention, firstNonEmpty(target.Status.Service, "--"))
+			}
 		}
 		if len(target.ControlActions) > 0 {
 			errors := 0

--- a/cmd/bktrader-ctl/supervisor_test.go
+++ b/cmd/bktrader-ctl/supervisor_test.go
@@ -48,14 +48,23 @@ func TestBuildSupervisorStatusSummaryShowsFallbackReadiness(t *testing.T) {
 			},
 			"status":{
 				"service":"platform-api",
-				"runtimes":[{
-					"runtimeId":"signal-1",
-					"runtimeKind":"signal",
-					"desiredStatus":"RUNNING",
-					"actualStatus":"ERROR",
-					"health":"recovering"
-				}]
-			},
+					"runtimes":[{
+						"runtimeId":"signal-1",
+						"runtimeKind":"signal",
+						"desiredStatus":"RUNNING",
+						"actualStatus":"ERROR",
+						"health":"recovering",
+						"applicationRestartPlan":{
+							"candidate":true,
+							"enabled":true,
+							"healthzOk":false,
+							"supported":true,
+							"due":true,
+							"decision":"blocked",
+							"blockedReason":"runtime-restart-healthz-unhealthy"
+						}
+					}]
+				},
 			"controlActions":[{"action":"runtime-restart","runtimeId":"signal-1"}]
 		}]
 	}`)
@@ -71,6 +80,7 @@ func TestBuildSupervisorStatusSummaryShowsFallbackReadiness(t *testing.T) {
 		"serviceState: failures=3/3 fallback=candidate attempts=2 suppressed=false backoffUntil=--",
 		"lastFallbackDecision=container-executor-not-configured at=2026-04-29T08:00:00Z",
 		"fallbackPlan: action=container-restart decision=blocked enabled=true executorConfigured=false executorKind=none executorDryRun=true executable=false suppressed=false backoffActive=false safetyGateOk=true blockedReason=container-executor-not-configured eligibleReason=--",
+		"runtimes: total=1 attention=1 restartPlans=1 restartEligible=0 service=platform-api",
 		"lastFailure=healthz-unhealthy: http 503",
 	}
 	for _, want := range expected {

--- a/docs/runtime-supervisor.md
+++ b/docs/runtime-supervisor.md
@@ -332,6 +332,7 @@ func ClearRestartState(state map[string]any, keys []string)
   - `autoRestartSuppressed=false` 且 `restartSeverity` 不是 `fatal`。
   - `nextRestartAt` 存在且已经到期。
   - 提交 restart 时固定 `force=false`、`confirm=true`，并带上 supervisor reason；同一个 target/runtime/`nextRestartAt` 只提交一次。
+- 当 runtime 进入 restart 关注范围（例如 `actualStatus=ERROR`、存在 `nextRestartAt`、fatal/suppressed）时，supervisor 会在对应 runtime 上附加只读 `applicationRestartPlan`，显式返回 `decision=blocked|eligible`、`enabled`、`healthzOk`、`supported`、`due`、`duplicate`、`blockedReason` / `eligibleReason`。该计划用于解释为什么某个 runtime 会或不会进入应用内 restart；当前 `supported=true` 仍只覆盖 `signal` / `signal-runtime`，因此 `live-session` 等 runtime 即使 ERROR 也只会显示 `blockedReason=runtime-restart-unsupported-kind`，不会被 supervisor 自动拉起。
 
 验收标准：
 
@@ -368,7 +369,7 @@ func ClearRestartState(state map[string]any, keys []string)
 
 ### Dashboard 视图
 
-前端 console 的 Runtime Supervisor 页面读取 `GET /api/v1/supervisor/status`，只展示 supervisor policy、service target、runtime 状态、应用内控制动作、`containerFallbackCandidate`、fallback `decision`、executor `kind`/`dryRun` 和 dry-run audit 摘要。该页面不提交 runtime 或容器控制请求；真正执行容器级 restart 前仍需单独 PR 设计 executor、权限边界和部署安全审查。
+前端 console 的 Runtime Supervisor 页面读取 `GET /api/v1/supervisor/status`，只展示 supervisor policy、service target、runtime 状态、`applicationRestartPlan`、应用内控制动作、`containerFallbackCandidate`、fallback `decision`、executor `kind`/`dryRun` 和 dry-run audit 摘要。该页面不提交 runtime 或容器控制请求；真正执行容器级 restart 前仍需单独 PR 设计 executor、权限边界和部署安全审查。
 
 ## 7. 安全边界
 

--- a/internal/service/runtime_status.go
+++ b/internal/service/runtime_status.go
@@ -14,24 +14,25 @@ type RuntimeStatusSnapshot struct {
 }
 
 type RuntimeStatus struct {
-	Service               string     `json:"service"`
-	RuntimeID             string     `json:"runtimeId"`
-	RuntimeKind           string     `json:"runtimeKind"`
-	AccountID             string     `json:"accountId,omitempty"`
-	StrategyID            string     `json:"strategyId,omitempty"`
-	DesiredStatus         string     `json:"desiredStatus,omitempty"`
-	ActualStatus          string     `json:"actualStatus,omitempty"`
-	Health                string     `json:"health,omitempty"`
-	RestartAttempt        int        `json:"restartAttempt"`
-	NextRestartAt         string     `json:"nextRestartAt,omitempty"`
-	RestartBackoff        string     `json:"restartBackoff,omitempty"`
-	RestartReason         string     `json:"restartReason,omitempty"`
-	RestartSeverity       string     `json:"restartSeverity,omitempty"`
-	LastRestartError      string     `json:"lastRestartError,omitempty"`
-	AutoRestartSuppressed bool       `json:"autoRestartSuppressed"`
-	LastHealthyAt         string     `json:"lastHealthyAt,omitempty"`
-	LastCheckedAt         string     `json:"lastCheckedAt"`
-	UpdatedAt             *time.Time `json:"updatedAt,omitempty"`
+	Service                string                                   `json:"service"`
+	RuntimeID              string                                   `json:"runtimeId"`
+	RuntimeKind            string                                   `json:"runtimeKind"`
+	AccountID              string                                   `json:"accountId,omitempty"`
+	StrategyID             string                                   `json:"strategyId,omitempty"`
+	DesiredStatus          string                                   `json:"desiredStatus,omitempty"`
+	ActualStatus           string                                   `json:"actualStatus,omitempty"`
+	Health                 string                                   `json:"health,omitempty"`
+	RestartAttempt         int                                      `json:"restartAttempt"`
+	NextRestartAt          string                                   `json:"nextRestartAt,omitempty"`
+	RestartBackoff         string                                   `json:"restartBackoff,omitempty"`
+	RestartReason          string                                   `json:"restartReason,omitempty"`
+	RestartSeverity        string                                   `json:"restartSeverity,omitempty"`
+	LastRestartError       string                                   `json:"lastRestartError,omitempty"`
+	AutoRestartSuppressed  bool                                     `json:"autoRestartSuppressed"`
+	LastHealthyAt          string                                   `json:"lastHealthyAt,omitempty"`
+	LastCheckedAt          string                                   `json:"lastCheckedAt"`
+	UpdatedAt              *time.Time                               `json:"updatedAt,omitempty"`
+	ApplicationRestartPlan *RuntimeSupervisorApplicationRestartPlan `json:"applicationRestartPlan,omitempty"`
 }
 
 var liveRuntimeStatusUpdatedAtKeys = []string{

--- a/internal/service/runtime_supervisor.go
+++ b/internal/service/runtime_supervisor.go
@@ -18,6 +18,9 @@ const (
 	defaultRuntimeSupervisorHTTPTimeout       = 5 * time.Second
 	defaultRuntimeSupervisorServiceFailThresh = 3
 
+	runtimeSupervisorApplicationRestartDecisionBlocked  = "blocked"
+	runtimeSupervisorApplicationRestartDecisionEligible = "eligible"
+
 	runtimeSupervisorContainerFallbackDecisionBlocked  = "blocked"
 	runtimeSupervisorContainerFallbackDecisionEligible = "eligible"
 
@@ -128,6 +131,22 @@ type RuntimeSupervisorControlAction struct {
 	RequestedAt time.Time `json:"requestedAt"`
 }
 
+type RuntimeSupervisorApplicationRestartPlan struct {
+	RuntimeID      string `json:"runtimeId"`
+	RuntimeKind    string `json:"runtimeKind"`
+	Candidate      bool   `json:"candidate"`
+	Enabled        bool   `json:"enabled"`
+	HealthzOK      bool   `json:"healthzOk"`
+	Supported      bool   `json:"supported"`
+	Due            bool   `json:"due"`
+	Duplicate      bool   `json:"duplicate"`
+	Decision       string `json:"decision"`
+	BlockedReason  string `json:"blockedReason,omitempty"`
+	EligibleReason string `json:"eligibleReason,omitempty"`
+	Reason         string `json:"reason,omitempty"`
+	NextRestartAt  string `json:"nextRestartAt,omitempty"`
+}
+
 type RuntimeSupervisorServiceState struct {
 	ConsecutiveFailures                 int        `json:"consecutiveFailures"`
 	FailureThreshold                    int        `json:"failureThreshold"`
@@ -184,6 +203,26 @@ type runtimeSupervisorContainerFallbackDecisionInput struct {
 type runtimeSupervisorContainerFallbackDecisionResult struct {
 	Decision       string
 	Executable     bool
+	BlockedReason  string
+	EligibleReason string
+}
+
+type runtimeSupervisorApplicationRestartDecisionInput struct {
+	Candidate            bool
+	Enabled              bool
+	HealthzOK            bool
+	Supported            bool
+	DesiredRunning       bool
+	ActualError          bool
+	Suppressed           bool
+	Fatal                bool
+	NextRestartAtPresent bool
+	Due                  bool
+	Duplicate            bool
+}
+
+type runtimeSupervisorApplicationRestartDecisionResult struct {
+	Decision       string
 	BlockedReason  string
 	EligibleReason string
 }
@@ -307,6 +346,7 @@ func (s *RuntimeSupervisor) Collect(ctx context.Context) RuntimeSupervisorSnapsh
 		targetSnapshot.ServiceState = s.updateServiceState(target, targetSnapshot.Healthz, targetSnapshot.RuntimeStatus, now)
 		targetSnapshot.ContainerFallbackPlan, targetSnapshot.ServiceState = s.updateContainerFallbackPlan(target, targetSnapshot.ServiceState, now)
 		if targetSnapshot.RuntimeStatus.Error == "" && targetSnapshot.RuntimeStatus.Reachable {
+			status = s.attachApplicationRestartPlans(target, status, targetSnapshot.Healthz, now)
 			targetSnapshot.Status = &status
 			targetSnapshot.ControlActions = s.submitApplicationRestarts(ctx, target, status, targetSnapshot.Healthz, now)
 		}
@@ -623,16 +663,137 @@ func runtimeSupervisorServiceKey(target RuntimeSupervisorTarget) string {
 	return strings.TrimSpace(target.Name) + "|" + strings.TrimSpace(target.BaseURL)
 }
 
+func (s *RuntimeSupervisor) attachApplicationRestartPlans(target RuntimeSupervisorTarget, status RuntimeStatusSnapshot, healthz RuntimeSupervisorProbe, now time.Time) RuntimeStatusSnapshot {
+	for i := range status.Runtimes {
+		plan := s.runtimeSupervisorApplicationRestartPlan(target, status.Runtimes[i], healthz, now)
+		if plan != nil {
+			status.Runtimes[i].ApplicationRestartPlan = plan
+		}
+	}
+	return status
+}
+
+func (s *RuntimeSupervisor) runtimeSupervisorApplicationRestartPlan(target RuntimeSupervisorTarget, runtime RuntimeStatus, healthz RuntimeSupervisorProbe, now time.Time) *RuntimeSupervisorApplicationRestartPlan {
+	if !runtimeSupervisorApplicationRestartCandidate(runtime) {
+		return nil
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	now = now.UTC()
+	nextRestartAt := strings.TrimSpace(runtime.NextRestartAt)
+	_, nextRestartAtPresent := ParseRestartTime(map[string]any{"nextRestartAt": nextRestartAt}, "nextRestartAt")
+	due := runtimeSupervisorRestartDueAt(runtime, now)
+	duplicate := due && s.runtimeRestartAlreadySubmitted(target, runtime)
+	reason := runtimeSupervisorRestartReason(target, runtime)
+	decision := evaluateRuntimeSupervisorApplicationRestartDecision(runtimeSupervisorApplicationRestartDecisionInput{
+		Candidate:            true,
+		Enabled:              s != nil && s.options.EnableApplicationRestart,
+		HealthzOK:            runtimeSupervisorHealthzOK(healthz),
+		Supported:            runtimeSupervisorRestartSupportedKind(runtime.RuntimeKind),
+		DesiredRunning:       strings.EqualFold(strings.TrimSpace(runtime.DesiredStatus), "RUNNING"),
+		ActualError:          strings.EqualFold(strings.TrimSpace(runtime.ActualStatus), "ERROR"),
+		Suppressed:           runtime.AutoRestartSuppressed,
+		Fatal:                strings.EqualFold(strings.TrimSpace(runtime.RestartSeverity), "fatal"),
+		NextRestartAtPresent: nextRestartAtPresent,
+		Due:                  due,
+		Duplicate:            duplicate,
+	})
+	return &RuntimeSupervisorApplicationRestartPlan{
+		RuntimeID:      strings.TrimSpace(runtime.RuntimeID),
+		RuntimeKind:    strings.TrimSpace(runtime.RuntimeKind),
+		Candidate:      true,
+		Enabled:        s != nil && s.options.EnableApplicationRestart,
+		HealthzOK:      runtimeSupervisorHealthzOK(healthz),
+		Supported:      runtimeSupervisorRestartSupportedKind(runtime.RuntimeKind),
+		Due:            due,
+		Duplicate:      duplicate,
+		Decision:       decision.Decision,
+		BlockedReason:  decision.BlockedReason,
+		EligibleReason: decision.EligibleReason,
+		Reason:         reason,
+		NextRestartAt:  nextRestartAt,
+	}
+}
+
+func runtimeSupervisorApplicationRestartCandidate(runtime RuntimeStatus) bool {
+	if strings.TrimSpace(runtime.RuntimeID) == "" {
+		return false
+	}
+	if strings.TrimSpace(runtime.NextRestartAt) != "" || runtime.AutoRestartSuppressed {
+		return true
+	}
+	if strings.EqualFold(strings.TrimSpace(runtime.RestartSeverity), "fatal") {
+		return true
+	}
+	actual := strings.ToUpper(strings.TrimSpace(runtime.ActualStatus))
+	health := strings.ToLower(strings.TrimSpace(runtime.Health))
+	return actual == "ERROR" || health == "error" || health == "suppressed" || health == "unreachable" || health == "stale"
+}
+
+func evaluateRuntimeSupervisorApplicationRestartDecision(input runtimeSupervisorApplicationRestartDecisionInput) runtimeSupervisorApplicationRestartDecisionResult {
+	blocked := func(reason string) runtimeSupervisorApplicationRestartDecisionResult {
+		return runtimeSupervisorApplicationRestartDecisionResult{
+			Decision:      runtimeSupervisorApplicationRestartDecisionBlocked,
+			BlockedReason: reason,
+		}
+	}
+	if !input.Candidate {
+		return blocked("runtime-restart-not-candidate")
+	}
+	if !input.Enabled {
+		return blocked("runtime-restart-disabled")
+	}
+	if !input.HealthzOK {
+		return blocked("runtime-restart-healthz-unhealthy")
+	}
+	if !input.Supported {
+		return blocked("runtime-restart-unsupported-kind")
+	}
+	if !input.DesiredRunning {
+		return blocked("runtime-restart-desired-not-running")
+	}
+	if !input.ActualError {
+		return blocked("runtime-restart-actual-not-error")
+	}
+	if input.Suppressed {
+		return blocked("runtime-restart-suppressed")
+	}
+	if input.Fatal {
+		return blocked("runtime-restart-fatal")
+	}
+	if !input.NextRestartAtPresent {
+		return blocked("runtime-restart-next-at-missing")
+	}
+	if !input.Due {
+		return blocked("runtime-restart-not-due")
+	}
+	if input.Duplicate {
+		return blocked("runtime-restart-duplicate")
+	}
+	return runtimeSupervisorApplicationRestartDecisionResult{
+		Decision:       runtimeSupervisorApplicationRestartDecisionEligible,
+		EligibleReason: "runtime-restart-eligible",
+	}
+}
+
+func runtimeSupervisorHealthzOK(healthz RuntimeSupervisorProbe) bool {
+	if !healthz.Reachable || strings.TrimSpace(healthz.Error) != "" {
+		return false
+	}
+	return healthz.StatusCode == 0 || (healthz.StatusCode >= http.StatusOK && healthz.StatusCode < http.StatusMultipleChoices)
+}
+
 func (s *RuntimeSupervisor) submitApplicationRestarts(ctx context.Context, target RuntimeSupervisorTarget, status RuntimeStatusSnapshot, healthz RuntimeSupervisorProbe, now time.Time) []RuntimeSupervisorControlAction {
 	if s == nil || !s.options.EnableApplicationRestart {
 		return nil
 	}
-	if !healthz.Reachable || healthz.Error != "" {
+	if !runtimeSupervisorHealthzOK(healthz) {
 		return nil
 	}
 	actions := make([]RuntimeSupervisorControlAction, 0)
 	for _, runtime := range status.Runtimes {
-		if !runtimeSupervisorRestartDue(runtime, now) {
+		if runtime.ApplicationRestartPlan == nil || runtime.ApplicationRestartPlan.Decision != runtimeSupervisorApplicationRestartDecisionEligible {
 			continue
 		}
 		if s.runtimeRestartAlreadySubmitted(target, runtime) {
@@ -686,7 +847,7 @@ func runtimeSupervisorRestartDue(runtime RuntimeStatus, now time.Time) bool {
 	if strings.TrimSpace(runtime.RuntimeID) == "" {
 		return false
 	}
-	if !strings.EqualFold(strings.TrimSpace(runtime.RuntimeKind), "signal") {
+	if !runtimeSupervisorRestartSupportedKind(runtime.RuntimeKind) {
 		return false
 	}
 	if !strings.EqualFold(strings.TrimSpace(runtime.DesiredStatus), "RUNNING") {
@@ -701,6 +862,15 @@ func runtimeSupervisorRestartDue(runtime RuntimeStatus, now time.Time) bool {
 	if strings.EqualFold(strings.TrimSpace(runtime.RestartSeverity), "fatal") {
 		return false
 	}
+	return runtimeSupervisorRestartDueAt(runtime, now)
+}
+
+func runtimeSupervisorRestartSupportedKind(kind string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(kind))
+	return normalized == "signal" || normalized == "signal-runtime"
+}
+
+func runtimeSupervisorRestartDueAt(runtime RuntimeStatus, now time.Time) bool {
 	nextRestartAt, ok := ParseRestartTime(map[string]any{"nextRestartAt": runtime.NextRestartAt}, "nextRestartAt")
 	if !ok {
 		return false

--- a/internal/service/runtime_supervisor_test.go
+++ b/internal/service/runtime_supervisor_test.go
@@ -640,6 +640,16 @@ func TestRuntimeSupervisorSubmitsDueSignalRestartWhenEnabled(t *testing.T) {
 	if len(snapshot.Targets) != 1 || len(snapshot.Targets[0].ControlActions) != 1 {
 		t.Fatalf("expected one recorded control action, got %#v", snapshot.Targets)
 	}
+	if snapshot.Targets[0].Status == nil || len(snapshot.Targets[0].Status.Runtimes) != 1 {
+		t.Fatalf("expected supervisor status with one runtime, got %#v", snapshot.Targets[0].Status)
+	}
+	plan := snapshot.Targets[0].Status.Runtimes[0].ApplicationRestartPlan
+	if plan == nil {
+		t.Fatalf("expected application restart plan for due signal runtime, got %#v", snapshot.Targets[0].Status.Runtimes[0])
+	}
+	if plan.Decision != runtimeSupervisorApplicationRestartDecisionEligible || plan.EligibleReason != "runtime-restart-eligible" {
+		t.Fatalf("expected eligible application restart plan, got %+v", plan)
+	}
 	action := snapshot.Targets[0].ControlActions[0]
 	if !action.Submitted || action.StatusCode != http.StatusOK || action.Error != "" {
 		t.Fatalf("expected submitted restart action, got %+v", action)
@@ -650,6 +660,13 @@ func TestRuntimeSupervisorSubmitsDueSignalRestartWhenEnabled(t *testing.T) {
 	}
 	if len(second.Targets) != 1 || len(second.Targets[0].ControlActions) != 0 {
 		t.Fatalf("expected duplicate restart plan to skip new control actions, got %#v", second.Targets)
+	}
+	if second.Targets[0].Status == nil || len(second.Targets[0].Status.Runtimes) != 1 || second.Targets[0].Status.Runtimes[0].ApplicationRestartPlan == nil {
+		t.Fatalf("expected duplicate application restart plan in second snapshot, got %#v", second.Targets[0].Status)
+	}
+	secondPlan := second.Targets[0].Status.Runtimes[0].ApplicationRestartPlan
+	if !secondPlan.Duplicate || secondPlan.BlockedReason != "runtime-restart-duplicate" {
+		t.Fatalf("expected duplicate application restart plan to be blocked, got %+v", secondPlan)
 	}
 }
 
@@ -770,6 +787,13 @@ func TestRuntimeSupervisorSkipsApplicationRestartWhenHealthzFails(t *testing.T) 
 	if len(snapshot.Targets) != 1 || len(snapshot.Targets[0].ControlActions) != 0 {
 		t.Fatalf("expected no recorded control actions when healthz fails, got %#v", snapshot.Targets)
 	}
+	if snapshot.Targets[0].Status == nil || len(snapshot.Targets[0].Status.Runtimes) != 1 || snapshot.Targets[0].Status.Runtimes[0].ApplicationRestartPlan == nil {
+		t.Fatalf("expected blocked restart plan when healthz fails, got %#v", snapshot.Targets[0].Status)
+	}
+	plan := snapshot.Targets[0].Status.Runtimes[0].ApplicationRestartPlan
+	if plan.Decision != runtimeSupervisorApplicationRestartDecisionBlocked || plan.BlockedReason != "runtime-restart-healthz-unhealthy" || plan.HealthzOK {
+		t.Fatalf("expected healthz blocker in restart plan, got %+v", plan)
+	}
 }
 
 func TestRuntimeSupervisorSkipsApplicationRestartWhenSuppressedOrNotDue(t *testing.T) {
@@ -840,6 +864,32 @@ func TestRuntimeSupervisorSkipsApplicationRestartWhenSuppressedOrNotDue(t *testi
 	}
 	if len(snapshot.Targets) != 1 || len(snapshot.Targets[0].ControlActions) != 0 {
 		t.Fatalf("expected no recorded control actions, got %#v", snapshot.Targets)
+	}
+	if snapshot.Targets[0].Status == nil {
+		t.Fatalf("expected runtime status with blocked restart plans")
+	}
+	plans := make(map[string]*RuntimeSupervisorApplicationRestartPlan)
+	for _, runtime := range snapshot.Targets[0].Status.Runtimes {
+		if runtime.ApplicationRestartPlan != nil {
+			plans[runtime.RuntimeID] = runtime.ApplicationRestartPlan
+		}
+	}
+	expectedBlocked := map[string]string{
+		"suppressed-signal-runtime": "runtime-restart-suppressed",
+		"future-signal-runtime":     "runtime-restart-not-due",
+		"live-runtime":              "runtime-restart-unsupported-kind",
+	}
+	for runtimeID, want := range expectedBlocked {
+		plan := plans[runtimeID]
+		if plan == nil {
+			t.Fatalf("expected blocked restart plan for %s, got %#v", runtimeID, plans)
+		}
+		if plan.Decision != runtimeSupervisorApplicationRestartDecisionBlocked || plan.BlockedReason != want {
+			t.Fatalf("expected %s blocker for %s, got %+v", want, runtimeID, plan)
+		}
+	}
+	if _, ok := plans[""]; ok {
+		t.Fatalf("expected runtime without runtimeId to have no restart plan, got %#v", plans)
 	}
 }
 

--- a/web/console/src/pages/SupervisorStage.tsx
+++ b/web/console/src/pages/SupervisorStage.tsx
@@ -503,39 +503,60 @@ export function SupervisorStage() {
                       </TableRow>
                     </TableHeader>
                     <TableBody>
-                      {runtimeRows.map((runtime) => (
-                        <TableRow key={`${runtime.targetName}:${runtime.runtimeKind}:${runtime.runtimeId}`}>
-                          <TableCell>{runtime.targetName}</TableCell>
-                          <TableCell>
-                            <div className="flex max-w-[220px] flex-col gap-1">
-                              <span className="font-mono text-xs text-[var(--bk-text-primary)]">{shrink(runtime.runtimeId)}</span>
-                              {runtime.accountId && <span className="text-xs text-[var(--bk-text-muted)]">{shrink(runtime.accountId)}</span>}
-                            </div>
-                          </TableCell>
-                          <TableCell><Badge variant="metal">{runtime.runtimeKind}</Badge></TableCell>
-                          <TableCell><StatusBadge value={runtime.desiredStatus} /></TableCell>
-                          <TableCell><StatusBadge value={runtime.actualStatus} /></TableCell>
-                          <TableCell>
-                            <div className="flex items-center gap-2">
-                              <StatusBadge value={runtime.health} />
-                              {runtime.autoRestartSuppressed && <Badge variant="destructive">suppressed</Badge>}
-                            </div>
-                          </TableCell>
-                          <TableCell>
-                            <div className="flex flex-col gap-1">
-                              <span className="font-mono text-sm tabular-nums">{runtime.restartAttempt}</span>
-                              {runtime.restartSeverity && <StatusBadge value={runtime.restartSeverity} />}
-                              {runtime.lastRestartError && (
-                                <span className="max-w-[220px] truncate text-xs text-[var(--bk-text-muted)]" title={runtime.lastRestartError}>
-                                  {runtime.lastRestartError}
-                                </span>
-                              )}
-                            </div>
-                          </TableCell>
-                          <TableCell>{formatOptionalTime(runtime.nextRestartAt)}</TableCell>
-                          <TableCell>{formatOptionalTime(runtime.lastCheckedAt)}</TableCell>
-                        </TableRow>
-                      ))}
+                      {runtimeRows.map((runtime) => {
+                        const restartPlan = runtime.applicationRestartPlan;
+                        const restartPlanReason =
+                          restartPlan?.blockedReason ||
+                          restartPlan?.eligibleReason ||
+                          restartPlan?.reason;
+                        return (
+                          <TableRow key={`${runtime.targetName}:${runtime.runtimeKind}:${runtime.runtimeId}`}>
+                            <TableCell>{runtime.targetName}</TableCell>
+                            <TableCell>
+                              <div className="flex max-w-[220px] flex-col gap-1">
+                                <span className="font-mono text-xs text-[var(--bk-text-primary)]">{shrink(runtime.runtimeId)}</span>
+                                {runtime.accountId && <span className="text-xs text-[var(--bk-text-muted)]">{shrink(runtime.accountId)}</span>}
+                              </div>
+                            </TableCell>
+                            <TableCell><Badge variant="metal">{runtime.runtimeKind}</Badge></TableCell>
+                            <TableCell><StatusBadge value={runtime.desiredStatus} /></TableCell>
+                            <TableCell><StatusBadge value={runtime.actualStatus} /></TableCell>
+                            <TableCell>
+                              <div className="flex items-center gap-2">
+                                <StatusBadge value={runtime.health} />
+                                {runtime.autoRestartSuppressed && <Badge variant="destructive">suppressed</Badge>}
+                              </div>
+                            </TableCell>
+                            <TableCell>
+                              <div className="flex max-w-[240px] flex-col gap-1">
+                                <div className="flex flex-wrap items-center gap-1">
+                                  <span className="font-mono text-sm tabular-nums">{runtime.restartAttempt}</span>
+                                  {runtime.restartSeverity && <StatusBadge value={runtime.restartSeverity} />}
+                                  {restartPlan && (
+                                    <Badge variant={restartPlan.decision === 'eligible' ? 'success' : 'neutral'}>
+                                      {restartPlan.decision || 'blocked'}
+                                    </Badge>
+                                  )}
+                                  {restartPlan && !restartPlan.supported && <Badge variant="secondary">unsupported</Badge>}
+                                  {restartPlan?.duplicate && <Badge variant="neutral">duplicate</Badge>}
+                                </div>
+                                {restartPlanReason && (
+                                  <span className="truncate text-xs text-[var(--bk-text-muted)]" title={restartPlanReason}>
+                                    {restartPlanReason}
+                                  </span>
+                                )}
+                                {runtime.lastRestartError && (
+                                  <span className="truncate text-xs text-[var(--bk-text-muted)]" title={runtime.lastRestartError}>
+                                    {runtime.lastRestartError}
+                                  </span>
+                                )}
+                              </div>
+                            </TableCell>
+                            <TableCell>{formatOptionalTime(runtime.nextRestartAt)}</TableCell>
+                            <TableCell>{formatOptionalTime(runtime.lastCheckedAt)}</TableCell>
+                          </TableRow>
+                        );
+                      })}
                     </TableBody>
                   </Table>
                 )}

--- a/web/console/src/types/domain.ts
+++ b/web/console/src/types/domain.ts
@@ -391,6 +391,23 @@ export type RuntimeSupervisorRuntimeStatus = {
   lastHealthyAt?: string;
   lastCheckedAt: string;
   updatedAt?: string;
+  applicationRestartPlan?: RuntimeSupervisorApplicationRestartPlan;
+};
+
+export type RuntimeSupervisorApplicationRestartPlan = {
+  runtimeId?: string;
+  runtimeKind?: string;
+  candidate: boolean;
+  enabled: boolean;
+  healthzOk: boolean;
+  supported: boolean;
+  due: boolean;
+  duplicate: boolean;
+  decision?: 'blocked' | 'eligible' | string;
+  blockedReason?: string;
+  eligibleReason?: string;
+  reason?: string;
+  nextRestartAt?: string;
 };
 
 export type RuntimeSupervisorStatus = {


### PR DESCRIPTION
## 目的
继续推进 #270：在不扩大自动恢复范围的前提下，为 supervisor snapshot 增加只读 `applicationRestartPlan`，把每个需要关注的 runtime 为什么会/不会被应用内 restart 清楚暴露出来。

本 PR 只做解释面与观测面：
- signal due 且满足原有条件时仍走现有 `POST /api/v1/runtime/restart`。
- `live-session` 等非 signal runtime 即使 `actualStatus=ERROR`，也只会显示 `blockedReason=runtime-restart-unsupported-kind`，不会被 supervisor 自动拉起。
- 不新增 Docker/container executor，不修改 deployments/env，不改变默认 auto-restart 行为。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [x] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值无变化
- [x] 不存在直接调用 `mainnet` 凭证或路由地址的硬编码
- [x] DB migration 不涉及
- [x] 配置字段没有混改；不新增 env/config/deployments/Docker socket 接线

## 交易语义变更
- [x] 本次改动没有新增/修改 `signalKind`
- [x] 本次改动不影响订单方向判断（`side` / `reduceOnly` / `closePosition`）
- [x] 不涉及 `TestClassifyOrderIntent`

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

验证命令：
- `go test ./internal/service ./cmd/bktrader-ctl`
- `npx shadcn@latest docs badge table`
- `./node_modules/.bin/tsc --noEmit src/pages/SupervisorStage.tsx --jsx react-jsx --esModuleInterop --target esnext --module esnext --moduleResolution Bundler --allowSyntheticDefaultImports`
- `npm run build`
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
- `go build ./cmd/bktrader-ctl`
- `git diff --check`

备注：`npm ci` 成功，但当前本机 Node 为 `v20.6.1`，仍有 `validate-npm-package-name@7.0.2` 要求 `^20.17.0 || >=22.9.0` 的 engine warning，以及 npm audit 的 5 个 moderate 提示；与本 PR 改动无关。
