### PR TITLE
[codex] Validate supervisor target format

### DIFF
--- a/docs/runtime-supervisor.md
+++ b/docs/runtime-supervisor.md
@@ -332,7 +332,7 @@ func ClearRestartState(state map[string]any, keys []string)
 - `BKTRADER_ROLE=api` 在显式配置 `SUPERVISOR_TARGETS` 时会启动 read-only supervisor collector，用于让现有 console 继续通过 platform-api 读取 `GET /api/v1/supervisor/status`。
 - `BKTRADER_ROLE=supervisor` 只启动 read-only supervisor，不启动 live / signal / dashboard / notification 业务组件。
 - 生产 compose 已提供独立 `supervisor` 服务：使用 `platform-api` 二进制、`BKTRADER_ROLE=supervisor`、`HTTP_ADDR=:8081`，默认 `SUPERVISOR_STANDALONE_TARGETS=api=http://platform-api:8080`。该服务可通过 `DEPLOY_SERVICES=supervisor` 单独发布，挂掉不会停止 platform-api / live-runner / signal-runtime-runner。
-- `SUPERVISOR_TARGETS` 使用逗号分隔，支持 `name=http://host:port` 或直接填写 base URL；显式 `name=` 形式必须唯一，避免后续按 `targetName` 执行 suppress/backoff 控制时出现 allowlist 歧义。
+- `SUPERVISOR_TARGETS` 使用逗号分隔，支持 `name=http://host:port` 或直接填写 base URL；显式 `name=` 形式必须有非空 name、非空 base URL，且 name 必须唯一，避免后续按 `targetName` 执行 suppress/backoff 控制时出现 allowlist 歧义或静默跳过 target。
 - `SUPERVISOR_BEARER_TOKEN` 可选；设置后 read-only collector 会对所有 targets 的 `/healthz` 与 `/api/v1/runtime/status` 请求附加 `Authorization: Bearer <token>`，用于采集受鉴权保护的内网 runtime API。platform-api 会在 `/api/v1/runtime/status` 上接受该 token 作为只读 supervisor probe，不创建用户会话、不放行其他 API。当 target 指向其他容器、其他服务或非 loopback 地址时，应使用该 token 路径，不依赖 loopback 豁免。
 - 生产 compose 默认将 platform-api 配为 `SUPERVISOR_TARGETS=api=http://127.0.0.1:8080`；该 loopback 自采集只读取 `/healthz` 和 `/api/v1/runtime/status`，不会调用控制 API。启用鉴权时，`/api/v1/runtime/status` 仅在 `SUPERVISOR_TARGETS` 非空且请求来自 loopback 时免 token，用于 platform-api 的 supervisor 自采集；未配置 supervisor targets 时，loopback 请求仍需正常鉴权。
 - 独立 `supervisor` 服务跨容器采集 platform-api 时，请在生产 `.env` 配置强随机 `SUPERVISOR_BEARER_TOKEN`；若部署脚本发现该变量缺失，会生成强随机 token 写入 `.env` 并导出给本次 compose 调用。prod compose 要求该变量非空，`scripts/deploy.sh` 会拒绝使用示例值发布生产环境。示例值只能用于本地开发。

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -233,29 +233,37 @@ func (c Config) Validate() error {
 	default:
 		return fmt.Errorf("不支持的 SUPERVISOR_CONTAINER_EXECUTOR: %s（可选: noop；留空表示不配置 executor）", c.SupervisorContainerExecutor)
 	}
-	if duplicate := duplicateSupervisorTargetName(c.SupervisorTargets); duplicate != "" {
-		return fmt.Errorf("SUPERVISOR_TARGETS 包含重复 target name: %s", duplicate)
+	if err := validateSupervisorTargets(c.SupervisorTargets); err != nil {
+		return err
 	}
 	return nil
 }
 
-func duplicateSupervisorTargetName(targets []string) string {
+func validateSupervisorTargets(targets []string) error {
 	seen := make(map[string]struct{})
 	for _, raw := range targets {
-		name, _, ok := strings.Cut(strings.TrimSpace(raw), "=")
+		raw = strings.TrimSpace(raw)
+		if raw == "" {
+			continue
+		}
+		name, baseURL, ok := strings.Cut(raw, "=")
 		if !ok {
 			continue
 		}
 		name = strings.TrimSpace(name)
+		baseURL = strings.TrimSpace(baseURL)
 		if name == "" {
-			continue
+			return fmt.Errorf("SUPERVISOR_TARGETS 包含空 target name: %s", raw)
+		}
+		if baseURL == "" {
+			return fmt.Errorf("SUPERVISOR_TARGETS target %s 缺少 base URL", name)
 		}
 		if _, exists := seen[name]; exists {
-			return name
+			return fmt.Errorf("SUPERVISOR_TARGETS 包含重复 target name: %s", name)
 		}
 		seen[name] = struct{}{}
 	}
-	return ""
+	return nil
 }
 
 // RuntimeActionsEnabled reports whether this process is allowed to execute

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -129,6 +129,34 @@ func TestConfigValidateRejectsDuplicateSupervisorTargetNames(t *testing.T) {
 	}
 }
 
+func TestConfigValidateRejectsMalformedSupervisorTargets(t *testing.T) {
+	tests := []struct {
+		name    string
+		targets []string
+	}{
+		{
+			name:    "empty explicit name",
+			targets: []string{"=http://127.0.0.1:8080"},
+		},
+		{
+			name:    "missing explicit base url",
+			targets: []string{"api="},
+		},
+		{
+			name:    "blank explicit base url",
+			targets: []string{"api= "},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := Config{HTTPAddr: ":8080", StoreBackend: "memory", SupervisorTargets: tt.targets}
+			if err := cfg.Validate(); err == nil {
+				t.Fatalf("expected malformed supervisor target to fail validation")
+			}
+		})
+	}
+}
+
 func TestConfigValidateAllowsUnnamedSupervisorTargets(t *testing.T) {
 	cfg := Config{
 		HTTPAddr:          ":8080",


### PR DESCRIPTION
## 目的
继续推进 Issue #270 Stage 5 的真实 executor 前置安全收口：显式 `SUPERVISOR_TARGETS` 的 `name=url` 格式现在会参与 container fallback suppress/backoff 的 target allowlist，因此空 name 或空 base URL 不应被静默接受或跳过。

本 PR 不接 Docker、不挂载 docker.sock、不执行容器 restart，也不修改 deployments 或默认行为。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [x] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
- [x] `dispatchMode` 默认值有否变化？无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？不存在
- [x] DB migration 是否具备向下兼容幂等性？不涉及
- [x] 配置字段有没有无意被混改？仅新增 `SUPERVISOR_TARGETS` 显式 `name=url` 格式校验；未命名 base URL 保持原行为

## 交易语义变更
- [x] 本次改动是否新增/修改了 `signalKind`？否
- [x] 本次改动是否影响订单方向判断（`side` / `reduceOnly` / `closePosition`）？否
- [x] 若涉及上述改动，`go test ./internal/domain/... -run TestClassifyOrderIntent` 是否通过？不涉及
- [x] 若涉及交易链路语义（开仓/平仓/撤单/risk-exit），`go test ./internal/domain/... -run TestTradingReplayGoldenCases` 是否通过？不涉及

## 改动摘要
- `Config.Validate()` 拒绝显式 `SUPERVISOR_TARGETS` 中空 name 或空 base URL 的 `name=url` entry。
- 保持未命名 base URL targets 的现有自动命名行为。
- 更新 Runtime Supervisor 文档说明显式 `name=` 形式必须非空且唯一。

## 验证方式与测试证据
- [x] `go test ./internal/config ./internal/app`
- [x] `go test ./...`
- [x] `go build ./cmd/platform-api`
- [x] `go build ./cmd/db-migrate`
- [x] `git diff --check`

## Issue
Refs #270

## Codex 说明
本 PR 由 Codex 协助生成。范围限定在 supervisor target 格式配置校验，不修改 `internal/service/live*.go`、`execution_strategy.go`、`deployments/`、`.github/workflows/`，不改变任何实盘交易默认行为。