### PR TITLE
[codex] Notify dashboard on order and fill changes

### DIFF
--- a/docs/dashboard-sse-architecture.md
+++ b/docs/dashboard-sse-architecture.md
@@ -133,8 +133,10 @@ Current implementation uses these trigger paths:
 1. Polling fallback tickers enqueue non-blocking domain change notifications.
 2. The broker event loop coalesces notifications for a short window, then fetches and hashes the affected domain snapshots.
 3. Notification ack / unack operations enqueue `notifications` domain changes after their store write succeeds.
+4. Order create / submit / sync / fill settlement operations enqueue `orders` domain changes after their store write succeeds.
+5. Fill settlement operations enqueue `fills` domain changes after fill persistence succeeds.
 
-Most business write paths still rely on polling fallback. The first event-driven business slice is deliberately limited to low-risk notification ack state changes.
+Some business write paths still rely on polling fallback. Event-driven triggers currently cover low-risk notification ack state changes and order/fill snapshot refreshes.
 
 ### 6.1 Subscriber model
 

--- a/internal/service/order.go
+++ b/internal/service/order.go
@@ -32,6 +32,14 @@ func (p *Platform) CountOrders() (int, error) {
 	return p.store.CountOrders()
 }
 
+func (p *Platform) notifyDashboardOrdersChanged(reason string) {
+	p.NotifyDashboardChanged(DashboardDomainOrders, reason)
+}
+
+func (p *Platform) notifyDashboardFillsChanged(reason string) {
+	p.NotifyDashboardChanged(DashboardDomainFills, reason)
+}
+
 func (p *Platform) GetOrder(orderID string) (domain.Order, error) {
 	return p.store.GetOrderByID(orderID)
 }
@@ -171,6 +179,7 @@ func (p *Platform) CreateOrder(order domain.Order) (domain.Order, error) {
 		logger.Error("persist order failed", "error", err)
 		return domain.Order{}, err
 	}
+	p.notifyDashboardOrdersChanged("order-created")
 	logger.Debug("order persisted", "order_id", createdOrder.ID, "account_mode", account.Mode)
 	return p.executeCreatedOrder(account, createdOrder)
 }
@@ -532,6 +541,7 @@ func (p *Platform) applyLiveSubmissionResult(
 		if updateErr != nil {
 			return domain.Order{}, updateErr
 		}
+		p.notifyDashboardOrdersChanged("order-submit-failed")
 		if telemetryErr := p.recordLiveOrderExecutionEvent(updatedOrder, "submitted", time.Now().UTC(), true, submitErr); telemetryErr != nil {
 			logger.Warn("record live order submission event failed", "error", telemetryErr)
 		}
@@ -558,6 +568,7 @@ func (p *Platform) applyLiveSubmissionResult(
 	if err != nil {
 		return domain.Order{}, err
 	}
+	p.notifyDashboardOrdersChanged("order-submitted")
 	if telemetryErr := p.recordLiveOrderExecutionEvent(updatedOrder, "submitted", time.Now().UTC(), false, nil); telemetryErr != nil {
 		logger.Warn("record live order submission event failed", "error", telemetryErr)
 	}
@@ -569,6 +580,7 @@ func (p *Platform) applyLiveSubmissionResult(
 			if updateErr != nil {
 				return domain.Order{}, updateErr
 			}
+			p.notifyDashboardOrdersChanged("order-settlement-retry")
 			logger.Warn("live order immediate fill sync failed",
 				"exchange_order_id", submission.ExchangeOrderID,
 				"error", settleErr,
@@ -927,6 +939,7 @@ func (p *Platform) applyLiveSyncResult(account domain.Account, order domain.Orde
 	if err != nil {
 		return domain.Order{}, err
 	}
+	p.notifyDashboardOrdersChanged("order-synced")
 	if telemetryErr := p.recordLiveOrderExecutionEvent(updatedOrder, "synced", parseOptionalRFC3339(firstNonEmpty(syncResult.SyncedAt, stringValue(updatedOrder.Metadata["lastSyncAt"]))), false, nil); telemetryErr != nil {
 		logger.Warn("record live order sync event failed", "error", telemetryErr)
 	}
@@ -1092,11 +1105,17 @@ func terminalFilledFallbackDedupFingerprint(order domain.Order, syncResult LiveO
 
 func (p *Platform) finalizeExecutedOrder(account domain.Account, order domain.Order, fills []domain.Fill) (domain.Order, error) {
 	if len(fills) == 0 {
-		return p.store.UpdateOrder(order)
+		updated, err := p.store.UpdateOrder(order)
+		if err != nil {
+			return domain.Order{}, err
+		}
+		p.notifyDashboardOrdersChanged("order-updated")
+		return updated, nil
 	}
 
 	var updatedOrder domain.Order
 	var newFills []domain.Fill
+	createdFillCount := 0
 	if err := p.store.WithFillSettlementTx(order.ID, func(tx storepkg.FillSettlementStore) error {
 		filteredFills, err := filterExistingExecutionFillsWithStore(tx, order.ID, fills)
 		if err != nil {
@@ -1133,6 +1152,7 @@ func (p *Platform) finalizeExecutedOrder(account domain.Account, order domain.Or
 			if err != nil {
 				return err
 			}
+			createdFillCount++
 			executionPrice := createdFill.Price
 			if executionPrice <= 0 {
 				executionPrice = resolveExecutionPrice(order)
@@ -1199,6 +1219,10 @@ func (p *Platform) finalizeExecutedOrder(account domain.Account, order domain.Or
 		return nil
 	}); err != nil {
 		return domain.Order{}, err
+	}
+	p.notifyDashboardOrdersChanged("order-filled")
+	if createdFillCount > 0 {
+		p.notifyDashboardFillsChanged("fill-created")
 	}
 	if strings.EqualFold(account.Mode, "LIVE") && len(newFills) > 0 {
 		if telemetryErr := p.recordLiveOrderExecutionEvent(updatedOrder, "filled", parseOptionalRFC3339(stringValue(updatedOrder.Metadata["lastFilledAt"])), false, nil); telemetryErr != nil {

--- a/internal/service/order_dashboard_test.go
+++ b/internal/service/order_dashboard_test.go
@@ -1,0 +1,96 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/wuyaocheng/bktrader/internal/domain"
+	"github.com/wuyaocheng/bktrader/internal/store/memory"
+)
+
+func TestCreatePaperOrderNotifiesDashboardOrdersAndFills(t *testing.T) {
+	store := memory.NewStore()
+	platform := NewPlatform(store)
+	account, err := platform.CreateAccount("Paper Dashboard", "PAPER", "binance-futures")
+	if err != nil {
+		t.Fatalf("CreateAccount failed: %v", err)
+	}
+
+	if _, err := platform.CreateOrder(domain.Order{
+		AccountID: account.ID,
+		Symbol:    "BTCUSDT",
+		Side:      "BUY",
+		Type:      "MARKET",
+		Quantity:  0.01,
+		Price:     68000,
+	}); err != nil {
+		t.Fatalf("CreateOrder failed: %v", err)
+	}
+
+	changes := collectDashboardChanges(t, platform.DashboardBroker(), 3, 200*time.Millisecond)
+	requireDashboardChange(t, changes, DashboardDomainOrders, "order-created")
+	requireDashboardChange(t, changes, DashboardDomainOrders, "order-filled")
+	requireDashboardChange(t, changes, DashboardDomainFills, "fill-created")
+}
+
+func TestApplyLiveSyncResultWithoutFillsNotifiesDashboardOrders(t *testing.T) {
+	store := memory.NewStore()
+	platform := NewPlatform(store)
+	account, err := platform.CreateAccount("Live Dashboard", "LIVE", "binance-futures")
+	if err != nil {
+		t.Fatalf("CreateAccount failed: %v", err)
+	}
+	order, err := store.CreateOrder(domain.Order{
+		AccountID: account.ID,
+		Symbol:    "BTCUSDT",
+		Side:      "BUY",
+		Type:      "LIMIT",
+		Status:    "ACCEPTED",
+		Quantity:  0.01,
+		Price:     68000,
+		Metadata:  map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("CreateOrder failed: %v", err)
+	}
+
+	if _, err := platform.applyLiveSyncResult(account, order, LiveOrderSync{
+		Status:   "CANCELLED",
+		SyncedAt: time.Now().UTC().Format(time.RFC3339),
+		Metadata: map[string]any{
+			"exchangeOrderId": "exchange-order-1",
+		},
+	}); err != nil {
+		t.Fatalf("applyLiveSyncResult failed: %v", err)
+	}
+
+	change := waitDashboardChange(t, platform.DashboardBroker(), 100*time.Millisecond)
+	if change.Domain != DashboardDomainOrders || change.Reason != "order-synced" {
+		t.Fatalf("unexpected dashboard change: %+v", change)
+	}
+}
+
+func collectDashboardChanges(t *testing.T, broker *DashboardBroker, count int, timeout time.Duration) []dashboardChange {
+	t.Helper()
+	changes := make([]dashboardChange, 0, count)
+	deadline := time.After(timeout)
+	for len(changes) < count {
+		select {
+		case change := <-broker.changes:
+			changes = append(changes, change)
+		case <-deadline:
+			t.Fatalf("timed out waiting for %d dashboard changes, got %+v", count, changes)
+		}
+	}
+	return changes
+}
+
+func requireDashboardChange(t *testing.T, changes []dashboardChange, domain DashboardDomain, reason string) {
+	t.Helper()
+	for _, change := range changes {
+		if change.Domain == domain && change.Reason == reason {
+			return
+		}
+	}
+	t.Fatalf("expected dashboard change domain=%s reason=%s in %+v", domain, reason, changes)
+}


### PR DESCRIPTION
## 目的
继续推进 #195 的 event-driven DashboardBroker 分阶段改造，这一刀对应 PR-195-3：订单与成交变化后主动触发 Dashboard snapshot 刷新，但仍保持 `action=snapshot`，不做 incremental reducer。

本 PR 只在既有订单服务持久化成功出口追加 dashboard 通知，不改变 order submit / cancel / sync / fill settlement 的业务判断，不改变 orders/fills recent 50 payload 边界。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [x] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？不存在
- [x] DB migration 是否具备向下兼容幂等性？不涉及
- [x] 配置字段有没有无意被混改？不涉及配置/env/default 改动

## 交易语义变更
- [x] 本次改动是否新增/修改了 `signalKind`？否
- [x] 本次改动是否影响订单方向判断（`side` / `reduceOnly` / `closePosition`）？否
- [x] 若涉及上述改动，`go test ./internal/domain/... -run TestClassifyOrderIntent` 是否通过？不涉及
- [x] 若涉及交易链路语义（开仓/平仓/撤单/risk-exit），`go test ./internal/domain/... -run TestTradingReplayGoldenCases` 是否通过？不涉及

## 改动摘要
- `CreateOrder` 持久化成功后通知 `DashboardDomainOrders`。
- live submit / submit failure / sync / settlement retry 等订单状态更新成功后通知 `DashboardDomainOrders`。
- `finalizeExecutedOrder` 成功落账订单后通知 `DashboardDomainOrders`，并在实际 create/upsert fill 后通知 `DashboardDomainFills`。
- 补充 paper order immediate fill 与 live sync no-fill 的 dashboard notification 单元测试。
- 更新 Dashboard SSE 文档，说明 orders/fills 已接 event-driven snapshot refresh。

## 验证方式与测试证据
- [x] `go test ./internal/service -run 'Test(CreatePaperOrderNotifiesDashboardOrdersAndFills|ApplyLiveSyncResultWithoutFillsNotifiesDashboardOrders|DashboardBroker)' -count=1`
- [x] `go test ./...`
- [x] `go build ./cmd/platform-api`
- [x] `go build ./cmd/db-migrate`
- [x] `git diff --check`

## Issue
Refs #195

## Codex 说明
本 PR 由 Codex 协助生成。范围限定在 #195 的 orders/fills snapshot refresh slice；不接 positions / live-sessions，不改前端，不改 dispatchMode，不改交易执行默认行为。