### PR TITLE
[codex] Remove frontend order intent fallback inference

### DIFF
--- a/scripts/check_order_intent_inference.sh
+++ b/scripts/check_order_intent_inference.sh
@@ -58,8 +58,7 @@ ALLOWLIST = [
     allowed("internal/service/live_execution.go", r'side == "SELL"', 1, "execution side normalization"),
 
     # Existing Monitor fallback is tracked by issue #357 and must not grow.
-    allowed("web/console/src/utils/derivation.ts", r'side === "BUY"', 2, "issue #357 existing fallback"),
-    allowed("web/console/src/utils/derivation.ts", r'side === "SELL"', 1, "issue #357 existing fallback"),
+    allowed("web/console/src/utils/derivation.ts", r'side === "BUY"', 1, "order marker buy/sell visual direction"),
 ]
 
 

--- a/web/console/src/utils/derivation.test.ts
+++ b/web/console/src/utils/derivation.test.ts
@@ -14,10 +14,10 @@ describe("monitor chart marker labels", () => {
   it("distinguishes long and short entry/exit order markers", () => {
     const session = { id: "live-1", strategyId: "strategy-1" } as any;
     const orders: Order[] = [
-      order("o1", "BUY", 100, false, "2026-04-24T00:00:00Z"),
-      order("o2", "SELL", 101, false, "2026-04-24T00:01:00Z"),
-      order("o3", "SELL", 102, true, "2026-04-24T00:02:00Z", "SL"),
-      order("o4", "BUY", 103, true, "2026-04-24T00:03:00Z", "PT"),
+      order("o1", "BUY", 100, false, "2026-04-24T00:00:00Z", "", "", "proposalMetadata", "OPEN_LONG", "开多"),
+      order("o2", "SELL", 101, false, "2026-04-24T00:01:00Z", "", "", "proposalMetadata", "OPEN_SHORT", "开空"),
+      order("o3", "SELL", 102, true, "2026-04-24T00:02:00Z", "SL", "", "proposalMetadata", "CLOSE_LONG", "平多"),
+      order("o4", "BUY", 103, true, "2026-04-24T00:03:00Z", "PT", "", "proposalMetadata", "CLOSE_SHORT", "平空"),
     ];
 
     const markers = deriveSessionMarkers(session, orders, []);
@@ -30,6 +30,24 @@ describe("monitor chart marker labels", () => {
     ]);
   });
 
+  it("degrades missing order intent instead of inferring from side and reduceOnly", () => {
+    const session = { id: "live-1", strategyId: "strategy-1" } as any;
+    const orders: Order[] = [
+      order("o1", "SELL", 102, true, "2026-04-24T00:02:00Z", "SL"),
+    ];
+    const candles: SignalBarCandle[] = [
+      candle("2026-04-24T00:02:00Z"),
+      candle("2026-04-24T00:03:00Z"),
+      candle("2026-04-24T00:04:00Z"),
+    ];
+
+    const markers = deriveSessionMarkers(session, orders, []);
+    const { overlays } = deriveSignalMonitorDecorations(session, candles, null, orders, []);
+
+    expect(markers[0].text).toBe("未知 SL 102.00");
+    expect(overlays[0].lineStyle).toBe("dotted");
+  });
+
   it("anchors order markers to the signal bar trade limit key", () => {
     const session = { id: "live-1", strategyId: "strategy-1" } as any;
     const orders: Order[] = [
@@ -40,7 +58,10 @@ describe("monitor chart marker labels", () => {
         true,
         "2026-04-30T00:41:02Z",
         "SL",
-        "BTCUSDT|30m|2026-04-30T00:30:00Z"
+        "BTCUSDT|30m|2026-04-30T00:30:00Z",
+        "proposalMetadata",
+        "CLOSE_LONG",
+        "平多"
       ),
     ];
 
@@ -61,7 +82,9 @@ describe("monitor chart marker labels", () => {
         "2026-04-30T00:33:51Z",
         "",
         "BTCUSDT|30m|2026-04-30T00:30:00Z",
-        "proposalTopLevel"
+        "proposalTopLevel",
+        "OPEN_LONG",
+        "开多"
       ),
     ];
 
@@ -86,7 +109,10 @@ describe("monitor chart marker labels", () => {
         true,
         "2026-04-30T00:41:02Z",
         "SL",
-        "BTCUSDT|30m|2026-04-30T00:30:00Z"
+        "BTCUSDT|30m|2026-04-30T00:30:00Z",
+        "proposalMetadata",
+        "CLOSE_LONG",
+        "平多"
       ),
     ];
     const fills: Fill[] = [
@@ -348,14 +374,16 @@ function order(
   createdAt: string,
   reason = "",
   signalBarTradeLimitKey = "",
-  signalBarTradeLimitKeyPlacement: "proposalMetadata" | "proposalTopLevel" | "intentMetadata" | "orderMetadata" = "proposalMetadata"
+  signalBarTradeLimitKeyPlacement: "proposalMetadata" | "proposalTopLevel" | "intentMetadata" | "orderMetadata" = "proposalMetadata",
+  intent = "",
+  intentLabel = ""
 ): Order {
   const executionProposal: Record<string, unknown> = {
     role: reduceOnly ? "exit" : "entry",
     reason,
     reduceOnly,
   };
-  const intent: Record<string, unknown> = {};
+  const intentMetadata: Record<string, unknown> = {};
   const metadata: Record<string, unknown> = {
     liveSessionId: "live-1",
     reduceOnly,
@@ -365,8 +393,8 @@ function order(
     if (signalBarTradeLimitKeyPlacement === "proposalTopLevel") {
       executionProposal.signalBarTradeLimitKey = signalBarTradeLimitKey;
     } else if (signalBarTradeLimitKeyPlacement === "intentMetadata") {
-      intent.metadata = { signalBarTradeLimitKey };
-      metadata.intent = intent;
+      intentMetadata.metadata = { signalBarTradeLimitKey };
+      metadata.intent = intentMetadata;
     } else if (signalBarTradeLimitKeyPlacement === "orderMetadata") {
       metadata.signalBarTradeLimitKey = signalBarTradeLimitKey;
     } else {
@@ -383,6 +411,8 @@ function order(
     quantity: 0.01,
     price,
     reduceOnly,
+    intent: intent || undefined,
+    intentLabel: intentLabel || undefined,
     metadata,
     createdAt,
   };

--- a/web/console/src/utils/derivation.ts
+++ b/web/console/src/utils/derivation.ts
@@ -323,7 +323,7 @@ function annotationMarkerText(item: ChartAnnotation): string {
   const positionSide =
     type.includes("short") ? "SHORT" :
     type.includes("long") ? "LONG" :
-    executionOrderPositionSide(metadataSide, isExit);
+    annotationPositionSide(metadataSide, isExit);
   const actionLabel = isEntry ? "开" : isExit ? "平" : "";
   const sideLabel = positionSide === "SHORT" ? "空" : positionSide === "LONG" ? "多" : "";
   const reasonLabel = compactExecutionReasonLabel(
@@ -1337,38 +1337,17 @@ function executionOrderMarkerText(order: Order): string {
     const reasonLabel = compactExecutionReasonLabel(executionOrderReason(order));
     return [order.intentLabel, reasonLabel].filter(Boolean).join(" ");
   }
-  // fallback：兼容没有 intent 字段的旧订单数据
-  const side = String(order.side ?? "").trim().toUpperCase();
-  const isExit = isExitOrderMarker(order);
-  const positionSide = executionOrderPositionSide(side, isExit, order.intent);
-  const action = isExit ? "平" : "开";
-  const sideLabel = positionSide === "SHORT" ? "空" : positionSide === "LONG" ? "多" : "";
+  // 缺失 intentLabel 时显式 degraded，禁止前端从 side/reduceOnly 重建开平语义。
   const reasonLabel = compactExecutionReasonLabel(executionOrderReason(order));
-  return [action + sideLabel, reasonLabel].filter(Boolean).join(" ");
+  return ["未知", reasonLabel].filter(Boolean).join(" ");
 }
 
 function isExitOrderMarker(order: Order): boolean {
-  // 优先消费后端 intent 字段（由 ClassifyOrderIntent 唯一分类器注入）
-  // 只在明确的 CLOSE_/OPEN_ 前缀时短路；UNKNOWN 继续 fallback 到旧逻辑
+  // 消费后端 intent 字段（由 ClassifyOrderIntent 唯一分类器注入）。
+  // 缺失或 UNKNOWN 时显式 degraded，禁止前端用 reduceOnly/side 重建 classifier。
   if (order.intent?.startsWith("CLOSE_")) return true;
   if (order.intent?.startsWith("OPEN_")) return false;
-  // fallback：兼容没有 intent 字段的旧订单数据
-  const metadata = getRecord(order.metadata);
-  const proposal = getRecord(metadata.executionProposal ?? metadata.intent);
-  const role = String(metadata.orderRole ?? proposal.role ?? "").trim().toLowerCase();
-  const reason = normalizeExecutionReasonTag(executionOrderReason(order));
-  return (
-    order.reduceOnly === true ||
-    order.closePosition === true ||
-    metadata.reduceOnly === true ||
-    metadata.closePosition === true ||
-    proposal.reduceOnly === true ||
-    proposal.closePosition === true ||
-    role === "exit" ||
-    reason === "sl" ||
-    reason === "pt" ||
-    reason === "tp"
-  );
+  return false;
 }
 
 function executionOrderReason(order: Order): string {
@@ -1377,18 +1356,11 @@ function executionOrderReason(order: Order): string {
   return String(metadata.reason ?? proposal.reason ?? order.type ?? "").trim();
 }
 
-function executionOrderPositionSide(side: string, isExit: boolean, intent?: string): "LONG" | "SHORT" | "" {
-  // 优先从 intent 推导（由 ClassifyOrderIntent 唯一分类器注入）
-  if (intent) {
-    if (intent === "OPEN_LONG" || intent === "CLOSE_LONG") return "LONG";
-    if (intent === "OPEN_SHORT" || intent === "CLOSE_SHORT") return "SHORT";
-    return "";
-  }
-  // fallback：兼容没有 intent 字段的旧订单数据
-  if (side === "BUY") {
+function annotationPositionSide(metadataSide: string, isExit: boolean): "LONG" | "SHORT" | "" {
+  if (metadataSide === "BUY") {
     return isExit ? "SHORT" : "LONG";
   }
-  if (side === "SELL") {
+  if (metadataSide === "SELL") {
     return isExit ? "LONG" : "SHORT";
   }
   return "";


### PR DESCRIPTION
## 目的
收口 #357：Monitor 订单展示不再在前端用 `side` / `reduceOnly` / metadata 重建开平语义，改为强依赖后端 `intent` / `intentLabel`。

API 依赖：前端订单展示需要后端订单接口返回 `intent` / `intentLabel`。如果接口缺失这些字段，UI 会显式 degraded 为 `未知`，不再前端 fallback 推断。

Closes #357
Refs #359

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [x] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值无变化
- [x] 不存在直接调用 `mainnet` 凭证或路由地址的硬编码
- [x] 未新增 DB migration
- [x] 未混改配置字段

## 交易语义变更
- [x] 本次不新增/修改 `signalKind`
- [x] 本次不改变后端订单方向判断，只删除前端展示 fallback
- [ ] 若涉及上述改动，`go test ./internal/domain/... -run TestClassifyOrderIntent` 是否通过？
- [ ] 若涉及交易链路语义（开仓/平仓/撤单/risk-exit），`go test ./internal/domain/... -run TestTradingReplayGoldenCases` 是否通过？

## 验证方式与测试证据
- [x] `ORDER_INTENT_SENSOR_TEST=1 bash scripts/check_order_intent_inference.sh && bash scripts/check_order_intent_inference.sh`
- [x] `cd web/console && ./node_modules/.bin/vitest run src/utils/derivation.test.ts`
- [x] `cd web/console && ./node_modules/.bin/tsc --noEmit src/utils/derivation.ts --jsx react-jsx --esModuleInterop --target esnext --moduleResolution Bundler --allowSyntheticDefaultImports`
- [x] `cd web/console && npm run build`
- [x] `bash scripts/check_high_risk_defaults.sh`
- [x] `bash scripts/check_env_safety.sh`
- [x] `python3 scripts/check_migration_safety.py` advisory 通过退出码，输出历史重复 migration 序号提示

## 实现说明
- `executionOrderMarkerText()` 缺少 `intentLabel` 时显示 `未知`，不再从 `side/reduceOnly` 推导开多/平多。
- `isExitOrderMarker()` 只消费后端 `intent` 的 `CLOSE_` / `OPEN_` 前缀；缺失或 UNKNOWN 时 degraded 为非 exit 展示。
- 保留非订单 annotation marker 的既有方向展示，不把它混进订单 classifier。
- 同步收紧 #356 sensor allowlist：`derivation.ts` 里旧 frontend fallback 命中减少。