### PR TITLE
[codex] Add signal runtime auto-restart controls

### DIFF
--- a/cmd/bktrader-ctl/runtime.go
+++ b/cmd/bktrader-ctl/runtime.go
@@ -10,11 +10,19 @@ import (
 func init() {
 	runtimeCmd.AddCommand(runtimeStatusCmd)
 	runtimeCmd.AddCommand(runtimeRestartCmd)
+	runtimeCmd.AddCommand(runtimeSuppressAutoRestartCmd)
+	runtimeCmd.AddCommand(runtimeResumeAutoRestartCmd)
 	rootCmd.AddCommand(runtimeCmd)
 	runtimeRestartCmd.Flags().String("kind", "signal", "runtime 类型 (signal)")
 	runtimeRestartCmd.Flags().Bool("force", false, "强制重启 signal runtime")
 	runtimeRestartCmd.Flags().Bool("confirm", false, "确认执行重启操作")
 	runtimeRestartCmd.Flags().String("reason", "", "重启原因；--force 时必填")
+	runtimeSuppressAutoRestartCmd.Flags().String("kind", "signal", "runtime 类型 (signal)")
+	runtimeSuppressAutoRestartCmd.Flags().Bool("confirm", false, "确认执行 suppress 操作")
+	runtimeSuppressAutoRestartCmd.Flags().String("reason", "", "suppress 原因；必填")
+	runtimeResumeAutoRestartCmd.Flags().String("kind", "signal", "runtime 类型 (signal)")
+	runtimeResumeAutoRestartCmd.Flags().Bool("confirm", false, "确认执行 resume 操作")
+	runtimeResumeAutoRestartCmd.Flags().String("reason", "", "resume 原因；必填")
 }
 
 var runtimeCmd = &cobra.Command{
@@ -60,4 +68,44 @@ var runtimeRestartCmd = &cobra.Command{
 		handleResponse(resp, err)
 		return nil
 	},
+}
+
+var runtimeSuppressAutoRestartCmd = &cobra.Command{
+	Use:   "suppress-auto-restart <runtimeId>",
+	Short: "抑制 runtime 自动恢复 [MUTATING]",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runRuntimeAutoRestartControl(cmd, args[0], "/api/v1/runtime/suppress-auto-restart")
+	},
+}
+
+var runtimeResumeAutoRestartCmd = &cobra.Command{
+	Use:   "resume-auto-restart <runtimeId>",
+	Short: "恢复 runtime 自动恢复 [MUTATING]",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runRuntimeAutoRestartControl(cmd, args[0], "/api/v1/runtime/resume-auto-restart")
+	},
+}
+
+func runRuntimeAutoRestartControl(cmd *cobra.Command, runtimeID, path string) error {
+	confirm, _ := cmd.Flags().GetBool("confirm")
+	if !confirm && !dryRun {
+		return fmt.Errorf("操作需要 --confirm 确认")
+	}
+	reason, _ := cmd.Flags().GetString("reason")
+	if strings.TrimSpace(reason) == "" && !dryRun {
+		return fmt.Errorf("操作需要提供 --reason")
+	}
+	kind, _ := cmd.Flags().GetString("kind")
+	payload := map[string]any{
+		"runtimeId":   runtimeID,
+		"runtimeKind": kind,
+		"confirm":     confirm,
+		"reason":      reason,
+	}
+	client := getClient()
+	resp, err := client.Request("POST", path, payload)
+	handleResponse(resp, err)
+	return nil
 }

--- a/docs/runtime-supervisor.md
+++ b/docs/runtime-supervisor.md
@@ -243,7 +243,7 @@ POST /runtime/resume-auto-restart
 - `start` / `restart` 只能写入期望状态或触发应用内恢复，不得绕过业务安全校验。
 - `stop` 必须写入 `desiredStatus=STOPPED`，使 scanner 和 supervisor 不再自动拉起。
 - `resume-auto-restart` 只能解除 suppressed，不代表立即允许交易。
-- 当前统一控制 API 的第一步只落 `POST /api/v1/runtime/restart`，且只支持 `runtimeKind=signal`；请求必须显式传入 `confirm=true`，`force=true` 时必须传入非空 `reason` 并写入 runtime state 审计字段。该接口复用现有 signal runtime stop/start 安全检查，不做 live session 自动 dispatch，也不做 Docker/container restart。
+- 当前统一控制 API 已落最小 signal 切片：`POST /api/v1/runtime/restart`、`POST /api/v1/runtime/suppress-auto-restart`、`POST /api/v1/runtime/resume-auto-restart` 均只支持 `runtimeKind=signal` / `signal-runtime`。请求必须显式传入 `confirm=true`；`restart` 在 `force=true` 时必须传入非空 `reason`，`suppress-auto-restart` / `resume-auto-restart` 始终要求非空 `reason` 并写入 runtime state 审计字段。该接口复用现有 signal runtime 安全边界，不做 live session restart，不做 live session 自动 dispatch，也不做 Docker/container restart。
 
 ## 6. 推进阶段
 
@@ -371,7 +371,7 @@ func ClearRestartState(state map[string]any, keys []string)
 
 前端 console 的 Runtime Supervisor 页面读取 `GET /api/v1/supervisor/status`，展示 supervisor policy、service target、runtime 状态、`applicationRestartPlan`、应用内控制动作、`containerFallbackCandidate`、fallback `decision`、executor `kind`/`dryRun` 和 dry-run audit 摘要。
 
-当前页面只开放最小的手动应用内控制入口：对 `runtimeKind=signal` / `signal-runtime` 的 runtime，可在显式确认并填写 reason 后调用现有 `POST /api/v1/runtime/restart`。该入口固定 `confirm=true`、`force=false`，不支持 live-session restart，不提交 suppress/resume，不触碰 Docker/container fallback。真正执行容器级 restart 前仍需单独 PR 设计 executor、权限边界和部署安全审查。
+当前页面只开放最小的手动应用内控制入口：对 `runtimeKind=signal` / `signal-runtime` 的 runtime，可在显式确认并填写 reason 后调用现有 `POST /api/v1/runtime/restart`、`POST /api/v1/runtime/suppress-auto-restart`、`POST /api/v1/runtime/resume-auto-restart`。restart 入口固定 `confirm=true`、`force=false`；suppress/resume 只切换 signal runtime 自动恢复抑制状态并写审计 reason。该页面不支持 live-session restart，不触碰 Docker/container fallback。真正执行容器级 restart 前仍需单独 PR 设计 executor、权限边界和部署安全审查。
 
 ## 7. 安全边界
 

--- a/internal/http/registry.go
+++ b/internal/http/registry.go
@@ -17,6 +17,8 @@ var APIRegistry = []RouteEntry{
 	{Path: "/api/v1/overview", Methods: []string{"GET"}, Module: "system", CLICommand: "status", Idempotent: true, RiskLevel: "L0"},
 	{Path: "/api/v1/runtime/status", Methods: []string{"GET"}, Module: "runtime", CLICommand: "runtime status", Idempotent: true, RiskLevel: "L0"},
 	{Path: "/api/v1/runtime/restart", Methods: []string{"POST"}, Module: "runtime", CLICommand: "runtime restart", Idempotent: false, RiskLevel: "L1"},
+	{Path: "/api/v1/runtime/suppress-auto-restart", Methods: []string{"POST"}, Module: "runtime", CLICommand: "runtime suppress-auto-restart", Idempotent: false, RiskLevel: "L1"},
+	{Path: "/api/v1/runtime/resume-auto-restart", Methods: []string{"POST"}, Module: "runtime", CLICommand: "runtime resume-auto-restart", Idempotent: false, RiskLevel: "L1"},
 	{Path: "/api/v1/supervisor/status", Methods: []string{"GET"}, Module: "supervisor", CLICommand: "supervisor status", Idempotent: true, RiskLevel: "L0"},
 
 	// Auth

--- a/internal/http/runtime_control.go
+++ b/internal/http/runtime_control.go
@@ -17,6 +17,13 @@ type runtimeRestartRequest struct {
 	Reason      string `json:"reason,omitempty"`
 }
 
+type runtimeAutoRestartControlRequest struct {
+	RuntimeID   string `json:"runtimeId"`
+	RuntimeKind string `json:"runtimeKind"`
+	Confirm     bool   `json:"confirm"`
+	Reason      string `json:"reason"`
+}
+
 func registerRuntimeControlRoutes(mux *http.ServeMux, platform *service.Platform, cfg config.Config) {
 	mux.HandleFunc("/api/v1/runtime/restart", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
@@ -73,6 +80,77 @@ func registerRuntimeControlRoutes(mux *http.ServeMux, platform *service.Platform
 		default:
 			writeError(w, http.StatusBadRequest, "unsupported runtimeKind: "+request.RuntimeKind)
 		}
+	})
+	registerRuntimeAutoRestartControlRoute(mux, platform, cfg, "/api/v1/runtime/suppress-auto-restart", "suppress")
+	registerRuntimeAutoRestartControlRoute(mux, platform, cfg, "/api/v1/runtime/resume-auto-restart", "resume")
+}
+
+func registerRuntimeAutoRestartControlRoute(mux *http.ServeMux, platform *service.Platform, cfg config.Config, path, action string) {
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		if !cfg.RuntimeActionsEnabled() {
+			writeError(w, http.StatusConflict, "runtime action "+action+" auto-restart is disabled for BKTRADER_ROLE="+cfg.ProcessRole)
+			return
+		}
+		var request runtimeAutoRestartControlRequest
+		if err := decodeJSON(r, &request); err != nil {
+			writeError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		runtimeID := strings.TrimSpace(request.RuntimeID)
+		if runtimeID == "" {
+			writeError(w, http.StatusBadRequest, "runtimeId is required")
+			return
+		}
+		if !request.Confirm {
+			writeError(w, http.StatusBadRequest, "confirm=true is required for runtime auto-restart "+action)
+			return
+		}
+		reason := strings.TrimSpace(request.Reason)
+		if reason == "" {
+			writeError(w, http.StatusBadRequest, "reason is required for runtime auto-restart "+action)
+			return
+		}
+		var item any
+		var suppressed bool
+		switch strings.ToLower(strings.TrimSpace(request.RuntimeKind)) {
+		case "signal", "signal-runtime":
+			var updated any
+			var err error
+			options := service.SignalRuntimeAutoRestartControlOptions{
+				Reason: reason,
+				Source: "api",
+			}
+			if action == "suppress" {
+				updated, err = platform.SuppressSignalRuntimeAutoRestart(runtimeID, options)
+				suppressed = true
+			} else {
+				updated, err = platform.ResumeSignalRuntimeAutoRestart(runtimeID, options)
+			}
+			if err != nil {
+				writeRuntimeControlError(w, err)
+				return
+			}
+			item = updated
+		case "":
+			writeError(w, http.StatusBadRequest, "runtimeKind is required")
+			return
+		default:
+			writeError(w, http.StatusBadRequest, "unsupported runtimeKind: "+request.RuntimeKind)
+			return
+		}
+		writeJSON(w, http.StatusAccepted, map[string]any{
+			"status":                "accepted",
+			"message":               "runtime auto-restart " + action + " intent accepted",
+			"runtimeId":             runtimeID,
+			"runtimeKind":           "signal",
+			"autoRestartSuppressed": suppressed,
+			"reason":                reason,
+			"runtime":               item,
+		})
 	})
 }
 

--- a/internal/http/runtime_control_test.go
+++ b/internal/http/runtime_control_test.go
@@ -132,3 +132,127 @@ func TestRuntimeRestartRouteRejectsUnsupportedRuntimeKind(t *testing.T) {
 		t.Fatalf("expected 400, got %d body=%s", rec.Code, rec.Body.String())
 	}
 }
+
+func TestRuntimeAutoRestartControlRoutesSuppressAndResumeSignalRuntime(t *testing.T) {
+	platform := service.NewPlatform(memory.NewStore())
+	runtimeSession, err := platform.CreateSignalRuntimeSession("live-main", "strategy-bk-1d")
+	if err != nil {
+		t.Fatalf("CreateSignalRuntimeSession failed: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	registerRuntimeControlRoutes(mux, platform, config.Config{ProcessRole: "monolith"})
+
+	suppressRec := httptest.NewRecorder()
+	suppressReq := httptest.NewRequest(http.MethodPost, "/api/v1/runtime/suppress-auto-restart", strings.NewReader(`{"runtimeId":"`+runtimeSession.ID+`","runtimeKind":"signal","confirm":true,"reason":"maintenance window"}`))
+	mux.ServeHTTP(suppressRec, suppressReq)
+	if suppressRec.Code != http.StatusAccepted {
+		t.Fatalf("expected suppress 202, got %d body=%s", suppressRec.Code, suppressRec.Body.String())
+	}
+	var suppressPayload struct {
+		Status                string `json:"status"`
+		RuntimeID             string `json:"runtimeId"`
+		RuntimeKind           string `json:"runtimeKind"`
+		AutoRestartSuppressed bool   `json:"autoRestartSuppressed"`
+		Reason                string `json:"reason"`
+	}
+	if err := json.NewDecoder(suppressRec.Body).Decode(&suppressPayload); err != nil {
+		t.Fatalf("decode suppress response failed: %v", err)
+	}
+	if suppressPayload.Status != "accepted" || suppressPayload.RuntimeID != runtimeSession.ID || suppressPayload.RuntimeKind != "signal" {
+		t.Fatalf("unexpected suppress response: %+v", suppressPayload)
+	}
+	if !suppressPayload.AutoRestartSuppressed || suppressPayload.Reason != "maintenance window" {
+		t.Fatalf("expected suppress echoed state/reason, got %+v", suppressPayload)
+	}
+	stored, err := platform.GetSignalRuntimeSession(runtimeSession.ID)
+	if err != nil {
+		t.Fatalf("GetSignalRuntimeSession after suppress failed: %v", err)
+	}
+	if got := stored.State["autoRestartSuppressed"]; got != true {
+		t.Fatalf("expected autoRestartSuppressed true, got %#v", got)
+	}
+	if got := stored.State["autoRestartSuppressedSource"]; got != "api" {
+		t.Fatalf("expected autoRestartSuppressedSource api, got %#v", got)
+	}
+
+	resumeRec := httptest.NewRecorder()
+	resumeReq := httptest.NewRequest(http.MethodPost, "/api/v1/runtime/resume-auto-restart", strings.NewReader(`{"runtimeId":"`+runtimeSession.ID+`","runtimeKind":"signal","confirm":true,"reason":"maintenance finished"}`))
+	mux.ServeHTTP(resumeRec, resumeReq)
+	if resumeRec.Code != http.StatusAccepted {
+		t.Fatalf("expected resume 202, got %d body=%s", resumeRec.Code, resumeRec.Body.String())
+	}
+	var resumePayload struct {
+		Status                string `json:"status"`
+		RuntimeID             string `json:"runtimeId"`
+		RuntimeKind           string `json:"runtimeKind"`
+		AutoRestartSuppressed bool   `json:"autoRestartSuppressed"`
+		Reason                string `json:"reason"`
+	}
+	if err := json.NewDecoder(resumeRec.Body).Decode(&resumePayload); err != nil {
+		t.Fatalf("decode resume response failed: %v", err)
+	}
+	if resumePayload.Status != "accepted" || resumePayload.RuntimeID != runtimeSession.ID || resumePayload.RuntimeKind != "signal" {
+		t.Fatalf("unexpected resume response: %+v", resumePayload)
+	}
+	if resumePayload.AutoRestartSuppressed || resumePayload.Reason != "maintenance finished" {
+		t.Fatalf("expected resume echoed state/reason, got %+v", resumePayload)
+	}
+	stored, err = platform.GetSignalRuntimeSession(runtimeSession.ID)
+	if err != nil {
+		t.Fatalf("GetSignalRuntimeSession after resume failed: %v", err)
+	}
+	if got := stored.State["autoRestartSuppressed"]; got != nil {
+		t.Fatalf("expected autoRestartSuppressed cleared, got %#v", got)
+	}
+	if got := stored.State["autoRestartResumedSource"]; got != "api" {
+		t.Fatalf("expected autoRestartResumedSource api, got %#v", got)
+	}
+}
+
+func TestRuntimeAutoRestartControlRoutesRequireConfirmAndReason(t *testing.T) {
+	platform := service.NewPlatform(memory.NewStore())
+	runtimeSession, err := platform.CreateSignalRuntimeSession("live-main", "strategy-bk-1d")
+	if err != nil {
+		t.Fatalf("CreateSignalRuntimeSession failed: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	registerRuntimeControlRoutes(mux, platform, config.Config{ProcessRole: "monolith"})
+
+	tests := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "missing confirm",
+			body: `{"runtimeId":"` + runtimeSession.ID + `","runtimeKind":"signal","reason":"maintenance window"}`,
+		},
+		{
+			name: "missing reason",
+			body: `{"runtimeId":"` + runtimeSession.ID + `","runtimeKind":"signal","confirm":true}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/runtime/suppress-auto-restart", strings.NewReader(tt.body))
+			mux.ServeHTTP(rec, req)
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("expected 400, got %d body=%s", rec.Code, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestRuntimeAutoRestartControlRouteRejectsUnsupportedRuntimeKind(t *testing.T) {
+	mux := http.NewServeMux()
+	registerRuntimeControlRoutes(mux, service.NewPlatform(memory.NewStore()), config.Config{ProcessRole: "monolith"})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/runtime/suppress-auto-restart", strings.NewReader(`{"runtimeId":"runtime-1","runtimeKind":"live-session","confirm":true,"reason":"maintenance window"}`))
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d body=%s", rec.Code, rec.Body.String())
+	}
+}

--- a/internal/service/signal_runtime_sessions.go
+++ b/internal/service/signal_runtime_sessions.go
@@ -30,6 +30,11 @@ type SignalRuntimeRestartOptions struct {
 	Source string
 }
 
+type SignalRuntimeAutoRestartControlOptions struct {
+	Reason string
+	Source string
+}
+
 func (r *signalRuntimeRun) releaseRuntimeLease() {
 	if r == nil || r.releaseLease == nil {
 		return
@@ -451,6 +456,72 @@ func signalRuntimeRestartAuditState(state map[string]any, options SignalRuntimeR
 		out["restartRequestedSource"] = source
 	} else {
 		delete(out, "restartRequestedSource")
+	}
+	return out
+}
+
+func (p *Platform) SuppressSignalRuntimeAutoRestart(sessionID string, options SignalRuntimeAutoRestartControlOptions) (domain.SignalRuntimeSession, error) {
+	now := time.Now().UTC()
+	if err := p.updateSignalRuntimeSessionState(sessionID, func(session *domain.SignalRuntimeSession) {
+		state := signalRuntimeSuppressAutoRestartState(session.State, options, now)
+		session.State = state
+	}); err != nil {
+		return domain.SignalRuntimeSession{}, err
+	}
+	return p.GetSignalRuntimeSession(sessionID)
+}
+
+func (p *Platform) ResumeSignalRuntimeAutoRestart(sessionID string, options SignalRuntimeAutoRestartControlOptions) (domain.SignalRuntimeSession, error) {
+	now := time.Now().UTC()
+	if err := p.updateSignalRuntimeSessionState(sessionID, func(session *domain.SignalRuntimeSession) {
+		state := signalRuntimeResumeAutoRestartState(session.State, options, now)
+		session.State = state
+	}); err != nil {
+		return domain.SignalRuntimeSession{}, err
+	}
+	return p.GetSignalRuntimeSession(sessionID)
+}
+
+func signalRuntimeSuppressAutoRestartState(state map[string]any, options SignalRuntimeAutoRestartControlOptions, now time.Time) map[string]any {
+	out := cloneMetadata(state)
+	out["autoRestartSuppressed"] = true
+	out["autoRestartSuppressedAt"] = now.UTC().Format(time.RFC3339)
+	out["supervisorRestartReason"] = "manual-suppress-auto-restart"
+	if reason := strings.TrimSpace(options.Reason); reason != "" {
+		out["autoRestartSuppressedReason"] = reason
+	} else {
+		delete(out, "autoRestartSuppressedReason")
+	}
+	if source := strings.TrimSpace(options.Source); source != "" {
+		out["autoRestartSuppressedSource"] = source
+	} else {
+		delete(out, "autoRestartSuppressedSource")
+	}
+	delete(out, "nextAutoRestartAt")
+	delete(out, "supervisorRestartBackoff")
+	return out
+}
+
+func signalRuntimeResumeAutoRestartState(state map[string]any, options SignalRuntimeAutoRestartControlOptions, now time.Time) map[string]any {
+	out := cloneMetadata(state)
+	delete(out, "autoRestartSuppressed")
+	delete(out, "autoRestartSuppressedAt")
+	delete(out, "autoRestartSuppressedReason")
+	delete(out, "autoRestartSuppressedSource")
+	delete(out, "nextAutoRestartAt")
+	delete(out, "supervisorRestartBackoff")
+	delete(out, "supervisorRestartSeverity")
+	out["autoRestartResumedAt"] = now.UTC().Format(time.RFC3339)
+	out["supervisorRestartReason"] = "manual-resume-auto-restart"
+	if reason := strings.TrimSpace(options.Reason); reason != "" {
+		out["autoRestartResumedReason"] = reason
+	} else {
+		delete(out, "autoRestartResumedReason")
+	}
+	if source := strings.TrimSpace(options.Source); source != "" {
+		out["autoRestartResumedSource"] = source
+	} else {
+		delete(out, "autoRestartResumedSource")
 	}
 	return out
 }

--- a/internal/service/signal_runtime_sessions_persistence_test.go
+++ b/internal/service/signal_runtime_sessions_persistence_test.go
@@ -277,6 +277,85 @@ func TestRestartSignalRuntimeSessionWithoutForceKeepsRunningWhenExposureExists(t
 	}
 }
 
+func TestSignalRuntimeAutoRestartSuppressAndResumeAuditState(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	runtimeSession, err := platform.CreateSignalRuntimeSession("live-main", "strategy-bk-1d")
+	if err != nil {
+		t.Fatalf("CreateSignalRuntimeSession failed: %v", err)
+	}
+	now := time.Now().UTC()
+	runtimeSession.State["desiredStatus"] = "RUNNING"
+	runtimeSession.State["actualStatus"] = "ERROR"
+	runtimeSession.State["autoRestartSuppressed"] = true
+	runtimeSession.State["nextAutoRestartAt"] = now.Add(time.Minute).Format(time.RFC3339)
+	runtimeSession.State["supervisorRestartBackoff"] = time.Minute.String()
+	runtimeSession.State["supervisorRestartSeverity"] = "fatal"
+	runtimeSession.State["lastSupervisorError"] = "auth failed"
+	updated, err := platform.store.UpdateSignalRuntimeSession(runtimeSession)
+	if err != nil {
+		t.Fatalf("UpdateSignalRuntimeSession failed: %v", err)
+	}
+	platform.cacheSignalRuntimeSession(updated)
+
+	suppressed, err := platform.SuppressSignalRuntimeAutoRestart(runtimeSession.ID, SignalRuntimeAutoRestartControlOptions{
+		Reason: "operator paused runtime recovery during maintenance",
+		Source: "test",
+	})
+	if err != nil {
+		t.Fatalf("SuppressSignalRuntimeAutoRestart failed: %v", err)
+	}
+	if got := boolValue(suppressed.State["autoRestartSuppressed"]); !got {
+		t.Fatal("expected autoRestartSuppressed true")
+	}
+	if got := stringValue(suppressed.State["autoRestartSuppressedReason"]); got != "operator paused runtime recovery during maintenance" {
+		t.Fatalf("expected suppress reason, got %s", got)
+	}
+	if got := stringValue(suppressed.State["autoRestartSuppressedSource"]); got != "test" {
+		t.Fatalf("expected suppress source test, got %s", got)
+	}
+	if got := stringValue(suppressed.State["autoRestartSuppressedAt"]); got == "" {
+		t.Fatal("expected autoRestartSuppressedAt")
+	}
+	if got := stringValue(suppressed.State["nextAutoRestartAt"]); got != "" {
+		t.Fatalf("expected suppress to clear nextAutoRestartAt, got %s", got)
+	}
+	if got := stringValue(suppressed.State["supervisorRestartBackoff"]); got != "" {
+		t.Fatalf("expected suppress to clear supervisorRestartBackoff, got %s", got)
+	}
+	if got := stringValue(suppressed.State["lastSupervisorError"]); got != "auth failed" {
+		t.Fatalf("expected suppress to preserve lastSupervisorError, got %s", got)
+	}
+
+	resumed, err := platform.ResumeSignalRuntimeAutoRestart(runtimeSession.ID, SignalRuntimeAutoRestartControlOptions{
+		Reason: "maintenance finished and credentials rotated",
+		Source: "test",
+	})
+	if err != nil {
+		t.Fatalf("ResumeSignalRuntimeAutoRestart failed: %v", err)
+	}
+	if got := boolValue(resumed.State["autoRestartSuppressed"]); got {
+		t.Fatal("expected autoRestartSuppressed false after resume")
+	}
+	if got := stringValue(resumed.State["autoRestartSuppressedAt"]); got != "" {
+		t.Fatalf("expected resume to clear autoRestartSuppressedAt, got %s", got)
+	}
+	if got := stringValue(resumed.State["supervisorRestartSeverity"]); got != "" {
+		t.Fatalf("expected resume to clear supervisorRestartSeverity, got %s", got)
+	}
+	if got := stringValue(resumed.State["autoRestartResumedReason"]); got != "maintenance finished and credentials rotated" {
+		t.Fatalf("expected resume reason, got %s", got)
+	}
+	if got := stringValue(resumed.State["autoRestartResumedSource"]); got != "test" {
+		t.Fatalf("expected resume source test, got %s", got)
+	}
+	if got := stringValue(resumed.State["autoRestartResumedAt"]); got == "" {
+		t.Fatal("expected autoRestartResumedAt")
+	}
+	if got := stringValue(resumed.State["lastSupervisorError"]); got != "auth failed" {
+		t.Fatalf("expected resume to preserve lastSupervisorError for audit, got %s", got)
+	}
+}
+
 func markSignalRuntimeSessionRunningForTest(t *testing.T, platform *Platform, session domain.SignalRuntimeSession) domain.SignalRuntimeSession {
 	t.Helper()
 	now := time.Now().UTC()

--- a/web/console/src/pages/SupervisorStage.tsx
+++ b/web/console/src/pages/SupervisorStage.tsx
@@ -45,6 +45,11 @@ import {
 type LoadState = 'idle' | 'loading' | 'loaded' | 'error';
 type BadgeVariant = NonNullable<React.ComponentProps<typeof Badge>['variant']>;
 type RuntimeRow = RuntimeSupervisorRuntimeStatus & { targetName: string };
+type RuntimeControlActionKind = 'restart' | 'suppress-auto-restart' | 'resume-auto-restart';
+type RuntimeControlDialogState = {
+  runtime: RuntimeRow;
+  action: RuntimeControlActionKind;
+};
 
 const REFRESH_INTERVAL_MS = 15_000;
 
@@ -181,23 +186,43 @@ function runtimeRestartSupported(runtime: RuntimeSupervisorRuntimeStatus) {
   return kind === 'signal' || kind === 'signal-runtime';
 }
 
-function runtimeRestartActionKey(runtime: RuntimeRow) {
-  return `${runtime.targetName}:${runtime.runtimeKind}:${runtime.runtimeId}`;
+function runtimeControlActionKey(runtime: RuntimeRow, action: RuntimeControlActionKind) {
+  return `${runtime.targetName}:${runtime.runtimeKind}:${runtime.runtimeId}:${action}`;
 }
 
-function dashboardRuntimeRestartReason(runtime: RuntimeRow) {
-  return `dashboard manual restart: target=${runtime.targetName} runtime=${runtime.runtimeId}`;
+function runtimeControlPath(action: RuntimeControlActionKind) {
+  if (action === 'suppress-auto-restart') {
+    return '/api/v1/runtime/suppress-auto-restart';
+  }
+  if (action === 'resume-auto-restart') {
+    return '/api/v1/runtime/resume-auto-restart';
+  }
+  return '/api/v1/runtime/restart';
+}
+
+function runtimeControlLabel(action: RuntimeControlActionKind) {
+  if (action === 'suppress-auto-restart') {
+    return 'Suppress Auto Restart';
+  }
+  if (action === 'resume-auto-restart') {
+    return 'Resume Auto Restart';
+  }
+  return 'Restart Signal Runtime';
+}
+
+function dashboardRuntimeControlReason(runtime: RuntimeRow, action: RuntimeControlActionKind) {
+  return `dashboard manual ${action}: target=${runtime.targetName} runtime=${runtime.runtimeId}`;
 }
 
 export function SupervisorStage() {
   const [snapshot, setSnapshot] = useState<RuntimeSupervisorSnapshot | null>(null);
   const [loadState, setLoadState] = useState<LoadState>('idle');
   const [error, setError] = useState<string | null>(null);
-  const [restartDialogRuntime, setRestartDialogRuntime] = useState<RuntimeRow | null>(null);
-  const [restartReason, setRestartReason] = useState('');
-  const [restartSubmittingKey, setRestartSubmittingKey] = useState<string | null>(null);
-  const [restartNotice, setRestartNotice] = useState<string | null>(null);
-  const [restartError, setRestartError] = useState<string | null>(null);
+  const [controlDialog, setControlDialog] = useState<RuntimeControlDialogState | null>(null);
+  const [controlReason, setControlReason] = useState('');
+  const [controlSubmittingKey, setControlSubmittingKey] = useState<string | null>(null);
+  const [controlNotice, setControlNotice] = useState<string | null>(null);
+  const [controlError, setControlError] = useState<string | null>(null);
 
   const loadSnapshot = useCallback(async (silent = false) => {
     if (!silent) {
@@ -216,62 +241,64 @@ export function SupervisorStage() {
     }
   }, []);
 
-  const openRestartDialog = useCallback((runtime: RuntimeRow) => {
-    setRestartDialogRuntime(runtime);
-    setRestartReason(dashboardRuntimeRestartReason(runtime));
-    setRestartNotice(null);
-    setRestartError(null);
+  const openControlDialog = useCallback((runtime: RuntimeRow, action: RuntimeControlActionKind) => {
+    setControlDialog({ runtime, action });
+    setControlReason(dashboardRuntimeControlReason(runtime, action));
+    setControlNotice(null);
+    setControlError(null);
   }, []);
 
-  const closeRestartDialog = useCallback(() => {
-    if (restartSubmittingKey) {
+  const closeControlDialog = useCallback(() => {
+    if (controlSubmittingKey) {
       return;
     }
-    setRestartDialogRuntime(null);
-    setRestartReason('');
-  }, [restartSubmittingKey]);
+    setControlDialog(null);
+    setControlReason('');
+  }, [controlSubmittingKey]);
 
-  const submitRuntimeRestart = useCallback(async () => {
-    if (!restartDialogRuntime) {
+  const submitRuntimeControl = useCallback(async () => {
+    if (!controlDialog) {
       return;
     }
-    const reason = restartReason.trim();
+    const { runtime, action } = controlDialog;
+    const reason = controlReason.trim();
     if (!reason) {
-      setRestartError('restart reason is required');
+      setControlError('reason is required');
       return;
     }
-    const key = runtimeRestartActionKey(restartDialogRuntime);
-    setRestartSubmittingKey(key);
-    setRestartError(null);
-    setRestartNotice(null);
+    const key = runtimeControlActionKey(runtime, action);
+    setControlSubmittingKey(key);
+    setControlError(null);
+    setControlNotice(null);
     try {
-      await fetchJSON('/api/v1/runtime/restart', {
+      await fetchJSON(runtimeControlPath(action), {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          runtimeId: restartDialogRuntime.runtimeId,
-          runtimeKind: restartDialogRuntime.runtimeKind,
+          runtimeId: runtime.runtimeId,
+          runtimeKind: runtime.runtimeKind,
           confirm: true,
-          force: false,
+          force: action === 'restart' ? false : undefined,
           reason,
         }),
       });
     } catch (err) {
-      setRestartError(err instanceof Error ? err.message : 'runtime restart failed');
-      setRestartSubmittingKey(null);
+      setControlError(err instanceof Error ? err.message : 'runtime control failed');
+      setControlSubmittingKey(null);
       return;
     }
 
-    setRestartDialogRuntime(null);
-    setRestartReason('');
+    setControlDialog(null);
+    setControlReason('');
     const refreshed = await loadSnapshot(true);
+    const acceptedMessage = `${runtimeControlLabel(action)} accepted: ${shrink(runtime.runtimeId)}`;
     if (refreshed) {
-      setRestartNotice(`restart accepted: ${shrink(restartDialogRuntime.runtimeId)}`);
+      setControlNotice(acceptedMessage);
     } else {
-      setRestartNotice(`restart accepted; refresh failed: ${shrink(restartDialogRuntime.runtimeId)}`);
+      setControlNotice(`${acceptedMessage}; refresh failed`);
     }
-    setRestartSubmittingKey(null);
-  }, [loadSnapshot, restartDialogRuntime, restartReason]);
+    setControlSubmittingKey(null);
+  }, [controlDialog, controlReason, loadSnapshot]);
 
   useEffect(() => {
     void loadSnapshot();
@@ -614,9 +641,10 @@ export function SupervisorStage() {
                           restartPlan?.blockedReason ||
                           restartPlan?.eligibleReason ||
                           restartPlan?.reason;
-                        const restartActionKey = runtimeRestartActionKey(runtime);
                         const canRestart = runtimeRestartSupported(runtime);
-                        const restartSubmitting = restartSubmittingKey === restartActionKey;
+                        const restartSubmitting = controlSubmittingKey === runtimeControlActionKey(runtime, 'restart');
+                        const suppressAction: RuntimeControlActionKind = runtime.autoRestartSuppressed ? 'resume-auto-restart' : 'suppress-auto-restart';
+                        const suppressSubmitting = controlSubmittingKey === runtimeControlActionKey(runtime, suppressAction);
                         return (
                           <TableRow key={`${runtime.targetName}:${runtime.runtimeKind}:${runtime.runtimeId}`}>
                             <TableCell>{runtime.targetName}</TableCell>
@@ -664,18 +692,36 @@ export function SupervisorStage() {
                             <TableCell>{formatOptionalTime(runtime.lastCheckedAt)}</TableCell>
                             <TableCell>
                               {canRestart ? (
-                                <Button
-                                  type="button"
-                                  size="icon-sm"
-                                  variant="bento-outline"
-                                  className="rounded-lg"
-                                  onClick={() => openRestartDialog(runtime)}
-                                  disabled={Boolean(restartSubmittingKey) || restartSubmitting}
-                                  title="Restart signal runtime"
-                                  aria-label={`Restart signal runtime ${runtime.runtimeId}`}
-                                >
-                                  <RotateCw className={cn(restartSubmitting && 'animate-spin')} />
-                                </Button>
+                                <div className="flex items-center gap-1">
+                                  <Button
+                                    type="button"
+                                    size="icon-sm"
+                                    variant="bento-outline"
+                                    className="rounded-lg"
+                                    onClick={() => openControlDialog(runtime, 'restart')}
+                                    disabled={Boolean(controlSubmittingKey) || restartSubmitting}
+                                    title="Restart signal runtime"
+                                    aria-label={`Restart signal runtime ${runtime.runtimeId}`}
+                                  >
+                                    <RotateCw className={cn(restartSubmitting && 'animate-spin')} />
+                                  </Button>
+                                  <Button
+                                    type="button"
+                                    size="icon-sm"
+                                    variant={runtime.autoRestartSuppressed ? 'bento-outline' : 'bento-ghost'}
+                                    className="rounded-lg"
+                                    onClick={() => openControlDialog(runtime, suppressAction)}
+                                    disabled={Boolean(controlSubmittingKey) || suppressSubmitting}
+                                    title={runtime.autoRestartSuppressed ? 'Resume auto restart' : 'Suppress auto restart'}
+                                    aria-label={`${runtime.autoRestartSuppressed ? 'Resume' : 'Suppress'} auto restart for ${runtime.runtimeId}`}
+                                  >
+                                    {runtime.autoRestartSuppressed ? (
+                                      <CheckCircle2 className={cn(suppressSubmitting && 'animate-pulse')} />
+                                    ) : (
+                                      <ShieldAlert className={cn(suppressSubmitting && 'animate-pulse')} />
+                                    )}
+                                  </Button>
+                                </div>
                               ) : (
                                 <span className="text-xs text-[var(--bk-text-muted)]">--</span>
                               )}
@@ -694,8 +740,8 @@ export function SupervisorStage() {
                 <CardTitle>Control Actions</CardTitle>
                 <CardAction>
                   <div className="flex flex-wrap justify-end gap-2">
-                    {restartError && <Badge variant="destructive" title={restartError}>restart failed</Badge>}
-                    {restartNotice && <Badge variant="success" title={restartNotice}>restart accepted</Badge>}
+                    {controlError && <Badge variant="destructive" title={controlError}>control failed</Badge>}
+                    {controlNotice && <Badge variant="success" title={controlNotice}>control accepted</Badge>}
                     <Badge variant="neutral">{controlActionRows.length}</Badge>
                   </div>
                 </CardAction>
@@ -754,12 +800,14 @@ export function SupervisorStage() {
           </>
         )}
       </div>
-      <Dialog open={Boolean(restartDialogRuntime)} onOpenChange={(open) => !open && closeRestartDialog()}>
+      <Dialog open={Boolean(controlDialog)} onOpenChange={(open) => !open && closeControlDialog()}>
         <DialogContent tone="bento" className="max-w-lg rounded-lg border-[var(--bk-border)] bg-[var(--bk-surface-overlay-strong)] p-0">
           <DialogHeader className="border-b border-[var(--bk-border-soft)] bg-[var(--bk-surface-overlay)] px-6 py-4">
-            <DialogTitle className="text-lg font-semibold text-[var(--bk-text-primary)]">Restart Signal Runtime</DialogTitle>
+            <DialogTitle className="text-lg font-semibold text-[var(--bk-text-primary)]">
+              {controlDialog ? runtimeControlLabel(controlDialog.action) : 'Runtime Control'}
+            </DialogTitle>
             <DialogDescription className="text-sm text-[var(--bk-text-muted)]">
-              {restartDialogRuntime ? `${restartDialogRuntime.targetName} / ${shrink(restartDialogRuntime.runtimeId)}` : '--'}
+              {controlDialog ? `${controlDialog.runtime.targetName} / ${shrink(controlDialog.runtime.runtimeId)}` : '--'}
             </DialogDescription>
           </DialogHeader>
           <div className="flex flex-col gap-4 px-6 py-5">
@@ -769,16 +817,16 @@ export function SupervisorStage() {
               </label>
               <Textarea
                 id="supervisor-runtime-restart-reason"
-                value={restartReason}
-                onChange={(event) => setRestartReason(event.target.value)}
-                disabled={Boolean(restartSubmittingKey)}
+                value={controlReason}
+                onChange={(event) => setControlReason(event.target.value)}
+                disabled={Boolean(controlSubmittingKey)}
                 rows={4}
-                aria-invalid={restartReason.trim() === ''}
+                aria-invalid={controlReason.trim() === ''}
               />
             </div>
-            {restartError && (
+            {controlError && (
               <div className="rounded-lg border border-[var(--bk-status-danger)] bg-[var(--bk-status-danger-soft)] px-3 py-2 text-sm text-[var(--bk-status-danger)]">
-                {restartError}
+                {controlError}
               </div>
             )}
           </div>
@@ -787,8 +835,8 @@ export function SupervisorStage() {
               type="button"
               variant="bento-outline"
               className="rounded-lg"
-              onClick={closeRestartDialog}
-              disabled={Boolean(restartSubmittingKey)}
+              onClick={closeControlDialog}
+              disabled={Boolean(controlSubmittingKey)}
             >
               Cancel
             </Button>
@@ -796,11 +844,11 @@ export function SupervisorStage() {
               type="button"
               variant="bento-destructive"
               className="rounded-lg"
-              onClick={() => void submitRuntimeRestart()}
-              disabled={!restartReason.trim() || Boolean(restartSubmittingKey)}
+              onClick={() => void submitRuntimeControl()}
+              disabled={!controlReason.trim() || Boolean(controlSubmittingKey)}
             >
-              <RotateCw data-icon="inline-start" className={cn(restartSubmittingKey && 'animate-spin')} />
-              Submit Restart
+              <RotateCw data-icon="inline-start" className={cn(controlSubmittingKey && 'animate-spin')} />
+              Submit
             </Button>
           </DialogFooter>
         </DialogContent>


### PR DESCRIPTION
## 目的
为 Runtime Supervisor / Dashboard 继续推进 issue #270 的控制面小切片：在已支持 signal runtime restart 的基础上，增加 signal runtime 自动恢复的显式 suppress / resume 控制。

本 PR 只支持 `runtimeKind=signal` / `signal-runtime`：

- 新增 `POST /api/v1/runtime/suppress-auto-restart`
- 新增 `POST /api/v1/runtime/resume-auto-restart`
- 新增 `bktrader-ctl runtime suppress-auto-restart <runtimeId>`
- 新增 `bktrader-ctl runtime resume-auto-restart <runtimeId>`
- Supervisor Dashboard 增加 suppress / resume 按钮和 reason 确认弹窗

边界：不支持 live-session restart，不改 dispatch，不改默认行为，不触碰 Docker/container fallback executor。Refs #270。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [x] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

Codex 参与：基于最新 `main` 新建 `codex/issue-270-signal-restart-suppress`，实现 signal runtime suppress/resume auto-restart API、CLI、Dashboard 入口和测试。

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [ ] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) - 无变化
- [ ] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？ - 无
- [ ] DB migration 是否具备向下兼容幂等性？ - 不涉及 DB migration
- [ ] 配置字段有没有无意被混改？ - 无配置改动

## 交易语义变更
- [ ] 本次改动是否新增/修改了 `signalKind`？若是，需同步更新 Golden Case - 否
- [ ] 本次改动是否影响订单方向判断（`side` / `reduceOnly` / `closePosition`）？ - 否
- [ ] 若涉及上述改动，`go test ./internal/domain/... -run TestClassifyOrderIntent` 是否通过？ - 不涉及
- [ ] 若涉及交易链路语义（开仓/平仓/撤单/risk-exit），`go test ./internal/domain/... -run TestTradingReplayGoldenCases` 是否通过？ - 不涉及

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

已验证：

```bash
go test ./internal/service -run 'TestSignalRuntimeAutoRestartSuppressAndResumeAuditState|TestRestartSignalRuntimeSession'
go test ./internal/http -run 'TestRuntimeAutoRestartControl|TestRuntimeRestartRoute'
go test ./cmd/bktrader-ctl
./node_modules/.bin/tsc --noEmit src/pages/SupervisorStage.tsx --jsx react-jsx --esModuleInterop --target esnext --module esnext --moduleResolution Bundler --allowSyntheticDefaultImports

go test ./...
go build ./cmd/platform-api
go build ./cmd/db-migrate
go build ./cmd/bktrader-ctl
cd web/console && npm run build
bash scripts/check_high_risk_defaults.sh
bash scripts/check_env_safety.sh
git push -u origin codex/issue-270-signal-restart-suppress
```
