### PR TITLE
[codex] Add trading replay harness

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -22,6 +22,7 @@ _是否涉及默认行为、交易路径、部署流程、环境变量_
 - [ ] 本次改动是否新增/修改了 `signalKind`？若是，需同步更新 Golden Case
 - [ ] 本次改动是否影响订单方向判断（`side` / `reduceOnly` / `closePosition`）？
 - [ ] 若涉及上述改动，`go test ./internal/domain/... -run TestClassifyOrderIntent` 是否通过？
+- [ ] 若涉及交易链路语义（开仓/平仓/撤单/risk-exit），`go test ./internal/domain/... -run TestTradingReplayGoldenCases` 是否通过？
 
 ## 验证方式与测试证据
 _本地怎么测，测试环境怎么验_

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,9 @@ jobs:
       - name: Trading Harness Golden Cases
         run: go test ./internal/domain/... -run TestClassifyOrderIntent -v
 
+      - name: Trading Replay Harness Golden Cases
+        run: go test ./internal/domain/... -run TestTradingReplayGoldenCases -v
+
       - name: Build platform API
         run: go build ./cmd/platform-api
 

--- a/docs/trading/order-intent-matrix.md
+++ b/docs/trading/order-intent-matrix.md
@@ -28,6 +28,8 @@
 - **intent 与 Status 无关**：即使订单 Status = CANCELLED，intent 仍然可分类（用于回归和展示）
 - **intent 不参与结算**：结算和持仓更新严格基于交易所返回的 fills 和 status 事实
 - **intent 只用于**：展示、回归验证、审计追溯
+- **链路级语义必须跑 Replay Harness**：开仓 / 平仓 / 撤单 / `risk-exit` 相关改动需要通过 `go test ./internal/domain/... -run TestTradingReplayGoldenCases`
+- **Replay over-close 语义**：`chains` 表示已成功匹配的仓位部分；`violations` 表示 exit 数量中未匹配的剩余超量。
 
 ## 未来扩展：Hedge Mode（positionSide = LONG/SHORT）
 

--- a/docs/trading/signal-kind-contract.md
+++ b/docs/trading/signal-kind-contract.md
@@ -8,12 +8,15 @@
 | signalKind              | 允许的 Intent                    | 说明           |
 |-------------------------|--------------------------------|----------------|
 | `initial`               | `OPEN_LONG`, `OPEN_SHORT`      | 初始建仓       |
+| `initial-entry`         | `OPEN_LONG`, `OPEN_SHORT`      | 初始建仓事件别名 |
+| `entry`                 | `OPEN_LONG`, `OPEN_SHORT`      | 通用入场事件别名 |
 | `zero-initial-reentry`  | `OPEN_LONG`, `OPEN_SHORT`      | 零仓再入场     |
 | `sl-reentry`            | `OPEN_LONG`, `OPEN_SHORT`      | 止损后再入场   |
 | `pt-reentry`            | `OPEN_LONG`, `OPEN_SHORT`      | 止盈后再入场   |
 | `risk-exit`             | `CLOSE_LONG`, `CLOSE_SHORT`    | 风险退出       |
 | `sl`                    | `CLOSE_LONG`, `CLOSE_SHORT`    | 止损           |
 | `pt`                    | `CLOSE_LONG`, `CLOSE_SHORT`    | 止盈           |
+| `protect-exit`          | `CLOSE_LONG`, `CLOSE_SHORT`    | 保护性退出     |
 | `recovery-watchdog`     | `CLOSE_LONG`, `CLOSE_SHORT`    | 恢复看门狗平仓 |
 
 ## 规则

--- a/internal/domain/testdata/trading-replay/cancelled-entry-no-position.expected.json
+++ b/internal/domain/testdata/trading-replay/cancelled-entry-no-position.expected.json
@@ -1,0 +1,29 @@
+{
+  "chains": [],
+  "ignored": [
+    {
+      "orderId": "order-1777475288746567463",
+      "intent": "OPEN_LONG",
+      "reason": "cancelled_entry"
+    }
+  ],
+  "orphans": [
+    {
+      "orderId": "order-1777475288746567464",
+      "intent": "CLOSE_LONG",
+      "reason": "no_matching_position"
+    }
+  ],
+  "violations": [
+    {
+      "orderId": "order-1777475288746567464",
+      "code": "REDUCE_ONLY_WITHOUT_POSITION",
+      "message": "CLOSE_LONG has no matching virtual position"
+    },
+    {
+      "orderId": "order-1777475288746567464",
+      "code": "EXIT_WITHOUT_POSITION",
+      "message": "CLOSE_LONG has no matching virtual position"
+    }
+  ]
+}

--- a/internal/domain/testdata/trading-replay/cancelled-entry-no-position.input.json
+++ b/internal/domain/testdata/trading-replay/cancelled-entry-no-position.input.json
@@ -1,0 +1,17 @@
+[
+  {
+    "id": "order-1777475288746567463",
+    "side": "BUY",
+    "quantity": 0.2,
+    "status": "CANCELLED",
+    "signalKind": "zero-initial-reentry"
+  },
+  {
+    "id": "order-1777475288746567464",
+    "side": "SELL",
+    "reduceOnly": true,
+    "quantity": 0.2,
+    "status": "FILLED",
+    "signalKind": "risk-exit"
+  }
+]

--- a/internal/domain/testdata/trading-replay/cancelled-exit.expected.json
+++ b/internal/domain/testdata/trading-replay/cancelled-exit.expected.json
@@ -1,0 +1,10 @@
+{
+  "chains": [],
+  "ignored": [
+    {
+      "orderId": "cancelled-exit",
+      "intent": "CLOSE_LONG",
+      "reason": "cancelled_exit"
+    }
+  ]
+}

--- a/internal/domain/testdata/trading-replay/cancelled-exit.input.json
+++ b/internal/domain/testdata/trading-replay/cancelled-exit.input.json
@@ -1,0 +1,17 @@
+[
+  {
+    "id": "entry-before-cancelled-exit",
+    "side": "BUY",
+    "quantity": 0.2,
+    "status": "FILLED",
+    "signalKind": "zero-initial-reentry"
+  },
+  {
+    "id": "cancelled-exit",
+    "side": "SELL",
+    "reduceOnly": true,
+    "quantity": 0.2,
+    "status": "CANCELLED",
+    "signalKind": "risk-exit"
+  }
+]

--- a/internal/domain/testdata/trading-replay/exit-consumes-multiple-entries.expected.json
+++ b/internal/domain/testdata/trading-replay/exit-consumes-multiple-entries.expected.json
@@ -1,0 +1,22 @@
+{
+  "chains": [
+    {
+      "chainType": "OPEN_LONG_CLOSE_LONG",
+      "entryOrderIds": [
+        "entry-long-1",
+        "entry-long-2"
+      ],
+      "exitOrderIds": [
+        "exit-long-all"
+      ],
+      "entryIntents": [
+        "OPEN_LONG",
+        "OPEN_LONG"
+      ],
+      "exitIntents": [
+        "CLOSE_LONG"
+      ],
+      "display": "开多 → 平多"
+    }
+  ]
+}

--- a/internal/domain/testdata/trading-replay/exit-consumes-multiple-entries.input.json
+++ b/internal/domain/testdata/trading-replay/exit-consumes-multiple-entries.input.json
@@ -1,0 +1,24 @@
+[
+  {
+    "id": "entry-long-1",
+    "side": "BUY",
+    "quantity": 0.1,
+    "status": "FILLED",
+    "signalKind": "zero-initial-reentry"
+  },
+  {
+    "id": "entry-long-2",
+    "side": "BUY",
+    "quantity": 0.1,
+    "status": "FILLED",
+    "signalKind": "zero-initial-reentry"
+  },
+  {
+    "id": "exit-long-all",
+    "side": "SELL",
+    "reduceOnly": true,
+    "quantity": 0.2,
+    "status": "FILLED",
+    "signalKind": "risk-exit"
+  }
+]

--- a/internal/domain/testdata/trading-replay/new-entry-no-position.expected.json
+++ b/internal/domain/testdata/trading-replay/new-entry-no-position.expected.json
@@ -1,0 +1,29 @@
+{
+  "chains": [],
+  "ignored": [
+    {
+      "orderId": "new-entry",
+      "intent": "OPEN_LONG",
+      "reason": "not_filled"
+    }
+  ],
+  "orphans": [
+    {
+      "orderId": "exit-after-new-entry",
+      "intent": "CLOSE_LONG",
+      "reason": "no_matching_position"
+    }
+  ],
+  "violations": [
+    {
+      "orderId": "exit-after-new-entry",
+      "code": "REDUCE_ONLY_WITHOUT_POSITION",
+      "message": "CLOSE_LONG has no matching virtual position"
+    },
+    {
+      "orderId": "exit-after-new-entry",
+      "code": "EXIT_WITHOUT_POSITION",
+      "message": "CLOSE_LONG has no matching virtual position"
+    }
+  ]
+}

--- a/internal/domain/testdata/trading-replay/new-entry-no-position.input.json
+++ b/internal/domain/testdata/trading-replay/new-entry-no-position.input.json
@@ -1,0 +1,17 @@
+[
+  {
+    "id": "new-entry",
+    "side": "BUY",
+    "quantity": 0.2,
+    "status": "NEW",
+    "signalKind": "zero-initial-reentry"
+  },
+  {
+    "id": "exit-after-new-entry",
+    "side": "SELL",
+    "reduceOnly": true,
+    "quantity": 0.2,
+    "status": "FILLED",
+    "signalKind": "risk-exit"
+  }
+]

--- a/internal/domain/testdata/trading-replay/open-long-close-long.expected.json
+++ b/internal/domain/testdata/trading-replay/open-long-close-long.expected.json
@@ -1,0 +1,20 @@
+{
+  "chains": [
+    {
+      "chainType": "OPEN_LONG_CLOSE_LONG",
+      "entryOrderIds": [
+        "order-1777471086379688754"
+      ],
+      "exitOrderIds": [
+        "order-1777471148180758130"
+      ],
+      "entryIntents": [
+        "OPEN_LONG"
+      ],
+      "exitIntents": [
+        "CLOSE_LONG"
+      ],
+      "display": "开多 → 平多"
+    }
+  ]
+}

--- a/internal/domain/testdata/trading-replay/open-long-close-long.input.json
+++ b/internal/domain/testdata/trading-replay/open-long-close-long.input.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": "order-1777471086379688754",
+    "time": "2026-04-29T13:58:06.379689Z",
+    "side": "BUY",
+    "quantity": 0.2,
+    "status": "FILLED",
+    "signalKind": "zero-initial-reentry"
+  },
+  {
+    "id": "order-1777471148180758130",
+    "side": "SELL",
+    "reduceOnly": true,
+    "quantity": 0.2,
+    "status": "FILLED",
+    "signalKind": "risk-exit"
+  }
+]

--- a/internal/domain/testdata/trading-replay/open-short-close-short.expected.json
+++ b/internal/domain/testdata/trading-replay/open-short-close-short.expected.json
@@ -1,0 +1,20 @@
+{
+  "chains": [
+    {
+      "chainType": "OPEN_SHORT_CLOSE_SHORT",
+      "entryOrderIds": [
+        "order-1777486182526885338"
+      ],
+      "exitOrderIds": [
+        "order-1777486257764774887"
+      ],
+      "entryIntents": [
+        "OPEN_SHORT"
+      ],
+      "exitIntents": [
+        "CLOSE_SHORT"
+      ],
+      "display": "开空 → 平空"
+    }
+  ]
+}

--- a/internal/domain/testdata/trading-replay/open-short-close-short.input.json
+++ b/internal/domain/testdata/trading-replay/open-short-close-short.input.json
@@ -1,0 +1,17 @@
+[
+  {
+    "id": "order-1777486182526885338",
+    "side": "SELL",
+    "quantity": 0.2,
+    "status": "FILLED",
+    "signalKind": "initial-entry"
+  },
+  {
+    "id": "order-1777486257764774887",
+    "side": "BUY",
+    "reduceOnly": true,
+    "quantity": 0.2,
+    "status": "FILLED",
+    "signalKind": "risk-exit"
+  }
+]

--- a/internal/domain/testdata/trading-replay/orphan-exit.expected.json
+++ b/internal/domain/testdata/trading-replay/orphan-exit.expected.json
@@ -1,0 +1,22 @@
+{
+  "chains": [],
+  "orphans": [
+    {
+      "orderId": "orphan-exit",
+      "intent": "CLOSE_LONG",
+      "reason": "no_matching_position"
+    }
+  ],
+  "violations": [
+    {
+      "orderId": "orphan-exit",
+      "code": "REDUCE_ONLY_WITHOUT_POSITION",
+      "message": "CLOSE_LONG has no matching virtual position"
+    },
+    {
+      "orderId": "orphan-exit",
+      "code": "EXIT_WITHOUT_POSITION",
+      "message": "CLOSE_LONG has no matching virtual position"
+    }
+  ]
+}

--- a/internal/domain/testdata/trading-replay/orphan-exit.input.json
+++ b/internal/domain/testdata/trading-replay/orphan-exit.input.json
@@ -1,0 +1,10 @@
+[
+  {
+    "id": "orphan-exit",
+    "side": "SELL",
+    "reduceOnly": true,
+    "quantity": 0.2,
+    "status": "FILLED",
+    "signalKind": "risk-exit"
+  }
+]

--- a/internal/domain/testdata/trading-replay/over-close-quantity.expected.json
+++ b/internal/domain/testdata/trading-replay/over-close-quantity.expected.json
@@ -1,0 +1,27 @@
+{
+  "chains": [
+    {
+      "chainType": "OPEN_LONG_CLOSE_LONG",
+      "entryOrderIds": [
+        "entry-long-small"
+      ],
+      "exitOrderIds": [
+        "exit-long-too-large"
+      ],
+      "entryIntents": [
+        "OPEN_LONG"
+      ],
+      "exitIntents": [
+        "CLOSE_LONG"
+      ],
+      "display": "开多 → 平多"
+    }
+  ],
+  "violations": [
+    {
+      "orderId": "exit-long-too-large",
+      "code": "QUANTITY_MISMATCH",
+      "message": "CLOSE_LONG quantity 0.20000000 exceeds matching virtual position by 0.10000000"
+    }
+  ]
+}

--- a/internal/domain/testdata/trading-replay/over-close-quantity.input.json
+++ b/internal/domain/testdata/trading-replay/over-close-quantity.input.json
@@ -1,0 +1,17 @@
+[
+  {
+    "id": "entry-long-small",
+    "side": "BUY",
+    "quantity": 0.1,
+    "status": "FILLED",
+    "signalKind": "zero-initial-reentry"
+  },
+  {
+    "id": "exit-long-too-large",
+    "side": "SELL",
+    "reduceOnly": true,
+    "quantity": 0.2,
+    "status": "FILLED",
+    "signalKind": "risk-exit"
+  }
+]

--- a/internal/domain/testdata/trading-replay/partial-exit-quantity.expected.json
+++ b/internal/domain/testdata/trading-replay/partial-exit-quantity.expected.json
@@ -1,0 +1,36 @@
+{
+  "chains": [
+    {
+      "chainType": "OPEN_LONG_CLOSE_LONG",
+      "entryOrderIds": [
+        "entry-long-qty"
+      ],
+      "exitOrderIds": [
+        "exit-long-half-1"
+      ],
+      "entryIntents": [
+        "OPEN_LONG"
+      ],
+      "exitIntents": [
+        "CLOSE_LONG"
+      ],
+      "display": "开多 → 平多"
+    },
+    {
+      "chainType": "OPEN_LONG_CLOSE_LONG",
+      "entryOrderIds": [
+        "entry-long-qty"
+      ],
+      "exitOrderIds": [
+        "exit-long-half-2"
+      ],
+      "entryIntents": [
+        "OPEN_LONG"
+      ],
+      "exitIntents": [
+        "CLOSE_LONG"
+      ],
+      "display": "开多 → 平多"
+    }
+  ]
+}

--- a/internal/domain/testdata/trading-replay/partial-exit-quantity.input.json
+++ b/internal/domain/testdata/trading-replay/partial-exit-quantity.input.json
@@ -1,0 +1,25 @@
+[
+  {
+    "id": "entry-long-qty",
+    "side": "BUY",
+    "quantity": 0.2,
+    "status": "FILLED",
+    "signalKind": "zero-initial-reentry"
+  },
+  {
+    "id": "exit-long-half-1",
+    "side": "SELL",
+    "reduceOnly": true,
+    "quantity": 0.1,
+    "status": "FILLED",
+    "signalKind": "risk-exit"
+  },
+  {
+    "id": "exit-long-half-2",
+    "side": "SELL",
+    "reduceOnly": true,
+    "quantity": 0.1,
+    "status": "FILLED",
+    "signalKind": "protect-exit"
+  }
+]

--- a/internal/domain/testdata/trading-replay/reentry-stack-count.expected.json
+++ b/internal/domain/testdata/trading-replay/reentry-stack-count.expected.json
@@ -1,0 +1,20 @@
+{
+  "chains": [
+    {
+      "chainType": "OPEN_LONG_CLOSE_LONG",
+      "entryOrderIds": [
+        "entry-long-2"
+      ],
+      "exitOrderIds": [
+        "exit-long-2"
+      ],
+      "entryIntents": [
+        "OPEN_LONG"
+      ],
+      "exitIntents": [
+        "CLOSE_LONG"
+      ],
+      "display": "开多 → 平多"
+    }
+  ]
+}

--- a/internal/domain/testdata/trading-replay/reentry-stack-count.input.json
+++ b/internal/domain/testdata/trading-replay/reentry-stack-count.input.json
@@ -1,0 +1,24 @@
+[
+  {
+    "id": "entry-long-1",
+    "side": "BUY",
+    "quantity": 0.2,
+    "status": "FILLED",
+    "signalKind": "zero-initial-reentry"
+  },
+  {
+    "id": "entry-long-2",
+    "side": "BUY",
+    "quantity": 0.1,
+    "status": "FILLED",
+    "signalKind": "zero-initial-reentry"
+  },
+  {
+    "id": "exit-long-2",
+    "side": "SELL",
+    "reduceOnly": true,
+    "quantity": 0.1,
+    "status": "FILLED",
+    "signalKind": "risk-exit"
+  }
+]

--- a/internal/domain/testdata/trading-replay/risk-exit-long.expected.json
+++ b/internal/domain/testdata/trading-replay/risk-exit-long.expected.json
@@ -1,0 +1,20 @@
+{
+  "chains": [
+    {
+      "chainType": "OPEN_LONG_CLOSE_LONG",
+      "entryOrderIds": [
+        "entry-long"
+      ],
+      "exitOrderIds": [
+        "risk-exit-long"
+      ],
+      "entryIntents": [
+        "OPEN_LONG"
+      ],
+      "exitIntents": [
+        "CLOSE_LONG"
+      ],
+      "display": "开多 → 平多"
+    }
+  ]
+}

--- a/internal/domain/testdata/trading-replay/risk-exit-long.input.json
+++ b/internal/domain/testdata/trading-replay/risk-exit-long.input.json
@@ -1,0 +1,19 @@
+[
+  {
+    "id": "entry-long",
+    "side": "BUY",
+    "quantity": 0.2,
+    "status": "FILLED",
+    "signalKind": "zero-initial-reentry"
+  },
+  {
+    "id": "risk-exit-long",
+    "side": "SELL",
+    "reduceOnly": true,
+    "quantity": 0.2,
+    "status": "FILLED",
+    "metadata": {
+      "signalKind": "risk-exit"
+    }
+  }
+]

--- a/internal/domain/testdata/trading-replay/risk-exit-short.expected.json
+++ b/internal/domain/testdata/trading-replay/risk-exit-short.expected.json
@@ -1,0 +1,20 @@
+{
+  "chains": [
+    {
+      "chainType": "OPEN_SHORT_CLOSE_SHORT",
+      "entryOrderIds": [
+        "entry-short"
+      ],
+      "exitOrderIds": [
+        "risk-exit-short"
+      ],
+      "entryIntents": [
+        "OPEN_SHORT"
+      ],
+      "exitIntents": [
+        "CLOSE_SHORT"
+      ],
+      "display": "开空 → 平空"
+    }
+  ]
+}

--- a/internal/domain/testdata/trading-replay/risk-exit-short.input.json
+++ b/internal/domain/testdata/trading-replay/risk-exit-short.input.json
@@ -1,0 +1,17 @@
+[
+  {
+    "id": "entry-short",
+    "side": "SELL",
+    "quantity": 0.2,
+    "status": "FILLED",
+    "signalKind": "initial-entry"
+  },
+  {
+    "id": "risk-exit-short",
+    "side": "BUY",
+    "reduceOnly": true,
+    "quantity": 0.2,
+    "status": "FILLED",
+    "signalKind": "risk-exit"
+  }
+]

--- a/internal/domain/testdata/trading-replay/signal-kind-intent-mismatch.expected.json
+++ b/internal/domain/testdata/trading-replay/signal-kind-intent-mismatch.expected.json
@@ -1,0 +1,32 @@
+{
+  "chains": [
+    {
+      "chainType": "OPEN_LONG_CLOSE_LONG",
+      "entryOrderIds": [
+        "mismatch-risk-exit-open"
+      ],
+      "exitOrderIds": [
+        "mismatch-entry-close"
+      ],
+      "entryIntents": [
+        "OPEN_LONG"
+      ],
+      "exitIntents": [
+        "CLOSE_LONG"
+      ],
+      "display": "开多 → 平多"
+    }
+  ],
+  "violations": [
+    {
+      "orderId": "mismatch-risk-exit-open",
+      "code": "SIGNAL_KIND_INTENT_MISMATCH",
+      "message": "signalKind \"risk-exit\" expects exit intent, got OPEN_LONG"
+    },
+    {
+      "orderId": "mismatch-entry-close",
+      "code": "SIGNAL_KIND_INTENT_MISMATCH",
+      "message": "signalKind \"zero-initial-reentry\" expects entry intent, got CLOSE_LONG"
+    }
+  ]
+}

--- a/internal/domain/testdata/trading-replay/signal-kind-intent-mismatch.input.json
+++ b/internal/domain/testdata/trading-replay/signal-kind-intent-mismatch.input.json
@@ -1,0 +1,17 @@
+[
+  {
+    "id": "mismatch-risk-exit-open",
+    "side": "BUY",
+    "quantity": 0.2,
+    "status": "FILLED",
+    "signalKind": "risk-exit"
+  },
+  {
+    "id": "mismatch-entry-close",
+    "side": "SELL",
+    "reduceOnly": true,
+    "quantity": 0.2,
+    "status": "FILLED",
+    "signalKind": "zero-initial-reentry"
+  }
+]

--- a/internal/domain/testdata/trading-replay/unknown-intent.expected.json
+++ b/internal/domain/testdata/trading-replay/unknown-intent.expected.json
@@ -1,0 +1,10 @@
+{
+  "chains": [],
+  "violations": [
+    {
+      "orderId": "unknown-side-filled",
+      "code": "UNKNOWN_INTENT",
+      "message": "order intent is UNKNOWN"
+    }
+  ]
+}

--- a/internal/domain/testdata/trading-replay/unknown-intent.input.json
+++ b/internal/domain/testdata/trading-replay/unknown-intent.input.json
@@ -1,0 +1,8 @@
+[
+  {
+    "id": "unknown-side-filled",
+    "side": "",
+    "quantity": 0.2,
+    "status": "FILLED"
+  }
+]

--- a/internal/domain/testdata/trading-replay/unsupported-reversal.expected.json
+++ b/internal/domain/testdata/trading-replay/unsupported-reversal.expected.json
@@ -1,0 +1,27 @@
+{
+  "chains": [],
+  "orphans": [
+    {
+      "orderId": "close-short-while-long-open",
+      "intent": "CLOSE_SHORT",
+      "reason": "no_matching_position"
+    }
+  ],
+  "violations": [
+    {
+      "orderId": "close-short-while-long-open",
+      "code": "REDUCE_ONLY_WITHOUT_POSITION",
+      "message": "CLOSE_SHORT has no matching virtual position"
+    },
+    {
+      "orderId": "close-short-while-long-open",
+      "code": "EXIT_WITHOUT_POSITION",
+      "message": "CLOSE_SHORT has no matching virtual position"
+    },
+    {
+      "orderId": "close-short-while-long-open",
+      "code": "UNSUPPORTED_REVERSAL",
+      "message": "CLOSE_SHORT cannot close the opposite virtual position in replay v1"
+    }
+  ]
+}

--- a/internal/domain/testdata/trading-replay/unsupported-reversal.input.json
+++ b/internal/domain/testdata/trading-replay/unsupported-reversal.input.json
@@ -1,0 +1,17 @@
+[
+  {
+    "id": "entry-long",
+    "side": "BUY",
+    "quantity": 0.2,
+    "status": "FILLED",
+    "signalKind": "zero-initial-reentry"
+  },
+  {
+    "id": "close-short-while-long-open",
+    "side": "BUY",
+    "reduceOnly": true,
+    "quantity": 0.2,
+    "status": "FILLED",
+    "signalKind": "risk-exit"
+  }
+]

--- a/internal/domain/trading_replay.go
+++ b/internal/domain/trading_replay.go
@@ -1,0 +1,359 @@
+package domain
+
+import (
+	"fmt"
+	"math"
+	"strings"
+)
+
+const (
+	TradingReplayChainOpenLongCloseLong   = "OPEN_LONG_CLOSE_LONG"
+	TradingReplayChainOpenShortCloseShort = "OPEN_SHORT_CLOSE_SHORT"
+
+	ViolationExitWithoutPosition       = "EXIT_WITHOUT_POSITION"
+	ViolationReduceOnlyWithoutPosition = "REDUCE_ONLY_WITHOUT_POSITION"
+	ViolationSignalKindIntentMismatch  = "SIGNAL_KIND_INTENT_MISMATCH"
+	ViolationUnsupportedReversal       = "UNSUPPORTED_REVERSAL"
+	ViolationQuantityMismatch          = "QUANTITY_MISMATCH"
+	ViolationUnknownIntent             = "UNKNOWN_INTENT"
+
+	OrphanReasonNoMatchingPosition = "no_matching_position"
+
+	IgnoredReasonCancelledEntry = "cancelled_entry"
+	IgnoredReasonCancelledExit  = "cancelled_exit"
+	IgnoredReasonRejectedEntry  = "rejected_entry"
+	IgnoredReasonRejectedExit   = "rejected_exit"
+	IgnoredReasonNotFilled      = "not_filled"
+)
+
+// TradingReplayOrder is the stable JSON input shape for the offline replay harness.
+// It intentionally stays smaller than Order while preserving fields needed for
+// audit and future quantity-aware replay.
+type TradingReplayOrder struct {
+	ID            string         `json:"id"`
+	Time          string         `json:"time,omitempty"`
+	Side          string         `json:"side"`
+	ReduceOnly    bool           `json:"reduceOnly,omitempty"`
+	ClosePosition bool           `json:"closePosition,omitempty"`
+	PositionSide  string         `json:"positionSide,omitempty"`
+	Quantity      float64        `json:"quantity,omitempty"`
+	Status        string         `json:"status"`
+	SignalKind    string         `json:"signalKind,omitempty"`
+	Metadata      map[string]any `json:"metadata,omitempty"`
+}
+
+func (o TradingReplayOrder) EffectiveSignalKind() string {
+	if signalKind := strings.TrimSpace(o.SignalKind); signalKind != "" {
+		return signalKind
+	}
+	if o.Metadata != nil {
+		if v, ok := o.Metadata["signalKind"]; ok {
+			return strings.TrimSpace(fmt.Sprint(v))
+		}
+	}
+	return ""
+}
+
+func (o TradingReplayOrder) ToDomainOrder() Order {
+	metadata := make(map[string]any, len(o.Metadata)+1)
+	for k, v := range o.Metadata {
+		metadata[k] = v
+	}
+	if signalKind := strings.TrimSpace(o.SignalKind); signalKind != "" {
+		metadata["signalKind"] = signalKind
+	}
+	return Order{
+		ID:            o.ID,
+		Side:          o.Side,
+		Status:        o.Status,
+		Quantity:      o.Quantity,
+		ReduceOnly:    o.ReduceOnly,
+		ClosePosition: o.ClosePosition,
+		Metadata:      metadata,
+	}
+}
+
+type TradingReplayResult struct {
+	Chains     []TradingReplayChain     `json:"chains"`
+	Ignored    []TradingReplayIgnored   `json:"ignored,omitempty"`
+	Orphans    []TradingReplayOrphan    `json:"orphans,omitempty"`
+	Violations []TradingReplayViolation `json:"violations,omitempty"`
+}
+
+type TradingReplayChain struct {
+	ChainType     string   `json:"chainType"`
+	EntryOrderIDs []string `json:"entryOrderIds,omitempty"`
+	ExitOrderIDs  []string `json:"exitOrderIds,omitempty"`
+	EntryIntents  []string `json:"entryIntents,omitempty"`
+	ExitIntents   []string `json:"exitIntents,omitempty"`
+	Display       string   `json:"display"`
+}
+
+type TradingReplayIgnored struct {
+	OrderID string `json:"orderId"`
+	Intent  string `json:"intent"`
+	Reason  string `json:"reason"`
+}
+
+type TradingReplayOrphan struct {
+	OrderID string `json:"orderId"`
+	Intent  string `json:"intent"`
+	Reason  string `json:"reason"`
+}
+
+type TradingReplayViolation struct {
+	OrderID string `json:"orderId,omitempty"`
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+type replayEntry struct {
+	OrderID    string
+	Intent     OrderIntent
+	SignalKind string
+	Quantity   float64
+	Remaining  float64
+}
+
+func ReplayTradingOrders(orders []TradingReplayOrder) TradingReplayResult {
+	result := TradingReplayResult{
+		Chains: []TradingReplayChain{},
+	}
+	var longEntryStack []replayEntry
+	var shortEntryStack []replayEntry
+
+	for _, order := range orders {
+		domainOrder := order.ToDomainOrder()
+		intent := ClassifyOrderIntent(domainOrder)
+		intentText := string(intent)
+		status := strings.ToUpper(strings.TrimSpace(order.Status))
+
+		if reason, ignored := tradingReplayIgnoredReason(status, intent); ignored {
+			result.Ignored = append(result.Ignored, TradingReplayIgnored{
+				OrderID: order.ID,
+				Intent:  intentText,
+				Reason:  reason,
+			})
+			continue
+		}
+		if status != "FILLED" {
+			result.Ignored = append(result.Ignored, TradingReplayIgnored{
+				OrderID: order.ID,
+				Intent:  intentText,
+				Reason:  IgnoredReasonNotFilled,
+			})
+			continue
+		}
+
+		if violation, ok := tradingReplaySignalKindViolation(order, intent); ok {
+			result.Violations = append(result.Violations, violation)
+		}
+
+		switch intent {
+		case OrderIntentOpenLong:
+			longEntryStack = append(longEntryStack, replayEntryFromOrder(order, intent))
+		case OrderIntentOpenShort:
+			shortEntryStack = append(shortEntryStack, replayEntryFromOrder(order, intent))
+		case OrderIntentCloseLong:
+			if len(longEntryStack) == 0 {
+				result = appendTradingReplayExitViolation(result, order, domainOrder, intent, len(shortEntryStack) > 0)
+				continue
+			}
+			var chain TradingReplayChain
+			var violation TradingReplayViolation
+			var ok bool
+			chain, longEntryStack, violation, ok = consumeTradingReplayExit(TradingReplayChainOpenLongCloseLong, longEntryStack, order, intent)
+			result.Chains = append(result.Chains, chain)
+			if !ok {
+				result.Violations = append(result.Violations, violation)
+			}
+		case OrderIntentCloseShort:
+			if len(shortEntryStack) == 0 {
+				result = appendTradingReplayExitViolation(result, order, domainOrder, intent, len(longEntryStack) > 0)
+				continue
+			}
+			var chain TradingReplayChain
+			var violation TradingReplayViolation
+			var ok bool
+			chain, shortEntryStack, violation, ok = consumeTradingReplayExit(TradingReplayChainOpenShortCloseShort, shortEntryStack, order, intent)
+			result.Chains = append(result.Chains, chain)
+			if !ok {
+				result.Violations = append(result.Violations, violation)
+			}
+		case OrderIntentUnknown:
+			result.Violations = append(result.Violations, TradingReplayViolation{
+				OrderID: order.ID,
+				Code:    ViolationUnknownIntent,
+				Message: "order intent is UNKNOWN",
+			})
+		}
+	}
+
+	return result
+}
+
+func tradingReplayIgnoredReason(status string, intent OrderIntent) (string, bool) {
+	switch status {
+	case "CANCELLED", "CANCELED":
+		if intent.IsExit() {
+			return IgnoredReasonCancelledExit, true
+		}
+		return IgnoredReasonCancelledEntry, true
+	case "REJECTED":
+		if intent.IsExit() {
+			return IgnoredReasonRejectedExit, true
+		}
+		return IgnoredReasonRejectedEntry, true
+	default:
+		return "", false
+	}
+}
+
+func replayEntryFromOrder(order TradingReplayOrder, intent OrderIntent) replayEntry {
+	return replayEntry{
+		OrderID:    order.ID,
+		Intent:     intent,
+		SignalKind: order.EffectiveSignalKind(),
+		Quantity:   order.Quantity,
+		Remaining:  order.Quantity,
+	}
+}
+
+func consumeTradingReplayExit(chainType string, stack []replayEntry, exit TradingReplayOrder, exitIntent OrderIntent) (TradingReplayChain, []replayEntry, TradingReplayViolation, bool) {
+	if exit.Quantity <= 0 {
+		entry := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		return tradingReplayChain(chainType, []replayEntry{entry}, exit, exitIntent), stack, TradingReplayViolation{}, true
+	}
+
+	remainingExit := exit.Quantity
+	consumed := []replayEntry{}
+	for remainingExit > tradingReplayQuantityTolerance && len(stack) > 0 {
+		idx := len(stack) - 1
+		entry := stack[idx]
+		entryRemaining := entry.Remaining
+		if entryRemaining <= 0 {
+			entryRemaining = entry.Quantity
+		}
+		if entryRemaining <= tradingReplayQuantityTolerance {
+			stack = stack[:idx]
+			continue
+		}
+
+		take := math.Min(entryRemaining, remainingExit)
+		entry.Remaining = take
+		consumed = append(consumed, entry)
+		entryRemaining -= take
+		remainingExit -= take
+
+		if entryRemaining <= tradingReplayQuantityTolerance {
+			stack = stack[:idx]
+		} else {
+			stack[idx].Remaining = entryRemaining
+		}
+	}
+
+	chain := tradingReplayChain(chainType, chronologicalReplayEntries(consumed), exit, exitIntent)
+	if remainingExit > tradingReplayQuantityTolerance {
+		return chain, stack, TradingReplayViolation{
+			OrderID: exit.ID,
+			Code:    ViolationQuantityMismatch,
+			Message: fmt.Sprintf("%s quantity %.8f exceeds matching virtual position by %.8f", exitIntent, exit.Quantity, remainingExit),
+		}, false
+	}
+	return chain, stack, TradingReplayViolation{}, true
+}
+
+const tradingReplayQuantityTolerance = 1e-9
+
+func chronologicalReplayEntries(entries []replayEntry) []replayEntry {
+	chronological := make([]replayEntry, 0, len(entries))
+	for i := len(entries) - 1; i >= 0; i-- {
+		chronological = append(chronological, entries[i])
+	}
+	return chronological
+}
+
+func tradingReplayChain(chainType string, entries []replayEntry, exit TradingReplayOrder, exitIntent OrderIntent) TradingReplayChain {
+	chain := TradingReplayChain{
+		ChainType:    chainType,
+		ExitOrderIDs: []string{exit.ID},
+		ExitIntents:  []string{string(exitIntent)},
+		Display:      exitIntent.IntentLabel(),
+	}
+	for _, entry := range entries {
+		chain.EntryOrderIDs = append(chain.EntryOrderIDs, entry.OrderID)
+		chain.EntryIntents = append(chain.EntryIntents, string(entry.Intent))
+		if chain.Display == exitIntent.IntentLabel() {
+			chain.Display = entry.Intent.IntentLabel() + " → " + exitIntent.IntentLabel()
+		}
+	}
+	return chain
+}
+
+func appendTradingReplayExitViolation(result TradingReplayResult, order TradingReplayOrder, domainOrder Order, intent OrderIntent, oppositePositionOpen bool) TradingReplayResult {
+	result.Orphans = append(result.Orphans, TradingReplayOrphan{
+		OrderID: order.ID,
+		Intent:  string(intent),
+		Reason:  OrphanReasonNoMatchingPosition,
+	})
+	if domainOrder.EffectiveReduceOnly() || domainOrder.EffectiveClosePosition() {
+		result.Violations = append(result.Violations, TradingReplayViolation{
+			OrderID: order.ID,
+			Code:    ViolationReduceOnlyWithoutPosition,
+			Message: fmt.Sprintf("%s has no matching virtual position", intent),
+		})
+	}
+	result.Violations = append(result.Violations, TradingReplayViolation{
+		OrderID: order.ID,
+		Code:    ViolationExitWithoutPosition,
+		Message: fmt.Sprintf("%s has no matching virtual position", intent),
+	})
+	if oppositePositionOpen {
+		result.Violations = append(result.Violations, TradingReplayViolation{
+			OrderID: order.ID,
+			Code:    ViolationUnsupportedReversal,
+			Message: fmt.Sprintf("%s cannot close the opposite virtual position in replay v1", intent),
+		})
+	}
+	return result
+}
+
+func tradingReplaySignalKindViolation(order TradingReplayOrder, intent OrderIntent) (TradingReplayViolation, bool) {
+	signalKind := strings.ToLower(strings.TrimSpace(order.EffectiveSignalKind()))
+	if signalKind == "" {
+		return TradingReplayViolation{}, false
+	}
+
+	entrySignalKinds := map[string]bool{
+		"initial":              true,
+		"initial-entry":        true,
+		"zero-initial-reentry": true,
+		"sl-reentry":           true,
+		"pt-reentry":           true,
+		"entry":                true,
+	}
+	exitSignalKinds := map[string]bool{
+		"risk-exit":         true,
+		"sl":                true,
+		"pt":                true,
+		"protect-exit":      true,
+		"recovery-watchdog": true,
+	}
+
+	if entrySignalKinds[signalKind] && !intent.IsEntry() {
+		return TradingReplayViolation{
+			OrderID: order.ID,
+			Code:    ViolationSignalKindIntentMismatch,
+			Message: fmt.Sprintf("signalKind %q expects entry intent, got %s", signalKind, intent),
+		}, true
+	}
+	if exitSignalKinds[signalKind] && !intent.IsExit() {
+		return TradingReplayViolation{
+			OrderID: order.ID,
+			Code:    ViolationSignalKindIntentMismatch,
+			Message: fmt.Sprintf("signalKind %q expects exit intent, got %s", signalKind, intent),
+		}, true
+	}
+	return TradingReplayViolation{}, false
+}

--- a/internal/domain/trading_replay_test.go
+++ b/internal/domain/trading_replay_test.go
@@ -1,0 +1,76 @@
+package domain
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestTradingReplayGoldenCases(t *testing.T) {
+	casePaths, err := filepath.Glob(filepath.Join("testdata", "trading-replay", "*.input.json"))
+	if err != nil {
+		t.Fatalf("glob trading replay cases: %v", err)
+	}
+	if len(casePaths) == 0 {
+		t.Fatal("expected trading replay golden cases")
+	}
+
+	for _, inputPath := range casePaths {
+		name := strings.TrimSuffix(filepath.Base(inputPath), ".input.json")
+		t.Run(name, func(t *testing.T) {
+			inputRaw, err := os.ReadFile(inputPath)
+			if err != nil {
+				t.Fatalf("read input: %v", err)
+			}
+			var orders []TradingReplayOrder
+			if err := json.Unmarshal(inputRaw, &orders); err != nil {
+				t.Fatalf("decode input: %v", err)
+			}
+
+			got := ReplayTradingOrders(orders)
+
+			expectedPath := strings.TrimSuffix(inputPath, ".input.json") + ".expected.json"
+			expectedRaw, err := os.ReadFile(expectedPath)
+			if err != nil {
+				t.Fatalf("read expected snapshot: %v", err)
+			}
+			var expected TradingReplayResult
+			if err := json.Unmarshal(expectedRaw, &expected); err != nil {
+				t.Fatalf("decode expected snapshot: %v", err)
+			}
+
+			if !reflect.DeepEqual(got, expected) {
+				gotJSON, _ := json.MarshalIndent(got, "", "  ")
+				expectedJSON, _ := json.MarshalIndent(expected, "", "  ")
+				t.Fatalf("replay snapshot mismatch\nexpected:\n%s\n\ngot:\n%s", expectedJSON, gotJSON)
+			}
+		})
+	}
+}
+
+func TestTradingReplayOrderEffectiveSignalKindPrefersTopLevel(t *testing.T) {
+	order := TradingReplayOrder{
+		SignalKind: " risk-exit ",
+		Metadata:   map[string]any{"signalKind": "zero-initial-reentry"},
+	}
+	if got := order.EffectiveSignalKind(); got != "risk-exit" {
+		t.Fatalf("EffectiveSignalKind() = %q, want risk-exit", got)
+	}
+
+	domainOrder := order.ToDomainOrder()
+	if got := domainOrder.Metadata["signalKind"]; got != "risk-exit" {
+		t.Fatalf("ToDomainOrder metadata signalKind = %v, want risk-exit", got)
+	}
+}
+
+func TestTradingReplayOrderEffectiveSignalKindFallsBackToMetadata(t *testing.T) {
+	order := TradingReplayOrder{
+		Metadata: map[string]any{"signalKind": " zero-initial-reentry "},
+	}
+	if got := order.EffectiveSignalKind(); got != "zero-initial-reentry" {
+		t.Fatalf("EffectiveSignalKind() = %q, want zero-initial-reentry", got)
+	}
+}


### PR DESCRIPTION
## 目的
完成 #351 第一版 Trading Replay Harness：把交易语义从单笔 `ClassifyOrderIntent()` 扩展到离线订单链路回放，验证开仓 / 平仓 / 撤单 / risk-exit / orphan / signalKind 契约。

Closes #351

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [x] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) - 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？- 无
- [x] DB migration 是否具备向下兼容幂等性？- 无 DB migration
- [x] 配置字段有没有无意被混改？- 无配置字段改动

## 交易语义变更
- [x] 本次改动是否新增/修改了 `signalKind`？若是，需同步更新 Golden Case - 同步补充 `initial-entry` / `entry` / `protect-exit` 契约说明
- [x] 本次改动是否影响订单方向判断（`side` / `reduceOnly` / `closePosition`）？- 不改分类器，只新增 replay 消费方
- [x] 若涉及上述改动，`go test ./internal/domain/... -run TestClassifyOrderIntent` 是否通过？
- [x] 若涉及交易链路语义（开仓/平仓/撤单/risk-exit），`go test ./internal/domain/... -run TestTradingReplayGoldenCases` 是否通过？

## 验证方式与测试证据
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

验证已跑：

```bash
go test ./internal/domain/... -run 'Test(ClassifyOrderIntent|TradingReplay)' -v
go test ./...
go build ./cmd/platform-api
go build ./cmd/db-migrate
```

## 实现说明
- 新增 `ReplayTradingOrders()`，只做离线回放，不写 DB、不访问交易所、不改 live/execution 真实路径。
- 虚拟仓位使用 `longEntryStack` / `shortEntryStack`，entry 保留 remaining quantity，exit 按数量消耗，支持部分平仓与 over-close violation。
- `TradingReplayChain` 使用 `EntryOrderIDs` / `ExitOrderIDs` 数组 schema，支持一笔 exit 对多笔 entry 的链路表达。
- `TradingReplayOrder` 预留 `quantity` / `positionSide`，并实现 `EffectiveSignalKind()` 与 `ToDomainOrder()`。
- Replay 复用 `ClassifyOrderIntent()`，不重写 side/reduceOnly/closePosition 分类逻辑。
- 新增 14 组 snapshot cases，覆盖开多平多、开空平空、撤单、NEW 未成交、risk-exit 多/空、orphan、signalKind mismatch、reentry stack、unsupported reversal、部分平仓、over-close、cancelled exit、unknown intent。
- CI 新增独立 `Trading Replay Harness Golden Cases` step。
