### PR TITLE
[codex] align live replay baseline gates

### DIFF
--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -2358,7 +2358,7 @@ func liveIntradayResearchBaselineStateMatchesTemplate(state map[string]any) bool
 	switch key {
 	case "binance-testnet-btc-15m":
 		return symbol == "BTCUSDT" && timeframe == "15m"
-	case "binance-testnet-btc-30m":
+	case "binance-testnet-btc-30m", "binance-testnet-btc-30m-baseline-plus-t3-enhanced":
 		return symbol == "BTCUSDT" && timeframe == "30m"
 	default:
 		return false
@@ -5330,6 +5330,9 @@ func (p *Platform) resolveLiveSessionParameters(session domain.LiveSession, vers
 		"use_sma5_intraday_structure",
 		"reentry_min_stop_bps",
 		"reentry_atr_percentile_gte",
+		"min_atr_percentile",
+		"min_sma_atr_separation",
+		"quality_filter_shapes",
 		"signalDecisionMaxDeviationBps",
 	}
 	sessionParameterKeys = append(sessionParameterKeys, liveExecutionParameterOverrideKeys()...)
@@ -5869,6 +5872,15 @@ func normalizeLiveSessionOverrides(overrides map[string]any) map[string]any {
 	}
 	if atrPercentileGTE := parseFloatValue(overrides["reentry_atr_percentile_gte"]); atrPercentileGTE > 0 {
 		normalized["reentry_atr_percentile_gte"] = atrPercentileGTE
+	}
+	if minATRPercentile := parseFloatValue(overrides["min_atr_percentile"]); minATRPercentile > 0 {
+		normalized["min_atr_percentile"] = minATRPercentile
+	}
+	if minSeparation := parseFloatValue(overrides["min_sma_atr_separation"]); minSeparation > 0 {
+		normalized["min_sma_atr_separation"] = minSeparation
+	}
+	if shapes := normalizeStringList(overrides["quality_filter_shapes"]); len(shapes) > 0 {
+		normalized["quality_filter_shapes"] = shapes
 	}
 	return normalized
 }

--- a/internal/service/live_launch_flow_template_test.go
+++ b/internal/service/live_launch_flow_template_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"testing"
 
+	"github.com/wuyaocheng/bktrader/internal/domain"
 	"github.com/wuyaocheng/bktrader/internal/store/memory"
 )
 
@@ -330,8 +331,8 @@ func TestSyncLiveSessionRuntimeReconcilesIntradayLaunchTemplateBaseline(t *testi
 	if got := stringValue(synced.State["zero_initial_mode"]); got != "reentry_window" {
 		t.Fatalf("expected template baseline zero_initial_mode=reentry_window, got %s", got)
 	}
-	if got := maxIntValue(synced.State["max_trades_per_bar"], 0); got != 1 {
-		t.Fatalf("expected template baseline max_trades_per_bar=1, got %d", got)
+	if got := maxIntValue(synced.State["max_trades_per_bar"], 0); got != domain.ResearchBaselineMaxTradesPerBar {
+		t.Fatalf("expected template baseline max_trades_per_bar=%d, got %d", domain.ResearchBaselineMaxTradesPerBar, got)
 	}
 	if got := stringValue(synced.State["launchTemplateBaseline"]); got != "intraday-research" {
 		t.Fatalf("expected intraday research baseline marker, got %s", got)

--- a/internal/service/live_launch_templates.go
+++ b/internal/service/live_launch_templates.go
@@ -135,7 +135,7 @@ func (p *Platform) LiveLaunchTemplates() ([]LiveLaunchTemplate, error) {
 				liveOverrides[key] = value
 			}
 			baselineNotes = append(baselineNotes,
-				"该模板已显式固化 intraday research baseline：dir2 zero initial + reentry_window + reentry_size_schedule=[0.20, 0.10] + max_trades_per_bar=1。",
+				"该模板已显式固化 intraday research baseline：dir2 zero initial + reentry_window + reentry_size_schedule=[0.20, 0.10] + max_trades_per_bar=2。",
 				"非 1d 周期默认使用 canonical SMA5 hard filter；止损与移动止损参数分别固定为 stop_loss_atr=0.3、trailing_stop_atr=0.3、profit_protect_atr=1.0、delayed_trailing_activation_atr=0.5。",
 				"当前 research baseline 只提升 BTCUSDT 15m/30m；BTCUSDT 5m 暂保留为通用模板，因为现阶段 5m 对执行摩擦更敏感，尚不作为默认 intraday baseline 候选。",
 			)
@@ -186,24 +186,46 @@ func (p *Platform) LiveLaunchTemplates() ([]LiveLaunchTemplate, error) {
 			Notes: notes,
 		}
 	}
-	buildEnhancedTemplate := func() LiveLaunchTemplate {
+	buildLegacyEnhancedTemplate := func() LiveLaunchTemplate {
 		item := buildTemplate("BTCUSDT", "30m", 0.002, false)
 		item.Key = "binance-testnet-btc-30m-enhanced"
 		item.Name = "Binance Testnet BTCUSDT 30m T2-only 0.5bps"
-		item.Description = "BTCUSDT 30m 增强策略：live_intrabar_sma5_original_t2_breakout_tol_0p5bps。"
+		item.Description = "BTCUSDT 30m legacy 增强策略：live_intrabar_sma5_original_t2_breakout_tol_0p5bps。"
 		item.StrategyID = enhancedStrategyID
 		item.StrategyName = enhancedStrategyName
 		item.StrategyVersionID = enhancedStrategyVersionID
-		for key, value := range liveBTC30mEnhancedOverrides() {
+		for key, value := range liveBTC30mLegacyEnhancedOverrides() {
 			item.LaunchPayload.LiveSessionOverrides[key] = value
 		}
 		item.LaunchPayload.StrategyID = enhancedStrategyID
 		item.LaunchPayload.LaunchTemplateKey = item.Key
 		item.LaunchPayload.LaunchTemplateName = item.Name
 		item.Notes = append([]string{
-			fmt.Sprintf("增强模板单独使用 %s（strategyEngine=%s，历史 key %s 保留兼容），不改变原 BTCUSDT 30m 模板。", enhancedStrategyName, bkLiveIntrabarSMA5T2Only0p5BpsEngineKey, bkLiveIntrabarSMA5LegacyT3SepEngineKey),
-			"策略口径：SMA5 intrabar hard filter + original_t2 breakout + T2 shape tolerance 0.5 bps；t3_swing breakout 已摘除。",
-			"低波动 reentry gate 固化为 reentry_min_stop_bps=6 与 reentry_atr_percentile_gte=25，仅过滤 Zero-Initial/SL/PT reentry 开仓，不过滤止损出场。",
+			fmt.Sprintf("legacy 增强模板继续使用 %s（strategyEngine=%s），用于复现现有 T2-only live 行为。", enhancedStrategyName, bkLiveIntrabarSMA5T2Only0p5BpsEngineKey),
+			"策略口径：SMA5 intrabar hard filter + original_t2 breakout + T2 shape tolerance 0.5 bps；t3_swing breakout 不在该 legacy 模板启用。",
+			"低波动 reentry gate 仍为 reentry_min_stop_bps=6 与 reentry_atr_percentile_gte=25，仅过滤 Zero-Initial/SL/PT reentry 开仓，不过滤止损出场。",
+			"模板仍保持 dispatchMode 由前端提交前选择，默认展示为 manual-review。",
+		}, item.Notes...)
+		return item
+	}
+	buildBaselinePlusT3EnhancedTemplate := func() LiveLaunchTemplate {
+		item := buildTemplate("BTCUSDT", "30m", 0.002, false)
+		item.Key = "binance-testnet-btc-30m-baseline-plus-t3-enhanced"
+		item.Name = "Binance Testnet BTCUSDT 30m Baseline+T3 Enhanced"
+		item.Description = "BTCUSDT 30m 新增强策略：live_intrabar_sma5_baseline_plus_t3_enhanced。"
+		item.StrategyID = enhancedStrategyID
+		item.StrategyName = enhancedStrategyName
+		item.StrategyVersionID = enhancedStrategyVersionID
+		for key, value := range liveBTC30mBaselinePlusT3EnhancedOverrides() {
+			item.LaunchPayload.LiveSessionOverrides[key] = value
+		}
+		item.LaunchPayload.StrategyID = enhancedStrategyID
+		item.LaunchPayload.LaunchTemplateKey = item.Key
+		item.LaunchPayload.LaunchTemplateName = item.Name
+		item.Notes = append([]string{
+			fmt.Sprintf("Baseline+T3 增强模板单独使用 %s（strategyEngine=%s），旧 T2-only 模板 key %s 保留兼容。", enhancedStrategyName, bkLiveIntrabarSMA5BaselinePlusT3EnhancedEngineKey, "binance-testnet-btc-30m-enhanced"),
+			"策略口径：SMA5 intrabar hard filter + baseline_plus_t3 breakout，original_t2 与 t3_swing 均可锁定 reentry window。",
+			"baseline gate 固化为 min_atr_percentile=25 与 min_sma_atr_separation=0.1，仅过滤 entry/reentry window 锁定，不过滤止损出场。",
 			"模板仍保持 dispatchMode 由前端提交前选择，默认展示为 manual-review。",
 		}, item.Notes...)
 		return item
@@ -215,7 +237,7 @@ func (p *Platform) LiveLaunchTemplates() ([]LiveLaunchTemplate, error) {
 		buildTemplate("BTCUSDT", "30m", 0.002, true),
 	}
 	if hasEnhancedTemplate {
-		templates = append(templates, buildEnhancedTemplate())
+		templates = append(templates, buildLegacyEnhancedTemplate(), buildBaselinePlusT3EnhancedTemplate())
 	}
 	templates = append(templates,
 		buildTemplate("BTCUSDT", "4h", 0.002, false),
@@ -237,7 +259,7 @@ func liveLaunchTemplateAutoDispatchMode() string {
 
 func liveIntradayResearchBaselineTemplateKey(key string) bool {
 	switch strings.ToLower(strings.TrimSpace(key)) {
-	case "binance-testnet-btc-15m", "binance-testnet-btc-30m":
+	case "binance-testnet-btc-15m", "binance-testnet-btc-30m", "binance-testnet-btc-30m-baseline-plus-t3-enhanced":
 		return true
 	default:
 		return false
@@ -257,7 +279,7 @@ func liveIntradayResearchBaselineOverrides(strategyEngine string) map[string]any
 		"delayed_trailing_activation_atr":      0.5,
 		"long_reentry_atr":                     0.1,
 		"short_reentry_atr":                    0.0,
-		"max_trades_per_bar":                   1,
+		"max_trades_per_bar":                   domain.ResearchBaselineMaxTradesPerBar,
 		"reentry_size_schedule":                domain.ResearchBaselineReentrySizeSchedule(),
 		"executionEntryMaxSlippageBps":         8,
 		"executionEntryMaxBookAgeMs":           500,
@@ -268,7 +290,7 @@ func liveIntradayResearchBaselineOverrides(strategyEngine string) map[string]any
 	}
 }
 
-func liveBTC30mEnhancedOverrides() map[string]any {
+func liveBTC30mLegacyEnhancedOverrides() map[string]any {
 	overrides := liveIntradayResearchBaselineOverrides(bkLiveIntrabarSMA5T2Only0p5BpsEngineKey)
 	overrides["max_trades_per_bar"] = domain.ResearchBaselineMaxTradesPerBar
 	overrides["stop_loss_atr"] = 0.3
@@ -278,6 +300,22 @@ func liveBTC30mEnhancedOverrides() map[string]any {
 	overrides["use_sma5_intraday_structure"] = true
 	overrides["reentry_min_stop_bps"] = 6.0
 	overrides["reentry_atr_percentile_gte"] = 25.0
+	return overrides
+}
+
+func liveBTC30mBaselinePlusT3EnhancedOverrides() map[string]any {
+	overrides := liveIntradayResearchBaselineOverrides(bkLiveIntrabarSMA5BaselinePlusT3EnhancedEngineKey)
+	overrides["max_trades_per_bar"] = domain.ResearchBaselineMaxTradesPerBar
+	overrides["stop_loss_atr"] = 0.3
+	overrides["sl_reentry_min_delay_seconds"] = 60
+	overrides["breakout_shape"] = "baseline_plus_t3"
+	overrides["breakout_shape_tolerance_bps"] = defaultT2BreakoutShapeToleranceBps
+	overrides["use_sma5_intraday_structure"] = true
+	overrides["min_atr_percentile"] = 25.0
+	overrides["min_sma_atr_separation"] = 0.1
+	overrides["quality_filter_shapes"] = []string{"original_t2", "t3_swing"}
+	delete(overrides, "reentry_min_stop_bps")
+	delete(overrides, "reentry_atr_percentile_gte")
 	return overrides
 }
 

--- a/internal/service/live_launch_templates.go
+++ b/internal/service/live_launch_templates.go
@@ -36,6 +36,11 @@ type LiveLaunchTemplate struct {
 	Notes                  []string                 `json:"notes"`
 }
 
+const (
+	btc30mBaselinePlusT3ReentryMinStopBps       = 4.0
+	btc30mBaselinePlusT3ReentryATRPercentileGTE = 10.0
+)
+
 func (p *Platform) LiveLaunchTemplates() ([]LiveLaunchTemplate, error) {
 	strategyID, strategyName, strategyVersionID, strategyEngine, err := p.resolvePrimaryLiveTemplateStrategy()
 	if err != nil {
@@ -225,7 +230,7 @@ func (p *Platform) LiveLaunchTemplates() ([]LiveLaunchTemplate, error) {
 		item.Notes = append([]string{
 			fmt.Sprintf("Baseline+T3 增强模板单独使用 %s（strategyEngine=%s），旧 T2-only 模板 key %s 保留兼容。", enhancedStrategyName, bkLiveIntrabarSMA5BaselinePlusT3EnhancedEngineKey, "binance-testnet-btc-30m-enhanced"),
 			"策略口径：SMA5 intrabar hard filter + baseline_plus_t3 breakout，original_t2 与 t3_swing 均可锁定 reentry window。",
-			"baseline gate 固化为 min_atr_percentile=25 与 min_sma_atr_separation=0.1，仅过滤 entry/reentry window 锁定，不过滤止损出场。",
+			"baseline breakout gate 固化为 min_atr_percentile=25 与 min_sma_atr_separation=0.1；legacy reentry gate 保留但放松为 reentry_min_stop_bps=4 与 reentry_atr_percentile_gte=10，仅过滤 entry/reentry，不过滤止损出场。",
 			"模板仍保持 dispatchMode 由前端提交前选择，默认展示为 manual-review。",
 		}, item.Notes...)
 		return item
@@ -314,8 +319,8 @@ func liveBTC30mBaselinePlusT3EnhancedOverrides() map[string]any {
 	overrides["min_atr_percentile"] = 25.0
 	overrides["min_sma_atr_separation"] = 0.1
 	overrides["quality_filter_shapes"] = []string{"original_t2", "t3_swing"}
-	delete(overrides, "reentry_min_stop_bps")
-	delete(overrides, "reentry_atr_percentile_gte")
+	overrides["reentry_min_stop_bps"] = btc30mBaselinePlusT3ReentryMinStopBps
+	overrides["reentry_atr_percentile_gte"] = btc30mBaselinePlusT3ReentryATRPercentileGTE
 	return overrides
 }
 

--- a/internal/service/live_launch_templates_test.go
+++ b/internal/service/live_launch_templates_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"testing"
 
+	"github.com/wuyaocheng/bktrader/internal/domain"
 	storepkg "github.com/wuyaocheng/bktrader/internal/store"
 	"github.com/wuyaocheng/bktrader/internal/store/memory"
 )
@@ -33,8 +34,8 @@ func TestLiveLaunchTemplatesExposeBinanceTestnetVariants(t *testing.T) {
 	if err != nil {
 		t.Fatalf("list live launch templates failed: %v", err)
 	}
-	if len(templates) != 9 {
-		t.Fatalf("expected 9 launch templates, got %d", len(templates))
+	if len(templates) != 10 {
+		t.Fatalf("expected 10 launch templates, got %d", len(templates))
 	}
 
 	expected := map[string]struct {
@@ -43,16 +44,18 @@ func TestLiveLaunchTemplatesExposeBinanceTestnetVariants(t *testing.T) {
 		quantity         float64
 		researchBaseline bool
 		enhanced         bool
+		baselinePlusT3   bool
 	}{
-		"binance-testnet-btc-5m":           {symbol: "BTCUSDT", timeframe: "5m", quantity: 0.002},
-		"binance-testnet-btc-15m":          {symbol: "BTCUSDT", timeframe: "15m", quantity: 0.002, researchBaseline: true},
-		"binance-testnet-btc-30m":          {symbol: "BTCUSDT", timeframe: "30m", quantity: 0.002, researchBaseline: true},
-		"binance-testnet-btc-30m-enhanced": {symbol: "BTCUSDT", timeframe: "30m", quantity: 0.002, enhanced: true},
-		"binance-testnet-btc-4h":           {symbol: "BTCUSDT", timeframe: "4h", quantity: 0.002},
-		"binance-testnet-btc-1d":           {symbol: "BTCUSDT", timeframe: "1d", quantity: 0.002},
-		"binance-testnet-eth-5m":           {symbol: "ETHUSDT", timeframe: "5m", quantity: 0.1},
-		"binance-testnet-eth-4h":           {symbol: "ETHUSDT", timeframe: "4h", quantity: 0.1},
-		"binance-testnet-eth-1d":           {symbol: "ETHUSDT", timeframe: "1d", quantity: 0.1},
+		"binance-testnet-btc-5m":                            {symbol: "BTCUSDT", timeframe: "5m", quantity: 0.002},
+		"binance-testnet-btc-15m":                           {symbol: "BTCUSDT", timeframe: "15m", quantity: 0.002, researchBaseline: true},
+		"binance-testnet-btc-30m":                           {symbol: "BTCUSDT", timeframe: "30m", quantity: 0.002, researchBaseline: true},
+		"binance-testnet-btc-30m-enhanced":                  {symbol: "BTCUSDT", timeframe: "30m", quantity: 0.002, enhanced: true},
+		"binance-testnet-btc-30m-baseline-plus-t3-enhanced": {symbol: "BTCUSDT", timeframe: "30m", quantity: 0.002, enhanced: true, baselinePlusT3: true},
+		"binance-testnet-btc-4h":                            {symbol: "BTCUSDT", timeframe: "4h", quantity: 0.002},
+		"binance-testnet-btc-1d":                            {symbol: "BTCUSDT", timeframe: "1d", quantity: 0.002},
+		"binance-testnet-eth-5m":                            {symbol: "ETHUSDT", timeframe: "5m", quantity: 0.1},
+		"binance-testnet-eth-4h":                            {symbol: "ETHUSDT", timeframe: "4h", quantity: 0.1},
+		"binance-testnet-eth-1d":                            {symbol: "ETHUSDT", timeframe: "1d", quantity: 0.1},
 	}
 
 	for _, item := range templates {
@@ -174,10 +177,7 @@ func TestLiveLaunchTemplatesExposeBinanceTestnetVariants(t *testing.T) {
 			if got := parseFloatValue(item.LaunchPayload.LiveSessionOverrides["short_reentry_atr"]); got != 0.0 {
 				t.Fatalf("expected short_reentry_atr=0.0 for %s, got %v", item.Key, got)
 			}
-			expectedMaxTradesPerBar := 1
-			if want.enhanced {
-				expectedMaxTradesPerBar = 2
-			}
+			expectedMaxTradesPerBar := domain.ResearchBaselineMaxTradesPerBar
 			if got := maxIntValue(item.LaunchPayload.LiveSessionOverrides["max_trades_per_bar"], 0); got != expectedMaxTradesPerBar {
 				t.Fatalf("expected max_trades_per_bar=%d for %s, got %d", expectedMaxTradesPerBar, item.Key, got)
 			}
@@ -186,12 +186,6 @@ func TestLiveLaunchTemplatesExposeBinanceTestnetVariants(t *testing.T) {
 				t.Fatalf("expected reentry_size_schedule [0.20, 0.10] for %s, got %#v", item.Key, item.LaunchPayload.LiveSessionOverrides["reentry_size_schedule"])
 			}
 			if want.enhanced {
-				if got := stringValue(item.LaunchPayload.LiveSessionOverrides["strategyEngine"]); got != bkLiveIntrabarSMA5T2Only0p5BpsEngineKey {
-					t.Fatalf("expected enhanced strategy engine, got %s", got)
-				}
-				if got := stringValue(item.LaunchPayload.LiveSessionOverrides["breakout_shape"]); got != "original_t2" {
-					t.Fatalf("expected original_t2 breakout shape, got %s", got)
-				}
 				if got := parseFloatValue(item.LaunchPayload.LiveSessionOverrides["breakout_shape_tolerance_bps"]); got != 0.5 {
 					t.Fatalf("expected T2 breakout tolerance 0.5 bps, got %v", got)
 				}
@@ -201,11 +195,38 @@ func TestLiveLaunchTemplatesExposeBinanceTestnetVariants(t *testing.T) {
 				if got := maxIntValue(item.LaunchPayload.LiveSessionOverrides["sl_reentry_min_delay_seconds"], 0); got != 60 {
 					t.Fatalf("expected enhanced template SL-Reentry delay 60s, got %d", got)
 				}
-				if got := parseFloatValue(item.LaunchPayload.LiveSessionOverrides["reentry_min_stop_bps"]); got != 6.0 {
-					t.Fatalf("expected enhanced template reentry_min_stop_bps=6, got %v", got)
-				}
-				if got := parseFloatValue(item.LaunchPayload.LiveSessionOverrides["reentry_atr_percentile_gte"]); got != 25.0 {
-					t.Fatalf("expected enhanced template reentry_atr_percentile_gte=25, got %v", got)
+				if want.baselinePlusT3 {
+					if got := stringValue(item.LaunchPayload.LiveSessionOverrides["strategyEngine"]); got != bkLiveIntrabarSMA5BaselinePlusT3EnhancedEngineKey {
+						t.Fatalf("expected baseline+T3 enhanced strategy engine, got %s", got)
+					}
+					if got := stringValue(item.LaunchPayload.LiveSessionOverrides["breakout_shape"]); got != "baseline_plus_t3" {
+						t.Fatalf("expected baseline_plus_t3 breakout shape, got %s", got)
+					}
+					if got := parseFloatValue(item.LaunchPayload.LiveSessionOverrides["min_atr_percentile"]); got != 25.0 {
+						t.Fatalf("expected enhanced template min_atr_percentile=25, got %v", got)
+					}
+					if got := parseFloatValue(item.LaunchPayload.LiveSessionOverrides["min_sma_atr_separation"]); got != 0.1 {
+						t.Fatalf("expected enhanced template min_sma_atr_separation=0.1, got %v", got)
+					}
+					if _, ok := item.LaunchPayload.LiveSessionOverrides["reentry_min_stop_bps"]; ok {
+						t.Fatalf("expected baseline+T3 template to omit legacy reentry_min_stop_bps, got %#v", item.LaunchPayload.LiveSessionOverrides)
+					}
+					if _, ok := item.LaunchPayload.LiveSessionOverrides["reentry_atr_percentile_gte"]; ok {
+						t.Fatalf("expected baseline+T3 template to omit legacy reentry_atr_percentile_gte, got %#v", item.LaunchPayload.LiveSessionOverrides)
+					}
+				} else {
+					if got := stringValue(item.LaunchPayload.LiveSessionOverrides["strategyEngine"]); got != bkLiveIntrabarSMA5T2Only0p5BpsEngineKey {
+						t.Fatalf("expected legacy enhanced strategy engine, got %s", got)
+					}
+					if got := stringValue(item.LaunchPayload.LiveSessionOverrides["breakout_shape"]); got != "original_t2" {
+						t.Fatalf("expected original_t2 breakout shape, got %s", got)
+					}
+					if got := parseFloatValue(item.LaunchPayload.LiveSessionOverrides["reentry_min_stop_bps"]); got != 6.0 {
+						t.Fatalf("expected enhanced template reentry_min_stop_bps=6, got %v", got)
+					}
+					if got := parseFloatValue(item.LaunchPayload.LiveSessionOverrides["reentry_atr_percentile_gte"]); got != 25.0 {
+						t.Fatalf("expected enhanced template reentry_atr_percentile_gte=25, got %v", got)
+					}
 				}
 				if !boolValue(item.LaunchPayload.LiveSessionOverrides["use_sma5_intraday_structure"]) {
 					t.Fatalf("expected enhanced template to use SMA5 intraday structure")

--- a/internal/service/live_launch_templates_test.go
+++ b/internal/service/live_launch_templates_test.go
@@ -208,11 +208,11 @@ func TestLiveLaunchTemplatesExposeBinanceTestnetVariants(t *testing.T) {
 					if got := parseFloatValue(item.LaunchPayload.LiveSessionOverrides["min_sma_atr_separation"]); got != 0.1 {
 						t.Fatalf("expected enhanced template min_sma_atr_separation=0.1, got %v", got)
 					}
-					if _, ok := item.LaunchPayload.LiveSessionOverrides["reentry_min_stop_bps"]; ok {
-						t.Fatalf("expected baseline+T3 template to omit legacy reentry_min_stop_bps, got %#v", item.LaunchPayload.LiveSessionOverrides)
+					if got := parseFloatValue(item.LaunchPayload.LiveSessionOverrides["reentry_min_stop_bps"]); got != btc30mBaselinePlusT3ReentryMinStopBps {
+						t.Fatalf("expected baseline+T3 template reentry_min_stop_bps=%v, got %v", btc30mBaselinePlusT3ReentryMinStopBps, got)
 					}
-					if _, ok := item.LaunchPayload.LiveSessionOverrides["reentry_atr_percentile_gte"]; ok {
-						t.Fatalf("expected baseline+T3 template to omit legacy reentry_atr_percentile_gte, got %#v", item.LaunchPayload.LiveSessionOverrides)
+					if got := parseFloatValue(item.LaunchPayload.LiveSessionOverrides["reentry_atr_percentile_gte"]); got != btc30mBaselinePlusT3ReentryATRPercentileGTE {
+						t.Fatalf("expected baseline+T3 template reentry_atr_percentile_gte=%v, got %v", btc30mBaselinePlusT3ReentryATRPercentileGTE, got)
 					}
 				} else {
 					if got := stringValue(item.LaunchPayload.LiveSessionOverrides["strategyEngine"]); got != bkLiveIntrabarSMA5T2Only0p5BpsEngineKey {

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -844,7 +844,7 @@ func TestEvaluateSignalBarGateKeepsOriginalT2WithLegacyBreakoutShape(t *testing.
 	}
 }
 
-func TestEvaluateSignalBarGateIgnoresT3OnlyBreakoutShape(t *testing.T) {
+func TestEvaluateSignalBarGateAllowsT3SwingWithBaselinePlusT3Shape(t *testing.T) {
 	gate := evaluateSignalBarGate(map[string]any{
 		"timeframe": "30m",
 		"sma5":      68850.0,
@@ -862,11 +862,11 @@ func TestEvaluateSignalBarGateIgnoresT3OnlyBreakoutShape(t *testing.T) {
 		BreakoutShape:             "baseline_plus_t3",
 		BreakoutShapeToleranceBps: 0.5,
 	})
-	if boolValue(gate["longBreakoutPatternReady"]) || boolValue(gate["longReady"]) {
-		t.Fatalf("expected t3-only breakout shape to be ignored, got %#v", gate)
+	if !boolValue(gate["longBreakoutPatternReady"]) || !boolValue(gate["longReady"]) {
+		t.Fatalf("expected t3_swing breakout to pass with baseline_plus_t3 configured, got %#v", gate)
 	}
-	if got := stringValue(gate["longBreakoutShapeName"]); got != "" {
-		t.Fatalf("expected no breakout shape, got %s in %#v", got, gate)
+	if got := stringValue(gate["longBreakoutShapeName"]); got != "t3_swing" {
+		t.Fatalf("expected t3_swing breakout shape, got %s in %#v", got, gate)
 	}
 }
 
@@ -4381,8 +4381,8 @@ func TestNormalizeLiveSessionOverridesIncludesT2BreakoutTolerance(t *testing.T) 
 	}
 }
 
-func TestLiveBTC30mEnhancedOverridesEnableReentryGuards(t *testing.T) {
-	overrides := liveBTC30mEnhancedOverrides()
+func TestLiveBTC30mLegacyEnhancedOverridesEnableReentryGuards(t *testing.T) {
+	overrides := liveBTC30mLegacyEnhancedOverrides()
 	if got := stringValue(overrides["strategyEngine"]); got != bkLiveIntrabarSMA5T2Only0p5BpsEngineKey {
 		t.Fatalf("expected BTC 30m enhanced template to use T2-only engine, got %s", got)
 	}
@@ -4403,6 +4403,38 @@ func TestLiveBTC30mEnhancedOverridesEnableReentryGuards(t *testing.T) {
 	}
 	if got := parseFloatValue(overrides["reentry_atr_percentile_gte"]); got != 25.0 {
 		t.Fatalf("expected BTC 30m enhanced template to require reentry_atr_percentile_gte=25, got %v", got)
+	}
+}
+
+func TestLiveBTC30mBaselinePlusT3EnhancedOverridesUseBaselineQualityGates(t *testing.T) {
+	overrides := liveBTC30mBaselinePlusT3EnhancedOverrides()
+	if got := stringValue(overrides["strategyEngine"]); got != bkLiveIntrabarSMA5BaselinePlusT3EnhancedEngineKey {
+		t.Fatalf("expected BTC 30m baseline+T3 template to use enhanced engine, got %s", got)
+	}
+	if got := stringValue(overrides["breakout_shape"]); got != "baseline_plus_t3" {
+		t.Fatalf("expected BTC 30m baseline+T3 template to use baseline_plus_t3 breakout, got %s", got)
+	}
+	if got := parseFloatValue(overrides["breakout_shape_tolerance_bps"]); got != 0.5 {
+		t.Fatalf("expected BTC 30m baseline+T3 template to keep T2 tolerance 0.5 bps, got %v", got)
+	}
+	if got := maxIntValue(overrides["sl_reentry_min_delay_seconds"], 0); got != 60 {
+		t.Fatalf("expected BTC 30m baseline+T3 template to require 60s SL-Reentry delay, got %d", got)
+	}
+	if got := parseFloatValue(overrides["min_atr_percentile"]); got != 25.0 {
+		t.Fatalf("expected BTC 30m baseline+T3 template to require min_atr_percentile=25, got %v", got)
+	}
+	if got := parseFloatValue(overrides["min_sma_atr_separation"]); got != 0.1 {
+		t.Fatalf("expected BTC 30m baseline+T3 template to require min_sma_atr_separation=0.1, got %v", got)
+	}
+	shapes := normalizeStringList(overrides["quality_filter_shapes"])
+	if len(shapes) != 2 || shapes[0] != "original_t2" || shapes[1] != "t3_swing" {
+		t.Fatalf("expected quality filter shapes [original_t2 t3_swing], got %#v", shapes)
+	}
+	if _, ok := overrides["reentry_min_stop_bps"]; ok {
+		t.Fatalf("expected BTC 30m baseline+T3 template to omit reentry_min_stop_bps, got %#v", overrides)
+	}
+	if _, ok := overrides["reentry_atr_percentile_gte"]; ok {
+		t.Fatalf("expected BTC 30m baseline+T3 template to omit reentry_atr_percentile_gte, got %#v", overrides)
 	}
 }
 

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -818,6 +818,38 @@ func TestEvaluateSignalBarGateAllowsT2BreakoutTolerance(t *testing.T) {
 	}
 }
 
+func TestEvaluateSignalBarGateSeparatesBreakoutShapeFromPriceTrigger(t *testing.T) {
+	gate := evaluateSignalBarGate(map[string]any{
+		"timeframe": "30m",
+		"sma5":      68200.0,
+		"ma20":      68000.0,
+		"atr14":     800.0,
+		"current": map[string]any{
+			"close": 68600.0,
+			"high":  68950.0,
+			"low":   68100.0,
+		},
+		"prevBar1": map[string]any{"high": 69000.0, "low": 68100.0},
+		"prevBar2": map[string]any{"high": 68997.0, "low": 68000.0},
+		"prevBar3": map[string]any{"high": 68700.0, "low": 67900.0},
+	}, "BUY", "entry", "", 68950.0, "trade_tick.price", signalBarGateOptions{
+		BreakoutShape:             "original_t2",
+		BreakoutShapeToleranceBps: 0.5,
+	})
+	if !boolValue(gate["longBreakoutShapeReady"]) {
+		t.Fatalf("expected original_t2 structure to be ready before price trigger, got %#v", gate)
+	}
+	if boolValue(gate["longBreakoutPriceReady"]) || boolValue(gate["longBreakoutReady"]) || boolValue(gate["longReady"]) {
+		t.Fatalf("expected price trigger and full breakout to remain not ready, got %#v", gate)
+	}
+	if got := stringValue(gate["longBreakoutShapeName"]); got != "original_t2" {
+		t.Fatalf("expected original_t2 shape metadata, got %s in %#v", got, gate)
+	}
+	if got := parseFloatValue(gate["longBreakoutLevel"]); got != 68997.0 {
+		t.Fatalf("expected original_t2 level metadata, got %v in %#v", got, gate)
+	}
+}
+
 func TestEvaluateSignalBarGateKeepsOriginalT2WithLegacyBreakoutShape(t *testing.T) {
 	gate := evaluateSignalBarGate(map[string]any{
 		"timeframe": "30m",

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -4462,11 +4462,11 @@ func TestLiveBTC30mBaselinePlusT3EnhancedOverridesUseBaselineQualityGates(t *tes
 	if len(shapes) != 2 || shapes[0] != "original_t2" || shapes[1] != "t3_swing" {
 		t.Fatalf("expected quality filter shapes [original_t2 t3_swing], got %#v", shapes)
 	}
-	if _, ok := overrides["reentry_min_stop_bps"]; ok {
-		t.Fatalf("expected BTC 30m baseline+T3 template to omit reentry_min_stop_bps, got %#v", overrides)
+	if got := parseFloatValue(overrides["reentry_min_stop_bps"]); got != btc30mBaselinePlusT3ReentryMinStopBps {
+		t.Fatalf("expected BTC 30m baseline+T3 template to require reentry_min_stop_bps=%v, got %v", btc30mBaselinePlusT3ReentryMinStopBps, got)
 	}
-	if _, ok := overrides["reentry_atr_percentile_gte"]; ok {
-		t.Fatalf("expected BTC 30m baseline+T3 template to omit reentry_atr_percentile_gte, got %#v", overrides)
+	if got := parseFloatValue(overrides["reentry_atr_percentile_gte"]); got != btc30mBaselinePlusT3ReentryATRPercentileGTE {
+		t.Fatalf("expected BTC 30m baseline+T3 template to require reentry_atr_percentile_gte=%v, got %v", btc30mBaselinePlusT3ReentryATRPercentileGTE, got)
 	}
 }
 

--- a/internal/service/paper.go
+++ b/internal/service/paper.go
@@ -1229,6 +1229,9 @@ func (p *Platform) resolvePaperSessionParameters(session domain.PaperSession, ve
 		"fixed_slippage",
 		"dir2_zero_initial",
 		"zero_initial_mode",
+		"min_atr_percentile",
+		"min_sma_atr_separation",
+		"quality_filter_shapes",
 	} {
 		if value, ok := state[key]; ok {
 			parameters[key] = value
@@ -1283,7 +1286,7 @@ func normalizePaperSessionOverrides(overrides map[string]any) map[string]any {
 			normalized[key] = normalizeStrategyEngineKey(stringValue(value))
 		case "tradingFeeBps", "fundingRateBps", "fixed_slippage", "stop_loss_atr", "profit_protect_atr",
 			"long_reentry_atr", "short_reentry_atr", "trailing_stop_atr", "delayed_trailing_activation_atr",
-			"reentry_decay_factor":
+			"reentry_decay_factor", "min_atr_percentile", "min_sma_atr_separation":
 			normalized[key] = parseFloatValue(value)
 		case "fundingIntervalHours", "max_trades_per_bar":
 			normalized[key] = maxIntValue(value, 0)
@@ -1309,6 +1312,8 @@ func normalizePaperSessionOverrides(overrides map[string]any) map[string]any {
 			default:
 				normalized[key] = value
 			}
+		case "quality_filter_shapes":
+			normalized[key] = normalizeStringList(value)
 		}
 	}
 	return normalized

--- a/internal/service/strategy.go
+++ b/internal/service/strategy.go
@@ -617,6 +617,9 @@ func applyBacktestParameterAliases(parameters map[string]any) {
 		"reentryATRPercentileGTE":      "reentry_atr_percentile_gte",
 		"minStopBps":                   "min_stop_bps",
 		"atrPctGTE":                    "atr_pct_gte",
+		"minATRPercentile":             "min_atr_percentile",
+		"minSMAATRSeparation":          "min_sma_atr_separation",
+		"qualityFilterShapes":          "quality_filter_shapes",
 	}
 	for from, to := range aliases {
 		if _, ok := parameters[to]; ok {

--- a/internal/service/strategy_registry.go
+++ b/internal/service/strategy_registry.go
@@ -98,9 +98,10 @@ func defaultExecutionSemantics(mode ExecutionMode, parameters map[string]any) St
 }
 
 const (
-	bkLiveIntrabarSMA5T2Only0p5BpsEngineKey = "bk-live-intrabar-sma5-t2-only-0p5bps"
-	bkLiveIntrabarSMA5LegacyT3SepEngineKey  = "bk-live-intrabar-sma5-t3-sep"
-	defaultT2BreakoutShapeToleranceBps      = 0.5
+	bkLiveIntrabarSMA5T2Only0p5BpsEngineKey           = "bk-live-intrabar-sma5-t2-only-0p5bps"
+	bkLiveIntrabarSMA5BaselinePlusT3EnhancedEngineKey = "bk-live-intrabar-sma5-baseline-plus-t3-enhanced"
+	bkLiveIntrabarSMA5LegacyT3SepEngineKey            = "bk-live-intrabar-sma5-t3-sep"
+	defaultT2BreakoutShapeToleranceBps                = 0.5
 )
 
 func normalizeStrategyEngineKey(raw string) string {
@@ -127,6 +128,7 @@ func (p *Platform) registerStrategyEngine(engine StrategyEngine) {
 func (p *Platform) registerBuiltInStrategyEngines() {
 	p.registerStrategyEngine(bkStrategyEngine{platform: p})
 	p.registerStrategyEngine(bkLiveIntrabarSMA5T2Only0p5BpsEngine{platform: p})
+	p.registerStrategyEngine(bkLiveIntrabarSMA5BaselinePlusT3EnhancedEngine{platform: p})
 }
 
 func (p *Platform) resolveStrategyEngine(strategyVersionID string, parameters map[string]any) (StrategyEngine, string, error) {
@@ -216,11 +218,66 @@ func (e bkLiveIntrabarSMA5T2Only0p5BpsEngine) EvaluateSignal(context StrategySig
 	return bkStrategyEngine{platform: e.platform}.EvaluateSignal(context)
 }
 
+type bkLiveIntrabarSMA5BaselinePlusT3EnhancedEngine struct {
+	platform *Platform
+}
+
+func (e bkLiveIntrabarSMA5BaselinePlusT3EnhancedEngine) Key() string {
+	return bkLiveIntrabarSMA5BaselinePlusT3EnhancedEngineKey
+}
+
+func (e bkLiveIntrabarSMA5BaselinePlusT3EnhancedEngine) Describe() map[string]any {
+	return map[string]any{
+		"key":                  e.Key(),
+		"name":                 "BK Live Intrabar SMA5 Baseline+T3 Enhanced",
+		"supportedSignalBars":  []string{"30m"},
+		"supportedExecutions":  []string{"tick", "1min"},
+		"runtimeConsistency":   "live-intrabar-sma5-baseline-plus-t3-enhanced",
+		"backtestSlippageOnly": true,
+	}
+}
+
+func (e bkLiveIntrabarSMA5BaselinePlusT3EnhancedEngine) Run(context StrategyExecutionContext) (map[string]any, error) {
+	return e.platform.runStrategyReplay(context)
+}
+
+func (e bkLiveIntrabarSMA5BaselinePlusT3EnhancedEngine) EvaluateSignal(context StrategySignalEvaluationContext) (StrategySignalDecision, error) {
+	return bkStrategyEngine{platform: e.platform}.EvaluateSignal(context)
+}
+
+type EntryQualityGateResult struct {
+	Name       string         `json:"name"`
+	Scope      string         `json:"scope"`
+	Applied    bool           `json:"applied"`
+	Ready      bool           `json:"ready"`
+	Reason     string         `json:"reason,omitempty"`
+	Metrics    map[string]any `json:"metrics,omitempty"`
+	Thresholds map[string]any `json:"thresholds,omitempty"`
+}
+
+type EntryQualityReport struct {
+	Ready       bool                     `json:"ready"`
+	Reason      string                   `json:"reason,omitempty"`
+	GateResults []EntryQualityGateResult `json:"gates"`
+}
+
+type BreakoutQualityReport struct {
+	Shape       string                   `json:"shape,omitempty"`
+	Scope       string                   `json:"scope"`
+	Applied     bool                     `json:"applied"`
+	Ready       bool                     `json:"ready"`
+	Reason      string                   `json:"reason,omitempty"`
+	GateResults []EntryQualityGateResult `json:"gates,omitempty"`
+}
+
 type signalBarGateOptions struct {
 	BreakoutShape             string
 	BreakoutShapeToleranceBps float64
 	ReentryMinStopBps         float64
 	ReentryATRPercentileGTE   float64
+	MinATRPercentile          float64
+	MinSMAATRSeparation       float64
+	QualityFilterShapes       []string
 }
 
 func signalBarGateOptionsFromParameters(parameters map[string]any) signalBarGateOptions {
@@ -229,6 +286,9 @@ func signalBarGateOptionsFromParameters(parameters map[string]any) signalBarGate
 		BreakoutShapeToleranceBps: parseFloatValue(parameters["breakout_shape_tolerance_bps"]),
 		ReentryMinStopBps:         firstPositive(parseFloatValue(parameters["reentry_min_stop_bps"]), parseFloatValue(parameters["min_stop_bps"])),
 		ReentryATRPercentileGTE:   firstPositive(parseFloatValue(parameters["reentry_atr_percentile_gte"]), parseFloatValue(parameters["atr_pct_gte"])),
+		MinATRPercentile:          firstPositive(parseFloatValue(parameters["min_atr_percentile"]), parseFloatValue(parameters["breakout_min_atr_percentile"])),
+		MinSMAATRSeparation:       firstPositive(parseFloatValue(parameters["min_sma_atr_separation"]), parseFloatValue(parameters["breakout_min_sma_atr_separation"])),
+		QualityFilterShapes:       normalizeStringList(parameters["quality_filter_shapes"]),
 	}
 }
 
@@ -883,24 +943,31 @@ func evaluateSignalBarGate(signalBarState map[string]any, nextSide, nextRole, ne
 		longStructureReady = closePrice > ma20
 		shortStructureReady = closePrice < ma20
 	}
-	longBreakoutShapeName := ""
-	longBreakoutLevel := 0.0
-	if t2LongBreakoutShapeReady(prevHigh2, prevHigh1, gateOptions.BreakoutShapeToleranceBps) {
-		longBreakoutShapeName = "original_t2"
-		longBreakoutLevel = prevHigh2
-	}
-	shortBreakoutShapeName := ""
-	shortBreakoutLevel := 0.0
-	if t2ShortBreakoutShapeReady(prevLow2, prevLow1, gateOptions.BreakoutShapeToleranceBps) {
-		shortBreakoutShapeName = "original_t2"
-		shortBreakoutLevel = prevLow2
-	}
+	prevBar3 := mapValue(signalBarState["prevBar3"])
+	prevHigh3 := parseFloatValue(prevBar3["high"])
+	prevLow3 := parseFloatValue(prevBar3["low"])
+	longBreakoutShapeName, longBreakoutLevel := resolveLongBreakoutShape(
+		prevHigh1,
+		prevHigh2,
+		prevHigh3,
+		breakoutPrice,
+		gateOptions,
+	)
+	shortBreakoutShapeName, shortBreakoutLevel := resolveShortBreakoutShape(
+		prevLow1,
+		prevLow2,
+		prevLow3,
+		breakoutPrice,
+		gateOptions,
+	)
 	longBreakoutShapeReady := longBreakoutShapeName != "" && longBreakoutLevel > 0
 	shortBreakoutShapeReady := shortBreakoutShapeName != "" && shortBreakoutLevel > 0
 	longBreakoutPriceReady := breakoutPrice >= longBreakoutLevel && longBreakoutLevel > 0
 	shortBreakoutPriceReady := breakoutPrice <= shortBreakoutLevel && shortBreakoutLevel > 0
-	longBreakoutQualityReady := true
-	shortBreakoutQualityReady := true
+	longBreakoutQuality := evaluateBreakoutQualityGate(gateOptions, longBreakoutShapeName, longBreakoutLevel, sma5, atr14, parseFloatValue(signalBarState["atrPercentile"]))
+	shortBreakoutQuality := evaluateBreakoutQualityGate(gateOptions, shortBreakoutShapeName, shortBreakoutLevel, sma5, atr14, parseFloatValue(signalBarState["atrPercentile"]))
+	longBreakoutQualityReady := longBreakoutQuality.Ready
+	shortBreakoutQualityReady := shortBreakoutQuality.Ready
 	longBreakoutReady := longBreakoutShapeReady && longBreakoutPriceReady && longBreakoutQualityReady
 	shortBreakoutReady := shortBreakoutShapeReady && shortBreakoutPriceReady && shortBreakoutQualityReady
 	longReady := longStructureReady && longBreakoutReady
@@ -925,6 +992,10 @@ func evaluateSignalBarGate(signalBarState map[string]any, nextSide, nextRole, ne
 	result["shortBreakoutShapeName"] = shortBreakoutShapeName
 	result["longBreakoutLevel"] = longBreakoutLevel
 	result["shortBreakoutLevel"] = shortBreakoutLevel
+	result["longBreakoutQuality"] = longBreakoutQuality
+	result["shortBreakoutQuality"] = shortBreakoutQuality
+	result["longBreakoutRejectReason"] = longBreakoutQuality.Reason
+	result["shortBreakoutRejectReason"] = shortBreakoutQuality.Reason
 	result["longBreakoutReady"] = longBreakoutReady
 	result["shortBreakoutReady"] = shortBreakoutReady
 	result["longBreakoutPatternReady"] = longBreakoutReady
@@ -951,6 +1022,7 @@ func evaluateSignalBarGate(signalBarState map[string]any, nextSide, nextRole, ne
 
 func evaluateReentryEntryQualityGate(parameters map[string]any, signalBarState map[string]any, nextSide, nextRole, nextReason string, plannedPrice, marketPrice float64) map[string]any {
 	options := signalBarGateOptionsFromParameters(parameters)
+	report := EntryQualityReport{Ready: true, Reason: "reentry-entry-quality-ready"}
 	result := map[string]any{
 		"ready":            true,
 		"reason":           "reentry-entry-quality-ready",
@@ -963,10 +1035,14 @@ func evaluateReentryEntryQualityGate(parameters map[string]any, signalBarState m
 	reasonTag := stringValue(result["reasonTag"])
 	if result["role"] != "entry" || (reasonTag != "zero-initial-reentry" && reasonTag != "sl-reentry" && reasonTag != "pt-reentry") {
 		result["applied"] = false
+		report.GateResults = append(report.GateResults, EntryQualityGateResult{Name: "reentry-entry-quality", Scope: "reentry-only", Applied: false, Ready: true})
+		result["report"] = report
 		return result
 	}
 	if options.ReentryMinStopBps <= 0 && options.ReentryATRPercentileGTE <= 0 {
 		result["applied"] = false
+		report.GateResults = append(report.GateResults, EntryQualityGateResult{Name: "reentry-entry-quality", Scope: "reentry-only", Applied: false, Ready: true})
+		result["report"] = report
 		return result
 	}
 	result["applied"] = true
@@ -993,6 +1069,16 @@ func evaluateReentryEntryQualityGate(parameters map[string]any, signalBarState m
 	result["atrPercentile"] = atrPercentile
 	result["priceRef"] = priceRef
 	result["stopBps"] = stopBps
+	thresholds := map[string]any{
+		"minStopBps":       options.ReentryMinStopBps,
+		"atrPercentileGTE": options.ReentryATRPercentileGTE,
+	}
+	metrics := map[string]any{
+		"stopBps":       stopBps,
+		"atr14":         atr14,
+		"atrPercentile": atrPercentile,
+		"priceRef":      priceRef,
+	}
 
 	rejectReasons := []string{}
 	if options.ReentryMinStopBps > 0 && (stopBps <= 0 || stopBps < options.ReentryMinStopBps) {
@@ -1002,6 +1088,15 @@ func evaluateReentryEntryQualityGate(parameters map[string]any, signalBarState m
 		rejectReasons = append(rejectReasons, "atr_percentile")
 	}
 	if len(rejectReasons) == 0 {
+		report.GateResults = append(report.GateResults, EntryQualityGateResult{
+			Name:       "reentry-entry-quality",
+			Scope:      "reentry-only",
+			Applied:    true,
+			Ready:      true,
+			Metrics:    metrics,
+			Thresholds: thresholds,
+		})
+		result["report"] = report
 		return result
 	}
 	result["ready"] = false
@@ -1014,7 +1109,43 @@ func evaluateReentryEntryQualityGate(parameters map[string]any, signalBarState m
 	default:
 		result["reason"] = "reentry-entry-quality-not-ready"
 	}
+	report.Ready = false
+	report.Reason = stringValue(result["reason"])
+	report.GateResults = append(report.GateResults, EntryQualityGateResult{
+		Name:       "reentry-entry-quality",
+		Scope:      "reentry-only",
+		Applied:    true,
+		Ready:      false,
+		Reason:     report.Reason,
+		Metrics:    metrics,
+		Thresholds: thresholds,
+	})
+	result["report"] = report
 	return result
+}
+
+func resolveLongBreakoutShape(prevHigh1, prevHigh2, prevHigh3, observedPrice float64, options signalBarGateOptions) (string, float64) {
+	if t2LongBreakoutShapeReady(prevHigh2, prevHigh1, options.BreakoutShapeToleranceBps) && observedPrice >= prevHigh2 {
+		return "original_t2", prevHigh2
+	}
+	if strings.EqualFold(strings.TrimSpace(options.BreakoutShape), "baseline_plus_t3") &&
+		t3LongBreakoutShapeReady(prevHigh1, prevHigh2, prevHigh3) &&
+		observedPrice >= prevHigh3 {
+		return "t3_swing", prevHigh3
+	}
+	return "", 0
+}
+
+func resolveShortBreakoutShape(prevLow1, prevLow2, prevLow3, observedPrice float64, options signalBarGateOptions) (string, float64) {
+	if t2ShortBreakoutShapeReady(prevLow2, prevLow1, options.BreakoutShapeToleranceBps) && observedPrice <= prevLow2 {
+		return "original_t2", prevLow2
+	}
+	if strings.EqualFold(strings.TrimSpace(options.BreakoutShape), "baseline_plus_t3") &&
+		t3ShortBreakoutShapeReady(prevLow1, prevLow2, prevLow3) &&
+		observedPrice <= prevLow3 {
+		return "t3_swing", prevLow3
+	}
+	return "", 0
 }
 
 func t2LongBreakoutShapeReady(prevHigh2, prevHigh1, toleranceBps float64) bool {
@@ -1037,6 +1168,131 @@ func t2ShortBreakoutShapeReady(prevLow2, prevLow1, toleranceBps float64) bool {
 		return prevLow2 < prevLow1
 	}
 	return prevLow2 <= prevLow1*(1+toleranceBps/10000)
+}
+
+func t3LongBreakoutShapeReady(prevHigh1, prevHigh2, prevHigh3 float64) bool {
+	return prevHigh1 > 0 && prevHigh2 > 0 && prevHigh3 > 0 &&
+		prevHigh3 > prevHigh2 &&
+		prevHigh3 > prevHigh1 &&
+		prevHigh1 > prevHigh2
+}
+
+func t3ShortBreakoutShapeReady(prevLow1, prevLow2, prevLow3 float64) bool {
+	return prevLow1 > 0 && prevLow2 > 0 && prevLow3 > 0 &&
+		prevLow3 < prevLow2 &&
+		prevLow3 < prevLow1 &&
+		prevLow1 < prevLow2
+}
+
+func evaluateBreakoutQualityGate(options signalBarGateOptions, shape string, level, sma5, atr14, atrPercentile float64) BreakoutQualityReport {
+	report := BreakoutQualityReport{
+		Shape:   strings.TrimSpace(shape),
+		Scope:   "entry-only",
+		Applied: false,
+		Ready:   true,
+	}
+	if strings.TrimSpace(shape) == "" {
+		return report
+	}
+	if !breakoutQualityAppliesToShape(options, shape) || (options.MinATRPercentile <= 0 && options.MinSMAATRSeparation <= 0) {
+		return report
+	}
+	report.Applied = true
+	rejectReasons := []string{}
+	if options.MinATRPercentile > 0 {
+		ready := atrPercentile > 0 && atrPercentile >= options.MinATRPercentile
+		result := EntryQualityGateResult{
+			Name:    "min_atr_percentile",
+			Scope:   "entry-only",
+			Applied: true,
+			Ready:   ready,
+			Metrics: map[string]any{
+				"atrPercentile": atrPercentile,
+			},
+			Thresholds: map[string]any{
+				"minATRPercentile": options.MinATRPercentile,
+			},
+		}
+		if !ready {
+			result.Reason = "atr_percentile"
+			rejectReasons = append(rejectReasons, result.Reason)
+		}
+		report.GateResults = append(report.GateResults, result)
+	}
+	if options.MinSMAATRSeparation > 0 {
+		separation := 0.0
+		if level > 0 && sma5 > 0 && atr14 > 0 {
+			separation = math.Abs(level-sma5) / atr14
+		}
+		ready := separation > 0 && separation >= options.MinSMAATRSeparation
+		result := EntryQualityGateResult{
+			Name:    "min_sma_atr_separation",
+			Scope:   "entry-only",
+			Applied: true,
+			Ready:   ready,
+			Metrics: map[string]any{
+				"breakoutLevel":    level,
+				"sma5":             sma5,
+				"atr14":            atr14,
+				"smaATRSeparation": separation,
+			},
+			Thresholds: map[string]any{
+				"minSMAATRSeparation": options.MinSMAATRSeparation,
+			},
+		}
+		if !ready {
+			result.Reason = "sma_atr_separation"
+			rejectReasons = append(rejectReasons, result.Reason)
+		}
+		report.GateResults = append(report.GateResults, result)
+	}
+	if len(rejectReasons) > 0 {
+		report.Ready = false
+		report.Reason = rejectReasons[0]
+	}
+	return report
+}
+
+func breakoutQualityAppliesToShape(options signalBarGateOptions, shape string) bool {
+	normalizedShape := strings.ToLower(strings.TrimSpace(shape))
+	if normalizedShape == "" {
+		return false
+	}
+	shapes := options.QualityFilterShapes
+	if len(shapes) == 0 {
+		return normalizedShape == "t3_swing"
+	}
+	for _, item := range shapes {
+		if strings.EqualFold(strings.TrimSpace(item), normalizedShape) {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeStringList(value any) []string {
+	items := []string{}
+	add := func(raw string) {
+		for _, part := range strings.Split(raw, ",") {
+			normalized := strings.ToLower(strings.TrimSpace(part))
+			if normalized != "" {
+				items = append(items, normalized)
+			}
+		}
+	}
+	switch raw := value.(type) {
+	case []string:
+		for _, item := range raw {
+			add(item)
+		}
+	case []any:
+		for _, item := range raw {
+			add(stringValue(item))
+		}
+	case string:
+		add(raw)
+	}
+	return items
 }
 
 func sanitizeBreakoutShapeToleranceBps(toleranceBps float64) float64 {

--- a/internal/service/strategy_registry.go
+++ b/internal/service/strategy_registry.go
@@ -950,14 +950,12 @@ func evaluateSignalBarGate(signalBarState map[string]any, nextSide, nextRole, ne
 		prevHigh1,
 		prevHigh2,
 		prevHigh3,
-		breakoutPrice,
 		gateOptions,
 	)
 	shortBreakoutShapeName, shortBreakoutLevel := resolveShortBreakoutShape(
 		prevLow1,
 		prevLow2,
 		prevLow3,
-		breakoutPrice,
 		gateOptions,
 	)
 	longBreakoutShapeReady := longBreakoutShapeName != "" && longBreakoutLevel > 0
@@ -1124,25 +1122,23 @@ func evaluateReentryEntryQualityGate(parameters map[string]any, signalBarState m
 	return result
 }
 
-func resolveLongBreakoutShape(prevHigh1, prevHigh2, prevHigh3, observedPrice float64, options signalBarGateOptions) (string, float64) {
-	if t2LongBreakoutShapeReady(prevHigh2, prevHigh1, options.BreakoutShapeToleranceBps) && observedPrice >= prevHigh2 {
+func resolveLongBreakoutShape(prevHigh1, prevHigh2, prevHigh3 float64, options signalBarGateOptions) (string, float64) {
+	if t2LongBreakoutShapeReady(prevHigh2, prevHigh1, options.BreakoutShapeToleranceBps) {
 		return "original_t2", prevHigh2
 	}
 	if strings.EqualFold(strings.TrimSpace(options.BreakoutShape), "baseline_plus_t3") &&
-		t3LongBreakoutShapeReady(prevHigh1, prevHigh2, prevHigh3) &&
-		observedPrice >= prevHigh3 {
+		t3LongBreakoutShapeReady(prevHigh1, prevHigh2, prevHigh3) {
 		return "t3_swing", prevHigh3
 	}
 	return "", 0
 }
 
-func resolveShortBreakoutShape(prevLow1, prevLow2, prevLow3, observedPrice float64, options signalBarGateOptions) (string, float64) {
-	if t2ShortBreakoutShapeReady(prevLow2, prevLow1, options.BreakoutShapeToleranceBps) && observedPrice <= prevLow2 {
+func resolveShortBreakoutShape(prevLow1, prevLow2, prevLow3 float64, options signalBarGateOptions) (string, float64) {
+	if t2ShortBreakoutShapeReady(prevLow2, prevLow1, options.BreakoutShapeToleranceBps) {
 		return "original_t2", prevLow2
 	}
 	if strings.EqualFold(strings.TrimSpace(options.BreakoutShape), "baseline_plus_t3") &&
-		t3ShortBreakoutShapeReady(prevLow1, prevLow2, prevLow3) &&
-		observedPrice <= prevLow3 {
+		t3ShortBreakoutShapeReady(prevLow1, prevLow2, prevLow3) {
 		return "t3_swing", prevLow3
 	}
 	return "", 0

--- a/internal/service/strategy_replay.go
+++ b/internal/service/strategy_replay.go
@@ -42,44 +42,50 @@ type executionBar struct {
 }
 
 type strategyPosition struct {
-	Side       string
-	EntryPrice float64
-	StopLoss   float64
-	Protected  bool
-	Notional   float64
-	Reason     string
-	BarIndex   int
-	EntryTime  time.Time
-	HWM        float64
-	LWM        float64
+	Side          string
+	EntryPrice    float64
+	StopLoss      float64
+	Protected     bool
+	Notional      float64
+	Reason        string
+	BreakoutShape string
+	BarIndex      int
+	EntryTime     time.Time
+	HWM           float64
+	LWM           float64
 }
 
 type strategyReplayConfig struct {
-	SignalTimeframe           string
-	ExecutionDataSource       string
-	Symbol                    string
-	From                      time.Time
-	To                        time.Time
-	InitialBalance            float64
-	Dir1ReentryConfirm        bool
-	Dir2ZeroInitial           bool
-	ZeroInitialMode           string
-	FixedSlippage             float64
-	StopLossATR               float64
-	MaxTradesPerBar           int
-	ReentrySizeSchedule       []float64
-	LongReentryATR            float64
-	ShortReentryATR           float64
-	StopMode                  string
-	ProfitProtectATR          float64
-	TrailingStopATR           float64
-	DelayedTrailingATR        float64
-	TradingFeeRate            float64
-	FundingRate               float64
-	FundingIntervalHours      int
-	BreakoutShape             string
-	BreakoutShapeToleranceBps float64
-	UseSMA5IntradayStructure  bool
+	SignalTimeframe               string
+	ExecutionDataSource           string
+	Symbol                        string
+	From                          time.Time
+	To                            time.Time
+	InitialBalance                float64
+	Dir1ReentryConfirm            bool
+	Dir2ZeroInitial               bool
+	ZeroInitialMode               string
+	FixedSlippage                 float64
+	StopLossATR                   float64
+	MaxTradesPerBar               int
+	ReentrySizeSchedule           []float64
+	LongReentryATR                float64
+	ShortReentryATR               float64
+	StopMode                      string
+	ProfitProtectATR              float64
+	TrailingStopATR               float64
+	DelayedTrailingATR            float64
+	TradingFeeRate                float64
+	FundingRate                   float64
+	FundingIntervalHours          int
+	BreakoutShape                 string
+	BreakoutShapeToleranceBps     float64
+	UseSMA5IntradayStructure      bool
+	MinATRPercentile              float64
+	MinSMAATRSeparation           float64
+	QualityFilterShapes           []string
+	SignalDecisionMaxDeviationBps float64
+	SLReentryMinDelaySeconds      int
 }
 
 func (p *Platform) runStrategyReplay(context StrategyExecutionContext) (map[string]any, error) {
@@ -121,6 +127,7 @@ func (p *Platform) runStrategyReplayOnTick(cfg strategyReplayConfig, signals []s
 	defer iterator.Close()
 
 	engine := newStrategyReplayEngine(cfg)
+	closedTrueRanges := replayClosedTrueRanges(signals)
 	commission := cfg.TradingFeeRate
 	initialUsage := 0.10
 	if cfg.Dir2ZeroInitial {
@@ -166,41 +173,61 @@ func (p *Platform) runStrategyReplayOnTick(cfg strategyReplayConfig, signals []s
 			engine.lastExitSide = ""
 		}
 		engine.clearExpiredZeroInitialWindow(i)
+		highSoFar := math.Inf(-1)
+		lowSoFar := math.Inf(1)
+		qualityRejectRecorded := map[string]map[string]bool{
+			"long":  {},
+			"short": {},
+		}
 
 		for hasEvent && !nextEvent.Time.After(endT) {
 			current := nextEvent
 			engine.processedCount++
+			highSoFar = math.Max(highSoFar, current.Price)
+			lowSoFar = math.Min(lowSoFar, current.Price)
+			evalSig := sig
+			if replayUsesLiveAlignedSignal(cfg) {
+				evalSig = liveAlignedReplaySignal(signals, i, highSoFar, lowSoFar, current.Price, closedTrueRanges)
+			}
 			if engine.position == nil {
 				executed := false
 
-				longRegimeReady, shortRegimeReady := strategySignalRegimeReady(sig, engine.cfg.SignalTimeframe, engine.cfg.UseSMA5IntradayStructure)
+				longRegimeReady, shortRegimeReady := strategySignalRegimeReady(evalSig, engine.cfg.SignalTimeframe, engine.cfg.UseSMA5IntradayStructure)
 				if longRegimeReady {
-					reP := sig.PrevLow1 + cfg.LongReentryATR*sig.ATR
-					if breakout := resolveReplayInitialBreakout(sig, "long", current.Price, cfg); tradesInBar == 0 && breakout.Ready {
-						if engine.zeroInitialReentryWindowEnabled() {
-							engine.armZeroInitialWindow("long", i)
-						} else {
-							entry := math.Max(current.Price, breakout.Level) * (1 + cfg.FixedSlippage)
-							notional := engine.balance * initialUsage
-							stopLoss := resolveStopPrice("long", entry, sig, cfg.StopMode, cfg.StopLossATR)
-							engine.position = &strategyPosition{
-								Side:       "long",
-								EntryPrice: entry,
-								StopLoss:   stopLoss,
-								Protected:  false,
-								Notional:   notional,
-								Reason:     "Initial",
-								BarIndex:   i,
-								EntryTime:  current.Time,
-								HWM:        entry,
-								LWM:        entry,
+					reP := evalSig.PrevLow1 + cfg.LongReentryATR*evalSig.ATR
+					if breakout := resolveReplayInitialBreakout(evalSig, "long", current.Price, cfg); tradesInBar == 0 {
+						if breakout.QualityRejected && !qualityRejectRecorded["long"][breakout.RejectReason] {
+							engine.recordBreakoutQualityReject("long", breakout.RejectReason)
+							qualityRejectRecorded["long"][breakout.RejectReason] = true
+						}
+						if breakout.Ready {
+							if engine.zeroInitialReentryWindowEnabled() {
+								engine.armZeroInitialWindow("long", i, breakout.Shape)
+								engine.recordBreakoutLock("long", breakout.Shape)
+							} else {
+								entry := math.Max(current.Price, breakout.Level) * (1 + cfg.FixedSlippage)
+								notional := engine.balance * initialUsage
+								stopLoss := resolveStopPrice("long", entry, evalSig, cfg.StopMode, cfg.StopLossATR)
+								engine.position = &strategyPosition{
+									Side:          "long",
+									EntryPrice:    entry,
+									StopLoss:      stopLoss,
+									Protected:     false,
+									Notional:      notional,
+									Reason:        "Initial",
+									BreakoutShape: breakout.Shape,
+									BarIndex:      i,
+									EntryTime:     current.Time,
+									HWM:           entry,
+									LWM:           entry,
+								}
+								tradingFee := notional * commission
+								engine.balance -= tradingFee
+								engine.totalTradingFees += tradingFee
+								engine.appendTrade("BUY", current.Time, entry, "Initial", notional, 0, tradingFee, 0, breakout.Shape)
+								tradesInBar++
+								executed = true
 							}
-							tradingFee := notional * commission
-							engine.balance -= tradingFee
-							engine.totalTradingFees += tradingFee
-							engine.appendTrade("BUY", current.Time, entry, "Initial", notional, 0, tradingFee, 0)
-							tradesInBar++
-							executed = true
 						}
 					}
 					hasExitWindow := engine.lastExitSide == "long" && i-engine.lastExitBarIndex <= 1
@@ -208,6 +235,7 @@ func (p *Platform) runStrategyReplayOnTick(cfg strategyReplayConfig, signals []s
 					if hasExitWindow || hasZeroWindow {
 						if current.Price >= reP {
 							reason := "Zero-Initial-Reentry"
+							shape := engine.pendingZeroInitialShape
 							size := getReentrySize(1, cfg.ReentrySizeSchedule)
 							effectiveTradesInBar := 0
 							ok := size > 0
@@ -216,28 +244,30 @@ func (p *Platform) runStrategyReplayOnTick(cfg strategyReplayConfig, signals []s
 								if engine.lastExitReason == "SL" {
 									reason = "SL-Reentry"
 								}
+								shape = ""
 								size, effectiveTradesInBar, ok = resolveReplayReentrySlot(tradesInBar, cfg.MaxTradesPerBar, cfg.ReentrySizeSchedule)
 							}
-							if ok {
+							if ok && engine.replayReentryAllowed(evalSig, "long", reason, reP, current.Price, current.Time) {
 								notional := engine.balance * size
 								entry := reP * (1 + cfg.FixedSlippage)
-								stopLoss := resolveStopPrice("long", entry, sig, cfg.StopMode, cfg.StopLossATR)
+								stopLoss := resolveStopPrice("long", entry, evalSig, cfg.StopMode, cfg.StopLossATR)
 								engine.position = &strategyPosition{
-									Side:       "long",
-									EntryPrice: entry,
-									StopLoss:   stopLoss,
-									Protected:  false,
-									Notional:   notional,
-									Reason:     reason,
-									BarIndex:   i,
-									EntryTime:  current.Time,
-									HWM:        entry,
-									LWM:        entry,
+									Side:          "long",
+									EntryPrice:    entry,
+									StopLoss:      stopLoss,
+									Protected:     false,
+									Notional:      notional,
+									Reason:        reason,
+									BreakoutShape: shape,
+									BarIndex:      i,
+									EntryTime:     current.Time,
+									HWM:           entry,
+									LWM:           entry,
 								}
 								tradingFee := notional * commission
 								engine.balance -= tradingFee
 								engine.totalTradingFees += tradingFee
-								engine.appendTrade("BUY", current.Time, entry, reason, notional, 0, tradingFee, 0)
+								engine.appendTrade("BUY", current.Time, entry, reason, notional, 0, tradingFee, 0, shape)
 								if hasExitWindow {
 									tradesInBar = effectiveTradesInBar + 1
 								} else {
@@ -254,32 +284,40 @@ func (p *Platform) runStrategyReplayOnTick(cfg strategyReplayConfig, signals []s
 						}
 					}
 				} else if shortRegimeReady {
-					reP := sig.PrevHigh1 + cfg.ShortReentryATR*sig.ATR
-					if breakout := resolveReplayInitialBreakout(sig, "short", current.Price, cfg); tradesInBar == 0 && breakout.Ready {
-						if engine.zeroInitialReentryWindowEnabled() {
-							engine.armZeroInitialWindow("short", i)
-						} else {
-							entry := math.Min(current.Price, breakout.Level) * (1 - cfg.FixedSlippage)
-							notional := engine.balance * initialUsage
-							stopLoss := resolveStopPrice("short", entry, sig, cfg.StopMode, cfg.StopLossATR)
-							engine.position = &strategyPosition{
-								Side:       "short",
-								EntryPrice: entry,
-								StopLoss:   stopLoss,
-								Protected:  false,
-								Notional:   notional,
-								Reason:     "Initial",
-								BarIndex:   i,
-								EntryTime:  current.Time,
-								HWM:        entry,
-								LWM:        entry,
+					reP := evalSig.PrevHigh1 + cfg.ShortReentryATR*evalSig.ATR
+					if breakout := resolveReplayInitialBreakout(evalSig, "short", current.Price, cfg); tradesInBar == 0 {
+						if breakout.QualityRejected && !qualityRejectRecorded["short"][breakout.RejectReason] {
+							engine.recordBreakoutQualityReject("short", breakout.RejectReason)
+							qualityRejectRecorded["short"][breakout.RejectReason] = true
+						}
+						if breakout.Ready {
+							if engine.zeroInitialReentryWindowEnabled() {
+								engine.armZeroInitialWindow("short", i, breakout.Shape)
+								engine.recordBreakoutLock("short", breakout.Shape)
+							} else {
+								entry := math.Min(current.Price, breakout.Level) * (1 - cfg.FixedSlippage)
+								notional := engine.balance * initialUsage
+								stopLoss := resolveStopPrice("short", entry, evalSig, cfg.StopMode, cfg.StopLossATR)
+								engine.position = &strategyPosition{
+									Side:          "short",
+									EntryPrice:    entry,
+									StopLoss:      stopLoss,
+									Protected:     false,
+									Notional:      notional,
+									Reason:        "Initial",
+									BreakoutShape: breakout.Shape,
+									BarIndex:      i,
+									EntryTime:     current.Time,
+									HWM:           entry,
+									LWM:           entry,
+								}
+								tradingFee := notional * commission
+								engine.balance -= tradingFee
+								engine.totalTradingFees += tradingFee
+								engine.appendTrade("SHORT", current.Time, entry, "Initial", notional, 0, tradingFee, 0, breakout.Shape)
+								tradesInBar++
+								executed = true
 							}
-							tradingFee := notional * commission
-							engine.balance -= tradingFee
-							engine.totalTradingFees += tradingFee
-							engine.appendTrade("SHORT", current.Time, entry, "Initial", notional, 0, tradingFee, 0)
-							tradesInBar++
-							executed = true
 						}
 					}
 					hasExitWindow := engine.lastExitSide == "short" && i-engine.lastExitBarIndex <= 1
@@ -287,6 +325,7 @@ func (p *Platform) runStrategyReplayOnTick(cfg strategyReplayConfig, signals []s
 					if hasExitWindow || hasZeroWindow {
 						if current.Price <= reP {
 							reason := "Zero-Initial-Reentry"
+							shape := engine.pendingZeroInitialShape
 							size := getReentrySize(1, cfg.ReentrySizeSchedule)
 							effectiveTradesInBar := 0
 							ok := size > 0
@@ -295,28 +334,30 @@ func (p *Platform) runStrategyReplayOnTick(cfg strategyReplayConfig, signals []s
 								if engine.lastExitReason == "SL" {
 									reason = "SL-Reentry"
 								}
+								shape = ""
 								size, effectiveTradesInBar, ok = resolveReplayReentrySlot(tradesInBar, cfg.MaxTradesPerBar, cfg.ReentrySizeSchedule)
 							}
-							if ok {
+							if ok && engine.replayReentryAllowed(evalSig, "short", reason, reP, current.Price, current.Time) {
 								notional := engine.balance * size
 								entry := reP * (1 - cfg.FixedSlippage)
-								stopLoss := resolveStopPrice("short", entry, sig, cfg.StopMode, cfg.StopLossATR)
+								stopLoss := resolveStopPrice("short", entry, evalSig, cfg.StopMode, cfg.StopLossATR)
 								engine.position = &strategyPosition{
-									Side:       "short",
-									EntryPrice: entry,
-									StopLoss:   stopLoss,
-									Protected:  false,
-									Notional:   notional,
-									Reason:     reason,
-									BarIndex:   i,
-									EntryTime:  current.Time,
-									HWM:        entry,
-									LWM:        entry,
+									Side:          "short",
+									EntryPrice:    entry,
+									StopLoss:      stopLoss,
+									Protected:     false,
+									Notional:      notional,
+									Reason:        reason,
+									BreakoutShape: shape,
+									BarIndex:      i,
+									EntryTime:     current.Time,
+									HWM:           entry,
+									LWM:           entry,
 								}
 								tradingFee := notional * commission
 								engine.balance -= tradingFee
 								engine.totalTradingFees += tradingFee
-								engine.appendTrade("SHORT", current.Time, entry, reason, notional, 0, tradingFee, 0)
+								engine.appendTrade("SHORT", current.Time, entry, reason, notional, 0, tradingFee, 0, shape)
 								if hasExitWindow {
 									tradesInBar = effectiveTradesInBar + 1
 								} else {
@@ -697,7 +738,9 @@ type strategyReplayEngine struct {
 	lastExitReason             string
 	lastExitSide               string
 	lastExitBarIndex           int
+	lastExitTime               time.Time
 	pendingZeroInitialSide     string
+	pendingZeroInitialShape    string
 	pendingZeroInitialBarIndex int
 	currentBarIndex            int
 	tradesInBar                int
@@ -707,6 +750,35 @@ type strategyReplayEngine struct {
 	processedCount             int
 	totalTradingFees           float64
 	totalFundingPnL            float64
+	diagnostics                strategyReplayDiagnostics
+}
+
+type strategyReplayDiagnostics struct {
+	BreakoutLocks          map[string]map[string]int
+	BreakoutQualityRejects map[string]map[string]int
+	ActionableGateSkips    int
+	SLReentryDelaySkips    int
+}
+
+func (d strategyReplayDiagnostics) toMap() map[string]any {
+	return map[string]any{
+		"breakoutLocks":          cloneStringIntNestedMap(d.BreakoutLocks),
+		"breakoutQualityRejects": cloneStringIntNestedMap(d.BreakoutQualityRejects),
+		"actionableGateSkips":    d.ActionableGateSkips,
+		"slReentryDelaySkips":    d.SLReentryDelaySkips,
+	}
+}
+
+func cloneStringIntNestedMap(input map[string]map[string]int) map[string]any {
+	out := make(map[string]any, len(input))
+	for key, values := range input {
+		nested := make(map[string]int, len(values))
+		for nestedKey, value := range values {
+			nested[nestedKey] = value
+		}
+		out[key] = nested
+	}
+	return out
 }
 
 func newStrategyReplayEngine(cfg strategyReplayConfig) *strategyReplayEngine {
@@ -717,6 +789,16 @@ func newStrategyReplayEngine(cfg strategyReplayConfig) *strategyReplayEngine {
 		pendingZeroInitialBarIndex: -999,
 		equity:                     []float64{cfg.InitialBalance},
 		trades:                     make([]map[string]any, 0, 128),
+		diagnostics: strategyReplayDiagnostics{
+			BreakoutLocks: map[string]map[string]int{
+				"long":  {},
+				"short": {},
+			},
+			BreakoutQualityRejects: map[string]map[string]int{
+				"long":  {},
+				"short": {},
+			},
+		},
 	}
 }
 
@@ -727,12 +809,17 @@ func (e *strategyReplayEngine) zeroInitialReentryWindowEnabled() bool {
 func (e *strategyReplayEngine) clearExpiredZeroInitialWindow(currentBarIndex int) {
 	if currentBarIndex-e.pendingZeroInitialBarIndex > 1 {
 		e.pendingZeroInitialSide = ""
+		e.pendingZeroInitialShape = ""
 		e.pendingZeroInitialBarIndex = -999
 	}
 }
 
-func (e *strategyReplayEngine) armZeroInitialWindow(side string, currentBarIndex int) {
+func (e *strategyReplayEngine) armZeroInitialWindow(side string, currentBarIndex int, shape ...string) {
 	e.pendingZeroInitialSide = strings.ToLower(strings.TrimSpace(side))
+	e.pendingZeroInitialShape = ""
+	if len(shape) > 0 {
+		e.pendingZeroInitialShape = strings.TrimSpace(shape[0])
+	}
 	e.pendingZeroInitialBarIndex = currentBarIndex
 }
 
@@ -743,7 +830,77 @@ func (e *strategyReplayEngine) hasZeroInitialWindow(side string, currentBarIndex
 
 func (e *strategyReplayEngine) clearZeroInitialWindow() {
 	e.pendingZeroInitialSide = ""
+	e.pendingZeroInitialShape = ""
 	e.pendingZeroInitialBarIndex = -999
+}
+
+func (e *strategyReplayEngine) recordBreakoutLock(side, shape string) {
+	side = replayDiagnosticsSide(side)
+	shape = strings.TrimSpace(shape)
+	if side == "" || shape == "" {
+		return
+	}
+	if e.diagnostics.BreakoutLocks[side] == nil {
+		e.diagnostics.BreakoutLocks[side] = map[string]int{}
+	}
+	e.diagnostics.BreakoutLocks[side][shape]++
+}
+
+func (e *strategyReplayEngine) recordBreakoutQualityReject(side, reason string) {
+	side = replayDiagnosticsSide(side)
+	reason = strings.TrimSpace(reason)
+	if side == "" || reason == "" {
+		return
+	}
+	if e.diagnostics.BreakoutQualityRejects[side] == nil {
+		e.diagnostics.BreakoutQualityRejects[side] = map[string]int{}
+	}
+	e.diagnostics.BreakoutQualityRejects[side][reason]++
+}
+
+func replayDiagnosticsSide(side string) string {
+	switch strings.ToLower(strings.TrimSpace(side)) {
+	case "buy", "long":
+		return "long"
+	case "sell", "short":
+		return "short"
+	default:
+		return ""
+	}
+}
+
+func (e *strategyReplayEngine) replayReentryAllowed(sig strategySignalBar, side, reason string, plannedPrice, marketPrice float64, eventTime time.Time) bool {
+	if e.cfg.SLReentryMinDelaySeconds > 0 &&
+		strings.EqualFold(strings.TrimSpace(e.lastExitReason), "SL") &&
+		!e.lastExitTime.IsZero() &&
+		eventTime.UTC().Sub(e.lastExitTime.UTC()) < time.Duration(e.cfg.SLReentryMinDelaySeconds)*time.Second {
+		e.diagnostics.SLReentryDelaySkips++
+		return false
+	}
+	if e.cfg.SignalDecisionMaxDeviationBps > 0 && plannedPrice > 0 && marketPrice > 0 {
+		nextSide := "BUY"
+		if strings.EqualFold(strings.TrimSpace(side), "short") {
+			nextSide = "SELL"
+		}
+		if !isPlannedPriceActionable(nextSide, plannedPrice, marketPrice, e.cfg.SignalDecisionMaxDeviationBps) {
+			e.diagnostics.ActionableGateSkips++
+			return false
+		}
+	}
+	nextSide := "BUY"
+	if strings.EqualFold(strings.TrimSpace(side), "short") {
+		nextSide = "SELL"
+	}
+	gate := evaluateReentryEntryQualityGate(
+		replayParametersFromConfig(e.cfg),
+		replaySignalBarState(sig, e.cfg.Symbol, e.cfg.SignalTimeframe),
+		nextSide,
+		"entry",
+		reason,
+		plannedPrice,
+		marketPrice,
+	)
+	return boolValue(gate["ready"])
 }
 
 func (e *strategyReplayEngine) process(bar executionBar, signals []strategySignalBar) {
@@ -981,7 +1138,7 @@ func (e *strategyReplayEngine) tryExit(bar executionBar, sig strategySignalBar) 
 	e.position = nil
 }
 
-func (e *strategyReplayEngine) appendTrade(kind string, at time.Time, price float64, reason string, notional float64, pnl float64, tradingFee float64, fundingPnL float64) {
+func (e *strategyReplayEngine) appendTrade(kind string, at time.Time, price float64, reason string, notional float64, pnl float64, tradingFee float64, fundingPnL float64, breakoutShape ...string) {
 	record := map[string]any{
 		"time":       at.UTC().Format(time.RFC3339),
 		"type":       kind,
@@ -992,6 +1149,9 @@ func (e *strategyReplayEngine) appendTrade(kind string, at time.Time, price floa
 		"pnl":        pnl,
 		"tradingFee": tradingFee,
 		"fundingPnL": fundingPnL,
+	}
+	if len(breakoutShape) > 0 && strings.TrimSpace(breakoutShape[0]) != "" {
+		record["breakoutShapeName"] = strings.TrimSpace(breakoutShape[0])
 	}
 	e.equity = append(e.equity, e.balance)
 	e.trades = append(e.trades, record)
@@ -1014,6 +1174,7 @@ func (e *strategyReplayEngine) summary(signals []strategySignalBar) map[string]a
 	} else {
 		result["processedBars"] = e.processedCount
 	}
+	result["diagnostics"] = e.diagnostics.toMap()
 	result["tradingFees"] = e.totalTradingFees
 	result["fundingPnL"] = e.totalFundingPnL
 	if len(e.trades) == 0 {
@@ -1049,31 +1210,36 @@ func buildStrategyReplayConfig(context StrategyExecutionContext) strategyReplayC
 		stopLossATR = 0.05
 	}
 	return strategyReplayConfig{
-		SignalTimeframe:           normalizeSignalBarInterval(context.SignalTimeframe),
-		ExecutionDataSource:       strings.ToLower(context.ExecutionDataSource),
-		Symbol:                    normalizeBacktestSymbol(context.Symbol),
-		From:                      context.From,
-		To:                        context.To,
-		InitialBalance:            100000.0,
-		Dir1ReentryConfirm:        false,
-		Dir2ZeroInitial:           dir2ZeroInitial,
-		ZeroInitialMode:           resolveStrategyZeroInitialMode(dir2ZeroInitial, parameters["zero_initial_mode"]),
-		FixedSlippage:             strategyReplaySlippage(context, parameters),
-		StopLossATR:               stopLossATR,
-		MaxTradesPerBar:           maxIntValue(parameters["max_trades_per_bar"], domain.ResearchBaselineMaxTradesPerBar),
-		ReentrySizeSchedule:       reentrySizes,
-		LongReentryATR:            parseFloatValue(firstNonNil(parameters["long_reentry_atr"], 0.1)),
-		ShortReentryATR:           parseFloatValue(firstNonNil(parameters["short_reentry_atr"], 0.0)),
-		StopMode:                  stopMode,
-		ProfitProtectATR:          firstPositive(parseFloatValue(parameters["profit_protect_atr"]), 1.0),
-		TrailingStopATR:           parseFloatValue(parameters["trailing_stop_atr"]),
-		DelayedTrailingATR:        parseFloatValue(parameters["delayed_trailing_activation_atr"]),
-		TradingFeeRate:            context.Semantics.TradingFeeBps / 10000.0,
-		FundingRate:               context.Semantics.FundingRateBps / 10000.0,
-		FundingIntervalHours:      maxIntValue(context.Semantics.FundingIntervalHours, 8),
-		BreakoutShape:             strings.ToLower(strings.TrimSpace(stringValue(parameters["breakout_shape"]))),
-		BreakoutShapeToleranceBps: parseFloatValue(parameters["breakout_shape_tolerance_bps"]),
-		UseSMA5IntradayStructure:  boolValue(parameters["use_sma5_intraday_structure"]),
+		SignalTimeframe:               normalizeSignalBarInterval(context.SignalTimeframe),
+		ExecutionDataSource:           strings.ToLower(context.ExecutionDataSource),
+		Symbol:                        normalizeBacktestSymbol(context.Symbol),
+		From:                          context.From,
+		To:                            context.To,
+		InitialBalance:                100000.0,
+		Dir1ReentryConfirm:            false,
+		Dir2ZeroInitial:               dir2ZeroInitial,
+		ZeroInitialMode:               resolveStrategyZeroInitialMode(dir2ZeroInitial, parameters["zero_initial_mode"]),
+		FixedSlippage:                 strategyReplaySlippage(context, parameters),
+		StopLossATR:                   stopLossATR,
+		MaxTradesPerBar:               maxIntValue(parameters["max_trades_per_bar"], domain.ResearchBaselineMaxTradesPerBar),
+		ReentrySizeSchedule:           reentrySizes,
+		LongReentryATR:                parseFloatValue(firstNonNil(parameters["long_reentry_atr"], 0.1)),
+		ShortReentryATR:               parseFloatValue(firstNonNil(parameters["short_reentry_atr"], 0.0)),
+		StopMode:                      stopMode,
+		ProfitProtectATR:              firstPositive(parseFloatValue(parameters["profit_protect_atr"]), 1.0),
+		TrailingStopATR:               parseFloatValue(parameters["trailing_stop_atr"]),
+		DelayedTrailingATR:            parseFloatValue(parameters["delayed_trailing_activation_atr"]),
+		TradingFeeRate:                context.Semantics.TradingFeeBps / 10000.0,
+		FundingRate:                   context.Semantics.FundingRateBps / 10000.0,
+		FundingIntervalHours:          maxIntValue(context.Semantics.FundingIntervalHours, 8),
+		BreakoutShape:                 strings.ToLower(strings.TrimSpace(stringValue(parameters["breakout_shape"]))),
+		BreakoutShapeToleranceBps:     parseFloatValue(parameters["breakout_shape_tolerance_bps"]),
+		UseSMA5IntradayStructure:      boolValue(parameters["use_sma5_intraday_structure"]),
+		MinATRPercentile:              firstPositive(parseFloatValue(parameters["min_atr_percentile"]), parseFloatValue(parameters["breakout_min_atr_percentile"])),
+		MinSMAATRSeparation:           firstPositive(parseFloatValue(parameters["min_sma_atr_separation"]), parseFloatValue(parameters["breakout_min_sma_atr_separation"])),
+		QualityFilterShapes:           normalizeStringList(parameters["quality_filter_shapes"]),
+		SignalDecisionMaxDeviationBps: firstPositive(parseFloatValue(parameters["signalDecisionMaxDeviationBps"]), parseFloatValue(parameters["actionable_bps"])),
+		SLReentryMinDelaySeconds:      maxIntValue(parameters["sl_reentry_min_delay_seconds"], 0),
 	}
 }
 
@@ -1176,24 +1342,210 @@ func buildSignalBars(minuteBars []candleBar, timeframe string) ([]strategySignal
 	return signals, nil
 }
 
+func replayClosedTrueRanges(signals []strategySignalBar) []float64 {
+	trueRanges := make([]float64, len(signals))
+	for i, sig := range signals {
+		if i == 0 {
+			trueRanges[i] = sig.High - sig.Low
+			continue
+		}
+		highLow := sig.High - sig.Low
+		highClose := math.Abs(sig.High - signals[i-1].Close)
+		lowClose := math.Abs(sig.Low - signals[i-1].Close)
+		trueRanges[i] = math.Max(highLow, math.Max(highClose, lowClose))
+	}
+	return trueRanges
+}
+
+func liveAlignedReplaySignal(signals []strategySignalBar, index int, highSoFar, lowSoFar, closePrice float64, closedTrueRanges []float64) strategySignalBar {
+	sig := signals[index]
+	sig.High = highSoFar
+	sig.Low = lowSoFar
+	sig.Close = closePrice
+	if index >= 4 {
+		sum := closePrice
+		for i := index - 4; i < index; i++ {
+			sum += signals[i].Close
+		}
+		sig.MA5 = sum / 5
+	} else {
+		sig.MA5 = math.NaN()
+	}
+	if index >= 19 {
+		sum := closePrice
+		for i := index - 19; i < index; i++ {
+			sum += signals[i].Close
+		}
+		sig.MA20 = sum / 20
+	} else {
+		sig.MA20 = math.NaN()
+	}
+	currentTR := replayCurrentTrueRange(signals, index, highSoFar, lowSoFar, closePrice)
+	if index >= 13 {
+		sum := currentTR
+		for i := index - 13; i < index; i++ {
+			sum += closedTrueRanges[i]
+		}
+		sig.ATR = sum / 14
+	} else {
+		sig.ATR = math.NaN()
+	}
+	sig.ATRPercentile = replayCurrentATRPercentile(closedTrueRanges, index, sig.ATR)
+	if index >= 1 {
+		sig.PrevHigh1 = signals[index-1].High
+		sig.PrevLow1 = signals[index-1].Low
+	}
+	if index >= 2 {
+		sig.PrevHigh2 = signals[index-2].High
+		sig.PrevLow2 = signals[index-2].Low
+	}
+	if index >= 3 {
+		sig.PrevHigh3 = signals[index-3].High
+		sig.PrevLow3 = signals[index-3].Low
+	}
+	return sig
+}
+
+func replayCurrentTrueRange(signals []strategySignalBar, index int, highSoFar, lowSoFar, closePrice float64) float64 {
+	if index <= 0 {
+		return highSoFar - lowSoFar
+	}
+	prevClose := signals[index-1].Close
+	highLow := highSoFar - lowSoFar
+	highClose := math.Abs(highSoFar - prevClose)
+	lowClose := math.Abs(lowSoFar - prevClose)
+	if closePrice <= 0 {
+		return math.Max(highLow, math.Max(highClose, lowClose))
+	}
+	return math.Max(highLow, math.Max(highClose, lowClose))
+}
+
+func replayCurrentATRPercentile(closedTrueRanges []float64, index int, currentATR float64) float64 {
+	if math.IsNaN(currentATR) || math.IsInf(currentATR, 0) {
+		return math.NaN()
+	}
+	start := index - 239
+	if start < 0 {
+		start = 0
+	}
+	clean := make([]float64, 0, index-start+1)
+	for i := start; i < index; i++ {
+		value := rollingMeanOrNaN(closedTrueRanges, i, 14)
+		if !math.IsNaN(value) && !math.IsInf(value, 0) {
+			clean = append(clean, value)
+		}
+	}
+	clean = append(clean, currentATR)
+	if len(clean) < 50 {
+		return math.NaN()
+	}
+	lessOrEqual := 0
+	for _, value := range clean {
+		if value <= currentATR {
+			lessOrEqual++
+		}
+	}
+	return float64(lessOrEqual) / float64(len(clean)) * 100.0
+}
+
+func replayUsesLiveAlignedSignal(cfg strategyReplayConfig) bool {
+	return cfg.UseSMA5IntradayStructure && normalizeSignalBarInterval(cfg.SignalTimeframe) != "1d"
+}
+
 type replayInitialBreakout struct {
-	Ready bool
-	Level float64
-	Shape string
+	Ready           bool
+	Level           float64
+	Shape           string
+	QualityRejected bool
+	RejectReason    string
 }
 
 func resolveReplayInitialBreakout(sig strategySignalBar, side string, observedPrice float64, cfg strategyReplayConfig) replayInitialBreakout {
-	switch strings.ToLower(strings.TrimSpace(side)) {
-	case "long":
-		if t2LongBreakoutShapeReady(sig.PrevHigh2, sig.PrevHigh1, cfg.BreakoutShapeToleranceBps) && observedPrice >= sig.PrevHigh2 {
-			return replayInitialBreakout{Ready: true, Level: sig.PrevHigh2, Shape: "original_t2"}
-		}
-	case "short":
-		if t2ShortBreakoutShapeReady(sig.PrevLow2, sig.PrevLow1, cfg.BreakoutShapeToleranceBps) && observedPrice <= sig.PrevLow2 {
-			return replayInitialBreakout{Ready: true, Level: sig.PrevLow2, Shape: "original_t2"}
+	nextSide := "BUY"
+	fieldPrefix := "long"
+	if strings.EqualFold(strings.TrimSpace(side), "short") {
+		nextSide = "SELL"
+		fieldPrefix = "short"
+	}
+	gate := evaluateSignalBarGate(
+		replaySignalBarState(sig, cfg.Symbol, cfg.SignalTimeframe),
+		nextSide,
+		"entry",
+		"Initial",
+		observedPrice,
+		"replay.observed_price",
+		signalBarGateOptionsFromParameters(replayParametersFromConfig(cfg)),
+	)
+	shape := stringValue(gate[fieldPrefix+"BreakoutShapeName"])
+	level := parseFloatValue(gate[fieldPrefix+"BreakoutLevel"])
+	if boolValue(gate[fieldPrefix+"BreakoutReady"]) {
+		return replayInitialBreakout{Ready: true, Level: level, Shape: shape}
+	}
+	if shape != "" &&
+		boolValue(gate[fieldPrefix+"BreakoutShapeReady"]) &&
+		boolValue(gate[fieldPrefix+"BreakoutPriceReady"]) &&
+		!boolValue(gate[fieldPrefix+"BreakoutQualityReady"]) {
+		return replayInitialBreakout{
+			Ready:           false,
+			Level:           level,
+			Shape:           shape,
+			QualityRejected: true,
+			RejectReason:    stringValue(gate[fieldPrefix+"BreakoutRejectReason"]),
 		}
 	}
 	return replayInitialBreakout{}
+}
+
+func replaySignalBarState(sig strategySignalBar, symbol, timeframe string) map[string]any {
+	return map[string]any{
+		"symbol":         NormalizeSymbol(symbol),
+		"timeframe":      normalizeSignalBarInterval(timeframe),
+		"sma5":           sig.MA5,
+		"ma20":           sig.MA20,
+		"atr14":          sig.ATR,
+		"atrPercentile":  sig.ATRPercentile,
+		"current":        replayCandleMap(symbol, timeframe, sig.Time, sig.Open, sig.High, sig.Low, sig.Close),
+		"prevBar1":       replayCandleMap(symbol, timeframe, time.Time{}, 0, sig.PrevHigh1, sig.PrevLow1, 0),
+		"prevBar2":       replayCandleMap(symbol, timeframe, time.Time{}, 0, sig.PrevHigh2, sig.PrevLow2, 0),
+		"prevBar3":       replayCandleMap(symbol, timeframe, time.Time{}, 0, sig.PrevHigh3, sig.PrevLow3, 0),
+		"currentClosed":  false,
+		"barCount":       0,
+		"closedBarCount": 0,
+	}
+}
+
+func replayCandleMap(symbol, timeframe string, at time.Time, open, high, low, close float64) map[string]any {
+	item := map[string]any{
+		"symbol":    NormalizeSymbol(symbol),
+		"timeframe": normalizeSignalBarInterval(timeframe),
+		"open":      open,
+		"high":      high,
+		"low":       low,
+		"close":     close,
+	}
+	if !at.IsZero() {
+		item["barStart"] = at.UTC().Format(time.RFC3339)
+		item["time"] = at.UTC().Format(time.RFC3339)
+	}
+	return item
+}
+
+func replayParametersFromConfig(cfg strategyReplayConfig) map[string]any {
+	return map[string]any{
+		"breakout_shape":                cfg.BreakoutShape,
+		"breakout_shape_tolerance_bps":  cfg.BreakoutShapeToleranceBps,
+		"use_sma5_intraday_structure":   cfg.UseSMA5IntradayStructure,
+		"stop_loss_atr":                 cfg.StopLossATR,
+		"reentry_size_schedule":         cfg.ReentrySizeSchedule,
+		"max_trades_per_bar":            cfg.MaxTradesPerBar,
+		"long_reentry_atr":              cfg.LongReentryATR,
+		"short_reentry_atr":             cfg.ShortReentryATR,
+		"min_atr_percentile":            cfg.MinATRPercentile,
+		"min_sma_atr_separation":        cfg.MinSMAATRSeparation,
+		"quality_filter_shapes":         cfg.QualityFilterShapes,
+		"signalDecisionMaxDeviationBps": cfg.SignalDecisionMaxDeviationBps,
+		"sl_reentry_min_delay_seconds":  cfg.SLReentryMinDelaySeconds,
+	}
 }
 
 func strategySignalRegimeReady(sig strategySignalBar, timeframe string, useSMA5Intraday ...bool) (bool, bool) {
@@ -1226,12 +1578,12 @@ func strategySignalRegimeReady(sig strategySignalBar, timeframe string, useSMA5I
 
 func (p *Platform) loadStrategySignalBars(timeframe string) ([]strategySignalBar, error) {
 	switch normalizeSignalBarInterval(timeframe) {
-	case "5m":
+	case "5m", "15m", "30m":
 		minuteBars, err := p.loadCandleBars()
 		if err != nil {
 			return nil, err
 		}
-		return buildSignalBars(minuteBars, "5m")
+		return buildSignalBars(minuteBars, normalizeSignalBarInterval(timeframe))
 	case "4h":
 		return readSignalBarsCSV("BTC_4H_Signals.csv")
 	case "1d":
@@ -1654,23 +2006,24 @@ func pairStrategyTrades(events []map[string]any, source string) []map[string]any
 				quantity = notional / entryPrice
 			}
 			trades = append(trades, map[string]any{
-				"source":          source,
-				"side":            stringValue(current["type"]),
-				"quantity":        quantity,
-				"notional":        notional,
-				"entryTarget":     current["price"],
-				"entryTime":       current["time"],
-				"entryPrice":      current["price"],
-				"entryReason":     current["reason"],
-				"entryTradingFee": current["tradingFee"],
-				"exitTime":        event["time"],
-				"exitPrice":       event["price"],
-				"exitType":        event["reason"],
-				"exitTradingFee":  event["tradingFee"],
-				"fundingPnL":      event["fundingPnL"],
-				"realizedPnL":     event["pnl"],
-				"processedBars":   0,
-				"status":          "closed",
+				"source":             source,
+				"side":               stringValue(current["type"]),
+				"quantity":           quantity,
+				"notional":           notional,
+				"entryTarget":        current["price"],
+				"entryTime":          current["time"],
+				"entryPrice":         current["price"],
+				"entryReason":        current["reason"],
+				"entryBreakoutShape": current["breakoutShapeName"],
+				"entryTradingFee":    current["tradingFee"],
+				"exitTime":           event["time"],
+				"exitPrice":          event["price"],
+				"exitType":           event["reason"],
+				"exitTradingFee":     event["tradingFee"],
+				"fundingPnL":         event["fundingPnL"],
+				"realizedPnL":        event["pnl"],
+				"processedBars":      0,
+				"status":             "closed",
 			})
 			current = nil
 		}

--- a/internal/service/strategy_replay_test.go
+++ b/internal/service/strategy_replay_test.go
@@ -197,7 +197,7 @@ func TestResolveReplayInitialBreakoutAllowsT2Tolerance(t *testing.T) {
 	}
 }
 
-func TestResolveReplayInitialBreakoutIgnoresT3OnlyShape(t *testing.T) {
+func TestResolveReplayInitialBreakoutAllowsT3SwingWithBaselinePlusT3Shape(t *testing.T) {
 	cfg := strategyReplayConfig{
 		BreakoutShape:             "baseline_plus_t3",
 		BreakoutShapeToleranceBps: 0.5,
@@ -210,8 +210,8 @@ func TestResolveReplayInitialBreakoutIgnoresT3OnlyShape(t *testing.T) {
 		PrevHigh3: 69000,
 	}
 	breakout := resolveReplayInitialBreakout(sig, "long", 69010, cfg)
-	if breakout.Ready {
-		t.Fatalf("expected t3-only breakout shape to be ignored, got %#v", breakout)
+	if !breakout.Ready || breakout.Level != 69000 || breakout.Shape != "t3_swing" {
+		t.Fatalf("expected t3_swing breakout with baseline_plus_t3 shape, got %#v", breakout)
 	}
 }
 


### PR DESCRIPTION
## 目的
把回测 replay 和 live entry/reentry gate 往同一条决策线收敛，并把 research baseline 的 Baseline+T3 enhanced 以显式新模板接回 live。生产排查后额外确认：现有 T2-only enhanced live 被 legacy `reentry_min_stop_bps` / `reentry_atr_percentile_gte` / actionable gate 明显压低开仓，所以本 PR 保留旧模板语义，新增 Baseline+T3 模板，避免静默迁移运行中或既有 T2-only session。

主要改动：
- 新增 `bk-live-intrabar-sma5-baseline-plus-t3-enhanced` engine key。
- 提取/扩展 shared signal-bar gate metadata：reentry quality report、breakout quality report、T2/T3 shape、ATR percentile、SMA/ATR separation。
- live-aligned replay 使用 intrabar signal bar close/high/low、SMA5/MA20、ATR percentile，并复用 live gate 结果决定 breakout lock、reentry actionable、SL reentry cooldown。
- baseline sizing 对齐 `reentry_size_schedule=[0.20, 0.10]` + `max_trades_per_bar=2`。
- 保留 legacy `binance-testnet-btc-30m-enhanced` T2-only 模板，新增 `binance-testnet-btc-30m-baseline-plus-t3-enhanced`。
- Baseline+T3 模板使用 `baseline_plus_t3`、`quality_filter_shapes=[original_t2,t3_swing]`、`min_atr_percentile=25`、`min_sma_atr_separation=0.1`、`sl_reentry_min_delay_seconds=60`，并保留但放松 legacy reentry low-vol gate：`reentry_min_stop_bps=4`、`reentry_atr_percentile_gte=10`。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [x] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) - 没有变化，模板仍由前端提交前选择，默认 `manual-review`。
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？- 没有。
- [x] DB migration 是否具备向下兼容幂等性？- 不涉及 migration。
- [x] 配置字段有没有无意被混改？- 已将 legacy T2-only 模板和新 Baseline+T3 模板拆开，避免静默改旧 key。

## 交易语义变更
- [ ] 本次改动是否新增/修改了 `signalKind`？若是，需同步更新 Golden Case
- [ ] 本次改动是否影响订单方向判断（`side` / `reduceOnly` / `closePosition`）？
- [ ] 若涉及上述改动，`go test ./internal/domain/... -run TestClassifyOrderIntent` 是否通过？
- [ ] 若涉及交易链路语义（开仓/平仓/撤单/risk-exit），`go test ./internal/domain/... -run TestTradingReplayGoldenCases` 是否通过？

说明：本 PR 会影响 entry/reentry gate 与 replay entry timing，但不修改 order side/reduceOnly/closePosition 分类，也不修改 dispatchMode 默认值。

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

已跑：
- `go test ./internal/service`
- `go test ./internal/domain`
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
- pre-push harness: graphify rebuilt, high-risk defaults check passed, env safety check passed

备注：本地未提交的 `research/*` 投研文件没有纳入该 PR。
