### PR TITLE
[codex] Notify dashboard on position settlement

### DIFF
--- a/docs/dashboard-sse-architecture.md
+++ b/docs/dashboard-sse-architecture.md
@@ -135,8 +135,9 @@ Current implementation uses these trigger paths:
 3. Notification ack / unack operations enqueue `notifications` domain changes after their store write succeeds.
 4. Order create / submit / sync / fill settlement operations enqueue `orders` domain changes after their store write succeeds.
 5. Fill settlement operations enqueue `fills` domain changes after fill persistence succeeds.
+6. Fill settlement operations enqueue `positions` domain changes after position settlement succeeds.
 
-Some business write paths still rely on polling fallback. Event-driven triggers currently cover low-risk notification ack state changes and order/fill snapshot refreshes.
+Some business write paths still rely on polling fallback. Event-driven triggers currently cover low-risk notification ack state changes and order/fill/position snapshot refreshes.
 
 ### 6.1 Subscriber model
 

--- a/internal/service/order.go
+++ b/internal/service/order.go
@@ -40,6 +40,10 @@ func (p *Platform) notifyDashboardFillsChanged(reason string) {
 	p.NotifyDashboardChanged(DashboardDomainFills, reason)
 }
 
+func (p *Platform) notifyDashboardPositionsChanged(reason string) {
+	p.NotifyDashboardChanged(DashboardDomainPositions, reason)
+}
+
 func (p *Platform) GetOrder(orderID string) (domain.Order, error) {
 	return p.store.GetOrderByID(orderID)
 }
@@ -1116,6 +1120,7 @@ func (p *Platform) finalizeExecutedOrder(account domain.Account, order domain.Or
 	var updatedOrder domain.Order
 	var newFills []domain.Fill
 	createdFillCount := 0
+	appliedPositionFillCount := 0
 	if err := p.store.WithFillSettlementTx(order.ID, func(tx storepkg.FillSettlementStore) error {
 		filteredFills, err := filterExistingExecutionFillsWithStore(tx, order.ID, fills)
 		if err != nil {
@@ -1171,6 +1176,7 @@ func (p *Platform) finalizeExecutedOrder(account domain.Account, order domain.Or
 			if err := p.applyExecutionFillWithStore(tx, account, execOrder, executionPrice); err != nil {
 				return err
 			}
+			appliedPositionFillCount++
 		}
 
 		filledQuantity, err := tx.TotalFilledQuantityForOrder(order.ID)
@@ -1223,6 +1229,9 @@ func (p *Platform) finalizeExecutedOrder(account domain.Account, order domain.Or
 	p.notifyDashboardOrdersChanged("order-filled")
 	if createdFillCount > 0 {
 		p.notifyDashboardFillsChanged("fill-created")
+	}
+	if appliedPositionFillCount > 0 {
+		p.notifyDashboardPositionsChanged("position-updated")
 	}
 	if strings.EqualFold(account.Mode, "LIVE") && len(newFills) > 0 {
 		if telemetryErr := p.recordLiveOrderExecutionEvent(updatedOrder, "filled", parseOptionalRFC3339(stringValue(updatedOrder.Metadata["lastFilledAt"])), false, nil); telemetryErr != nil {

--- a/internal/service/order_dashboard_test.go
+++ b/internal/service/order_dashboard_test.go
@@ -27,10 +27,11 @@ func TestCreatePaperOrderNotifiesDashboardOrdersAndFills(t *testing.T) {
 		t.Fatalf("CreateOrder failed: %v", err)
 	}
 
-	changes := collectDashboardChanges(t, platform.DashboardBroker(), 3, 200*time.Millisecond)
+	changes := collectDashboardChanges(t, platform.DashboardBroker(), 4, 200*time.Millisecond)
 	requireDashboardChange(t, changes, DashboardDomainOrders, "order-created")
 	requireDashboardChange(t, changes, DashboardDomainOrders, "order-filled")
 	requireDashboardChange(t, changes, DashboardDomainFills, "fill-created")
+	requireDashboardChange(t, changes, DashboardDomainPositions, "position-updated")
 }
 
 func TestApplyLiveSyncResultWithoutFillsNotifiesDashboardOrders(t *testing.T) {


### PR DESCRIPTION
## 目的
继续推进 #195 的 event-driven DashboardBroker 分阶段改造，这一刀是 positions 的最小安全切片：成交 settlement 已经成功应用仓位后，主动触发 `positions` snapshot refresh。

本 PR 不接 live-session 状态变化，不触碰 `internal/service/live*.go`，不改仓位计算、不改订单执行、不改前端协议。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [x] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？不存在
- [x] DB migration 是否具备向下兼容幂等性？不涉及
- [x] 配置字段有没有无意被混改？不涉及配置/env/default 改动

## 交易语义变更
- [x] 本次改动是否新增/修改了 `signalKind`？否
- [x] 本次改动是否影响订单方向判断（`side` / `reduceOnly` / `closePosition`）？否
- [x] 若涉及上述改动，`go test ./internal/domain/... -run TestClassifyOrderIntent` 是否通过？不涉及
- [x] 若涉及交易链路语义（开仓/平仓/撤单/risk-exit），`go test ./internal/domain/... -run TestTradingReplayGoldenCases` 是否通过？不涉及

## 改动摘要
- 新增 `notifyDashboardPositionsChanged` helper。
- `finalizeExecutedOrder` 在 `applyExecutionFillWithStore` 成功应用 position fill 后，提交事务成功再通知 `DashboardDomainPositions`。
- 扩展 order dashboard 测试，验证 paper immediate fill 同时触发 `orders` / `fills` / `positions` dashboard change。
- 更新 Dashboard SSE 文档，说明 position settlement 已接 event-driven snapshot refresh。

## 验证方式与测试证据
- [x] `go test ./internal/service -run 'Test(CreatePaperOrderNotifiesDashboardOrdersAndFills|ApplyLiveSyncResultWithoutFillsNotifiesDashboardOrders|DashboardBroker)' -count=1`
- [x] `go test ./...`
- [x] `go build ./cmd/platform-api`
- [x] `go build ./cmd/db-migrate`
- [x] `git diff --check`

## Issue
Refs #195

## Codex 说明
本 PR 由 Codex 协助生成。范围限定在 #195 的 positions snapshot refresh 最小切片；live-sessions 事件触发仍留给后续单独评估。