### PR TITLE
[codex] Extract trading constraint checks

### DIFF
--- a/internal/domain/trading_constraints.go
+++ b/internal/domain/trading_constraints.go
@@ -1,0 +1,67 @@
+package domain
+
+import (
+	"fmt"
+	"strings"
+)
+
+type TradingConstraintViolation struct {
+	OrderID string `json:"orderId,omitempty"`
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+type TradingReplayViolation = TradingConstraintViolation
+
+func CheckSignalKindContract(orderID string, signalKind string, intent OrderIntent) (TradingConstraintViolation, bool) {
+	normalizedSignalKind := strings.ToLower(strings.TrimSpace(signalKind))
+	if normalizedSignalKind == "" {
+		return TradingConstraintViolation{}, false
+	}
+
+	entrySignalKinds := map[string]bool{
+		"initial":              true,
+		"initial-entry":        true,
+		"zero-initial-reentry": true,
+		"sl-reentry":           true,
+		"pt-reentry":           true,
+		"entry":                true,
+	}
+	exitSignalKinds := map[string]bool{
+		"risk-exit":         true,
+		"sl":                true,
+		"pt":                true,
+		"protect-exit":      true,
+		"recovery-watchdog": true,
+	}
+
+	if entrySignalKinds[normalizedSignalKind] && !intent.IsEntry() {
+		return TradingConstraintViolation{
+			OrderID: orderID,
+			Code:    ViolationSignalKindIntentMismatch,
+			Message: fmt.Sprintf("signalKind %q expects entry intent, got %s", normalizedSignalKind, intent),
+		}, true
+	}
+	if exitSignalKinds[normalizedSignalKind] && !intent.IsExit() {
+		return TradingConstraintViolation{
+			OrderID: orderID,
+			Code:    ViolationSignalKindIntentMismatch,
+			Message: fmt.Sprintf("signalKind %q expects exit intent, got %s", normalizedSignalKind, intent),
+		}, true
+	}
+	return TradingConstraintViolation{}, false
+}
+
+func CheckReduceOnlyConstraint(order Order, intent OrderIntent, hasMatchingPosition bool) (TradingConstraintViolation, bool) {
+	if hasMatchingPosition {
+		return TradingConstraintViolation{}, false
+	}
+	if !order.EffectiveReduceOnly() && !order.EffectiveClosePosition() {
+		return TradingConstraintViolation{}, false
+	}
+	return TradingConstraintViolation{
+		OrderID: order.ID,
+		Code:    ViolationReduceOnlyWithoutPosition,
+		Message: fmt.Sprintf("%s has no matching virtual position", intent),
+	}, true
+}

--- a/internal/domain/trading_constraints_test.go
+++ b/internal/domain/trading_constraints_test.go
@@ -1,0 +1,86 @@
+package domain
+
+import "testing"
+
+func TestTradingConstraintSignalKindContract(t *testing.T) {
+	t.Run("entry signal cannot produce exit intent", func(t *testing.T) {
+		violation, ok := CheckSignalKindContract("order-entry-close", "zero-initial-reentry", OrderIntentCloseLong)
+		if !ok {
+			t.Fatal("expected signalKind contract violation")
+		}
+		if violation.Code != ViolationSignalKindIntentMismatch {
+			t.Fatalf("violation code = %s, want %s", violation.Code, ViolationSignalKindIntentMismatch)
+		}
+		if violation.Message != `signalKind "zero-initial-reentry" expects entry intent, got CLOSE_LONG` {
+			t.Fatalf("violation message = %q", violation.Message)
+		}
+	})
+
+	t.Run("exit signal cannot produce entry intent", func(t *testing.T) {
+		violation, ok := CheckSignalKindContract("order-exit-open", "risk-exit", OrderIntentOpenLong)
+		if !ok {
+			t.Fatal("expected signalKind contract violation")
+		}
+		if violation.Code != ViolationSignalKindIntentMismatch {
+			t.Fatalf("violation code = %s, want %s", violation.Code, ViolationSignalKindIntentMismatch)
+		}
+		if violation.Message != `signalKind "risk-exit" expects exit intent, got OPEN_LONG` {
+			t.Fatalf("violation message = %q", violation.Message)
+		}
+	})
+
+	t.Run("empty signal is ignored", func(t *testing.T) {
+		if violation, ok := CheckSignalKindContract("order-empty-signal", "", OrderIntentOpenLong); ok {
+			t.Fatalf("expected no violation, got %+v", violation)
+		}
+	})
+
+	t.Run("matching signal and intent passes", func(t *testing.T) {
+		if violation, ok := CheckSignalKindContract("order-risk-exit", " risk-exit ", OrderIntentCloseShort); ok {
+			t.Fatalf("expected no violation, got %+v", violation)
+		}
+	})
+}
+
+func TestTradingConstraintReduceOnlyConstraint(t *testing.T) {
+	t.Run("reduce-only exit without position fails", func(t *testing.T) {
+		order := Order{ID: "reduce-only-no-position", Side: "SELL", ReduceOnly: true}
+		violation, ok := CheckReduceOnlyConstraint(order, OrderIntentCloseLong, false)
+		if !ok {
+			t.Fatal("expected reduceOnly constraint violation")
+		}
+		if violation.Code != ViolationReduceOnlyWithoutPosition {
+			t.Fatalf("violation code = %s, want %s", violation.Code, ViolationReduceOnlyWithoutPosition)
+		}
+		if violation.Message != "CLOSE_LONG has no matching virtual position" {
+			t.Fatalf("violation message = %q", violation.Message)
+		}
+	})
+
+	t.Run("metadata closePosition without position fails", func(t *testing.T) {
+		order := Order{
+			ID:       "close-position-no-position",
+			Side:     "BUY",
+			Metadata: map[string]any{"closePosition": true},
+		}
+		if violation, ok := CheckReduceOnlyConstraint(order, OrderIntentCloseShort, false); !ok {
+			t.Fatal("expected closePosition constraint violation")
+		} else if violation.Code != ViolationReduceOnlyWithoutPosition {
+			t.Fatalf("violation code = %s, want %s", violation.Code, ViolationReduceOnlyWithoutPosition)
+		}
+	})
+
+	t.Run("non reduce-only entry is ignored", func(t *testing.T) {
+		order := Order{ID: "entry", Side: "BUY"}
+		if violation, ok := CheckReduceOnlyConstraint(order, OrderIntentOpenLong, false); ok {
+			t.Fatalf("expected no violation, got %+v", violation)
+		}
+	})
+
+	t.Run("matching position passes", func(t *testing.T) {
+		order := Order{ID: "reduce-only-has-position", Side: "SELL", ReduceOnly: true}
+		if violation, ok := CheckReduceOnlyConstraint(order, OrderIntentCloseLong, true); ok {
+			t.Fatalf("expected no violation, got %+v", violation)
+		}
+	})
+}

--- a/internal/domain/trading_replay.go
+++ b/internal/domain/trading_replay.go
@@ -101,12 +101,6 @@ type TradingReplayOrphan struct {
 	Reason  string `json:"reason"`
 }
 
-type TradingReplayViolation struct {
-	OrderID string `json:"orderId,omitempty"`
-	Code    string `json:"code"`
-	Message string `json:"message"`
-}
-
 type replayEntry struct {
 	OrderID    string
 	Intent     OrderIntent
@@ -145,7 +139,7 @@ func ReplayTradingOrders(orders []TradingReplayOrder) TradingReplayResult {
 			continue
 		}
 
-		if violation, ok := tradingReplaySignalKindViolation(order, intent); ok {
+		if violation, ok := CheckSignalKindContract(order.ID, order.EffectiveSignalKind(), intent); ok {
 			result.Violations = append(result.Violations, violation)
 		}
 
@@ -297,12 +291,8 @@ func appendTradingReplayExitViolation(result TradingReplayResult, order TradingR
 		Intent:  string(intent),
 		Reason:  OrphanReasonNoMatchingPosition,
 	})
-	if domainOrder.EffectiveReduceOnly() || domainOrder.EffectiveClosePosition() {
-		result.Violations = append(result.Violations, TradingReplayViolation{
-			OrderID: order.ID,
-			Code:    ViolationReduceOnlyWithoutPosition,
-			Message: fmt.Sprintf("%s has no matching virtual position", intent),
-		})
+	if violation, ok := CheckReduceOnlyConstraint(domainOrder, intent, false); ok {
+		result.Violations = append(result.Violations, violation)
 	}
 	result.Violations = append(result.Violations, TradingReplayViolation{
 		OrderID: order.ID,
@@ -317,43 +307,4 @@ func appendTradingReplayExitViolation(result TradingReplayResult, order TradingR
 		})
 	}
 	return result
-}
-
-func tradingReplaySignalKindViolation(order TradingReplayOrder, intent OrderIntent) (TradingReplayViolation, bool) {
-	signalKind := strings.ToLower(strings.TrimSpace(order.EffectiveSignalKind()))
-	if signalKind == "" {
-		return TradingReplayViolation{}, false
-	}
-
-	entrySignalKinds := map[string]bool{
-		"initial":              true,
-		"initial-entry":        true,
-		"zero-initial-reentry": true,
-		"sl-reentry":           true,
-		"pt-reentry":           true,
-		"entry":                true,
-	}
-	exitSignalKinds := map[string]bool{
-		"risk-exit":         true,
-		"sl":                true,
-		"pt":                true,
-		"protect-exit":      true,
-		"recovery-watchdog": true,
-	}
-
-	if entrySignalKinds[signalKind] && !intent.IsEntry() {
-		return TradingReplayViolation{
-			OrderID: order.ID,
-			Code:    ViolationSignalKindIntentMismatch,
-			Message: fmt.Sprintf("signalKind %q expects entry intent, got %s", signalKind, intent),
-		}, true
-	}
-	if exitSignalKinds[signalKind] && !intent.IsExit() {
-		return TradingReplayViolation{
-			OrderID: order.ID,
-			Code:    ViolationSignalKindIntentMismatch,
-			Message: fmt.Sprintf("signalKind %q expects exit intent, got %s", signalKind, intent),
-		}, true
-	}
-	return TradingReplayViolation{}, false
 }


### PR DESCRIPTION
## 目的

跟进 #354，把 #351 replay harness 内部的通用交易约束抽到 `internal/domain`，避免后续 live/monitor/更高层 harness 重复维护 signalKind 和 reduceOnly 规则。

Closes #354

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [x] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？- 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？- 无
- [x] DB migration 是否具备向下兼容幂等性？- 无 DB migration
- [x] 配置字段有没有无意被混改？- 无配置字段改动

## 交易语义变更
- [ ] 本次改动是否新增/修改了 `signalKind`？若是，需同步更新 Golden Case
- [x] 本次改动是否影响订单方向判断（`side` / `reduceOnly` / `closePosition`）？- 不改 `ClassifyOrderIntent()`，只抽通用 constraint checks
- [x] 若涉及上述改动，`go test ./internal/domain/... -run TestClassifyOrderIntent` 是否通过？
- [x] 若涉及交易链路语义（开仓/平仓/撤单/risk-exit），`go test ./internal/domain/... -run TestTradingReplayGoldenCases` 是否通过？

## 验证方式与测试证据
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

验证已跑：

```bash
go test ./internal/domain/... -run 'Test(ClassifyOrderIntent|TradingReplay|TradingConstraint)' -v
go test ./...
go build ./cmd/platform-api
go build ./cmd/db-migrate
```

## 实现说明
- 新增 `TradingConstraintViolation` 通用类型，并用 `type TradingReplayViolation = TradingConstraintViolation` 保持 replay JSON shape 不变。
- 新增 `CheckSignalKindContract(orderID, signalKind, intent)`。
- 新增 `CheckReduceOnlyConstraint(order, intent, hasMatchingPosition)`。
- `ReplayTradingOrders()` 改为复用上述 API，删除 replay 内部私有 signalKind/reduceOnly 判断。
- 新增 `trading_constraints_test.go` 覆盖 entry/exit signalKind mismatch、空 signalKind、reduceOnly 无仓位、metadata closePosition、非 reduceOnly entry、已有匹配仓位等场景。
