### PR TITLE
[codex] Clear stale flat recovery error

### DIFF
--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -5041,6 +5041,7 @@ func (p *Platform) completeRecoveredLiveSessionMetadata(session domain.LiveSessi
 		delete(state, "positionReconcileGateDBPosition")
 		delete(state, "positionReconcileGateExchangePosition")
 		applyLiveRecoveryTakeoverState(state, false)
+		clearStaleLiveRecoveryErrorForFlatState(state)
 		if !metadataEqual(state, session.State) {
 			session, err = p.store.UpdateLiveSessionState(session.ID, state)
 			if err != nil {

--- a/internal/service/live_recovery.go
+++ b/internal/service/live_recovery.go
@@ -11,6 +11,36 @@ import (
 
 const livePositionRecoveryStatusClosingPending = "closing-pending"
 
+func clearStaleLiveRecoveryErrorForFlatState(state map[string]any) {
+	if state == nil || strings.TrimSpace(stringValue(state["lastRecoveryError"])) == "" {
+		return
+	}
+	if !boolValue(state["protectionRecoveryAuthoritative"]) {
+		return
+	}
+	if !strings.EqualFold(stringValue(state["positionRecoveryStatus"]), "flat") {
+		return
+	}
+	protectionStatus := strings.TrimSpace(stringValue(state["protectionRecoveryStatus"]))
+	if protectionStatus != "" && !strings.EqualFold(protectionStatus, "flat") {
+		return
+	}
+	if hasRecoveredLiveRealPosition(state) || hasActiveVirtualPositionSnapshot(mapValue(state["virtualPosition"])) {
+		return
+	}
+	if isLiveSessionRecoveryCloseOnlyMode(state) ||
+		isLiveSessionRecoveryReconcileGateBlocked(state) ||
+		boolValue(state["positionReconcileGateBlocking"]) {
+		return
+	}
+	switch strings.ToLower(strings.TrimSpace(stringValue(state["positionReconcileGateStatus"]))) {
+	case livePositionReconcileGateStatusStale, livePositionReconcileGateStatusConflict, livePositionReconcileGateStatusError:
+		return
+	}
+	delete(state, "lastRecoveryError")
+	state["lastRecoveryStatus"] = "flat"
+}
+
 func (p *Platform) refreshLiveSessionProtectionState(session domain.LiveSession) (domain.LiveSession, error) {
 	account, err := p.store.GetAccount(session.AccountID)
 	if err != nil {
@@ -70,6 +100,7 @@ func (p *Platform) refreshLiveSessionProtectionState(session domain.LiveSession)
 	}
 	state["positionRecoveryStatus"] = status
 	state["protectionRecoveryStatus"] = status
+	clearStaleLiveRecoveryErrorForFlatState(state)
 	if found {
 		appendTimelineEvent(state, "recovery", time.Now().UTC(), "live-position-recovered", map[string]any{
 			"symbol":               sessionSymbol,
@@ -139,6 +170,7 @@ func (p *Platform) refreshLiveSessionPositionContext(session domain.LiveSession,
 		applyLivePositionReconcileGateState(state, reconcileGate)
 		applyLiveRecoveryTakeoverState(state, takeoverActive)
 		applyRecoveryMode(state)
+		clearStaleLiveRecoveryErrorForFlatState(state)
 		updated, updateErr := p.store.UpdateLiveSessionState(refreshed.ID, state)
 		if updateErr != nil {
 			return domain.LiveSession{}, updateErr

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -12212,6 +12212,99 @@ func TestCompleteRecoveredLiveSessionMetadataClearsCloseOnlyTakeoverWhenPosition
 	}
 }
 
+func TestRefreshLiveSessionForAccountSnapshotClearsRecoveryErrorWhenAuthoritativeFlat(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	account, err := platform.store.GetAccount("live-main")
+	if err != nil {
+		t.Fatalf("get account failed: %v", err)
+	}
+	account.Metadata = cloneMetadata(account.Metadata)
+	account.Metadata["liveSyncSnapshot"] = map[string]any{
+		"source":        "binance-rest-account-v3",
+		"executionMode": "rest",
+		"syncStatus":    "SYNCED",
+		"positions":     []map[string]any{},
+		"openOrders":    []map[string]any{},
+	}
+	if _, err := platform.store.UpdateAccount(account); err != nil {
+		t.Fatalf("update account failed: %v", err)
+	}
+	session, err := platform.CreateLiveSession("", "live-main", "strategy-bk-1d", map[string]any{
+		"symbol":          "BTCUSDT",
+		"signalTimeframe": "1d",
+	})
+	if err != nil {
+		t.Fatalf("create live session failed: %v", err)
+	}
+	state := cloneMetadata(session.State)
+	state["lastRecoveryError"] = "live session not found: "
+	state["lastRecoveryStatus"] = "lease-not-acquired"
+	session, err = platform.store.UpdateLiveSessionState(session.ID, state)
+	if err != nil {
+		t.Fatalf("seed recovery error failed: %v", err)
+	}
+
+	updated := platform.refreshLiveSessionForAccountSnapshot(session, time.Date(2026, 5, 17, 1, 0, 0, 0, time.UTC))
+
+	if got := stringValue(updated.State["lastRecoveryError"]); got != "" {
+		t.Fatalf("expected authoritative flat refresh to clear lastRecoveryError, got %s", got)
+	}
+	if got := stringValue(updated.State["lastRecoveryStatus"]); got != "flat" {
+		t.Fatalf("expected lastRecoveryStatus flat, got %s", got)
+	}
+	if got := stringValue(updated.State["positionRecoveryStatus"]); got != "flat" {
+		t.Fatalf("expected positionRecoveryStatus flat, got %s", got)
+	}
+	if got := stringValue(updated.State["protectionRecoveryStatus"]); got != "flat" {
+		t.Fatalf("expected protectionRecoveryStatus flat, got %s", got)
+	}
+	if !boolValue(updated.State["protectionRecoveryAuthoritative"]) {
+		t.Fatal("expected authoritative recovery snapshot")
+	}
+}
+
+func TestRefreshLiveSessionForAccountSnapshotKeepsRecoveryErrorWhenFlatSnapshotNotAuthoritative(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	account, err := platform.store.GetAccount("live-main")
+	if err != nil {
+		t.Fatalf("get account failed: %v", err)
+	}
+	account.Metadata = cloneMetadata(account.Metadata)
+	account.Metadata["liveSyncSnapshot"] = map[string]any{
+		"source":        "platform-live-reconciliation",
+		"executionMode": "local",
+		"syncStatus":    "SYNCED",
+		"positions":     []map[string]any{},
+		"openOrders":    []map[string]any{},
+	}
+	if _, err := platform.store.UpdateAccount(account); err != nil {
+		t.Fatalf("update account failed: %v", err)
+	}
+	session, err := platform.CreateLiveSession("", "live-main", "strategy-bk-1d", map[string]any{
+		"symbol":          "BTCUSDT",
+		"signalTimeframe": "1d",
+	})
+	if err != nil {
+		t.Fatalf("create live session failed: %v", err)
+	}
+	state := cloneMetadata(session.State)
+	state["lastRecoveryError"] = "live session not found: "
+	state["lastRecoveryStatus"] = "lease-not-acquired"
+	session, err = platform.store.UpdateLiveSessionState(session.ID, state)
+	if err != nil {
+		t.Fatalf("seed recovery error failed: %v", err)
+	}
+
+	updated := platform.refreshLiveSessionForAccountSnapshot(session, time.Date(2026, 5, 17, 1, 5, 0, 0, time.UTC))
+
+	if got := stringValue(updated.State["lastRecoveryError"]); got != "live session not found: " {
+		t.Fatalf("expected non-authoritative flat refresh to preserve lastRecoveryError, got %s", got)
+	}
+	if boolValue(updated.State["protectionRecoveryAuthoritative"]) {
+		t.Fatal("expected local fallback recovery snapshot to remain non-authoritative")
+	}
+}
+
 func TestSyncLiveSessionsForAccountSnapshotDoesNotResumeOtherBlockedSession(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
 	session, err := platform.CreateLiveSession("", "live-main", "strategy-bk-1d", map[string]any{


### PR DESCRIPTION
## 目的
修复 ETH recovery-watchdog 平仓后，交易所 REST 已确认账户 flat，但 LiveSession 仍因残留 `lastRecoveryError="live session not found: "` 被前端会话面板标红的问题。

Root cause：`RecoverLiveTradingOnStartup` 失败会写入 `lastRecoveryError`，但后续 `live-account-sync` / protection refresh 已经从 Binance REST 得到 authoritative flat 事实时，只刷新 `positionRecoveryStatus/protectionRecoveryStatus`，没有清理这个 stale recovery error。

本 PR 增加一个很窄的清理收口：只有在权威快照确认 flat、没有真实/虚拟仓位、没有 close-only/reconcile blocking 状态时，才删除 stale `lastRecoveryError`，并将 `lastRecoveryStatus` 标为 `flat`。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [x] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) - 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？- 无
- [x] DB migration 是否具备向下兼容幂等性？- 无 migration
- [x] 配置字段有没有无意被混改？- 无配置改动

## 交易语义变更
- [x] 本次改动是否新增/修改了 `signalKind`？若是，需同步更新 Golden Case - 否
- [x] 本次改动是否影响订单方向判断（`side` / `reduceOnly` / `closePosition`）？- 否
- [ ] 若涉及上述改动，`go test ./internal/domain/... -run TestClassifyOrderIntent` 是否通过？- 不涉及
- [ ] 若涉及交易链路语义（开仓/平仓/撤单/risk-exit），`go test ./internal/domain/... -run TestTradingReplayGoldenCases` 是否通过？- 不涉及

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

验证已通过：
- `go test ./internal/service -run 'TestRefreshLiveSessionForAccountSnapshot(ClearsRecoveryErrorWhenAuthoritativeFlat|KeepsRecoveryErrorWhenFlatSnapshotNotAuthoritative)|TestCompleteRecoveredLiveSessionMetadataClearsCloseOnlyTakeoverWhenPositionFlat'`
- `go test ./internal/service`
- `bash scripts/check_high_risk_defaults.sh`
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
