### PR TITLE
[codex] Add dashboard broker event loop

### DIFF
--- a/docs/dashboard-sse-architecture.md
+++ b/docs/dashboard-sse-architecture.md
@@ -126,7 +126,14 @@ Stronger JTI uniqueness with UUID has been implemented in PR #198 (Issue #193).
 
 ## 6. DashboardBroker Design
 
-`DashboardBroker` is responsible for polling selected backend data, detecting changes, and publishing SSE events to subscribers.
+`DashboardBroker` is responsible for collecting selected backend snapshots, detecting changes, and publishing SSE events to subscribers.
+
+Current implementation uses two trigger paths:
+
+1. Polling fallback tickers enqueue non-blocking domain change notifications.
+2. The broker event loop coalesces notifications for a short window, then fetches and hashes the affected domain snapshots.
+
+No business write path is connected to `NotifyChanged` yet. The first event-driven slice only introduces the broker-side framework and keeps polling as the active fallback trigger.
 
 ### 6.1 Subscriber model
 
@@ -137,7 +144,7 @@ Stronger JTI uniqueness with UUID has been implemented in PR #198 (Issue #193).
 
 ### 6.2 No-subscriber behavior
 
-When there are no subscribers, `checkAndPublish` returns immediately.
+When there are no subscribers, `publishSnapshotForDomain` returns immediately.
 
 This avoids unnecessary:
 
@@ -173,6 +180,7 @@ Current SSE payloads are deliberately conservative.
 | Event type | Payload source | Notes |
 |---|---|---|
 | `live-sessions` | `ListLiveSessionsSummary()` | Strips heavy `sourceStates` and `signalBarStates`. |
+| `signal-runtime-sessions` | `ListSignalRuntimeSessionsSummary()` | Runtime session summary snapshot. |
 | `positions` | `ListPositions()` | Full position list. |
 | `orders` | `ListOrdersWithLimit(50, 0)` | Recent 50 only. |
 | `fills` | `ListFillsWithLimit(50, 0)` | Recent 50 only. |

--- a/internal/service/dashboard_broker.go
+++ b/internal/service/dashboard_broker.go
@@ -20,22 +20,79 @@ type DashboardEvent struct {
 	Timestamp time.Time `json:"timestamp"`
 }
 
+// DashboardDomain identifies a dashboard snapshot domain.
+type DashboardDomain string
+
+const (
+	DashboardDomainLiveSessions          DashboardDomain = "live-sessions"
+	DashboardDomainSignalRuntimeSessions DashboardDomain = "signal-runtime-sessions"
+	DashboardDomainPositions             DashboardDomain = "positions"
+	DashboardDomainOrders                DashboardDomain = "orders"
+	DashboardDomainFills                 DashboardDomain = "fills"
+	DashboardDomainAlerts                DashboardDomain = "alerts"
+	DashboardDomainNotifications         DashboardDomain = "notifications"
+	DashboardDomainMonitorHealth         DashboardDomain = "monitor-health"
+)
+
+type dashboardChange struct {
+	Domain DashboardDomain
+	Reason string
+}
+
 // DashboardBroker 负责仪表盘实时数据的事件分发。
-// 采用"轮询检测变更 + 增量推送"模式。
+// 采用"变更通知合并 + snapshot 推送"模式，保留轮询作为兜底触发源。
 type DashboardBroker struct {
-	mu          sync.RWMutex
-	subscribers map[int]chan DashboardEvent
-	nextID      int
-	seq         int64
-	lastHashes  map[string]string
-	platform    *Platform
+	mu             sync.RWMutex
+	subscribers    map[int]chan DashboardEvent
+	nextID         int
+	seq            int64
+	lastHashes     map[string]string
+	platform       *Platform
+	changes        chan dashboardChange
+	fetchFuncs     map[DashboardDomain]func() (any, error)
+	coalesceWindow time.Duration
 }
 
 func NewDashboardBroker(platform *Platform) *DashboardBroker {
-	return &DashboardBroker{
-		subscribers: make(map[int]chan DashboardEvent),
-		lastHashes:  make(map[string]string),
-		platform:    platform,
+	b := &DashboardBroker{
+		subscribers:    make(map[int]chan DashboardEvent),
+		lastHashes:     make(map[string]string),
+		platform:       platform,
+		changes:        make(chan dashboardChange, 128),
+		fetchFuncs:     make(map[DashboardDomain]func() (any, error)),
+		coalesceWindow: 300 * time.Millisecond,
+	}
+	b.registerDefaultFetchFuncs()
+	return b
+}
+
+func (b *DashboardBroker) registerDefaultFetchFuncs() {
+	if b.platform == nil {
+		return
+	}
+	b.fetchFuncs[DashboardDomainLiveSessions] = func() (any, error) {
+		return b.platform.ListLiveSessionsSummary()
+	}
+	b.fetchFuncs[DashboardDomainSignalRuntimeSessions] = func() (any, error) {
+		return b.platform.ListSignalRuntimeSessionsSummary(), nil
+	}
+	b.fetchFuncs[DashboardDomainPositions] = func() (any, error) {
+		return b.platform.ListPositions()
+	}
+	b.fetchFuncs[DashboardDomainOrders] = func() (any, error) {
+		return b.platform.ListOrdersWithLimit(50, 0)
+	}
+	b.fetchFuncs[DashboardDomainFills] = func() (any, error) {
+		return b.platform.ListFillsWithLimit(50, 0)
+	}
+	b.fetchFuncs[DashboardDomainAlerts] = func() (any, error) {
+		return b.platform.ListAlerts()
+	}
+	b.fetchFuncs[DashboardDomainNotifications] = func() (any, error) {
+		return b.platform.ListNotifications(true)
+	}
+	b.fetchFuncs[DashboardDomainMonitorHealth] = func() (any, error) {
+		return b.platform.HealthSnapshot()
 	}
 }
 
@@ -93,13 +150,64 @@ func hashPayload(payload any) string {
 	return hex.EncodeToString(hash[:])
 }
 
-// checkAndPublish 检测数据变更并推送
-func (b *DashboardBroker) checkAndPublish(eventType string, fetchData func() (any, error)) {
+// NotifyChanged schedules a dashboard domain snapshot check without blocking the caller.
+func (b *DashboardBroker) NotifyChanged(domain DashboardDomain, reason string) {
+	select {
+	case b.changes <- dashboardChange{Domain: domain, Reason: reason}:
+	default:
+	}
+}
+
+// StartEventLoop 合并短时间窗口内的 dashboard 变更信号并发布 snapshot。
+func (b *DashboardBroker) StartEventLoop(ctx context.Context) {
+	timer := time.NewTimer(b.coalesceWindow)
+	if !timer.Stop() {
+		<-timer.C
+	}
+	pending := make(map[DashboardDomain]struct{})
+	timerActive := false
+
+	flush := func() {
+		for domain := range pending {
+			b.publishSnapshotForDomain(domain)
+			delete(pending, domain)
+		}
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			if timerActive && !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			return
+		case change := <-b.changes:
+			if change.Domain == "" {
+				continue
+			}
+			pending[change.Domain] = struct{}{}
+			if !timerActive {
+				timer.Reset(b.coalesceWindow)
+				timerActive = true
+			}
+		case <-timer.C:
+			timerActive = false
+			flush()
+		}
+	}
+}
+
+// publishSnapshotForDomain 检测指定 domain 数据变更并推送 snapshot。
+func (b *DashboardBroker) publishSnapshotForDomain(domain DashboardDomain) {
 	b.mu.RLock()
 	hasSubscribers := len(b.subscribers) > 0
+	fetchData := b.fetchFuncs[domain]
 	b.mu.RUnlock()
 
-	if !hasSubscribers {
+	if !hasSubscribers || fetchData == nil {
 		return
 	}
 
@@ -112,6 +220,7 @@ func (b *DashboardBroker) checkAndPublish(eventType string, fetchData func() (an
 		return
 	}
 
+	eventType := string(domain)
 	b.mu.RLock()
 	lastHash := b.lastHashes[eventType]
 	b.mu.RUnlock()
@@ -126,7 +235,7 @@ func (b *DashboardBroker) checkAndPublish(eventType string, fetchData func() (an
 
 // StartPolling 启动轮询检查
 func (b *DashboardBroker) StartPolling(ctx context.Context, cfg config.Config) {
-	startTicker := func(intervalMs int, eventType string, fetchData func() (any, error)) {
+	startTicker := func(intervalMs int, domain DashboardDomain) {
 		interval := time.Duration(intervalMs) * time.Millisecond
 		ticker := time.NewTicker(interval)
 		go func() {
@@ -136,36 +245,20 @@ func (b *DashboardBroker) StartPolling(ctx context.Context, cfg config.Config) {
 				case <-ctx.Done():
 					return
 				case <-ticker.C:
-					b.checkAndPublish(eventType, fetchData)
+					b.NotifyChanged(domain, "polling")
 				}
 			}
 		}()
 	}
 
-	startTicker(cfg.DashboardLiveSessionsPollMs, "live-sessions", func() (any, error) {
-		return b.platform.ListLiveSessionsSummary()
-	})
-	startTicker(cfg.DashboardLiveSessionsPollMs, "signal-runtime-sessions", func() (any, error) {
-		return b.platform.ListSignalRuntimeSessionsSummary(), nil
-	})
-	startTicker(cfg.DashboardPositionsPollMs, "positions", func() (any, error) {
-		return b.platform.ListPositions()
-	})
-	startTicker(cfg.DashboardOrdersPollMs, "orders", func() (any, error) {
-		return b.platform.ListOrdersWithLimit(50, 0)
-	})
-	startTicker(cfg.DashboardFillsPollMs, "fills", func() (any, error) {
-		return b.platform.ListFillsWithLimit(50, 0)
-	})
-	startTicker(cfg.DashboardAlertsPollMs, "alerts", func() (any, error) {
-		return b.platform.ListAlerts()
-	})
-	startTicker(cfg.DashboardNotificationsPollMs, "notifications", func() (any, error) {
-		return b.platform.ListNotifications(true)
-	})
-	startTicker(cfg.DashboardMonitorHealthPollMs, "monitor-health", func() (any, error) {
-		return b.platform.HealthSnapshot()
-	})
+	startTicker(cfg.DashboardLiveSessionsPollMs, DashboardDomainLiveSessions)
+	startTicker(cfg.DashboardLiveSessionsPollMs, DashboardDomainSignalRuntimeSessions)
+	startTicker(cfg.DashboardPositionsPollMs, DashboardDomainPositions)
+	startTicker(cfg.DashboardOrdersPollMs, DashboardDomainOrders)
+	startTicker(cfg.DashboardFillsPollMs, DashboardDomainFills)
+	startTicker(cfg.DashboardAlertsPollMs, DashboardDomainAlerts)
+	startTicker(cfg.DashboardNotificationsPollMs, DashboardDomainNotifications)
+	startTicker(cfg.DashboardMonitorHealthPollMs, DashboardDomainMonitorHealth)
 }
 
 // PushInitialSnapshot 手动为某个连接推送当前最新数据
@@ -179,32 +272,34 @@ func (b *DashboardBroker) PushInitialSnapshot(id int) {
 
 	// Push latest state to new subscriber
 	// This ensures they don't have to wait for the next change
-	b.pushLatestIfAvailable("live-sessions", func() (any, error) { return b.platform.ListLiveSessionsSummary() }, ch)
-	b.pushLatestIfAvailable("signal-runtime-sessions", func() (any, error) {
-		return b.platform.ListSignalRuntimeSessionsSummary(), nil
-	}, ch)
-	b.pushLatestIfAvailable("positions", func() (any, error) { return b.platform.ListPositions() }, ch)
-	b.pushLatestIfAvailable("orders", func() (any, error) { return b.platform.ListOrdersWithLimit(50, 0) }, ch)
-	b.pushLatestIfAvailable("fills", func() (any, error) { return b.platform.ListFillsWithLimit(50, 0) }, ch)
-	b.pushLatestIfAvailable("alerts", func() (any, error) { return b.platform.ListAlerts() }, ch)
-	b.pushLatestIfAvailable("notifications", func() (any, error) { return b.platform.ListNotifications(true) }, ch)
-	b.pushLatestIfAvailable("monitor-health", func() (any, error) { return b.platform.HealthSnapshot() }, ch)
+	b.pushLatestIfAvailable(DashboardDomainLiveSessions, ch)
+	b.pushLatestIfAvailable(DashboardDomainSignalRuntimeSessions, ch)
+	b.pushLatestIfAvailable(DashboardDomainPositions, ch)
+	b.pushLatestIfAvailable(DashboardDomainOrders, ch)
+	b.pushLatestIfAvailable(DashboardDomainFills, ch)
+	b.pushLatestIfAvailable(DashboardDomainAlerts, ch)
+	b.pushLatestIfAvailable(DashboardDomainNotifications, ch)
+	b.pushLatestIfAvailable(DashboardDomainMonitorHealth, ch)
 }
 
-func (b *DashboardBroker) pushLatestIfAvailable(eventType string, fetchData func() (any, error), ch chan<- DashboardEvent) {
+func (b *DashboardBroker) pushLatestIfAvailable(domain DashboardDomain, ch chan<- DashboardEvent) {
+	b.mu.RLock()
+	fetchData := b.fetchFuncs[domain]
+	b.mu.RUnlock()
+	if fetchData == nil {
+		return
+	}
+
 	data, err := fetchData()
 	if err != nil {
 		return
 	}
 
-	hash := hashPayload(data)
+	eventType := string(domain)
 
 	b.mu.Lock()
 	b.seq++
 	seq := b.seq
-	if hash != "" {
-		b.lastHashes[eventType] = hash
-	}
 	b.mu.Unlock()
 
 	event := DashboardEvent{

--- a/internal/service/dashboard_broker_test.go
+++ b/internal/service/dashboard_broker_test.go
@@ -1,0 +1,187 @@
+package service
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/wuyaocheng/bktrader/internal/config"
+)
+
+func newTestDashboardBroker(window time.Duration) *DashboardBroker {
+	b := NewDashboardBroker(nil)
+	b.coalesceWindow = window
+	return b
+}
+
+func TestNotifyChangedNonBlocking(t *testing.T) {
+	b := newTestDashboardBroker(10 * time.Millisecond)
+	for i := 0; i < cap(b.changes); i++ {
+		b.changes <- dashboardChange{Domain: DashboardDomainOrders, Reason: "fill-buffer"}
+	}
+
+	done := make(chan struct{})
+	go func() {
+		b.NotifyChanged(DashboardDomainOrders, "channel-full")
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("NotifyChanged blocked when change channel was full")
+	}
+}
+
+func TestDashboardBrokerCoalescesSameDomain(t *testing.T) {
+	b := newTestDashboardBroker(20 * time.Millisecond)
+	var fetches atomic.Int64
+	b.fetchFuncs[DashboardDomainOrders] = func() (any, error) {
+		fetches.Add(1)
+		return map[string]any{"orders": []string{"order-1"}}, nil
+	}
+	_, ch := b.Subscribe(10)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go b.StartEventLoop(ctx)
+
+	for i := 0; i < 100; i++ {
+		b.NotifyChanged(DashboardDomainOrders, "test")
+	}
+
+	event := waitDashboardEvent(t, ch, 250*time.Millisecond)
+	if event.Type != string(DashboardDomainOrders) || event.Action != "snapshot" {
+		t.Fatalf("unexpected event: %+v", event)
+	}
+	time.Sleep(40 * time.Millisecond)
+	if got := fetches.Load(); got != 1 {
+		t.Fatalf("expected one fetch for coalesced domain, got %d", got)
+	}
+}
+
+func TestDashboardBrokerCoalescesMultipleDomains(t *testing.T) {
+	b := newTestDashboardBroker(20 * time.Millisecond)
+	var orderFetches atomic.Int64
+	var fillFetches atomic.Int64
+	b.fetchFuncs[DashboardDomainOrders] = func() (any, error) {
+		orderFetches.Add(1)
+		return map[string]any{"orders": []string{"order-1"}}, nil
+	}
+	b.fetchFuncs[DashboardDomainFills] = func() (any, error) {
+		fillFetches.Add(1)
+		return map[string]any{"fills": []string{"fill-1"}}, nil
+	}
+	_, ch := b.Subscribe(10)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go b.StartEventLoop(ctx)
+
+	for i := 0; i < 10; i++ {
+		b.NotifyChanged(DashboardDomainOrders, "test")
+		b.NotifyChanged(DashboardDomainFills, "test")
+	}
+
+	seen := make(map[string]bool)
+	for len(seen) < 2 {
+		event := waitDashboardEvent(t, ch, 250*time.Millisecond)
+		seen[event.Type] = true
+	}
+	if !seen[string(DashboardDomainOrders)] || !seen[string(DashboardDomainFills)] {
+		t.Fatalf("expected orders and fills events, got %#v", seen)
+	}
+	if got := orderFetches.Load(); got != 1 {
+		t.Fatalf("expected one orders fetch, got %d", got)
+	}
+	if got := fillFetches.Load(); got != 1 {
+		t.Fatalf("expected one fills fetch, got %d", got)
+	}
+}
+
+func TestDashboardBrokerNoSubscriberSkipsFetch(t *testing.T) {
+	b := newTestDashboardBroker(10 * time.Millisecond)
+	var fetches atomic.Int64
+	b.fetchFuncs[DashboardDomainOrders] = func() (any, error) {
+		fetches.Add(1)
+		return map[string]any{"orders": []string{"order-1"}}, nil
+	}
+
+	b.publishSnapshotForDomain(DashboardDomainOrders)
+
+	if got := fetches.Load(); got != 0 {
+		t.Fatalf("expected no fetch without subscribers, got %d", got)
+	}
+}
+
+func TestDashboardBrokerInitialSnapshotDoesNotSuppressBroadcast(t *testing.T) {
+	b := newTestDashboardBroker(10 * time.Millisecond)
+	currentPayload := atomic.Value{}
+	currentPayload.Store(map[string]any{"orders": []string{"h1"}})
+	b.fetchFuncs[DashboardDomainOrders] = func() (any, error) {
+		return currentPayload.Load(), nil
+	}
+
+	subA, chA := b.Subscribe(10)
+	b.PushInitialSnapshot(subA)
+	eventA := waitDashboardEvent(t, chA, 100*time.Millisecond)
+	if eventA.Type != string(DashboardDomainOrders) {
+		t.Fatalf("expected initial orders event for subscriber A, got %+v", eventA)
+	}
+
+	currentPayload.Store(map[string]any{"orders": []string{"h2"}})
+
+	subB, chB := b.Subscribe(10)
+	b.PushInitialSnapshot(subB)
+	eventB := waitDashboardEvent(t, chB, 100*time.Millisecond)
+	if eventB.Type != string(DashboardDomainOrders) {
+		t.Fatalf("expected initial orders event for subscriber B, got %+v", eventB)
+	}
+
+	b.publishSnapshotForDomain(DashboardDomainOrders)
+
+	broadcastA := waitDashboardEvent(t, chA, 100*time.Millisecond)
+	if broadcastA.Type != string(DashboardDomainOrders) || broadcastA.Action != "snapshot" {
+		t.Fatalf("expected orders broadcast for subscriber A, got %+v", broadcastA)
+	}
+	broadcastB := waitDashboardEvent(t, chB, 100*time.Millisecond)
+	if broadcastB.Type != string(DashboardDomainOrders) || broadcastB.Action != "snapshot" {
+		t.Fatalf("expected orders broadcast for subscriber B, got %+v", broadcastB)
+	}
+}
+
+func TestDashboardBrokerPollingTriggersNotifyChanged(t *testing.T) {
+	b := newTestDashboardBroker(10 * time.Millisecond)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	b.StartPolling(ctx, config.Config{
+		DashboardLiveSessionsPollMs:  10,
+		DashboardPositionsPollMs:     10,
+		DashboardOrdersPollMs:        10,
+		DashboardFillsPollMs:         10,
+		DashboardAlertsPollMs:        10,
+		DashboardNotificationsPollMs: 10,
+		DashboardMonitorHealthPollMs: 10,
+	})
+
+	select {
+	case change := <-b.changes:
+		if change.Domain == "" || change.Reason != "polling" {
+			t.Fatalf("unexpected polling change: %+v", change)
+		}
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("expected polling to enqueue a dashboard change")
+	}
+}
+
+func waitDashboardEvent(t *testing.T, ch <-chan DashboardEvent, timeout time.Duration) DashboardEvent {
+	t.Helper()
+	select {
+	case event := <-ch:
+		return event
+	case <-time.After(timeout):
+		t.Fatal("timed out waiting for dashboard event")
+		return DashboardEvent{}
+	}
+}

--- a/internal/service/platform.go
+++ b/internal/service/platform.go
@@ -184,15 +184,23 @@ func (p *Platform) SetProcessRole(role string) {
 	p.processRole = role
 }
 
-// StartDashboardBroker 启动仪表盘实时数据轮询检测
+// StartDashboardBroker 启动仪表盘实时数据通知合并与轮询兜底
 func (p *Platform) StartDashboardBroker(ctx context.Context, cfg config.Config) {
-	p.logger("service.platform").Info("starting dashboard broker polling")
+	p.logger("service.platform").Info("starting dashboard broker")
+	go p.dashboardBroker.StartEventLoop(ctx)
 	go p.dashboardBroker.StartPolling(ctx, cfg)
 }
 
 // DashboardBroker 返回内部仪表盘事件分发器
 func (p *Platform) DashboardBroker() *DashboardBroker {
 	return p.dashboardBroker
+}
+
+func (p *Platform) NotifyDashboardChanged(domain DashboardDomain, reason string) {
+	if p.dashboardBroker == nil {
+		return
+	}
+	p.dashboardBroker.NotifyChanged(domain, reason)
 }
 
 func (p *Platform) SetBacktestDataDirs(minuteDataDir, tickDataDir string) {


### PR DESCRIPTION
## 目的
为 #195 的 PR-195-1 落地 DashboardBroker 事件驱动基础框架：新增 domain 变更通知、短窗口 coalescing event loop，并让现有 polling fallback 通过非阻塞通知进入统一 snapshot 发布路径。

本 PR 不接入 notifications / alerts / orders / fills / positions / live-sessions 等业务写路径，不改前端 SSE 协议，不引入 incremental action，不删除 polling fallback。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [x] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？不存在
- [x] DB migration 是否具备向下兼容幂等性？不涉及
- [x] 配置字段有没有无意被混改？不涉及配置/env/default 改动

## 交易语义变更
- [x] 本次改动是否新增/修改了 `signalKind`？否
- [x] 本次改动是否影响订单方向判断（`side` / `reduceOnly` / `closePosition`）？否
- [x] 若涉及上述改动，`go test ./internal/domain/... -run TestClassifyOrderIntent` 是否通过？不涉及
- [x] 若涉及交易链路语义（开仓/平仓/撤单/risk-exit），`go test ./internal/domain/... -run TestTradingReplayGoldenCases` 是否通过？不涉及

## 改动摘要
- 新增 `DashboardDomain` 与 `DashboardBroker.NotifyChanged(domain, reason)`，通知 channel 满时直接 drop，确保写路径后续接入时不会阻塞。
- 新增 `StartEventLoop`，用 300ms coalescing window 合并同 domain / 多 domain 通知后再发布 snapshot。
- 抽出 domain -> fetch 函数映射，让 initial snapshot、polling fallback、event loop 共享同一套 payload source。
- `Platform.StartDashboardBroker` 同时启动 event loop 和 polling fallback，并新增 nil-safe `NotifyDashboardChanged` 便捷封装。
- 更新 `docs/dashboard-sse-architecture.md`，记录当前 broker-side event framework，明确业务写路径尚未接入。

## 验证方式与测试证据
- [x] `go test ./internal/service -run TestDashboardBroker -count=1`
- [x] `go test ./internal/http`
- [x] `go test ./internal/service`（第一次受 runtime/WS 噪音影响失败且未提取到具体 fail event，复跑通过）
- [x] `go test ./...`
- [x] `go build ./cmd/platform-api`
- [x] `go build ./cmd/db-migrate`
- [x] `git diff --check`

## Issue
Refs #195

## Codex 说明
本 PR 由 Codex 协助生成，范围限定在 #195 PR-195-1 的 broker 基础架构与 coalescing 机制。未修改 `internal/service/live*.go`、`internal/service/execution_strategy.go`、`deployments/`、`.github/workflows/`，不改变任何实盘交易默认行为。