### PR TITLE
[codex] Fix live health for unprotected active positions

### DIFF
--- a/web/console/src/utils/derivation.test.ts
+++ b/web/console/src/utils/derivation.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   deriveRuntimeMarketSnapshot,
+  deriveLiveSessionHealth,
   deriveSelectedOrHighlightedLiveSession,
   deriveSessionMarkers,
   deriveSignalBarStateCandles,
@@ -8,7 +9,7 @@ import {
   markerText,
   mergeLivePriceIntoSignalBars,
 } from "./derivation";
-import { ChartAnnotation, Fill, Order, Position, SignalBarCandle } from "../types/domain";
+import { ChartAnnotation, Fill, LiveSessionExecutionSummary, Order, Position, SignalBarCandle } from "../types/domain";
 
 describe("monitor chart marker labels", () => {
   it("distinguishes long and short entry/exit order markers", () => {
@@ -363,6 +364,65 @@ describe("live monitor candles", () => {
 
     expect(market.tradePrice).toBe(77100);
     expect(market.tradePriceAt).toBe("2026-04-24T00:00:10Z");
+  });
+});
+
+describe("live session health", () => {
+  it("keeps a normal active position active when exchange-side protection is absent", () => {
+    const summary: LiveSessionExecutionSummary = {
+      orderCount: 1,
+      fillCount: 1,
+      latestOrder: order("entry-1", "SELL", 2113.94, false, "2026-05-18T06:08:57Z"),
+      latestFill: null,
+      position: {
+        id: "position-1",
+        accountId: "account-1",
+        symbol: "ETHUSDT",
+        side: "SHORT",
+        quantity: 0.099,
+        entryPrice: 2113.94,
+        markPrice: 2118.99,
+        updatedAt: "2026-05-18T06:15:41Z",
+      } as Position,
+    };
+
+    const health = deriveLiveSessionHealth(
+      {
+        id: "live-1",
+        accountId: "account-1",
+        strategyId: "strategy-bk-eth-pretouch-timing",
+        status: "RUNNING",
+        state: { protectionRecoveryStatus: "unprotected-open-position" },
+        createdAt: "2026-05-18T06:00:00Z",
+      } as any,
+      summary
+    );
+
+    expect(health.status).toBe("active");
+    expect(health.detail).toContain("未发现交易所保护单");
+  });
+
+  it("keeps unprotected recovery state as an error when no active position is available", () => {
+    const health = deriveLiveSessionHealth(
+      {
+        id: "live-1",
+        accountId: "account-1",
+        strategyId: "strategy-bk-eth-pretouch-timing",
+        status: "RUNNING",
+        state: { protectionRecoveryStatus: "unprotected-open-position" },
+        createdAt: "2026-05-18T06:00:00Z",
+      } as any,
+      {
+        orderCount: 0,
+        fillCount: 0,
+        latestOrder: null,
+        latestFill: null,
+        position: null,
+      }
+    );
+
+    expect(health.status).toBe("error");
+    expect(health.detail).toContain("恢复的持仓缺失止损/止盈保护");
   });
 });
 

--- a/web/console/src/utils/derivation.ts
+++ b/web/console/src/utils/derivation.ts
@@ -1562,6 +1562,8 @@ export function deriveLiveSessionHealth(session: LiveSession, summary: LiveSessi
   const syncError = String(session.state?.lastSyncError ?? "").trim();
   const protectionRecoveryStatus = String(session.state?.protectionRecoveryStatus ?? "").trim();
   const isRunning = String(session.status).toUpperCase() === "RUNNING";
+  const activeQuantity = Math.abs(Number(summary.position?.quantity ?? 0));
+  const hasActivePosition = summary.position != null && activeQuantity > 0;
   const exitDispatchFailure = resolveLiveExitDispatchFailure(session, summary);
 
   // 1. 恢复错误（具备最高健康度权重）
@@ -1572,8 +1574,9 @@ export function deriveLiveSessionHealth(session: LiveSession, summary: LiveSessi
     };
   }
 
-  // 2. 保护状态错误
-  if (protectionRecoveryStatus === "unprotected-open-position") {
+  // 2. 保护状态错误。正常策略自有持仓没有交易所侧保护单时，
+  // 不应把整条 live session 健康度压成 error；真实持仓状态优先展示为 active。
+  if (protectionRecoveryStatus === "unprotected-open-position" && !hasActivePosition) {
     return {
       status: "error",
       detail: "风险: 恢复的持仓缺失止损/止盈保护",
@@ -1605,10 +1608,14 @@ export function deriveLiveSessionHealth(session: LiveSession, summary: LiveSessi
   }
   
   // 6. 活跃持仓状态
-  if (summary.position && Math.abs(Number(summary.position.quantity ?? 0)) > 0) {
+  if (hasActivePosition && summary.position) {
+    const protectionDetail =
+      protectionRecoveryStatus === "unprotected-open-position"
+        ? " · 未发现交易所保护单，运行时风控监控中"
+        : "";
     return {
       status: "active",
-      detail: `持有 ${summary.position.side ?? "仓位"} ${formatMaybeNumber(summary.position.quantity)} @ ${formatMaybeNumber(summary.position.entryPrice)}`,
+      detail: `持有 ${summary.position.side ?? "仓位"} ${formatMaybeNumber(summary.position.quantity)} @ ${formatMaybeNumber(summary.position.entryPrice)}${protectionDetail}`,
     };
   }
 


### PR DESCRIPTION
## 目的
修复实盘正常开仓后控制台把 live session 健康度立即显示成 `ERROR`，平仓后又恢复 `IDLE` 的误报。生产事实通过 `bktrader-ctl --json` 核对：最近开平仓链路是正常 entry/exit，当前 session/runtime/account sync 健康且无持仓，因此问题收敛到前端健康度派生逻辑。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [x] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值没有变化
- [x] 不存在直接调用 `mainnet` 凭证或路由地址的硬编码
- [x] 不涉及 DB migration
- [x] 配置字段没有被混改

## 交易语义变更
- [x] 本次改动不新增/修改 `signalKind`
- [x] 本次改动不影响订单方向判断（`side` / `reduceOnly` / `closePosition`）
- [x] 不涉及订单分类，未运行 `go test ./internal/domain/... -run TestClassifyOrderIntent`
- [x] 不涉及交易链路语义，未运行 `go test ./internal/domain/... -run TestTradingReplayGoldenCases`

## 改动说明
- `deriveLiveSessionHealth` 在存在真实 active position 时不再把 `protectionRecoveryStatus=unprotected-open-position` 直接派生成 `error`。
- active 状态 detail 会保留“未发现交易所保护单”的提示，避免把风险信号吞掉。
- 没有 active position 的 `unprotected-open-position` 仍保持 `error`，保留恢复异常的保守展示。
- 未修改 `internal/service/live*.go`、执行策略、下单、dispatch、reconcile、部署或 CI。

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

验证命令：
- `cd web/console && npm test -- src/utils/derivation.test.ts` (15 tests passed)
- `cd web/console && ./node_modules/.bin/tsc --noEmit src/pages/AccountStage.tsx --jsx react-jsx --esModuleInterop --target esnext --module esnext --moduleResolution Bundler --allowSyntheticDefaultImports`
- `cd web/console && npm run build`