### PR TITLE
[codex] Add T3 overlay rejection diagnostics

### DIFF
--- a/internal/service/pretouch_event_detector.go
+++ b/internal/service/pretouch_event_detector.go
@@ -174,9 +174,10 @@ func (d *PretouchEventDetector) OnNewHourlyBarOpen(openTime time.Time, openPrice
 
 // PretouchDetectionResult is the output of tick processing.
 type PretouchDetectionResult struct {
-	Detected bool
-	Event    domain.PretouchEvent
-	Reason   string // reason if not detected (for debugging)
+	Detected    bool
+	Event       domain.PretouchEvent
+	Reason      string         // reason if not detected (for debugging)
+	Diagnostics map[string]any // structured context for rejected near-touch events
 }
 
 // OnTick processes a new tick and checks for pretouch event detection.
@@ -404,28 +405,61 @@ func (d *PretouchEventDetector) OnTickT3Overlay(tick TickData) PretouchDetection
 	touchTime := tick.Time
 	touchPrice := tick.Price
 	signalBarStart := d.currentBar.OpenTime
+	diagnostics := map[string]any{
+		"shape":                  "t3_swing",
+		"side":                   side,
+		"level":                  level,
+		"touchPrice":             touchPrice,
+		"atr":                    atr,
+		"signalBarStart":         formatOptionalRFC3339(signalBarStart),
+		"tickTime":               formatOptionalRFC3339(touchTime),
+		"current":                pretouchBarSnapshot(d.currentBar),
+		"prevBar1":               pretouchBarSnapshot(&prevBar1),
+		"prevBar2":               pretouchBarSnapshot(&prevBar2),
+		"prevBar3":               pretouchBarSnapshot(&prevBar3),
+		"longStructureReady":     longReady,
+		"shortStructureReady":    shortReady,
+		"maxPreTouchSeconds":     d.config.MaxPreTouchSeconds,
+		"minAbsSpeed300sATR":     d.config.MinSpeed300sATR,
+		"maxEff300s":             d.config.MaxEff300s,
+		"roundtripCostThreshold": d.config.CostQ50Threshold,
+	}
 	preTouchSeconds := touchTime.Sub(signalBarStart).Seconds()
+	diagnostics["preTouchSeconds"] = preTouchSeconds
 	if preTouchSeconds > d.config.MaxPreTouchSeconds {
-		return PretouchDetectionResult{Reason: fmt.Sprintf("t3_pre_touch_seconds=%.0f > %.0f", preTouchSeconds, d.config.MaxPreTouchSeconds)}
+		return PretouchDetectionResult{
+			Reason:      fmt.Sprintf("t3_pre_touch_seconds=%.0f > %.0f", preTouchSeconds, d.config.MaxPreTouchSeconds),
+			Diagnostics: diagnostics,
+		}
 	}
 
 	touchExtATR := (touchPrice - level) / atr
 	if side == "short" {
 		touchExtATR = (level - touchPrice) / atr
 	}
+	diagnostics["touchExtensionATR"] = touchExtATR
 	speed300s := d.computeSpeed300s(atr)
+	diagnostics["speed300sATR"] = speed300s
 	if math.Abs(speed300s) < d.config.MinSpeed300sATR {
-		return PretouchDetectionResult{Reason: fmt.Sprintf("t3_speed_300s=%.4f < %.4f", math.Abs(speed300s), d.config.MinSpeed300sATR)}
+		return PretouchDetectionResult{
+			Reason:      fmt.Sprintf("t3_speed_300s=%.4f < %.4f", math.Abs(speed300s), d.config.MinSpeed300sATR),
+			Diagnostics: diagnostics,
+		}
 	}
 	eff300s := d.computeEff300s()
+	diagnostics["eff300s"] = eff300s
 	if eff300s > d.config.MaxEff300s {
-		return PretouchDetectionResult{Reason: fmt.Sprintf("t3_eff_300s=%.4f > %.4f", eff300s, d.config.MaxEff300s)}
+		return PretouchDetectionResult{
+			Reason:      fmt.Sprintf("t3_eff_300s=%.4f > %.4f", eff300s, d.config.MaxEff300s),
+			Diagnostics: diagnostics,
+		}
 	}
 
 	roundtripCostATR := 0.10
 	if tick.BestAsk > 0 && tick.BestBid > 0 && tick.BestAsk >= tick.BestBid {
 		roundtripCostATR = (tick.BestAsk - tick.BestBid) / atr
 	}
+	diagnostics["roundtripCostATR"] = roundtripCostATR
 	costPenalty := 1.0
 	if roundtripCostATR >= d.config.CostQ50Threshold {
 		costPenalty = d.config.CostQ50Penalty

--- a/internal/service/strategy_engine_pretouch_timing.go
+++ b/internal/service/strategy_engine_pretouch_timing.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"os"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -79,6 +80,9 @@ type bkLiveEthPretouchTimingEngine struct {
 	modelPath   string
 	t3ModelPath string
 	config      PretouchDetectorConfig
+
+	t3MissLogMu  sync.Mutex
+	t3MissLogKey string
 }
 
 func newBkLiveEthPretouchTimingEngine(platform *Platform) *bkLiveEthPretouchTimingEngine {
@@ -436,6 +440,7 @@ func (e *bkLiveEthPretouchTimingEngine) evaluateT3ShadowOverlay(ctx StrategySign
 	}
 	result := e.t3Detector.OnTickT3Overlay(tick)
 	if !result.Detected {
+		e.logT3ShadowOverlayMiss(ctx, tick, leadMissReason, result)
 		return StrategySignalDecision{}, false
 	}
 
@@ -553,6 +558,72 @@ func (e *bkLiveEthPretouchTimingEngine) evaluateT3ShadowOverlay(ctx StrategySign
 		Reason:   fmt.Sprintf("pretouch_t3_overlay_%s", result.Event.Side),
 		Metadata: metadata,
 	}, true
+}
+
+func (e *bkLiveEthPretouchTimingEngine) logT3ShadowOverlayMiss(ctx StrategySignalEvaluationContext, tick TickData, leadMissReason string, result PretouchDetectionResult) {
+	if e == nil || e.platform == nil || !pretouchT3OverlayMissLoggable(result.Reason) {
+		return
+	}
+	diagnostics := cloneMetadata(result.Diagnostics)
+	category := pretouchT3OverlayMissReasonCategory(result.Reason)
+	signalBarStart := firstNonEmpty(stringValue(diagnostics["signalBarStart"]), formatOptionalRFC3339(ctx.EventTime.Truncate(time.Hour)))
+	key := strings.Join([]string{
+		NormalizeSymbol(ctx.ExecutionContext.Symbol),
+		signalBarStart,
+		category,
+		stringValue(diagnostics["side"]),
+	}, "|")
+	if !e.shouldLogT3ShadowOverlayMiss(key) {
+		return
+	}
+	e.platform.logger("service.pretouch_timing",
+		"symbol", ctx.ExecutionContext.Symbol,
+		"strategy_version_id", ctx.ExecutionContext.StrategyVersionID,
+		"signal_timeframe", ctx.ExecutionContext.SignalTimeframe,
+	).Info("pretouch T3 overlay rejected",
+		"lead_miss_reason", leadMissReason,
+		"t3_miss_reason", result.Reason,
+		"t3_miss_category", category,
+		"event_time", formatOptionalRFC3339(ctx.EventTime),
+		"tick_price", tick.Price,
+		"diagnostics", diagnostics,
+	)
+}
+
+func (e *bkLiveEthPretouchTimingEngine) shouldLogT3ShadowOverlayMiss(key string) bool {
+	if e == nil {
+		return false
+	}
+	e.t3MissLogMu.Lock()
+	defer e.t3MissLogMu.Unlock()
+	if key != "" && e.t3MissLogKey == key {
+		return false
+	}
+	e.t3MissLogKey = key
+	return true
+}
+
+func pretouchT3OverlayMissLoggable(reason string) bool {
+	switch pretouchT3OverlayMissReasonCategory(reason) {
+	case "t3_pre_touch_seconds", "t3_speed_300s", "t3_eff_300s":
+		return true
+	default:
+		return false
+	}
+}
+
+func pretouchT3OverlayMissReasonCategory(reason string) string {
+	reason = strings.TrimSpace(reason)
+	switch {
+	case strings.HasPrefix(reason, "t3_pre_touch_seconds="):
+		return "t3_pre_touch_seconds"
+	case strings.HasPrefix(reason, "t3_speed_300s="):
+		return "t3_speed_300s"
+	case strings.HasPrefix(reason, "t3_eff_300s="):
+		return "t3_eff_300s"
+	default:
+		return reason
+	}
 }
 
 type pretouchShadowSubmitContext struct {

--- a/internal/service/strategy_engine_pretouch_timing_test.go
+++ b/internal/service/strategy_engine_pretouch_timing_test.go
@@ -1,7 +1,10 @@
 package service
 
 import (
+	"bytes"
+	"log/slog"
 	"math"
+	"strings"
 	"testing"
 	"time"
 
@@ -547,6 +550,56 @@ func TestPretouchTimingEngineAttachesT3StopGateProfileToOverlayIntent(t *testing
 	intentGate := mapValue(intent.Metadata["pretouchT3StopGate"])
 	if !boolValue(intentGate["pass"]) {
 		t.Fatalf("expected stop gate pass in intent metadata, got %#v", intentGate)
+	}
+}
+
+func TestPretouchTimingEngineLogsT3OverlayDetectorMissOncePerSignalBar(t *testing.T) {
+	start := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
+	engine := testPretouchTimingEngine("fast", 0.75)
+
+	var logs bytes.Buffer
+	previousLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelInfo})))
+	defer slog.SetDefault(previousLogger)
+
+	ctx := testPretouchT3OverlaySignalContext(start, 100.0)
+	enablePretouchRiskOnShadow(&ctx, true)
+	ctx.ExecutionContext.Parameters["pretouchShadowOverlayMaxPreTouchSec"] = 30.0
+	if _, err := engine.EvaluateSignal(ctx); err != nil {
+		t.Fatalf("initial evaluate failed: %v", err)
+	}
+
+	logs.Reset()
+	ctx = testPretouchT3OverlaySignalContext(start.Add(60*time.Second), 106.1)
+	enablePretouchRiskOnShadow(&ctx, true)
+	ctx.ExecutionContext.Parameters["pretouchShadowOverlayMaxPreTouchSec"] = 30.0
+	decision, err := engine.EvaluateSignal(ctx)
+	if err != nil {
+		t.Fatalf("evaluate failed: %v", err)
+	}
+	if decision.Action != "wait" || decision.Reason != "no_level_touch" {
+		t.Fatalf("expected lead wait/no_level_touch to remain unchanged, got %#v", decision)
+	}
+	output := logs.String()
+	if !strings.Contains(output, "pretouch T3 overlay rejected") {
+		t.Fatalf("expected T3 overlay rejection log, got %q", output)
+	}
+	if !strings.Contains(output, "t3_miss_category=t3_pre_touch_seconds") {
+		t.Fatalf("expected normalized T3 miss category in log, got %q", output)
+	}
+	if !strings.Contains(output, "preTouchSeconds:60") || !strings.Contains(output, "maxPreTouchSeconds:30") {
+		t.Fatalf("expected timing diagnostics in log, got %q", output)
+	}
+
+	logs.Reset()
+	ctx = testPretouchT3OverlaySignalContext(start.Add(61*time.Second), 106.1)
+	enablePretouchRiskOnShadow(&ctx, true)
+	ctx.ExecutionContext.Parameters["pretouchShadowOverlayMaxPreTouchSec"] = 30.0
+	if _, err := engine.EvaluateSignal(ctx); err != nil {
+		t.Fatalf("repeat evaluate failed: %v", err)
+	}
+	if strings.Contains(logs.String(), "pretouch T3 overlay rejected") {
+		t.Fatalf("expected repeated same-bar rejection to be throttled, got %q", logs.String())
 	}
 }
 


### PR DESCRIPTION
## 目的
补齐 ETH pretouch T3 shadow overlay 的拒绝诊断日志。生产上 lead detector 未命中时会继续尝试 T3 overlay；但如果 T3 已触碰 level 后被 `t3_pre_touch_seconds` / `t3_speed_300s` / `t3_eff_300s` 等门槛拒绝，main 代码只返回最终 lead 的 `wait/no_level_touch`，没有留下 T3 拒绝原因。这个 PR 只补 observability，不改变信号、下单、仓位或默认参数语义。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [x] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) — 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？— 无
- [x] DB migration 是否具备向下兼容幂等性？— 不涉及 migration
- [x] 配置字段有没有无意被混改？— 无

## 交易语义变更
- [x] 本次改动是否新增/修改了 `signalKind`？若是，需同步更新 Golden Case — 否
- [x] 本次改动是否影响订单方向判断（`side` / `reduceOnly` / `closePosition`）？— 否
- [ ] 若涉及上述改动，`go test ./internal/domain/... -run TestClassifyOrderIntent` 是否通过？— 不涉及
- [ ] 若涉及交易链路语义（开仓/平仓/撤单/risk-exit），`go test ./internal/domain/... -run TestTradingReplayGoldenCases` 是否通过？— 不涉及

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

验证已跑：
- `go test ./internal/service -run 'TestPretouchTimingEngineLogsT3OverlayDetectorMissOncePerSignalBar|TestPretouchTimingEngineSubmitsT3OverlayForSandboxShadow|TestPretouchEventDetectorRejectsLatePretouch'`
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
- `bash scripts/check_high_risk_defaults.sh`

## 改动摘要
- 为 T3 overlay detector 的 near-touch 拒绝路径附加结构化 diagnostics，包括 level、side、signal bar、preTouchSeconds、速度/效率门槛、prev/current bar snapshot。
- 在 T3 shadow overlay 未通过 detector 门槛时记录 `pretouch T3 overlay rejected`，包含 lead miss reason、T3 miss reason、归一化 category 和 diagnostics。
- 日志按 `symbol + signalBarStart + missCategory + side` 节流，避免同一根 K 内每个 tick 刷屏。
- 新增回归测试确认最终交易决策仍保持 `wait/no_level_touch`，但 T3 拒绝日志会出现且同 bar 重复拒绝会被节流。
