### PR TITLE
[codex] prevent exit-only trace reversal pairs

### DIFF
--- a/internal/service/live_trade_pairs.go
+++ b/internal/service/live_trade_pairs.go
@@ -181,7 +181,17 @@ func buildLiveTradePairsForSymbol(
 		absQty := absFloat(signedQty)
 		remainingFee := event.fill.Fee
 		prevNetQty := state.netQty
+		exitOnly := liveTradeFillIsExitOnly(event)
 		if prevNetQty == 0 || sameSign(prevNetQty, signedQty) {
+			if exitOnly {
+				pairIndex++
+				orphan := newLiveTradePairBuilder(pairIndex, session, event.order.Symbol, liveTradeSideFromSignedQty(-signedQty))
+				orphan.addNote("exit-only-fill-without-derived-position")
+				orphan.exitVerdict = "orphan-exit"
+				orphan.addExit(event, absQty, remainingFee, 0)
+				results = append(results, orphan.finalizeClosed())
+				continue
+			}
 			if current == nil {
 				pairIndex++
 				current = newLiveTradePairBuilder(pairIndex, session, event.order.Symbol, liveTradeSideFromSignedQty(signedQty))
@@ -208,13 +218,23 @@ func buildLiveTradePairsForSymbol(
 		}
 		current.addExit(event, closingQty, closingFee, realizedPnL)
 
-		applyPnLFill(&state, event.order.Side, event.fill.Quantity, event.fill.Price)
 		remainingQty := absQty - closingQty
+		appliedQty := event.fill.Quantity
+		if exitOnly && tradingQuantityPositive(remainingQty) {
+			current.addNote("exit-only-fill-exceeded-derived-position")
+			appliedQty = closingQty
+		}
+		if tradingQuantityPositive(appliedQty) {
+			applyPnLFill(&state, event.order.Side, appliedQty, event.fill.Price)
+		}
 		if !tradingQuantityExceeds(absFloat(prevNetQty)-closingQty, 0) {
 			results = append(results, current.finalizeClosed())
 			current = nil
 		}
 		if tradingQuantityPositive(remainingQty) {
+			if exitOnly {
+				continue
+			}
 			pairIndex++
 			current = newLiveTradePairBuilder(pairIndex, session, event.order.Symbol, liveTradeSideFromSignedQty(signedQty))
 			current.addEntry(event, remainingQty, remainingFee)
@@ -236,6 +256,12 @@ func liveTradePairRelevantFills(fills []domain.Fill, orderByID map[string]domain
 		items = append(items, fill)
 	}
 	return items
+}
+
+func liveTradeFillIsExitOnly(event liveTradeFillEvent) bool {
+	return event.order.EffectiveReduceOnly() ||
+		event.order.EffectiveClosePosition() ||
+		strings.EqualFold(strings.TrimSpace(event.intent.role), "exit")
 }
 
 func (p *Platform) fetchLiveTradeDecisionEvents(liveSessionID string, orderByID map[string]domain.Order) (map[string]domain.StrategyDecisionEvent, error) {
@@ -496,7 +522,9 @@ func (b *liveTradePairBuilder) addExit(event liveTradeFillEvent, qty, fee, reali
 
 func (b *liveTradePairBuilder) finalizeClosed() domain.LiveTradePair {
 	verdict := "normal"
-	if b.exitQty <= 0 {
+	if b.exitVerdict == "orphan-exit" {
+		verdict = "orphan-exit"
+	} else if b.exitQty <= 0 {
 		verdict = "orphan-exit"
 	} else if b.hasUnsafeExitOrder {
 		verdict = "mismatch"

--- a/internal/service/live_trade_pairs_test.go
+++ b/internal/service/live_trade_pairs_test.go
@@ -403,6 +403,66 @@ func TestListLiveTradePairsKeepsCancelledOrderWithExchangeTradeID(t *testing.T) 
 	assertTradePairFloat(t, pair.NetPnL, 19.80)
 }
 
+func TestListLiveTradePairsDoesNotOpenReversalFromOversizedReduceOnlyExit(t *testing.T) {
+	platform, session := newLiveTradePairTestPlatform(t)
+	start := time.Date(2026, 4, 22, 6, 0, 0, 0, time.UTC)
+
+	entry := createLiveTradePairOrder(t, platform, session, tradePairOrderFixture{
+		side:       "BUY",
+		reason:     "initial",
+		quantity:   0.0015,
+		price:      100,
+		fee:        0.01,
+		createdAt:  start,
+		fillAt:     start.Add(time.Second),
+		reduceOnly: false,
+	})
+	exit := createLiveTradePairOrder(t, platform, session, tradePairOrderFixture{
+		side:       "SELL",
+		reason:     "SL",
+		quantity:   0.013,
+		price:      120,
+		fee:        0.10,
+		createdAt:  start.Add(time.Minute),
+		fillAt:     start.Add(time.Minute + time.Second),
+		reduceOnly: true,
+	})
+
+	openItems, err := platform.ListLiveTradePairs(domain.LiveTradePairQuery{
+		LiveSessionID: session.ID,
+		Status:        "open",
+		Limit:         10,
+	})
+	if err != nil {
+		t.Fatalf("list open live trade pairs: %v", err)
+	}
+	if len(openItems) != 0 {
+		t.Fatalf("expected no open pair from oversized reduce-only exit, got %#v", openItems)
+	}
+
+	items, err := platform.ListLiveTradePairs(domain.LiveTradePairQuery{
+		LiveSessionID: session.ID,
+		Status:        "closed",
+		Limit:         10,
+	})
+	if err != nil {
+		t.Fatalf("list closed live trade pairs: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 closed pair, got %d: %#v", len(items), items)
+	}
+	pair := items[0]
+	if got := pair.EntryOrderIDs; len(got) != 1 || got[0] != entry.ID {
+		t.Fatalf("expected entry order %s, got %#v", entry.ID, got)
+	}
+	if got := pair.ExitOrderIDs; len(got) != 1 || got[0] != exit.ID {
+		t.Fatalf("expected exit order %s, got %#v", exit.ID, got)
+	}
+	assertTradePairFloat(t, pair.EntryQuantity, 0.0015)
+	assertTradePairFloat(t, pair.ExitQuantity, 0.0015)
+	assertTradePairHasNote(t, pair, "exit-only-fill-exceeded-derived-position")
+}
+
 func TestListLiveTradePairsIgnoresRejectedOrderWithZeroExecutedQuantity(t *testing.T) {
 	platform, session := newLiveTradePairTestPlatform(t)
 	start := time.Date(2026, 4, 22, 6, 0, 0, 0, time.UTC)
@@ -846,6 +906,16 @@ func assertTradePairFloat(t *testing.T, got, want float64) {
 	if math.Abs(got-want) > 1e-9 {
 		t.Fatalf("expected %.12f, got %.12f", want, got)
 	}
+}
+
+func assertTradePairHasNote(t *testing.T, pair domain.LiveTradePair, want string) {
+	t.Helper()
+	for _, note := range pair.Notes {
+		if note == want {
+			return
+		}
+	}
+	t.Fatalf("expected note %q in %#v", want, pair.Notes)
 }
 
 func timePointer(value time.Time) *time.Time {


### PR DESCRIPTION
## 目的
修复生产追溯页卡仍显示“持仓中”的真实根因。

使用 `bktrader-ctl --json` 查生产事实后确认：
- `bktrader-ctl position list --json` 返回空数组，本地当前无持仓。
- 最近一组订单是 `BUY FILLED 0.013` 后接 `SELL reduceOnly FILLED 0.013`，真实业务上应已平仓。
- 用生产 `order list` + `fill list` 复算当前追溯状态机后发现，最新 `SELL reduceOnly` 因历史派生净仓只剩约 `0.0015 LONG`，被拆成：`0.0015` 用于平仓，剩余约 `0.0115` 被错误当成反手开空，所以页面显示 `SHORT 持仓中`。

修复：trade pair 追溯中，`reduceOnly` / `closePosition` / intent role=`exit` 的成交只能作为 exit 消费派生仓位，不能把超出派生仓位的剩余数量开启 reversal entry。若发生超额，给 pair 加 `exit-only-fill-exceeded-derived-position` note；若没有可匹配派生仓位，则记录为 `orphan-exit`，但不生成 open pair。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [x] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) - 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？- 无
- [x] DB migration 是否具备向下兼容幂等性？- 无 migration
- [x] 配置字段有没有无意被混改？- 无配置改动

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

生产只读查询：
- `bktrader-ctl status --json`
- `bktrader-ctl live list --json`
- `bktrader-ctl order list --json`
- `bktrader-ctl fill list --json`
- `bktrader-ctl position list --json`
- `bktrader-ctl order get order-1777559306848846627 --json`
- `bktrader-ctl order get order-1777559556143983631 --json`

本地验证：
- `go test ./internal/service -run 'TestListLiveTradePairs(DoesNotOpenReversalFromOversizedReduceOnlyExit|KeepsCancelledOrderWithExchangeTradeID|IgnoresCancelled|KeepsPartially|IgnoresRejected|KeepsExpired|KeepsInterleaved)'`
- `go test ./internal/service`
- `go test ./internal/http`
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`

新增回归：
- `TestListLiveTradePairsDoesNotOpenReversalFromOversizedReduceOnlyExit`
