### PR TITLE
[codex] Add order intent inference sensor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,11 @@ jobs:
       
       - name: Check high risk defaults
         run: bash scripts/check_high_risk_defaults.sh
+
+      - name: Check order intent inference
+        run: |
+          ORDER_INTENT_SENSOR_TEST=1 bash scripts/check_order_intent_inference.sh
+          bash scripts/check_order_intent_inference.sh
         
       - name: Check env safety
         run: bash scripts/check_env_safety.sh

--- a/scripts/check_order_intent_inference.sh
+++ b/scripts/check_order_intent_inference.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python3 - <<'PY'
+from __future__ import annotations
+
+import re
+import sys
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+ROOT = Path.cwd()
+
+SCAN_ROOTS = [
+    ROOT / "internal",
+    ROOT / "web" / "console" / "src",
+]
+
+SIDE_PATTERN = re.compile(
+    r"""(?:\bside\s*(?:==|===|!=|!==)\s*["'](?:BUY|SELL)["'])|(?:["'](?:BUY|SELL)["']\s*(?:==|===|!=|!==)\s*\bside\b)"""
+)
+
+EXCLUDED_PARTS = {
+    "node_modules",
+    "testdata",
+}
+
+EXCLUDED_SUFFIXES = (
+    "_test.go",
+    ".test.ts",
+    ".test.tsx",
+)
+
+@dataclass(frozen=True)
+class AllowlistEntry:
+    path: str
+    line_pattern: re.Pattern[str]
+    count: int
+    reason: str
+
+
+def allowed(path: str, line_pattern: str, count: int, reason: str) -> AllowlistEntry:
+    return AllowlistEntry(path=path, line_pattern=re.compile(line_pattern), count=count, reason=reason)
+
+
+# Existing, reviewed hits. Counts make identical duplicate lines fail too.
+ALLOWLIST = [
+    # Canonical domain classifier: the only source of order intent semantics.
+    allowed("internal/domain/order_intent.go", r'side == "BUY".*!isExit', 1, "canonical classifier"),
+    allowed("internal/domain/order_intent.go", r'side == "SELL".*!isExit', 1, "canonical classifier"),
+    allowed("internal/domain/order_intent.go", r'side == "SELL".*isExit', 1, "canonical classifier"),
+    allowed("internal/domain/order_intent.go", r'side == "BUY".*isExit', 1, "canonical classifier"),
+
+    # Existing service execution side validation/normalization is an execution boundary, not display semantics.
+    allowed("internal/service/backtest.go", r'side != "BUY".*side != "SELL".*side != "LONG".*side != "SHORT"', 1, "backtest side validation"),
+    allowed("internal/service/live_execution.go", r'side != "BUY".*side != "SELL"', 1, "execution side validation"),
+    allowed("internal/service/live_execution.go", r'side == "SELL"', 1, "execution side normalization"),
+
+    # Existing Monitor fallback is tracked by issue #357 and must not grow.
+    allowed("web/console/src/utils/derivation.ts", r'side === "BUY"', 2, "issue #357 existing fallback"),
+    allowed("web/console/src/utils/derivation.ts", r'side === "SELL"', 1, "issue #357 existing fallback"),
+]
+
+
+def is_scanned_source(path: Path) -> bool:
+    if any(part in EXCLUDED_PARTS for part in path.parts):
+        return False
+    if path.name.endswith(EXCLUDED_SUFFIXES):
+        return False
+    return path.suffix in {".go", ".ts", ".tsx"}
+
+
+def matches_sensor(rel: str, line: str) -> bool:
+    return bool(SIDE_PATTERN.search(line))
+
+
+if os.environ.get("ORDER_INTENT_SENSOR_TEST") == "1":
+    cases = [
+        ("web/console/src/example.ts", 'if (order.intent === "CLOSE_LONG") {', False),
+        ("web/console/src/example.ts", 'if (intent === "OPEN_LONG" || intent === "CLOSE_LONG") return "LONG";', False),
+        ("web/console/src/example.ts", 'if (side === "BUY") {', True),
+        ("internal/example.go", 'if side == "SELL" {', True),
+    ]
+    for rel, line, want in cases:
+        got = matches_sensor(rel, line)
+        if got != want:
+            print(f"self-test failed for {rel}: {line!r}: got {got}, want {want}", file=sys.stderr)
+            sys.exit(1)
+    print("Order intent inference sensor self-test passed.")
+    sys.exit(0)
+
+
+unexpected_hits: list[tuple[str, int, str]] = []
+allowlist_hits = [0 for _ in ALLOWLIST]
+allowlist_locations: list[list[str]] = [[] for _ in ALLOWLIST]
+
+for root in SCAN_ROOTS:
+    if not root.exists():
+        continue
+    for path in root.rglob("*"):
+        if not path.is_file() or not is_scanned_source(path):
+            continue
+        rel = path.relative_to(ROOT).as_posix()
+        for lineno, raw_line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            line = raw_line.strip()
+            if not matches_sensor(rel, line):
+                continue
+            matched = False
+            for idx, entry in enumerate(ALLOWLIST):
+                if rel == entry.path and entry.line_pattern.search(line):
+                    allowlist_hits[idx] += 1
+                    allowlist_locations[idx].append(f"{rel}:{lineno}")
+                    matched = True
+                    break
+            if not matched:
+                unexpected_hits.append((rel, lineno, line))
+
+failures: list[str] = []
+
+for rel, lineno, line in unexpected_hits:
+    failures.append(f"{rel}:{lineno}\n  {line}\n  allowed=0, found=1")
+
+for idx, entry in enumerate(ALLOWLIST):
+    found = allowlist_hits[idx]
+    if found != entry.count:
+        locations = ", ".join(allowlist_locations[idx]) or entry.path
+        failures.append(
+            f"{locations}\n"
+            f"  allowlist entry count mismatch: {entry.line_pattern.pattern}\n"
+            f"  reason={entry.reason}, allowed={entry.count}, found={found}"
+        )
+
+if failures:
+    print("Order intent inference sensor failed.", file=sys.stderr)
+    print("", file=sys.stderr)
+    print("Do not add a second order semantics classifier from side/reduceOnly.", file=sys.stderr)
+    print("Display/replay/analysis semantics must use domain.ClassifyOrderIntent()", file=sys.stderr)
+    print("or backend-provided intent / intentLabel.", file=sys.stderr)
+    print("", file=sys.stderr)
+    print("If this is an execution safety boundary, update the allowlist with a concrete reason.", file=sys.stderr)
+    print("", file=sys.stderr)
+    for failure in failures:
+        print(failure, file=sys.stderr)
+        print("", file=sys.stderr)
+    sys.exit(1)
+
+print("Order intent inference sensor passed.")
+PY


### PR DESCRIPTION
## 目的
为 #356 增加订单语义重复推断 sensor，阻止后续新增 `side ==/=== BUY|SELL` 这类第二套展示/回放/分析语义推导。

注意：本 sensor 不拦截前端消费后端 `intent` / `intentLabel`，例如 `order.intent === "CLOSE_LONG"` 属于合法消费路径。

Closes #356
Refs #359

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [x] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值无变化
- [x] 不存在直接调用 `mainnet` 凭证或路由地址的硬编码
- [x] 未新增 DB migration
- [x] 未混改配置字段

## 交易语义变更
- [x] 本次不新增/修改 `signalKind`
- [x] 本次不改变订单方向判断，只新增防新增重复推断的 sensor
- [ ] 若涉及上述改动，`go test ./internal/domain/... -run TestClassifyOrderIntent` 是否通过？
- [ ] 若涉及交易链路语义（开仓/平仓/撤单/risk-exit），`go test ./internal/domain/... -run TestTradingReplayGoldenCases` 是否通过？

## 验证方式与测试证据
- [x] `ORDER_INTENT_SENSOR_TEST=1 bash scripts/check_order_intent_inference.sh`
- [x] `bash scripts/check_order_intent_inference.sh`
- [x] 自测覆盖：`order.intent === "CLOSE_LONG"` 不触发；`side === "BUY"` 会触发
- [x] `bash scripts/check_high_risk_defaults.sh`
- [x] `bash scripts/check_env_safety.sh`
- [x] `python3 scripts/check_migration_safety.py` advisory 通过退出码，输出历史重复 migration 序号提示

## 实现说明
- 新增 `scripts/check_order_intent_inference.sh`，扫描 `internal/` 与 `web/console/src/`。
- 当前版本只拦 `side` 与 `BUY` / `SELL` 的直接单行判断；多行窗口或 AST 可作为后续增强。
- 对当前已审阅历史命中使用带原因和计数的 allowlist，新增同类命中会失败。
- 接入 CI `High Risk Defenses`，让 PR 默认跑该防线。