### PR TITLE
[codex] fix live trade pair audit pnl

### DIFF
--- a/internal/service/live_trade_pairs.go
+++ b/internal/service/live_trade_pairs.go
@@ -99,10 +99,6 @@ func (p *Platform) ListLiveTradePairs(query domain.LiveTradePairQuery) ([]domain
 		uniqueSymbols[NormalizeSymbol(order.Symbol)] = struct{}{}
 	}
 
-	if len(uniqueSymbols) > 1 {
-		p.logger("service.live_trade_pairs", "session_id", liveSessionID).Warn("live session has orders for multiple symbols, trade pairs might be miscalculated")
-	}
-
 	fills, err := p.store.QueryFills(domain.FillQuery{OrderIDs: orderIDs})
 	if err != nil {
 		return nil, err
@@ -136,6 +132,43 @@ func (p *Platform) ListLiveTradePairs(query domain.LiveTradePairQuery) ([]domain
 		}
 	})
 
+	results := make([]domain.LiveTradePair, 0, len(fillEvents))
+	eventsBySymbol := make(map[string][]liveTradeFillEvent, len(uniqueSymbols))
+	for _, event := range fillEvents {
+		symbol := NormalizeSymbol(event.order.Symbol)
+		eventsBySymbol[symbol] = append(eventsBySymbol[symbol], event)
+	}
+	symbols := make([]string, 0, len(eventsBySymbol))
+	for symbol := range eventsBySymbol {
+		symbols = append(symbols, symbol)
+	}
+	sort.Strings(symbols)
+	for _, symbol := range symbols {
+		results = append(results, buildLiveTradePairsForSymbol(session, eventsBySymbol[symbol], currentPositionBySymbol)...)
+	}
+
+	sort.SliceStable(results, func(i, j int) bool {
+		leftTime := results[i].EntryAt
+		rightTime := results[j].EntryAt
+		switch {
+		case leftTime.After(rightTime):
+			return true
+		case leftTime.Before(rightTime):
+			return false
+		default:
+			return results[i].ID > results[j].ID
+		}
+	})
+	results = filterAndLimitLiveTradePairs(results, normalizeLiveTradePairStatus(query.Status), normalizeLiveTradePairLimit(query.Limit))
+	p.enrichLiveTradePairs(results, orderByID)
+	return results, nil
+}
+
+func buildLiveTradePairsForSymbol(
+	session domain.LiveSession,
+	fillEvents []liveTradeFillEvent,
+	currentPositionBySymbol map[string]domain.Position,
+) []domain.LiveTradePair {
 	state := pnlState{}
 	results := make([]domain.LiveTradePair, 0, len(fillEvents))
 	var current *liveTradePairBuilder
@@ -191,22 +224,7 @@ func (p *Platform) ListLiveTradePairs(query domain.LiveTradePairQuery) ([]domain
 	if current != nil {
 		results = append(results, current.finalizeOpen(currentPositionBySymbol[current.symbol]))
 	}
-
-	sort.SliceStable(results, func(i, j int) bool {
-		leftTime := results[i].EntryAt
-		rightTime := results[j].EntryAt
-		switch {
-		case leftTime.After(rightTime):
-			return true
-		case leftTime.Before(rightTime):
-			return false
-		default:
-			return results[i].ID > results[j].ID
-		}
-	})
-	results = filterAndLimitLiveTradePairs(results, normalizeLiveTradePairStatus(query.Status), normalizeLiveTradePairLimit(query.Limit))
-	p.enrichLiveTradePairs(results, orderByID)
-	return results, nil
+	return results
 }
 
 func liveTradePairRelevantFills(fills []domain.Fill, orderByID map[string]domain.Order) []domain.Fill {
@@ -296,6 +314,9 @@ func buildLiveTradeFillEvents(
 		if !ok {
 			continue
 		}
+		if !liveTradeOrderCanContributeFills(order) {
+			continue
+		}
 		eventTime := fill.CreatedAt
 		if fill.ExchangeTradeTime != nil && !fill.ExchangeTradeTime.IsZero() {
 			eventTime = fill.ExchangeTradeTime.UTC()
@@ -310,6 +331,19 @@ func buildLiveTradeFillEvents(
 		})
 	}
 	return items
+}
+
+func liveTradeOrderCanContributeFills(order domain.Order) bool {
+	switch strings.ToUpper(strings.TrimSpace(order.Status)) {
+	case "FILLED", "PARTIALLY_FILLED":
+		return true
+	case "CANCELLED", "CANCELED", "REJECTED", "EXPIRED", "EXPIRED_IN_MATCH":
+		return tradingQuantityPositive(parseFloatValue(order.Metadata["filledQuantity"])) ||
+			tradingQuantityPositive(parseFloatValue(order.Metadata["executedQty"])) ||
+			tradingQuantityPositive(parseFloatValue(order.Metadata["cumQty"]))
+	default:
+		return false
+	}
 }
 
 func decisionEventIDFromOrder(order domain.Order) string {

--- a/internal/service/live_trade_pairs_test.go
+++ b/internal/service/live_trade_pairs_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"fmt"
 	"math"
+	"strings"
 	"testing"
 	"time"
 
@@ -146,6 +147,326 @@ func TestListLiveTradePairsReturnsOpenTradeWithUnrealizedPnLAndAggregatedEntries
 	assertTradePairFloat(t, pair.NetPnL, pair.UnrealizedPnL-0.03)
 }
 
+func TestListLiveTradePairsKeepsInterleavedSymbolsIndependent(t *testing.T) {
+	platform, session := newLiveTradePairTestPlatform(t)
+	start := time.Date(2026, 4, 22, 6, 0, 0, 0, time.UTC)
+
+	btcEntry := createLiveTradePairOrder(t, platform, session, tradePairOrderFixture{
+		symbol:     "BTCUSDT",
+		side:       "BUY",
+		reason:     "initial",
+		quantity:   0.01,
+		price:      100,
+		fee:        0.10,
+		createdAt:  start,
+		fillAt:     start.Add(time.Second),
+		reduceOnly: false,
+	})
+	ethEntry := createLiveTradePairOrder(t, platform, session, tradePairOrderFixture{
+		symbol:     "ETHUSDT",
+		side:       "BUY",
+		reason:     "initial",
+		quantity:   0.5,
+		price:      200,
+		fee:        0.20,
+		createdAt:  start.Add(time.Minute),
+		fillAt:     start.Add(time.Minute + time.Second),
+		reduceOnly: false,
+	})
+	btcExit := createLiveTradePairOrder(t, platform, session, tradePairOrderFixture{
+		symbol:     "BTCUSDT",
+		side:       "SELL",
+		reason:     "PT",
+		quantity:   0.01,
+		price:      110,
+		fee:        0.10,
+		createdAt:  start.Add(2 * time.Minute),
+		fillAt:     start.Add(2*time.Minute + time.Second),
+		reduceOnly: true,
+	})
+	ethExit := createLiveTradePairOrder(t, platform, session, tradePairOrderFixture{
+		symbol:     "ETHUSDT",
+		side:       "SELL",
+		reason:     "SL",
+		quantity:   0.5,
+		price:      190,
+		fee:        0.20,
+		createdAt:  start.Add(3 * time.Minute),
+		fillAt:     start.Add(3*time.Minute + time.Second),
+		reduceOnly: true,
+	})
+
+	items, err := platform.ListLiveTradePairs(domain.LiveTradePairQuery{
+		LiveSessionID: session.ID,
+		Status:        "closed",
+		Limit:         10,
+	})
+	if err != nil {
+		t.Fatalf("list live trade pairs: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("expected 2 closed pairs, got %d: %#v", len(items), items)
+	}
+
+	bySymbol := map[string]domain.LiveTradePair{}
+	for _, item := range items {
+		bySymbol[item.Symbol] = item
+	}
+	btcPair, ok := bySymbol["BTCUSDT"]
+	if !ok {
+		t.Fatalf("missing BTCUSDT pair: %#v", items)
+	}
+	if got := btcPair.EntryOrderIDs; len(got) != 1 || got[0] != btcEntry.ID {
+		t.Fatalf("expected BTC entry order %s, got %#v", btcEntry.ID, got)
+	}
+	if got := btcPair.ExitOrderIDs; len(got) != 1 || got[0] != btcExit.ID {
+		t.Fatalf("expected BTC exit order %s, got %#v", btcExit.ID, got)
+	}
+	assertTradePairFloat(t, btcPair.EntryQuantity, 0.01)
+	assertTradePairFloat(t, btcPair.RealizedPnL, 0.10)
+	assertTradePairFloat(t, btcPair.NetPnL, -0.10)
+
+	ethPair, ok := bySymbol["ETHUSDT"]
+	if !ok {
+		t.Fatalf("missing ETHUSDT pair: %#v", items)
+	}
+	if got := ethPair.EntryOrderIDs; len(got) != 1 || got[0] != ethEntry.ID {
+		t.Fatalf("expected ETH entry order %s, got %#v", ethEntry.ID, got)
+	}
+	if got := ethPair.ExitOrderIDs; len(got) != 1 || got[0] != ethExit.ID {
+		t.Fatalf("expected ETH exit order %s, got %#v", ethExit.ID, got)
+	}
+	assertTradePairFloat(t, ethPair.EntryQuantity, 0.5)
+	assertTradePairFloat(t, ethPair.RealizedPnL, -5)
+	assertTradePairFloat(t, ethPair.NetPnL, -5.4)
+}
+
+func TestListLiveTradePairsIgnoresCancelledOrderWithoutExecutedQuantity(t *testing.T) {
+	platform, session := newLiveTradePairTestPlatform(t)
+	start := time.Date(2026, 4, 22, 6, 0, 0, 0, time.UTC)
+
+	cancelled := createLiveTradePairOrder(t, platform, session, tradePairOrderFixture{
+		status:     "CANCELLED",
+		side:       "BUY",
+		reason:     "initial",
+		quantity:   1,
+		price:      100,
+		fee:        0.10,
+		createdAt:  start,
+		fillAt:     start.Add(time.Second),
+		reduceOnly: false,
+	})
+	entry := createLiveTradePairOrder(t, platform, session, tradePairOrderFixture{
+		side:       "BUY",
+		reason:     "initial",
+		quantity:   1,
+		price:      110,
+		fee:        0.10,
+		createdAt:  start.Add(time.Minute),
+		fillAt:     start.Add(time.Minute + time.Second),
+		reduceOnly: false,
+	})
+	exit := createLiveTradePairOrder(t, platform, session, tradePairOrderFixture{
+		side:       "SELL",
+		reason:     "PT",
+		quantity:   1,
+		price:      120,
+		fee:        0.10,
+		createdAt:  start.Add(2 * time.Minute),
+		fillAt:     start.Add(2*time.Minute + time.Second),
+		reduceOnly: true,
+	})
+
+	items, err := platform.ListLiveTradePairs(domain.LiveTradePairQuery{
+		LiveSessionID: session.ID,
+		Status:        "closed",
+		Limit:         10,
+	})
+	if err != nil {
+		t.Fatalf("list live trade pairs: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 closed pair, got %d: %#v", len(items), items)
+	}
+	pair := items[0]
+	if got := pair.EntryOrderIDs; len(got) != 1 || got[0] != entry.ID {
+		t.Fatalf("expected entry order %s only, got %#v; cancelled order was %s", entry.ID, got, cancelled.ID)
+	}
+	if got := pair.ExitOrderIDs; len(got) != 1 || got[0] != exit.ID {
+		t.Fatalf("expected exit order %s, got %#v", exit.ID, got)
+	}
+	assertTradePairFloat(t, pair.EntryAvgPrice, 110)
+	assertTradePairFloat(t, pair.ExitAvgPrice, 120)
+	assertTradePairFloat(t, pair.RealizedPnL, 10)
+	assertTradePairFloat(t, pair.Fees, 0.20)
+	assertTradePairFloat(t, pair.NetPnL, 9.80)
+}
+
+func TestListLiveTradePairsKeepsPartiallyFilledCancelledOrderWithExecutedQuantity(t *testing.T) {
+	platform, session := newLiveTradePairTestPlatform(t)
+	start := time.Date(2026, 4, 22, 6, 0, 0, 0, time.UTC)
+
+	entry := createLiveTradePairOrder(t, platform, session, tradePairOrderFixture{
+		status:     "CANCELLED",
+		side:       "BUY",
+		reason:     "initial",
+		quantity:   0.4,
+		price:      100,
+		fee:        0.10,
+		createdAt:  start,
+		fillAt:     start.Add(time.Second),
+		reduceOnly: false,
+		metadata: map[string]any{
+			"filledQuantity": 0.4,
+		},
+	})
+	exit := createLiveTradePairOrder(t, platform, session, tradePairOrderFixture{
+		side:       "SELL",
+		reason:     "PT",
+		quantity:   0.4,
+		price:      125,
+		fee:        0.10,
+		createdAt:  start.Add(time.Minute),
+		fillAt:     start.Add(time.Minute + time.Second),
+		reduceOnly: true,
+	})
+
+	items, err := platform.ListLiveTradePairs(domain.LiveTradePairQuery{
+		LiveSessionID: session.ID,
+		Status:        "closed",
+		Limit:         10,
+	})
+	if err != nil {
+		t.Fatalf("list live trade pairs: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 closed pair, got %d: %#v", len(items), items)
+	}
+	pair := items[0]
+	if got := pair.EntryOrderIDs; len(got) != 1 || got[0] != entry.ID {
+		t.Fatalf("expected cancelled partial entry order %s, got %#v", entry.ID, got)
+	}
+	if got := pair.ExitOrderIDs; len(got) != 1 || got[0] != exit.ID {
+		t.Fatalf("expected exit order %s, got %#v", exit.ID, got)
+	}
+	assertTradePairFloat(t, pair.RealizedPnL, 10)
+	assertTradePairFloat(t, pair.NetPnL, 9.80)
+}
+
+func TestListLiveTradePairsIgnoresRejectedOrderWithZeroExecutedQuantity(t *testing.T) {
+	platform, session := newLiveTradePairTestPlatform(t)
+	start := time.Date(2026, 4, 22, 6, 0, 0, 0, time.UTC)
+
+	rejected := createLiveTradePairOrder(t, platform, session, tradePairOrderFixture{
+		status:     "REJECTED",
+		side:       "BUY",
+		reason:     "initial",
+		quantity:   1,
+		price:      100,
+		fee:        0.10,
+		createdAt:  start,
+		fillAt:     start.Add(time.Second),
+		reduceOnly: false,
+		metadata: map[string]any{
+			"executedQty": 0,
+		},
+	})
+	entry := createLiveTradePairOrder(t, platform, session, tradePairOrderFixture{
+		side:       "BUY",
+		reason:     "initial",
+		quantity:   1,
+		price:      110,
+		fee:        0.10,
+		createdAt:  start.Add(time.Minute),
+		fillAt:     start.Add(time.Minute + time.Second),
+		reduceOnly: false,
+	})
+	exit := createLiveTradePairOrder(t, platform, session, tradePairOrderFixture{
+		side:       "SELL",
+		reason:     "PT",
+		quantity:   1,
+		price:      120,
+		fee:        0.10,
+		createdAt:  start.Add(2 * time.Minute),
+		fillAt:     start.Add(2*time.Minute + time.Second),
+		reduceOnly: true,
+	})
+
+	items, err := platform.ListLiveTradePairs(domain.LiveTradePairQuery{
+		LiveSessionID: session.ID,
+		Status:        "closed",
+		Limit:         10,
+	})
+	if err != nil {
+		t.Fatalf("list live trade pairs: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 closed pair, got %d: %#v", len(items), items)
+	}
+	pair := items[0]
+	if got := pair.EntryOrderIDs; len(got) != 1 || got[0] != entry.ID {
+		t.Fatalf("expected entry order %s only, got %#v; rejected order was %s", entry.ID, got, rejected.ID)
+	}
+	if got := pair.ExitOrderIDs; len(got) != 1 || got[0] != exit.ID {
+		t.Fatalf("expected exit order %s, got %#v", exit.ID, got)
+	}
+	assertTradePairFloat(t, pair.EntryAvgPrice, 110)
+	assertTradePairFloat(t, pair.RealizedPnL, 10)
+	assertTradePairFloat(t, pair.NetPnL, 9.80)
+}
+
+func TestListLiveTradePairsKeepsExpiredOrderWithCumQty(t *testing.T) {
+	platform, session := newLiveTradePairTestPlatform(t)
+	start := time.Date(2026, 4, 22, 6, 0, 0, 0, time.UTC)
+
+	entry := createLiveTradePairOrder(t, platform, session, tradePairOrderFixture{
+		status:     "EXPIRED",
+		side:       "BUY",
+		reason:     "initial",
+		quantity:   0.25,
+		price:      100,
+		fee:        0.05,
+		createdAt:  start,
+		fillAt:     start.Add(time.Second),
+		reduceOnly: false,
+		metadata: map[string]any{
+			"cumQty": 0.25,
+		},
+	})
+	exit := createLiveTradePairOrder(t, platform, session, tradePairOrderFixture{
+		side:       "SELL",
+		reason:     "PT",
+		quantity:   0.25,
+		price:      120,
+		fee:        0.05,
+		createdAt:  start.Add(time.Minute),
+		fillAt:     start.Add(time.Minute + time.Second),
+		reduceOnly: true,
+	})
+
+	items, err := platform.ListLiveTradePairs(domain.LiveTradePairQuery{
+		LiveSessionID: session.ID,
+		Status:        "closed",
+		Limit:         10,
+	})
+	if err != nil {
+		t.Fatalf("list live trade pairs: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 closed pair, got %d: %#v", len(items), items)
+	}
+	pair := items[0]
+	if got := pair.EntryOrderIDs; len(got) != 1 || got[0] != entry.ID {
+		t.Fatalf("expected expired partial entry order %s, got %#v", entry.ID, got)
+	}
+	if got := pair.ExitOrderIDs; len(got) != 1 || got[0] != exit.ID {
+		t.Fatalf("expected exit order %s, got %#v", exit.ID, got)
+	}
+	assertTradePairFloat(t, pair.RealizedPnL, 5)
+	assertTradePairFloat(t, pair.Fees, 0.10)
+	assertTradePairFloat(t, pair.NetPnL, 4.90)
+}
+
 func TestListLiveTradePairsFallsBackWhenTelemetryTablesAreUnavailable(t *testing.T) {
 	baseStore := memory.NewStore()
 	platform := NewPlatform(&testMissingLiveTradePairTelemetryStore{Store: baseStore})
@@ -253,6 +574,8 @@ type liveTradeFixture struct {
 }
 
 type tradePairOrderFixture struct {
+	symbol            string
+	status            string
 	side              string
 	reason            string
 	quantity          float64
@@ -263,6 +586,7 @@ type tradePairOrderFixture struct {
 	reduceOnly        bool
 	decisionEventID   string
 	targetPriceSource string
+	metadata          map[string]any
 }
 
 type liveTradePairTargetedQueryStore struct {
@@ -399,6 +723,10 @@ func createLiveTradePairOrder(t *testing.T, platform *Platform, session domain.L
 	if fixture.reduceOnly {
 		role = "exit"
 	}
+	symbol := NormalizeSymbol(fixture.symbol)
+	if symbol == "" {
+		symbol = "BTCUSDT"
+	}
 	orderMeta := map[string]any{
 		"liveSessionId": session.ID,
 		"executionMode": "live",
@@ -406,7 +734,7 @@ func createLiveTradePairOrder(t *testing.T, platform *Platform, session domain.L
 			"role":     role,
 			"reason":   fixture.reason,
 			"side":     fixture.side,
-			"symbol":   "BTCUSDT",
+			"symbol":   symbol,
 			"quantity": fixture.quantity,
 			"status":   "dispatchable",
 			"metadata": map[string]any{
@@ -418,11 +746,14 @@ func createLiveTradePairOrder(t *testing.T, platform *Platform, session domain.L
 		orderMeta["decisionEventId"] = fixture.decisionEventID
 		mapValue(orderMeta["executionProposal"])["decisionEventId"] = fixture.decisionEventID
 	}
+	for key, value := range fixture.metadata {
+		orderMeta[key] = value
+	}
 
 	order, err := platform.store.CreateOrder(domain.Order{
 		AccountID:         session.AccountID,
 		StrategyVersionID: "strategy-version-test",
-		Symbol:            "BTCUSDT",
+		Symbol:            symbol,
 		Side:              fixture.side,
 		Type:              "MARKET",
 		Status:            "FILLED",
@@ -434,6 +765,16 @@ func createLiveTradePairOrder(t *testing.T, platform *Platform, session domain.L
 	})
 	if err != nil {
 		t.Fatalf("create order: %v", err)
+	}
+	status := strings.ToUpper(strings.TrimSpace(fixture.status))
+	if status == "" {
+		status = "FILLED"
+	}
+	order.Status = status
+	order.Metadata = orderMeta
+	order, err = platform.store.UpdateOrder(order)
+	if err != nil {
+		t.Fatalf("update order: %v", err)
 	}
 	if _, err := platform.store.CreateFill(domain.Fill{
 		OrderID:           order.ID,


### PR DESCRIPTION
## 目的
修复管理控制 / 事务审计追溯页卡里开平订单对和盈亏统计不准的问题。

根因有两层：
- 追溯聚合此前用单个净持仓 / PnL 状态机扫描整个 live session，多 symbol 交错成交时会把不同 symbol 的订单互相配对。
- `CANCELLED` / `REJECTED` / `EXPIRED` 这类无执行量证据的终态订单，如果残留脏 fill，会被当成真实成交参与追溯，污染开仓均价、平仓配对和 PnL。

本 PR 将 trade pair 构建按 symbol 独立聚合，并要求终态取消/拒绝/过期订单必须带有 `filledQuantity` / `executedQty` / `cumQty` 执行量证据才参与追溯；部分成交后取消的订单仍保留。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [x] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) - 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？- 无
- [x] DB migration 是否具备向下兼容幂等性？- 无 migration
- [x] 配置字段有没有无意被混改？- 无配置改动

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

本地验证：
- `go test ./internal/service`
- `go test ./internal/http`
- pre-push harness checks passed, including high-risk defaults check, env safety check, and backend package checks.

新增回归覆盖：
- `TestListLiveTradePairsIgnoresCancelledOrderWithoutExecutedQuantity`
- `TestListLiveTradePairsKeepsPartiallyFilledCancelledOrderWithExecutedQuantity`
- `TestListLiveTradePairsKeepsInterleavedSymbolsIndependent`
