### PR TITLE
[codex] fix t3 live market replay

### DIFF
--- a/internal/service/live_market_data.go
+++ b/internal/service/live_market_data.go
@@ -555,7 +555,7 @@ func (p *Platform) buildLiveExecutionPlanFromMarketData(
 
 	var result map[string]any
 	switch normalized := normalizeStrategyEngineKey(engineKey); normalized {
-	case "bk-default", bkLiveIntrabarSMA5T2Only0p5BpsEngineKey:
+	case "bk-default", bkLiveIntrabarSMA5T2Only0p5BpsEngineKey, bkLiveIntrabarSMA5BaselinePlusT3EnhancedEngineKey:
 		result, err = runStrategyReplayOnMinuteBars(cfg, signals, minuteBars)
 	default:
 		result, err = engine.Run(context)

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -1655,6 +1655,90 @@ func TestBuildLiveExecutionPlanFromMarketDataUsesLiveSnapshotForEnhanced30m(t *t
 	}
 }
 
+func TestBuildLiveExecutionPlanFromMarketDataUsesLiveSnapshotForBaselinePlusT3Enhanced30m(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+
+	session, err := platform.CreateLiveSession("", "live-main", "strategy-bk-btc-30m-enhanced-t3", map[string]any{
+		"symbol":              "BTCUSDT",
+		"signalTimeframe":     "30m",
+		"executionDataSource": "tick",
+	})
+	if err != nil {
+		t.Fatalf("create live session failed: %v", err)
+	}
+
+	version, err := platform.resolveCurrentStrategyVersion(session.StrategyID)
+	if err != nil {
+		t.Fatalf("resolve strategy version failed: %v", err)
+	}
+	parameters, err := platform.resolveLiveSessionParameters(session, version)
+	if err != nil {
+		t.Fatalf("resolve live session parameters failed: %v", err)
+	}
+	engine, engineKey, err := platform.resolveStrategyEngine(version.ID, parameters)
+	if err != nil {
+		t.Fatalf("resolve strategy engine failed: %v", err)
+	}
+	if got := normalizeStrategyEngineKey(engineKey); got != bkLiveIntrabarSMA5BaselinePlusT3EnhancedEngineKey {
+		t.Fatalf("expected baseline+T3 enhanced engine, got %s", got)
+	}
+
+	signalCandles := make([]candleBar, 0, 48)
+	minuteBars := make([]candleBar, 0, 48)
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	for i := 0; i < 48; i++ {
+		ts := start.Add(time.Duration(i) * 30 * time.Minute)
+		open := 100.0 + float64(i)*0.5
+		close := open + 0.25
+		high := close + 0.75
+		low := open - 0.75
+		signalCandles = append(signalCandles, candleBar{
+			Time:   ts,
+			Open:   open,
+			High:   high,
+			Low:    low,
+			Close:  close,
+			Volume: 10 + float64(i),
+		})
+		minuteBars = append(minuteBars, candleBar{
+			Time:   ts.Add(time.Minute),
+			Open:   open,
+			High:   high,
+			Low:    low,
+			Close:  close,
+			Volume: 1,
+		})
+	}
+	signalBars, err := buildStrategySignalBarsFromCandles(signalCandles)
+	if err != nil {
+		t.Fatalf("build signal bars failed: %v", err)
+	}
+
+	platform.liveMarketMu.Lock()
+	platform.liveMarketData["BTCUSDT"] = liveMarketSnapshot{
+		Symbol:     "BTCUSDT",
+		MinuteBars: minuteBars,
+		SignalBars: map[string][]strategySignalBar{"30m": signalBars},
+		UpdatedAt:  time.Now().UTC(),
+	}
+	platform.liveMarketMu.Unlock()
+
+	plan, err := platform.buildLiveExecutionPlanFromMarketData(
+		session,
+		version,
+		engine,
+		engineKey,
+		parameters,
+		defaultExecutionSemantics(ExecutionModeLive, parameters),
+	)
+	if err != nil {
+		t.Fatalf("build baseline+T3 enhanced 30m live execution plan failed: %v", err)
+	}
+	if plan == nil {
+		t.Fatal("expected plan slice, got nil")
+	}
+}
+
 func TestResolveLiveSessionParametersDefaultsMissingStopsToTrailingForLive(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
 


### PR DESCRIPTION
## 目的
修复 PR #379 合并后 `strategy-bk-btc-30m-enhanced-t3` 实盘 session 没有 decision 日志的问题。

生产排查发现当前 T3 live session 的 runtime / 行情入口均为 RUNNING/healthy，但策略触发阶段持续失败：`open /app/BTC_1min_Clean.csv: no such file or directory`。根因是 T3 engine 没有进入 live market snapshot replay allowlist，fallback 到 `engine.Run(context)` 后尝试读取容器内不存在的研究 CSV。

本 PR 将 `bk-live-intrabar-sma5-baseline-plus-t3-enhanced` 纳入 live warmed market cache replay 路径，并补 T3 专项回归测试，防止再次退回磁盘 CSV。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [x] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) — 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？— 无
- [x] DB migration 是否具备向下兼容幂等性？— 不涉及 migration
- [x] 配置字段有没有无意被混改？— 无

## 交易语义变更
- [x] 本次改动是否新增/修改了 `signalKind`？若是，需同步更新 Golden Case — 否
- [x] 本次改动是否影响订单方向判断（`side` / `reduceOnly` / `closePosition`）？— 否
- [ ] 若涉及上述改动，`go test ./internal/domain/... -run TestClassifyOrderIntent` 是否通过？
- [ ] 若涉及交易链路语义（开仓/平仓/撤单/risk-exit），`go test ./internal/domain/... -run TestTradingReplayGoldenCases` 是否通过？

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

验证已通过：

```text
go test ./internal/service -run 'TestBuildLiveExecutionPlanFromMarketDataUsesLiveSnapshotFor(Enhanced30m|BaselinePlusT3Enhanced30m)'
go test ./...
go build ./cmd/platform-api
go build ./cmd/db-migrate
```

推送时 pre-push harness 也通过：graphify rebuild、high risk defaults check、env safety check、backend changed-scope checks。
