### PR TITLE
[codex] clear stale live recovery error

### DIFF
--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -5041,7 +5041,7 @@ func (p *Platform) completeRecoveredLiveSessionMetadata(session domain.LiveSessi
 		delete(state, "positionReconcileGateDBPosition")
 		delete(state, "positionReconcileGateExchangePosition")
 		applyLiveRecoveryTakeoverState(state, false)
-		clearStaleLiveRecoveryErrorForFlatState(state)
+		clearStaleLiveRecoveryErrorForAuthoritativeState(state)
 		if !metadataEqual(state, session.State) {
 			session, err = p.store.UpdateLiveSessionState(session.ID, state)
 			if err != nil {

--- a/internal/service/live_recovery.go
+++ b/internal/service/live_recovery.go
@@ -11,21 +11,11 @@ import (
 
 const livePositionRecoveryStatusClosingPending = "closing-pending"
 
-func clearStaleLiveRecoveryErrorForFlatState(state map[string]any) {
+func clearStaleLiveRecoveryErrorForAuthoritativeState(state map[string]any) {
 	if state == nil || strings.TrimSpace(stringValue(state["lastRecoveryError"])) == "" {
 		return
 	}
 	if !boolValue(state["protectionRecoveryAuthoritative"]) {
-		return
-	}
-	if !strings.EqualFold(stringValue(state["positionRecoveryStatus"]), "flat") {
-		return
-	}
-	protectionStatus := strings.TrimSpace(stringValue(state["protectionRecoveryStatus"]))
-	if protectionStatus != "" && !strings.EqualFold(protectionStatus, "flat") {
-		return
-	}
-	if hasRecoveredLiveRealPosition(state) || hasActiveVirtualPositionSnapshot(mapValue(state["virtualPosition"])) {
 		return
 	}
 	if isLiveSessionRecoveryCloseOnlyMode(state) ||
@@ -37,8 +27,28 @@ func clearStaleLiveRecoveryErrorForFlatState(state map[string]any) {
 	case livePositionReconcileGateStatusStale, livePositionReconcileGateStatusConflict, livePositionReconcileGateStatusError:
 		return
 	}
-	delete(state, "lastRecoveryError")
-	state["lastRecoveryStatus"] = "flat"
+	positionStatus := strings.ToLower(strings.TrimSpace(stringValue(state["positionRecoveryStatus"])))
+	protectionStatus := strings.ToLower(strings.TrimSpace(stringValue(state["protectionRecoveryStatus"])))
+	switch positionStatus {
+	case "flat":
+		if protectionStatus != "" && protectionStatus != "flat" {
+			return
+		}
+		if hasRecoveredLiveRealPosition(state) || hasActiveVirtualPositionSnapshot(mapValue(state["virtualPosition"])) {
+			return
+		}
+		delete(state, "lastRecoveryError")
+		state["lastRecoveryStatus"] = "flat"
+	case "protected-open-position", "unprotected-open-position", "monitoring-open-position":
+		if protectionStatus != "" && protectionStatus != positionStatus {
+			return
+		}
+		if !hasRecoveredLiveRealPosition(state) {
+			return
+		}
+		delete(state, "lastRecoveryError")
+		state["lastRecoveryStatus"] = "recovered"
+	}
 }
 
 func (p *Platform) refreshLiveSessionProtectionState(session domain.LiveSession) (domain.LiveSession, error) {
@@ -100,7 +110,7 @@ func (p *Platform) refreshLiveSessionProtectionState(session domain.LiveSession)
 	}
 	state["positionRecoveryStatus"] = status
 	state["protectionRecoveryStatus"] = status
-	clearStaleLiveRecoveryErrorForFlatState(state)
+	clearStaleLiveRecoveryErrorForAuthoritativeState(state)
 	if found {
 		appendTimelineEvent(state, "recovery", time.Now().UTC(), "live-position-recovered", map[string]any{
 			"symbol":               sessionSymbol,
@@ -170,7 +180,7 @@ func (p *Platform) refreshLiveSessionPositionContext(session domain.LiveSession,
 		applyLivePositionReconcileGateState(state, reconcileGate)
 		applyLiveRecoveryTakeoverState(state, takeoverActive)
 		applyRecoveryMode(state)
-		clearStaleLiveRecoveryErrorForFlatState(state)
+		clearStaleLiveRecoveryErrorForAuthoritativeState(state)
 		updated, updateErr := p.store.UpdateLiveSessionState(refreshed.ID, state)
 		if updateErr != nil {
 			return domain.LiveSession{}, updateErr

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -12263,6 +12263,87 @@ func TestRefreshLiveSessionForAccountSnapshotClearsRecoveryErrorWhenAuthoritativ
 	}
 }
 
+func TestRefreshLiveSessionForAccountSnapshotClearsRecoveryErrorWhenAuthoritativeOpenPosition(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	account, err := platform.store.GetAccount("live-main")
+	if err != nil {
+		t.Fatalf("get account failed: %v", err)
+	}
+	checkedAt := time.Date(2026, 5, 17, 1, 10, 0, 0, time.UTC)
+	account.Metadata = cloneMetadata(account.Metadata)
+	account.Metadata["liveSyncSnapshot"] = map[string]any{
+		"source":        "binance-rest-account-v3",
+		"executionMode": "rest",
+		"syncStatus":    "SYNCED",
+		"positions": []map[string]any{
+			{
+				"symbol":     "BTCUSDT",
+				"side":       "LONG",
+				"quantity":   0.01,
+				"entryPrice": 70000.0,
+				"markPrice":  70100.0,
+			},
+		},
+		"openOrders": []map[string]any{},
+	}
+	account.Metadata["livePositionReconcileGate"] = map[string]any{
+		"symbols": map[string]any{
+			"BTCUSDT": map[string]any{
+				"status":     livePositionReconcileGateStatusVerified,
+				"blocking":   false,
+				"source":     "binance-rest-account-v3",
+				"comparedAt": checkedAt.Format(time.RFC3339),
+			},
+		},
+	}
+	if _, err := platform.store.UpdateAccount(account); err != nil {
+		t.Fatalf("update account failed: %v", err)
+	}
+	if _, err := platform.store.SavePosition(domain.Position{
+		AccountID:         "live-main",
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "LONG",
+		Quantity:          0.01,
+		EntryPrice:        70000.0,
+		MarkPrice:         70100.0,
+	}); err != nil {
+		t.Fatalf("save position failed: %v", err)
+	}
+	session, err := platform.CreateLiveSession("", "live-main", "strategy-bk-1d", map[string]any{
+		"symbol":          "BTCUSDT",
+		"signalTimeframe": "1d",
+	})
+	if err != nil {
+		t.Fatalf("create live session failed: %v", err)
+	}
+	state := cloneMetadata(session.State)
+	state["lastRecoveryError"] = "live session not found: "
+	state["lastRecoveryStatus"] = "lease-not-acquired"
+	session, err = platform.store.UpdateLiveSessionState(session.ID, state)
+	if err != nil {
+		t.Fatalf("seed recovery error failed: %v", err)
+	}
+
+	updated := platform.refreshLiveSessionForAccountSnapshot(session, checkedAt)
+
+	if got := stringValue(updated.State["lastRecoveryError"]); got != "" {
+		t.Fatalf("expected authoritative open-position refresh to clear lastRecoveryError, got %s", got)
+	}
+	if got := stringValue(updated.State["lastRecoveryStatus"]); got != "recovered" {
+		t.Fatalf("expected lastRecoveryStatus recovered, got %s", got)
+	}
+	if got := stringValue(updated.State["positionRecoveryStatus"]); got != "unprotected-open-position" {
+		t.Fatalf("expected positionRecoveryStatus unprotected-open-position, got %s", got)
+	}
+	if got := stringValue(updated.State["protectionRecoveryStatus"]); got != "unprotected-open-position" {
+		t.Fatalf("expected protectionRecoveryStatus unprotected-open-position, got %s", got)
+	}
+	if !boolValue(updated.State["protectionRecoveryAuthoritative"]) {
+		t.Fatal("expected authoritative recovery snapshot")
+	}
+}
+
 func TestRefreshLiveSessionForAccountSnapshotKeepsRecoveryErrorWhenFlatSnapshotNotAuthoritative(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
 	account, err := platform.store.GetAccount("live-main")
@@ -12299,6 +12380,67 @@ func TestRefreshLiveSessionForAccountSnapshotKeepsRecoveryErrorWhenFlatSnapshotN
 
 	if got := stringValue(updated.State["lastRecoveryError"]); got != "live session not found: " {
 		t.Fatalf("expected non-authoritative flat refresh to preserve lastRecoveryError, got %s", got)
+	}
+	if boolValue(updated.State["protectionRecoveryAuthoritative"]) {
+		t.Fatal("expected local fallback recovery snapshot to remain non-authoritative")
+	}
+}
+
+func TestRefreshLiveSessionForAccountSnapshotKeepsRecoveryErrorWhenOpenPositionNotAuthoritative(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	account, err := platform.store.GetAccount("live-main")
+	if err != nil {
+		t.Fatalf("get account failed: %v", err)
+	}
+	account.Metadata = cloneMetadata(account.Metadata)
+	account.Metadata["liveSyncSnapshot"] = map[string]any{
+		"source":        "platform-live-reconciliation",
+		"executionMode": "local",
+		"syncStatus":    "SYNCED",
+		"positions": []map[string]any{
+			{
+				"symbol":     "BTCUSDT",
+				"side":       "LONG",
+				"quantity":   0.01,
+				"entryPrice": 70000.0,
+				"markPrice":  70100.0,
+			},
+		},
+		"openOrders": []map[string]any{},
+	}
+	if _, err := platform.store.UpdateAccount(account); err != nil {
+		t.Fatalf("update account failed: %v", err)
+	}
+	if _, err := platform.store.SavePosition(domain.Position{
+		AccountID:         "live-main",
+		StrategyVersionID: "strategy-version-bk-1d-v010",
+		Symbol:            "BTCUSDT",
+		Side:              "LONG",
+		Quantity:          0.01,
+		EntryPrice:        70000.0,
+		MarkPrice:         70100.0,
+	}); err != nil {
+		t.Fatalf("save position failed: %v", err)
+	}
+	session, err := platform.CreateLiveSession("", "live-main", "strategy-bk-1d", map[string]any{
+		"symbol":          "BTCUSDT",
+		"signalTimeframe": "1d",
+	})
+	if err != nil {
+		t.Fatalf("create live session failed: %v", err)
+	}
+	state := cloneMetadata(session.State)
+	state["lastRecoveryError"] = "live session not found: "
+	state["lastRecoveryStatus"] = "lease-not-acquired"
+	session, err = platform.store.UpdateLiveSessionState(session.ID, state)
+	if err != nil {
+		t.Fatalf("seed recovery error failed: %v", err)
+	}
+
+	updated := platform.refreshLiveSessionForAccountSnapshot(session, time.Date(2026, 5, 17, 1, 15, 0, 0, time.UTC))
+
+	if got := stringValue(updated.State["lastRecoveryError"]); got != "live session not found: " {
+		t.Fatalf("expected non-authoritative open-position refresh to preserve lastRecoveryError, got %s", got)
 	}
 	if boolValue(updated.State["protectionRecoveryAuthoritative"]) {
 		t.Fatal("expected local fallback recovery snapshot to remain non-authoritative")


### PR DESCRIPTION
## 目的
修复生产 CD/runner 启动恢复竞争后，live session 已经存在且持续刷新权威持仓上下文，但旧的 `lastRecoveryError=live session not found:` 仍留在 state 里，导致前端会话控制显示“恢复异常”并产生 `live-recovery-error-*` critical alert。

Root cause：PR #438 已经覆盖了“权威 flat 快照清理旧 recovery error”，但当前生产是有真实 ETH 持仓的 `unprotected-open-position`。`refreshLiveSessionProtectionState` 会继续用旧 session state 做整包更新，open-position 场景没有清 stale recovery error，于是 `lastRecoveryStatus=lease-not-acquired` 和旧 `lastRecoveryError` 可以同时存在。

本 PR 将 stale recovery error 清理规则扩展到“权威、非 reconcile 阻断、已确认真实 open position”的状态。它只清理过期错误，不解除 `unprotected-open-position` 风险状态；如果持仓仍无交易所保护单，现有独立风险提示仍会保留。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [x] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值无变化
- [x] 不存在直接调用 `mainnet` 凭证或路由地址的硬编码
- [x] 不涉及 DB migration
- [x] 不涉及配置字段混改

## 交易语义变更
- [x] 本次不新增/修改 `signalKind`
- [x] 本次不影响订单方向判断（`side` / `reduceOnly` / `closePosition`）
- [x] 不涉及 `go test ./internal/domain/... -run TestClassifyOrderIntent`
- [x] 不涉及 `go test ./internal/domain/... -run TestTradingReplayGoldenCases`

## 验证方式与测试证据
- [x] `go test ./internal/service -run 'TestRefreshLiveSessionForAccountSnapshot(ClearsRecoveryErrorWhenAuthoritativeFlat|ClearsRecoveryErrorWhenAuthoritativeOpenPosition|KeepsRecoveryErrorWhenFlatSnapshotNotAuthoritative|KeepsRecoveryErrorWhenOpenPositionNotAuthoritative)|TestRecoverLiveTradingOnStartupTreatsRuntimeLeaseRaceAsTransient'`
- [x] `go test ./internal/service`
- [x] `go test ./...`
- [x] `go build ./cmd/platform-api`
- [x] `go build ./cmd/db-migrate`
- [x] `bash scripts/check_high_risk_defaults.sh`
- [x] `bash scripts/check_env_safety.sh`
- [x] `git diff --check`
