### PR TITLE
[codex] Keep live SL exits market-only

### DIFF
--- a/internal/service/execution_strategy.go
+++ b/internal/service/execution_strategy.go
@@ -298,53 +298,28 @@ func (bookAwareExecutionStrategy) BuildProposal(ctx ExecutionPlanningContext) (E
 			proposal.Metadata["expectedFillCoverage"] = slProtection.ExpectedCoverage
 			proposal.Metadata["quoteGapBps"] = slProtection.QuoteGapBps
 			proposal.Metadata["slProtectionDepthMode"] = slProtection.DepthMode
-			if wideSpreadMode == slWideSpreadModeSpreadCappedLimit && slProtection.Price > 0 {
-				restingTimeout := profile.RestingTimeoutSeconds
-				if restingTimeout <= 0 {
-					restingTimeout = 1
-				}
-				proposal.Type = "LIMIT"
-				proposal.LimitPrice = slProtection.Price
-				proposal.PriceHint = slProtection.Price
-				proposal.PriceSource = "sl_protection.spread_capped"
-				proposal.TimeInForce = strings.ToUpper(strings.TrimSpace(firstNonEmpty(profile.TimeInForce, "GTC")))
-				proposal.PostOnly = false
-				proposal.Metadata["executionMode"] = "sl-spread-capped-limit"
-				proposal.Metadata["executionExpiresAt"] = ctx.EventTime.UTC().Add(time.Duration(restingTimeout) * time.Second).Format(time.RFC3339)
-				proposal.Metadata["executionRestingTimeoutSeconds"] = restingTimeout
-				proposal.Metadata["executionDecision"] = "sl-slippage-protected"
-				proposal.Metadata["executionDecisionContext"] = mergeExecutionDecisionContext(
-					mapValue(proposal.Metadata["executionDecisionContext"]),
-					map[string]any{
-						"slProtectionBranch":    true,
-						"slProtectionMode":      slWideSpreadModeSpreadCappedLimit,
-						"slProtectionObserved":  true,
-						"slMaxSlippageBps":      slMaxSlippageBps,
-						"slProtectionDepthMode": slProtection.DepthMode,
-						"topDepthQty":           slProtection.TopDepthQty,
-						"topDepthNotional":      slProtection.TopDepthNotional,
-						"expectedFillCoverage":  slProtection.ExpectedCoverage,
-						"quoteGapBps":           slProtection.QuoteGapBps,
-						"fallbackOrderType":     timeoutFallbackType,
-						"restingTimeoutSeconds": restingTimeout,
-					},
-				)
-				return proposal, nil
+			extraContext := map[string]any{
+				"slProtectionBranch":    true,
+				"slProtectionMode":      "market-dispatch",
+				"slProtectionObserved":  true,
+				"slMaxSlippageBps":      slMaxSlippageBps,
+				"slProtectionDepthMode": slProtection.DepthMode,
+				"topDepthQty":           slProtection.TopDepthQty,
+				"topDepthNotional":      slProtection.TopDepthNotional,
+				"expectedFillCoverage":  slProtection.ExpectedCoverage,
+				"quoteGapBps":           slProtection.QuoteGapBps,
+			}
+			if wideSpreadMode == slWideSpreadModeSpreadCappedLimit {
+				const suppressedReason = "reduce-only-sl-market-required"
+				proposal.Metadata["slProtectionRequestedMode"] = slWideSpreadModeSpreadCappedLimit
+				proposal.Metadata["slProtectionSuppressedReason"] = suppressedReason
+				extraContext["slProtectionRequestedMode"] = slWideSpreadModeSpreadCappedLimit
+				extraContext["slProtectionSuppressedReason"] = suppressedReason
 			}
 			proposal.Metadata["executionDecision"] = "direct-dispatch"
 			proposal.Metadata["executionDecisionContext"] = mergeExecutionDecisionContext(
 				mapValue(proposal.Metadata["executionDecisionContext"]),
-				map[string]any{
-					"slProtectionBranch":    true,
-					"slProtectionMode":      "market-dispatch",
-					"slProtectionObserved":  true,
-					"slMaxSlippageBps":      slMaxSlippageBps,
-					"slProtectionDepthMode": slProtection.DepthMode,
-					"topDepthQty":           slProtection.TopDepthQty,
-					"topDepthNotional":      slProtection.TopDepthNotional,
-					"expectedFillCoverage":  slProtection.ExpectedCoverage,
-					"quoteGapBps":           slProtection.QuoteGapBps,
-				},
+				extraContext,
 			)
 			return proposal, nil
 		}

--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -5748,9 +5748,14 @@ func deriveLiveSignalIntent(decision StrategySignalDecision, symbol string) *Sig
 		"pretouchShadowOverlaySizing",
 		"pretouchT3StopGate",
 		"pretouchT3ExitProfile",
+		"livePositionState",
 	} {
 		if value, ok := meta[key]; ok {
-			intent.Metadata[key] = value
+			if metadata := mapValue(value); len(metadata) > 0 {
+				intent.Metadata[key] = cloneMetadata(metadata)
+			} else {
+				intent.Metadata[key] = value
+			}
 		}
 	}
 	if event, ok := meta["pretouchEvent"].(domain.PretouchEvent); ok {

--- a/internal/service/live_launch_templates.go
+++ b/internal/service/live_launch_templates.go
@@ -376,8 +376,6 @@ func buildEthPretouchTimingTemplate(strategyID, strategyName, strategyVersionID 
 		"executionEntryMaxSourceDivergenceBps":    8,
 		"executionSLExitOrderType":                "MARKET",
 		"executionSLExitMaxSpreadBps":             8,
-		"executionSLExitWideSpreadMode":           slWideSpreadModeSpreadCappedLimit,
-		"executionSLExitRestingTimeoutSeconds":    1,
 		"executionSLMaxSlippageBps":               8,
 		"executionSLExitTimeoutFallbackOrderType": "MARKET",
 		"dispatchCooldownSeconds":                 30,

--- a/internal/service/live_launch_templates_test.go
+++ b/internal/service/live_launch_templates_test.go
@@ -175,11 +175,11 @@ func TestLiveLaunchTemplatesExposeBinanceTestnetVariants(t *testing.T) {
 			if got := parseFloatValue(item.LaunchPayload.LiveSessionOverrides["pretouchBaseOrderQuantity"]); got != want.quantity {
 				t.Fatalf("expected pretouchBaseOrderQuantity=%v, got %v", want.quantity, got)
 			}
-			if got := stringValue(item.LaunchPayload.LiveSessionOverrides["executionSLExitWideSpreadMode"]); got != slWideSpreadModeSpreadCappedLimit {
-				t.Fatalf("expected pretouch template SL wide-spread mode %s, got %s", slWideSpreadModeSpreadCappedLimit, got)
+			if _, ok := item.LaunchPayload.LiveSessionOverrides["executionSLExitWideSpreadMode"]; ok {
+				t.Fatalf("expected pretouch template not to rest SL exits as capped limits: %#v", item.LaunchPayload.LiveSessionOverrides)
 			}
-			if got := maxIntValue(item.LaunchPayload.LiveSessionOverrides["executionSLExitRestingTimeoutSeconds"], 0); got != 1 {
-				t.Fatalf("expected pretouch template SL capped-limit timeout 1s, got %d", got)
+			if _, ok := item.LaunchPayload.LiveSessionOverrides["executionSLExitRestingTimeoutSeconds"]; ok {
+				t.Fatalf("expected pretouch template not to configure SL resting timeout: %#v", item.LaunchPayload.LiveSessionOverrides)
 			}
 			if got := stringValue(item.LaunchPayload.LiveSessionOverrides["executionSLExitTimeoutFallbackOrderType"]); got != "MARKET" {
 				t.Fatalf("expected pretouch template SL timeout fallback MARKET, got %s", got)

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -60,6 +60,50 @@ func TestDeriveLiveSignalIntentUsesNextPlannedStep(t *testing.T) {
 	}
 }
 
+func TestDeriveLiveSignalIntentCarriesLivePositionStateForExitTelemetry(t *testing.T) {
+	decision := StrategySignalDecision{
+		Action: "advance-plan",
+		Metadata: map[string]any{
+			"signalBarDecision": map[string]any{"ready": true},
+			"marketPrice":       2068.87,
+			"marketSource":      "order_book.bestBid",
+			"signalKind":        "risk-exit",
+			"decisionState":     "exit-ready",
+			"signalBarStateKey": "binance|ETHUSDT|signal|1h",
+			"currentPosition": map[string]any{
+				"found":      true,
+				"symbol":     "ETHUSDT",
+				"side":       "LONG",
+				"quantity":   0.273,
+				"entryPrice": 2067.51,
+			},
+			"livePositionState": map[string]any{
+				"stopLossSource":      "breakeven-stop",
+				"targetPrice":         2069.57751,
+				"targetPriceSource":   "breakeven-stop",
+				"riskMultiple":        0.938576779,
+				"breakevenStopActive": true,
+			},
+			"nextPlannedSide":   "SELL",
+			"nextPlannedRole":   "exit",
+			"nextPlannedReason": "SL",
+			"nextPlannedPrice":  2069.57751,
+		},
+	}
+
+	intent := deriveLiveSignalIntent(decision, "ETHUSDT")
+	if intent == nil {
+		t.Fatal("expected exit intent")
+	}
+	liveState := mapValue(intent.Metadata["livePositionState"])
+	if got := stringValue(liveState["stopLossSource"]); got != "breakeven-stop" {
+		t.Fatalf("expected livePositionState stopLossSource to be carried, got %s", got)
+	}
+	if got := parseFloatValue(liveState["targetPrice"]); got != 2069.57751 {
+		t.Fatalf("expected target price telemetry to be carried, got %v", got)
+	}
+}
+
 func TestDeriveLiveSignalIntentNormalizesExitSideFromCurrentPosition(t *testing.T) {
 	decision := StrategySignalDecision{
 		Action: "advance-plan",
@@ -3126,7 +3170,7 @@ func TestBookAwareExecutionStrategyKeepsMarketSLWithDefaultSlippageTelemetry(t *
 	}
 }
 
-func TestBookAwareExecutionStrategyUsesSpreadCappedLimitForWideSLWhenConfigured(t *testing.T) {
+func TestBookAwareExecutionStrategySuppressesSpreadCappedLimitForWideSLWhenConfigured(t *testing.T) {
 	strategy := bookAwareExecutionStrategy{}
 	eventTime := time.Date(2026, 5, 21, 10, 30, 21, 0, time.UTC)
 	proposal, err := strategy.BuildProposal(ExecutionPlanningContext{
@@ -3162,42 +3206,107 @@ func TestBookAwareExecutionStrategyUsesSpreadCappedLimitForWideSLWhenConfigured(
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if proposal.Type != "LIMIT" || proposal.TimeInForce != "GTC" || proposal.PostOnly {
-		t.Fatalf("expected non-post-only LIMIT GTC SL proposal, got type=%s tif=%s postOnly=%v", proposal.Type, proposal.TimeInForce, proposal.PostOnly)
+	if proposal.Type != "MARKET" || proposal.LimitPrice != 0 || proposal.TimeInForce != "" || proposal.PostOnly {
+		t.Fatalf("expected reduce-only SL to remain MARKET, got type=%s limit=%v tif=%s postOnly=%v", proposal.Type, proposal.LimitPrice, proposal.TimeInForce, proposal.PostOnly)
 	}
 	if !proposal.ReduceOnly {
-		t.Fatal("expected capped SL proposal to stay reduceOnly")
+		t.Fatal("expected SL proposal to stay reduceOnly")
 	}
-	if got := proposal.LimitPrice; got != 2120.506652 {
-		t.Fatalf("expected spread-capped limit price 2120.506652, got %v", got)
+	if got := stringValue(proposal.Metadata["executionDecision"]); got != "direct-dispatch" {
+		t.Fatalf("expected direct-dispatch decision, got %s", got)
 	}
-	if got := proposal.PriceHint; got != proposal.LimitPrice {
-		t.Fatalf("expected price hint to track capped limit price, got priceHint=%v limit=%v", proposal.PriceHint, proposal.LimitPrice)
+	if got := stringValue(proposal.Metadata["executionExpiresAt"]); got != "" {
+		t.Fatalf("expected no resting expiry for MARKET SL, got %s", got)
 	}
-	if got := proposal.PriceSource; got != "sl_protection.spread_capped" {
-		t.Fatalf("expected capped price source, got %s", got)
+	if got := stringValue(proposal.Metadata["slProtectionRequestedMode"]); got != slWideSpreadModeSpreadCappedLimit {
+		t.Fatalf("expected requested capped mode telemetry, got %s", got)
 	}
-	if got := stringValue(proposal.Metadata["executionDecision"]); got != "sl-slippage-protected" {
-		t.Fatalf("expected sl-slippage-protected decision, got %s", got)
-	}
-	if got := stringValue(proposal.Metadata["executionExpiresAt"]); got != eventTime.Add(time.Second).Format(time.RFC3339) {
-		t.Fatalf("expected 1s SL capped-limit expiry, got %s", got)
-	}
-	if got := maxIntValue(proposal.Metadata["executionRestingTimeoutSeconds"], 0); got != 1 {
-		t.Fatalf("expected resting timeout metadata 1s, got %d", got)
+	if got := stringValue(proposal.Metadata["slProtectionSuppressedReason"]); got != "reduce-only-sl-market-required" {
+		t.Fatalf("expected SL protection suppression telemetry, got %s", got)
 	}
 	if got := parseFloatValue(proposal.Metadata["slCappedPrice"]); got != 2120.506652 {
 		t.Fatalf("expected telemetry slCappedPrice 2120.506652, got %v", got)
 	}
 	context := mapValue(proposal.Metadata["executionDecisionContext"])
-	if got := stringValue(context["slProtectionMode"]); got != slWideSpreadModeSpreadCappedLimit {
-		t.Fatalf("expected spread-capped-limit protection mode, got %s", got)
+	if got := stringValue(context["slProtectionMode"]); got != "market-dispatch" {
+		t.Fatalf("expected market-dispatch protection mode, got %s", got)
+	}
+	if got := stringValue(context["slProtectionRequestedMode"]); got != slWideSpreadModeSpreadCappedLimit {
+		t.Fatalf("expected requested capped mode context, got %s", got)
+	}
+	if got := stringValue(context["slProtectionSuppressedReason"]); got != "reduce-only-sl-market-required" {
+		t.Fatalf("expected suppressed reason context, got %s", got)
 	}
 	if got := parseFloatValue(context["expectedFillCoverage"]); got != 0.9247311827956989 {
 		t.Fatalf("expected top-book coverage telemetry, got %v", got)
 	}
-	if got := stringValue(context["fallbackOrderType"]); got != "MARKET" {
-		t.Fatalf("expected MARKET fallback metadata, got %s", got)
+}
+
+func TestBookAwareExecutionStrategyKeepsProfitLockedWideSLMarketWhenCappedModeConfigured(t *testing.T) {
+	strategy := bookAwareExecutionStrategy{}
+	proposal, err := strategy.BuildProposal(ExecutionPlanningContext{
+		Session: domain.LiveSession{},
+		Execution: StrategyExecutionContext{
+			Parameters: map[string]any{
+				"executionSLExitWideSpreadMode":        slWideSpreadModeSpreadCappedLimit,
+				"executionSLExitRestingTimeoutSeconds": 1,
+				"executionSLMaxSlippageBps":            8.0,
+			},
+		},
+		EventTime: time.Date(2026, 5, 23, 18, 15, 49, 0, time.UTC),
+		Intent: SignalIntent{
+			Action:      "exit",
+			Role:        "exit",
+			Reason:      "SL",
+			Side:        "SELL",
+			Symbol:      "ETHUSDT",
+			PriceHint:   2068.87,
+			PriceSource: "order_book.bestBid",
+			Quantity:    0.273,
+			SignalKind:  "risk-exit",
+			Metadata: map[string]any{
+				"bestBid":    2068.87,
+				"bestAsk":    2073.53,
+				"bestBidQty": 0.058,
+				"bestAskQty": 0.115,
+				"spreadBps":  22.499034376208524,
+				"currentPosition": map[string]any{
+					"found":      true,
+					"symbol":     "ETHUSDT",
+					"side":       "LONG",
+					"quantity":   0.273,
+					"entryPrice": 2067.51,
+					"hwm":        2072.88,
+				},
+				"livePositionState": map[string]any{
+					"stopLossSource":      "breakeven-stop",
+					"targetPriceSource":   "breakeven-stop",
+					"targetPrice":         2069.57751,
+					"riskMultiple":        0.9385767790261956,
+					"breakevenStopActive": true,
+				},
+				"signalBarStateKey": "state-eth-pretouch-sl",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if proposal.Type != "MARKET" || proposal.LimitPrice != 0 || proposal.TimeInForce != "" || proposal.PostOnly {
+		t.Fatalf("expected profit-locked SL to remain MARKET, got type=%s limit=%v tif=%s postOnly=%v", proposal.Type, proposal.LimitPrice, proposal.TimeInForce, proposal.PostOnly)
+	}
+	if got := proposal.PriceHint; got != 2068.87 {
+		t.Fatalf("expected MARKET SL price hint to stay at current bid, got %v", got)
+	}
+	if got := parseFloatValue(proposal.Metadata["slCappedPrice"]); got != 2071.8730400000004 {
+		t.Fatalf("expected production capped price telemetry 2071.8730400000004, got %v", got)
+	}
+	if got := stringValue(proposal.Metadata["slProtectionSuppressedReason"]); got != "reduce-only-sl-market-required" {
+		t.Fatalf("expected capped-limit suppression reason, got %s", got)
+	}
+	liveState := mapValue(proposal.Metadata["livePositionState"])
+	if got := stringValue(liveState["stopLossSource"]); got != "breakeven-stop" {
+		t.Fatalf("expected breakeven stop telemetry to survive proposal build, got %s", got)
 	}
 }
 

--- a/internal/store/memory/store.go
+++ b/internal/store/memory/store.go
@@ -317,8 +317,6 @@ func NewStore() *Store {
 			"executionEntryMaxSourceDivergenceBps":         8,
 			"executionSLExitOrderType":                     "MARKET",
 			"executionSLExitMaxSpreadBps":                  8,
-			"executionSLExitWideSpreadMode":                "spread-capped-limit",
-			"executionSLExitRestingTimeoutSeconds":         1,
 			"executionSLMaxSlippageBps":                    8,
 			"executionSLExitTimeoutFallbackOrderType":      "MARKET",
 			"dispatchCooldownSeconds":                      30,


### PR DESCRIPTION
## 目的
修复 PR #450 暴露的 SL 出场执行风险：宽点差下的 `spread-capped-limit` 会把 reduce-only SL 变成非即时成交的 resting LIMIT，在浮盈/成本锁定回撤场景里可能错过本应立即执行的退出价。现在 SL 宽点差只保留 capped price / 深度 telemetry，真实 reduce-only SL 始终保持 MARKET。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [x] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [x] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) - 未改变 dispatchMode；ETH pretouch 模板仍沿用既有默认。
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？- 否。
- [x] DB migration 是否具备向下兼容幂等性？- 无 DB migration。
- [x] 配置字段有没有无意被混改？- 有意移除 ETH pretouch 默认 `executionSLExitWideSpreadMode` / `executionSLExitRestingTimeoutSeconds`，避免新 session 继续默认 resting SL。

## 交易语义变更
- [ ] 本次改动是否新增/修改了 `signalKind`？若是，需同步更新 Golden Case
- [x] 本次改动是否影响订单方向判断（`side` / `reduceOnly` / `closePosition`）？- 影响 reduce-only SL 执行方式：宽点差也强制 MARKET，不再转换成 LIMIT。
- [x] 若涉及上述改动，`go test ./internal/domain/... -run TestClassifyOrderIntent` 是否通过？
- [x] 若涉及交易链路语义（开仓/平仓/撤单/risk-exit），`go test ./internal/domain/... -run TestTradingReplayGoldenCases` 是否通过？

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

验证：
- `go test ./internal/service -run 'TestBookAwareExecutionStrategy(SuppressesSpreadCappedLimitForWideSLWhenConfigured|KeepsProfitLockedWideSLMarketWhenCappedModeConfigured|FallsBackToMarketAfterSLTimeout|KeepsMarketSLWhenSlippageProtectionConfigured|KeepsMarketSLWithDefaultSlippageTelemetry)|TestDeriveLiveSignalIntent(CarriesLivePositionStateForExitTelemetry|UsesNextPlannedStep|NormalizesExitSideFromCurrentPosition|NormalizesShortExitSideFromCurrentPosition)|TestListLiveLaunchTemplates'`
- `go test ./internal/service`
- `go test ./internal/domain/... -run TestTradingReplayGoldenCases`
- `go test ./internal/domain/... -run TestClassifyOrderIntent`
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
- `bash scripts/check_high_risk_defaults.sh`
- `git diff --check`

Root cause:
- `spread-capped-limit` 在 spread 超过 cap 时，生成的 capped SELL limit 位于 best bid 上方，本质上可能无法立即成交。
- SL 出场是风险降低路径，不能用等待限价替代 MARKET 清仓；这次 ETHUSDT 生产单因此先等 1 秒，再 fallback MARKET，实际成交质量劣化。

本 PR 的行为：
- 残留或新配置 `executionSLExitWideSpreadMode=spread-capped-limit` 时，reduce-only SL 仍然 MARKET。
- 保留 `slCappedPrice`、top depth、coverage、quote gap telemetry，并新增 `slProtectionRequestedMode` / `slProtectionSuppressedReason`，方便复盘确认为什么没有走 resting LIMIT。
- `deriveLiveSignalIntent` 会把 `livePositionState` 带入订单 metadata，后续能直接看到 `breakeven-stop` / `trailing-stop` / `targetPrice` 等执行背景。
