### PR TITLE
[codex] fix cd deploy image tag drift

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -243,6 +243,7 @@ jobs:
           images: ghcr.io/${{ github.repository_owner }}/bktrader-app
           tags: |
             type=ref,event=branch
+            type=raw,value=sha-${{ github.sha }}
             type=sha,prefix=sha-
             type=raw,value=latest,enable={{is_default_branch}}
 
@@ -327,7 +328,7 @@ jobs:
         env:
           DEPLOY_PATH: /Users/fujun/services/bktrader
           IMAGE_REPO: ghcr.io/${{ github.repository_owner }}/bktrader-app
-          IMAGE_TAG: latest
+          IMAGE_TAG: sha-${{ github.sha }}
           APP_ENV_FILE: /Users/fujun/services/bktrader/.env
           DEPLOY_SERVICES: ${{ needs.changes.outputs.deploy_services }}
           GHCR_USERNAME: ${{ secrets.GHCR_USERNAME }}

--- a/docs/cd-service-routing.md
+++ b/docs/cd-service-routing.md
@@ -11,6 +11,8 @@
 
 四个服务共用同一个 Docker image，因此后端代码变化都会先构建并推送镜像；是否重启某个服务由 `DEPLOY_SERVICES` 决定。
 
+生产部署必须使用本次 commit 对应的不可变镜像 tag（`sha-<github.sha>`），不能用 mutable `latest` 作为 Compose 部署输入。`latest` 仍可发布给人工排查或手动拉取，但 selective deploy 下如果只重启 `platform-api`，用 `latest` 会让未重启的 worker 继续运行旧 digest，同时 Compose 配置看起来仍是同一个 `latest` tag，容易掩盖 API / runner 版本漂移。使用 commit SHA tag 后，当前运行容器的镜像版本可以从 tag / label 直接追溯到具体 commit。
+
 ## 路由原则
 
 1. 共享基础设施变化才全量重启。


### PR DESCRIPTION
## 目的

修复 CD selective deploy 使用 mutable `latest` 作为部署输入导致的版本漂移可观测性问题。

## Root Cause

后端四个服务共用同一个 Docker image，但 CD 会按 diff 只重启部分 compose services。此前 deploy job 固定传入 `IMAGE_TAG=latest`。

当某次 API-only 变更构建并推送了新的 `latest` 后，CD 只重启 `platform-api`，未重启的 worker 仍运行旧 digest；但 compose 配置和镜像名都显示为 `latest`，容易掩盖 API / runner 实际 commit 不一致的问题。

## 修改点

- Docker metadata 额外推送不可变长 SHA tag：`sha-${{ github.sha }}`。
- Deploy job 使用 `IMAGE_TAG=sha-${{ github.sha }}`，让本次被选择部署的服务绑定到具体 commit image。
- 文档补充 selective deploy 下为什么不能用 `latest` 作为生产部署输入。

`latest` 仍会继续发布，保留给人工排查和手动拉取；生产 CD 不再依赖它做 compose 输入。

## 行为变化

Selective deploy 仍只重启 `DEPLOY_SERVICES` 指定的服务，但每次重启的服务会明确运行当前 commit 的 immutable image tag。未重启服务如果保留旧版本，也能从容器 image/tag/label 看出具体 commit，避免同名 `latest` 掩盖漂移。

## 验证

- `git diff --check`
- Ruby YAML parse smoke: confirmed `.github/workflows/cd.yml` parses and deploy `IMAGE_TAG` points to `sha-${{ github.sha }}`.

## AI Agent 参与声明

- [x] 本 PR 由 Codex 辅助生成，范围限定在 CD image tag wiring 与对应文档。
