### PR TITLE
[codex] Fix orphaned signal runtime leases

### DIFF
--- a/internal/service/runtime_lease.go
+++ b/internal/service/runtime_lease.go
@@ -31,6 +31,11 @@ func (p *Platform) acquireRuntimeLease(ctx context.Context, resourceType, resour
 
 func (p *Platform) acquireRuntimeLeaseWithTiming(ctx context.Context, resourceType, resourceID string, ttl, heartbeatInterval time.Duration) (context.Context, func(), bool, error) {
 	ownerID := p.runtimeLeaseOwnerID
+	logger := p.logger("service.runtime_lease",
+		"resource_type", resourceType,
+		"resource_id", resourceID,
+		"owner_id", ownerID,
+	)
 	lease, ok, err := p.store.AcquireRuntimeLease(domain.RuntimeLeaseAcquireRequest{
 		ResourceType: resourceType,
 		ResourceID:   resourceID,
@@ -38,15 +43,17 @@ func (p *Platform) acquireRuntimeLeaseWithTiming(ctx context.Context, resourceTy
 		TTL:          ttl,
 	})
 	if err != nil || !ok {
+		if err == nil {
+			logger.Debug("runtime lease held by another owner",
+				"holder_owner_id", lease.OwnerID,
+				"holder_expires_at", lease.ExpiresAt,
+				"holder_updated_at", lease.UpdatedAt,
+			)
+		}
 		return ctx, func() {}, ok, err
 	}
 
 	leaseCtx, cancel := context.WithCancel(ctx)
-	logger := p.logger("service.runtime_lease",
-		"resource_type", resourceType,
-		"resource_id", resourceID,
-		"owner_id", ownerID,
-	)
 	logger.Debug("runtime lease acquired", "expires_at", lease.ExpiresAt)
 
 	var once sync.Once

--- a/internal/service/signal_runtime_ws.go
+++ b/internal/service/signal_runtime_ws.go
@@ -124,6 +124,8 @@ type signalRuntimeWSProfile struct {
 	pingWriteTimeout time.Duration
 }
 
+var signalRuntimePersistedStopCheckInterval = 5 * time.Second
+
 type signalRuntimeLoopRunner func(context.Context, string) (bool, error)
 type signalRuntimeBackoffWaiter func(context.Context, time.Duration) bool
 
@@ -627,8 +629,10 @@ func (p *Platform) runExchangeWebsocketLoop(
 	})
 	connected := true
 
-	ticker := time.NewTicker(wsProfile.pingInterval)
-	defer ticker.Stop()
+	pingTicker := time.NewTicker(wsProfile.pingInterval)
+	defer pingTicker.Stop()
+	stopCheckTicker := time.NewTicker(signalRuntimePersistedStopCheckInterval)
+	defer stopCheckTicker.Stop()
 
 	done := make(chan error, 1)
 	go func() {
@@ -697,7 +701,20 @@ func (p *Platform) runExchangeWebsocketLoop(
 				"error", err,
 			)
 			return connected, err
-		case <-ticker.C:
+		case <-stopCheckTicker.C:
+			stopRequested, stopCheckErr := p.persistedSignalRuntimeStopRequested(session.ID)
+			if stopCheckErr != nil {
+				logger.Warn("signal runtime persisted stop check failed", "error", stopCheckErr)
+			} else if stopRequested {
+				passiveTimeout := p.runtimePolicy.WSPassiveCloseTimeoutSeconds
+				if passiveTimeout <= 0 {
+					passiveTimeout = 2
+				}
+				logger.Info("signal runtime persisted stop observed; closing websocket")
+				_ = conn.WriteControl(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, "session stopped"), time.Now().Add(time.Duration(passiveTimeout)*time.Second))
+				return connected, nil
+			}
+		case <-pingTicker.C:
 			if err := conn.WriteControl(websocket.PingMessage, []byte("ping"), time.Now().Add(wsProfile.pingWriteTimeout)); err != nil {
 				logger.Warn("signal runtime websocket ping failed",
 					"connected", connected,
@@ -714,6 +731,24 @@ func (p *Platform) runExchangeWebsocketLoop(
 			})
 		}
 	}
+}
+
+func (p *Platform) persistedSignalRuntimeStopRequested(sessionID string) (bool, error) {
+	session, err := p.store.GetSignalRuntimeSession(sessionID)
+	if err != nil {
+		if isSignalRuntimeSessionNotFoundError(err) {
+			return true, nil
+		}
+		return false, err
+	}
+	if strings.EqualFold(session.Status, "STOPPED") || strings.EqualFold(session.Status, "ERROR") {
+		return true, nil
+	}
+	desired := strings.TrimSpace(stringValue(session.State["desiredStatus"]))
+	if desired != "" && !strings.EqualFold(desired, "RUNNING") {
+		return true, nil
+	}
+	return false, nil
 }
 
 // validateSignalBarContinuityAfterReconnect checks if a signal bar close was missed

--- a/internal/service/signal_runtime_ws_test.go
+++ b/internal/service/signal_runtime_ws_test.go
@@ -310,6 +310,155 @@ func TestRunExchangeWebsocketLoopRecordsReconnectObservability(t *testing.T) {
 	}
 }
 
+func TestRunExchangeWebsocketLoopStopsWhenPersistedSessionStopped(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	platform.SetRuntimePolicy(RuntimePolicy{
+		WSReadStaleTimeoutSeconds:    5,
+		WSPingIntervalSeconds:        1,
+		WSPassiveCloseTimeoutSeconds: 1,
+	})
+	if got := platform.signalRuntimeWSProfileForAttempt(0).pingInterval; got != time.Second {
+		t.Fatalf("test setup expected 1s ping interval, got %s", got)
+	}
+	originalStopCheckInterval := signalRuntimePersistedStopCheckInterval
+	signalRuntimePersistedStopCheckInterval = 50 * time.Millisecond
+	t.Cleanup(func() {
+		signalRuntimePersistedStopCheckInterval = originalStopCheckInterval
+	})
+	now := time.Now().UTC()
+	session := domain.SignalRuntimeSession{
+		ID:             "runtime-external-stop",
+		Status:         "RUNNING",
+		RuntimeAdapter: "binance-market-ws",
+		State: map[string]any{
+			"desiredStatus": "RUNNING",
+			"actualStatus":  "RUNNING",
+			"subscriptions": []map[string]any{{
+				"sourceKey":  "binance-trade-tick",
+				"role":       "trigger",
+				"symbol":     "BTCUSDT",
+				"channel":    "btcusdt@trade",
+				"adapterKey": "binance-market-ws",
+			}},
+		},
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	persisted, err := platform.store.CreateSignalRuntimeSession(session)
+	if err != nil {
+		t.Fatalf("persist runtime session failed: %v", err)
+	}
+	platform.cacheSignalRuntimeSession(persisted)
+
+	subscribed := make(chan struct{})
+	upgrader := websocket.Upgrader{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade failed: %v", err)
+			return
+		}
+		defer conn.Close()
+		if _, _, err := conn.ReadMessage(); err != nil {
+			t.Errorf("read subscribe payload failed: %v", err)
+			return
+		}
+		close(subscribed)
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}))
+	defer server.Close()
+
+	type loopResult struct {
+		connected bool
+		err       error
+	}
+	resultCh := make(chan loopResult, 1)
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	go func() {
+		connected, err := platform.runExchangeWebsocketLoop(context.Background(), persisted, wsURL, func([]map[string]any) (map[string]any, error) {
+			return map[string]any{
+				"method": "SUBSCRIBE",
+				"params": []string{"btcusdt@trade"},
+				"id":     1,
+			}, nil
+		})
+		resultCh <- loopResult{connected: connected, err: err}
+	}()
+
+	select {
+	case <-subscribed:
+	case <-time.After(time.Second):
+		t.Fatal("expected runtime websocket to subscribe")
+	}
+	deadline := time.Now().Add(time.Second)
+	for {
+		current, err := platform.store.GetSignalRuntimeSession(persisted.ID)
+		if err != nil {
+			t.Fatalf("get connected runtime session failed: %v", err)
+		}
+		if stringValue(current.State["connectedAt"]) != "" {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("expected websocket connected state before external stop, got %#v", current.State)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	stopped := persisted
+	stopped.Status = "STOPPED"
+	stopped.State = cloneMetadata(stopped.State)
+	stopped.State["desiredStatus"] = "STOPPED"
+	stopped.State["actualStatus"] = "STOPPED"
+	if _, err := platform.store.UpdateSignalRuntimeSession(stopped); err != nil {
+		t.Fatalf("persist external stop failed: %v", err)
+	}
+
+	select {
+	case result := <-resultCh:
+		if !result.connected {
+			t.Fatal("expected websocket loop to report connected before external stop")
+		}
+		if result.err != nil {
+			t.Fatalf("expected persisted stop to end loop cleanly, got %v", result.err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected persisted external stop to close websocket loop")
+	}
+}
+
+func TestPersistedSignalRuntimeStopRequestedTreatsDeletedSessionAsStop(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	session, err := platform.store.CreateSignalRuntimeSession(domain.SignalRuntimeSession{
+		ID:             "runtime-deleted",
+		Status:         "RUNNING",
+		RuntimeAdapter: "binance-market-ws",
+		State: map[string]any{
+			"desiredStatus": "RUNNING",
+		},
+		CreatedAt: time.Now().UTC(),
+		UpdatedAt: time.Now().UTC(),
+	})
+	if err != nil {
+		t.Fatalf("create runtime session failed: %v", err)
+	}
+	if err := platform.store.DeleteSignalRuntimeSession(session.ID); err != nil {
+		t.Fatalf("delete runtime session failed: %v", err)
+	}
+
+	stopRequested, err := platform.persistedSignalRuntimeStopRequested(session.ID)
+	if err != nil {
+		t.Fatalf("persisted stop check failed: %v", err)
+	}
+	if !stopRequested {
+		t.Fatal("expected deleted persisted session to request runner stop")
+	}
+}
+
 func TestFilterStatesBySymbolKeepsBlankEntriesForBackwardCompatibility(t *testing.T) {
 	sourceStates := map[string]any{
 		"btc":    map[string]any{"symbol": "BTCUSDT"},


### PR DESCRIPTION
## 目的
修复 signal runtime stop/delete 跨进程后，实际持有 WebSocket/lease 的 runner 没有退出，导致后续启动报 `runtime lease not acquired` / `signal runtime session lease held by another runner` 的问题。

这次从代码路径判断，CD 路由本身覆盖 `internal/service/live.go` 相关服务；更像是控制面已经把 runtime 持久化为 `STOPPED` 或删除，但旧 owner 进程只监听本地 `ctx`，没有监听 DB 里的 stop/delete 事实，于是继续 heartbeat runtime lease。PR 做两件事：

- signal runtime WebSocket loop 每 5 秒读取持久化 runtime session；如果看到 session 已删除、`STOPPED`、`ERROR`，或 `desiredStatus != RUNNING`，就主动正常关闭 websocket 并退出 runner，从而走 defer 释放 runtime lease。
- runtime lease acquire 失败但没有 store error 时，补充 holder owner / expires / updated 日志，方便下一次生产日志直接定位谁还在占 lease。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [x] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) - 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？- 无
- [x] DB migration 是否具备向下兼容幂等性？- 无 migration
- [x] 配置字段有没有无意被混改？- 无配置字段改动

## 交易语义变更
- [x] 本次改动是否新增/修改了 `signalKind`？若是，需同步更新 Golden Case - 否
- [x] 本次改动是否影响订单方向判断（`side` / `reduceOnly` / `closePosition`）？- 否
- [x] 若涉及上述改动，`go test ./internal/domain/... -run TestClassifyOrderIntent` 是否通过？- 不涉及
- [x] 若涉及交易链路语义（开仓/平仓/撤单/risk-exit），`go test ./internal/domain/... -run TestTradingReplayGoldenCases` 是否通过？- 不涉及

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

已验证：

- `go test ./internal/service -run 'TestRunExchangeWebsocketLoopStopsWhenPersistedSessionStopped|TestRuntimeLease|TestStopSignalRuntimeSessionCancelsRunnerAndReleasesLeaseOnce' -count=1`
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
- `bash scripts/check_high_risk_defaults.sh`
