### PR TITLE
[codex] Add supervisor container fallback backoff gate

### DIFF
--- a/cmd/bktrader-ctl/supervisor.go
+++ b/cmd/bktrader-ctl/supervisor.go
@@ -14,11 +14,18 @@ func init() {
 	supervisorCmd.AddCommand(supervisorStatusCmd)
 	supervisorCmd.AddCommand(supervisorSuppressContainerFallbackCmd)
 	supervisorCmd.AddCommand(supervisorResumeContainerFallbackCmd)
+	supervisorCmd.AddCommand(supervisorDeferContainerFallbackCmd)
+	supervisorCmd.AddCommand(supervisorClearContainerFallbackBackoffCmd)
 	rootCmd.AddCommand(supervisorCmd)
 	supervisorSuppressContainerFallbackCmd.Flags().Bool("confirm", false, "确认抑制 container fallback")
 	supervisorSuppressContainerFallbackCmd.Flags().String("reason", "", "抑制原因；必填")
 	supervisorResumeContainerFallbackCmd.Flags().Bool("confirm", false, "确认恢复 container fallback")
 	supervisorResumeContainerFallbackCmd.Flags().String("reason", "", "恢复原因；必填")
+	supervisorDeferContainerFallbackCmd.Flags().Bool("confirm", false, "确认延后 container fallback")
+	supervisorDeferContainerFallbackCmd.Flags().String("reason", "", "延后原因；必填")
+	supervisorDeferContainerFallbackCmd.Flags().Int("seconds", 0, "延后秒数；必填且必须大于 0")
+	supervisorClearContainerFallbackBackoffCmd.Flags().Bool("confirm", false, "确认清理 container fallback backoff")
+	supervisorClearContainerFallbackBackoffCmd.Flags().String("reason", "", "清理原因；必填")
 }
 
 var supervisorCmd = &cobra.Command{
@@ -55,7 +62,30 @@ var supervisorResumeContainerFallbackCmd = &cobra.Command{
 	},
 }
 
+var supervisorDeferContainerFallbackCmd = &cobra.Command{
+	Use:   "defer-container-fallback <targetName>",
+	Short: "为 supervisor 容器兜底计划设置 backoff [MUTATING]",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		seconds, _ := cmd.Flags().GetInt("seconds")
+		return runSupervisorContainerFallbackControlWithBackoff(cmd, args[0], "/api/v1/supervisor/container-fallback/defer", seconds)
+	},
+}
+
+var supervisorClearContainerFallbackBackoffCmd = &cobra.Command{
+	Use:   "clear-container-fallback-backoff <targetName>",
+	Short: "清理 supervisor 容器兜底 backoff [MUTATING]",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runSupervisorContainerFallbackControl(cmd, args[0], "/api/v1/supervisor/container-fallback/clear-backoff")
+	},
+}
+
 func runSupervisorContainerFallbackControl(cmd *cobra.Command, targetName, path string) error {
+	return runSupervisorContainerFallbackControlWithBackoff(cmd, targetName, path, 0)
+}
+
+func runSupervisorContainerFallbackControlWithBackoff(cmd *cobra.Command, targetName, path string, backoffSeconds int) error {
 	confirm, _ := cmd.Flags().GetBool("confirm")
 	if !confirm && !dryRun {
 		return fmt.Errorf("操作需要 --confirm 确认")
@@ -68,6 +98,11 @@ func runSupervisorContainerFallbackControl(cmd *cobra.Command, targetName, path 
 		"targetName": targetName,
 		"confirm":    confirm,
 		"reason":     reason,
+	}
+	if backoffSeconds > 0 {
+		payload["backoffSeconds"] = backoffSeconds
+	} else if strings.Contains(path, "/defer") && !dryRun {
+		return fmt.Errorf("操作需要提供 --seconds 且必须大于 0")
 	}
 	client := getClient()
 	resp, err := client.Request("POST", path, payload)
@@ -110,22 +145,28 @@ type supervisorProbe struct {
 }
 
 type supervisorServiceState struct {
-	ConsecutiveFailures                 int    `json:"consecutiveFailures"`
-	FailureThreshold                    int    `json:"failureThreshold"`
-	LastFailureReason                   string `json:"lastFailureReason,omitempty"`
-	ContainerFallbackCandidate          bool   `json:"containerFallbackCandidate"`
-	ContainerFallbackReason             string `json:"containerFallbackReason,omitempty"`
-	ContainerFallbackSuppressed         bool   `json:"containerFallbackSuppressed"`
-	ContainerFallbackSuppressedAt       string `json:"containerFallbackSuppressedAt,omitempty"`
-	ContainerFallbackSuppressedReason   string `json:"containerFallbackSuppressedReason,omitempty"`
-	ContainerFallbackSuppressedSource   string `json:"containerFallbackSuppressedSource,omitempty"`
-	ContainerFallbackResumedAt          string `json:"containerFallbackResumedAt,omitempty"`
-	ContainerFallbackResumedReason      string `json:"containerFallbackResumedReason,omitempty"`
-	ContainerFallbackResumedSource      string `json:"containerFallbackResumedSource,omitempty"`
-	ContainerFallbackBackoffUntil       string `json:"containerFallbackBackoffUntil,omitempty"`
-	ContainerFallbackAttemptCount       int    `json:"containerFallbackAttemptCount"`
-	LastContainerFallbackDecisionAt     string `json:"lastContainerFallbackDecisionAt,omitempty"`
-	LastContainerFallbackDecisionReason string `json:"lastContainerFallbackDecisionReason,omitempty"`
+	ConsecutiveFailures                   int    `json:"consecutiveFailures"`
+	FailureThreshold                      int    `json:"failureThreshold"`
+	LastFailureReason                     string `json:"lastFailureReason,omitempty"`
+	ContainerFallbackCandidate            bool   `json:"containerFallbackCandidate"`
+	ContainerFallbackReason               string `json:"containerFallbackReason,omitempty"`
+	ContainerFallbackSuppressed           bool   `json:"containerFallbackSuppressed"`
+	ContainerFallbackSuppressedAt         string `json:"containerFallbackSuppressedAt,omitempty"`
+	ContainerFallbackSuppressedReason     string `json:"containerFallbackSuppressedReason,omitempty"`
+	ContainerFallbackSuppressedSource     string `json:"containerFallbackSuppressedSource,omitempty"`
+	ContainerFallbackResumedAt            string `json:"containerFallbackResumedAt,omitempty"`
+	ContainerFallbackResumedReason        string `json:"containerFallbackResumedReason,omitempty"`
+	ContainerFallbackResumedSource        string `json:"containerFallbackResumedSource,omitempty"`
+	ContainerFallbackBackoffUntil         string `json:"containerFallbackBackoffUntil,omitempty"`
+	ContainerFallbackBackoffSetAt         string `json:"containerFallbackBackoffSetAt,omitempty"`
+	ContainerFallbackBackoffReason        string `json:"containerFallbackBackoffReason,omitempty"`
+	ContainerFallbackBackoffSource        string `json:"containerFallbackBackoffSource,omitempty"`
+	ContainerFallbackBackoffClearedAt     string `json:"containerFallbackBackoffClearedAt,omitempty"`
+	ContainerFallbackBackoffClearedReason string `json:"containerFallbackBackoffClearedReason,omitempty"`
+	ContainerFallbackBackoffClearedSource string `json:"containerFallbackBackoffClearedSource,omitempty"`
+	ContainerFallbackAttemptCount         int    `json:"containerFallbackAttemptCount"`
+	LastContainerFallbackDecisionAt       string `json:"lastContainerFallbackDecisionAt,omitempty"`
+	LastContainerFallbackDecisionReason   string `json:"lastContainerFallbackDecisionReason,omitempty"`
 }
 
 type supervisorContainerFallbackPlan struct {
@@ -287,6 +328,21 @@ func buildSupervisorStatusSummary(data []byte) (string, error) {
 				target.ServiceState.ContainerFallbackResumedReason,
 				firstNonEmpty(target.ServiceState.ContainerFallbackResumedSource, "--"),
 				firstNonEmpty(target.ServiceState.ContainerFallbackResumedAt, "--"),
+			)
+		}
+		if strings.TrimSpace(target.ServiceState.ContainerFallbackBackoffReason) != "" {
+			fmt.Fprintf(&out, "  fallbackBackoff reason=%s source=%s setAt=%s until=%s\n",
+				target.ServiceState.ContainerFallbackBackoffReason,
+				firstNonEmpty(target.ServiceState.ContainerFallbackBackoffSource, "--"),
+				firstNonEmpty(target.ServiceState.ContainerFallbackBackoffSetAt, "--"),
+				firstNonEmpty(target.ServiceState.ContainerFallbackBackoffUntil, "--"),
+			)
+		}
+		if strings.TrimSpace(target.ServiceState.ContainerFallbackBackoffClearedReason) != "" {
+			fmt.Fprintf(&out, "  fallbackBackoffCleared reason=%s source=%s at=%s\n",
+				target.ServiceState.ContainerFallbackBackoffClearedReason,
+				firstNonEmpty(target.ServiceState.ContainerFallbackBackoffClearedSource, "--"),
+				firstNonEmpty(target.ServiceState.ContainerFallbackBackoffClearedAt, "--"),
 			)
 		}
 		if strings.TrimSpace(target.ServiceState.LastContainerFallbackDecisionReason) != "" {

--- a/docs/runtime-supervisor.md
+++ b/docs/runtime-supervisor.md
@@ -343,6 +343,7 @@ func ClearRestartState(state map[string]any, keys []string)
 - `GET /api/v1/supervisor/status` 返回最近一次 read-only supervisor 采集快照，并在顶层 `policy` 中暴露 `applicationRestartEnabled`、`serviceFailureThreshold`、`containerRestartEnabled`、`containerExecutorConfigured`。这些字段只反映当前 supervisor policy，不代表已执行或允许执行容器 restart。
 - `bktrader-ctl runtime status --json` 和 `bktrader-ctl supervisor status --json` 提供 CLI 只读巡检入口；`bktrader-ctl supervisor status` 的人类可读输出会汇总 policy、target reachability、runtime attention、control action 数量，以及 container fallback 的 `decision`、`enabled` / `executorConfigured` / `executable` readiness、dry-run gates 和当前失败 episode 的 decision audit。
 - `bktrader-ctl supervisor suppress-container-fallback <targetName> --confirm --reason "<原因>"` 和 `resume-container-fallback` 提供人工抑制/恢复入口；该入口只按已配置的 target name 切换 supervisor 内存态 gate 和审计字段，不接受 URL、container name、compose service 或 shell command，不调用 Docker API。
+- `bktrader-ctl supervisor defer-container-fallback <targetName> --seconds <N> --confirm --reason "<原因>"` 和 `clear-container-fallback-backoff` 提供人工 backoff 设置/清理入口；该入口只影响 `containerFallbackBackoffUntil` gate 和审计字段，不执行容器操作。
 - `bktrader-ctl runtime start|stop|restart|suppress-auto-restart|resume-auto-restart` 是统一 runtime 控制入口，当前只支持 signal runtime；所有 mutating 命令都要求 `--confirm`，除普通 `restart` 外还要求 `--reason`，并支持 `--dry-run` 预览请求。
 - `SUPERVISOR_APPLICATION_RESTART_ENABLED=false` 为默认值；只有显式设为 `true` 时，supervisor 才会对满足全部条件的 signal runtime 提交应用内 `POST /api/v1/runtime/restart`：
   - 目标服务 `/healthz` 可达且成功。
@@ -385,6 +386,7 @@ func ClearRestartState(state map[string]any, keys []string)
 - `internal/service/runtime_supervisor.go` 已定义 `ContainerFallbackExecutor` 接口和 `NoopContainerFallbackExecutor`，用于先跑通 executor readiness 与 decision/audit plumbing。executor 必须声明 descriptor，并通过 `kind`/`dryRun` 区分 noop dry-run 与未来真实执行器；`GET /api/v1/supervisor/status` 的 policy 同步返回 `containerExecutorKind`、`containerExecutorDryRun`。默认 supervisor options 不配置 executor，因此生产路径仍返回 `containerExecutorConfigured=false`、`containerExecutorKind=none`、`containerExecutorDryRun=true`；只有显式设置 `SUPERVISOR_CONTAINER_EXECUTOR=noop` 时才会接入 noop executor。noop executor 的 `Restart` 只返回 `executed=false`，不触碰 Docker API、不访问 docker.sock、不执行容器 restart。
 - 当前 service fallback 只把 `/healthz` 不可达或非 2xx、`/api/v1/runtime/status` 连接不可达视为服务级失败；`/runtime/status` JSON decode 失败不会触发容器兜底候选，避免把业务状态或响应格式问题误判成需要重启容器。
 - `POST /api/v1/supervisor/container-fallback/suppress` 和 `resume` 是人工 gate，只接受 `targetName`、`confirm=true`、非空 `reason`，并写入 `containerFallbackSuppressed*` / `containerFallbackResumed*` 审计字段；它不依赖 `SUPERVISOR_CONTAINER_RESTART_ENABLED`，也不代表容器 restart 被授权执行。若存在重复 target name，请先修正 `SUPERVISOR_TARGETS`，API 会拒绝 ambiguous target。
+- `POST /api/v1/supervisor/container-fallback/defer` 和 `clear-backoff` 是人工 backoff gate，只接受 `targetName`、`confirm=true`、非空 `reason`，其中 `defer` 还要求 `backoffSeconds>0`；它只写入 `containerFallbackBackoffUntil` 和 backoff 审计字段，健康恢复会清理当前 failure episode 的 backoff 状态。
 - 达到 `SUPERVISOR_SERVICE_FAILURE_THRESHOLD` 后只记录 `containerFallbackCandidate=true` 和原因，不调用 Docker API，不挂载 Docker socket，不执行容器 restart。
 - 后续真正执行容器级 restart 前，仍需单独设计 executor、backoff、人工抑制、权限边界和部署安全审查。
 

--- a/internal/http/supervisor_status.go
+++ b/internal/http/supervisor_status.go
@@ -4,15 +4,17 @@ import (
 	"errors"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/wuyaocheng/bktrader/internal/config"
 	"github.com/wuyaocheng/bktrader/internal/service"
 )
 
 type supervisorContainerFallbackControlRequest struct {
-	TargetName string `json:"targetName"`
-	Confirm    bool   `json:"confirm"`
-	Reason     string `json:"reason"`
+	TargetName     string `json:"targetName"`
+	Confirm        bool   `json:"confirm"`
+	Reason         string `json:"reason"`
+	BackoffSeconds int    `json:"backoffSeconds,omitempty"`
 }
 
 func registerSupervisorStatusRoutes(mux *http.ServeMux, platform *service.Platform, cfg config.Config) {
@@ -30,6 +32,8 @@ func registerSupervisorStatusRoutes(mux *http.ServeMux, platform *service.Platfo
 	})
 	registerSupervisorContainerFallbackControlRoute(mux, platform, cfg, "/api/v1/supervisor/container-fallback/suppress", true)
 	registerSupervisorContainerFallbackControlRoute(mux, platform, cfg, "/api/v1/supervisor/container-fallback/resume", false)
+	registerSupervisorContainerFallbackBackoffRoute(mux, platform, cfg, "/api/v1/supervisor/container-fallback/defer", false)
+	registerSupervisorContainerFallbackBackoffRoute(mux, platform, cfg, "/api/v1/supervisor/container-fallback/clear-backoff", true)
 }
 
 func registerSupervisorContainerFallbackControlRoute(mux *http.ServeMux, platform *service.Platform, cfg config.Config, path string, suppressed bool) {
@@ -94,10 +98,78 @@ func registerSupervisorContainerFallbackControlRoute(mux *http.ServeMux, platfor
 	})
 }
 
+func registerSupervisorContainerFallbackBackoffRoute(mux *http.ServeMux, platform *service.Platform, cfg config.Config, path string, clear bool) {
+	action := "defer"
+	if clear {
+		action = "clear-backoff"
+	}
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		if !cfg.RuntimeActionsEnabled() {
+			writeError(w, http.StatusConflict, "supervisor container fallback "+action+" is disabled for BKTRADER_ROLE="+cfg.ProcessRole)
+			return
+		}
+		var request supervisorContainerFallbackControlRequest
+		if err := decodeJSON(r, &request); err != nil {
+			writeError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		targetName := strings.TrimSpace(request.TargetName)
+		if targetName == "" {
+			writeError(w, http.StatusBadRequest, "targetName is required")
+			return
+		}
+		if !request.Confirm {
+			writeError(w, http.StatusBadRequest, "confirm=true is required for supervisor container fallback "+action)
+			return
+		}
+		reason := strings.TrimSpace(request.Reason)
+		if reason == "" {
+			writeError(w, http.StatusBadRequest, "reason is required for supervisor container fallback "+action)
+			return
+		}
+		if !clear && request.BackoffSeconds <= 0 {
+			writeError(w, http.StatusBadRequest, "backoffSeconds must be positive for supervisor container fallback "+action)
+			return
+		}
+		options := service.RuntimeSupervisorContainerFallbackControlOptions{
+			Confirm:         true,
+			Reason:          reason,
+			Source:          "api",
+			BackoffDuration: time.Duration(request.BackoffSeconds) * time.Second,
+		}
+		var result service.RuntimeSupervisorContainerFallbackControlResult
+		var err error
+		if clear {
+			result, err = platform.ClearRuntimeSupervisorContainerFallbackBackoff(targetName, options)
+		} else {
+			result, err = platform.DeferRuntimeSupervisorContainerFallback(targetName, options)
+		}
+		if err != nil {
+			writeSupervisorContainerFallbackControlError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusAccepted, map[string]any{
+			"status":       "accepted",
+			"message":      "supervisor container fallback " + action + " accepted",
+			"targetName":   result.TargetName,
+			"backoffUntil": result.BackoffUntil,
+			"reason":       result.Reason,
+			"source":       result.Source,
+			"updatedAt":    result.UpdatedAt,
+			"serviceState": result.ServiceState,
+		})
+	})
+}
+
 func writeSupervisorContainerFallbackControlError(w http.ResponseWriter, err error) {
 	switch {
 	case errors.Is(err, service.ErrRuntimeSupervisorControlConfirmRequired),
 		errors.Is(err, service.ErrRuntimeSupervisorControlReasonRequired),
+		errors.Is(err, service.ErrRuntimeSupervisorBackoffDurationRequired),
 		errors.Is(err, service.ErrRuntimeSupervisorTargetRequired):
 		writeError(w, http.StatusBadRequest, err.Error())
 	case errors.Is(err, service.ErrRuntimeSupervisorTargetNotFound):

--- a/internal/http/supervisor_status_test.go
+++ b/internal/http/supervisor_status_test.go
@@ -177,6 +177,83 @@ func TestSupervisorContainerFallbackControlSuppressesAndResumesTarget(t *testing
 	}
 }
 
+func TestSupervisorContainerFallbackControlDefersAndClearsBackoff(t *testing.T) {
+	targetServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/healthz":
+			http.Error(w, "not ready", http.StatusServiceUnavailable)
+		case "/api/v1/runtime/status":
+			writeJSON(w, http.StatusOK, service.RuntimeStatusSnapshot{Service: "platform-api"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer targetServer.Close()
+
+	platform := service.NewPlatform(memory.NewStore())
+	supervisor := service.NewRuntimeSupervisorWithOptions(
+		[]service.RuntimeSupervisorTarget{{Name: "api", BaseURL: targetServer.URL}},
+		targetServer.Client(),
+		service.RuntimeSupervisorOptions{
+			ServiceFailureThreshold:   1,
+			EnableContainerFallback:   true,
+			ContainerFallbackExecutor: service.NewNoopContainerFallbackExecutor(true),
+		},
+	)
+	supervisor.Collect(context.Background())
+	platform.SetRuntimeSupervisor(supervisor)
+
+	mux := http.NewServeMux()
+	registerSupervisorStatusRoutes(mux, platform, config.Config{})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/supervisor/container-fallback/defer", strings.NewReader(`{"targetName":"api","confirm":true,"reason":"cooldown","backoffSeconds":300}`))
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("expected defer 202, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	var deferPayload struct {
+		BackoffUntil string                                `json:"backoffUntil"`
+		Reason       string                                `json:"reason"`
+		ServiceState service.RuntimeSupervisorServiceState `json:"serviceState"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&deferPayload); err != nil {
+		t.Fatalf("decode defer payload failed: %v", err)
+	}
+	if deferPayload.BackoffUntil == "" || deferPayload.Reason != "cooldown" || deferPayload.ServiceState.ContainerFallbackBackoffUntil == nil {
+		t.Fatalf("unexpected defer payload: %+v", deferPayload)
+	}
+	if deferPayload.ServiceState.ContainerFallbackBackoffReason != "cooldown" || deferPayload.ServiceState.ContainerFallbackBackoffSource != "api" {
+		t.Fatalf("expected backoff audit state, got %+v", deferPayload.ServiceState)
+	}
+
+	blocked := supervisor.Collect(context.Background()).Targets[0]
+	if blocked.ContainerFallbackPlan == nil || blocked.ContainerFallbackPlan.BlockedReason != "container-fallback-backoff-active" {
+		t.Fatalf("expected backoff plan to block fallback, got %+v", blocked.ContainerFallbackPlan)
+	}
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodPost, "/api/v1/supervisor/container-fallback/clear-backoff", strings.NewReader(`{"targetName":"api","confirm":true,"reason":"stable"}`))
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("expected clear-backoff 202, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	var clearPayload struct {
+		BackoffUntil *string                               `json:"backoffUntil"`
+		Reason       string                                `json:"reason"`
+		ServiceState service.RuntimeSupervisorServiceState `json:"serviceState"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&clearPayload); err != nil {
+		t.Fatalf("decode clear payload failed: %v", err)
+	}
+	if clearPayload.BackoffUntil != nil || clearPayload.Reason != "stable" || clearPayload.ServiceState.ContainerFallbackBackoffUntil != nil {
+		t.Fatalf("unexpected clear payload: %+v", clearPayload)
+	}
+	if clearPayload.ServiceState.ContainerFallbackBackoffClearedReason != "stable" || clearPayload.ServiceState.ContainerFallbackBackoffClearedSource != "api" {
+		t.Fatalf("expected backoff clear audit state, got %+v", clearPayload.ServiceState)
+	}
+}
+
 func TestSupervisorContainerFallbackControlValidation(t *testing.T) {
 	platform := service.NewPlatform(memory.NewStore())
 	supervisor := service.NewRuntimeSupervisor(
@@ -190,26 +267,37 @@ func TestSupervisorContainerFallbackControlValidation(t *testing.T) {
 
 	tests := []struct {
 		name       string
+		path       string
 		body       string
 		wantStatus int
 	}{
 		{
 			name:       "missing target",
+			path:       "/api/v1/supervisor/container-fallback/suppress",
 			body:       `{"confirm":true,"reason":"maintenance"}`,
 			wantStatus: http.StatusBadRequest,
 		},
 		{
 			name:       "missing confirm",
+			path:       "/api/v1/supervisor/container-fallback/suppress",
 			body:       `{"targetName":"api","reason":"maintenance"}`,
 			wantStatus: http.StatusBadRequest,
 		},
 		{
 			name:       "missing reason",
+			path:       "/api/v1/supervisor/container-fallback/suppress",
 			body:       `{"targetName":"api","confirm":true}`,
 			wantStatus: http.StatusBadRequest,
 		},
 		{
+			name:       "missing backoff seconds",
+			path:       "/api/v1/supervisor/container-fallback/defer",
+			body:       `{"targetName":"api","confirm":true,"reason":"cooldown"}`,
+			wantStatus: http.StatusBadRequest,
+		},
+		{
 			name:       "missing configured target",
+			path:       "/api/v1/supervisor/container-fallback/suppress",
 			body:       `{"targetName":"missing","confirm":true,"reason":"maintenance"}`,
 			wantStatus: http.StatusNotFound,
 		},
@@ -217,7 +305,7 @@ func TestSupervisorContainerFallbackControlValidation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			rec := httptest.NewRecorder()
-			req := httptest.NewRequest(http.MethodPost, "/api/v1/supervisor/container-fallback/suppress", strings.NewReader(tt.body))
+			req := httptest.NewRequest(http.MethodPost, tt.path, strings.NewReader(tt.body))
 			mux.ServeHTTP(rec, req)
 			if rec.Code != tt.wantStatus {
 				t.Fatalf("expected %d, got %d body=%s", tt.wantStatus, rec.Code, rec.Body.String())

--- a/internal/service/runtime_supervisor.go
+++ b/internal/service/runtime_supervisor.go
@@ -31,11 +31,12 @@ const (
 )
 
 var (
-	ErrRuntimeSupervisorControlConfirmRequired = errors.New("runtime supervisor control confirm required")
-	ErrRuntimeSupervisorControlReasonRequired  = errors.New("runtime supervisor control reason required")
-	ErrRuntimeSupervisorTargetRequired         = errors.New("runtime supervisor target is required")
-	ErrRuntimeSupervisorTargetNotFound         = errors.New("runtime supervisor target not found")
-	ErrRuntimeSupervisorTargetAmbiguous        = errors.New("runtime supervisor target is ambiguous")
+	ErrRuntimeSupervisorControlConfirmRequired  = errors.New("runtime supervisor control confirm required")
+	ErrRuntimeSupervisorControlReasonRequired   = errors.New("runtime supervisor control reason required")
+	ErrRuntimeSupervisorBackoffDurationRequired = errors.New("runtime supervisor backoff duration must be positive")
+	ErrRuntimeSupervisorTargetRequired          = errors.New("runtime supervisor target is required")
+	ErrRuntimeSupervisorTargetNotFound          = errors.New("runtime supervisor target not found")
+	ErrRuntimeSupervisorTargetAmbiguous         = errors.New("runtime supervisor target is ambiguous")
 )
 
 type RuntimeSupervisorOptions struct {
@@ -157,24 +158,30 @@ type RuntimeSupervisorApplicationRestartPlan struct {
 }
 
 type RuntimeSupervisorServiceState struct {
-	ConsecutiveFailures                 int        `json:"consecutiveFailures"`
-	FailureThreshold                    int        `json:"failureThreshold"`
-	LastFailureReason                   string     `json:"lastFailureReason,omitempty"`
-	LastFailureAt                       *time.Time `json:"lastFailureAt,omitempty"`
-	LastHealthyAt                       *time.Time `json:"lastHealthyAt,omitempty"`
-	ContainerFallbackCandidate          bool       `json:"containerFallbackCandidate"`
-	ContainerFallbackReason             string     `json:"containerFallbackReason,omitempty"`
-	ContainerFallbackSuppressed         bool       `json:"containerFallbackSuppressed"`
-	ContainerFallbackSuppressedAt       *time.Time `json:"containerFallbackSuppressedAt,omitempty"`
-	ContainerFallbackSuppressedReason   string     `json:"containerFallbackSuppressedReason,omitempty"`
-	ContainerFallbackSuppressedSource   string     `json:"containerFallbackSuppressedSource,omitempty"`
-	ContainerFallbackResumedAt          *time.Time `json:"containerFallbackResumedAt,omitempty"`
-	ContainerFallbackResumedReason      string     `json:"containerFallbackResumedReason,omitempty"`
-	ContainerFallbackResumedSource      string     `json:"containerFallbackResumedSource,omitempty"`
-	ContainerFallbackBackoffUntil       *time.Time `json:"containerFallbackBackoffUntil,omitempty"`
-	ContainerFallbackAttemptCount       int        `json:"containerFallbackAttemptCount"`
-	LastContainerFallbackDecisionAt     *time.Time `json:"lastContainerFallbackDecisionAt,omitempty"`
-	LastContainerFallbackDecisionReason string     `json:"lastContainerFallbackDecisionReason,omitempty"`
+	ConsecutiveFailures                   int        `json:"consecutiveFailures"`
+	FailureThreshold                      int        `json:"failureThreshold"`
+	LastFailureReason                     string     `json:"lastFailureReason,omitempty"`
+	LastFailureAt                         *time.Time `json:"lastFailureAt,omitempty"`
+	LastHealthyAt                         *time.Time `json:"lastHealthyAt,omitempty"`
+	ContainerFallbackCandidate            bool       `json:"containerFallbackCandidate"`
+	ContainerFallbackReason               string     `json:"containerFallbackReason,omitempty"`
+	ContainerFallbackSuppressed           bool       `json:"containerFallbackSuppressed"`
+	ContainerFallbackSuppressedAt         *time.Time `json:"containerFallbackSuppressedAt,omitempty"`
+	ContainerFallbackSuppressedReason     string     `json:"containerFallbackSuppressedReason,omitempty"`
+	ContainerFallbackSuppressedSource     string     `json:"containerFallbackSuppressedSource,omitempty"`
+	ContainerFallbackResumedAt            *time.Time `json:"containerFallbackResumedAt,omitempty"`
+	ContainerFallbackResumedReason        string     `json:"containerFallbackResumedReason,omitempty"`
+	ContainerFallbackResumedSource        string     `json:"containerFallbackResumedSource,omitempty"`
+	ContainerFallbackBackoffUntil         *time.Time `json:"containerFallbackBackoffUntil,omitempty"`
+	ContainerFallbackBackoffSetAt         *time.Time `json:"containerFallbackBackoffSetAt,omitempty"`
+	ContainerFallbackBackoffReason        string     `json:"containerFallbackBackoffReason,omitempty"`
+	ContainerFallbackBackoffSource        string     `json:"containerFallbackBackoffSource,omitempty"`
+	ContainerFallbackBackoffClearedAt     *time.Time `json:"containerFallbackBackoffClearedAt,omitempty"`
+	ContainerFallbackBackoffClearedReason string     `json:"containerFallbackBackoffClearedReason,omitempty"`
+	ContainerFallbackBackoffClearedSource string     `json:"containerFallbackBackoffClearedSource,omitempty"`
+	ContainerFallbackAttemptCount         int        `json:"containerFallbackAttemptCount"`
+	LastContainerFallbackDecisionAt       *time.Time `json:"lastContainerFallbackDecisionAt,omitempty"`
+	LastContainerFallbackDecisionReason   string     `json:"lastContainerFallbackDecisionReason,omitempty"`
 }
 
 type RuntimeSupervisorContainerFallbackPlan struct {
@@ -195,21 +202,27 @@ type RuntimeSupervisorContainerFallbackPlan struct {
 }
 
 type runtimeSupervisorServiceState struct {
-	ConsecutiveFailures                 int
-	LastFailureReason                   string
-	LastFailureAt                       time.Time
-	LastHealthyAt                       time.Time
-	ContainerFallbackSuppressed         bool
-	ContainerFallbackSuppressedAt       time.Time
-	ContainerFallbackSuppressedReason   string
-	ContainerFallbackSuppressedSource   string
-	ContainerFallbackResumedAt          time.Time
-	ContainerFallbackResumedReason      string
-	ContainerFallbackResumedSource      string
-	ContainerFallbackBackoffUntil       time.Time
-	ContainerFallbackAttemptCount       int
-	LastContainerFallbackDecisionAt     time.Time
-	LastContainerFallbackDecisionReason string
+	ConsecutiveFailures                   int
+	LastFailureReason                     string
+	LastFailureAt                         time.Time
+	LastHealthyAt                         time.Time
+	ContainerFallbackSuppressed           bool
+	ContainerFallbackSuppressedAt         time.Time
+	ContainerFallbackSuppressedReason     string
+	ContainerFallbackSuppressedSource     string
+	ContainerFallbackResumedAt            time.Time
+	ContainerFallbackResumedReason        string
+	ContainerFallbackResumedSource        string
+	ContainerFallbackBackoffUntil         time.Time
+	ContainerFallbackBackoffSetAt         time.Time
+	ContainerFallbackBackoffReason        string
+	ContainerFallbackBackoffSource        string
+	ContainerFallbackBackoffClearedAt     time.Time
+	ContainerFallbackBackoffClearedReason string
+	ContainerFallbackBackoffClearedSource string
+	ContainerFallbackAttemptCount         int
+	LastContainerFallbackDecisionAt       time.Time
+	LastContainerFallbackDecisionReason   string
 }
 
 type runtimeSupervisorContainerFallbackDecisionInput struct {
@@ -249,15 +262,17 @@ type runtimeSupervisorApplicationRestartDecisionResult struct {
 }
 
 type RuntimeSupervisorContainerFallbackControlOptions struct {
-	Confirm bool
-	Reason  string
-	Source  string
+	Confirm         bool
+	Reason          string
+	Source          string
+	BackoffDuration time.Duration
 }
 
 type RuntimeSupervisorContainerFallbackControlResult struct {
 	TargetName    string                        `json:"targetName"`
 	TargetBaseURL string                        `json:"targetBaseUrl"`
 	Suppressed    bool                          `json:"suppressed"`
+	BackoffUntil  *time.Time                    `json:"backoffUntil,omitempty"`
 	Reason        string                        `json:"reason"`
 	Source        string                        `json:"source"`
 	UpdatedAt     time.Time                     `json:"updatedAt"`
@@ -309,6 +324,26 @@ func (p *Platform) ResumeRuntimeSupervisorContainerFallback(targetName string, o
 		return RuntimeSupervisorContainerFallbackControlResult{}, ErrRuntimeSupervisorTargetNotFound
 	}
 	return supervisor.ResumeContainerFallback(targetName, options)
+}
+
+func (p *Platform) DeferRuntimeSupervisorContainerFallback(targetName string, options RuntimeSupervisorContainerFallbackControlOptions) (RuntimeSupervisorContainerFallbackControlResult, error) {
+	p.mu.Lock()
+	supervisor := p.runtimeSupervisor
+	p.mu.Unlock()
+	if supervisor == nil {
+		return RuntimeSupervisorContainerFallbackControlResult{}, ErrRuntimeSupervisorTargetNotFound
+	}
+	return supervisor.DeferContainerFallback(targetName, options)
+}
+
+func (p *Platform) ClearRuntimeSupervisorContainerFallbackBackoff(targetName string, options RuntimeSupervisorContainerFallbackControlOptions) (RuntimeSupervisorContainerFallbackControlResult, error) {
+	p.mu.Lock()
+	supervisor := p.runtimeSupervisor
+	p.mu.Unlock()
+	if supervisor == nil {
+		return RuntimeSupervisorContainerFallbackControlResult{}, ErrRuntimeSupervisorTargetNotFound
+	}
+	return supervisor.ClearContainerFallbackBackoff(targetName, options)
 }
 
 func NewRuntimeSupervisor(targets []RuntimeSupervisorTarget, client *http.Client) *RuntimeSupervisor {
@@ -436,6 +471,14 @@ func (s *RuntimeSupervisor) ResumeContainerFallback(targetName string, options R
 	return s.setContainerFallbackSuppressed(targetName, false, options)
 }
 
+func (s *RuntimeSupervisor) DeferContainerFallback(targetName string, options RuntimeSupervisorContainerFallbackControlOptions) (RuntimeSupervisorContainerFallbackControlResult, error) {
+	return s.setContainerFallbackBackoff(targetName, options, false)
+}
+
+func (s *RuntimeSupervisor) ClearContainerFallbackBackoff(targetName string, options RuntimeSupervisorContainerFallbackControlOptions) (RuntimeSupervisorContainerFallbackControlResult, error) {
+	return s.setContainerFallbackBackoff(targetName, options, true)
+}
+
 func (s *RuntimeSupervisor) setContainerFallbackSuppressed(targetName string, suppressed bool, options RuntimeSupervisorContainerFallbackControlOptions) (RuntimeSupervisorContainerFallbackControlResult, error) {
 	if s == nil {
 		return RuntimeSupervisorContainerFallbackControlResult{}, ErrRuntimeSupervisorTargetNotFound
@@ -481,6 +524,63 @@ func (s *RuntimeSupervisor) setContainerFallbackSuppressed(targetName string, su
 		TargetName:    target.Name,
 		TargetBaseURL: target.BaseURL,
 		Suppressed:    suppressed,
+		Reason:        reason,
+		Source:        source,
+		UpdatedAt:     now,
+		ServiceState:  runtimeSupervisorServiceStateSnapshot(state, s.options.ServiceFailureThreshold),
+	}, nil
+}
+
+func (s *RuntimeSupervisor) setContainerFallbackBackoff(targetName string, options RuntimeSupervisorContainerFallbackControlOptions, clear bool) (RuntimeSupervisorContainerFallbackControlResult, error) {
+	if s == nil {
+		return RuntimeSupervisorContainerFallbackControlResult{}, ErrRuntimeSupervisorTargetNotFound
+	}
+	if !options.Confirm {
+		return RuntimeSupervisorContainerFallbackControlResult{}, ErrRuntimeSupervisorControlConfirmRequired
+	}
+	reason := strings.TrimSpace(options.Reason)
+	if reason == "" {
+		return RuntimeSupervisorContainerFallbackControlResult{}, ErrRuntimeSupervisorControlReasonRequired
+	}
+	if !clear && options.BackoffDuration <= 0 {
+		return RuntimeSupervisorContainerFallbackControlResult{}, ErrRuntimeSupervisorBackoffDurationRequired
+	}
+	target, err := s.targetByName(targetName)
+	if err != nil {
+		return RuntimeSupervisorContainerFallbackControlResult{}, err
+	}
+	source := strings.TrimSpace(options.Source)
+	if source == "" {
+		source = "api"
+	}
+	now := time.Now().UTC()
+	key := runtimeSupervisorServiceKey(target)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.serviceStates == nil {
+		s.serviceStates = make(map[string]runtimeSupervisorServiceState)
+	}
+	state := s.serviceStates[key]
+	var backoffUntil *time.Time
+	if clear {
+		state.ContainerFallbackBackoffUntil = time.Time{}
+		state.ContainerFallbackBackoffClearedAt = now
+		state.ContainerFallbackBackoffClearedReason = reason
+		state.ContainerFallbackBackoffClearedSource = source
+	} else {
+		until := now.Add(options.BackoffDuration).UTC()
+		state.ContainerFallbackBackoffUntil = until
+		state.ContainerFallbackBackoffSetAt = now
+		state.ContainerFallbackBackoffReason = reason
+		state.ContainerFallbackBackoffSource = source
+		backoffUntil = &until
+	}
+	s.serviceStates[key] = state
+	return RuntimeSupervisorContainerFallbackControlResult{
+		TargetName:    target.Name,
+		TargetBaseURL: target.BaseURL,
+		Suppressed:    state.ContainerFallbackSuppressed,
+		BackoffUntil:  backoffUntil,
 		Reason:        reason,
 		Source:        source,
 		UpdatedAt:     now,
@@ -590,6 +690,12 @@ func (s *RuntimeSupervisor) updateServiceState(target RuntimeSupervisorTarget, h
 		state.LastHealthyAt = now
 		state.ContainerFallbackAttemptCount = 0
 		state.ContainerFallbackBackoffUntil = time.Time{}
+		state.ContainerFallbackBackoffSetAt = time.Time{}
+		state.ContainerFallbackBackoffReason = ""
+		state.ContainerFallbackBackoffSource = ""
+		state.ContainerFallbackBackoffClearedAt = time.Time{}
+		state.ContainerFallbackBackoffClearedReason = ""
+		state.ContainerFallbackBackoffClearedSource = ""
 		state.LastContainerFallbackDecisionAt = time.Time{}
 		state.LastContainerFallbackDecisionReason = ""
 	}
@@ -623,16 +729,20 @@ func runtimeSupervisorServiceStateSnapshot(state runtimeSupervisorServiceState, 
 		threshold = defaultRuntimeSupervisorServiceFailThresh
 	}
 	out := RuntimeSupervisorServiceState{
-		ConsecutiveFailures:                 state.ConsecutiveFailures,
-		FailureThreshold:                    threshold,
-		LastFailureReason:                   state.LastFailureReason,
-		ContainerFallbackSuppressed:         state.ContainerFallbackSuppressed,
-		ContainerFallbackSuppressedReason:   state.ContainerFallbackSuppressedReason,
-		ContainerFallbackSuppressedSource:   state.ContainerFallbackSuppressedSource,
-		ContainerFallbackResumedReason:      state.ContainerFallbackResumedReason,
-		ContainerFallbackResumedSource:      state.ContainerFallbackResumedSource,
-		ContainerFallbackAttemptCount:       state.ContainerFallbackAttemptCount,
-		LastContainerFallbackDecisionReason: state.LastContainerFallbackDecisionReason,
+		ConsecutiveFailures:                   state.ConsecutiveFailures,
+		FailureThreshold:                      threshold,
+		LastFailureReason:                     state.LastFailureReason,
+		ContainerFallbackSuppressed:           state.ContainerFallbackSuppressed,
+		ContainerFallbackSuppressedReason:     state.ContainerFallbackSuppressedReason,
+		ContainerFallbackSuppressedSource:     state.ContainerFallbackSuppressedSource,
+		ContainerFallbackResumedReason:        state.ContainerFallbackResumedReason,
+		ContainerFallbackResumedSource:        state.ContainerFallbackResumedSource,
+		ContainerFallbackBackoffReason:        state.ContainerFallbackBackoffReason,
+		ContainerFallbackBackoffSource:        state.ContainerFallbackBackoffSource,
+		ContainerFallbackBackoffClearedReason: state.ContainerFallbackBackoffClearedReason,
+		ContainerFallbackBackoffClearedSource: state.ContainerFallbackBackoffClearedSource,
+		ContainerFallbackAttemptCount:         state.ContainerFallbackAttemptCount,
+		LastContainerFallbackDecisionReason:   state.LastContainerFallbackDecisionReason,
 	}
 	if !state.LastFailureAt.IsZero() {
 		lastFailureAt := state.LastFailureAt.UTC()
@@ -653,6 +763,14 @@ func runtimeSupervisorServiceStateSnapshot(state runtimeSupervisorServiceState, 
 	if !state.ContainerFallbackBackoffUntil.IsZero() {
 		backoffUntil := state.ContainerFallbackBackoffUntil.UTC()
 		out.ContainerFallbackBackoffUntil = &backoffUntil
+	}
+	if !state.ContainerFallbackBackoffSetAt.IsZero() {
+		backoffSetAt := state.ContainerFallbackBackoffSetAt.UTC()
+		out.ContainerFallbackBackoffSetAt = &backoffSetAt
+	}
+	if !state.ContainerFallbackBackoffClearedAt.IsZero() {
+		backoffClearedAt := state.ContainerFallbackBackoffClearedAt.UTC()
+		out.ContainerFallbackBackoffClearedAt = &backoffClearedAt
 	}
 	if !state.LastContainerFallbackDecisionAt.IsZero() {
 		lastDecisionAt := state.LastContainerFallbackDecisionAt.UTC()

--- a/internal/service/runtime_supervisor_test.go
+++ b/internal/service/runtime_supervisor_test.go
@@ -446,6 +446,82 @@ func TestRuntimeSupervisorContainerFallbackSuppressionBlocksEligiblePlan(t *test
 	}
 }
 
+func TestRuntimeSupervisorContainerFallbackBackoffBlocksEligiblePlan(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/healthz":
+			http.Error(w, "not ready", http.StatusServiceUnavailable)
+		case "/api/v1/runtime/status":
+			writeRuntimeSupervisorTestJSON(t, w, RuntimeStatusSnapshot{Service: "platform-api"})
+		default:
+			t.Errorf("unexpected request path %s", r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	supervisor := NewRuntimeSupervisorWithOptions(
+		[]RuntimeSupervisorTarget{{Name: "api", BaseURL: server.URL}},
+		server.Client(),
+		RuntimeSupervisorOptions{
+			ServiceFailureThreshold:   1,
+			EnableContainerFallback:   true,
+			ContainerFallbackExecutor: NewNoopContainerFallbackExecutor(true),
+		},
+	)
+	initial := supervisor.Collect(context.Background()).Targets[0]
+	if initial.ContainerFallbackPlan == nil || !initial.ContainerFallbackPlan.Executable {
+		t.Fatalf("expected initial noop plan to be eligible, got %+v", initial.ContainerFallbackPlan)
+	}
+
+	deferred, err := supervisor.DeferContainerFallback("api", RuntimeSupervisorContainerFallbackControlOptions{
+		Confirm:         true,
+		Reason:          "operator cooling down restart loop",
+		Source:          "ctl",
+		BackoffDuration: 5 * time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("defer container fallback failed: %v", err)
+	}
+	if deferred.BackoffUntil == nil || deferred.ServiceState.ContainerFallbackBackoffUntil == nil {
+		t.Fatalf("expected backoff until in result, got %+v", deferred)
+	}
+	if deferred.ServiceState.ContainerFallbackBackoffReason != "operator cooling down restart loop" || deferred.ServiceState.ContainerFallbackBackoffSource != "ctl" || deferred.ServiceState.ContainerFallbackBackoffSetAt == nil {
+		t.Fatalf("expected backoff audit fields, got %+v", deferred.ServiceState)
+	}
+
+	blocked := supervisor.Collect(context.Background()).Targets[0]
+	if blocked.ContainerFallbackPlan == nil {
+		t.Fatalf("expected fallback plan after backoff, got %+v", blocked)
+	}
+	if blocked.ContainerFallbackPlan.Executable || blocked.ContainerFallbackPlan.BlockedReason != "container-fallback-backoff-active" {
+		t.Fatalf("expected backoff plan to block execution, got %+v", blocked.ContainerFallbackPlan)
+	}
+	if blocked.ServiceState.LastContainerFallbackDecisionReason != "container-fallback-backoff-active" {
+		t.Fatalf("expected backoff decision audit, got %+v", blocked.ServiceState)
+	}
+
+	cleared, err := supervisor.ClearContainerFallbackBackoff("api", RuntimeSupervisorContainerFallbackControlOptions{
+		Confirm: true,
+		Reason:  "operator verified target stable",
+		Source:  "ctl",
+	})
+	if err != nil {
+		t.Fatalf("clear container fallback backoff failed: %v", err)
+	}
+	if cleared.BackoffUntil != nil || cleared.ServiceState.ContainerFallbackBackoffUntil != nil {
+		t.Fatalf("expected clear to remove backoff, got %+v", cleared)
+	}
+	if cleared.ServiceState.ContainerFallbackBackoffClearedReason != "operator verified target stable" || cleared.ServiceState.ContainerFallbackBackoffClearedSource != "ctl" || cleared.ServiceState.ContainerFallbackBackoffClearedAt == nil {
+		t.Fatalf("expected backoff clear audit fields, got %+v", cleared.ServiceState)
+	}
+
+	eligible := supervisor.Collect(context.Background()).Targets[0]
+	if eligible.ContainerFallbackPlan == nil || !eligible.ContainerFallbackPlan.Executable || eligible.ContainerFallbackPlan.Decision != runtimeSupervisorContainerFallbackDecisionEligible {
+		t.Fatalf("expected clear to restore eligible noop plan, got %+v", eligible.ContainerFallbackPlan)
+	}
+}
+
 func TestRuntimeSupervisorContainerFallbackControlValidation(t *testing.T) {
 	supervisor := NewRuntimeSupervisorWithOptions(
 		[]RuntimeSupervisorTarget{{Name: "api", BaseURL: "http://127.0.0.1:8080"}},
@@ -457,6 +533,9 @@ func TestRuntimeSupervisorContainerFallbackControlValidation(t *testing.T) {
 	}
 	if _, err := supervisor.SuppressContainerFallback("api", RuntimeSupervisorContainerFallbackControlOptions{Confirm: true}); !errors.Is(err, ErrRuntimeSupervisorControlReasonRequired) {
 		t.Fatalf("expected reason required, got %v", err)
+	}
+	if _, err := supervisor.DeferContainerFallback("api", RuntimeSupervisorContainerFallbackControlOptions{Confirm: true, Reason: "maintenance"}); !errors.Is(err, ErrRuntimeSupervisorBackoffDurationRequired) {
+		t.Fatalf("expected backoff duration required, got %v", err)
 	}
 	if _, err := supervisor.SuppressContainerFallback("", RuntimeSupervisorContainerFallbackControlOptions{Confirm: true, Reason: "maintenance"}); !errors.Is(err, ErrRuntimeSupervisorTargetRequired) {
 		t.Fatalf("expected target required, got %v", err)


### PR DESCRIPTION
## 目的
继续推进 Issue #270 Stage 5 的真实 executor 前置安全能力：为 supervisor container fallback 增加人工 backoff gate，允许运维在真实执行器接入前先手动设置/清理 `containerFallbackBackoffUntil`。

本 PR 不接 Docker、不挂载 docker.sock、不执行容器 restart。控制 API 只接受已配置的 `targetName`，不接受 URL、container name、compose service 或 shell command。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [x] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
- [x] `dispatchMode` 默认值有否变化？无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？不存在
- [x] DB migration 是否具备向下兼容幂等性？不涉及
- [x] 配置字段有没有无意被混改？不涉及配置/env/default 改动

## 交易语义变更
- [x] 本次改动是否新增/修改了 `signalKind`？否
- [x] 本次改动是否影响订单方向判断（`side` / `reduceOnly` / `closePosition`）？否
- [x] 若涉及上述改动，`go test ./internal/domain/... -run TestClassifyOrderIntent` 是否通过？不涉及
- [x] 若涉及交易链路语义（开仓/平仓/撤单/risk-exit），`go test ./internal/domain/... -run TestTradingReplayGoldenCases` 是否通过？不涉及

## 改动摘要
- 新增 `POST /api/v1/supervisor/container-fallback/defer|clear-backoff`，沿用 runtime action role gate，要求 `targetName`、`confirm=true`、非空 `reason`，其中 defer 要求 `backoffSeconds>0`。
- 新增 `bktrader-ctl supervisor defer-container-fallback|clear-container-fallback-backoff <targetName>`。
- 在 supervisor service state 暴露 backoff set/clear 审计字段，并让 backoff gate 阻断 eligible noop fallback plan。
- 补充 service/http tests 和 runtime supervisor 文档。

## 验证方式与测试证据
- [x] `go test ./internal/service -run 'TestRuntimeSupervisorContainerFallback|TestNoopContainerFallback'`
- [x] `go test ./internal/http -run TestSupervisor`
- [x] `go test ./cmd/bktrader-ctl -run TestBuildSupervisorStatusSummary`
- [x] `go test ./...`
- [x] `go build ./cmd/platform-api`
- [x] `go build ./cmd/db-migrate`
- [x] `git diff --check`

## Issue
Refs #270

## Codex 说明
本 PR 由 Codex 协助生成。范围限定在 supervisor container fallback 的人工 backoff gate，不修改 `internal/service/live*.go`、`execution_strategy.go`、`deployments/`、`.github/workflows/`，不改变任何实盘交易默认行为。