### PR TITLE
fix(live): prevent dynamic intent engine from entering plan-exhausted loop

### DIFF
--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -3740,6 +3740,9 @@ func (p *Platform) evaluateLiveSessionOnSignal(session domain.LiveSession, runti
 	var nextPlannedSide string
 	var nextPlannedRole string
 	var nextPlannedReason string
+	engineKey := stringValue(state["strategyEngine"])
+	isDynamicIntentEngine := engineKey == bkLiveEthPretouchTimingEngineKey
+
 	if index >= 0 && index < len(plan) {
 		step := plan[index]
 		nextPlannedEvent = step.EventTime
@@ -3752,6 +3755,12 @@ func (p *Platform) evaluateLiveSessionOnSignal(session domain.LiveSession, runti
 		state["lastStrategyEvaluationNextPlannedSide"] = nextPlannedSide
 		state["lastStrategyEvaluationNextPlannedRole"] = nextPlannedRole
 		state["lastStrategyEvaluationNextPlannedReason"] = nextPlannedReason
+	} else if isDynamicIntentEngine {
+		state["lastStrategyEvaluationNextPlannedEventAt"] = ""
+		state["lastStrategyEvaluationNextPlannedPrice"] = float64(0)
+		state["lastStrategyEvaluationNextPlannedSide"] = ""
+		state["lastStrategyEvaluationNextPlannedRole"] = ""
+		state["lastStrategyEvaluationNextPlannedReason"] = "dynamic-intent"
 	} else {
 		state["lastStrategyEvaluationStatus"] = "plan-exhausted"
 		delete(state, "lastStrategyIntent")


### PR DESCRIPTION
## Description
Fixes an issue where the live session gets trapped in a `plan-exhausted` / `plan-rollover-scheduled` loop.

### Changes
- Updated the evaluation logic in `internal/service/live.go` to add an explicit bypass for `bkLiveEthPretouchTimingEngineKey`.
- For this dynamic intent-based engine, the execution context now receives empty planned event properties instead of defaulting into the `plan-exhausted` termination path.

### Context
Since PR #425 safely skipped the generation of the static batch replay queue (returning `planLength == 0`), the signal evaluation loop at runtime incorrectly saw `index >= planLength (0 >= 0)` and triggered a `plan-exhausted` cycle on every tick. This fix allows the dynamic intent engine to continue processing real-time signals.