### PR TITLE
fix(live): skip batch replay for pretouch timing engine during live session bootstrap

### DIFF
--- a/internal/service/live_market_data.go
+++ b/internal/service/live_market_data.go
@@ -565,6 +565,10 @@ func (p *Platform) buildLiveExecutionPlanFromMarketData(
 	switch normalized := normalizeStrategyEngineKey(engineKey); normalized {
 	case "bk-default", bkLiveIntrabarSMA5T2Only0p5BpsEngineKey, bkLiveIntrabarSMA5BaselinePlusT3EnhancedEngineKey:
 		result, err = runStrategyReplayOnMinuteBars(cfg, signals, minuteBars)
+	case bkLiveEthPretouchTimingEngineKey:
+		// Pretouch timing engine is a live-only engine and computes state dynamically in EvaluateSignal.
+		// It does not use or support offline batch replay for plan generation.
+		return nil, nil
 	default:
 		result, err = engine.Run(context)
 	}


### PR DESCRIPTION
## Description
Fixes a critical issue where the live session fails to initialize with the error:
`Error: pretouch timing engine does not support batch replay; use EvaluateSignal for live`

### Changes
- Updated `buildLiveExecutionPlanFromMarketData` in `internal/service/live_market_data.go` to explicitly return `nil, nil` when the strategy engine is `bk-live-eth-pretouch-timing`.

### Context
This engine is a pure real-time streaming engine (Live-only). It evaluates ticks on-the-fly and makes decisions dynamically, without producing a static `paperPlannedOrder` queue during offline replay. The live session bootstrap sequence previously forced it into a batch replay which caused an error.