### PR TITLE
[codex] keep exchange-backed terminal fills in trace

### DIFF
--- a/internal/service/live_trade_pairs.go
+++ b/internal/service/live_trade_pairs.go
@@ -314,7 +314,7 @@ func buildLiveTradeFillEvents(
 		if !ok {
 			continue
 		}
-		if !liveTradeOrderCanContributeFills(order) {
+		if !liveTradeOrderCanContributeFill(order, fill) {
 			continue
 		}
 		eventTime := fill.CreatedAt
@@ -333,11 +333,14 @@ func buildLiveTradeFillEvents(
 	return items
 }
 
-func liveTradeOrderCanContributeFills(order domain.Order) bool {
+func liveTradeOrderCanContributeFill(order domain.Order, fill domain.Fill) bool {
 	switch strings.ToUpper(strings.TrimSpace(order.Status)) {
 	case "FILLED", "PARTIALLY_FILLED":
 		return true
 	case "CANCELLED", "CANCELED", "REJECTED", "EXPIRED", "EXPIRED_IN_MATCH":
+		if strings.TrimSpace(fill.ExchangeTradeID) != "" {
+			return true
+		}
 		return tradingQuantityPositive(parseFloatValue(order.Metadata["filledQuantity"])) ||
 			tradingQuantityPositive(parseFloatValue(order.Metadata["executedQty"])) ||
 			tradingQuantityPositive(parseFloatValue(order.Metadata["cumQty"]))

--- a/internal/service/live_trade_pairs_test.go
+++ b/internal/service/live_trade_pairs_test.go
@@ -353,6 +353,56 @@ func TestListLiveTradePairsKeepsPartiallyFilledCancelledOrderWithExecutedQuantit
 	assertTradePairFloat(t, pair.NetPnL, 9.80)
 }
 
+func TestListLiveTradePairsKeepsCancelledOrderWithExchangeTradeID(t *testing.T) {
+	platform, session := newLiveTradePairTestPlatform(t)
+	start := time.Date(2026, 4, 22, 6, 0, 0, 0, time.UTC)
+
+	entry := createLiveTradePairOrder(t, platform, session, tradePairOrderFixture{
+		side:       "BUY",
+		reason:     "initial",
+		quantity:   1,
+		price:      100,
+		fee:        0.10,
+		createdAt:  start,
+		fillAt:     start.Add(time.Second),
+		reduceOnly: false,
+	})
+	exit := createLiveTradePairOrder(t, platform, session, tradePairOrderFixture{
+		status:          "CANCELLED",
+		side:            "SELL",
+		reason:          "PT",
+		quantity:        1,
+		price:           120,
+		fee:             0.10,
+		createdAt:       start.Add(time.Minute),
+		fillAt:          start.Add(time.Minute + time.Second),
+		reduceOnly:      true,
+		exchangeTradeID: "exchange-trade-exit-1",
+	})
+
+	items, err := platform.ListLiveTradePairs(domain.LiveTradePairQuery{
+		LiveSessionID: session.ID,
+		Status:        "closed",
+		Limit:         10,
+	})
+	if err != nil {
+		t.Fatalf("list live trade pairs: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 closed pair, got %d: %#v", len(items), items)
+	}
+	pair := items[0]
+	if got := pair.EntryOrderIDs; len(got) != 1 || got[0] != entry.ID {
+		t.Fatalf("expected entry order %s, got %#v", entry.ID, got)
+	}
+	if got := pair.ExitOrderIDs; len(got) != 1 || got[0] != exit.ID {
+		t.Fatalf("expected cancelled exchange-backed exit order %s, got %#v", exit.ID, got)
+	}
+	assertTradePairFloat(t, pair.RealizedPnL, 20)
+	assertTradePairFloat(t, pair.Fees, 0.20)
+	assertTradePairFloat(t, pair.NetPnL, 19.80)
+}
+
 func TestListLiveTradePairsIgnoresRejectedOrderWithZeroExecutedQuantity(t *testing.T) {
 	platform, session := newLiveTradePairTestPlatform(t)
 	start := time.Date(2026, 4, 22, 6, 0, 0, 0, time.UTC)
@@ -576,6 +626,7 @@ type liveTradeFixture struct {
 type tradePairOrderFixture struct {
 	symbol            string
 	status            string
+	exchangeTradeID   string
 	side              string
 	reason            string
 	quantity          float64
@@ -778,6 +829,7 @@ func createLiveTradePairOrder(t *testing.T, platform *Platform, session domain.L
 	}
 	if _, err := platform.store.CreateFill(domain.Fill{
 		OrderID:           order.ID,
+		ExchangeTradeID:   fixture.exchangeTradeID,
 		Price:             fixture.price,
 		Quantity:          fixture.quantity,
 		Fee:               fixture.fee,


### PR DESCRIPTION
## 目的
修复 PR #365 CD 后追溯页卡仍显示“持仓中”的边界情况。

原因：#365 为了过滤 `CANCELLED` / `REJECTED` / `EXPIRED` 订单上的脏 fill，只允许这些终态订单在 metadata 存在 `filledQuantity` / `executedQty` / `cumQty` 时参与 trade pair 追溯。但生产里可能存在真实平仓 fill 挂在 `CANCELLED` 订单上，且订单 metadata 没写执行量；这会导致真实 exit fill 被过滤，entry 无法被抵消，于是追溯仍显示 open/持仓中。

本 PR 将过滤条件补齐：对于这些终态订单，如果 fill 自身带有 `exchangeTradeID`，也视为交易所权威成交证据，允许参与追溯。无 metadata 执行量、且没有 exchange trade id 的脏 fill 仍会被过滤。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [x] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) - 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？- 无
- [x] DB migration 是否具备向下兼容幂等性？- 无 migration
- [x] 配置字段有没有无意被混改？- 无配置改动

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

本地验证：
- `go test ./internal/service -run 'TestListLiveTradePairs(KeepsCancelledOrderWithExchangeTradeID|IgnoresCancelled|KeepsPartially|IgnoresRejected|KeepsExpired|KeepsInterleaved)'`
- `go test ./internal/service`
- `go test ./internal/http`

新增回归：
- `TestListLiveTradePairsKeepsCancelledOrderWithExchangeTradeID`
