### PR TITLE
[codex] Infer missed signal bar closes

### DIFF
--- a/internal/service/signal_runtime_ws.go
+++ b/internal/service/signal_runtime_ws.go
@@ -1136,6 +1136,8 @@ func mergeSignalBarHistory(existing any, summary map[string]any, eventTime time.
 		"updatedAt": eventTime.UTC().Format(time.RFC3339Nano),
 	})
 
+	markPriorOpenSignalBarsClosed(items, bar)
+
 	matchIndex := -1
 	barKey := signalBarHistoryKey(bar)
 	for i, item := range items {
@@ -1158,6 +1160,50 @@ func mergeSignalBarHistory(existing any, summary map[string]any, eventTime time.
 		out = append(out, item)
 	}
 	return out
+}
+
+func markPriorOpenSignalBarsClosed(items []map[string]any, current map[string]any) {
+	currentStart, ok := signalBarTimestampMillis(current["barStart"])
+	if !ok {
+		return
+	}
+	currentSymbol := NormalizeSymbol(stringValue(current["symbol"]))
+	currentTimeframe := strings.ToLower(strings.TrimSpace(stringValue(current["timeframe"])))
+	if currentSymbol == "" || currentTimeframe == "" {
+		return
+	}
+	for _, item := range items {
+		if item == nil || boolValue(item["isClosed"]) {
+			continue
+		}
+		if NormalizeSymbol(stringValue(item["symbol"])) != currentSymbol {
+			continue
+		}
+		if strings.ToLower(strings.TrimSpace(stringValue(item["timeframe"]))) != currentTimeframe {
+			continue
+		}
+		itemStart, ok := signalBarTimestampMillis(item["barStart"])
+		if !ok || itemStart >= currentStart {
+			continue
+		}
+		itemEnd, ok := signalBarTimestampMillis(item["barEnd"])
+		if ok && itemEnd > currentStart {
+			continue
+		}
+		item["isClosed"] = true
+		item["closedByNextBar"] = true
+	}
+}
+
+func signalBarTimestampMillis(raw any) (int64, bool) {
+	if numeric, ok := toFloat64(raw); ok && numeric > 0 {
+		return int64(numeric), true
+	}
+	parsed := parseOptionalRFC3339(stringValue(raw))
+	if parsed.IsZero() {
+		return 0, false
+	}
+	return parsed.UTC().UnixMilli(), true
 }
 
 func deriveSignalBarStates(sourceStates map[string]any) map[string]any {

--- a/internal/service/signal_runtime_ws_test.go
+++ b/internal/service/signal_runtime_ws_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -655,6 +656,62 @@ func TestDeriveSignalBarStatesUsesOpenCurrentBarWithClosedHistory(t *testing.T) 
 	}
 	if boolValue(gate["longBreakoutShapeReady"]) {
 		t.Fatalf("expected breakout shape to remain false for this monotonic sample, got %#v", gate)
+	}
+}
+
+func TestMergeSignalBarHistoryClosesPriorOpenBarWhenNextBarArrives(t *testing.T) {
+	key := signalBindingMatchKey("binance-kline", "signal", "BTCUSDT", map[string]any{"timeframe": "30m"})
+	sourceStates := map[string]any{}
+	base := time.Date(2026, 4, 30, 5, 0, 0, 0, time.UTC)
+	eventTime := base
+
+	merge := func(start time.Time, high, low, close string, closed bool) {
+		sourceStates = mergeSignalSourceState(sourceStates, map[string]any{
+			"sourceKey":          "binance-kline",
+			"role":               "signal",
+			"streamType":         "signal_bar",
+			"symbol":             "BTCUSDT",
+			"subscriptionSymbol": "BTCUSDT",
+			"timeframe":          "30m",
+			"barStart":           strconv.FormatInt(start.UnixMilli(), 10),
+			"barEnd":             strconv.FormatInt(start.Add(30*time.Minute).Add(-time.Millisecond).UnixMilli(), 10),
+			"open":               close,
+			"high":               high,
+			"low":                low,
+			"close":              close,
+			"volume":             "100",
+			"isClosed":           closed,
+		}, eventTime)
+		eventTime = eventTime.Add(time.Second)
+	}
+
+	merge(base, "75587.90", "75388.30", "75400.00", true)
+	merge(base.Add(30*time.Minute), "75708.70", "75392.20", "75653.30", true)
+	merge(base.Add(60*time.Minute), "75653.30", "75555.80", "75641.60", false)
+	merge(base.Add(90*time.Minute), "75648.00", "75638.30", "75647.90", false)
+
+	entry := mapValue(sourceStates[key])
+	bars := normalizeSignalBarEntries(entry["bars"])
+	if len(bars) != 4 {
+		t.Fatalf("expected four signal bars, got %#v", bars)
+	}
+	if !boolValue(bars[2]["isClosed"]) || !boolValue(bars[2]["closedByNextBar"]) {
+		t.Fatalf("expected missing final close to be inferred on prior bar, got %#v", bars[2])
+	}
+	if boolValue(bars[3]["isClosed"]) {
+		t.Fatalf("expected latest bar to remain open, got %#v", bars[3])
+	}
+
+	states := deriveSignalBarStates(sourceStates)
+	state := mapValue(states[key])
+	if state == nil {
+		t.Fatalf("expected signal bar state, got %#v", states)
+	}
+	if got := stringValue(mapValue(state["prevBar1"])["barStart"]); got != strconv.FormatInt(base.Add(60*time.Minute).UnixMilli(), 10) {
+		t.Fatalf("expected inferred-closed 06:00 bar to become prevBar1, got %#v", state["prevBar1"])
+	}
+	if got := stringValue(mapValue(state["prevBar2"])["barStart"]); got != strconv.FormatInt(base.Add(30*time.Minute).UnixMilli(), 10) {
+		t.Fatalf("expected 05:30 bar to become prevBar2, got %#v", state["prevBar2"])
 	}
 }
 


### PR DESCRIPTION
## 目的
修复 signal runtime 偶发漏掉 kline final close (`x=true`) 时，下一根 bar 到来后上一根仍保持 `isClosed=false`，导致 `prevBar1/prevBar2` 窗口错位、BO / reentry 判断漏信号的问题。

这次排查中 `2026-04-30 06:00 UTC` 的 30m bar 没有进入 closed 序列，导致 `2026-04-30 06:30 UTC` 判断时仍用 05:30/05:00 作为 T1/T2。修复后，收到更新一根 signal bar 时，会对同 symbol/timeframe 的更早 open bar 做保守补闭合，让信号窗口恢复到最新连续历史。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [x] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) — 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？— 无
- [x] DB migration 是否具备向下兼容幂等性？— 不涉及 DB migration
- [x] 配置字段有没有无意被混改？— 无配置字段改动

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

验证已跑：

```bash
go test ./internal/service -run 'TestMergeSignalBarHistoryClosesPriorOpenBarWhenNextBarArrives|TestDeriveSignalBarStatesUsesOpenCurrentBarWithClosedHistory|TestDeriveSignalBarStatesDedupesCanonicalBarHistory|TestEvaluateSignalBarGateAllowsT2BreakoutTolerance'
go test ./...
```

新增回归覆盖：`TestMergeSignalBarHistoryClosesPriorOpenBarWhenNextBarArrives`，复现 06:00 final close 缺失、06:30 新 bar 到来后应将 06:00 补入 closed history 的场景。

Codex assisted with investigation, implementation, validation, branch push, and draft PR creation.
