### PR TITLE
[codex] Guard dashboard fetch function registration

### DIFF
--- a/internal/service/dashboard_broker.go
+++ b/internal/service/dashboard_broker.go
@@ -70,30 +70,40 @@ func (b *DashboardBroker) registerDefaultFetchFuncs() {
 	if b.platform == nil {
 		return
 	}
-	b.fetchFuncs[DashboardDomainLiveSessions] = func() (any, error) {
+	b.RegisterDashboardFetchFunc(DashboardDomainLiveSessions, func() (any, error) {
 		return b.platform.ListLiveSessionsSummary()
-	}
-	b.fetchFuncs[DashboardDomainSignalRuntimeSessions] = func() (any, error) {
+	})
+	b.RegisterDashboardFetchFunc(DashboardDomainSignalRuntimeSessions, func() (any, error) {
 		return b.platform.ListSignalRuntimeSessionsSummary(), nil
-	}
-	b.fetchFuncs[DashboardDomainPositions] = func() (any, error) {
+	})
+	b.RegisterDashboardFetchFunc(DashboardDomainPositions, func() (any, error) {
 		return b.platform.ListPositions()
-	}
-	b.fetchFuncs[DashboardDomainOrders] = func() (any, error) {
+	})
+	b.RegisterDashboardFetchFunc(DashboardDomainOrders, func() (any, error) {
 		return b.platform.ListOrdersWithLimit(50, 0)
-	}
-	b.fetchFuncs[DashboardDomainFills] = func() (any, error) {
+	})
+	b.RegisterDashboardFetchFunc(DashboardDomainFills, func() (any, error) {
 		return b.platform.ListFillsWithLimit(50, 0)
-	}
-	b.fetchFuncs[DashboardDomainAlerts] = func() (any, error) {
+	})
+	b.RegisterDashboardFetchFunc(DashboardDomainAlerts, func() (any, error) {
 		return b.platform.ListAlerts()
-	}
-	b.fetchFuncs[DashboardDomainNotifications] = func() (any, error) {
+	})
+	b.RegisterDashboardFetchFunc(DashboardDomainNotifications, func() (any, error) {
 		return b.platform.ListNotifications(true)
-	}
-	b.fetchFuncs[DashboardDomainMonitorHealth] = func() (any, error) {
+	})
+	b.RegisterDashboardFetchFunc(DashboardDomainMonitorHealth, func() (any, error) {
 		return b.platform.HealthSnapshot()
+	})
+}
+
+// RegisterDashboardFetchFunc installs or replaces the snapshot fetcher for a dashboard domain.
+func (b *DashboardBroker) RegisterDashboardFetchFunc(domain DashboardDomain, fetchData func() (any, error)) {
+	if domain == "" || fetchData == nil {
+		return
 	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.fetchFuncs[domain] = fetchData
 }
 
 func (b *DashboardBroker) Subscribe(buffer int) (int, <-chan DashboardEvent) {

--- a/internal/service/dashboard_broker_test.go
+++ b/internal/service/dashboard_broker_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -38,10 +39,10 @@ func TestNotifyChangedNonBlocking(t *testing.T) {
 func TestDashboardBrokerCoalescesSameDomain(t *testing.T) {
 	b := newTestDashboardBroker(20 * time.Millisecond)
 	var fetches atomic.Int64
-	b.fetchFuncs[DashboardDomainOrders] = func() (any, error) {
+	b.RegisterDashboardFetchFunc(DashboardDomainOrders, func() (any, error) {
 		fetches.Add(1)
 		return map[string]any{"orders": []string{"order-1"}}, nil
-	}
+	})
 	_, ch := b.Subscribe(10)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -66,14 +67,14 @@ func TestDashboardBrokerCoalescesMultipleDomains(t *testing.T) {
 	b := newTestDashboardBroker(20 * time.Millisecond)
 	var orderFetches atomic.Int64
 	var fillFetches atomic.Int64
-	b.fetchFuncs[DashboardDomainOrders] = func() (any, error) {
+	b.RegisterDashboardFetchFunc(DashboardDomainOrders, func() (any, error) {
 		orderFetches.Add(1)
 		return map[string]any{"orders": []string{"order-1"}}, nil
-	}
-	b.fetchFuncs[DashboardDomainFills] = func() (any, error) {
+	})
+	b.RegisterDashboardFetchFunc(DashboardDomainFills, func() (any, error) {
 		fillFetches.Add(1)
 		return map[string]any{"fills": []string{"fill-1"}}, nil
-	}
+	})
 	_, ch := b.Subscribe(10)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -104,10 +105,10 @@ func TestDashboardBrokerCoalescesMultipleDomains(t *testing.T) {
 func TestDashboardBrokerNoSubscriberSkipsFetch(t *testing.T) {
 	b := newTestDashboardBroker(10 * time.Millisecond)
 	var fetches atomic.Int64
-	b.fetchFuncs[DashboardDomainOrders] = func() (any, error) {
+	b.RegisterDashboardFetchFunc(DashboardDomainOrders, func() (any, error) {
 		fetches.Add(1)
 		return map[string]any{"orders": []string{"order-1"}}, nil
-	}
+	})
 
 	b.publishSnapshotForDomain(DashboardDomainOrders)
 
@@ -116,13 +117,98 @@ func TestDashboardBrokerNoSubscriberSkipsFetch(t *testing.T) {
 	}
 }
 
+func TestDashboardBrokerRegisterFetchFuncReplacesFetcher(t *testing.T) {
+	b := newTestDashboardBroker(10 * time.Millisecond)
+	b.RegisterDashboardFetchFunc(DashboardDomainOrders, func() (any, error) {
+		return map[string]any{"orders": []string{"old"}}, nil
+	})
+	b.RegisterDashboardFetchFunc(DashboardDomainOrders, func() (any, error) {
+		return map[string]any{"orders": []string{"new"}}, nil
+	})
+	_, ch := b.Subscribe(10)
+
+	b.publishSnapshotForDomain(DashboardDomainOrders)
+
+	event := waitDashboardEvent(t, ch, 100*time.Millisecond)
+	payload, ok := event.Payload.(map[string]any)
+	if !ok {
+		t.Fatalf("expected map payload, got %#v", event.Payload)
+	}
+	orders, ok := payload["orders"].([]string)
+	if !ok || len(orders) != 1 || orders[0] != "new" {
+		t.Fatalf("expected replacement fetcher payload, got %#v", event.Payload)
+	}
+}
+
+func TestDashboardBrokerRegisterFetchFuncIgnoresInvalidInput(t *testing.T) {
+	b := newTestDashboardBroker(10 * time.Millisecond)
+	b.RegisterDashboardFetchFunc("", func() (any, error) {
+		return map[string]any{"orders": []string{"unexpected"}}, nil
+	})
+	b.RegisterDashboardFetchFunc(DashboardDomainOrders, nil)
+	if len(b.fetchFuncs) != 0 {
+		t.Fatalf("expected invalid fetch funcs to be ignored, got %#v", b.fetchFuncs)
+	}
+}
+
+func TestDashboardBrokerRegisterFetchFuncConcurrentWithSnapshots(t *testing.T) {
+	b := newTestDashboardBroker(10 * time.Millisecond)
+	subID, ch := b.Subscribe(512)
+	done := make(chan struct{})
+	drained := make(chan struct{})
+	go func() {
+		defer close(drained)
+		for {
+			select {
+			case <-done:
+				return
+			case <-ch:
+			}
+		}
+	}()
+	defer func() {
+		close(done)
+		<-drained
+		b.Unsubscribe(subID)
+	}()
+
+	b.RegisterDashboardFetchFunc(DashboardDomainOrders, func() (any, error) {
+		return map[string]any{"orders": []string{"initial"}}, nil
+	})
+
+	var wg sync.WaitGroup
+	wg.Add(3)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 200; i++ {
+			value := i
+			b.RegisterDashboardFetchFunc(DashboardDomainOrders, func() (any, error) {
+				return map[string]any{"orders": []int{value}}, nil
+			})
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 200; i++ {
+			b.publishSnapshotForDomain(DashboardDomainOrders)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 200; i++ {
+			b.PushInitialSnapshot(subID)
+		}
+	}()
+	wg.Wait()
+}
+
 func TestDashboardBrokerInitialSnapshotDoesNotSuppressBroadcast(t *testing.T) {
 	b := newTestDashboardBroker(10 * time.Millisecond)
 	currentPayload := atomic.Value{}
 	currentPayload.Store(map[string]any{"orders": []string{"h1"}})
-	b.fetchFuncs[DashboardDomainOrders] = func() (any, error) {
+	b.RegisterDashboardFetchFunc(DashboardDomainOrders, func() (any, error) {
 		return currentPayload.Load(), nil
-	}
+	})
 
 	subA, chA := b.Subscribe(10)
 	b.PushInitialSnapshot(subA)
@@ -180,9 +266,9 @@ func TestStartDashboardBrokerPollingPublishesThroughEventLoop(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
 	b := platform.DashboardBroker()
 	b.coalesceWindow = 10 * time.Millisecond
-	b.fetchFuncs[DashboardDomainNotifications] = func() (any, error) {
+	b.RegisterDashboardFetchFunc(DashboardDomainNotifications, func() (any, error) {
 		return map[string]any{"notifications": []string{"notification-1"}}, nil
-	}
+	})
 	_, ch := b.Subscribe(10)
 
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
## 目的
继续收口 #195 DashboardBroker 的内部并发边界：将 dashboard domain snapshot fetcher 的注册封装到 `RegisterDashboardFetchFunc()`，由 broker mutex 统一保护 map 写入与读取。

当前生产路径仍只在 broker 初始化时注册默认 fetcher；这个 PR 不改变 SSE payload、polling、coalescing、前端协议或任何 live/交易路径。主要是为后续如果需要动态注册 dashboard fetcher 时避免裸 map 写入带来的 data race 风险。

Review follow-up: 补充 `go test -race` 覆盖的并发场景，交错执行 fetcher 注册/替换、`publishSnapshotForDomain` 和 `PushInitialSnapshot`。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [x] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) - 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？- 无
- [x] DB migration 是否具备向下兼容幂等性？- 不涉及
- [x] 配置字段有没有无意被混改？- 不涉及

## 交易语义变更
- [x] 本次改动是否新增/修改了 `signalKind`？若是，需同步更新 Golden Case - 否
- [x] 本次改动是否影响订单方向判断（`side` / `reduceOnly` / `closePosition`）？- 否
- [ ] 若涉及上述改动，`go test ./internal/domain/... -run TestClassifyOrderIntent` 是否通过？
- [ ] 若涉及交易链路语义（开仓/平仓/撤单/risk-exit），`go test ./internal/domain/... -run TestTradingReplayGoldenCases` 是否通过？

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

验证：
- `go test ./internal/service -run 'TestDashboardBroker|TestStartDashboardBroker'`
- `go test ./internal/service -run 'TestDashboardBrokerRegisterFetchFunc|TestDashboardBrokerInitialSnapshot'`
- `go test -race ./internal/service -run 'TestDashboardBrokerRegisterFetchFuncConcurrentWithSnapshots'`
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
