### PR TITLE
[codex] Normalize recovery map orders through domain intent

### DIFF
--- a/internal/service/live_recovery.go
+++ b/internal/service/live_recovery.go
@@ -618,10 +618,89 @@ func nonNegativeDuration(value time.Duration) time.Duration {
 
 func isProtectionOrder(order map[string]any) bool {
 	orderType := strings.ToUpper(strings.TrimSpace(firstNonEmpty(stringValue(order["origType"]), stringValue(order["type"]))))
-	if boolValue(order["reduceOnly"]) || boolValue(order["closePosition"]) {
+	if recoveryMapOrderIntent(order).IsExit() {
+		return true
+	}
+	if recoveryMapOrderHasExitFlags(order) {
 		return true
 	}
 	return strings.Contains(orderType, "STOP") || strings.Contains(orderType, "TAKE_PROFIT")
+}
+
+func recoveryMapOrderIntent(order map[string]any) domain.OrderIntent {
+	return domain.ClassifyOrderIntent(recoveryMapToDomainOrder(order))
+}
+
+func recoveryMapToDomainOrder(order map[string]any) domain.Order {
+	if order == nil {
+		return domain.Order{}
+	}
+	metadata := cloneMetadata(mapValue(order["metadata"]))
+	if metadata == nil {
+		metadata = map[string]any{}
+	}
+	proposal := firstNonEmptyMapValue(metadata["executionProposal"], metadata["intent"])
+	intent := mapValue(metadata["intent"])
+	return domain.Order{
+		ID: firstNonEmpty(
+			stringValue(order["id"]),
+			stringValue(order["orderId"]),
+			stringValue(order["clientOrderId"]),
+		),
+		Side: firstNonEmpty(
+			stringValue(order["side"]),
+			stringValue(metadata["side"]),
+			stringValue(proposal["side"]),
+			stringValue(intent["side"]),
+		),
+		Status: firstNonEmpty(
+			stringValue(order["status"]),
+			stringValue(order["orderStatus"]),
+			stringValue(metadata["status"]),
+		),
+		Quantity: firstPositiveFloatValue(
+			order["quantity"],
+			order["origQty"],
+			order["executedQty"],
+			metadata["quantity"],
+			proposal["quantity"],
+		),
+		ReduceOnly: boolValue(order["reduceOnly"]) ||
+			boolValue(metadata["reduceOnly"]) ||
+			boolValue(proposal["reduceOnly"]) ||
+			boolValue(intent["reduceOnly"]),
+		ClosePosition: boolValue(order["closePosition"]) ||
+			boolValue(metadata["closePosition"]) ||
+			boolValue(proposal["closePosition"]) ||
+			boolValue(intent["closePosition"]),
+		Metadata: metadata,
+	}
+}
+
+func recoveryMapOrderHasExitFlags(order map[string]any) bool {
+	if order == nil {
+		return false
+	}
+	metadata := mapValue(order["metadata"])
+	proposal := firstNonEmptyMapValue(metadata["executionProposal"], metadata["intent"])
+	intent := mapValue(metadata["intent"])
+	return boolValue(order["reduceOnly"]) ||
+		boolValue(order["closePosition"]) ||
+		boolValue(metadata["reduceOnly"]) ||
+		boolValue(metadata["closePosition"]) ||
+		boolValue(proposal["reduceOnly"]) ||
+		boolValue(proposal["closePosition"]) ||
+		boolValue(intent["reduceOnly"]) ||
+		boolValue(intent["closePosition"])
+}
+
+func firstPositiveFloatValue(values ...any) float64 {
+	for _, value := range values {
+		if parsed := parseFloatValue(value); parsed > 0 {
+			return parsed
+		}
+	}
+	return 0
 }
 
 func isStopProtectionOrder(order map[string]any) bool {
@@ -763,7 +842,7 @@ func activeLiveWatchdogExitOrder(orders []map[string]any) (map[string]any, bool)
 		if len(order) == 0 {
 			continue
 		}
-		if !boolValue(order["reduceOnly"]) && !boolValue(order["closePosition"]) {
+		if !recoveryMapOrderIntent(order).IsExit() && !recoveryMapOrderHasExitFlags(order) {
 			continue
 		}
 		if isStopProtectionOrder(order) || isTakeProfitProtectionOrder(order) {

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -8490,6 +8490,7 @@ func TestRefreshLiveSessionPositionContextDoesNotCrossProtectedBoundary(t *testi
 		"openOrders": []map[string]any{
 			{
 				"symbol":        "BTCUSDT",
+				"side":          "SELL",
 				"origType":      "STOP_MARKET",
 				"reduceOnly":    true,
 				"closePosition": true,
@@ -8833,6 +8834,7 @@ func TestRefreshLiveSessionPositionContextTracksActiveReduceOnlyExitOrder(t *tes
 		"openOrders": []map[string]any{
 			{
 				"symbol":     "BTCUSDT",
+				"side":       "SELL",
 				"origType":   "MARKET",
 				"type":       "MARKET",
 				"status":     "NEW",
@@ -8888,6 +8890,123 @@ func TestRefreshLiveSessionPositionContextTracksActiveReduceOnlyExitOrder(t *tes
 	}
 	if got := stringValue(updated.State["watchdogExitStatus"]); got != "order-working" {
 		t.Fatalf("expected watchdog order-working status, got %s", got)
+	}
+}
+
+func TestRecoveryMapOrderIntentUsesDomainClassifier(t *testing.T) {
+	cases := []struct {
+		name  string
+		order map[string]any
+		want  domain.OrderIntent
+	}{
+		{
+			name: "top-level reduce-only sell closes long",
+			order: map[string]any{
+				"id":         "order-1",
+				"side":       "SELL",
+				"status":     "NEW",
+				"quantity":   "0.010",
+				"reduceOnly": true,
+			},
+			want: domain.OrderIntentCloseLong,
+		},
+		{
+			name: "metadata close-position buy closes short",
+			order: map[string]any{
+				"orderId": "order-2",
+				"status":  "NEW",
+				"metadata": map[string]any{
+					"side":          "BUY",
+					"quantity":      0.02,
+					"closePosition": "true",
+				},
+			},
+			want: domain.OrderIntentCloseShort,
+		},
+		{
+			name: "execution proposal metadata supplies legacy side and reduce-only",
+			order: map[string]any{
+				"clientOrderId": "order-3",
+				"status":        "NEW",
+				"metadata": map[string]any{
+					"executionProposal": map[string]any{
+						"side":       "SELL",
+						"quantity":   0.03,
+						"reduceOnly": true,
+					},
+				},
+			},
+			want: domain.OrderIntentCloseLong,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			domainOrder := recoveryMapToDomainOrder(tc.order)
+			if got := domain.ClassifyOrderIntent(domainOrder); got != tc.want {
+				t.Fatalf("ClassifyOrderIntent(recoveryMapToDomainOrder()) = %s, want %s, order=%+v", got, tc.want, domainOrder)
+			}
+		})
+	}
+}
+
+func TestRecoveryMapOrderHasExitFlagsKeepsMissingSideFailSafe(t *testing.T) {
+	order := map[string]any{
+		"orderId":    "missing-side-exit",
+		"status":     "NEW",
+		"reduceOnly": true,
+	}
+	if got := recoveryMapOrderIntent(order); got != domain.OrderIntentUnknown {
+		t.Fatalf("expected missing side to classify UNKNOWN, got %s", got)
+	}
+	if !recoveryMapOrderHasExitFlags(order) {
+		t.Fatal("expected missing-side reduceOnly order to retain fail-safe exit flag")
+	}
+	if !isProtectionOrder(order) {
+		t.Fatal("expected missing-side reduceOnly order to remain a protection order")
+	}
+}
+
+func TestActiveLiveWatchdogExitOrderUsesRecoveryMapClassifier(t *testing.T) {
+	order, ok := activeLiveWatchdogExitOrder([]map[string]any{
+		{
+			"orderId":  "entry-order",
+			"side":     "BUY",
+			"status":   "NEW",
+			"quantity": 0.01,
+		},
+		{
+			"orderId": "exit-order",
+			"status":  "NEW",
+			"metadata": map[string]any{
+				"executionProposal": map[string]any{
+					"side":       "SELL",
+					"quantity":   0.01,
+					"reduceOnly": true,
+				},
+			},
+		},
+	})
+	if !ok {
+		t.Fatal("expected active exit order from recovery map classifier")
+	}
+	if got := liveWatchdogExitOrderID(order); got != "exit-order" {
+		t.Fatalf("expected exit-order, got %s", got)
+	}
+}
+
+func TestActiveLiveWatchdogExitOrderKeepsMissingSideReduceOnlyFailSafe(t *testing.T) {
+	order, ok := activeLiveWatchdogExitOrder([]map[string]any{
+		{
+			"orderId":    "missing-side-exit-order",
+			"status":     "NEW",
+			"reduceOnly": true,
+		},
+	})
+	if !ok {
+		t.Fatal("expected missing-side reduceOnly order to remain active watchdog exit")
+	}
+	if got := liveWatchdogExitOrderID(order); got != "missing-side-exit-order" {
+		t.Fatalf("expected missing-side-exit-order, got %s", got)
 	}
 }
 


### PR DESCRIPTION
## 目的
收口 #358：live recovery 的 map 形态订单不再在调用点直接组合 `reduceOnly` / `closePosition` 判断业务语义，而是先转换为 `domain.Order`，再复用 `domain.ClassifyOrderIntent()`。

Closes #358
Refs #359

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [x] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值无变化
- [x] 不存在直接调用 `mainnet` 凭证或路由地址的硬编码
- [x] 未新增 DB migration
- [x] 未混改配置字段

## 交易语义变更
- [x] 本次不新增/修改 `signalKind`
- [x] 本次将 recovery map 订单语义判断收敛到 `ClassifyOrderIntent()`
- [x] `go test ./internal/domain/... -run TestClassifyOrderIntent -v` 通过
- [x] `go test ./internal/domain/...` 通过

## 验证方式与测试证据
- [x] `go test ./internal/service -run 'TestRecoveryMapOrderIntentUsesDomainClassifier|TestActiveLiveWatchdogExitOrderUsesRecoveryMapClassifier|TestRefreshLiveSessionPositionContextTracksActiveReduceOnlyExitOrder|TestRefreshLiveSessionPositionContextDoesNotCrossProtectedBoundary'`\n- [x] `go test ./internal/service -run 'TestRefreshLiveSessionPositionContext.*Recovery|TestRefreshLiveSessionPositionContext.*Watchdog|TestRecoverRunningLiveSession.*|TestStartLiveSession.*Recovery|TestClosePositionAllowsRecoveredCloseOnlyTakeover'`\n- [x] `go test ./internal/service`\n- [x] `go test ./internal/domain/...`\n- [x] `go test ./...`\n- [x] `go build ./cmd/platform-api`\n- [x] `go build ./cmd/db-migrate`\n- [x] `bash scripts/check_order_intent_inference.sh`\n- [x] `bash scripts/check_high_risk_defaults.sh`\n- [x] `bash scripts/check_env_safety.sh`\n- [x] `python3 scripts/check_migration_safety.py` advisory 通过退出码，输出历史重复 migration 序号提示\n\n## 实现说明\n- 新增 `recoveryMapToDomainOrder()` / `recoveryMapOrderIntent()`，集中处理 map order 到 domain order 的转换。\n- 转换 helper 读取 `id/orderId/clientOrderId`、`side`、`status/orderStatus`、`quantity/origQty/executedQty`、`reduceOnly`、`closePosition` 和 metadata / executionProposal。\n- `isProtectionOrder()` 和 `activeLiveWatchdogExitOrder()` 改为消费 `recoveryMapOrderIntent(...).IsExit()`。\n- STOP / TAKE_PROFIT 类型保护单识别保留原有逻辑。\n- 不改 recovery 状态机、不改 dispatch、不改真实下单路径。