### PR TITLE
[codex] Add supervisor restart plan diagnostics

### DIFF
--- a/cmd/bktrader-ctl/supervisor.go
+++ b/cmd/bktrader-ctl/supervisor.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -246,7 +247,14 @@ func buildSupervisorStatusSummary(data []byte) (string, error) {
 				}
 			}
 			if restartPlans > 0 {
-				fmt.Fprintf(&out, "  runtimes: total=%d attention=%d restartPlans=%d restartEligible=%d service=%s\n", len(target.Status.Runtimes), attention, restartPlans, restartEligible, firstNonEmpty(target.Status.Service, "--"))
+				fmt.Fprintf(&out, "  runtimes: total=%d attention=%d restartPlans=%d restartEligible=%d restartBlockedReasons=%s service=%s\n",
+					len(target.Status.Runtimes),
+					attention,
+					restartPlans,
+					restartEligible,
+					supervisorApplicationRestartBlockedReasons(target.Status.Runtimes),
+					firstNonEmpty(target.Status.Service, "--"),
+				)
 			} else {
 				fmt.Fprintf(&out, "  runtimes: total=%d attention=%d service=%s\n", len(target.Status.Runtimes), attention, firstNonEmpty(target.Status.Service, "--"))
 			}
@@ -300,4 +308,31 @@ func supervisorRuntimeNeedsAttention(runtime supervisorRuntimeStatus) bool {
 	actual := strings.ToUpper(strings.TrimSpace(runtime.ActualStatus))
 	health := strings.ToLower(strings.TrimSpace(runtime.Health))
 	return actual == "ERROR" || health == "error" || health == "suppressed" || health == "unreachable" || health == "stale"
+}
+
+func supervisorApplicationRestartBlockedReasons(runtimes []supervisorRuntimeStatus) string {
+	counts := make(map[string]int)
+	for _, runtime := range runtimes {
+		if runtime.ApplicationRestartPlan == nil {
+			continue
+		}
+		reason := strings.TrimSpace(runtime.ApplicationRestartPlan.BlockedReason)
+		if reason == "" {
+			continue
+		}
+		counts[reason]++
+	}
+	if len(counts) == 0 {
+		return "--"
+	}
+	reasons := make([]string, 0, len(counts))
+	for reason := range counts {
+		reasons = append(reasons, reason)
+	}
+	sort.Strings(reasons)
+	parts := make([]string, 0, len(reasons))
+	for _, reason := range reasons {
+		parts = append(parts, fmt.Sprintf("%s:%d", reason, counts[reason]))
+	}
+	return strings.Join(parts, ",")
 }

--- a/cmd/bktrader-ctl/supervisor_test.go
+++ b/cmd/bktrader-ctl/supervisor_test.go
@@ -80,7 +80,7 @@ func TestBuildSupervisorStatusSummaryShowsFallbackReadiness(t *testing.T) {
 		"serviceState: failures=3/3 fallback=candidate attempts=2 suppressed=false backoffUntil=--",
 		"lastFallbackDecision=container-executor-not-configured at=2026-04-29T08:00:00Z",
 		"fallbackPlan: action=container-restart decision=blocked enabled=true executorConfigured=false executorKind=none executorDryRun=true executable=false suppressed=false backoffActive=false safetyGateOk=true blockedReason=container-executor-not-configured eligibleReason=--",
-		"runtimes: total=1 attention=1 restartPlans=1 restartEligible=0 service=platform-api",
+		"runtimes: total=1 attention=1 restartPlans=1 restartEligible=0 restartBlockedReasons=runtime-restart-healthz-unhealthy:1 service=platform-api",
 		"lastFailure=healthz-unhealthy: http 503",
 	}
 	for _, want := range expected {
@@ -183,5 +183,76 @@ func TestBuildSupervisorStatusSummaryHandlesClearTarget(t *testing.T) {
 	}
 	if strings.Contains(summary, "fallbackPlan:") {
 		t.Fatalf("did not expect fallback plan for clear target, got:\n%s", summary)
+	}
+}
+
+func TestBuildSupervisorStatusSummaryAggregatesRestartBlockedReasons(t *testing.T) {
+	payload := []byte(`{
+		"checkedAt":"2026-04-29T08:00:00Z",
+		"targets":[{
+			"name":"api",
+			"baseUrl":"http://127.0.0.1:8080",
+			"healthz":{"path":"/healthz","statusCode":200,"reachable":true},
+			"runtimeStatus":{"path":"/api/v1/runtime/status","statusCode":200,"reachable":true},
+			"serviceState":{"consecutiveFailures":0,"failureThreshold":3,"containerFallbackCandidate":false},
+			"status":{
+				"service":"platform-api",
+				"runtimes":[{
+					"runtimeId":"signal-1",
+					"runtimeKind":"signal",
+					"desiredStatus":"RUNNING",
+					"actualStatus":"ERROR",
+					"health":"error",
+					"applicationRestartPlan":{
+						"candidate":true,
+						"enabled":true,
+						"healthzOk":true,
+						"supported":true,
+						"due":false,
+						"decision":"blocked",
+						"blockedReason":"runtime-restart-not-due"
+					}
+				},{
+					"runtimeId":"signal-2",
+					"runtimeKind":"signal",
+					"desiredStatus":"RUNNING",
+					"actualStatus":"ERROR",
+					"health":"error",
+					"applicationRestartPlan":{
+						"candidate":true,
+						"enabled":true,
+						"healthzOk":false,
+						"supported":true,
+						"due":true,
+						"decision":"blocked",
+						"blockedReason":"runtime-restart-healthz-unhealthy"
+					}
+				},{
+					"runtimeId":"signal-3",
+					"runtimeKind":"signal",
+					"desiredStatus":"RUNNING",
+					"actualStatus":"ERROR",
+					"health":"error",
+					"applicationRestartPlan":{
+						"candidate":true,
+						"enabled":true,
+						"healthzOk":true,
+						"supported":true,
+						"due":false,
+						"decision":"blocked",
+						"blockedReason":"runtime-restart-not-due"
+					}
+				}]
+			}
+		}]
+	}`)
+
+	summary, err := buildSupervisorStatusSummary(payload)
+	if err != nil {
+		t.Fatalf("build supervisor summary failed: %v", err)
+	}
+	want := "runtimes: total=3 attention=3 restartPlans=3 restartEligible=0 restartBlockedReasons=runtime-restart-healthz-unhealthy:1,runtime-restart-not-due:2 service=platform-api"
+	if !strings.Contains(summary, want) {
+		t.Fatalf("expected summary to contain %q, got:\n%s", want, summary)
 	}
 }

--- a/docs/runtime-supervisor.md
+++ b/docs/runtime-supervisor.md
@@ -327,12 +327,12 @@ func ClearRestartState(state map[string]any, keys []string)
 - `SUPERVISOR_APPLICATION_RESTART_ENABLED=false` 为默认值；只有显式设为 `true` 时，supervisor 才会对满足全部条件的 signal runtime 提交应用内 `POST /api/v1/runtime/restart`：
   - 目标服务 `/healthz` 可达且成功。
   - `/api/v1/runtime/status` 可读。
-  - runtimeKind 为 `signal`。
+  - runtimeKind 为 `signal`；外部 target 可返回 `signal-runtime` 作为兼容 alias，语义等同 `signal`，不代表新增 runtime class。
   - `desiredStatus=RUNNING` 且 `actualStatus=ERROR`。
   - `autoRestartSuppressed=false` 且 `restartSeverity` 不是 `fatal`。
   - `nextRestartAt` 存在且已经到期。
   - 提交 restart 时固定 `force=false`、`confirm=true`，并带上 supervisor reason；同一个 target/runtime/`nextRestartAt` 只提交一次。
-- 当 runtime 进入 restart 关注范围（例如 `actualStatus=ERROR`、存在 `nextRestartAt`、fatal/suppressed）时，supervisor 会在对应 runtime 上附加只读 `applicationRestartPlan`，显式返回 `decision=blocked|eligible`、`enabled`、`healthzOk`、`supported`、`due`、`duplicate`、`blockedReason` / `eligibleReason`。该计划用于解释为什么某个 runtime 会或不会进入应用内 restart；当前 `supported=true` 仍只覆盖 `signal` / `signal-runtime`，因此 `live-session` 等 runtime 即使 ERROR 也只会显示 `blockedReason=runtime-restart-unsupported-kind`，不会被 supervisor 自动拉起。
+- 当 runtime 进入 restart 关注范围（例如 `actualStatus=ERROR`、存在 `nextRestartAt`、fatal/suppressed）时，supervisor 会在对应 runtime 上附加只读 `applicationRestartPlan`，显式返回 `decision=blocked|eligible`、`enabled`、`healthzOk`、`supported`、`due`、`duplicate`、`blockedReason` / `eligibleReason`。该计划用于解释为什么某个 runtime 会或不会进入应用内 restart；当前 `supported=true` 仍只覆盖 `signal` 及其兼容 alias `signal-runtime`，因此 `live-session` 等 runtime 即使 ERROR 也只会显示 `blockedReason=runtime-restart-unsupported-kind`，不会被 supervisor 自动拉起。
 
 验收标准：
 

--- a/web/console/src/pages/SupervisorStage.tsx
+++ b/web/console/src/pages/SupervisorStage.tsx
@@ -150,6 +150,22 @@ function PolicyBadge({ enabled, enabledLabel, disabledLabel }: { enabled: boolea
   return <Badge variant={enabled ? 'secondary' : 'neutral'}>{enabled ? enabledLabel : disabledLabel}</Badge>;
 }
 
+function applicationRestartPlanTitle(plan?: RuntimeSupervisorRuntimeStatus['applicationRestartPlan']) {
+  if (!plan) {
+    return undefined;
+  }
+  return [
+    `decision=${plan.decision || 'blocked'}`,
+    `enabled=${plan.enabled}`,
+    `healthzOk=${plan.healthzOk}`,
+    `supported=${plan.supported}`,
+    `due=${plan.due}`,
+    `duplicate=${plan.duplicate}`,
+    plan.blockedReason ? `blockedReason=${plan.blockedReason}` : undefined,
+    plan.eligibleReason ? `eligibleReason=${plan.eligibleReason}` : undefined,
+  ].filter(Boolean).join(' ');
+}
+
 export function SupervisorStage() {
   const [snapshot, setSnapshot] = useState<RuntimeSupervisorSnapshot | null>(null);
   const [loadState, setLoadState] = useState<LoadState>('idle');
@@ -505,6 +521,7 @@ export function SupervisorStage() {
                     <TableBody>
                       {runtimeRows.map((runtime) => {
                         const restartPlan = runtime.applicationRestartPlan;
+                        const restartPlanTitle = applicationRestartPlanTitle(restartPlan);
                         const restartPlanReason =
                           restartPlan?.blockedReason ||
                           restartPlan?.eligibleReason ||
@@ -533,12 +550,12 @@ export function SupervisorStage() {
                                   <span className="font-mono text-sm tabular-nums">{runtime.restartAttempt}</span>
                                   {runtime.restartSeverity && <StatusBadge value={runtime.restartSeverity} />}
                                   {restartPlan && (
-                                    <Badge variant={restartPlan.decision === 'eligible' ? 'success' : 'neutral'}>
+                                    <Badge variant={restartPlan.decision === 'eligible' ? 'success' : 'neutral'} title={restartPlanTitle}>
                                       {restartPlan.decision || 'blocked'}
                                     </Badge>
                                   )}
-                                  {restartPlan && !restartPlan.supported && <Badge variant="secondary">unsupported</Badge>}
-                                  {restartPlan?.duplicate && <Badge variant="neutral">duplicate</Badge>}
+                                  {restartPlan && !restartPlan.supported && <Badge variant="secondary" title={restartPlanTitle}>unsupported</Badge>}
+                                  {restartPlan?.duplicate && <Badge variant="neutral" title={restartPlanTitle}>duplicate</Badge>}
                                 </div>
                                 {restartPlanReason && (
                                   <span className="truncate text-xs text-[var(--bk-text-muted)]" title={restartPlanReason}>


### PR DESCRIPTION
## 目的
补齐 PR #350 后的 follow-up 诊断信息，让 supervisor restart plan 更容易在 CLI、前端和文档里对齐排查：

- `bktrader-ctl supervisor status` 汇总 application restart plan 的 blocked reason 计数。
- Supervisor 前端 Runtime Status 的 restart plan badge 暴露完整 gate title：`enabled` / `healthzOk` / `supported` / `due` / `duplicate`。
- 文档明确 `signal-runtime` 是 `signal` 的兼容 alias，不是新增 runtime class。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [x] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) — 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？— 无
- [x] DB migration 是否具备向下兼容幂等性？— 不涉及 DB migration
- [x] 配置字段有没有无意被混改？— 未修改配置字段

## 交易语义变更
- [x] 本次改动是否新增/修改了 `signalKind`？若是，需同步更新 Golden Case — 否
- [x] 本次改动是否影响订单方向判断（`side` / `reduceOnly` / `closePosition`）？— 否
- [x] 若涉及上述改动，`go test ./internal/domain/... -run TestClassifyOrderIntent` 是否通过？— 不涉及

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

本地已验证：

```bash
go test ./cmd/bktrader-ctl
go test ./...
go build ./cmd/platform-api
go build ./cmd/db-migrate
go build ./cmd/bktrader-ctl
cd web/console && npx shadcn@latest docs badge table
cd web/console && ./node_modules/.bin/tsc --noEmit src/pages/SupervisorStage.tsx --jsx react-jsx --esModuleInterop --target esnext --module esnext --moduleResolution Bundler --allowSyntheticDefaultImports
cd web/console && npm run build
git diff --check
```

备注：`npm ci` 在本地 Node v20.6.1 下有 `validate-npm-package-name` engine warning（要求 `^20.17.0 || >=22.9.0`）和既有 5 个 moderate vulnerabilities；安装和构建均完成。