### PR TITLE
fix(live): cache 1h signal bars in market snapshot for engine bootstrap

### DIFF
--- a/internal/service/live_market_data.go
+++ b/internal/service/live_market_data.go
@@ -140,6 +140,10 @@ func (p *Platform) refreshLiveMarketSnapshot(symbol string) error {
 	if err != nil {
 		return err
 	}
+	signal1H, err := p.syncStoredSignalBars(normalizedSymbol, "1h", fastSignalStart, end)
+	if err != nil {
+		return err
+	}
 	signal1D, err := p.syncStoredSignalBars(normalizedSymbol, "1d", signalStart, end)
 	if err != nil {
 		return err
@@ -156,6 +160,7 @@ func (p *Platform) refreshLiveMarketSnapshot(symbol string) error {
 			"5m":  signal5M,
 			"15m": signal15M,
 			"30m": signal30M,
+			"1h":  signal1H,
 			"1d":  signal1D,
 			"4h":  signal4H,
 		},
@@ -167,6 +172,7 @@ func (p *Platform) refreshLiveMarketSnapshot(symbol string) error {
 		"signal_5m_bar_count", len(signal5M),
 		"signal_15m_bar_count", len(signal15M),
 		"signal_30m_bar_count", len(signal30M),
+		"signal_1h_bar_count", len(signal1H),
 		"signal_1d_bar_count", len(signal1D),
 		"signal_4h_bar_count", len(signal4H),
 	)


### PR DESCRIPTION
## Description
Fixes a critical issue where the strategy engine fails to bootstrap for 1h strategies because 1h signal bars were not pre-warmed in the live market snapshot.

### Changes
- Added `1h` timeframe to the list of signal bars synced during `refreshLiveMarketSnapshot` in `live_market_data.go`.

### Context
This resolves the production issue where the `live-session` was stuck and failing with:
`not enough 1h signal bars from market source for ETHUSDT`
This occurred because PR #417 introduced 1h support but missed adding the cache warming for it.