### PR TITLE
[codex] Expose supervisor runtime lifecycle controls

### DIFF
--- a/docs/runtime-supervisor.md
+++ b/docs/runtime-supervisor.md
@@ -380,7 +380,7 @@ func ClearRestartState(state map[string]any, keys []string)
 
 前端 console 的 Runtime Supervisor 页面读取 `GET /api/v1/supervisor/status`，展示 supervisor policy、service target、runtime 状态、`applicationRestartPlan`、应用内控制动作、`containerFallbackCandidate`、fallback `decision`、executor `kind`/`dryRun` 和 dry-run audit 摘要。
 
-当前页面只开放最小的手动应用内控制入口：对 `runtimeKind=signal` / `signal-runtime` 的 runtime，可在显式确认并填写 reason 后调用现有 `POST /api/v1/runtime/restart`、`POST /api/v1/runtime/suppress-auto-restart`、`POST /api/v1/runtime/resume-auto-restart`。restart 入口固定 `confirm=true`、`force=false`；suppress/resume 只切换 signal runtime 自动恢复抑制状态并写审计 reason。该页面不支持 live-session restart，不触碰 Docker/container fallback。真正执行容器级 restart 前仍需单独 PR 设计 executor、权限边界和部署安全审查。
+当前页面只开放最小的手动应用内控制入口：对 `runtimeKind=signal` / `signal-runtime` 的 runtime，可在显式确认并填写 reason 后调用现有 `POST /api/v1/runtime/start`、`POST /api/v1/runtime/stop`、`POST /api/v1/runtime/restart`、`POST /api/v1/runtime/suppress-auto-restart`、`POST /api/v1/runtime/resume-auto-restart`。start/stop/restart 入口固定 `confirm=true`，其中 stop/restart 固定 `force=false`，保留 active position/order 防护；suppress/resume 只切换 signal runtime 自动恢复抑制状态并写审计 reason。该页面不支持 live-session start/stop/restart，不触碰 Docker/container fallback。真正执行容器级 restart 前仍需单独 PR 设计 executor、权限边界和部署安全审查。
 
 ## 7. 安全边界
 

--- a/web/console/src/pages/SupervisorStage.tsx
+++ b/web/console/src/pages/SupervisorStage.tsx
@@ -3,12 +3,14 @@ import {
   AlertTriangle,
   CheckCircle2,
   Clock3,
+  Play,
   RefreshCw,
   RotateCw,
   ServerCog,
   ShieldAlert,
   Signal,
   SlidersHorizontal,
+  Square,
   XCircle,
 } from 'lucide-react';
 import { Badge } from '../components/ui/badge';
@@ -45,7 +47,7 @@ import {
 type LoadState = 'idle' | 'loading' | 'loaded' | 'error';
 type BadgeVariant = NonNullable<React.ComponentProps<typeof Badge>['variant']>;
 type RuntimeRow = RuntimeSupervisorRuntimeStatus & { targetName: string };
-type RuntimeControlActionKind = 'restart' | 'suppress-auto-restart' | 'resume-auto-restart';
+type RuntimeControlActionKind = 'start' | 'stop' | 'restart' | 'suppress-auto-restart' | 'resume-auto-restart';
 type RuntimeControlDialogState = {
   runtime: RuntimeRow;
   action: RuntimeControlActionKind;
@@ -283,9 +285,23 @@ function applicationRestartPlanTitle(plan?: RuntimeSupervisorRuntimeStatus['appl
   ].filter(Boolean).join(' ');
 }
 
-function runtimeRestartSupported(runtime: RuntimeSupervisorRuntimeStatus) {
+function normalizedRuntimeStatus(value?: string) {
+  return String(value || '').trim().toUpperCase();
+}
+
+function runtimeControlSupported(runtime: RuntimeSupervisorRuntimeStatus) {
   const kind = String(runtime.runtimeKind || '').trim().toLowerCase();
   return kind === 'signal' || kind === 'signal-runtime';
+}
+
+function runtimeStartDisabled(runtime: RuntimeSupervisorRuntimeStatus) {
+  return ['RUNNING', 'STARTING', 'RECOVERING'].includes(normalizedRuntimeStatus(runtime.actualStatus));
+}
+
+function runtimeStopDisabled(runtime: RuntimeSupervisorRuntimeStatus) {
+  const actual = normalizedRuntimeStatus(runtime.actualStatus);
+  const desired = normalizedRuntimeStatus(runtime.desiredStatus);
+  return actual === 'STOPPING' || (actual === 'STOPPED' && desired === 'STOPPED');
 }
 
 function runtimeControlActionKey(runtime: RuntimeRow, action: RuntimeControlActionKind) {
@@ -293,6 +309,12 @@ function runtimeControlActionKey(runtime: RuntimeRow, action: RuntimeControlActi
 }
 
 function runtimeControlPath(action: RuntimeControlActionKind) {
+  if (action === 'start') {
+    return '/api/v1/runtime/start';
+  }
+  if (action === 'stop') {
+    return '/api/v1/runtime/stop';
+  }
   if (action === 'suppress-auto-restart') {
     return '/api/v1/runtime/suppress-auto-restart';
   }
@@ -303,6 +325,12 @@ function runtimeControlPath(action: RuntimeControlActionKind) {
 }
 
 function runtimeControlLabel(action: RuntimeControlActionKind) {
+  if (action === 'start') {
+    return 'Start Signal Runtime';
+  }
+  if (action === 'stop') {
+    return 'Stop Signal Runtime';
+  }
   if (action === 'suppress-auto-restart') {
     return 'Suppress Auto Restart';
   }
@@ -373,16 +401,19 @@ export function SupervisorStage() {
     setControlError(null);
     setControlNotice(null);
     try {
+      const payload: Record<string, unknown> = {
+        runtimeId: runtime.runtimeId,
+        runtimeKind: runtime.runtimeKind,
+        confirm: true,
+        reason,
+      };
+      if (action === 'restart' || action === 'stop') {
+        payload.force = false;
+      }
       await fetchJSON(runtimeControlPath(action), {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          runtimeId: runtime.runtimeId,
-          runtimeKind: runtime.runtimeKind,
-          confirm: true,
-          force: action === 'restart' ? false : undefined,
-          reason,
-        }),
+        body: JSON.stringify(payload),
       });
     } catch (err) {
       setControlError(err instanceof Error ? err.message : 'runtime control failed');
@@ -445,6 +476,20 @@ export function SupervisorStage() {
   const targets = snapshot?.targets ?? [];
   const policy = snapshot?.policy;
   const isLoading = loadState === 'loading' || loadState === 'idle';
+  const ControlSubmitIcon =
+    controlDialog?.action === 'start'
+      ? Play
+      : controlDialog?.action === 'stop'
+        ? Square
+        : controlDialog?.action === 'resume-auto-restart'
+          ? CheckCircle2
+          : controlDialog?.action === 'suppress-auto-restart'
+            ? ShieldAlert
+            : RotateCw;
+  const controlSubmitVariant =
+    controlDialog?.action === 'start' || controlDialog?.action === 'resume-auto-restart'
+      ? 'bento-primary'
+      : 'bento-destructive';
 
   return (
     <div className="absolute inset-0 overflow-y-auto bg-[var(--bk-canvas)] p-6">
@@ -743,10 +788,14 @@ export function SupervisorStage() {
                           restartPlan?.blockedReason ||
                           restartPlan?.eligibleReason ||
                           restartPlan?.reason;
-                        const canRestart = runtimeRestartSupported(runtime);
+                        const canControl = runtimeControlSupported(runtime);
+                        const startSubmitting = controlSubmittingKey === runtimeControlActionKey(runtime, 'start');
+                        const stopSubmitting = controlSubmittingKey === runtimeControlActionKey(runtime, 'stop');
                         const restartSubmitting = controlSubmittingKey === runtimeControlActionKey(runtime, 'restart');
                         const suppressAction: RuntimeControlActionKind = runtime.autoRestartSuppressed ? 'resume-auto-restart' : 'suppress-auto-restart';
                         const suppressSubmitting = controlSubmittingKey === runtimeControlActionKey(runtime, suppressAction);
+                        const startDisabled = runtimeStartDisabled(runtime);
+                        const stopDisabled = runtimeStopDisabled(runtime);
                         const lifecycleAudit = runtimeLifecycleAudit(runtime);
                         const autoRestartAudit = runtimeAutoRestartAudit(runtime);
                         return (
@@ -808,8 +857,32 @@ export function SupervisorStage() {
                             <TableCell>{formatOptionalTime(runtime.nextRestartAt)}</TableCell>
                             <TableCell>{formatOptionalTime(runtime.lastCheckedAt)}</TableCell>
                             <TableCell>
-                              {canRestart ? (
-                                <div className="flex items-center gap-1">
+                              {canControl ? (
+                                <div className="flex flex-wrap items-center gap-1">
+                                  <Button
+                                    type="button"
+                                    size="icon-sm"
+                                    variant="bento-outline"
+                                    className="rounded-lg"
+                                    onClick={() => openControlDialog(runtime, 'start')}
+                                    disabled={Boolean(controlSubmittingKey) || startSubmitting || startDisabled}
+                                    title="Start signal runtime"
+                                    aria-label={`Start signal runtime ${runtime.runtimeId}`}
+                                  >
+                                    <Play fill="currentColor" className={cn(startSubmitting && 'animate-pulse')} />
+                                  </Button>
+                                  <Button
+                                    type="button"
+                                    size="icon-sm"
+                                    variant="bento-ghost"
+                                    className="rounded-lg"
+                                    onClick={() => openControlDialog(runtime, 'stop')}
+                                    disabled={Boolean(controlSubmittingKey) || stopSubmitting || stopDisabled}
+                                    title="Stop signal runtime"
+                                    aria-label={`Stop signal runtime ${runtime.runtimeId}`}
+                                  >
+                                    <Square fill="currentColor" className={cn(stopSubmitting && 'animate-pulse')} />
+                                  </Button>
                                   <Button
                                     type="button"
                                     size="icon-sm"
@@ -959,12 +1032,16 @@ export function SupervisorStage() {
             </Button>
             <Button
               type="button"
-              variant="bento-destructive"
+              variant={controlSubmitVariant}
               className="rounded-lg"
               onClick={() => void submitRuntimeControl()}
               disabled={!controlReason.trim() || Boolean(controlSubmittingKey)}
             >
-              <RotateCw data-icon="inline-start" className={cn(controlSubmittingKey && 'animate-spin')} />
+              <ControlSubmitIcon
+                data-icon="inline-start"
+                fill={controlDialog?.action === 'start' || controlDialog?.action === 'stop' ? 'currentColor' : 'none'}
+                className={cn(controlSubmittingKey && (controlDialog?.action === 'restart' ? 'animate-spin' : 'animate-pulse'))}
+              />
               Submit
             </Button>
           </DialogFooter>


### PR DESCRIPTION
## 目的
Refs #270.

在 Runtime Supervisor Dashboard 上接入已合并的 signal runtime lifecycle 控制 API，让操作员可以在显式确认并填写 reason 后手动提交 start / stop intent，并继续保留 restart 与 suppress/resume 入口。

本 PR 只覆盖 `runtimeKind=signal` / `signal-runtime` 的 UI 入口，不新增 live-session 控制，不触碰 Docker/container fallback。Dashboard 发起 stop/restart 时固定 `force=false`，保留 active position/order 防护。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [x] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) - 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？- 无
- [x] DB migration 是否具备向下兼容幂等性？- 不涉及
- [x] 配置字段有没有无意被混改？- 无

## 交易语义变更
- [x] 本次改动是否新增/修改了 `signalKind`？若是，需同步更新 Golden Case - 否
- [x] 本次改动是否影响订单方向判断（`side` / `reduceOnly` / `closePosition`）？- 否
- [x] 若涉及上述改动，`go test ./internal/domain/... -run TestClassifyOrderIntent` 是否通过？- 不涉及
- [x] 若涉及交易链路语义（开仓/平仓/撤单/risk-exit），`go test ./internal/domain/... -run TestTradingReplayGoldenCases` 是否通过？- 不涉及

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

验证：
- `cd web/console && ./node_modules/.bin/tsc --noEmit src/pages/SupervisorStage.tsx --jsx react-jsx --esModuleInterop --target esnext --module esnext --moduleResolution Bundler --allowSyntheticDefaultImports`
- `cd web/console && npm run build`
- `bash scripts/check_high_risk_defaults.sh`
- `bash scripts/check_env_safety.sh`
