### PR TITLE
[codex] Fix live CD signal runtime routing

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -70,6 +70,7 @@ jobs:
           add_live_services() {
             add_service platform-api
             add_service live-runner
+            add_service signal-runtime-runner
           }
 
           add_signal_runtime_services() {
@@ -133,13 +134,13 @@ jobs:
             esac
 
             case "$file" in
-              cmd/platform-api/*|cmd/platform-worker/*|internal/*|db/*|deployments/*|scripts/deploy.sh|Dockerfile|.dockerignore)
+              cmd/platform-api/*|cmd/platform-worker/*|internal/*|db/*|deployments/*|scripts/deploy.sh|Dockerfile|.dockerignore|.github/workflows/cd.yml)
                 backend_changed=true
                 ;;
             esac
 
             case "$file" in
-              Dockerfile|.dockerignore|deployments/docker-compose.prod.yml|scripts/deploy.sh|internal/app/*|internal/config/*|internal/store/*|internal/domain/*|db/*)
+              Dockerfile|.dockerignore|.github/workflows/cd.yml|deployments/docker-compose.prod.yml|scripts/deploy.sh|internal/app/*|internal/config/*|internal/store/*|internal/domain/*|db/*)
                 add_all_backend_services
                 ;;
             esac

--- a/docs/cd-service-routing.md
+++ b/docs/cd-service-routing.md
@@ -17,7 +17,7 @@
 
 1. 共享基础设施变化才全量重启。
 2. API 查询、摘要、dashboard 相关变化只重启 `platform-api`。
-3. live 执行相关变化重启 `platform-api` 和 `live-runner`。
+3. live 执行和策略评价相关变化重启 `platform-api`、`live-runner` 和 `signal-runtime-runner`，因为 signal runtime 进程也可能直接触发 live session 评价。
 4. signal runtime 相关变化重启 `platform-api` 和 `signal-runtime-runner`。
 5. Telegram/通知相关变化只额外重启 `notification-worker`。
 6. 未明确归类但属于后端的文件仍走全量 fallback，避免漏部署。
@@ -26,12 +26,12 @@
 
 | 文件范围 | 部署服务 |
 | --- | --- |
-| `Dockerfile`, `.dockerignore`, `deployments/docker-compose.prod.yml`, `scripts/deploy.sh` | 全部后端服务 |
+| `Dockerfile`, `.dockerignore`, `.github/workflows/cd.yml`, `deployments/docker-compose.prod.yml`, `scripts/deploy.sh` | 全部后端服务 |
 | `internal/app/**`, `internal/config/**`, `internal/store/**`, `internal/domain/**`, `db/**` | 全部后端服务 |
 | `cmd/platform-api/**`, `internal/http/**` | `platform-api` |
 | `cmd/platform-worker/**` | `live-runner`, `signal-runtime-runner`, `notification-worker` |
 | `internal/service/state_util*`, `logs.go`, `dashboard_broker*`, `chart*`, `paper*`, `pnl*`, `strategy_replay*` | `platform-api` |
-| `internal/service/live*`, `order*`, `execution_strategy.go`, `precision_tolerance.go`, `strategy_registry.go`, `live_account_flow.go`, `live_launch*`, `live_trade*`, `telemetry*` | `platform-api`, `live-runner` |
+| `internal/service/live*`, `order*`, `execution_strategy.go`, `precision_tolerance.go`, `strategy_registry.go`, `live_account_flow.go`, `live_launch*`, `live_trade*`, `telemetry*` | `platform-api`, `live-runner`, `signal-runtime-runner` |
 | `internal/service/live_market_data.go`, `signal_runtime*`, `runtime_lease*` | `platform-api`, `signal-runtime-runner` |
 | `internal/service/runtime_event_consumer*` | `live-runner`, `signal-runtime-runner` |
 | `internal/service/runtime_event_bus*` | `live-runner`, `signal-runtime-runner` |
@@ -47,10 +47,10 @@
 platform-api
 ```
 
-`internal/service/live.go` 同时影响 HTTP live 控制入口和 live runner 后台恢复/同步，因此部署：
+`internal/service/live.go` 同时影响 HTTP live 控制入口、live runner 后台恢复/同步，以及 signal runtime 触发 live session 评价的路径，因此部署：
 
 ```text
-platform-api live-runner
+platform-api live-runner signal-runtime-runner
 ```
 
 `internal/service/telegram.go` 影响通知查询和 Telegram dispatcher，因此部署：


### PR DESCRIPTION
## 目的
修复 CD selective deploy 路由漏部署 `signal-runtime-runner` 的问题。#426 合并后 `platform-api` 和 `live-runner` 已部署，但生产上 `signal-runtime-runner` 仍跑旧镜像，导致 ETH pretouch timing live session 继续写旧的 `plan-exhausted` 状态；手动 dispatch `deploy_services=signal-runtime-runner` 后生产已恢复为 `waiting-decision / no_level_touch`。

本次改动：
- 把 live 执行和策略评价相关路径的服务集合从 `platform-api live-runner` 扩展为 `platform-api live-runner signal-runtime-runner`。
- 把 `.github/workflows/cd.yml` 自身纳入 `backend_changed` 和全后端服务部署路由，避免只改 CD 路由的 PR 合并后只跑 changes job、不实际部署。
- 同步更新 CD 路由文档。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [x] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) - 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？- 无
- [x] DB migration 是否具备向下兼容幂等性？- 不涉及
- [x] 配置字段有没有无意被混改？- 无

## 交易语义变更
- [x] 本次改动是否新增/修改了 `signalKind`？若是，需同步更新 Golden Case - 否
- [x] 本次改动是否影响订单方向判断（`side` / `reduceOnly` / `closePosition`）？- 否
- [x] 若涉及上述改动，`go test ./internal/domain/... -run TestClassifyOrderIntent` 是否通过？- 不涉及
- [x] 若涉及交易链路语义（开仓/平仓/撤单/risk-exit），`go test ./internal/domain/... -run TestTradingReplayGoldenCases` 是否通过？- 不涉及

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

本地验证：
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/cd.yml"); puts "workflow yaml ok"'`
- `ruby -e 'text=File.read(".github/workflows/cd.yml"); live=text[/add_live_services\\(\\) \\{\\n(.*?)\\n          \\}/m,1] or abort("missing add_live_services"); abort("live missing signal-runtime-runner") unless live.include?("add_service signal-runtime-runner"); abort("workflow not backend_changed") unless text.match?(/cmd\\/platform-api\\/\\*\\|cmd\\/platform-worker\\/\\*\\|internal\\/\\*\\|db\\/\\*\\|deployments\\/\\*\\|scripts\\/deploy\\.sh\\|Dockerfile\\|\\.dockerignore\\|\\.github\\/workflows\\/cd\\.yml/); abort("workflow not all backend services") unless text.match?(/Dockerfile\\|\\.dockerignore\\|\\.github\\/workflows\\/cd\\.yml\\|deployments\\/docker-compose\\.prod\\.yml\\|scripts\\/deploy\\.sh/); puts "routing assertions ok"'`

生产验证：
- 手动 CD run `25924729722` 已成功部署 `signal-runtime-runner`，日志显示容器 `bktrader-signal-runtime-runner` Recreated/Started。
- `bktrader-ctl live list --json` 复查当前 ETH session 已从旧 `plan-exhausted` 转为 `lastStrategyEvaluationStatus=waiting-decision`，最新 decision 为 `no_level_touch`。
- `bktrader-ctl order list --json` / `fill list --json` / `position list --json` 复查该 session 无订单、无成交、无持仓。