### PR TITLE
[codex] fix production monitor chart summary

### DIFF
--- a/internal/service/account_summary_test.go
+++ b/internal/service/account_summary_test.go
@@ -1,0 +1,106 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/wuyaocheng/bktrader/internal/domain"
+	"github.com/wuyaocheng/bktrader/internal/store/memory"
+)
+
+func TestListAccountSummariesFallsBackToLatestEquitySnapshotForLocalLiveSync(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	account, err := platform.CreateAccount("Binance Testnet", "LIVE", "binance-futures")
+	if err != nil {
+		t.Fatalf("CreateAccount failed: %v", err)
+	}
+	account.Metadata = map[string]any{
+		"lastLiveSyncAt": "2026-05-18T07:34:06Z",
+		"liveSyncSnapshot": map[string]any{
+			"source":        "platform-live-reconciliation",
+			"syncStatus":    "SYNCED",
+			"positionCount": 0,
+		},
+	}
+	if _, err := platform.store.UpdateAccount(account); err != nil {
+		t.Fatalf("UpdateAccount failed: %v", err)
+	}
+	if _, err := platform.store.CreateAccountEquitySnapshot(domain.AccountEquitySnapshot{
+		AccountID:         account.ID,
+		StartEquity:       5000.00,
+		RealizedPnL:       -24.50,
+		UnrealizedPnL:     0,
+		Fees:              1.01,
+		NetEquity:         4974.49,
+		ExposureNotional:  0,
+		OpenPositionCount: 0,
+	}); err != nil {
+		t.Fatalf("CreateAccountEquitySnapshot failed: %v", err)
+	}
+
+	summaries, err := platform.ListAccountSummaries()
+	if err != nil {
+		t.Fatalf("ListAccountSummaries failed: %v", err)
+	}
+	got, ok := accountSummaryByAccountIDForTest(summaries, account.ID)
+	if !ok {
+		t.Fatalf("expected summary for %s, got %+v", account.ID, summaries)
+	}
+	if got.NetEquity != 4974.49 {
+		t.Fatalf("expected fallback net equity 4974.49, got %.2f", got.NetEquity)
+	}
+	if got.WalletBalance != 4974.49 || got.MarginBalance != 4974.49 || got.AvailableBalance != 4974.49 {
+		t.Fatalf("expected flat-account balances to use snapshot net equity, got wallet=%.2f margin=%.2f available=%.2f", got.WalletBalance, got.MarginBalance, got.AvailableBalance)
+	}
+	if got.UpdatedAt.IsZero() {
+		t.Fatal("expected fallback summary updatedAt from latest snapshot")
+	}
+}
+
+func TestListAccountSummariesUsesLiveRestBalanceSnapshot(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	account, err := platform.CreateAccount("Binance Testnet", "LIVE", "binance-futures")
+	if err != nil {
+		t.Fatalf("CreateAccount failed: %v", err)
+	}
+	account.Metadata = map[string]any{
+		"lastLiveSyncAt": "2026-05-18T07:34:06Z",
+		"liveSyncSnapshot": map[string]any{
+			"source":                "binance-rest-account-v3",
+			"syncStatus":            "SYNCED",
+			"totalWalletBalance":    5020.00,
+			"totalUnrealizedProfit": 20.00,
+			"totalMarginBalance":    5040.00,
+			"availableBalance":      4900.00,
+			"positions": []any{
+				map[string]any{"notional": -100.5},
+			},
+		},
+	}
+	if _, err := platform.store.UpdateAccount(account); err != nil {
+		t.Fatalf("UpdateAccount failed: %v", err)
+	}
+
+	summaries, err := platform.ListAccountSummaries()
+	if err != nil {
+		t.Fatalf("ListAccountSummaries failed: %v", err)
+	}
+	got, ok := accountSummaryByAccountIDForTest(summaries, account.ID)
+	if !ok {
+		t.Fatalf("expected summary for %s, got %+v", account.ID, summaries)
+	}
+	if got.NetEquity != 5040 || got.WalletBalance != 5020 || got.AvailableBalance != 4900 {
+		t.Fatalf("expected live rest balances, got net=%.2f wallet=%.2f available=%.2f", got.NetEquity, got.WalletBalance, got.AvailableBalance)
+	}
+	if got.ExposureNotional != 100.5 || got.OpenPositionCount != 1 {
+		t.Fatalf("expected live rest exposure/count, got %.2f/%d", got.ExposureNotional, got.OpenPositionCount)
+	}
+}
+
+func accountSummaryByAccountIDForTest(summaries []domain.AccountSummary, accountID string) (domain.AccountSummary, bool) {
+	for _, summary := range summaries {
+		if summary.AccountID == accountID {
+			return summary, true
+		}
+	}
+	return domain.AccountSummary{}, false
+}

--- a/internal/service/strategy.go
+++ b/internal/service/strategy.go
@@ -332,6 +332,16 @@ func (p *Platform) ListAccountSummaries() ([]domain.AccountSummary, error) {
 	for _, account := range accounts {
 		if liveSummary, ok := buildLiveAccountSummaryFromSnapshot(account); ok {
 			liveSummaries = append(liveSummaries, liveSummary)
+		} else if strings.EqualFold(account.Mode, "LIVE") {
+			latestSnapshot, ok, err := p.latestAccountEquitySnapshot(account.ID)
+			if err != nil {
+				return nil, err
+			}
+			if ok {
+				liveSummaries = append(liveSummaries, buildLiveAccountSummaryFromEquitySnapshot(account, latestSnapshot))
+			} else {
+				paperAccounts = append(paperAccounts, account)
+			}
 		} else {
 			paperAccounts = append(paperAccounts, account)
 		}
@@ -404,6 +414,9 @@ func buildLiveAccountSummaryFromSnapshot(account domain.Account) (domain.Account
 	if len(snapshot) == 0 || !strings.EqualFold(stringValue(snapshot["syncStatus"]), "SYNCED") {
 		return domain.AccountSummary{}, false
 	}
+	if !liveSyncSnapshotHasBalanceFields(snapshot) {
+		return domain.AccountSummary{}, false
+	}
 	updatedAt := time.Now().UTC()
 	if raw := stringValue(account.Metadata["lastLiveSyncAt"]); raw != "" {
 		if parsed, err := time.Parse(time.RFC3339, raw); err == nil {
@@ -429,6 +442,55 @@ func buildLiveAccountSummaryFromSnapshot(account domain.Account) (domain.Account
 		OpenPositionCount: len(metadataList(snapshot["positions"])),
 		UpdatedAt:         updatedAt,
 	}, true
+}
+
+func liveSyncSnapshotHasBalanceFields(snapshot map[string]any) bool {
+	return parseFloatValue(snapshot["totalWalletBalance"]) > 0 ||
+		parseFloatValue(snapshot["totalMarginBalance"]) > 0 ||
+		parseFloatValue(snapshot["availableBalance"]) > 0
+}
+
+func (p *Platform) latestAccountEquitySnapshot(accountID string) (domain.AccountEquitySnapshot, bool, error) {
+	items, err := p.store.ListAccountEquitySnapshots(domain.AccountEquitySnapshotQuery{
+		AccountID: accountID,
+		Limit:     1,
+	})
+	if err != nil {
+		return domain.AccountEquitySnapshot{}, false, err
+	}
+	if len(items) == 0 {
+		return domain.AccountEquitySnapshot{}, false, nil
+	}
+	return items[len(items)-1], true, nil
+}
+
+func buildLiveAccountSummaryFromEquitySnapshot(account domain.Account, snapshot domain.AccountEquitySnapshot) domain.AccountSummary {
+	updatedAt := snapshot.CreatedAt
+	if updatedAt.IsZero() {
+		updatedAt = time.Now().UTC()
+	}
+	availableBalance := 0.0
+	if snapshot.OpenPositionCount == 0 {
+		availableBalance = snapshot.NetEquity
+	}
+	return domain.AccountSummary{
+		AccountID:         account.ID,
+		AccountName:       account.Name,
+		Mode:              account.Mode,
+		Exchange:          account.Exchange,
+		Status:            account.Status,
+		StartEquity:       round2(snapshot.StartEquity),
+		RealizedPnL:       round2(snapshot.RealizedPnL),
+		UnrealizedPnL:     round2(snapshot.UnrealizedPnL),
+		Fees:              round2(snapshot.Fees),
+		NetEquity:         round2(snapshot.NetEquity),
+		AvailableBalance:  round2(availableBalance),
+		WalletBalance:     round2(snapshot.NetEquity),
+		MarginBalance:     round2(snapshot.NetEquity),
+		ExposureNotional:  round2(snapshot.ExposureNotional),
+		OpenPositionCount: snapshot.OpenPositionCount,
+		UpdatedAt:         updatedAt,
+	}
 }
 
 func sumSnapshotPositionNotional(value any) float64 {

--- a/web/console/src/pages/MonitorStage.tsx
+++ b/web/console/src/pages/MonitorStage.tsx
@@ -54,6 +54,7 @@ const MONITOR_CANDLE_CACHE_LIMIT = 1500;
 const MONITOR_LIVE_SESSION_DETAIL_FIELDS = [
   "timeline",
   "breakoutHistory",
+  "lastStrategyEvaluationSourceStates",
   "lastStrategyEvaluationSignalBarStates",
 ];
 
@@ -119,16 +120,13 @@ function mergeMonitorCandles(existing: ChartCandle[], incoming: ChartCandle[], d
     : merged.slice(merged.length - MONITOR_CANDLE_CACHE_LIMIT);
 }
 
-function mergeSignalBars(fallbackBars: SignalBarCandle[], runtimeBars: SignalBarCandle[]) {
+function mergeSignalBars(...barGroups: SignalBarCandle[][]) {
   const byTime = new Map<string, SignalBarCandle>();
-  for (const item of fallbackBars) {
-    if (item.time) {
-      byTime.set(item.time, item);
-    }
-  }
-  for (const item of runtimeBars) {
-    if (item.time) {
-      byTime.set(item.time, item);
+  for (const bars of barGroups) {
+    for (const item of bars) {
+      if (item.time) {
+        byTime.set(item.time, item);
+      }
     }
   }
   return Array.from(byTime.values()).sort((a, b) => Date.parse(a.time) - Date.parse(b.time));
@@ -285,20 +283,27 @@ export function MonitorStage({ syncLiveOrder, dockTab, onDockTabChange, dockCont
   const monitorSymbol = monitorSignalSymbol || sessionSymbol;
 
   const monitorBars = useMemo(() => {
-    const sourceBars = deriveSignalBarCandles(getRecord(highlightedLiveRuntimeState.sourceStates), {
+    const selection = {
       targetSymbol: monitorSymbol,
       targetTimeframe: monitorSignalTimeframe,
       targetStateKey: monitorSignalBarStateKey,
-    });
-    const stateBars = deriveSignalBarStateCandles(getRecord(highlightedLiveRuntimeState.signalBarStates), {
-      targetSymbol: monitorSymbol,
-      targetTimeframe: monitorSignalTimeframe,
-      targetStateKey: monitorSignalBarStateKey,
-    });
-    return mergeSignalBars(sourceBars, stateBars);
+    };
+    const sessionSourceBars = deriveSignalBarCandles(
+      getRecord(monitorSessionState.lastStrategyEvaluationSourceStates),
+      selection
+    );
+    const sessionStateBars = deriveSignalBarStateCandles(
+      getRecord(monitorSessionState.lastStrategyEvaluationSignalBarStates),
+      selection
+    );
+    const runtimeSourceBars = deriveSignalBarCandles(getRecord(highlightedLiveRuntimeState.sourceStates), selection);
+    const runtimeStateBars = deriveSignalBarStateCandles(getRecord(highlightedLiveRuntimeState.signalBarStates), selection);
+    return mergeSignalBars(sessionSourceBars, sessionStateBars, runtimeSourceBars, runtimeStateBars);
   }, [
     highlightedLiveRuntimeState.sourceStates,
     highlightedLiveRuntimeState.signalBarStates,
+    monitorSessionState.lastStrategyEvaluationSourceStates,
+    monitorSessionState.lastStrategyEvaluationSignalBarStates,
     monitorSymbol,
     monitorSignalTimeframe,
     monitorSignalBarStateKey,

--- a/web/console/src/utils/liveSessionDetail.test.ts
+++ b/web/console/src/utils/liveSessionDetail.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import type { LiveSession } from "../types/domain";
+import { mergeLiveSessionDetail, mergeLiveSessionSnapshot } from "./liveSessionDetail";
+
+function liveSession(state: Record<string, unknown>): LiveSession {
+  return {
+    id: "live-session-1",
+    alias: "",
+    accountId: "account-1",
+    strategyId: "strategy-1",
+    status: "RUNNING",
+    state,
+    createdAt: "2026-05-18T07:00:00Z",
+  };
+}
+
+describe("live session detail merging", () => {
+  it("preserves loaded source-state bars across summary refreshes", () => {
+    const sourceStates = {
+      "binance-kline|signal|ETHUSDT|1h": {
+        streamType: "signal_bar",
+        symbol: "ETHUSDT",
+        timeframe: "1h",
+        bars: [
+          {
+            barStart: "1779080400000",
+            open: "2122.07",
+            high: "2123.59",
+            low: "2116.65",
+            close: "2116.67",
+          },
+        ],
+      },
+    };
+
+    const withDetail = mergeLiveSessionDetail(
+      [liveSession({ status: "summary" })],
+      liveSession({ lastStrategyEvaluationSourceStates: sourceStates }),
+      ["lastStrategyEvaluationSourceStates"]
+    );
+    const afterSummaryRefresh = mergeLiveSessionSnapshot(withDetail, [liveSession({ status: "summary-refresh" })]);
+
+    expect(afterSummaryRefresh[0]?.state?.lastStrategyEvaluationSourceStates).toEqual(sourceStates);
+  });
+});


### PR DESCRIPTION
## 目的
修复生产主监控页展示异常：summary 轮询剥离全量 signal bars 后，主图只剩少量 K 线并导致历史开仓/BO 标记挤在一起；同时 live account summary 在本地 reconcile 快照不含余额字段时把净值显示为 `0.00`。

Root cause：
- `/api/v1/live/sessions?view=summary` 为减小 payload 会剥离 `sourceStates.bars`，Monitor 主图只从 summary/runtime 精简状态取数时只能拿到 `current/prevBar1..3`。
- 当前生产 `/api/v1/chart/candles` 对 ETH/BTC 1h fallback 返回空，无法补齐历史 K 线。
- `platform-live-reconciliation` 类型的 `liveSyncSnapshot` 只包含订单/成交/持仓摘要，不包含 `totalWalletBalance` / `totalMarginBalance` / `availableBalance`，旧 summary 逻辑把缺失字段解析为 0。

本次改动：
- Monitor detail lazy-load 增加 `lastStrategyEvaluationSourceStates`，并把 detail 中的全量 signal bars 合并进主图数据源。
- `mergeSignalBars` 支持多个来源合并，避免 REST fallback 为空时只剩精简 runtime bars。
- live account summary 遇到无余额字段的 synced 快照时，回退到最新 account equity snapshot，避免净值误显示为 0。
- 增加后端 account summary 回归测试和前端 live session detail merge 回归测试。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [x] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) - 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？- 无
- [x] DB migration 是否具备向下兼容幂等性？- 不涉及 migration
- [x] 配置字段有没有无意被混改？- 无

## 交易语义变更
- [x] 本次改动是否新增/修改了 `signalKind`？若是，需同步更新 Golden Case - 否
- [x] 本次改动是否影响订单方向判断（`side` / `reduceOnly` / `closePosition`）？- 否
- [ ] 若涉及上述改动，`go test ./internal/domain/... -run TestClassifyOrderIntent` 是否通过？- 不涉及
- [ ] 若涉及交易链路语义（开仓/平仓/撤单/risk-exit），`go test ./internal/domain/... -run TestTradingReplayGoldenCases` 是否通过？- 不涉及

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

已运行：
- `go test ./internal/service -run 'TestListAccountSummaries'`
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
- `cd web/console && npm test -- liveSessionDetail.test.ts`
- `cd web/console && ./node_modules/.bin/tsc --noEmit src/pages/MonitorStage.tsx --jsx react-jsx --esModuleInterop --target esnext --module esnext --moduleResolution Bundler --allowSyntheticDefaultImports`
- `cd web/console && npm run build`

Notes：`npm ci` 有现存 engine/audit warning；build 和测试均通过。
