### PR TITLE
[codex] Add supervisor signal restart action

### DIFF
--- a/docs/runtime-supervisor.md
+++ b/docs/runtime-supervisor.md
@@ -369,7 +369,9 @@ func ClearRestartState(state map[string]any, keys []string)
 
 ### Dashboard 视图
 
-前端 console 的 Runtime Supervisor 页面读取 `GET /api/v1/supervisor/status`，只展示 supervisor policy、service target、runtime 状态、`applicationRestartPlan`、应用内控制动作、`containerFallbackCandidate`、fallback `decision`、executor `kind`/`dryRun` 和 dry-run audit 摘要。该页面不提交 runtime 或容器控制请求；真正执行容器级 restart 前仍需单独 PR 设计 executor、权限边界和部署安全审查。
+前端 console 的 Runtime Supervisor 页面读取 `GET /api/v1/supervisor/status`，展示 supervisor policy、service target、runtime 状态、`applicationRestartPlan`、应用内控制动作、`containerFallbackCandidate`、fallback `decision`、executor `kind`/`dryRun` 和 dry-run audit 摘要。
+
+当前页面只开放最小的手动应用内控制入口：对 `runtimeKind=signal` / `signal-runtime` 的 runtime，可在显式确认并填写 reason 后调用现有 `POST /api/v1/runtime/restart`。该入口固定 `confirm=true`、`force=false`，不支持 live-session restart，不提交 suppress/resume，不触碰 Docker/container fallback。真正执行容器级 restart 前仍需单独 PR 设计 executor、权限边界和部署安全审查。
 
 ## 7. 安全边界
 

--- a/web/console/src/pages/SupervisorStage.tsx
+++ b/web/console/src/pages/SupervisorStage.tsx
@@ -15,6 +15,14 @@ import { Badge } from '../components/ui/badge';
 import { Button } from '../components/ui/button';
 import { Card, CardAction, CardContent, CardHeader, CardTitle } from '../components/ui/card';
 import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '../components/ui/dialog';
+import {
   Table,
   TableBody,
   TableCell,
@@ -23,6 +31,7 @@ import {
   TableRow,
 } from '../components/ui/table';
 import { Separator } from '../components/ui/separator';
+import { Textarea } from '../components/ui/textarea';
 import { cn } from '../lib/utils';
 import { fetchJSON } from '../utils/api';
 import { formatTime, shrink } from '../utils/format';
@@ -35,6 +44,7 @@ import {
 
 type LoadState = 'idle' | 'loading' | 'loaded' | 'error';
 type BadgeVariant = NonNullable<React.ComponentProps<typeof Badge>['variant']>;
+type RuntimeRow = RuntimeSupervisorRuntimeStatus & { targetName: string };
 
 const REFRESH_INTERVAL_MS = 15_000;
 
@@ -166,10 +176,28 @@ function applicationRestartPlanTitle(plan?: RuntimeSupervisorRuntimeStatus['appl
   ].filter(Boolean).join(' ');
 }
 
+function runtimeRestartSupported(runtime: RuntimeSupervisorRuntimeStatus) {
+  const kind = String(runtime.runtimeKind || '').trim().toLowerCase();
+  return kind === 'signal' || kind === 'signal-runtime';
+}
+
+function runtimeRestartActionKey(runtime: RuntimeRow) {
+  return `${runtime.targetName}:${runtime.runtimeKind}:${runtime.runtimeId}`;
+}
+
+function dashboardRuntimeRestartReason(runtime: RuntimeRow) {
+  return `dashboard manual restart: target=${runtime.targetName} runtime=${runtime.runtimeId}`;
+}
+
 export function SupervisorStage() {
   const [snapshot, setSnapshot] = useState<RuntimeSupervisorSnapshot | null>(null);
   const [loadState, setLoadState] = useState<LoadState>('idle');
   const [error, setError] = useState<string | null>(null);
+  const [restartDialogRuntime, setRestartDialogRuntime] = useState<RuntimeRow | null>(null);
+  const [restartReason, setRestartReason] = useState('');
+  const [restartSubmittingKey, setRestartSubmittingKey] = useState<string | null>(null);
+  const [restartNotice, setRestartNotice] = useState<string | null>(null);
+  const [restartError, setRestartError] = useState<string | null>(null);
 
   const loadSnapshot = useCallback(async (silent = false) => {
     if (!silent) {
@@ -185,6 +213,57 @@ export function SupervisorStage() {
       setLoadState('error');
     }
   }, []);
+
+  const openRestartDialog = useCallback((runtime: RuntimeRow) => {
+    setRestartDialogRuntime(runtime);
+    setRestartReason(dashboardRuntimeRestartReason(runtime));
+    setRestartNotice(null);
+    setRestartError(null);
+  }, []);
+
+  const closeRestartDialog = useCallback(() => {
+    if (restartSubmittingKey) {
+      return;
+    }
+    setRestartDialogRuntime(null);
+    setRestartReason('');
+  }, [restartSubmittingKey]);
+
+  const submitRuntimeRestart = useCallback(async () => {
+    if (!restartDialogRuntime) {
+      return;
+    }
+    const reason = restartReason.trim();
+    if (!reason) {
+      setRestartError('restart reason is required');
+      return;
+    }
+    const key = runtimeRestartActionKey(restartDialogRuntime);
+    setRestartSubmittingKey(key);
+    setRestartError(null);
+    setRestartNotice(null);
+    try {
+      await fetchJSON('/api/v1/runtime/restart', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          runtimeId: restartDialogRuntime.runtimeId,
+          runtimeKind: restartDialogRuntime.runtimeKind,
+          confirm: true,
+          force: false,
+          reason,
+        }),
+      });
+      setRestartNotice(`restart accepted: ${shrink(restartDialogRuntime.runtimeId)}`);
+      setRestartDialogRuntime(null);
+      setRestartReason('');
+      await loadSnapshot(true);
+    } catch (err) {
+      setRestartError(err instanceof Error ? err.message : 'runtime restart failed');
+    } finally {
+      setRestartSubmittingKey(null);
+    }
+  }, [loadSnapshot, restartDialogRuntime, restartReason]);
 
   useEffect(() => {
     void loadSnapshot();
@@ -516,6 +595,7 @@ export function SupervisorStage() {
                         <TableHead>Restart</TableHead>
                         <TableHead>Next</TableHead>
                         <TableHead>Checked</TableHead>
+                        <TableHead>Action</TableHead>
                       </TableRow>
                     </TableHeader>
                     <TableBody>
@@ -526,6 +606,9 @@ export function SupervisorStage() {
                           restartPlan?.blockedReason ||
                           restartPlan?.eligibleReason ||
                           restartPlan?.reason;
+                        const restartActionKey = runtimeRestartActionKey(runtime);
+                        const canRestart = runtimeRestartSupported(runtime);
+                        const restartSubmitting = restartSubmittingKey === restartActionKey;
                         return (
                           <TableRow key={`${runtime.targetName}:${runtime.runtimeKind}:${runtime.runtimeId}`}>
                             <TableCell>{runtime.targetName}</TableCell>
@@ -571,6 +654,24 @@ export function SupervisorStage() {
                             </TableCell>
                             <TableCell>{formatOptionalTime(runtime.nextRestartAt)}</TableCell>
                             <TableCell>{formatOptionalTime(runtime.lastCheckedAt)}</TableCell>
+                            <TableCell>
+                              {canRestart ? (
+                                <Button
+                                  type="button"
+                                  size="icon-sm"
+                                  variant="bento-outline"
+                                  className="rounded-lg"
+                                  onClick={() => openRestartDialog(runtime)}
+                                  disabled={Boolean(restartSubmittingKey) || restartSubmitting}
+                                  title="Restart signal runtime"
+                                  aria-label={`Restart signal runtime ${runtime.runtimeId}`}
+                                >
+                                  <RotateCw className={cn(restartSubmitting && 'animate-spin')} />
+                                </Button>
+                              ) : (
+                                <span className="text-xs text-[var(--bk-text-muted)]">--</span>
+                              )}
+                            </TableCell>
                           </TableRow>
                         );
                       })}
@@ -584,7 +685,11 @@ export function SupervisorStage() {
               <CardHeader>
                 <CardTitle>Control Actions</CardTitle>
                 <CardAction>
-                  <Badge variant="neutral">{controlActionRows.length}</Badge>
+                  <div className="flex flex-wrap justify-end gap-2">
+                    {restartError && <Badge variant="destructive" title={restartError}>restart failed</Badge>}
+                    {restartNotice && <Badge variant="success" title={restartNotice}>restart accepted</Badge>}
+                    <Badge variant="neutral">{controlActionRows.length}</Badge>
+                  </div>
                 </CardAction>
               </CardHeader>
               <CardContent>
@@ -641,6 +746,57 @@ export function SupervisorStage() {
           </>
         )}
       </div>
+      <Dialog open={Boolean(restartDialogRuntime)} onOpenChange={(open) => !open && closeRestartDialog()}>
+        <DialogContent tone="bento" className="max-w-lg rounded-lg border-[var(--bk-border)] bg-[var(--bk-surface-overlay-strong)] p-0">
+          <DialogHeader className="border-b border-[var(--bk-border-soft)] bg-[var(--bk-surface-overlay)] px-6 py-4">
+            <DialogTitle className="text-lg font-semibold text-[var(--bk-text-primary)]">Restart Signal Runtime</DialogTitle>
+            <DialogDescription className="text-sm text-[var(--bk-text-muted)]">
+              {restartDialogRuntime ? `${restartDialogRuntime.targetName} / ${shrink(restartDialogRuntime.runtimeId)}` : '--'}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex flex-col gap-4 px-6 py-5">
+            <div className="flex flex-col gap-2">
+              <label htmlFor="supervisor-runtime-restart-reason" className="text-xs font-medium uppercase text-[var(--bk-text-muted)]">
+                Reason
+              </label>
+              <Textarea
+                id="supervisor-runtime-restart-reason"
+                value={restartReason}
+                onChange={(event) => setRestartReason(event.target.value)}
+                disabled={Boolean(restartSubmittingKey)}
+                rows={4}
+                aria-invalid={restartReason.trim() === ''}
+              />
+            </div>
+            {restartError && (
+              <div className="rounded-lg border border-[var(--bk-status-danger)] bg-[var(--bk-status-danger-soft)] px-3 py-2 text-sm text-[var(--bk-status-danger)]">
+                {restartError}
+              </div>
+            )}
+          </div>
+          <DialogFooter className="border-t border-[var(--bk-border-soft)] bg-[var(--bk-surface-muted)]/30 px-6 py-4">
+            <Button
+              type="button"
+              variant="bento-outline"
+              className="rounded-lg"
+              onClick={closeRestartDialog}
+              disabled={Boolean(restartSubmittingKey)}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              variant="bento-destructive"
+              className="rounded-lg"
+              onClick={() => void submitRuntimeRestart()}
+              disabled={!restartReason.trim() || Boolean(restartSubmittingKey)}
+            >
+              <RotateCw data-icon="inline-start" className={cn(restartSubmittingKey && 'animate-spin')} />
+              Submit Restart
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/web/console/src/pages/SupervisorStage.tsx
+++ b/web/console/src/pages/SupervisorStage.tsx
@@ -208,9 +208,11 @@ export function SupervisorStage() {
       setSnapshot(payload);
       setError(null);
       setLoadState('loaded');
+      return true;
     } catch (err) {
       setError(err instanceof Error ? err.message : '读取 supervisor 状态失败');
       setLoadState('error');
+      return false;
     }
   }, []);
 
@@ -254,15 +256,21 @@ export function SupervisorStage() {
           reason,
         }),
       });
-      setRestartNotice(`restart accepted: ${shrink(restartDialogRuntime.runtimeId)}`);
-      setRestartDialogRuntime(null);
-      setRestartReason('');
-      await loadSnapshot(true);
     } catch (err) {
       setRestartError(err instanceof Error ? err.message : 'runtime restart failed');
-    } finally {
       setRestartSubmittingKey(null);
+      return;
     }
+
+    setRestartDialogRuntime(null);
+    setRestartReason('');
+    const refreshed = await loadSnapshot(true);
+    if (refreshed) {
+      setRestartNotice(`restart accepted: ${shrink(restartDialogRuntime.runtimeId)}`);
+    } else {
+      setRestartNotice(`restart accepted; refresh failed: ${shrink(restartDialogRuntime.runtimeId)}`);
+    }
+    setRestartSubmittingKey(null);
   }, [loadSnapshot, restartDialogRuntime, restartReason]);
 
   useEffect(() => {


### PR DESCRIPTION
## 目的
为 Runtime Supervisor Dashboard 补齐 issue #270 的一个最小控制面切片：允许人工从只读运行态视图中对 `signal` / `signal-runtime` 发起应用内 restart。

本 PR 只复用既有 `POST /api/v1/runtime/restart`，并固定提交 `confirm=true`、`force=false` 和可审计 reason。它不支持 `live-session` restart，不提交 suppress/resume，不触碰 Docker/container fallback executor。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [x] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

Codex 参与：对齐远端 `main` 后创建 `codex/issue-270-supervisor-followup`，实现 Dashboard 手动 signal runtime restart 入口并补充文档边界。

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [ ] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) - 无变化
- [ ] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？ - 无
- [ ] DB migration 是否具备向下兼容幂等性？ - 不涉及 DB migration
- [ ] 配置字段有没有无意被混改？ - 无配置改动

## 交易语义变更
- [ ] 本次改动是否新增/修改了 `signalKind`？若是，需同步更新 Golden Case - 否
- [ ] 本次改动是否影响订单方向判断（`side` / `reduceOnly` / `closePosition`）？ - 否
- [ ] 若涉及上述改动，`go test ./internal/domain/... -run TestClassifyOrderIntent` 是否通过？ - 不涉及
- [ ] 若涉及交易链路语义（开仓/平仓/撤单/risk-exit），`go test ./internal/domain/... -run TestTradingReplayGoldenCases` 是否通过？ - 不涉及

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

已验证：

```bash
cd web/console
./node_modules/.bin/tsc --noEmit src/pages/SupervisorStage.tsx --jsx react-jsx --esModuleInterop --target esnext --module esnext --moduleResolution Bundler --allowSyntheticDefaultImports
npm run build
git push -u origin codex/issue-270-supervisor-followup
```

`git push` 触发的 pre-push harness / safety sensors 已通过。