### PR TITLE
[codex] log cd deploy image input

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -48,6 +48,13 @@ fi
 
 export IMAGE_REPO IMAGE_TAG APP_ENV_FILE
 
+echo "Deploy image: ${IMAGE_REPO}:${IMAGE_TAG}"
+if [[ -n "$DEPLOY_SERVICES" ]]; then
+  echo "Deploy service input: ${DEPLOY_SERVICES}"
+else
+  echo "Deploy service input: <all compose services>"
+fi
+
 deploy_args=()
 if [[ -n "$DEPLOY_SERVICES" ]]; then
   for service in $DEPLOY_SERVICES; do


### PR DESCRIPTION
## 目的
为 CD immutable image tag 验证补一条明确的部署输入日志。合并后 backend CD 会因为 `scripts/deploy.sh` 变更触发，日志中应出现 `Deploy image: ghcr.io/folgercn/bktrader-app:sha-${{ github.sha }}`，用于确认 #377 的 `IMAGE_TAG=sha-${{ github.sha }}` 已在真实部署链路生效。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [x] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) — 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？— 无
- [x] DB migration 是否具备向下兼容幂等性？— 不涉及
- [x] 配置字段有没有无意被混改？— 无

## 交易语义变更
- [x] 本次改动是否新增/修改了 `signalKind`？若是，需同步更新 Golden Case — 否
- [x] 本次改动是否影响订单方向判断（`side` / `reduceOnly` / `closePosition`）？— 否
- [ ] 若涉及上述改动，`go test ./internal/domain/... -run TestClassifyOrderIntent` 是否通过？
- [ ] 若涉及交易链路语义（开仓/平仓/撤单/risk-exit），`go test ./internal/domain/... -run TestTradingReplayGoldenCases` 是否通过？

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

验证：

```bash
bash -n scripts/deploy.sh
```

预期合并后验证点：

1. CD `Deploy via docker compose` 日志出现 `Deploy image: ghcr.io/folgercn/bktrader-app:sha-<merge sha>`。
2. 生产容器 `org.opencontainers.image.revision` 对应本 PR 的 merge commit。
3. `docker inspect` 中四个后端业务容器的 image/revision 保持一致。
