### PR TITLE
[codex] Notify dashboard on live session changes

### DIFF
--- a/docs/dashboard-sse-architecture.md
+++ b/docs/dashboard-sse-architecture.md
@@ -136,8 +136,9 @@ Current implementation uses these trigger paths:
 4. Order create / submit / sync / fill settlement operations enqueue `orders` domain changes after their store write succeeds.
 5. Fill settlement operations enqueue `fills` domain changes after fill persistence succeeds.
 6. Fill settlement operations enqueue `positions` domain changes after position settlement succeeds.
+7. Live session create / update / delete / status / state writes enqueue `live-sessions` domain changes after the store write succeeds.
 
-Some business write paths still rely on polling fallback. Event-driven triggers currently cover low-risk notification ack state changes and order/fill/position snapshot refreshes.
+Some business write paths still rely on polling fallback. Event-driven triggers currently cover notification ack state changes and order/fill/position/live-session snapshot refreshes.
 
 ### 6.1 Subscriber model
 

--- a/internal/service/dashboard_live_session_store.go
+++ b/internal/service/dashboard_live_session_store.go
@@ -1,0 +1,103 @@
+package service
+
+import (
+	"github.com/wuyaocheng/bktrader/internal/domain"
+	"github.com/wuyaocheng/bktrader/internal/store"
+)
+
+type dashboardLiveSessionNotifyingStore struct {
+	store.Repository
+	notify func(DashboardDomain, string)
+}
+
+type dashboardLiveSessionNotifyingCASStore struct {
+	*dashboardLiveSessionNotifyingStore
+	cas liveSessionControlStateCompareAndSwapStore
+}
+
+type storeWrapper interface {
+	UnwrapStoreRepository() store.Repository
+}
+
+func newDashboardLiveSessionNotifyingStore(repo store.Repository, notify func(DashboardDomain, string)) store.Repository {
+	base := &dashboardLiveSessionNotifyingStore{
+		Repository: repo,
+		notify:     notify,
+	}
+	if cas, ok := repo.(liveSessionControlStateCompareAndSwapStore); ok {
+		return &dashboardLiveSessionNotifyingCASStore{
+			dashboardLiveSessionNotifyingStore: base,
+			cas:                                cas,
+		}
+	}
+	return base
+}
+
+func dashboardRootRepository(repo store.Repository) store.Repository {
+	for {
+		unwrapper, ok := repo.(storeWrapper)
+		if !ok {
+			return repo
+		}
+		repo = unwrapper.UnwrapStoreRepository()
+	}
+}
+
+func (s *dashboardLiveSessionNotifyingStore) UnwrapStoreRepository() store.Repository {
+	return s.Repository
+}
+
+func (s *dashboardLiveSessionNotifyingStore) notifyLiveSessions(reason string) {
+	if s.notify == nil {
+		return
+	}
+	s.notify(DashboardDomainLiveSessions, reason)
+}
+
+func (s *dashboardLiveSessionNotifyingStore) CreateLiveSession(accountID, strategyID string) (domain.LiveSession, error) {
+	session, err := s.Repository.CreateLiveSession(accountID, strategyID)
+	if err == nil {
+		s.notifyLiveSessions("live-session-created")
+	}
+	return session, err
+}
+
+func (s *dashboardLiveSessionNotifyingStore) UpdateLiveSession(session domain.LiveSession) (domain.LiveSession, error) {
+	updated, err := s.Repository.UpdateLiveSession(session)
+	if err == nil {
+		s.notifyLiveSessions("live-session-updated")
+	}
+	return updated, err
+}
+
+func (s *dashboardLiveSessionNotifyingStore) DeleteLiveSession(sessionID string) error {
+	err := s.Repository.DeleteLiveSession(sessionID)
+	if err == nil {
+		s.notifyLiveSessions("live-session-deleted")
+	}
+	return err
+}
+
+func (s *dashboardLiveSessionNotifyingStore) UpdateLiveSessionStatus(sessionID, status string) (domain.LiveSession, error) {
+	session, err := s.Repository.UpdateLiveSessionStatus(sessionID, status)
+	if err == nil {
+		s.notifyLiveSessions("live-session-status-updated")
+	}
+	return session, err
+}
+
+func (s *dashboardLiveSessionNotifyingStore) UpdateLiveSessionState(sessionID string, state map[string]any) (domain.LiveSession, error) {
+	session, err := s.Repository.UpdateLiveSessionState(sessionID, state)
+	if err == nil {
+		s.notifyLiveSessions("live-session-state-updated")
+	}
+	return session, err
+}
+
+func (s *dashboardLiveSessionNotifyingCASStore) UpdateLiveSessionStateIfControlRequest(sessionID, requestID string, version int64, state map[string]any) (domain.LiveSession, bool, error) {
+	session, ok, err := s.cas.UpdateLiveSessionStateIfControlRequest(sessionID, requestID, version, state)
+	if err == nil && ok {
+		s.notifyLiveSessions("live-session-control-state-updated")
+	}
+	return session, ok, err
+}

--- a/internal/service/live_dashboard_test.go
+++ b/internal/service/live_dashboard_test.go
@@ -1,0 +1,163 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/wuyaocheng/bktrader/internal/store"
+	"github.com/wuyaocheng/bktrader/internal/store/memory"
+)
+
+func TestLiveSessionStoreWritesNotifyDashboard(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+
+	session, err := platform.CreateLiveSession("", "live-main", "strategy-bk-1d", nil)
+	if err != nil {
+		t.Fatalf("CreateLiveSession failed: %v", err)
+	}
+	waitForDashboardChange(t, platform.DashboardBroker(), DashboardDomainLiveSessions, "live-session-created", 100*time.Millisecond)
+
+	session.Alias = "Primary live"
+	if _, err := platform.UpdateLiveSession(session.ID, session.Alias, "", "", nil); err != nil {
+		t.Fatalf("UpdateLiveSession failed: %v", err)
+	}
+	waitForDashboardChange(t, platform.DashboardBroker(), DashboardDomainLiveSessions, "live-session-updated", 100*time.Millisecond)
+
+	if _, err := platform.store.UpdateLiveSessionStatus(session.ID, "RUNNING"); err != nil {
+		t.Fatalf("UpdateLiveSessionStatus failed: %v", err)
+	}
+	waitForDashboardChange(t, platform.DashboardBroker(), DashboardDomainLiveSessions, "live-session-status-updated", 100*time.Millisecond)
+
+	state := cloneMetadata(session.State)
+	state["lastEvent"] = "test"
+	if _, err := platform.store.UpdateLiveSessionState(session.ID, state); err != nil {
+		t.Fatalf("UpdateLiveSessionState failed: %v", err)
+	}
+	change := waitDashboardChange(t, platform.DashboardBroker(), 100*time.Millisecond)
+	if change.Domain != DashboardDomainLiveSessions || change.Reason != "live-session-state-updated" {
+		t.Fatalf("unexpected state dashboard change: %+v", change)
+	}
+}
+
+func TestLiveSessionDeleteNotifyDashboardOnSuccessOnly(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	session, err := platform.CreateLiveSession("", "live-main", "strategy-bk-1d", nil)
+	if err != nil {
+		t.Fatalf("CreateLiveSession failed: %v", err)
+	}
+	drainDashboardChanges(platform.DashboardBroker())
+
+	if err := platform.store.DeleteLiveSession(session.ID); err != nil {
+		t.Fatalf("DeleteLiveSession failed: %v", err)
+	}
+	change := waitDashboardChange(t, platform.DashboardBroker(), 100*time.Millisecond)
+	if change.Domain != DashboardDomainLiveSessions || change.Reason != "live-session-deleted" {
+		t.Fatalf("unexpected delete dashboard change: %+v", change)
+	}
+
+	drainDashboardChanges(platform.DashboardBroker())
+	if err := platform.store.DeleteLiveSession("missing-live-session"); err == nil {
+		t.Fatal("expected missing live session delete to fail")
+	}
+	select {
+	case change := <-platform.DashboardBroker().changes:
+		t.Fatalf("unexpected dashboard change for failed delete: %+v", change)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestDashboardRootRepositoryUnwrapsStoreWrappers(t *testing.T) {
+	root := memory.NewStore()
+	wrapped := &testStoreWrapper{Repository: root}
+	if got := dashboardRootRepository(wrapped); got != root {
+		t.Fatalf("expected root repository unwrap, got %#v", got)
+	}
+}
+
+func TestLiveSessionControlCASNotifyDashboardOnlyWhenUpdated(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	session, err := platform.CreateLiveSession("", "live-main", "strategy-bk-1d", nil)
+	if err != nil {
+		t.Fatalf("CreateLiveSession failed: %v", err)
+	}
+	_ = waitDashboardChange(t, platform.DashboardBroker(), 100*time.Millisecond)
+
+	state := cloneMetadata(session.State)
+	state["controlRequestId"] = "request-1"
+	state["controlVersion"] = int64(3)
+	if _, err := platform.store.UpdateLiveSessionState(session.ID, state); err != nil {
+		t.Fatalf("UpdateLiveSessionState failed: %v", err)
+	}
+	_ = waitDashboardChange(t, platform.DashboardBroker(), 100*time.Millisecond)
+	drainDashboardChanges(platform.DashboardBroker())
+
+	staleState := cloneMetadata(state)
+	staleState["actualStatus"] = "STALE"
+	_, ok, err := platform.updateLiveSessionControlStateIfPrevious(session.ID, liveSessionControlRequest{
+		ID:      "request-older",
+		Version: 3,
+	}, staleState)
+	if err != nil {
+		t.Fatalf("stale control state update failed: %v", err)
+	}
+	if ok {
+		t.Fatal("expected stale control request update to be skipped")
+	}
+	select {
+	case change := <-platform.DashboardBroker().changes:
+		t.Fatalf("unexpected dashboard change for stale CAS: %+v", change)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	nextState := cloneMetadata(state)
+	nextState["actualStatus"] = "RUNNING"
+	_, ok, err = platform.updateLiveSessionControlStateIfPrevious(session.ID, liveSessionControlRequest{
+		ID:      "request-1",
+		Version: 3,
+	}, nextState)
+	if err != nil {
+		t.Fatalf("current control state update failed: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected current control request update to succeed")
+	}
+	change := waitDashboardChange(t, platform.DashboardBroker(), 100*time.Millisecond)
+	if change.Domain != DashboardDomainLiveSessions || change.Reason != "live-session-control-state-updated" {
+		t.Fatalf("unexpected control dashboard change: %+v", change)
+	}
+}
+
+type testStoreWrapper struct {
+	store.Repository
+}
+
+func (s *testStoreWrapper) UnwrapStoreRepository() store.Repository {
+	return s.Repository
+}
+
+func drainDashboardChanges(broker *DashboardBroker) {
+	for {
+		select {
+		case <-broker.changes:
+		default:
+			return
+		}
+	}
+}
+
+func waitForDashboardChange(t *testing.T, broker *DashboardBroker, domain DashboardDomain, reason string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.After(timeout)
+	seen := make([]dashboardChange, 0)
+	for {
+		select {
+		case change := <-broker.changes:
+			seen = append(seen, change)
+			if change.Domain == domain && change.Reason == reason {
+				return
+			}
+		case <-deadline:
+			t.Fatalf("timed out waiting for dashboard change domain=%s reason=%s, saw %+v", domain, reason, seen)
+		}
+	}
+}

--- a/internal/service/logs.go
+++ b/internal/service/logs.go
@@ -262,7 +262,7 @@ func (p *Platform) ListLogEvents(query UnifiedLogEventQuery) (UnifiedLogEventPag
 }
 
 func (p *Platform) queryStrategyDecisionEvents(query domain.StrategyDecisionEventQuery) ([]domain.StrategyDecisionEvent, error) {
-	if reader, ok := p.store.(strategyDecisionEventQueryReader); ok {
+	if reader, ok := dashboardRootRepository(p.store).(strategyDecisionEventQueryReader); ok {
 		return reader.QueryStrategyDecisionEvents(query)
 	}
 	items, err := p.store.ListStrategyDecisionEvents("")
@@ -315,7 +315,7 @@ func (p *Platform) queryStrategyDecisionEvents(query domain.StrategyDecisionEven
 }
 
 func (p *Platform) queryOrderExecutionEvents(query domain.OrderExecutionEventQuery) ([]domain.OrderExecutionEvent, error) {
-	if reader, ok := p.store.(orderExecutionEventQueryReader); ok {
+	if reader, ok := dashboardRootRepository(p.store).(orderExecutionEventQueryReader); ok {
 		return reader.QueryOrderExecutionEvents(query)
 	}
 	items, err := p.store.ListOrderExecutionEvents("")
@@ -360,7 +360,7 @@ func (p *Platform) queryOrderExecutionEvents(query domain.OrderExecutionEventQue
 }
 
 func (p *Platform) queryPositionAccountSnapshots(query domain.PositionAccountSnapshotQuery) ([]domain.PositionAccountSnapshot, error) {
-	if reader, ok := p.store.(positionAccountSnapshotQueryReader); ok {
+	if reader, ok := dashboardRootRepository(p.store).(positionAccountSnapshotQueryReader); ok {
 		return reader.QueryPositionAccountSnapshots(query)
 	}
 	items, err := p.store.ListPositionAccountSnapshots("")

--- a/internal/service/platform.go
+++ b/internal/service/platform.go
@@ -162,6 +162,7 @@ func NewPlatform(store store.Repository) *Platform {
 	platform.registerBuiltInSignalRuntimeAdapters()
 	platform.registerBuiltInExecutionStrategies()
 	platform.dashboardBroker = NewDashboardBroker(platform)
+	platform.store = newDashboardLiveSessionNotifyingStore(platform.store, platform.NotifyDashboardChanged)
 	platform.logger("service.platform").Info("platform initialized",
 		"strategy_engine_count", len(platform.strategyEngines),
 		"live_adapter_count", len(platform.liveAdapters),

--- a/internal/service/telemetry.go
+++ b/internal/service/telemetry.go
@@ -151,7 +151,7 @@ func (p *Platform) getStrategyDecisionEvent(liveSessionID, decisionEventID strin
 	if decisionEventID == "" {
 		return domain.StrategyDecisionEvent{}, false, nil
 	}
-	if reader, ok := p.store.(strategyDecisionEventQueryReader); ok {
+	if reader, ok := dashboardRootRepository(p.store).(strategyDecisionEventQueryReader); ok {
 		items, err := reader.QueryStrategyDecisionEvents(domain.StrategyDecisionEventQuery{
 			LiveSessionID:   strings.TrimSpace(liveSessionID),
 			DecisionEventID: decisionEventID,
@@ -352,7 +352,7 @@ func (p *Platform) strategyDecisionEventExists(liveSessionID, decisionEventID st
 	if decisionEventID == "" {
 		return false, nil
 	}
-	if reader, ok := p.store.(strategyDecisionEventQueryReader); ok {
+	if reader, ok := dashboardRootRepository(p.store).(strategyDecisionEventQueryReader); ok {
 		items, err := reader.QueryStrategyDecisionEvents(domain.StrategyDecisionEventQuery{
 			LiveSessionID:   strings.TrimSpace(liveSessionID),
 			DecisionEventID: decisionEventID,


### PR DESCRIPTION
## 目的
实现 #195 / PR-195-4 的最小版本：live session create / update / delete / status / state 写入成功后，主动通知 `DashboardDomainLiveSessions`，让 Dashboard SSE 及时刷新 live-sessions summary snapshot。

范围刻意收窄：
- 只触发 `live-sessions` snapshot。
- 仍然使用既有 `ListLiveSessionsSummary()` payload 边界。
- 不暴露 `sourceStates` / `signalBarStates`。
- 不改 dispatchMode、不改下单、不改 reconcile / recovery / auto-dispatch 判定。
- alerts / monitor-health 暂不接入，避免扩大状态机范围。

实现方式：在 service 层给 `Platform.store` 加一个很薄的 notifying wrapper，只覆盖 live session 写方法。成功写入后发 dashboard notification；失败路径不发通知。控制面 CAS 路径 `UpdateLiveSessionStateIfControlRequest` 保持原子语义，并且只有 CAS 成功时才通知。logs / telemetry 的 optional query reader 会 unwrap 到原始 store，避免 wrapper 隐藏已有查询能力。

Review follow-up:
- 补充 delete 成功通知、失败不通知测试。
- 将 wrapper unwrap 约定抽成通用 `storeWrapper` / `UnwrapStoreRepository()`，降低后续新增 optional store interface 时遗漏的概率。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [x] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) - 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？- 无
- [x] DB migration 是否具备向下兼容幂等性？- 不涉及
- [x] 配置字段有没有无意被混改？- 不涉及

## 交易语义变更
- [x] 本次改动是否新增/修改了 `signalKind`？若是，需同步更新 Golden Case - 否
- [x] 本次改动是否影响订单方向判断（`side` / `reduceOnly` / `closePosition`）？- 否
- [ ] 若涉及上述改动，`go test ./internal/domain/... -run TestClassifyOrderIntent` 是否通过？
- [ ] 若涉及交易链路语义（开仓/平仓/撤单/risk-exit），`go test ./internal/domain/... -run TestTradingReplayGoldenCases` 是否通过？

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

验证：
- `go test ./internal/service -run 'TestLiveSession.*Dashboard|TestLiveSessionControlCASNotifyDashboardOnlyWhenUpdated|TestDashboardRootRepositoryUnwrapsStoreWrappers'`
- `go test ./internal/service`
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
