### PR TITLE
[codex] fix live runner control scanner startup

### DIFF
--- a/internal/app/server.go
+++ b/internal/app/server.go
@@ -174,14 +174,12 @@ func StartRuntimeComponents(ctx context.Context, platform *service.Platform, cfg
 		consumer, err := service.NewNATSRuntimeEventConsumer(cfg.NATSURL, platform)
 		if err != nil {
 			logger.Warn("runtime event consumer unavailable; continuing without JetStream consume", "error", err)
-			return
-		}
-		if err := consumer.Start(ctx); err != nil {
+		} else if err := consumer.Start(ctx); err != nil {
 			consumer.Close()
 			logger.Warn("runtime event consumer failed to start", "error", err)
-			return
+		} else {
+			platform.SetRuntimeEventConsumerEnabled(true)
 		}
-		platform.SetRuntimeEventConsumerEnabled(true)
 	}
 	if runtime.StartSignalRuntimeScanner {
 		platform.StartSignalRuntimeScanner(ctx)

--- a/internal/app/server_test.go
+++ b/internal/app/server_test.go
@@ -1,6 +1,13 @@
 package app
 
-import "testing"
+import (
+	"context"
+	"testing"
+
+	"github.com/wuyaocheng/bktrader/internal/config"
+	"github.com/wuyaocheng/bktrader/internal/service"
+	"github.com/wuyaocheng/bktrader/internal/store/memory"
+)
 
 func TestRuntimeOptionsForSignalRuntimeRunner(t *testing.T) {
 	options := RuntimeOptionsForRole("signal-runtime-runner")
@@ -75,5 +82,28 @@ func TestRuntimeOptionsForMonolithStartAllRuntimeComponents(t *testing.T) {
 	}
 	if options.StartReadOnlyRuntimeSupervisor {
 		t.Fatal("expected monolith not to start read-only supervisor by default")
+	}
+}
+
+func TestStartRuntimeComponentsContinuesAfterRuntimeEventConsumerFailure(t *testing.T) {
+	platform := service.NewPlatform(memory.NewStore())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	StartRuntimeComponents(ctx, platform, config.Config{
+		ProcessRole:     "live-runner",
+		RuntimeEventBus: "nats",
+		NATSURL:         "nats://127.0.0.1:1",
+	}, RuntimeOptions{
+		StartRuntimeEventConsumer:      true,
+		StartLiveSessionControlScanner: true,
+	})
+
+	if platform.RuntimeEventConsumerEnabled() {
+		t.Fatal("expected runtime event consumer to remain disabled after connection failure")
+	}
+	status := platform.LiveSessionControlScannerStatus()
+	if !status.Enabled {
+		t.Fatalf("expected live session control scanner to start after consumer failure, got %+v", status)
 	}
 }


### PR DESCRIPTION
## 目的

修复 live-runner 启动时 runtime event consumer 初始化失败会提前终止后续后台组件启动的问题，确保 LiveSession control scanner 仍然启动并消费 start/stop 控制意图。

## Root Cause

生产排查中看到 `btc30min_plus` 的 stop 控制意图已写入：`desiredStatus=STOPPED`、`actualStatus=RUNNING`，但 live-control history 只有 `request_accepted`，`runnerPickups=0`。

live-runner 日志同时显示 runtime event consumer 因 NATS/JetStream 不可用而失败。`StartRuntimeComponents` 在该失败路径直接 `return`，导致后面的 `StartLiveSessionControlScanner` 没有执行，所以 runner 永远不会接走已有 stop 意图。

## 修改点

- runtime event consumer 初始化或启动失败时，仅记录 warn 并保持 consumer disabled。
- 不再让该失败阻断后续 runtime components，包括 live session control scanner。
- 增加回归测试覆盖 consumer 失败后 scanner 仍启动。

## 行为变化

live-runner 在 NATS/JetStream 暂时不可用时，仍会继续启动 live sync/control scanner 等本地安全控制组件。事件消费仍保持 disabled，不会假装成功。

## 验证

- `/usr/local/go/bin/go test ./internal/app`

## AI Agent 参与声明

- [x] 本 PR 由 Codex 辅助生成，变更范围限定在 live-runner 启动链路与对应回归测试。
