### PR TITLE
[codex] Package pretouch model in app image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,5 +19,7 @@ RUN apk add --no-cache ca-certificates tzdata
 COPY --from=backend-builder /out/platform-api /usr/local/bin/platform-api
 COPY --from=backend-builder /out/platform-worker /usr/local/bin/platform-worker
 COPY configs/app.example.env ./configs/app.example.env
+COPY data/pretouch_model.json ./data/pretouch_model.json
+RUN test -s data/pretouch_model.json
 EXPOSE 8080
 CMD ["platform-api"]


### PR DESCRIPTION
## 目的
修复 ETH pretouch timing 生产运行时出现 `no_model_loaded` 的问题。当前策略默认从 `data/pretouch_model.json` 加载模型，本地仓库已跟踪该文件，但 runtime Docker image 没有把 `data/` 或模型文件复制进去，导致 signal-runtime-runner 检测到 pretouch event 后无法进入 timing/RF 推理，只能 `wait` 跳过。

本次改动只把 `data/pretouch_model.json` 复制到最终 app image 的 `/app/data/pretouch_model.json`，并在镜像构建阶段用 `test -s` 保证模型文件缺失或为空时直接失败。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [x] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) - 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？- 无
- [x] DB migration 是否具备向下兼容幂等性？- 不涉及
- [x] 配置字段有没有无意被混改？- 无

## 交易语义变更
- [x] 本次改动是否新增/修改了 `signalKind`？若是，需同步更新 Golden Case - 否
- [x] 本次改动是否影响订单方向判断（`side` / `reduceOnly` / `closePosition`）？- 否
- [x] 若涉及上述改动，`go test ./internal/domain/... -run TestClassifyOrderIntent` 是否通过？- 不涉及
- [x] 若涉及交易链路语义（开仓/平仓/撤单/risk-exit），`go test ./internal/domain/... -run TestTradingReplayGoldenCases` 是否通过？- 不涉及

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

本地验证：
- `git diff --check`
- `ruby -e 'docker=File.read("Dockerfile"); abort("missing model copy") unless docker.include?("COPY data/pretouch_model.json ./data/pretouch_model.json"); abort("missing nonempty model check") unless docker.include?("RUN test -s data/pretouch_model.json"); abort("model missing locally") unless File.size?("data/pretouch_model.json"); puts "pretouch model packaging assertions ok"'`
- `go test ./internal/service -run 'TestPretouch|TestBkLive|TestLiveSession|TestZeroInitial'`

未运行：
- 本机 Docker daemon 未启动，`docker version --format ...` 无法连接 `/Users/wuyaocheng/.docker/run/docker.sock`。Docker build validation 需要交给 GitHub checks/CD 跑。

生产证据：
- `bktrader-ctl live list --json` 看到 ETH pretouch timing session 在触发附近出现 `no_model_loaded`，说明模型缺失会阻断 pretouch event 后续推理。
- 当前 `order list` / `fill list` / `position list` 对应 session 均为空；本 PR 不改变交易默认行为，只修复模型文件可用性。