### PR TITLE
fix: isolate ETH pretouch launch strategy

### DIFF
--- a/db/migrations/031_eth_pretouch_timing_strategy.sql
+++ b/db/migrations/031_eth_pretouch_timing_strategy.sql
@@ -99,8 +99,11 @@ set signal_timeframe = excluded.signal_timeframe,
     execution_timeframe = excluded.execution_timeframe,
     parameters = excluded.parameters;
 
+-- Restore BTC 30m bindings for strategy-bk-btc-30m-enhanced.
+-- Note: This hardcodes the expected bindings. If they were modified previously by another process, this will overwrite those changes.
 update strategy_versions
-set parameters = jsonb_set(
+set signal_timeframe = '30m',
+    parameters = jsonb_set(
     parameters || '{
         "strategyEngine": "bk-live-intrabar-sma5-t2-only-0p5bps",
         "symbol": "BTCUSDT",

--- a/db/migrations/031_eth_pretouch_timing_strategy.sql
+++ b/db/migrations/031_eth_pretouch_timing_strategy.sql
@@ -1,0 +1,200 @@
+insert into strategies (id, name, status, description, created_at)
+values (
+    'strategy-bk-eth-pretouch-timing',
+    'BK Live ETH Pretouch Timing',
+    'ACTIVE',
+    'ETHUSDT 1h live pretouch timing strategy with Go-native timing classifier and RF probability sizing.',
+    now()
+)
+on conflict (id) do update
+set name = excluded.name,
+    status = excluded.status,
+    description = excluded.description;
+
+insert into strategy_versions (
+    id,
+    strategy_id,
+    version,
+    signal_timeframe,
+    execution_timeframe,
+    parameters,
+    created_at
+)
+values (
+    'strategy-version-bk-eth-pretouch-timing-v010',
+    'strategy-bk-eth-pretouch-timing',
+    'v0.1.0',
+    '1h',
+    'tick',
+    '{
+        "strategyEngine": "bk-live-eth-pretouch-timing",
+        "symbol": "ETHUSDT",
+        "signalTimeframe": "1h",
+        "executionDataSource": "tick",
+        "positionSizingMode": "intent_quantity",
+        "defaultOrderQuantity": 0.100,
+        "pretouchBaseOrderQuantity": 0.100,
+        "pretouchBaseShare": 0.80,
+        "pretouchCostQ50Threshold": 0.116865,
+        "pretouchCostQ50Penalty": 0.50,
+        "pretouchSpeedThreshold": 0.228106,
+        "pretouchMaxPreTouchSec": 1800.0,
+        "pretouchMaxEff300s": 1.0,
+        "stop_loss_atr": 0.45,
+        "breakeven_at_r": 0.8,
+        "trail_start_r": 1.5,
+        "trail_buffer_atr": 0.05,
+        "max_hold_hours": 2.0,
+        "executionStrategy": "book-aware-v1",
+        "executionEntryOrderType": "MARKET",
+        "executionEntryMaxSpreadBps": 8,
+        "executionEntryMaxSlippageBps": 8,
+        "executionEntryMaxBookAgeMs": 500,
+        "executionEntryMinTopBookCoverage": 0.5,
+        "executionEntryMaxSourceDivergenceBps": 8,
+        "executionSLExitOrderType": "MARKET",
+        "executionSLExitMaxSpreadBps": 8,
+        "executionSLMaxSlippageBps": 8,
+        "dispatchCooldownSeconds": 30,
+        "signalBindings": [
+            {
+                "sourceKey": "binance-kline",
+                "sourceName": "Binance Futures Kline",
+                "exchange": "BINANCE",
+                "role": "signal",
+                "streamType": "signal_bar",
+                "symbol": "ETHUSDT",
+                "status": "ACTIVE",
+                "options": {"timeframe": "1h"},
+                "timeframe": "1h"
+            },
+            {
+                "sourceKey": "binance-trade-tick",
+                "sourceName": "Binance Futures Trade Tick",
+                "exchange": "BINANCE",
+                "role": "trigger",
+                "streamType": "trade_tick",
+                "symbol": "ETHUSDT",
+                "status": "ACTIVE",
+                "options": {},
+                "timeframe": ""
+            },
+            {
+                "sourceKey": "binance-order-book",
+                "sourceName": "Binance Futures Order Book",
+                "exchange": "BINANCE",
+                "role": "feature",
+                "streamType": "order_book",
+                "symbol": "ETHUSDT",
+                "status": "ACTIVE",
+                "options": {},
+                "timeframe": ""
+            }
+        ]
+    }'::jsonb,
+    now()
+)
+on conflict (id) do update
+set signal_timeframe = excluded.signal_timeframe,
+    execution_timeframe = excluded.execution_timeframe,
+    parameters = excluded.parameters;
+
+update strategy_versions
+set parameters = jsonb_set(
+    parameters || '{
+        "strategyEngine": "bk-live-intrabar-sma5-t2-only-0p5bps",
+        "symbol": "BTCUSDT",
+        "signalTimeframe": "30m"
+    }'::jsonb,
+    '{signalBindings}',
+    '[
+        {
+            "sourceKey": "binance-kline",
+            "sourceName": "Binance Futures Kline",
+            "exchange": "BINANCE",
+            "role": "signal",
+            "streamType": "signal_bar",
+            "symbol": "BTCUSDT",
+            "status": "ACTIVE",
+            "options": {"timeframe": "30m"},
+            "timeframe": "30m"
+        },
+        {
+            "sourceKey": "binance-trade-tick",
+            "sourceName": "Binance Futures Trade Tick",
+            "exchange": "BINANCE",
+            "role": "trigger",
+            "streamType": "trade_tick",
+            "symbol": "BTCUSDT",
+            "status": "ACTIVE",
+            "options": {},
+            "timeframe": ""
+        },
+        {
+            "sourceKey": "binance-order-book",
+            "sourceName": "Binance Futures Order Book",
+            "exchange": "BINANCE",
+            "role": "feature",
+            "streamType": "order_book",
+            "symbol": "BTCUSDT",
+            "status": "ACTIVE",
+            "options": {},
+            "timeframe": ""
+        }
+    ]'::jsonb,
+    true
+)
+where id = 'strategy-version-bk-btc-30m-enhanced-v010'
+  and strategy_id = 'strategy-bk-btc-30m-enhanced';
+
+update live_sessions
+set strategy_id = 'strategy-bk-eth-pretouch-timing',
+    state = state || '{
+        "strategyEngine": "bk-live-eth-pretouch-timing",
+        "strategyVersionId": "strategy-version-bk-eth-pretouch-timing-v010",
+        "symbol": "ETHUSDT",
+        "signalTimeframe": "1h",
+        "launchTemplateKey": "binance-testnet-eth-pretouch-timing",
+        "launchTemplateName": "Binance Testnet ETHUSDT Pretouch Timing",
+        "launchTemplateSymbol": "ETHUSDT",
+        "launchTemplateTimeframe": "1h"
+    }'::jsonb
+where state->>'launchTemplateKey' = 'binance-testnet-eth-pretouch-timing'
+  and strategy_id = 'strategy-bk-btc-30m-enhanced';
+
+update signal_runtime_sessions as s
+set strategy_id = 'strategy-bk-eth-pretouch-timing',
+    state = jsonb_set(
+        jsonb_set(
+            state || '{
+                "launchTemplateKey": "binance-testnet-eth-pretouch-timing",
+                "launchTemplateName": "Binance Testnet ETHUSDT Pretouch Timing",
+                "launchTemplateSymbol": "ETHUSDT",
+                "launchTemplateTimeframe": "1h"
+            }'::jsonb,
+            '{sourceStates}',
+            (
+                coalesce(s.state->'sourceStates', '{}'::jsonb)
+                - '|trigger|BTCUSDT'
+                - 'binance-kline|signal|BTCUSDT|30m'
+                - 'binance-trade-tick|trigger|BTCUSDT'
+                - 'binance-order-book|feature|BTCUSDT'
+            ),
+            true
+        ),
+        '{signalBarStates}',
+        (
+            coalesce(s.state->'signalBarStates', '{}'::jsonb)
+            - 'binance-kline|signal|BTCUSDT|30m'
+        ),
+        true
+    )
+where s.state->>'launchTemplateKey' = 'binance-testnet-eth-pretouch-timing'
+  and s.strategy_id = 'strategy-bk-btc-30m-enhanced'
+  and not exists (
+      select 1
+      from signal_runtime_sessions existing
+      where existing.account_id = s.account_id
+        and existing.strategy_id = 'strategy-bk-eth-pretouch-timing'
+        and existing.id <> s.id
+  );

--- a/internal/service/live_launch_templates.go
+++ b/internal/service/live_launch_templates.go
@@ -68,6 +68,16 @@ func (p *Platform) LiveLaunchTemplates() ([]LiveLaunchTemplate, error) {
 		t3EnhancedStrategyVersionID = versionID
 		hasT3EnhancedTemplate = true
 	}
+	pretouchStrategyID := ""
+	pretouchStrategyName := ""
+	pretouchStrategyVersionID := ""
+	hasPretouchTemplate := false
+	if id, name, versionID, _, err := p.resolveLiveTemplateStrategy(bkLiveEthPretouchTimingStrategyID); err == nil {
+		pretouchStrategyID = id
+		pretouchStrategyName = name
+		pretouchStrategyVersionID = versionID
+		hasPretouchTemplate = true
+	}
 
 	baseBinding := map[string]any{
 		"adapterKey":    "binance-futures",
@@ -248,13 +258,15 @@ func (p *Platform) LiveLaunchTemplates() ([]LiveLaunchTemplate, error) {
 		return item
 	}
 
-	pretouchTemplate := buildEthPretouchTimingTemplate(strategyID, strategyName, strategyVersionID)
-	templates := []LiveLaunchTemplate{
-		pretouchTemplate,
+	templates := []LiveLaunchTemplate{}
+	if hasPretouchTemplate {
+		templates = append(templates, buildEthPretouchTimingTemplate(pretouchStrategyID, pretouchStrategyName, pretouchStrategyVersionID))
+	}
+	templates = append(templates,
 		buildTemplate("BTCUSDT", "5m", 0.002, false),
 		buildTemplate("BTCUSDT", "15m", 0.002, true),
 		buildTemplate("BTCUSDT", "30m", 0.002, true),
-	}
+	)
 	if hasEnhancedTemplate {
 		templates = append(templates, buildLegacyEnhancedTemplate())
 	}

--- a/internal/service/live_launch_templates_test.go
+++ b/internal/service/live_launch_templates_test.go
@@ -48,6 +48,7 @@ func TestLiveLaunchTemplatesExposeBinanceTestnetVariants(t *testing.T) {
 		researchBaseline    bool
 		enhanced            bool
 		baselinePlusT3      bool
+		pretouch            bool
 		defaultTemplate     bool
 		defaultDispatchMode string
 	}{
@@ -61,7 +62,7 @@ func TestLiveLaunchTemplatesExposeBinanceTestnetVariants(t *testing.T) {
 		"binance-testnet-eth-5m":                            {symbol: "ETHUSDT", timeframe: "5m", quantity: 0.1},
 		"binance-testnet-eth-4h":                            {symbol: "ETHUSDT", timeframe: "4h", quantity: 0.1},
 		"binance-testnet-eth-1d":                            {symbol: "ETHUSDT", timeframe: "1d", quantity: 0.1},
-		"binance-testnet-eth-pretouch-timing":               {symbol: "ETHUSDT", timeframe: "1h", quantity: 0.1, defaultTemplate: true, defaultDispatchMode: "auto-dispatch"},
+		"binance-testnet-eth-pretouch-timing":               {symbol: "ETHUSDT", timeframe: "1h", quantity: 0.1, pretouch: true, defaultTemplate: true, defaultDispatchMode: "auto-dispatch"},
 	}
 
 	for idx, item := range templates {
@@ -78,6 +79,9 @@ func TestLiveLaunchTemplatesExposeBinanceTestnetVariants(t *testing.T) {
 			if want.baselinePlusT3 {
 				expectedStrategyID = "strategy-bk-btc-30m-enhanced-t3"
 			}
+		}
+		if want.pretouch {
+			expectedStrategyID = bkLiveEthPretouchTimingStrategyID
 		}
 		if item.StrategyID != expectedStrategyID {
 			t.Fatalf("expected %s, got %s", expectedStrategyID, item.StrategyID)
@@ -159,6 +163,9 @@ func TestLiveLaunchTemplatesExposeBinanceTestnetVariants(t *testing.T) {
 			t.Fatalf("expected defaultOrderQuantity=%v, got %v", want.quantity, got)
 		}
 		if item.Key == "binance-testnet-eth-pretouch-timing" {
+			if item.StrategyName != "BK Live ETH Pretouch Timing" {
+				t.Fatalf("expected pretouch template to use dedicated strategy name, got %s", item.StrategyName)
+			}
 			if got := stringValue(item.LaunchPayload.LiveSessionOverrides["positionSizingMode"]); got != "intent_quantity" {
 				t.Fatalf("expected pretouch template positionSizingMode=intent_quantity, got %s", got)
 			}

--- a/internal/service/signal_runtime_sessions.go
+++ b/internal/service/signal_runtime_sessions.go
@@ -392,7 +392,10 @@ func (p *Platform) startSignalRuntimeSession(parent context.Context, sessionID s
 	state["plan"] = plan
 	state["subscriptions"] = subscriptions
 	sourceStates := cloneMetadata(mapValue(state["sourceStates"]))
-	sourceStates = reconcileSignalRuntimeSourceStates(sourceStates, p.bootstrapSignalRuntimeSourceStates(subscriptions), subscriptions)
+	sourceStates, droppedKeys, addedKeys := reconcileSignalRuntimeSourceStates(sourceStates, p.bootstrapSignalRuntimeSourceStates(subscriptions), subscriptions)
+	if len(droppedKeys) > 0 || len(addedKeys) > 0 {
+		logger.Debug("reconciled signal runtime source states", "dropped", droppedKeys, "added", addedKeys)
+	}
 	state["sourceStates"] = sourceStates
 	state["signalBarStates"] = deriveSignalBarStates(sourceStates)
 	state["desiredStatus"] = "RUNNING"

--- a/internal/service/signal_runtime_sessions.go
+++ b/internal/service/signal_runtime_sessions.go
@@ -392,9 +392,7 @@ func (p *Platform) startSignalRuntimeSession(parent context.Context, sessionID s
 	state["plan"] = plan
 	state["subscriptions"] = subscriptions
 	sourceStates := cloneMetadata(mapValue(state["sourceStates"]))
-	if len(sourceStates) == 0 {
-		sourceStates = p.bootstrapSignalRuntimeSourceStates(subscriptions)
-	}
+	sourceStates = reconcileSignalRuntimeSourceStates(sourceStates, p.bootstrapSignalRuntimeSourceStates(subscriptions), subscriptions)
 	state["sourceStates"] = sourceStates
 	state["signalBarStates"] = deriveSignalBarStates(sourceStates)
 	state["desiredStatus"] = "RUNNING"

--- a/internal/service/signal_runtime_source_state_test.go
+++ b/internal/service/signal_runtime_source_state_test.go
@@ -40,12 +40,18 @@ func TestFilterSignalRuntimeSourceStatesBySubscriptionsDropsOutOfPlanEntries(t *
 			"symbol":     "ETHUSDT",
 			"streamType": "trade_tick",
 		},
+		"binance-order-book|feature|ETHUSDT": map[string]any{
+			"sourceKey":  "binance-order-book",
+			"role":       "feature",
+			"symbol":     "ETHUSDT",
+			"streamType": "order_book",
+		},
 		"|trigger|BTCUSDT": map[string]any{
 			"symbol": "BTCUSDT",
 		},
 	}
 
-	filtered := filterSignalRuntimeSourceStatesBySubscriptions(sourceStates, subscriptions)
+	filtered, _ := filterSignalRuntimeSourceStatesBySubscriptions(sourceStates, subscriptions)
 	if _, ok := filtered["|trigger|BTCUSDT"]; ok {
 		t.Fatalf("expected out-of-plan BTC source state to be pruned, got %#v", filtered)
 	}
@@ -54,5 +60,8 @@ func TestFilterSignalRuntimeSourceStatesBySubscriptionsDropsOutOfPlanEntries(t *
 	}
 	if _, ok := filtered["binance-trade-tick|trigger|ETHUSDT"]; !ok {
 		t.Fatalf("expected ETH trade tick source state to remain, got %#v", filtered)
+	}
+	if _, ok := filtered["binance-order-book|feature|ETHUSDT"]; !ok {
+		t.Fatalf("expected ETH order book source state to remain, got %#v", filtered)
 	}
 }

--- a/internal/service/signal_runtime_source_state_test.go
+++ b/internal/service/signal_runtime_source_state_test.go
@@ -1,0 +1,58 @@
+package service
+
+import "testing"
+
+func TestFilterSignalRuntimeSourceStatesBySubscriptionsDropsOutOfPlanEntries(t *testing.T) {
+	subscriptions := []map[string]any{
+		{
+			"sourceKey":  "binance-kline",
+			"role":       "signal",
+			"symbol":     "ETHUSDT",
+			"streamType": "signal_bar",
+			"options":    map[string]any{"timeframe": "1h"},
+		},
+		{
+			"sourceKey":  "binance-trade-tick",
+			"role":       "trigger",
+			"symbol":     "ETHUSDT",
+			"streamType": "trade_tick",
+			"options":    map[string]any{},
+		},
+		{
+			"sourceKey":  "binance-order-book",
+			"role":       "feature",
+			"symbol":     "ETHUSDT",
+			"streamType": "order_book",
+			"options":    map[string]any{},
+		},
+	}
+	sourceStates := map[string]any{
+		"binance-kline|signal|ETHUSDT|1h": map[string]any{
+			"sourceKey":  "binance-kline",
+			"role":       "signal",
+			"symbol":     "ETHUSDT",
+			"timeframe":  "1h",
+			"streamType": "signal_bar",
+		},
+		"binance-trade-tick|trigger|ETHUSDT": map[string]any{
+			"sourceKey":  "binance-trade-tick",
+			"role":       "trigger",
+			"symbol":     "ETHUSDT",
+			"streamType": "trade_tick",
+		},
+		"|trigger|BTCUSDT": map[string]any{
+			"symbol": "BTCUSDT",
+		},
+	}
+
+	filtered := filterSignalRuntimeSourceStatesBySubscriptions(sourceStates, subscriptions)
+	if _, ok := filtered["|trigger|BTCUSDT"]; ok {
+		t.Fatalf("expected out-of-plan BTC source state to be pruned, got %#v", filtered)
+	}
+	if _, ok := filtered["binance-kline|signal|ETHUSDT|1h"]; !ok {
+		t.Fatalf("expected ETH 1h kline source state to remain, got %#v", filtered)
+	}
+	if _, ok := filtered["binance-trade-tick|trigger|ETHUSDT"]; !ok {
+		t.Fatalf("expected ETH trade tick source state to remain, got %#v", filtered)
+	}
+}

--- a/internal/service/signal_runtime_ws.go
+++ b/internal/service/signal_runtime_ws.go
@@ -653,8 +653,10 @@ func (p *Platform) runExchangeWebsocketLoop(
 				state["lastEventAt"] = now.Format(time.RFC3339)
 				state["lastEventSummary"] = summary
 				state["signalEventCount"] = maxIntValue(state["signalEventCount"], 0) + 1
-				state["sourceStates"] = mergeSignalSourceState(state["sourceStates"], summary, now)
-				state["signalBarStates"] = deriveSignalBarStates(mapValue(state["sourceStates"]))
+				sourceStates := mergeSignalSourceState(state["sourceStates"], summary, now)
+				sourceStates = filterSignalRuntimeSourceStatesBySubscriptions(sourceStates, metadataList(state["subscriptions"]))
+				state["sourceStates"] = sourceStates
+				state["signalBarStates"] = deriveSignalBarStates(sourceStates)
 				updateRuntimeHealthSummary(state, summary, now)
 				appendSignalRuntimeTimeline(state, now, "market", firstNonEmpty(stringValue(summary["event"]), "message"), map[string]any{
 					"symbol":    stringValue(summary["symbol"]),
@@ -1116,6 +1118,56 @@ func mergeSignalSourceState(existing any, summary map[string]any, eventTime time
 		stateMap[key] = entry
 	}
 	return stateMap
+}
+
+func reconcileSignalRuntimeSourceStates(existing, bootstrap map[string]any, subscriptions []map[string]any) map[string]any {
+	out := filterSignalRuntimeSourceStatesBySubscriptions(existing, subscriptions)
+	if out == nil {
+		out = map[string]any{}
+	}
+	for key, value := range bootstrap {
+		if _, ok := out[key]; ok {
+			continue
+		}
+		out[key] = cloneMetadata(mapValue(value))
+		if out[key] == nil {
+			out[key] = value
+		}
+	}
+	return out
+}
+
+func filterSignalRuntimeSourceStatesBySubscriptions(sourceStates map[string]any, subscriptions []map[string]any) map[string]any {
+	if len(sourceStates) == 0 || len(subscriptions) == 0 {
+		return cloneMetadata(sourceStates)
+	}
+	allowed := make(map[string]struct{}, len(subscriptions))
+	for _, subscription := range subscriptions {
+		key := signalBindingMatchKey(
+			stringValue(subscription["sourceKey"]),
+			stringValue(subscription["role"]),
+			stringValue(subscription["symbol"]),
+			metadataValue(subscription["options"]),
+		)
+		if strings.Trim(key, "|") == "" {
+			continue
+		}
+		allowed[key] = struct{}{}
+	}
+	if len(allowed) == 0 {
+		return cloneMetadata(sourceStates)
+	}
+	out := make(map[string]any, len(sourceStates))
+	for key, value := range sourceStates {
+		if _, ok := allowed[key]; !ok {
+			continue
+		}
+		out[key] = cloneMetadata(mapValue(value))
+		if out[key] == nil {
+			out[key] = value
+		}
+	}
+	return out
 }
 
 func mergeSignalBarHistory(existing any, summary map[string]any, eventTime time.Time, limit int) []any {

--- a/internal/service/signal_runtime_ws.go
+++ b/internal/service/signal_runtime_ws.go
@@ -654,7 +654,7 @@ func (p *Platform) runExchangeWebsocketLoop(
 				state["lastEventSummary"] = summary
 				state["signalEventCount"] = maxIntValue(state["signalEventCount"], 0) + 1
 				sourceStates := mergeSignalSourceState(state["sourceStates"], summary, now)
-				sourceStates = filterSignalRuntimeSourceStatesBySubscriptions(sourceStates, metadataList(state["subscriptions"]))
+				sourceStates, _ = filterSignalRuntimeSourceStatesBySubscriptions(sourceStates, metadataList(state["subscriptions"]))
 				state["sourceStates"] = sourceStates
 				state["signalBarStates"] = deriveSignalBarStates(sourceStates)
 				updateRuntimeHealthSummary(state, summary, now)
@@ -1120,11 +1120,12 @@ func mergeSignalSourceState(existing any, summary map[string]any, eventTime time
 	return stateMap
 }
 
-func reconcileSignalRuntimeSourceStates(existing, bootstrap map[string]any, subscriptions []map[string]any) map[string]any {
-	out := filterSignalRuntimeSourceStatesBySubscriptions(existing, subscriptions)
+func reconcileSignalRuntimeSourceStates(existing, bootstrap map[string]any, subscriptions []map[string]any) (map[string]any, []string, []string) {
+	out, dropped := filterSignalRuntimeSourceStatesBySubscriptions(existing, subscriptions)
 	if out == nil {
 		out = map[string]any{}
 	}
+	added := make([]string, 0)
 	for key, value := range bootstrap {
 		if _, ok := out[key]; ok {
 			continue
@@ -1133,13 +1134,14 @@ func reconcileSignalRuntimeSourceStates(existing, bootstrap map[string]any, subs
 		if out[key] == nil {
 			out[key] = value
 		}
+		added = append(added, key)
 	}
-	return out
+	return out, dropped, added
 }
 
-func filterSignalRuntimeSourceStatesBySubscriptions(sourceStates map[string]any, subscriptions []map[string]any) map[string]any {
+func filterSignalRuntimeSourceStatesBySubscriptions(sourceStates map[string]any, subscriptions []map[string]any) (map[string]any, []string) {
 	if len(sourceStates) == 0 || len(subscriptions) == 0 {
-		return cloneMetadata(sourceStates)
+		return cloneMetadata(sourceStates), nil
 	}
 	allowed := make(map[string]struct{}, len(subscriptions))
 	for _, subscription := range subscriptions {
@@ -1155,11 +1157,13 @@ func filterSignalRuntimeSourceStatesBySubscriptions(sourceStates map[string]any,
 		allowed[key] = struct{}{}
 	}
 	if len(allowed) == 0 {
-		return cloneMetadata(sourceStates)
+		return cloneMetadata(sourceStates), nil
 	}
 	out := make(map[string]any, len(sourceStates))
+	dropped := make([]string, 0)
 	for key, value := range sourceStates {
 		if _, ok := allowed[key]; !ok {
+			dropped = append(dropped, key)
 			continue
 		}
 		out[key] = cloneMetadata(mapValue(value))
@@ -1167,7 +1171,7 @@ func filterSignalRuntimeSourceStatesBySubscriptions(sourceStates map[string]any,
 			out[key] = value
 		}
 	}
-	return out
+	return out, dropped
 }
 
 func mergeSignalBarHistory(existing any, summary map[string]any, eventTime time.Time, limit int) []any {

--- a/internal/service/strategy_engine_pretouch_timing.go
+++ b/internal/service/strategy_engine_pretouch_timing.go
@@ -8,8 +8,10 @@ import (
 )
 
 const (
-	bkLiveEthPretouchTimingEngineKey = "bk-live-eth-pretouch-timing"
-	defaultPretouchModelPath         = "data/pretouch_model.json"
+	bkLiveEthPretouchTimingEngineKey         = "bk-live-eth-pretouch-timing"
+	bkLiveEthPretouchTimingStrategyID        = "strategy-bk-eth-pretouch-timing"
+	bkLiveEthPretouchTimingStrategyVersionID = "strategy-version-bk-eth-pretouch-timing-v010"
+	defaultPretouchModelPath                 = "data/pretouch_model.json"
 )
 
 // bkLiveEthPretouchTimingEngine implements the ETH pretouch timing strategy.

--- a/internal/store/memory/store.go
+++ b/internal/store/memory/store.go
@@ -219,6 +219,91 @@ func NewStore() *Store {
 	store.strategies[t3EnhancedStrategy.ID] = t3EnhancedStrategy
 	store.strategyVersion[t3EnhancedVersion.ID] = t3EnhancedVersion
 
+	pretouchStrategy := domain.Strategy{
+		ID:          "strategy-bk-eth-pretouch-timing",
+		Name:        "BK Live ETH Pretouch Timing",
+		Status:      "ACTIVE",
+		Description: "ETHUSDT 1h live pretouch timing strategy with Go-native timing classifier and RF probability sizing.",
+		CreatedAt:   now,
+	}
+	pretouchBindings := []map[string]any{
+		{
+			"sourceKey":  "binance-kline",
+			"sourceName": "Binance Futures Kline",
+			"exchange":   "BINANCE",
+			"role":       "signal",
+			"streamType": "signal_bar",
+			"symbol":     "ETHUSDT",
+			"status":     "ACTIVE",
+			"options":    map[string]any{"timeframe": "1h"},
+			"timeframe":  "1h",
+		},
+		{
+			"sourceKey":  "binance-trade-tick",
+			"sourceName": "Binance Futures Trade Tick",
+			"exchange":   "BINANCE",
+			"role":       "trigger",
+			"streamType": "trade_tick",
+			"symbol":     "ETHUSDT",
+			"status":     "ACTIVE",
+			"options":    map[string]any{},
+			"timeframe":  "",
+		},
+		{
+			"sourceKey":  "binance-order-book",
+			"sourceName": "Binance Futures Order Book",
+			"exchange":   "BINANCE",
+			"role":       "feature",
+			"streamType": "order_book",
+			"symbol":     "ETHUSDT",
+			"status":     "ACTIVE",
+			"options":    map[string]any{},
+			"timeframe":  "",
+		},
+	}
+	pretouchVersion := domain.StrategyVersion{
+		ID:                 "strategy-version-bk-eth-pretouch-timing-v010",
+		StrategyID:         pretouchStrategy.ID,
+		Version:            "v0.1.0",
+		SignalTimeframe:    "1h",
+		ExecutionTimeframe: "tick",
+		Parameters: map[string]any{
+			"strategyEngine":                       "bk-live-eth-pretouch-timing",
+			"symbol":                               "ETHUSDT",
+			"signalTimeframe":                      "1h",
+			"executionDataSource":                  "tick",
+			"positionSizingMode":                   "intent_quantity",
+			"defaultOrderQuantity":                 0.100,
+			"pretouchBaseOrderQuantity":            0.100,
+			"pretouchBaseShare":                    0.80,
+			"pretouchCostQ50Threshold":             0.116865,
+			"pretouchCostQ50Penalty":               0.50,
+			"pretouchSpeedThreshold":               0.228106,
+			"pretouchMaxPreTouchSec":               1800.0,
+			"pretouchMaxEff300s":                   1.0,
+			"stop_loss_atr":                        0.45,
+			"breakeven_at_r":                       0.8,
+			"trail_start_r":                        1.5,
+			"trail_buffer_atr":                     0.05,
+			"max_hold_hours":                       2.0,
+			"executionStrategy":                    "book-aware-v1",
+			"executionEntryOrderType":              "MARKET",
+			"executionEntryMaxSpreadBps":           8,
+			"executionEntryMaxSlippageBps":         8,
+			"executionEntryMaxBookAgeMs":           500,
+			"executionEntryMinTopBookCoverage":     0.5,
+			"executionEntryMaxSourceDivergenceBps": 8,
+			"executionSLExitOrderType":             "MARKET",
+			"executionSLExitMaxSpreadBps":          8,
+			"executionSLMaxSlippageBps":            8,
+			"dispatchCooldownSeconds":              30,
+			"signalBindings":                       pretouchBindings,
+		},
+		CreatedAt: now,
+	}
+	store.strategies[pretouchStrategy.ID] = pretouchStrategy
+	store.strategyVersion[pretouchVersion.ID] = pretouchVersion
+
 	live := domain.Account{
 		ID:       "live-main",
 		Name:     "Live Main",

--- a/research/entry_redesign/scripts/timing_probability_unified/multi_timeframe_builder.py
+++ b/research/entry_redesign/scripts/timing_probability_unified/multi_timeframe_builder.py
@@ -1,0 +1,404 @@
+"""multi_timeframe_builder — 多时间框架 pretouch 事件生成器
+
+从 1s bar cache 重新构建 30min/4h 的 signal bar 和 pretouch 事件。
+
+流程：
+1. 从 1s bars resample 成目标时间框架 bars (30min / 4h)
+2. 计算 breakout level (prev_high_2 / prev_low_2)
+3. 检测 pretouch 事件 (touch_extension_atr, speed_300s_atr 等)
+4. 应用质量过滤 (touch_Nm, eff_300s <= 1.0)
+5. 输出 events CSV 供 pipeline 使用
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+PROJECT_ROOT = Path(__file__).resolve().parents[4]
+BARS_CACHE_DIR = (
+    PROJECT_ROOT
+    / "research"
+    / "probabilistic_v6_runs"
+    / "walkforward_delay60_original_t2_feature60_valbest"
+    / "bars_cache"
+)
+
+OUTPUT_DIR = PROJECT_ROOT / "research" / "entry_redesign" / "scripts" / "output" / "multi_timeframe"
+
+
+@dataclass
+class TimeframeConfig:
+    """时间框架配置"""
+    name: str              # "30min" / "1h" / "4h"
+    resample_rule: str     # "30min" / "1h" / "4h"
+    bar_seconds: int       # 1800 / 3600 / 14400
+    max_pre_touch_seconds: float  # 触发必须在 bar 开始后多少秒内
+    max_hold_hours: float  # 最大持仓时间
+    atr_lookback: int      # ATR 计算回看 bar 数
+    min_speed_300s_atr: float  # speed gate 阈值（会从 train set 重新计算 q10）
+
+
+# 预定义配置
+TIMEFRAME_CONFIGS = {
+    "30min": TimeframeConfig(
+        name="30min",
+        resample_rule="30min",
+        bar_seconds=1800,
+        max_pre_touch_seconds=900,   # 30min bar 的前 15 分钟
+        max_hold_hours=1.0,          # 缩短 hold
+        atr_lookback=14,
+        min_speed_300s_atr=0.0,      # 从 train set 重新计算
+    ),
+    "1h": TimeframeConfig(
+        name="1h",
+        resample_rule="1h",
+        bar_seconds=3600,
+        max_pre_touch_seconds=1800,  # 1h bar 的前 30 分钟
+        max_hold_hours=2.0,
+        atr_lookback=14,
+        min_speed_300s_atr=0.0,
+    ),
+    "4h": TimeframeConfig(
+        name="4h",
+        resample_rule="4h",
+        bar_seconds=14400,
+        max_pre_touch_seconds=7200,  # 4h bar 的前 2 小时
+        max_hold_hours=8.0,          # 扩大 hold
+        atr_lookback=14,
+        min_speed_300s_atr=0.0,
+    ),
+}
+
+
+def load_all_1s_bars(symbol: str) -> pd.DataFrame:
+    """加载指定 symbol 的所有月份 1s bar 数据并合并。"""
+    pattern = f"{symbol}_*_flow_1s.pkl"
+    files = sorted(BARS_CACHE_DIR.glob(pattern))
+    if not files:
+        raise FileNotFoundError(f"No 1s bar files found for {symbol} in {BARS_CACHE_DIR}")
+
+    dfs = []
+    for f in files:
+        df = pd.read_pickle(f)
+        dfs.append(df)
+        logger.info("Loaded %s: %d bars", f.name, len(df))
+
+    combined = pd.concat(dfs).sort_index()
+    combined = combined[~combined.index.duplicated(keep='first')]
+    logger.info("Combined %s: %d bars, %s to %s", symbol, len(combined),
+                combined.index.min(), combined.index.max())
+    return combined
+
+
+def resample_to_timeframe(bars_1s: pd.DataFrame, rule: str) -> pd.DataFrame:
+    """将 1s bars resample 到目标时间框架。"""
+    resampled = bars_1s.resample(rule).agg({
+        "open": "first",
+        "high": "max",
+        "low": "min",
+        "close": "last",
+        "volume": "sum",
+    }).dropna(subset=["open"])
+    logger.info("Resampled to %s: %d bars", rule, len(resampled))
+    return resampled
+
+
+def compute_atr(bars: pd.DataFrame, lookback: int = 14) -> pd.Series:
+    """计算 ATR（简单 range 均值）。"""
+    ranges = bars["high"] - bars["low"]
+    return ranges.rolling(lookback, min_periods=1).mean()
+
+
+def detect_pretouch_events(
+    bars_tf: pd.DataFrame,
+    bars_1s: pd.DataFrame,
+    config: TimeframeConfig,
+    symbol: str,
+) -> pd.DataFrame:
+    """检测指定时间框架下的 pretouch 事件（向量化优化版）。
+
+    优化策略：
+    1. 预先将 1s bars 的 index 转为 numpy int64 数组
+    2. 用 np.searchsorted 做 O(log N) 的时间范围查找
+    3. 批量处理所有 signal bars
+    """
+    atr_series = compute_atr(bars_tf, config.atr_lookback)
+    events = []
+
+    bar_times = bars_tf.index.tolist()
+    n_bars = len(bar_times)
+
+    if n_bars < 3:
+        return pd.DataFrame()
+
+    # 预处理：将 1s bars index 转为 int64 纳秒数组用于 searchsorted
+    bars_1s_times = bars_1s.index.astype(np.int64)
+    bars_1s_high = bars_1s["high"].values
+    bars_1s_low = bars_1s["low"].values
+    bars_1s_close = bars_1s["close"].values
+    bars_1s_open = bars_1s["open"].values
+
+    bar_seconds_td = pd.Timedelta(seconds=config.bar_seconds)
+    speed_window_td = pd.Timedelta(seconds=300)
+
+    processed = 0
+    for i in range(2, n_bars):
+        signal_bar_start = bar_times[i]
+        signal_bar_end = signal_bar_start + bar_seconds_td
+
+        # prev bars
+        prev_bar_1_high = bars_tf.iloc[i - 1]["high"]
+        prev_bar_1_low = bars_tf.iloc[i - 1]["low"]
+        prev_bar_1_open = bars_tf.iloc[i - 1]["open"]
+        prev_bar_1_close = bars_tf.iloc[i - 1]["close"]
+
+        prev_bar_2_high = bars_tf.iloc[i - 2]["high"]
+        prev_bar_2_low = bars_tf.iloc[i - 2]["low"]
+
+        # Breakout levels
+        long_level = prev_bar_2_high
+        short_level = prev_bar_2_low
+
+        atr = atr_series.iloc[i]
+        if atr <= 0 or np.isnan(atr):
+            continue
+
+        # 用 searchsorted 快速定位 signal bar 内的 1s bars 范围
+        start_ns = signal_bar_start.value
+        end_ns = signal_bar_end.value
+        idx_start = np.searchsorted(bars_1s_times, start_ns, side='left')
+        idx_end = np.searchsorted(bars_1s_times, end_ns, side='left')
+
+        if idx_start >= idx_end:
+            continue
+
+        # 取 signal bar 内的 1s 数据切片
+        sig_high = bars_1s_high[idx_start:idx_end]
+        sig_low = bars_1s_low[idx_start:idx_end]
+        sig_close = bars_1s_close[idx_start:idx_end]
+
+        # Long touch: first 1s bar where high >= long_level
+        if prev_bar_1_high < long_level:
+            long_touch_indices = np.where(sig_high >= long_level)[0]
+            if len(long_touch_indices) > 0:
+                touch_local_idx = long_touch_indices[0]
+                touch_abs_idx = idx_start + touch_local_idx
+                touch_time = bars_1s.index[touch_abs_idx]
+                touch_price = float(sig_high[touch_local_idx])
+
+                event = _build_event_fast(
+                    symbol=symbol, side="long",
+                    touch_time=touch_time, touch_price=touch_price,
+                    level=long_level, atr=atr,
+                    signal_bar_start=signal_bar_start,
+                    prev_bar_1_open=prev_bar_1_open, prev_bar_1_high=prev_bar_1_high,
+                    prev_bar_1_low=prev_bar_1_low, prev_bar_1_close=prev_bar_1_close,
+                    bars_1s_times=bars_1s_times, bars_1s_high=bars_1s_high,
+                    bars_1s_low=bars_1s_low, bars_1s_close=bars_1s_close,
+                    bars_1s_open=bars_1s_open, bars_1s_index=bars_1s.index,
+                    config=config,
+                )
+                if event is not None:
+                    events.append(event)
+
+        # Short touch: first 1s bar where low <= short_level
+        if prev_bar_1_low > short_level:
+            short_touch_indices = np.where(sig_low <= short_level)[0]
+            if len(short_touch_indices) > 0:
+                touch_local_idx = short_touch_indices[0]
+                touch_abs_idx = idx_start + touch_local_idx
+                touch_time = bars_1s.index[touch_abs_idx]
+                touch_price = float(sig_low[touch_local_idx])
+
+                event = _build_event_fast(
+                    symbol=symbol, side="short",
+                    touch_time=touch_time, touch_price=touch_price,
+                    level=short_level, atr=atr,
+                    signal_bar_start=signal_bar_start,
+                    prev_bar_1_open=prev_bar_1_open, prev_bar_1_high=prev_bar_1_high,
+                    prev_bar_1_low=prev_bar_1_low, prev_bar_1_close=prev_bar_1_close,
+                    bars_1s_times=bars_1s_times, bars_1s_high=bars_1s_high,
+                    bars_1s_low=bars_1s_low, bars_1s_close=bars_1s_close,
+                    bars_1s_open=bars_1s_open, bars_1s_index=bars_1s.index,
+                    config=config,
+                )
+                if event is not None:
+                    events.append(event)
+
+        processed += 1
+        if processed % 1000 == 0:
+            logger.info("  Processed %d/%d bars, %d events so far", processed, n_bars - 2, len(events))
+
+    if not events:
+        return pd.DataFrame()
+
+    df = pd.DataFrame(events)
+    logger.info("Detected %d raw pretouch events for %s %s", len(df), symbol, config.name)
+    return df
+
+
+def _build_event_fast(
+    symbol: str, side: str,
+    touch_time: pd.Timestamp, touch_price: float,
+    level: float, atr: float,
+    signal_bar_start: pd.Timestamp,
+    prev_bar_1_open: float, prev_bar_1_high: float,
+    prev_bar_1_low: float, prev_bar_1_close: float,
+    bars_1s_times: np.ndarray, bars_1s_high: np.ndarray,
+    bars_1s_low: np.ndarray, bars_1s_close: np.ndarray,
+    bars_1s_open: np.ndarray, bars_1s_index,
+    config: TimeframeConfig,
+) -> dict | None:
+    """构建单个事件（向量化版本，避免 DataFrame 操作）。"""
+
+    pre_touch_seconds = (touch_time - signal_bar_start).total_seconds()
+    if pre_touch_seconds > config.max_pre_touch_seconds:
+        return None
+
+    # touch_extension_atr
+    if side == "long":
+        touch_ext_atr = (touch_price - level) / atr
+    else:
+        touch_ext_atr = (level - touch_price) / atr
+
+    # speed_300s: 用 searchsorted 找 300s 窗口
+    window_start_ns = (touch_time - pd.Timedelta(seconds=300)).value
+    touch_ns = touch_time.value
+    ws_idx = np.searchsorted(bars_1s_times, window_start_ns, side='left')
+    we_idx = np.searchsorted(bars_1s_times, touch_ns, side='right')
+
+    if we_idx - ws_idx < 10:
+        return None
+
+    speed_close = bars_1s_close[ws_idx:we_idx]
+    speed_high = bars_1s_high[ws_idx:we_idx]
+    speed_low = bars_1s_low[ws_idx:we_idx]
+
+    first_price = float(speed_close[0])
+    last_price = float(speed_close[-1])
+    speed_300s_atr = (last_price - first_price) / atr
+
+    # eff_300s
+    high_300 = float(speed_high.max())
+    low_300 = float(speed_low.min())
+    total_range = high_300 - low_300
+    net_move = abs(last_price - first_price)
+    eff_300s = net_move / total_range if total_range > 0 else 0.0
+
+    if eff_300s > 1.0:
+        return None
+
+    # roundtrip_cost_atr (simplified)
+    roundtrip_cost_atr = 0.10  # placeholder
+
+    # prev1 features
+    prev1_range = prev_bar_1_high - prev_bar_1_low
+    prev1_body_atr = abs(prev_bar_1_close - prev_bar_1_open) / atr
+    prev1_range_atr = prev1_range / atr
+    prev1_close_pos = (prev_bar_1_close - prev_bar_1_low) / prev1_range if prev1_range > 0 else 0.5
+    if side == "short":
+        prev1_close_pos = 1.0 - prev1_close_pos
+
+    # signal_open
+    sig_start_idx = np.searchsorted(bars_1s_times, signal_bar_start.value, side='left')
+    signal_open = float(bars_1s_open[sig_start_idx]) if sig_start_idx < len(bars_1s_open) else touch_price
+    level_to_signal_open_atr = (level - signal_open) / atr
+
+    event_id = f"{symbol}_{config.name}_{touch_time.strftime('%Y%m%d_%H%M%S')}_{side}"
+
+    return {
+        "event_id": event_id,
+        "symbol": symbol,
+        "side": side,
+        "touch_time": touch_time,
+        "touch_price": touch_price,
+        "level": level,
+        "atr": atr,
+        "touch_extension_atr": touch_ext_atr,
+        "speed_300s_atr": speed_300s_atr,
+        "eff_300s": eff_300s,
+        "pre_touch_seconds": pre_touch_seconds,
+        "roundtrip_cost_atr": roundtrip_cost_atr,
+        "signal_start": signal_bar_start,
+        "signal_end": signal_bar_start + pd.Timedelta(seconds=config.bar_seconds),
+        "signal_open": signal_open,
+        "signal_high": 0.0,
+        "signal_low": 0.0,
+        "signal_close": 0.0,
+        "prev1_body_atr": prev1_body_atr,
+        "prev1_range_atr": prev1_range_atr,
+        "prev1_close_pos_side": prev1_close_pos,
+        "level_to_signal_open_atr": level_to_signal_open_atr,
+        "timeframe": config.name,
+        "max_hold_hours": config.max_hold_hours,
+    }
+
+
+def build_multi_timeframe_events(
+    symbol: str = "ETHUSDT",
+    timeframes: list[str] | None = None,
+) -> dict[str, pd.DataFrame]:
+    """为指定 symbol 构建多时间框架的 pretouch 事件池。
+
+    Returns
+    -------
+    dict[str, pd.DataFrame]
+        key 为时间框架名称，value 为事件 DataFrame。
+    """
+    if timeframes is None:
+        timeframes = ["30min", "1h", "4h"]
+
+    # Load all 1s bars
+    bars_1s = load_all_1s_bars(symbol)
+
+    results = {}
+    for tf_name in timeframes:
+        config = TIMEFRAME_CONFIGS[tf_name]
+        logger.info("=" * 60)
+        logger.info("Building %s events for %s", tf_name, symbol)
+        logger.info("=" * 60)
+
+        # Resample to target timeframe
+        bars_tf = resample_to_timeframe(bars_1s, config.resample_rule)
+
+        # Detect pretouch events
+        events = detect_pretouch_events(bars_tf, bars_1s, config, symbol)
+
+        if events.empty:
+            logger.warning("No events detected for %s %s", symbol, tf_name)
+            results[tf_name] = events
+            continue
+
+        # Save to CSV
+        OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+        out_path = OUTPUT_DIR / f"pretouch_events_{symbol}_{tf_name}.csv"
+        events.to_csv(out_path, index=False)
+        logger.info("Saved %d events to %s", len(events), out_path)
+
+        results[tf_name] = events
+
+    return results
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(name)s: %(message)s")
+
+    results = build_multi_timeframe_events(symbol="ETHUSDT", timeframes=["30min", "1h", "4h"])
+
+    print("\n" + "=" * 60)
+    print("Multi-Timeframe Event Summary")
+    print("=" * 60)
+    for tf, df in results.items():
+        if df.empty:
+            print(f"  {tf}: 0 events")
+        else:
+            print(f"  {tf}: {len(df)} events, {df['touch_time'].min()} to {df['touch_time'].max()}")
+            print(f"       long={len(df[df['side']=='long'])}, short={len(df[df['side']=='short'])}")
+            print(f"       speed_300s_atr: mean={df['speed_300s_atr'].abs().mean():.4f}, min={df['speed_300s_atr'].abs().min():.4f}")


### PR DESCRIPTION
## 目的
修复生产从快捷模板拉起 `ETHUSDT 1h pretouch timing` 后，live session 仍显示 `BK BTCUSDT 30m T2-only 0.5bps · v0.1.0`、策略信号源里残留 BTC 的问题。

`bktrader-ctl --json` 只读核查结果：当前 running session 的 `state.symbol=ETHUSDT`、`state.signalTimeframe=1h`、`state.strategyEngine=bk-live-eth-pretouch-timing`，但 `strategyId=strategy-bk-btc-30m-enhanced`；对应 signal runtime 订阅了 ETH 三源，同时 `sourceStates` 里残留 `|trigger|BTCUSDT`。根因是 pretouch 快捷模板复用了 BTC T2 strategy id，launch 的独占绑定替换把 BTC T2 strategy 当前版本的 `signalBindings` 改成 ETH。

本 PR：
- 新增独立 `strategy-bk-eth-pretouch-timing` / `strategy-version-bk-eth-pretouch-timing-v010`，快捷模板只指向这个 strategy。
- 新增迁移 `031_eth_pretouch_timing_strategy.sql`：创建 pretouch strategy/version，恢复 `strategy-bk-btc-30m-enhanced` 的 BTC 30m bindings，并把已经由 pretouch 模板误挂在 BTC strategy 下的 live/runtime session 定向迁到新 strategy id。
- runtime 启动与消息合并时按当前 subscriptions 裁剪 `sourceStates`，防止不在 plan 里的 BTC 残留继续污染展示/诊断。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [x] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

风险说明：涉及 DB migration、live/runtime session strategy identity 修正、signal runtime source state 过滤；不改变下单 side/reduceOnly/closePosition 语义，不改 `dispatchMode` 默认值，不引入 mainnet 硬编码。

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) — 无变化。
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？— 无。
- [x] DB migration 是否具备向下兼容幂等性？— 使用 fixed id + `on conflict`，并定向匹配 pretouch launch template。
- [x] 配置字段有没有无意被混改？— 迁移仅恢复 BTC T2 bindings、创建 ETH pretouch strategy、迁移 pretouch template session/runtime identity。

## 交易语义变更
- [ ] 本次改动是否新增/修改了 `signalKind`？若是，需同步更新 Golden Case
- [ ] 本次改动是否影响订单方向判断（`side` / `reduceOnly` / `closePosition`）？
- [ ] 若涉及上述改动，`go test ./internal/domain/... -run TestClassifyOrderIntent` 是否通过？
- [ ] 若涉及交易链路语义（开仓/平仓/撤单/risk-exit），`go test ./internal/domain/... -run TestTradingReplayGoldenCases` 是否通过？

本 PR 不修改 signalKind、订单方向、reduceOnly、closePosition。

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

本地验证：
- `go test ./internal/service -run 'TestLiveLaunchTemplates|TestLaunchLiveFlowEnhanced|TestFilterSignalRuntimeSourceStates|TestBindStrategySignalSourceCanonicalizesHourly|TestSignalSourceCatalogAdvertisesHourly|TestPretouch' -count=1`\n- `go test ./internal/store/memory -count=1`\n- `go test ./internal/store/postgres -run 'Test' -count=1`\n- `go test ./...`\n- `go build ./cmd/platform-api`\n- `go build ./cmd/db-migrate`\n- `scripts/check_migration_safety.py db/migrations/031_eth_pretouch_timing_strategy.sql`：只报历史 migration 编号重复 advisory，非本 PR 新增编号。\n\n生产只读预检：\n- `bktrader-ctl position list --json`：当前无 active position。\n- `bktrader-ctl order list --json` 过滤 open/pending：当前无 open order。