### PR TITLE
[codex] fix pretouch live risk exit

### DIFF
--- a/internal/service/strategy_engine_pretouch_timing.go
+++ b/internal/service/strategy_engine_pretouch_timing.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"fmt"
+	"math"
 	"os"
 	"strings"
 	"time"
@@ -85,11 +86,9 @@ func (e *bkLiveEthPretouchTimingEngine) EvaluateSignal(ctx StrategySignalEvaluat
 		return StrategySignalDecision{Action: "wait", Reason: "symbol_not_eth"}, nil
 	}
 
-	// Extract tick data from trigger summary
+	// Extract tick data from trigger summary. Open-position exits may still use
+	// order-book prices when the trigger itself has no trade price.
 	triggerPrice := parseFloatValue(ctx.TriggerSummary["price"])
-	if triggerPrice <= 0 {
-		return StrategySignalDecision{Action: "wait", Reason: "no_trigger_price"}, nil
-	}
 
 	config := pretouchConfigFromParameters(e.config, ctx.ExecutionContext.Parameters)
 	e.detector.SetConfig(config)
@@ -98,6 +97,14 @@ func (e *bkLiveEthPretouchTimingEngine) EvaluateSignal(ctx StrategySignalEvaluat
 	e.detector.SyncBars(closedBars, currentBar)
 
 	orderBookStats := extractOrderBookStats(ctx.TriggerSummary, ctx.SourceStates)
+
+	if decision, handled := pretouchEvaluateOpenPositionExit(ctx, triggerPrice, orderBookStats); handled {
+		return decision, nil
+	}
+
+	if triggerPrice <= 0 {
+		return StrategySignalDecision{Action: "wait", Reason: "no_trigger_price"}, nil
+	}
 
 	// Build tick from trigger
 	tick := TickData{
@@ -280,6 +287,109 @@ func (e *bkLiveEthPretouchTimingEngine) EvaluateSignal(ctx StrategySignalEvaluat
 			"biasActionable":                isLiquidityBiasActionable(nextSide, "entry", "Pretouch-Timing", orderBookStats.bias),
 		},
 	}, nil
+}
+
+func pretouchEvaluateOpenPositionExit(ctx StrategySignalEvaluationContext, triggerPrice float64, orderBookStats orderBookDecisionStats) (StrategySignalDecision, bool) {
+	currentPosition := cloneMetadata(ctx.CurrentPosition)
+	if !hasActiveLivePositionSnapshot(currentPosition) {
+		return StrategySignalDecision{}, false
+	}
+
+	symbol := NormalizeSymbol(ctx.ExecutionContext.Symbol)
+	timeframe := normalizeSignalBarInterval(ctx.ExecutionContext.SignalTimeframe)
+	signalBarState, signalBarStateKey := pretouchSignalBarStateFromEvaluationContext(ctx, symbol, timeframe)
+	exitSide := normalizeLiveExitIntentSide("", currentPosition)
+	marketPrice, marketSource := pickDecisionMarketPrice(ctx.TriggerSummary, ctx.SourceStates, exitSide)
+	if marketPrice <= 0 && triggerPrice > 0 {
+		marketPrice = triggerPrice
+		marketSource = "trade_tick.price"
+	}
+
+	positionPnLBps := computePositionPnLBps(currentPosition, marketPrice)
+	signalBarDecision := map[string]any{
+		"ready":     false,
+		"side":      exitSide,
+		"role":      "exit",
+		"reason":    "SL",
+		"timeframe": timeframe,
+	}
+	livePositionState := map[string]any{}
+	nextPlannedPrice := 0.0
+	action := "wait"
+	reason := "missing-signal-bars"
+	if signalBarState != nil {
+		signalBarDecision["current"] = cloneMetadata(mapValue(signalBarState["current"]))
+		signalBarDecision["prevBar1"] = cloneMetadata(mapValue(signalBarState["prevBar1"]))
+		signalBarDecision["prevBar2"] = cloneMetadata(mapValue(signalBarState["prevBar2"]))
+		signalBarDecision["prevBar3"] = cloneMetadata(mapValue(signalBarState["prevBar3"]))
+		signalBarDecision["atr14"] = parseFloatValue(signalBarState["atr14"])
+		signalBarDecision["atrPercentile"] = parseFloatValue(signalBarState["atrPercentile"])
+		livePositionState = evaluateLiveExitState(ctx.ExecutionContext.Parameters, currentPosition, signalBarState, marketPrice, cloneMetadata(ctx.SessionState), "SL")
+		if len(livePositionState) > 0 {
+			signalBarDecision["livePositionState"] = cloneMetadata(livePositionState)
+			nextPlannedPrice = parseFloatValue(livePositionState["targetPrice"])
+			if boolValue(livePositionState["ready"]) {
+				action = "advance-plan"
+				reason = "pretouch_sl_exit"
+				signalBarDecision["ready"] = true
+			} else {
+				reason = firstNonEmpty(stringValue(livePositionState["waitReason"]), "exit-signal-not-ready")
+			}
+		}
+	}
+	if nextPlannedPrice <= 0 {
+		nextPlannedPrice = marketPrice
+	}
+
+	decisionState := classifyStrategyDecisionState(action, reason, "exit")
+	exitProximityBps := computePriceProximityBps(nextPlannedPrice, marketPrice)
+	signalKind := classifyStrategySignalKind(action, reason, "exit", "SL", currentPosition, positionPnLBps, 0, exitProximityBps, orderBookStats.bias)
+	suggestedQuantity := math.Abs(parseFloatValue(currentPosition["quantity"]))
+	if signalBarStateKey == "" && signalBarState != nil {
+		signalBarStateKey = resolveSignalBarTradeLimitKey(signalBarState, symbol, timeframe)
+	}
+
+	return StrategySignalDecision{
+		Action: action,
+		Reason: reason,
+		Metadata: map[string]any{
+			"signalSource":                  "pretouch-timing-unified",
+			"signalBarDecision":             signalBarDecision,
+			"signalBarState":                cloneMetadata(signalBarState),
+			"signalBarStateKey":             signalBarStateKey,
+			liveSignalBarTradeLimitKeyField: signalBarStateKey,
+			"currentPosition":               currentPosition,
+			"livePositionState":             cloneMetadata(livePositionState),
+			"nextPlannedEvent":              formatOptionalRFC3339(ctx.EventTime),
+			"nextPlannedPrice":              nextPlannedPrice,
+			"nextPlannedSide":               exitSide,
+			"nextPlannedRole":               "exit",
+			"nextPlannedReason":             "SL",
+			"marketPrice":                   marketPrice,
+			"marketSource":                  marketSource,
+			"signalKind":                    signalKind,
+			"decisionState":                 decisionState,
+			"suggestedQuantity":             suggestedQuantity,
+			"positionPnLBps":                positionPnLBps,
+			"exitProximityBps":              exitProximityBps,
+			"spreadBps":                     orderBookStats.spreadBps,
+			"bestBid":                       orderBookStats.bestBid,
+			"bestAsk":                       orderBookStats.bestAsk,
+			"bestBidQty":                    orderBookStats.bestBidQty,
+			"bestAskQty":                    orderBookStats.bestAskQty,
+			"bookImbalance":                 orderBookStats.imbalance,
+			"liquidityBias":                 orderBookStats.bias,
+			"biasActionable":                isLiquidityBiasActionable(exitSide, "exit", "SL", orderBookStats.bias),
+		},
+	}, true
+}
+
+func pretouchSignalBarStateFromEvaluationContext(ctx StrategySignalEvaluationContext, symbol, timeframe string) (map[string]any, string) {
+	if state, key := pickSignalBarState(ctx.SignalBarStates, symbol, timeframe); state != nil {
+		return state, key
+	}
+	derived := deriveSignalBarStates(ctx.SourceStates)
+	return pickSignalBarState(derived, symbol, timeframe)
 }
 
 func pretouchConfigFromParameters(base PretouchDetectorConfig, parameters map[string]any) PretouchDetectorConfig {

--- a/internal/service/strategy_engine_pretouch_timing_test.go
+++ b/internal/service/strategy_engine_pretouch_timing_test.go
@@ -50,6 +50,147 @@ func TestPretouchTimingEngineAdvancePlanProducesLiveIntentMetadata(t *testing.T)
 	}
 }
 
+func TestPretouchTimingEngineProducesRiskExitForLongStopLossBreach(t *testing.T) {
+	start := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
+	engine := testPretouchTimingEngine("fast", 0.75)
+	ctx := testPretouchSignalContext(start.Add(60*time.Second), 99.0)
+	ctx.ExecutionContext.Parameters["stop_loss_atr"] = 0.45
+	ctx.CurrentPosition = map[string]any{
+		"id":         "position-long",
+		"found":      true,
+		"symbol":     "ETHUSDT",
+		"side":       "LONG",
+		"quantity":   0.068,
+		"entryPrice": 100.0,
+	}
+	ctx.SignalBarStates = testPretouchExitSignalBarStates(start, 99.0)
+	setPretouchOrderBook(&ctx, 99.0, 99.1)
+
+	decision, err := engine.EvaluateSignal(ctx)
+	if err != nil {
+		t.Fatalf("evaluate failed: %v", err)
+	}
+	if decision.Action != "advance-plan" {
+		t.Fatalf("expected advance-plan risk exit, got action=%s reason=%s metadata=%#v", decision.Action, decision.Reason, decision.Metadata)
+	}
+	if got := stringValue(decision.Metadata["nextPlannedRole"]); got != "exit" {
+		t.Fatalf("expected exit role, got %s", got)
+	}
+	if got := stringValue(decision.Metadata["nextPlannedReason"]); got != "SL" {
+		t.Fatalf("expected SL reason, got %s", got)
+	}
+	if got := stringValue(decision.Metadata["nextPlannedSide"]); got != "SELL" {
+		t.Fatalf("expected SELL exit side, got %s", got)
+	}
+	if got := stringValue(decision.Metadata["signalKind"]); got != "risk-exit" {
+		t.Fatalf("expected risk-exit signal kind, got %s", got)
+	}
+	livePositionState := mapValue(decision.Metadata["livePositionState"])
+	if !boolValue(livePositionState["ready"]) {
+		t.Fatalf("expected live position exit state ready, got %#v", livePositionState)
+	}
+	if got := parseFloatValue(livePositionState["targetPrice"]); math.Abs(got-99.1) > 1e-9 {
+		t.Fatalf("expected target stop 99.1, got %v", got)
+	}
+
+	intent := deriveLiveSignalIntent(decision, "ETHUSDT")
+	if intent == nil {
+		t.Fatal("expected exit intent")
+	}
+	if intent.Side != "SELL" || intent.Role != "exit" || intent.SignalKind != "risk-exit" {
+		t.Fatalf("unexpected exit intent: %#v", intent)
+	}
+	if math.Abs(intent.Quantity-0.068) > 1e-9 {
+		t.Fatalf("expected intent quantity to match current position, got %v", intent.Quantity)
+	}
+}
+
+func TestPretouchTimingEngineProducesRiskExitForShortTrailingStopBreach(t *testing.T) {
+	start := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
+	engine := testPretouchTimingEngine("fast", 0.75)
+	ctx := testPretouchSignalContext(start.Add(60*time.Second), 96.8)
+	ctx.ExecutionContext.Parameters["stop_loss_atr"] = 0.45
+	ctx.ExecutionContext.Parameters["trailing_stop_atr"] = 0.3
+	ctx.CurrentPosition = map[string]any{
+		"id":         "position-short",
+		"found":      true,
+		"symbol":     "ETHUSDT",
+		"side":       "SHORT",
+		"quantity":   0.069,
+		"entryPrice": 100.0,
+	}
+	ctx.SessionState = map[string]any{
+		"watermarkPositionKey": buildLivePositionWatermarkKey(ctx.CurrentPosition),
+		"hwm":                  100.0,
+		"lwm":                  96.0,
+	}
+	ctx.SignalBarStates = testPretouchExitSignalBarStates(start, 96.8)
+	setPretouchOrderBook(&ctx, 96.7, 96.8)
+
+	decision, err := engine.EvaluateSignal(ctx)
+	if err != nil {
+		t.Fatalf("evaluate failed: %v", err)
+	}
+	if decision.Action != "advance-plan" {
+		t.Fatalf("expected advance-plan risk exit, got action=%s reason=%s metadata=%#v", decision.Action, decision.Reason, decision.Metadata)
+	}
+	if got := stringValue(decision.Metadata["nextPlannedSide"]); got != "BUY" {
+		t.Fatalf("expected BUY exit side, got %s", got)
+	}
+	livePositionState := mapValue(decision.Metadata["livePositionState"])
+	if got := stringValue(livePositionState["targetPriceSource"]); got != "trailing-stop" {
+		t.Fatalf("expected trailing-stop source, got %s in %#v", got, livePositionState)
+	}
+	if got := parseFloatValue(livePositionState["targetPrice"]); math.Abs(got-96.6) > 1e-9 {
+		t.Fatalf("expected trailing stop 96.6, got %v", got)
+	}
+
+	intent := deriveLiveSignalIntent(decision, "ETHUSDT")
+	if intent == nil {
+		t.Fatal("expected exit intent")
+	}
+	if intent.Side != "BUY" || intent.Role != "exit" || intent.SignalKind != "risk-exit" {
+		t.Fatalf("unexpected exit intent: %#v", intent)
+	}
+	if math.Abs(intent.Quantity-0.069) > 1e-9 {
+		t.Fatalf("expected intent quantity to match current position, got %v", intent.Quantity)
+	}
+}
+
+func TestPretouchTimingEngineHoldsOpenPositionWhenStopNotBreached(t *testing.T) {
+	start := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
+	engine := testPretouchTimingEngine("fast", 0.75)
+	ctx := testPretouchSignalContext(start.Add(60*time.Second), 100.5)
+	ctx.ExecutionContext.Parameters["stop_loss_atr"] = 0.45
+	ctx.CurrentPosition = map[string]any{
+		"id":         "position-long",
+		"found":      true,
+		"symbol":     "ETHUSDT",
+		"side":       "LONG",
+		"quantity":   0.068,
+		"entryPrice": 100.0,
+	}
+	ctx.SignalBarStates = testPretouchExitSignalBarStates(start, 100.5)
+	setPretouchOrderBook(&ctx, 100.5, 100.6)
+
+	decision, err := engine.EvaluateSignal(ctx)
+	if err != nil {
+		t.Fatalf("evaluate failed: %v", err)
+	}
+	if decision.Action != "wait" {
+		t.Fatalf("expected open position to wait while stop is intact, got %#v", decision)
+	}
+	if got := stringValue(decision.Metadata["nextPlannedRole"]); got != "exit" {
+		t.Fatalf("expected exit monitoring role, got %s", got)
+	}
+	if got := stringValue(decision.Metadata["signalKind"]); got != "risk-exit-watch" {
+		t.Fatalf("expected risk-exit-watch signal kind, got %s", got)
+	}
+	if intent := deriveLiveSignalIntent(decision, "ETHUSDT"); intent != nil {
+		t.Fatalf("expected no live intent while stop is intact, got %#v", intent)
+	}
+}
+
 func TestPretouchTimingEngineSkipsWhenModelMissing(t *testing.T) {
 	start := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
 	engine := testPretouchTimingEngine("fast", 0.75)
@@ -230,4 +371,68 @@ func testPretouchSignalBars(currentStart time.Time) []any {
 		"isClosed":  false,
 	})
 	return bars
+}
+
+func testPretouchExitSignalBarStates(currentStart time.Time, closePrice float64) map[string]any {
+	key := signalBindingMatchKey("binance-kline", "signal", "ETHUSDT", map[string]any{"timeframe": "1h"})
+	return map[string]any{
+		key: map[string]any{
+			"symbol":         "ETHUSDT",
+			"timeframe":      "1h",
+			"barCount":       20,
+			"closedBarCount": 19,
+			"currentClosed":  false,
+			"atr14":          2.0,
+			"atrPercentile":  0.5,
+			"current": map[string]any{
+				"symbol":    "ETHUSDT",
+				"timeframe": "1h",
+				"barStart":  currentStart.Format(time.RFC3339),
+				"open":      closePrice,
+				"high":      closePrice + 0.5,
+				"low":       closePrice - 0.5,
+				"close":     closePrice,
+				"isClosed":  false,
+			},
+			"prevBar1": map[string]any{
+				"symbol":    "ETHUSDT",
+				"timeframe": "1h",
+				"barStart":  currentStart.Add(-time.Hour).Format(time.RFC3339),
+				"open":      100.0,
+				"high":      101.0,
+				"low":       99.0,
+				"close":     100.0,
+				"isClosed":  true,
+			},
+			"prevBar2": map[string]any{
+				"symbol":    "ETHUSDT",
+				"timeframe": "1h",
+				"barStart":  currentStart.Add(-2 * time.Hour).Format(time.RFC3339),
+				"open":      100.0,
+				"high":      101.0,
+				"low":       99.0,
+				"close":     100.0,
+				"isClosed":  true,
+			},
+			"prevBar3": map[string]any{
+				"symbol":    "ETHUSDT",
+				"timeframe": "1h",
+				"barStart":  currentStart.Add(-3 * time.Hour).Format(time.RFC3339),
+				"open":      100.0,
+				"high":      101.0,
+				"low":       99.0,
+				"close":     100.0,
+				"isClosed":  true,
+			},
+		},
+	}
+}
+
+func setPretouchOrderBook(ctx *StrategySignalEvaluationContext, bestBid, bestAsk float64) {
+	ctx.SourceStates["binance-order-book|feature|ETHUSDT|"].(map[string]any)["summary"] = map[string]any{
+		"bestBid":    bestBid,
+		"bestAsk":    bestAsk,
+		"bestBidQty": 20.0,
+		"bestAskQty": 10.0,
+	}
 }


### PR DESCRIPTION
## 目的
修复 ETH pretouch timing live 策略在持仓期间缺少普通退出 leg 的问题。

生产排查里最近几笔 ETH pretouch entry 都是正常 `normal-entry / Pretouch-Timing`，但平仓连续落到 `recovery-watchdog / sl-breached-fallback`。这说明安全兜底在工作，但 pretouch timing 引擎本身只处理事件检测和 entry，没有在已有真实持仓时优先产生普通 `risk-exit` 决策。

本 PR 让 pretouch timing 引擎在 `CurrentPosition` 存在时先复用统一 live exit 状态：
- 优先评估 `SL` / trailing stop 退出，不继续检测新的 pretouch entry。
- 触发时产出 `nextPlannedRole=exit`、`nextPlannedReason=SL`、`signalKind=risk-exit`。
- exit 数量来自当前持仓，exit side 由持仓方向归一化。
- 未触发时保持 `wait` / `risk-exit-watch`，不生成 live intent。

Codex 参与：本 PR 由 Codex 根据生产 `bktrader-ctl --json` 排查结果实现，我已按当前 diff 和验证结果整理描述。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [x] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

风险定级说明：改动不触碰 `internal/service/live*.go`、dispatch、recovery、默认 `dispatchMode` 或部署配置，但会改变 live pretouch timing 策略在持仓期间的交易决策输出，让原先常态由 recovery watchdog 接走的 SL 退出进入普通 `risk-exit` 链路，因此按 L2 处理并需要重点 review。

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [ ] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main)
- [ ] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？
- [ ] DB migration 是否具备向下兼容幂等性？
- [ ] 配置字段有没有无意被混改？

补充：以上四项均未修改。

## 交易语义变更
- [x] 本次改动是否新增/修改了 `signalKind`？若是，需同步更新 Golden Case
- [x] 本次改动是否影响订单方向判断（`side` / `reduceOnly` / `closePosition`）？
- [x] 若涉及上述改动，`go test ./internal/domain/... -run TestClassifyOrderIntent` 是否通过？
- [x] 若涉及交易链路语义（开仓/平仓/撤单/risk-exit），`go test ./internal/domain/... -run TestTradingReplayGoldenCases` 是否通过？

说明：没有新增 signalKind，只让 pretouch timing 引擎开始输出既有 `risk-exit`。`go test ./...` 已覆盖 domain 包相关测试。

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

已执行：

```sh
go test ./internal/service -run 'TestPretouchTimingEngine|TestDeriveLiveSignalIntent|TestEvaluateLiveExitState'
go test ./internal/service
go test ./...
go build ./cmd/platform-api
go build ./cmd/db-migrate
git diff --check
git push -u origin codex/fix-pretouch-engine-live-bootstrap
```

`git push` 触发的 pre-push harness 已重建 graphify 并通过 repository safety sensors：high risk defaults check passed，env safety check passed。
