### PR TITLE
[codex] Notify dashboard on notification ack changes

### DIFF
--- a/docs/dashboard-sse-architecture.md
+++ b/docs/dashboard-sse-architecture.md
@@ -128,12 +128,13 @@ Stronger JTI uniqueness with UUID has been implemented in PR #198 (Issue #193).
 
 `DashboardBroker` is responsible for collecting selected backend snapshots, detecting changes, and publishing SSE events to subscribers.
 
-Current implementation uses two trigger paths:
+Current implementation uses these trigger paths:
 
 1. Polling fallback tickers enqueue non-blocking domain change notifications.
 2. The broker event loop coalesces notifications for a short window, then fetches and hashes the affected domain snapshots.
+3. Notification ack / unack operations enqueue `notifications` domain changes after their store write succeeds.
 
-No business write path is connected to `NotifyChanged` yet. The first event-driven slice only introduces the broker-side framework and keeps polling as the active fallback trigger.
+Most business write paths still rely on polling fallback. The first event-driven business slice is deliberately limited to low-risk notification ack state changes.
 
 ### 6.1 Subscriber model
 

--- a/internal/service/dashboard_broker_test.go
+++ b/internal/service/dashboard_broker_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/wuyaocheng/bktrader/internal/config"
+	"github.com/wuyaocheng/bktrader/internal/store/memory"
 )
 
 func newTestDashboardBroker(window time.Duration) *DashboardBroker {
@@ -172,6 +173,34 @@ func TestDashboardBrokerPollingTriggersNotifyChanged(t *testing.T) {
 		}
 	case <-time.After(250 * time.Millisecond):
 		t.Fatal("expected polling to enqueue a dashboard change")
+	}
+}
+
+func TestStartDashboardBrokerPollingPublishesThroughEventLoop(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	b := platform.DashboardBroker()
+	b.coalesceWindow = 10 * time.Millisecond
+	b.fetchFuncs[DashboardDomainNotifications] = func() (any, error) {
+		return map[string]any{"notifications": []string{"notification-1"}}, nil
+	}
+	_, ch := b.Subscribe(10)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	slowPollMs := int((24 * time.Hour) / time.Millisecond)
+	platform.StartDashboardBroker(ctx, config.Config{
+		DashboardLiveSessionsPollMs:  slowPollMs,
+		DashboardPositionsPollMs:     slowPollMs,
+		DashboardOrdersPollMs:        slowPollMs,
+		DashboardFillsPollMs:         slowPollMs,
+		DashboardAlertsPollMs:        slowPollMs,
+		DashboardNotificationsPollMs: 10,
+		DashboardMonitorHealthPollMs: slowPollMs,
+	})
+
+	event := waitDashboardEvent(t, ch, 250*time.Millisecond)
+	if event.Type != string(DashboardDomainNotifications) || event.Action != "snapshot" {
+		t.Fatalf("unexpected event from broker startup path: %+v", event)
 	}
 }
 

--- a/internal/service/notifications.go
+++ b/internal/service/notifications.go
@@ -69,9 +69,18 @@ func (p *Platform) ListNotifications(includeAcked bool) ([]domain.PlatformNotifi
 }
 
 func (p *Platform) AckNotification(notificationID string) (domain.NotificationAck, error) {
-	return p.store.UpsertNotificationAck(strings.TrimSpace(notificationID))
+	ack, err := p.store.UpsertNotificationAck(strings.TrimSpace(notificationID))
+	if err != nil {
+		return domain.NotificationAck{}, err
+	}
+	p.NotifyDashboardChanged(DashboardDomainNotifications, "notification-acked")
+	return ack, nil
 }
 
 func (p *Platform) UnackNotification(notificationID string) error {
-	return p.store.DeleteNotificationAck(strings.TrimSpace(notificationID))
+	if err := p.store.DeleteNotificationAck(strings.TrimSpace(notificationID)); err != nil {
+		return err
+	}
+	p.NotifyDashboardChanged(DashboardDomainNotifications, "notification-unacked")
+	return nil
 }

--- a/internal/service/notifications_test.go
+++ b/internal/service/notifications_test.go
@@ -1,0 +1,45 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/wuyaocheng/bktrader/internal/store/memory"
+)
+
+func TestAckNotificationNotifiesDashboard(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+
+	if _, err := platform.AckNotification("alert-1"); err != nil {
+		t.Fatalf("AckNotification returned error: %v", err)
+	}
+
+	change := waitDashboardChange(t, platform.DashboardBroker(), 100*time.Millisecond)
+	if change.Domain != DashboardDomainNotifications || change.Reason != "notification-acked" {
+		t.Fatalf("unexpected dashboard change: %+v", change)
+	}
+}
+
+func TestUnackNotificationNotifiesDashboard(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+
+	if err := platform.UnackNotification("alert-1"); err != nil {
+		t.Fatalf("UnackNotification returned error: %v", err)
+	}
+
+	change := waitDashboardChange(t, platform.DashboardBroker(), 100*time.Millisecond)
+	if change.Domain != DashboardDomainNotifications || change.Reason != "notification-unacked" {
+		t.Fatalf("unexpected dashboard change: %+v", change)
+	}
+}
+
+func waitDashboardChange(t *testing.T, broker *DashboardBroker, timeout time.Duration) dashboardChange {
+	t.Helper()
+	select {
+	case change := <-broker.changes:
+		return change
+	case <-time.After(timeout):
+		t.Fatal("timed out waiting for dashboard change")
+		return dashboardChange{}
+	}
+}


### PR DESCRIPTION
## 目的
继续推进 #195 的 event-driven DashboardBroker 分阶段改造，这一刀只接入低风险 notifications ack 状态变化：通知 ack / unack 持久化成功后，主动通知 DashboardBroker 刷新 `notifications` snapshot。

本 PR 不接入 alerts 源头变化，不碰 `internal/service/live*.go`，不接 orders / fills / positions / live-sessions，不改前端 SSE 协议，不引入 incremental action，不删除 polling fallback。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [x] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？不存在
- [x] DB migration 是否具备向下兼容幂等性？不涉及
- [x] 配置字段有没有无意被混改？不涉及配置/env/default 改动

## 交易语义变更
- [x] 本次改动是否新增/修改了 `signalKind`？否
- [x] 本次改动是否影响订单方向判断（`side` / `reduceOnly` / `closePosition`）？否
- [x] 若涉及上述改动，`go test ./internal/domain/... -run TestClassifyOrderIntent` 是否通过？不涉及
- [x] 若涉及交易链路语义（开仓/平仓/撤单/risk-exit），`go test ./internal/domain/... -run TestTradingReplayGoldenCases` 是否通过？不涉及

## 改动摘要
- `AckNotification` 在 `UpsertNotificationAck` 成功后调用 `NotifyDashboardChanged(DashboardDomainNotifications, "notification-acked")`。
- `UnackNotification` 在 `DeleteNotificationAck` 成功后调用 `NotifyDashboardChanged(DashboardDomainNotifications, "notification-unacked")`。
- 补充 ack/unack dashboard notification 单元测试。
- 补充 `StartDashboardBroker -> polling -> event loop -> subscriber receives event` 启动链路测试，覆盖 #386 review 中的非阻塞建议。
- 更新 Dashboard SSE 文档，说明当前业务写路径接入范围仅限 notification ack 状态变化。

## 验证方式与测试证据
- [x] `go test ./internal/service -run 'Test(AckNotificationNotifiesDashboard|UnackNotificationNotifiesDashboard|StartDashboardBrokerPollingPublishesThroughEventLoop|DashboardBroker)' -count=1`
- [x] `go test ./...`
- [x] `go build ./cmd/platform-api`
- [x] `go build ./cmd/db-migrate`
- [x] `git diff --check`

## Issue
Refs #195

## Codex 说明
本 PR 由 Codex 协助生成。范围限定在 #195 的 notifications-only event-driven slice；alerts / orders / fills / positions / live-sessions 仍由 polling fallback 兜底，留给后续更小 PR 处理。