### PR TITLE
[codex] fix recovery watchdog auto dispatch

### DIFF
--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -4024,7 +4024,8 @@ func (p *Platform) evaluateLiveSessionOnSignal(session domain.LiveSession, runti
 			return err
 		}
 	}
-	if !shouldAutoDispatchLiveIntent(updatedSession, intent, eventTime) {
+	dispatchIntent := resolveLiveAutoDispatchIntent(updatedSession, intent)
+	if !shouldAutoDispatchLiveIntent(updatedSession, dispatchIntent, eventTime) {
 		return nil
 	}
 	if _, err := p.dispatchLiveSessionIntent(updatedSession); err != nil {
@@ -4038,7 +4039,7 @@ func (p *Platform) evaluateLiveSessionOnSignal(session domain.LiveSession, runti
 			state["lastDispatchedAt"] = eventTime.UTC().Format(time.RFC3339)
 		}
 		if strings.TrimSpace(stringValue(state["lastDispatchedIntentSignature"])) == "" {
-			state["lastDispatchedIntentSignature"] = buildLiveIntentSignature(intent)
+			state["lastDispatchedIntentSignature"] = buildLiveIntentSignature(dispatchIntent)
 		}
 		state["lastAutoDispatchError"] = err.Error()
 		state["lastAutoDispatchAttemptAt"] = eventTime.UTC().Format(time.RFC3339)
@@ -4077,6 +4078,7 @@ func preserveLiveSessionNonRegressiveFacts(state map[string]any, latest map[stri
 			state[key] = value
 		}
 	}
+	preservePendingLiveRecoveryWatchdogIntent(state, latest)
 	preserveLatestSLExitFillFact(state, latest)
 	if liveSLReentryWindowConsumed(state) {
 		delete(state, "lastSLExitReentrySide")
@@ -4097,6 +4099,59 @@ func liveSessionNonRegressiveFactKeys() []string {
 		"lastSLExitReentryConsumedReason",
 		"lastSLExitReentryConsumedEntryOrderId",
 		"lastSLExitReentryConsumedEntryStatus",
+	}
+}
+
+func preservePendingLiveRecoveryWatchdogIntent(state map[string]any, latest map[string]any) {
+	if len(mapValue(firstNonEmptyMapValue(state["lastExecutionProposal"], state["lastStrategyIntent"]))) > 0 {
+		return
+	}
+	pending := pendingLiveRecoveryWatchdogIntent(latest)
+	if len(pending) == 0 {
+		return
+	}
+	state["lastExecutionProposal"] = cloneMetadata(pending)
+	if latestIntent := mapValue(latest["lastStrategyIntent"]); isLiveWatchdogFallbackProposal(latestIntent) {
+		state["lastStrategyIntent"] = cloneMetadata(latestIntent)
+	} else {
+		state["lastStrategyIntent"] = cloneMetadata(pending)
+	}
+	if signature := strings.TrimSpace(stringValue(latest["lastStrategyIntentSignature"])); signature != "" {
+		state["lastStrategyIntentSignature"] = signature
+	} else {
+		state["lastStrategyIntentSignature"] = buildLiveIntentSignature(pending)
+	}
+	for _, key := range []string{
+		"positionRecoveryStatus",
+		"positionRecoverySource",
+		"hasRecoveredPosition",
+		"hasRecoveredRealPosition",
+		"hasRecoveredVirtualPosition",
+		"recoveredPosition",
+		"positionReconcileGateStatus",
+		"positionReconcileGateBlocking",
+		"positionReconcileGateScenario",
+		"positionReconcileGateSource",
+		"positionReconcileGateComparedAt",
+		"recoveryTakeoverActive",
+		"recoveryTakeoverState",
+		"recoveryActionMatrix",
+		"recoveryManualReviewRequired",
+	} {
+		if value, ok := latest[key]; ok {
+			state[key] = value
+		}
+	}
+	for _, key := range []string{
+		"watchdogExitTriggeredAt",
+		"watchdogExitReason",
+		"watchdogExitOrderId",
+		"watchdogExitOrderStatus",
+		"watchdogExitStatus",
+	} {
+		if value, ok := latest[key]; ok {
+			state[key] = value
+		}
 	}
 }
 

--- a/internal/service/live_execution.go
+++ b/internal/service/live_execution.go
@@ -444,6 +444,33 @@ func shouldBlockAutoDispatchForLiveEntryTradeLimit(session domain.LiveSession, i
 	return validateLiveSignalBarEntryTradeLimit(session, intent) != nil
 }
 
+func pendingLiveRecoveryWatchdogIntent(state map[string]any) map[string]any {
+	if state == nil {
+		return nil
+	}
+	pending := cloneMetadata(mapValue(firstNonEmptyMapValue(state["lastExecutionProposal"], state["lastStrategyIntent"])))
+	if len(pending) == 0 {
+		return nil
+	}
+	if !isLiveWatchdogFallbackProposal(pending) {
+		return nil
+	}
+	if !strings.EqualFold(strings.TrimSpace(stringValue(pending["status"])), "dispatchable") {
+		return nil
+	}
+	if !isRecoveryTriggeredPassiveCloseProposal(pending) {
+		return nil
+	}
+	return pending
+}
+
+func resolveLiveAutoDispatchIntent(session domain.LiveSession, intent map[string]any) map[string]any {
+	if len(intent) > 0 {
+		return intent
+	}
+	return pendingLiveRecoveryWatchdogIntent(session.State)
+}
+
 func validateLiveSignalBarEntryTradeLimit(session domain.LiveSession, proposalMap map[string]any) error {
 	if !liveEntryCountsTowardSignalBarLimit(proposalMap) {
 		return nil

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -5469,6 +5469,128 @@ func TestUpdateLiveSessionStatePreservingNonRegressiveFactsKeepsLatestCountedBar
 	}
 }
 
+func TestUpdateLiveSessionStatePreservingNonRegressiveFactsKeepsPendingWatchdogFallback(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	session, err := platform.CreateLiveSession("", "live-main", "strategy-bk-1d", map[string]any{
+		"symbol":          "BTCUSDT",
+		"signalTimeframe": "30m",
+	})
+	if err != nil {
+		t.Fatalf("create live session failed: %v", err)
+	}
+	pending := executionProposalToMap(ExecutionProposal{
+		Action:            "risk-exit-fallback",
+		Role:              "exit",
+		Reason:            "sl-breached-fallback",
+		Side:              "SELL",
+		Symbol:            "BTCUSDT",
+		Type:              "MARKET",
+		Quantity:          0.002,
+		PriceHint:         68880,
+		PriceSource:       "fallback-watchdog",
+		TimeInForce:       "GTC",
+		ReduceOnly:        true,
+		SignalKind:        "recovery-watchdog",
+		DecisionState:     "unprotected",
+		ExecutionStrategy: "book-aware-v1",
+		Status:            "dispatchable",
+		Metadata: map[string]any{
+			"strategyVersionId": "strategy-version-bk-1d-v010",
+			"runtimeSessionId":  "runtime-1",
+			"recoveryTriggered": true,
+			"executionContext": map[string]any{
+				"strategyVersionId":   "strategy-version-bk-1d-v010",
+				"signalTimeframe":     "30m",
+				"executionDataSource": "tick",
+				"executionMode":       "live",
+				"symbol":              "BTCUSDT",
+			},
+		},
+	})
+	session, err = platform.store.UpdateLiveSessionState(session.ID, map[string]any{
+		"symbol":                      "BTCUSDT",
+		"signalTimeframe":             "30m",
+		"positionRecoveryStatus":      livePositionRecoveryStatusClosingPending,
+		"lastExecutionProposal":       pending,
+		"lastStrategyIntent":          cloneMetadata(pending),
+		"lastStrategyIntentSignature": buildLiveIntentSignature(pending),
+		"watchdogExitStatus":          "intent-ready",
+		"watchdogExitReason":          "sl-breached-fallback",
+	})
+	if err != nil {
+		t.Fatalf("seed live session state failed: %v", err)
+	}
+
+	staleDecisionState := cloneMetadata(session.State)
+	delete(staleDecisionState, "lastExecutionProposal")
+	delete(staleDecisionState, "lastStrategyIntent")
+	delete(staleDecisionState, "lastStrategyIntentSignature")
+	staleDecisionState["lastStrategyDecision"] = map[string]any{
+		"action": "wait",
+		"reason": "no_level_touch",
+	}
+
+	updated, err := platform.updateLiveSessionStatePreservingNonRegressiveFacts(session.ID, staleDecisionState)
+	if err != nil {
+		t.Fatalf("update live session state failed: %v", err)
+	}
+	proposal := mapValue(updated.State["lastExecutionProposal"])
+	if !isLiveWatchdogFallbackProposal(proposal) {
+		t.Fatalf("expected pending watchdog proposal to survive stale wait write, got %+v", proposal)
+	}
+	if got := stringValue(updated.State["lastStrategyIntentSignature"]); got != buildLiveIntentSignature(pending) {
+		t.Fatalf("expected pending watchdog signature to survive, got %q", got)
+	}
+	if got := stringValue(updated.State["watchdogExitStatus"]); got != "intent-ready" {
+		t.Fatalf("expected watchdog exit status to survive, got %s", got)
+	}
+}
+
+func TestUpdateLiveSessionStatePreservingNonRegressiveFactsDoesNotKeepEntryProposal(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	session, err := platform.CreateLiveSession("", "live-main", "strategy-bk-1d", map[string]any{
+		"symbol":          "BTCUSDT",
+		"signalTimeframe": "30m",
+	})
+	if err != nil {
+		t.Fatalf("create live session failed: %v", err)
+	}
+	entryProposal := map[string]any{
+		"action":            "entry",
+		"role":              "entry",
+		"reason":            "Initial",
+		"side":              "BUY",
+		"symbol":            "BTCUSDT",
+		"signalKind":        "entry",
+		"signalBarStateKey": "BTCUSDT|30m|2026-04-22T03:00:00Z",
+		"status":            "dispatchable",
+	}
+	session, err = platform.store.UpdateLiveSessionState(session.ID, map[string]any{
+		"symbol":                "BTCUSDT",
+		"signalTimeframe":       "30m",
+		"lastExecutionProposal": entryProposal,
+		"lastStrategyIntent":    cloneMetadata(entryProposal),
+	})
+	if err != nil {
+		t.Fatalf("seed live session state failed: %v", err)
+	}
+
+	staleDecisionState := cloneMetadata(session.State)
+	delete(staleDecisionState, "lastExecutionProposal")
+	delete(staleDecisionState, "lastStrategyIntent")
+
+	updated, err := platform.updateLiveSessionStatePreservingNonRegressiveFacts(session.ID, staleDecisionState)
+	if err != nil {
+		t.Fatalf("update live session state failed: %v", err)
+	}
+	if proposal := mapValue(updated.State["lastExecutionProposal"]); len(proposal) != 0 {
+		t.Fatalf("expected stale wait write not to preserve ordinary entry proposal, got %+v", proposal)
+	}
+	if intent := mapValue(updated.State["lastStrategyIntent"]); len(intent) != 0 {
+		t.Fatalf("expected stale wait write not to preserve ordinary entry intent, got %+v", intent)
+	}
+}
+
 func TestUpdateLiveSessionStatePreservingNonRegressiveFactsKeepsLatestSLExitFill(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
 	session, err := platform.CreateLiveSession("", "live-main", "strategy-bk-1d", map[string]any{
@@ -6210,6 +6332,150 @@ func TestRecoveryMonitoringAllowsVerifiedCloseAutoDispatch(t *testing.T) {
 	}
 	if !shouldAutoDispatchLiveIntent(session, intent, now) {
 		t.Fatal("expected verified recovery-monitoring takeover close to auto-dispatch")
+	}
+}
+
+func TestEvaluateLiveSessionOnSignalAutoDispatchesPendingWatchdogFallback(t *testing.T) {
+	platform, session, runtimeSessionID, summary, eventTime := prepareLiveDecisionTelemetryFixture(t)
+	submitCount := 0
+	platform.registerLiveAdapter(testLiveAccountSyncAdapter{
+		key: "test-pending-watchdog-auto-dispatch",
+		submitOrderFunc: func(_ domain.Account, order domain.Order, _ map[string]any) (LiveOrderSubmission, error) {
+			submitCount++
+			if order.Side != "SELL" || !order.ReduceOnly {
+				t.Fatalf("expected reduce-only SELL watchdog close, got side=%s reduceOnly=%t", order.Side, order.ReduceOnly)
+			}
+			if got := stringValue(order.Metadata["signalKind"]); got != "recovery-watchdog" {
+				t.Fatalf("expected recovery-watchdog signal kind, got %s", got)
+			}
+			return LiveOrderSubmission{
+				Status:          "ACCEPTED",
+				ExchangeOrderID: "watchdog-exit-order-1",
+				AcceptedAt:      eventTime.UTC().Format(time.RFC3339),
+			}, nil
+		},
+	})
+	account, err := platform.store.GetAccount("live-main")
+	if err != nil {
+		t.Fatalf("get account failed: %v", err)
+	}
+	account.Status = "READY"
+	account.Metadata = cloneMetadata(account.Metadata)
+	account.Metadata["liveBinding"] = map[string]any{
+		"adapterKey":     "test-pending-watchdog-auto-dispatch",
+		"connectionMode": "mock",
+		"executionMode":  "mock",
+	}
+	if _, err := platform.store.UpdateAccount(account); err != nil {
+		t.Fatalf("update account failed: %v", err)
+	}
+	if _, err := platform.store.SavePosition(domain.Position{
+		AccountID:         session.AccountID,
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "LONG",
+		Quantity:          0.002,
+		EntryPrice:        69000,
+		MarkPrice:         68880,
+	}); err != nil {
+		t.Fatalf("save recovered position failed: %v", err)
+	}
+
+	pending := executionProposalToMap(ExecutionProposal{
+		Action:            "risk-exit-fallback",
+		Role:              "exit",
+		Reason:            "sl-breached-fallback",
+		Side:              "SELL",
+		Symbol:            "BTCUSDT",
+		Type:              "MARKET",
+		Quantity:          0.002,
+		PriceHint:         68880,
+		PriceSource:       "fallback-watchdog",
+		TimeInForce:       "GTC",
+		ReduceOnly:        true,
+		SignalKind:        "recovery-watchdog",
+		DecisionState:     "unprotected",
+		ExecutionStrategy: "book-aware-v1",
+		Status:            "dispatchable",
+		Metadata: map[string]any{
+			"strategyVersionId":      "strategy-version-bk-1d-v010",
+			"runtimeSessionId":       runtimeSessionID,
+			"executionMode":          "live",
+			"recoveryTriggered":      true,
+			"positionRecoveryStatus": livePositionRecoveryStatusClosingPending,
+			"executionContext": map[string]any{
+				"strategyVersionId":   "strategy-version-bk-1d-v010",
+				"signalTimeframe":     "1d",
+				"executionDataSource": "tick",
+				"executionMode":       "live",
+				"symbol":              "BTCUSDT",
+			},
+		},
+	})
+	state := cloneMetadata(session.State)
+	state["dispatchMode"] = "auto-dispatch"
+	state["positionRecoveryStatus"] = livePositionRecoveryStatusClosingPending
+	state["positionReconcileGateStatus"] = livePositionReconcileGateStatusVerified
+	state["recoveryTakeoverActive"] = true
+	state["recoveryTakeoverState"] = liveRecoveryTakeoverStateMonitoring
+	state["hasRecoveredPosition"] = true
+	state["hasRecoveredRealPosition"] = true
+	state["lastDispatchedOrderStatus"] = "FILLED"
+	state["lastSyncedOrderStatus"] = "FILLED"
+	state["lastExecutionProposal"] = pending
+	state["lastStrategyIntent"] = cloneMetadata(pending)
+	state["lastStrategyIntentSignature"] = buildLiveIntentSignature(pending)
+	state["watchdogExitStatus"] = "intent-ready"
+	state["watchdogExitReason"] = "sl-breached-fallback"
+	session, err = platform.store.UpdateLiveSessionState(session.ID, state)
+	if err != nil {
+		t.Fatalf("seed live session state failed: %v", err)
+	}
+	if !boolValue(session.State["hasRecoveredPosition"]) || stringValue(session.State["positionReconcileGateStatus"]) != livePositionReconcileGateStatusVerified {
+		t.Fatalf("seed recovery state missing: %+v", session.State)
+	}
+	eventTime = time.Now().UTC()
+	summary = cloneMetadata(summary)
+	summary["price"] = 68990.0
+	if err := platform.updateSignalRuntimeSessionState(runtimeSessionID, func(runtimeSession *domain.SignalRuntimeSession) {
+		state := cloneMetadata(runtimeSession.State)
+		state["lastEventAt"] = eventTime.Format(time.RFC3339)
+		state["lastHeartbeatAt"] = eventTime.Format(time.RFC3339)
+		state["lastEventSummary"] = cloneMetadata(summary)
+		sourceStates := cloneMetadata(mapValue(state["sourceStates"]))
+		for key, item := range sourceStates {
+			sourceState := cloneMetadata(mapValue(item))
+			sourceState["lastEventAt"] = eventTime.Format(time.RFC3339)
+			sourceStates[key] = sourceState
+		}
+		state["sourceStates"] = sourceStates
+		runtimeSession.State = state
+		runtimeSession.UpdatedAt = eventTime
+	}); err != nil {
+		t.Fatalf("refresh runtime state failed: %v", err)
+	}
+
+	if err := platform.evaluateLiveSessionOnSignal(session, runtimeSessionID, summary, eventTime); err != nil {
+		t.Fatalf("evaluate live session failed: %v", err)
+	}
+	if submitCount != 1 {
+		updated, _ := platform.store.GetLiveSession(session.ID)
+		proposal := mapValue(updated.State["lastExecutionProposal"])
+		t.Fatalf("expected one watchdog exit submission, got %d; status=%s recovery=%s/%s proposal=%+v autoErr=%s", submitCount, stringValue(updated.State["lastStrategyEvaluationStatus"]), stringValue(updated.State["recoveryTakeoverState"]), stringValue(updated.State["positionRecoveryStatus"]), proposal, stringValue(updated.State["lastAutoDispatchError"]))
+	}
+	updated, err := platform.store.GetLiveSession(session.ID)
+	if err != nil {
+		t.Fatalf("get updated live session failed: %v", err)
+	}
+	dispatched := mapValue(updated.State["lastDispatchedIntent"])
+	if !isLiveWatchdogFallbackProposal(dispatched) {
+		t.Fatalf("expected watchdog fallback to be dispatched, got %+v", dispatched)
+	}
+	if got := stringValue(updated.State["lastDispatchedOrderStatus"]); got != "ACCEPTED" {
+		t.Fatalf("expected accepted watchdog exit order, got %s", got)
+	}
+	if proposal := mapValue(updated.State["lastExecutionProposal"]); len(proposal) != 0 {
+		t.Fatalf("expected dispatched watchdog proposal to be consumed, got %+v", proposal)
 	}
 }
 


### PR DESCRIPTION
## 目的
修复生产 ETH 1h pretouch timing 持仓恢复后的一个安全缺口：`bktrader-ctl --json` 显示真实持仓仍在，且 session 已生成 `risk-exit-fallback` / `recovery-watchdog` / `reduceOnly=true` / `dispatchable` 的退出意图，但普通 tick 决策为 `no_level_touch` 时自动派单只看当前信号 intent，导致 pending recovery watchdog 退出意图停在 `session.State`，没有进入 reduceOnly 退出单提交。

本 PR 只收敛这个恢复退出派单问题：当 session 已经存在 dispatchable recovery-watchdog fallback close intent，且原有 recovery / reconcile / auto-dispatch gate 均允许时，普通 `wait` 决策不会丢掉该 pending intent，并会让自动派单入口消费它。普通 entry proposal 不会被 stale wait 写入复活。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [x] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) — 无默认值变化；仍必须 session 已是 `auto-dispatch` 才可能自动派单。
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？— 无。
- [x] DB migration 是否具备向下兼容幂等性？— 无 DB migration。
- [x] 配置字段有没有无意被混改？— 无配置字段变更。

## 交易语义变更
- [ ] 本次改动是否新增/修改了 `signalKind`？若是，需同步更新 Golden Case
- [x] 本次改动是否影响订单方向判断（`side` / `reduceOnly` / `closePosition`）？— 影响恢复 watchdog reduceOnly close intent 的派单消费路径，不改变 side 推导。
- [x] 若涉及上述改动，`go test ./internal/domain/... -run TestClassifyOrderIntent` 是否通过？
- [x] 若涉及交易链路语义（开仓/平仓/撤单/risk-exit），`go test ./internal/domain/... -run TestTradingReplayGoldenCases` 是否通过？

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

验证已通过：

```bash
go test ./internal/service -run 'Test(UpdateLiveSessionStatePreservingNonRegressiveFactsKeepsPendingWatchdogFallback|UpdateLiveSessionStatePreservingNonRegressiveFactsDoesNotKeepEntryProposal|EvaluateLiveSessionOnSignalAutoDispatchesPendingWatchdogFallback|ShouldAutoDispatchLiveIntentBlocksUnresolvedRecoveryWatchdogClose|RecoveryMonitoringAllowsVerifiedCloseAutoDispatch|RecoveryMonitoringStillDisablesEntryAutoDispatch|RefreshLiveSessionPositionContext.*Watchdog|DispatchLiveSessionIntent.*RecoveredPassiveClose|RecoverRunningLiveSessionAllowsVerifiedTakeoverPassiveCloseDispatch)' -count=1
go test ./internal/service
go test ./...
go test ./internal/domain/... -run TestClassifyOrderIntent
go test ./internal/domain/... -run TestTradingReplayGoldenCases
go build ./cmd/platform-api
go build ./cmd/db-migrate
bash scripts/check_high_risk_defaults.sh
```

生产侧只做了 read-only 诊断；没有执行任何 live mutation。
