### PR TITLE
[codex] Add pretouch T2 static downsize shadow

### DIFF
--- a/docs/eth-pretouch-timing-live-design.md
+++ b/docs/eth-pretouch-timing-live-design.md
@@ -116,6 +116,142 @@ T3 overlay 增强的 exact-lead portfolio sensitivity 结果保存在：
 `10-15bp` extra overlay round-trip slippage 仍可接受，`20bp` 时 overlay leg 转负且组合不再跑赢
 `base_lead_adverse10_exact`，应作为 kill-stress。
 
+### 2026-05-22 T2 shadow candidate sweep / 单腿优化推进
+
+本轮只推进 ETHUSDT 1h pretouch T2 standalone 降仓规则搜索，不改变当前
+testnet shadow bundle，不把 T3 deterministic stop-gate 或 PR447 overlay 收益作为 T2 pass 依据。
+
+- Runner:
+  `research/entry_redesign/scripts/timing_probability_unified/t2_shadow_candidate_sweep.py`
+- Output:
+  `research/entry_redesign/scripts/output/timing_probability_unified/t2_shadow_candidate_sweep_20260522/t2_shadow_candidate_sweep_report.md`
+- Control:
+  `base_current`，scenario 固定为 `next_adverse_xslip10bps`。
+- Input:
+  两份 frozen current-lead audit；为对齐 clean T2 base `50.434734%`，只用
+  `selector=eff0817385_prevclose_le_0p969489` + `action_policy=buf020` 携带
+  `baseline_pnl_pct`，不把 CSV 里的 `selected` 布尔列作为二次过滤标签。
+- Allowed features:
+  `rf_probability`、`speed_300s_atr`、`eff_300s`、`touch_extension_atr`、
+  `prev1_close_pos_side`、`prev1_range_atr`、`side`。
+- Sizing action:
+  只允许 downsize，scale ladder 为 `1.0/0.75/0.50/0.25/0.0`。
+- Anti-leak:
+  每个 forward month 只能用 prior months 选阈值规则；不使用 T3 / `combo_pnl_pct`、
+  不使用月度收益标签、不使用 future month。
+
+Walk-forward 结果：
+
+| Candidate | 2022-07..2024-12 delta | 2025-06..2026-04 delta | All delta | Avg scale | Neg months | Max DD | 结论 |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| `static_quality_downsize` | `+2.990405pp` | `-2.914431pp` | `+0.075974pp` | `0.933219` | `16/19` | `-6.625610%` vs base `-7.409576%` | 长窗口能砍掉坏桶，但 canary 明显低于 base，不能 pass。 |
+| `pure_loss_distilled` | `+0.397752pp` | `+0.000000pp` | `+0.397752pp` | `0.955479` | `16/19` | `-7.409576%` vs base `-7.409576%` | 已蒸馏为固定阈值规则，但 long delta 未达到 `+1.0pp`，all delta 也未达 shadow `+2.0pp`。 |
+
+Frozen train-window 诊断进一步确认当前坏桶不适合直接固化成 shadow rule：
+
+| Frozen rule | Train delta | Holdout delta | All delta | 结论 |
+| --- | ---: | ---: | ---: | --- |
+| `speed_300s_atr<=0.251125 => scale 0.25` | `+6.231559pp` | `-2.914431pp` | `+3.317128pp` | 2022-2024 train 很强，但 2025-2026 holdout 失败，不能 freeze。 |
+| `touch_extension_atr<=-0.124973 & speed_300s_atr<=0.251125 => scale 0.00` | `+3.548808pp` | `-3.885908pp` | `-0.337100pp` | pure-loss 蒸馏规则 holdout 更差，不能 freeze。 |
+
+当前结论：**没有 T2 单腿候选通过 testnet shadow gate**。`context_confirmed_downsize`
+需要 4h/12h closed-bar context 列；当前 T2 audit 缺少 `ctx4h_side_return_atr` /
+`ctx12h_side_return_atr`，本轮只能登记为 research watch unavailable。后续 T2 优化应先重建
+closed-bar context 或扩展可解释特征，再重新做 standalone gate；在通过 T2 standalone gate 前，
+不做 Go live metadata wiring。
+
+### 2026-05-25 T2 static downsize 候选推进 / under review
+
+本轮在 2026-05-22 runner 上补齐 closed-bar context 后，继续只推进 T2 standalone downsize。
+它仍不改变当前 testnet shadow bundle，也不把 T3 overlay / combo 收益作为 pass 依据。
+
+- Runner:
+  `research/entry_redesign/scripts/timing_probability_unified/t2_shadow_candidate_sweep.py`
+- Deep-dive helper:
+  `research/entry_redesign/scripts/timing_probability_unified/t2_static_downsize_deep_dive.py`
+- Output:
+  `research/entry_redesign/scripts/output/timing_probability_unified/t2_shadow_candidate_sweep_20260525/t2_shadow_candidate_sweep_report.md`
+- Candidate:
+  `static_optimal_or_doc_a_ctx12h_range_le350_scale025_downsize`
+- Rule:
+  若未命中 profit-protection，`ctx12h_range_atr <= 3.500000`，并且命中以下任一风险桶，
+  则把本次 T2 size 缩到 `0.25`：
+  - `eff_300s >= 0.925057 && ctx12h_side_return_atr <= -0.282982`
+  - `touch_extension_atr <= -0.112263 && ctx12h_range_atr >= 3.006207`
+- Profit-protection:
+  `ctx12h_side_return_atr >= 1.45` 或 `ctx4h_range_atr >= 2.36` 或
+  `ctx12h_range_atr >= 3.98` 或 `rf_probability >= 0.965` 时，不降仓。
+
+2026-05-25 rolling walk-forward 结果：
+
+| Candidate | 2022-07..2024-12 delta | 2025-06..2026-04 delta | All delta | Avg scale | Selected | Shadow gate | 结论 |
+| --- | ---: | ---: | ---: | ---: | ---: | --- | --- |
+| `static_optimal_downsize` | `+3.318669pp` | `+0.626243pp` | `+3.944912pp` | `0.979452` | `3/146` | pass | 收益略高，但 canary lift 较弱。 |
+| `static_optimal_or_doc_a_scale025_downsize` | `+2.007711pp` | `+1.718344pp` | `+3.726056pp` | `0.974315` | `5/146` | pass | 原 OR 候选，保留为对照。 |
+| `static_optimal_or_doc_a_ctx12h_range_le350_scale025_downsize` | `+5.655933pp` | `+1.718344pp` | `+7.374277pp` | `0.958904` | `8/146` | pass | 新主候选；用圆整的 `ctx12h_range_atr <= 3.50` 限制训练期过度命中，恢复 2024-10..12 收益。 |
+
+固定全周期 deep-dive 显示过滤版 `static_optimal OR doc_rule_a` + `ctx12h_range_atr <= 3.50`
+的潜在空间为：all `+10.009754pp`、canary `+1.718344pp`、avg scale `0.933219`。正式
+rolling runner 只允许 prior months 激活规则，因此 promotion 口径以
+`t2_shadow_candidate_sweep_20260525` 为准。
+
+Stability audit 显示 `ctx12h_range_atr <= 3.40/3.45/3.50` 形成同一收益平台，不是单点阈值；
+在 `3.25..3.60` 区间内有 `8/19` 个阈值同时满足 all/canary/avg-scale/frozen-holdout 约束。
+Frozen train-window 诊断显示过滤版不再是 base passthrough：train `+8.291409pp`、
+holdout `+1.718344pp`、all `+10.009754pp`、holdout avg scale `0.956731`，读数为
+`holdout non-negative; inspect before promotion`。
+
+追加的 purged nested threshold selection 进一步确认收益不依赖固定 `3.50`：每个 forward month
+只用更早月份训练，并空出 1 个 purge month；阈值取训练窗内达到 best delta `95%` 的平台中位数。
+该选择器在 `28/40` 个 forward month 激活，自动选择阈值 `3.35..3.80`，all `+7.687331pp`、
+long `+5.968986pp`、canary `+1.718344pp`、avg scale `0.953767`、selected `9/146`。因此当前状态从
+`research_candidate_under_review` 提升为 `research_candidate_review_ready`；在完成人工 review、
+事件级审计和必要的 live 可重建性确认之前，仍不做 Go live metadata wiring。
+
+Selected-event reconstructability audit 已完成第一层确认：
+
+- Script:
+  `research/entry_redesign/scripts/timing_probability_unified/t2_downsize_selected_event_reconstructability.py`
+- Output:
+  `research/entry_redesign/scripts/output/timing_probability_unified/t2_downsize_selected_event_reconstructability_20260525/`
+- Result:
+  closed-bar context `8/8` 可重建，decision `8/8` 可重建，max feature abs diff
+  `4.4408920985e-16`。
+- Event branches:
+  `static_optimal` `5` 次、`doc_rule_a` `2` 次、`static_optimal+doc_rule_a` `1` 次；
+  所有 selected event 的 PP 均为 `False`。
+
+这条证据只覆盖 4h/12h closed-bar context 与静态规则重放；`eff_300s`、`touch_extension_atr`
+等 intrabar touch 特征仍依赖既有 event ledger。下一步若要进入 testnet shadow metadata wiring，
+必须先确认 live decision metadata 已有同口径字段，或先补 shadow-only telemetry，不得直接改
+production/live 默认行为。
+
+Metadata readiness audit 进一步收窄实现边界：
+
+- Script:
+  `research/entry_redesign/scripts/timing_probability_unified/t2_downsize_live_metadata_readiness_audit.py`
+- Output:
+  `research/entry_redesign/scripts/output/timing_probability_unified/t2_downsize_live_metadata_readiness_20260525/`
+- Static code read:
+  `rf_probability`、`eff_300s`、`touch_extension_atr` 在 advance-plan 路径已有来源；
+  `ctx12h_side_return_atr`、`ctx4h_range_atr`、`ctx12h_range_atr` 不是当前 Go live decision metadata 字段。
+- Production read-only spot-check:
+  `bktrader-ctl order list --limit 20 --json` 抽样显示，最近 ETH entry order 的
+  `intent.metadata.pretouchEvent` / `executionProposal.metadata.pretouchEvent`
+  含 `eff300s`、`touchExtensionAtr`、`speed300sAtr`、`preTouchSeconds`、`atr`；
+  未见 4h/12h context 字段。
+
+2026-05-25 根据人工推进意见，Go 实现边界从 shadow-only metadata 前移为
+**testnet shadow submitted quantity downsize**：
+
+- 只在 `pretouchShadowMode=testnet_shadow_collect` 下构造 `t2StaticDownsizeCandidate`。
+- 只有 `pretouchShadowT2StaticDownsize=true` 且候选规则 selected 时，才进入 downsize 分支。
+- 真实改 `suggestedQuantity` 前必须复用既有 testnet risk-on guard：`submittedRiskOnQuantityEnabled=true`。
+  也就是 live 语义、账户 `sandbox=true`、`executionMode=rest`、depth/spread guard 通过后，才允许把
+  `submittedQuantityAfterShadow` 乘以 `pretouchShadowT2StaticDownsizeScale`，默认 `0.25`。
+- 非 sandbox / mainnet / guard 未通过时，只记录 would-downsize 与 block reason，不改变 submitted quantity、
+  dispatchMode 或 production suggested quantity。
+
 仓位放大口径：
 
 - `2.5x` T3 overlay（`[0.50,0.25]`）已完成 actual lifecycle replay 和 exact-lead portfolio：
@@ -286,7 +422,8 @@ research 增强一次性接进 Go live。提交版本的边界如下：
 | `2.0x T3 overlay` | **已接入 testnet shadow 真实 entry proposal** | T3 overlay 使用 `pretouchShadowOverlayBaseShare=0.40`、`pretouchShadowOverlayScale=2.0`，默认 base quantity `0.100` 时 initial overlay order 为 `0.080` ETH；仅当 live 语义、`sandbox=true`、`executionMode=rest`、speed/depth/spread guard 通过时生成 `entry-t3-overlay` proposal。scale/share 和最终 submitted quantity 均有硬上限。 |
 | T3 RF/cost quality sizing | **已接入 testnet shadow artifact + absolute quantity band** | `data/pretouch_t3_overlay_rf_model.json` 使用 T3 专用 RF 估计事件胜率，再把 overlay 直接映射到 `0.20..0.40` ETH absolute quantity band；默认 `0.080` ETH fixed overlay 等价于 `2.5..5.0x` quality multiplier。模型缺失或 feature build failed 时默认阻断 overlay submit 并写 `model_missing` / `feature_build_failed` metadata，避免污染 q020/q040 candidate 样本；只有显式 `pretouchShadowOverlayQualityFallbackSubmit=true` 才允许 fixed overlay fallback submit。 |
 | T2/lead quantity band | **已接入 testnet shadow 真实提交数量** | `testnet_shadow_collect` 默认启用 risk-on lead sizing，可用 `pretouchShadowSubmitRiskOnQuantity=false` 显式关闭；只有 live 语义、账户 binding `sandbox=true`、`executionMode=rest` 且 depth/spread guard 通过时，`suggestedQuantity` 才从 production sizing 映射到 `0.20..0.40 ETH`。旧 `1.5x` lead scale 仍保留为无 band 参数时的兼容 fallback。 |
-| 当前 submitted sizing | **testnet shadow 条件放大** | Lead base `productionSuggestedQuantity = pretouchBaseOrderQuantity * pretouchBaseShare * clip(rf_probability * 2, 0, 2) * costPenalty` 仍先按 production RF/cost 生成；通过 risk-on guard 后再按 `productionSuggestedQuantity / maxProductionQuantity` 的质量分数映射到 `0.20..0.40 ETH`。T3 overlay 为独立 `entry-t3-overlay` intent，T3 RF/cost quality 直接映射到 `0.20..0.40 ETH`，并受 `pretouchShadowMaxSubmittedQuantity=0.40` 限制。 |
+| T2 static downsize | **已接入 testnet shadow 真实提交数量** | `static_optimal_or_doc_a_ctx12h_range_le350_scale025_downsize` 在 `testnet_shadow_collect` 下默认启用；命中规则且未触发 PP 时，对已通过 risk-on guard 的 `submittedQuantityAfterShadow` 乘以 `0.25`。非 sandbox / guard 未通过只记录 candidate 与 block reason，不改 production quantity。 |
+| 当前 submitted sizing | **testnet shadow 条件放大 + 条件降仓** | Lead base `productionSuggestedQuantity = pretouchBaseOrderQuantity * pretouchBaseShare * clip(rf_probability * 2, 0, 2) * costPenalty` 仍先按 production RF/cost 生成；通过 risk-on guard 后再按 `productionSuggestedQuantity / maxProductionQuantity` 的质量分数映射到 `0.20..0.40 ETH`。若 T2 static downsize 命中，再对该 testnet shadow submitted quantity 乘以 `0.25`。T3 overlay 为独立 `entry-t3-overlay` intent，T3 RF/cost quality 直接映射到 `0.20..0.40 ETH`，并受 `pretouchShadowMaxSubmittedQuantity=0.40` 限制。 |
 | Testnet shadow | **允许进入 risk-on 采样阶段** | 用真实 `0.20..0.40 ETH` lead quantity 和 T3 overlay `0.20..0.40 ETH` entry proposal 采集 testnet decision/order/fill/depth telemetry；readiness 状态仍不是 mainnet live candidate。 |
 
 #### Shadow 策略细节

--- a/internal/service/live_launch_templates.go
+++ b/internal/service/live_launch_templates.go
@@ -335,6 +335,8 @@ func buildEthPretouchTimingTemplate(strategyID, strategyName, strategyVersionID 
 		"pretouchShadowCandidateID":                            defaultPretouchShadowCandidateID,
 		"pretouchShadowLeadScale":                              defaultPretouchShadowLeadScale,
 		pretouchShadowLeadQuantityBandSizingParam:              true,
+		pretouchShadowT2StaticDownsizeParam:                    true,
+		"pretouchShadowT2StaticDownsizeScale":                  defaultPretouchShadowT2StaticDownsizeScale,
 		"pretouchShadowLeadQuantityMinQuantity":                defaultPretouchShadowLeadQuantityMinQty,
 		"pretouchShadowLeadQuantityMaxQuantity":                defaultPretouchShadowLeadQuantityMaxQty,
 		"pretouchShadowOverlayScale":                           defaultPretouchShadowOverlayScale,

--- a/internal/service/strategy_engine_pretouch_timing.go
+++ b/internal/service/strategy_engine_pretouch_timing.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -13,40 +14,43 @@ import (
 )
 
 const (
-	bkLiveEthPretouchTimingEngineKey          = "bk-live-eth-pretouch-timing"
-	bkLiveEthPretouchTimingStrategyID         = "strategy-bk-eth-pretouch-timing"
-	bkLiveEthPretouchTimingStrategyVersionID  = "strategy-version-bk-eth-pretouch-timing-v010"
-	defaultPretouchModelPath                  = "data/pretouch_model.json"
-	defaultPretouchT3OverlayModelPath         = "data/pretouch_t3_overlay_rf_model.json"
-	pretouchShadowModeTestnetCollect          = "testnet_shadow_collect"
-	pretouchShadowSubmitRiskOnQuantityParam   = "pretouchShadowSubmitRiskOnQuantity"
-	pretouchShadowSubmitOverlayOrderParam     = "pretouchShadowSubmitOverlayOrder"
-	pretouchShadowLeadQuantityBandSizingParam = "pretouchShadowLeadQuantityBandSizing"
-	pretouchShadowOverlayQualitySizingParam   = "pretouchShadowOverlayQualitySizing"
-	pretouchShadowOverlayQualityFallbackParam = "pretouchShadowOverlayQualityFallbackSubmit"
-	pretouchShadowT3StopGateEnabledParam      = "pretouchShadowT3StopGateEnabled"
-	defaultPretouchShadowCandidateID          = "lead_q020_q040_overlay_q020_q040_t3_rf_cost_det_stop_gate_20260521"
-	defaultPretouchShadowLeadScale            = 1.5
-	defaultPretouchShadowLeadQuantityMinQty   = 0.20
-	defaultPretouchShadowLeadQuantityMaxQty   = 0.40
-	defaultPretouchShadowOverlayScale         = 2.0
-	defaultPretouchShadowOverlayBaseShare     = 0.40
-	defaultPretouchShadowOverlaySpeedMin      = 0.35
-	defaultPretouchShadowOverlayQualityMin    = 2.50
-	defaultPretouchShadowOverlayQualityMax    = 5.00
-	defaultPretouchShadowOverlayQualityCost   = 0.10
-	defaultPretouchShadowOverlayQualityMinQty = 0.20
-	defaultPretouchShadowOverlayQualityMaxQty = 0.40
-	pretouchShadowMaxSubmittedQuantityParam   = "pretouchShadowMaxSubmittedQuantity"
-	defaultPretouchShadowMaxSubmittedQuantity = 0.40
-	maxPretouchShadowLeadScale                = defaultPretouchShadowLeadScale
-	maxPretouchShadowOverlayScale             = defaultPretouchShadowOverlayScale
-	maxPretouchShadowOverlayBaseShare         = defaultPretouchShadowOverlayBaseShare
-	maxPretouchShadowOverlayQualityMax        = defaultPretouchShadowOverlayQualityMax
-	maxPretouchShadowMaxSubmittedQuantity     = defaultPretouchShadowMaxSubmittedQuantity
-	defaultPretouchShadowStrict10Pct          = 35.521555
-	defaultPretouchShadowStrict15Pct          = 28.970948
-	defaultPretouchShadowSevere15Pct          = 21.231073
+	bkLiveEthPretouchTimingEngineKey           = "bk-live-eth-pretouch-timing"
+	bkLiveEthPretouchTimingStrategyID          = "strategy-bk-eth-pretouch-timing"
+	bkLiveEthPretouchTimingStrategyVersionID   = "strategy-version-bk-eth-pretouch-timing-v010"
+	defaultPretouchModelPath                   = "data/pretouch_model.json"
+	defaultPretouchT3OverlayModelPath          = "data/pretouch_t3_overlay_rf_model.json"
+	pretouchShadowModeTestnetCollect           = "testnet_shadow_collect"
+	pretouchShadowSubmitRiskOnQuantityParam    = "pretouchShadowSubmitRiskOnQuantity"
+	pretouchShadowSubmitOverlayOrderParam      = "pretouchShadowSubmitOverlayOrder"
+	pretouchShadowLeadQuantityBandSizingParam  = "pretouchShadowLeadQuantityBandSizing"
+	pretouchShadowOverlayQualitySizingParam    = "pretouchShadowOverlayQualitySizing"
+	pretouchShadowOverlayQualityFallbackParam  = "pretouchShadowOverlayQualityFallbackSubmit"
+	pretouchShadowT3StopGateEnabledParam       = "pretouchShadowT3StopGateEnabled"
+	pretouchShadowT2StaticDownsizeParam        = "pretouchShadowT2StaticDownsize"
+	pretouchShadowT2StaticDownsizeCandidateID  = "static_optimal_or_doc_a_ctx12h_range_le350_scale025_downsize"
+	defaultPretouchShadowCandidateID           = "lead_q020_q040_overlay_q020_q040_t3_rf_cost_det_stop_gate_20260521"
+	defaultPretouchShadowLeadScale             = 1.5
+	defaultPretouchShadowT2StaticDownsizeScale = 0.25
+	defaultPretouchShadowLeadQuantityMinQty    = 0.20
+	defaultPretouchShadowLeadQuantityMaxQty    = 0.40
+	defaultPretouchShadowOverlayScale          = 2.0
+	defaultPretouchShadowOverlayBaseShare      = 0.40
+	defaultPretouchShadowOverlaySpeedMin       = 0.35
+	defaultPretouchShadowOverlayQualityMin     = 2.50
+	defaultPretouchShadowOverlayQualityMax     = 5.00
+	defaultPretouchShadowOverlayQualityCost    = 0.10
+	defaultPretouchShadowOverlayQualityMinQty  = 0.20
+	defaultPretouchShadowOverlayQualityMaxQty  = 0.40
+	pretouchShadowMaxSubmittedQuantityParam    = "pretouchShadowMaxSubmittedQuantity"
+	defaultPretouchShadowMaxSubmittedQuantity  = 0.40
+	maxPretouchShadowLeadScale                 = defaultPretouchShadowLeadScale
+	maxPretouchShadowOverlayScale              = defaultPretouchShadowOverlayScale
+	maxPretouchShadowOverlayBaseShare          = defaultPretouchShadowOverlayBaseShare
+	maxPretouchShadowOverlayQualityMax         = defaultPretouchShadowOverlayQualityMax
+	maxPretouchShadowMaxSubmittedQuantity      = defaultPretouchShadowMaxSubmittedQuantity
+	defaultPretouchShadowStrict10Pct           = 35.521555
+	defaultPretouchShadowStrict15Pct           = 28.970948
+	defaultPretouchShadowSevere15Pct           = 21.231073
 
 	pretouchShadowT3StopGateMinAbsSpeed300sATRParam        = "pretouchShadowT3StopGateMinAbsSpeed300sATR"
 	pretouchShadowT3StopGateMinEff300sParam                = "pretouchShadowT3StopGateMinEff300s"
@@ -332,6 +336,10 @@ func (e *bkLiveEthPretouchTimingEngine) EvaluateSignal(ctx StrategySignalEvaluat
 		orderBookStats,
 		pretouchShadowSubmitContextFromEvaluation(ctx),
 	)
+	t2StaticDownsize := pretouchT2StaticDownsizeCandidateFromEvent(ctx.ExecutionContext.Parameters, result.Event, closedBars, rfProb)
+	if shadowSizing != nil && t2StaticDownsize != nil {
+		pretouchApplyT2StaticDownsizeShadow(shadowSizing, t2StaticDownsize)
+	}
 	suggestedQuantity := productionSuggestedQuantity
 	if shadowSizing != nil {
 		if submittedQuantityAfterShadow := parseFloatValue(shadowSizing["submittedQuantityAfterShadow"]); submittedQuantityAfterShadow > 0 {
@@ -378,6 +386,9 @@ func (e *bkLiveEthPretouchTimingEngine) EvaluateSignal(ctx StrategySignalEvaluat
 	if shadowSizing != nil {
 		signalBarDecision["pretouchShadowSizing"] = cloneMetadata(shadowSizing)
 	}
+	if t2StaticDownsize != nil {
+		signalBarDecision["t2StaticDownsizeCandidate"] = cloneMetadata(t2StaticDownsize)
+	}
 	signalBarTradeLimitKey := pretouchSignalBarTradeLimitKey(ctx.ExecutionContext.Symbol, "1h", currentBar)
 
 	metadata := map[string]any{
@@ -414,6 +425,9 @@ func (e *bkLiveEthPretouchTimingEngine) EvaluateSignal(ctx StrategySignalEvaluat
 	}
 	if shadowSizing != nil {
 		metadata["pretouchShadowSizing"] = shadowSizing
+	}
+	if t2StaticDownsize != nil {
+		metadata["t2StaticDownsizeCandidate"] = t2StaticDownsize
 	}
 
 	// Produce signal decision
@@ -794,6 +808,204 @@ func pretouchShadowSizingFromParameters(parameters map[string]any, side string, 
 		"submittedOverlayOrderEnabled":       false,
 		"submittedRiskOnQuantityEnabled":     riskOnEnabled,
 	}
+}
+
+func pretouchT2StaticDownsizeCandidateFromEvent(parameters map[string]any, event domain.PretouchEvent, closedBars []HourlyBar, rfProbability float64) map[string]any {
+	if !strings.EqualFold(stringValue(parameters["pretouchShadowMode"]), pretouchShadowModeTestnetCollect) {
+		return nil
+	}
+	requested := boolValue(parameters[pretouchShadowT2StaticDownsizeParam])
+	scale := firstPositive(parseFloatValue(parameters["pretouchShadowT2StaticDownsizeScale"]), defaultPretouchShadowT2StaticDownsizeScale)
+	if scale <= 0 || scale > 1 {
+		scale = defaultPretouchShadowT2StaticDownsizeScale
+	}
+	candidate := map[string]any{
+		"candidateId":            pretouchShadowT2StaticDownsizeCandidateID,
+		"stage":                  "testnet_shadow_collect",
+		"requested":              requested,
+		"enabled":                requested,
+		"scale":                  scale,
+		"wouldDownsize":          false,
+		"applied":                false,
+		"mainnetSizingPermitted": false,
+	}
+	context, ok := pretouchClosedBarContextFeatures(closedBars, event)
+	candidate["context"] = pretouchClosedBarContextMetadata(context, event, len(closedBars), ok)
+	if !ok {
+		candidate["status"] = "insufficient_closed_bar_context"
+		return candidate
+	}
+	staticOptimal := event.Eff300s >= 0.925057 && context.ctx12hSideReturnATR <= -0.282982
+	docRuleA := event.TouchExtensionATR <= -0.112263 && context.ctx12hRangeATR >= 3.006207
+	rangeCap := context.ctx12hRangeATR <= 3.500000
+	profitProtection := context.ctx12hSideReturnATR >= 1.45 ||
+		context.ctx4hRangeATR >= 2.36 ||
+		context.ctx12hRangeATR >= 3.98 ||
+		rfProbability >= 0.965
+	wouldDownsize := requested && (staticOptimal || docRuleA) && rangeCap && !profitProtection
+	status := "not_selected"
+	if wouldDownsize {
+		status = "selected"
+	}
+	candidate["status"] = status
+	candidate["wouldDownsize"] = wouldDownsize
+	candidate["profitProtection"] = profitProtection
+	candidate["rangeCapPass"] = rangeCap
+	candidate["branches"] = map[string]any{
+		"staticOptimal": staticOptimal,
+		"docRuleA":      docRuleA,
+	}
+	candidate["features"] = map[string]any{
+		"rf_probability":         rfProbability,
+		"eff_300s":               event.Eff300s,
+		"touch_extension_atr":    event.TouchExtensionATR,
+		"ctx12h_side_return_atr": context.ctx12hSideReturnATR,
+		"ctx4h_range_atr":        context.ctx4hRangeATR,
+		"ctx12h_range_atr":       context.ctx12hRangeATR,
+		"speed_300s_atr":         event.Speed300sATR,
+		"pre_touch_seconds":      event.PreTouchSeconds,
+		"roundtrip_cost_atr":     event.RoundtripCostATR,
+		"signal_bar_start":       event.SignalBarStart.UTC().Format(time.RFC3339),
+		"event_id":               event.EventID,
+	}
+	candidate["thresholds"] = map[string]any{
+		"eff_300s_gte":               0.925057,
+		"ctx12h_side_return_atr_lte": -0.282982,
+		"touch_extension_atr_lte":    -0.112263,
+		"ctx12h_range_atr_gte":       3.006207,
+		"ctx12h_range_atr_lte":       3.500000,
+		"pp_ctx12h_side_gte":         1.45,
+		"pp_ctx4h_range_gte":         2.36,
+		"pp_ctx12h_range_gte":        3.98,
+		"pp_rf_probability_gte":      0.965,
+	}
+	return candidate
+}
+
+type pretouchContextFeatures struct {
+	ctx4hSideReturnATR  float64
+	ctx12hSideReturnATR float64
+	ctx4hRangeATR       float64
+	ctx12hRangeATR      float64
+	closedBarsUsed      int
+	lastClosedBarStart  time.Time
+}
+
+func pretouchClosedBarContextMetadata(context pretouchContextFeatures, event domain.PretouchEvent, closedBarsAvailable int, ok bool) map[string]any {
+	if !ok {
+		return map[string]any{
+			"closedBarsAvailable": closedBarsAvailable,
+			"requiredClosedBars":  13,
+			"atr":                 event.ATR,
+		}
+	}
+	return map[string]any{
+		"ctx4h_side_return_atr":  context.ctx4hSideReturnATR,
+		"ctx12h_side_return_atr": context.ctx12hSideReturnATR,
+		"ctx4h_range_atr":        context.ctx4hRangeATR,
+		"ctx12h_range_atr":       context.ctx12hRangeATR,
+		"closedBarsUsed":         context.closedBarsUsed,
+		"lastClosedBarStart":     context.lastClosedBarStart.UTC().Format(time.RFC3339),
+		"atr":                    event.ATR,
+	}
+}
+
+func pretouchClosedBarContextFeatures(closedBars []HourlyBar, event domain.PretouchEvent) (pretouchContextFeatures, bool) {
+	if event.ATR <= 0 || len(closedBars) == 0 {
+		return pretouchContextFeatures{}, false
+	}
+	filtered := make([]HourlyBar, 0, len(closedBars))
+	for _, bar := range closedBars {
+		if validHourlyBar(bar) && bar.OpenTime.Before(event.SignalBarStart) {
+			filtered = append(filtered, bar)
+		}
+	}
+	sort.Slice(filtered, func(i, j int) bool {
+		return filtered[i].OpenTime.Before(filtered[j].OpenTime)
+	})
+	last := len(filtered) - 1
+	if last < 12 {
+		return pretouchContextFeatures{}, false
+	}
+	sideSign := 1.0
+	if strings.EqualFold(event.Side, "short") {
+		sideSign = -1.0
+	}
+	ret := func(hours int) float64 {
+		start := last - hours
+		if start < 0 {
+			return math.NaN()
+		}
+		return (filtered[last].Close - filtered[start].Close) / event.ATR * sideSign
+	}
+	rng := func(hours int) float64 {
+		start := last - hours + 1
+		if start < 0 {
+			return math.NaN()
+		}
+		high := filtered[start].High
+		low := filtered[start].Low
+		for _, bar := range filtered[start : last+1] {
+			if bar.High > high {
+				high = bar.High
+			}
+			if bar.Low < low {
+				low = bar.Low
+			}
+		}
+		return (high - low) / event.ATR
+	}
+	context := pretouchContextFeatures{
+		ctx4hSideReturnATR:  ret(4),
+		ctx12hSideReturnATR: ret(12),
+		ctx4hRangeATR:       rng(4),
+		ctx12hRangeATR:      rng(12),
+		closedBarsUsed:      len(filtered),
+		lastClosedBarStart:  filtered[last].OpenTime,
+	}
+	if !pretouchIsFiniteFloat(context.ctx4hSideReturnATR) ||
+		!pretouchIsFiniteFloat(context.ctx12hSideReturnATR) ||
+		!pretouchIsFiniteFloat(context.ctx4hRangeATR) ||
+		!pretouchIsFiniteFloat(context.ctx12hRangeATR) {
+		return pretouchContextFeatures{}, false
+	}
+	return context, true
+}
+
+func pretouchIsFiniteFloat(value float64) bool {
+	return !math.IsNaN(value) && !math.IsInf(value, 0)
+}
+
+func pretouchApplyT2StaticDownsizeShadow(shadowSizing map[string]any, candidate map[string]any) {
+	if shadowSizing == nil || candidate == nil {
+		return
+	}
+	shadowSizing["t2StaticDownsizeCandidate"] = cloneMetadata(candidate)
+	if !boolValue(candidate["wouldDownsize"]) {
+		return
+	}
+	if !boolValue(shadowSizing["submittedRiskOnQuantityEnabled"]) {
+		candidate["appliedBlockReason"] = "risk_on_shadow_quantity_not_enabled"
+		shadowSizing["t2StaticDownsizeCandidate"] = cloneMetadata(candidate)
+		return
+	}
+	before := parseFloatValue(shadowSizing["submittedQuantityAfterShadow"])
+	scale := parseFloatValue(candidate["scale"])
+	if before <= 0 || scale <= 0 || scale > 1 {
+		candidate["appliedBlockReason"] = "invalid_shadow_quantity_or_scale"
+		shadowSizing["t2StaticDownsizeCandidate"] = cloneMetadata(candidate)
+		return
+	}
+	after := before * scale
+	candidate["applied"] = true
+	candidate["submittedQuantityBeforeT2Downsize"] = before
+	candidate["submittedQuantityAfterT2Downsize"] = after
+	shadowSizing["submittedQuantityBeforeT2Downsize"] = before
+	shadowSizing["submittedQuantityAfterT2Downsize"] = after
+	shadowSizing["submittedQuantityAfterShadow"] = after
+	shadowSizing["submittedQuantity"] = after
+	shadowSizing["submittedSizingMode"] = fmt.Sprintf("%s_t2_static_downsize%.2f", stringValue(shadowSizing["submittedSizingMode"]), scale)
+	shadowSizing["t2StaticDownsizeCandidate"] = cloneMetadata(candidate)
 }
 
 func pretouchShadowLeadQuantityBandSizingRequested(parameters map[string]any) bool {

--- a/internal/service/strategy_engine_pretouch_timing_test.go
+++ b/internal/service/strategy_engine_pretouch_timing_test.go
@@ -228,6 +228,114 @@ func TestPretouchTimingEngineSubmitsRiskOnLeadQuantityForSandboxShadow(t *testin
 	}
 }
 
+func TestPretouchTimingEngineAppliesT2StaticDownsizeForSandboxShadow(t *testing.T) {
+	start := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
+	engine := testPretouchTimingEngine("fast", 0.75)
+	ctx := testPretouchSignalContext(start, 101)
+	enablePretouchRiskOnShadow(&ctx, true)
+	ctx.ExecutionContext.Parameters[pretouchShadowT2StaticDownsizeParam] = true
+	ctx.SourceStates["binance-kline|signal|ETHUSDT|1h"].(map[string]any)["bars"] = testPretouchT2DownsizeSignalBars(start)
+
+	first, err := engine.EvaluateSignal(ctx)
+	if err != nil {
+		t.Fatalf("first evaluate failed: %v", err)
+	}
+	if first.Action != "wait" {
+		t.Fatalf("expected first tick to wait, got %#v", first)
+	}
+
+	ctx = testPretouchSignalContext(start.Add(60*time.Second), 105.1)
+	enablePretouchRiskOnShadow(&ctx, true)
+	ctx.ExecutionContext.Parameters[pretouchShadowT2StaticDownsizeParam] = true
+	ctx.SourceStates["binance-kline|signal|ETHUSDT|1h"].(map[string]any)["bars"] = testPretouchT2DownsizeSignalBars(start)
+	setPretouchOrderBook(&ctx, 105.09, 105.1)
+	decision, err := engine.EvaluateSignal(ctx)
+	if err != nil {
+		t.Fatalf("evaluate failed: %v", err)
+	}
+	if decision.Action != "advance-plan" {
+		t.Fatalf("expected advance-plan, got action=%s reason=%s metadata=%#v", decision.Action, decision.Reason, decision.Metadata)
+	}
+	if got := parseFloatValue(decision.Metadata["productionSuggestedQuantity"]); math.Abs(got-0.12) > 1e-9 {
+		t.Fatalf("expected production suggested quantity 0.12, got %v", got)
+	}
+	if got := parseFloatValue(decision.Metadata["suggestedQuantity"]); math.Abs(got-0.0875) > 1e-9 {
+		t.Fatalf("expected T2 downsize shadow quantity 0.0875, got %v", got)
+	}
+	shadow := mapValue(decision.Metadata["pretouchShadowSizing"])
+	if shadow == nil {
+		t.Fatalf("expected pretouchShadowSizing metadata: %#v", decision.Metadata)
+	}
+	t2 := mapValue(shadow["t2StaticDownsizeCandidate"])
+	if t2 == nil {
+		t.Fatalf("expected T2 static downsize candidate metadata: %#v", shadow)
+	}
+	if !boolValue(t2["wouldDownsize"]) || !boolValue(t2["applied"]) {
+		t.Fatalf("expected downsize candidate applied: %#v", t2)
+	}
+	if got := parseFloatValue(shadow["submittedQuantityBeforeT2Downsize"]); math.Abs(got-0.35) > 1e-9 {
+		t.Fatalf("expected before-T2 quantity 0.35, got %v in %#v", got, shadow)
+	}
+	if got := parseFloatValue(shadow["submittedQuantityAfterT2Downsize"]); math.Abs(got-0.0875) > 1e-9 {
+		t.Fatalf("expected after-T2 quantity 0.0875, got %v in %#v", got, shadow)
+	}
+	if !strings.Contains(stringValue(shadow["submittedSizingMode"]), "t2_static_downsize0.25") {
+		t.Fatalf("expected submitted sizing mode to include t2 downsize: %#v", shadow)
+	}
+
+	intent := deriveLiveSignalIntent(decision, "ETHUSDT")
+	if intent == nil {
+		t.Fatalf("expected live signal intent from decision")
+	}
+	if math.Abs(intent.Quantity-0.0875) > 1e-9 {
+		t.Fatalf("expected live intent quantity to submit T2 downsize shadow size 0.0875, got %v", intent.Quantity)
+	}
+}
+
+func TestPretouchTimingEngineDoesNotApplyT2StaticDownsizeOutsideSandbox(t *testing.T) {
+	start := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
+	engine := testPretouchTimingEngine("fast", 0.75)
+	ctx := testPretouchSignalContext(start, 101)
+	enablePretouchRiskOnShadow(&ctx, false)
+	ctx.ExecutionContext.Parameters[pretouchShadowT2StaticDownsizeParam] = true
+	ctx.SourceStates["binance-kline|signal|ETHUSDT|1h"].(map[string]any)["bars"] = testPretouchT2DownsizeSignalBars(start)
+
+	first, err := engine.EvaluateSignal(ctx)
+	if err != nil {
+		t.Fatalf("first evaluate failed: %v", err)
+	}
+	if first.Action != "wait" {
+		t.Fatalf("expected first tick to wait, got %#v", first)
+	}
+
+	ctx = testPretouchSignalContext(start.Add(60*time.Second), 105.1)
+	enablePretouchRiskOnShadow(&ctx, false)
+	ctx.ExecutionContext.Parameters[pretouchShadowT2StaticDownsizeParam] = true
+	ctx.SourceStates["binance-kline|signal|ETHUSDT|1h"].(map[string]any)["bars"] = testPretouchT2DownsizeSignalBars(start)
+	setPretouchOrderBook(&ctx, 105.09, 105.1)
+	decision, err := engine.EvaluateSignal(ctx)
+	if err != nil {
+		t.Fatalf("evaluate failed: %v", err)
+	}
+	if got := parseFloatValue(decision.Metadata["suggestedQuantity"]); math.Abs(got-0.12) > 1e-9 {
+		t.Fatalf("expected non-sandbox quantity to remain production 0.12, got %v", got)
+	}
+	shadow := mapValue(decision.Metadata["pretouchShadowSizing"])
+	if shadow == nil {
+		t.Fatalf("expected pretouchShadowSizing metadata: %#v", decision.Metadata)
+	}
+	t2 := mapValue(shadow["t2StaticDownsizeCandidate"])
+	if t2 == nil || !boolValue(t2["wouldDownsize"]) {
+		t.Fatalf("expected T2 candidate to be recorded as would-downsize: %#v", shadow)
+	}
+	if boolValue(t2["applied"]) {
+		t.Fatalf("expected non-sandbox T2 candidate not to apply: %#v", t2)
+	}
+	if got := stringValue(t2["appliedBlockReason"]); got != "risk_on_shadow_quantity_not_enabled" {
+		t.Fatalf("expected risk-on block reason, got %s in %#v", got, t2)
+	}
+}
+
 func TestPretouchTimingEngineMapsMaxRiskOnLeadQuantityToPointFour(t *testing.T) {
 	start := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
 	engine := testPretouchTimingEngine("fast", 1.0)
@@ -1306,6 +1414,45 @@ func testPretouchT3OverlaySignalContext(eventTime time.Time, price float64) Stra
 func testPretouchSignalBars(currentStart time.Time) []any {
 	bars := make([]any, 0, 7)
 	for _, bar := range pretouchDetectorClosedBars(currentStart) {
+		bars = append(bars, map[string]any{
+			"symbol":    "ETHUSDT",
+			"timeframe": "1h",
+			"barStart":  bar.OpenTime.Format(time.RFC3339),
+			"open":      bar.Open,
+			"high":      bar.High,
+			"low":       bar.Low,
+			"close":     bar.Close,
+			"isClosed":  true,
+		})
+	}
+	bars = append(bars, map[string]any{
+		"symbol":    "ETHUSDT",
+		"timeframe": "1h",
+		"barStart":  currentStart.Format(time.RFC3339),
+		"open":      100.0,
+		"high":      100.0,
+		"low":       100.0,
+		"close":     100.0,
+		"isClosed":  false,
+	})
+	return bars
+}
+
+func testPretouchT2DownsizeSignalBars(currentStart time.Time) []any {
+	closed := make([]HourlyBar, 0, 14)
+	for i := 14; i >= 1; i-- {
+		openTime := currentStart.Add(-time.Duration(i) * time.Hour)
+		bar := HourlyBar{OpenTime: openTime, Open: 100, High: 105, Low: 95, Close: 100}
+		if i >= 13 {
+			bar = HourlyBar{OpenTime: openTime, Open: 120, High: 121, Low: 119, Close: 120}
+		}
+		if i == 1 {
+			bar = HourlyBar{OpenTime: openTime, Open: 100, High: 104, Low: 96, Close: 100}
+		}
+		closed = append(closed, bar)
+	}
+	bars := make([]any, 0, len(closed)+1)
+	for _, bar := range closed {
 		bars = append(bars, map[string]any{
 			"symbol":    "ETHUSDT",
 			"timeframe": "1h",

--- a/research/entry_redesign/pretouch_static_downsize_optimization_20260523.md
+++ b/research/entry_redesign/pretouch_static_downsize_optimization_20260523.md
@@ -1,0 +1,241 @@
+# ETH Pretouch (T2) 静态 Downsize 规则优化回测研究与对齐实施方案
+
+本文档记录了针对 `original_t2` ETHUSDT 1h 独立 Downsize 规则在 2022-07 至 2026-04 长周期回测（包含 Canary 推广验证段）中的优化研究成果、具体规则定义、详细回测表现及后续研究对齐方向。
+
+> 2026-05-25 更新：本文最初的规则 A / B 来自全量数据高维 grid search，因此只能视为
+> research hypothesis，不能直接作为 Go live 对齐依据。正式晋级口径以后续
+> `t2_shadow_candidate_sweep_20260525` 的 rolling walk-forward / frozen train-window
+> 诊断为准。当前主候选是
+> `static_optimal_or_doc_a_ctx12h_range_le350_scale025_downsize`，不是本文的 `static_rule_a` /
+> `static_rule_b` 直接 `scale=0.0` 版本。
+
+---
+
+## 1. 优化背景与动机
+
+在此前的优化尝试中，由于未引入 1h 棒线的 Context 时序上下文特征，所使用的纯局部突破特征（如 `prev1_range_atr`）对于潜在恶劣行情的规避能力受限。旧方案在 4 年长周期回测中仅实现了约 **+2.2%** 的增幅，无法满足通过 Canary 影子系统高确定性晋级门槛（$\ge +0.5pp$ 且回撤不恶化）。
+
+为此，我们引入了 1h 时序上下文特征（如 12小时波动区间宽度 `ctx12h_range_atr`），并使用高维网格搜索（Grid Search）在全量数据集上挖掘极佳的静态 Downsize 拦截规则，获得了两个表现极其优异的候选方案。
+
+---
+
+## 2. 优化规则定义
+
+优化方案包含 **前置避险（Profit Protection）判定** 和 **静态 Downsize 条件判定** 两个核心步骤。
+
+### 2.1 前置避险机制（Profit Protection - PP）
+为防止在超强单边大行情中错失收益，不论规则 A 还是规则 B，在触发前都必须先通过 PP 判定。如果满足以下任一条件，系统判定为“高胜率/高盈亏比避险安全区”，**不执行 Downsize**（照常足额进场）：
+1.  **趋势强弱**：$ctx12h\_side\_return\_atr \ge 1.45$ （过去 12 小时的单向趋势极强）
+2.  **波动状态**：$ctx4h\_range\_atr \ge 2.36$ 或 $ctx12h\_range\_atr \ge 3.98$ （波动极度活跃）
+3.  **模型胜率**：$rf\_probability \ge 0.965$ （随机森林预测胜率极高）
+
+### 2.2 规则 A (收益最大化 - Profit Maximization)
+在未触发前置避险机制时，若同时满足以下拦截条件，则**将仓位下调至 0.0（即放弃本次交易）**：
+*   **突破触及偏离度**：$touch\_extension\_atr \le -0.112263$（突破偏离关键点较少，极易形成假突破假触及）
+*   **中期波动宽度**：$ctx12h\_range\_atr \ge 3.006207$（过去 12 小时波动偏宽，背景市场洗盘剧烈）
+
+### 2.3 规则 B (回撤改善 - Drawdown Mitigation)
+在未触发前置避险机制时，若同时满足以下拦截条件，则**将仓位下调至 0.0（即放弃本次交易）**：
+*   **突破触及偏离度**：$touch\_extension\_atr \ge -0.1147$（突破偏离关键点较多）
+*   **中期波动宽度**：$ctx12h\_range\_atr \le 3.39274$（过去 12 小时整体处于震荡收缩或低波动状态）
+
+---
+
+## 3. 回测指标总体对比
+
+以下为 **Baseline (基准策略)**、**规则 A** 与 **规则 B** 在长周期回测中的核心指标对比：
+
+| 指标维度 | Baseline 基准 | 规则 A (收益最大化) | 规则 B (回撤改善) |
+| :--- | :---: | :---: | :---: |
+| **下调规则** | 无 | `touch_ext <= -0.112263` & `ctx12h_range >= 3.0062` | `touch_ext >= -0.1147` & `ctx12h_range <= 3.3927` |
+| **四年总收益 (PnL)** | 50.4347% | **58.3023%** (**+7.8676pp**) | **56.4308%** (**+5.9961pp**) |
+| **历史段收益 (Long-cycle)** | 16.5805% | **22.4697%** (**+5.8892pp**) | **20.5990%** (**+4.0185pp**) |
+| **测试段收益 (Canary)** | 33.8542% | **35.8326%** (**+1.9800pp** / 过 promozione 关) | **35.8326%** (**+1.9776pp** / 过 promozione 关) |
+| **最大回撤 (Max DD)** | -7.4096% | -7.4096% (持平) | **-6.2758%** (**显著降低 1.1338pp，回撤改善 15.3%**) |
+| **最惨单月收益** | -4.4311% | -4.4311% (持平) | **-2.5768%** (**大幅改善，亏损压缩 41.8%**) |
+| **负收益月份数** | 19 个 | **18 个** (减少 1 个) | **18 个** (减少 1 个) |
+| **下调生效率 (Hits / 总事件)**| - | 11 / 146 = 7.5% | 13 / 146 = 8.9% |
+| **平均尺寸比例 (Avg Scale)** | 1.0000 | 0.9247 | 0.9110 |
+
+---
+
+## 4. 月度收益明细表 (Monthly PnL Table)
+
+以下列出各月 PnL（百分比 %）及两种规则相对于 Baseline 的收益改变值（Delta %）：
+
+| 月份 | Baseline PnL | 规则 A PnL | 规则 A Delta | 规则 B PnL | 规则 B Delta |
+| :--- | :---: | :---: | :---: | :---: | :---: |
+| **2022-07** | +1.5655 | +1.5655 | 0.0000 | +1.8734 | +0.3079 |
+| **2022-08** | -2.5768 | -2.2655 | +0.3113 | -2.5768 | 0.0000 |
+| **2022-09** | +7.6652 | +7.6652 | 0.0000 | +6.0704 | -1.5948 |
+| **2022-10** | +0.4971 | +0.8119 | +0.3148 | +0.4971 | 0.0000 |
+| **2022-11** | -0.6353 | -0.6353 | 0.0000 | -0.6353 | 0.0000 |
+| **2022-12** | -1.0254 | +0.5176 | +1.5430 | -0.7142 | +0.3111 |
+| **2023-01** | +4.5332 | +4.5332 | 0.0000 | +4.5332 | 0.0000 |
+| **2023-02** | -0.6256 | -0.3143 | +0.3113 | -0.6256 | 0.0000 |
+| **2023-03** | -0.0888 | -0.0888 | 0.0000 | -0.0888 | 0.0000 |
+| **2023-04** | -0.6292 | -0.6292 | 0.0000 | -0.6292 | 0.0000 |
+| **2023-05** | -0.9287 | -0.9287 | 0.0000 | -0.9287 | 0.0000 |
+| **2023-06** | -0.1217 | -0.1217 | 0.0000 | +0.2296 | +0.3513 |
+| **2023-07** | -2.4652 | -2.4652 | 0.0000 | -2.4652 | 0.0000 |
+| **2023-08** | -0.6285 | -0.6285 | 0.0000 | -0.3165 | +0.3121 |
+| **2023-09** | +0.5351 | +0.5351 | 0.0000 | +0.5351 | 0.0000 |
+| **2023-10** | +0.5580 | +0.8724 | +0.3145 | +0.5580 | 0.0000 |
+| **2023-11** | -0.3740 | -0.3740 | 0.0000 | -0.6386 | -0.2646 |
+| **2023-12** | +1.9853 | +1.9853 | 0.0000 | +1.9853 | 0.0000 |
+| **2024-01** | -0.1594 | -0.1594 | 0.0000 | -0.1594 | 0.0000 |
+| **2024-02** | -0.7366 | -0.7366 | 0.0000 | -0.7366 | 0.0000 |
+| **2024-03** | +4.6652 | +4.6652 | 0.0000 | +2.9518 | -1.7135 |
+| **2024-04** | +5.0971 | +5.0971 | 0.0000 | +5.0971 | 0.0000 |
+| **2024-05** | -0.7112 | -0.7112 | 0.0000 | -0.7112 | 0.0000 |
+| **2024-06** | -3.0323 | -0.6677 | +2.3647 | -0.6677 | +2.3647 |
+| **2024-07** | +5.1810 | +5.4933 | +0.3123 | +5.1810 | 0.0000 |
+| **2024-08** | -0.8780 | -0.8780 | 0.0000 | -0.8780 | 0.0000 |
+| **2024-10** | +1.3655 | +1.7829 | +0.4174 | +1.3655 | 0.0000 |
+| **2024-11** | +2.9801 | +2.9801 | 0.0000 | +3.6057 | +0.6256 |
+| **2024-12** | -4.4311 | -4.4311 | 0.0000 | -1.1124 | +3.3187 |
+| **2025-06** | -0.9478 | -0.9478 | 0.0000 | -0.9478 | 0.0000 |
+| **2025-07** | +4.6047 | +4.6047 | 0.0000 | +4.6047 | 0.0000 |
+| **2025-08** | +10.4234 | +10.4234 | 0.0000 | +10.4234 | 0.0000 |
+| **2025-09** | -1.6000 | -1.6000 | 0.0000 | -1.6000 | 0.0000 |
+| **2025-10** | +1.6242 | +1.6242 | 0.0000 | +1.6242 | 0.0000 |
+| **2025-11** | +6.7450 | +6.7450 | 0.0000 | +7.0577 | +0.3127 |
+| **2025-12** | +1.3152 | +1.3152 | 0.0000 | +1.3152 | 0.0000 |
+| **2026-01** | +3.0880 | +3.0880 | 0.0000 | +3.0880 | 0.0000 |
+| **2026-02** | +3.7128 | +4.0263 | +0.3135 | +3.7128 | 0.0000 |
+| **2026-03** | +1.8302 | +1.8302 | 0.0000 | +1.8302 | 0.0000 |
+| **2026-04** | +3.0581 | +4.7230 | +1.6649 | +4.7230 | +1.6649 |
+
+---
+
+## 5. 拦截事件审计明细 (Event Audit)
+
+### 5.1 规则 A 拦截明细 (共 11 次)
+规则 A 在长周期内所拦截的 **11次事件全部为负收益交易（胜率 100% 规避）**，没有任何一次正收益误伤：
+*   **2022-08**：拦截 1 次 PnL 为 `-0.3113%` 的交易。
+*   **2022-10**：拦截 1 次 PnL 为 `-0.3148%` 的交易。
+*   **2022-12**：拦截 2 次 PnL 分别为 `-0.3111%` 和 `-1.2319%` 的交易。
+*   **2023-02**：拦截 1 次 PnL 为 `-0.3113%` 的交易。
+*   **2023-10**：拦截 1 次 PnL 为 `-0.3145%` 的交易。
+*   **2024-06**：拦截 1 次 PnL 为 `-2.3647%` 的恶劣重仓亏损。
+*   **2024-07**：拦截 1 次 PnL 为 `-0.3123%` 的交易。
+*   **2024-10**：拦截 1 次 PnL 为 `-0.4174%` 的交易。
+*   **2026-02**：拦截 1 次 PnL 为 `-0.3135%` 的交易（测试段）。
+*   **2026-04**：拦截 1 次 PnL 为 `-1.6649%` 的大亏损单（测试段）。
+
+### 5.2 规则 B 拦截明细 (共 13 次)
+规则 B 拦截了 13 次事件，其中有 3 次为正收益误伤，但其通过**完美规避 2024-12 月的超级黑天鹅大单**（避开 `-3.3187%` 巨亏），实现了极致的最大回撤压缩：
+*   **2022-07**：拦截 1 次 PnL 为 `-0.3079%` 的交易。
+*   **2022-09**：误伤 1 次 PnL 为 `+1.5948%` 的正收益交易。
+*   **2022-12**：拦截 1 次 PnL 为 `-0.3111%` 的交易。
+*   **2023-06**：拦截 1 次 PnL 为 `-0.3513%` 的交易。
+*   **2023-08**：拦截 1 次 PnL 为 `-0.3121%` 的交易。
+*   **2023-11**：误伤 1 次 PnL 为 `+0.2646%` 的正收益交易。
+*   **2024-03**：误伤 1 次 PnL 为 `+1.7135%` 的正收益交易。
+*   **2024-06**：拦截 1 次 PnL 为 `-2.3647%` 的亏损大单。
+*   **2024-11**：拦截 2 次 PnL 分别为 `-0.3137%` 和 `-0.3119%` 的交易。
+*   **2024-12**：**拦截 1 次 PnL 为 `-3.3187%` 的超级黑天鹅亏损（全周期最差月份核心源头）**。
+*   **2025-11**：拦截 1 次 PnL 为 `-0.3127%` 的交易（测试段）。
+*   **2026-04**：拦截 1 次 PnL 为 `-1.6649%` 的亏损大单（测试段）。
+
+---
+
+## 6. 后续研究对齐方向
+
+### 6.1 正式 runner 对齐
+
+后续不再把本文的 A/B 全量搜索结果直接接入 live。研究推进顺序为：
+
+*   用 `t2_static_downsize_deep_dive.py` 做固定规则、命中事件、集中度、scale ladder 诊断。
+*   用 `t2_shadow_candidate_sweep.py` 做正式 rolling walk-forward / frozen train-window gate。
+*   只有候选通过人工 review 后，才讨论 Go metadata wiring。
+
+### 6.2 当前 under-review 候选
+
+当前更稳的候选不是 `scale=0.0` 的规则 A / B，而是：
+
+```text
+static_optimal_or_doc_a_ctx12h_range_le350_scale025_downsize
+
+if NOT profit_protection
+   and ctx12h_range_atr <= 3.500000
+   and (
+       (eff_300s >= 0.925057 and ctx12h_side_return_atr <= -0.282982)
+       or
+       (touch_extension_atr <= -0.112263 and ctx12h_range_atr >= 3.006207)
+   ):
+    scale = 0.25
+else:
+    scale = 1.0
+```
+
+2026-05-25 rolling walk-forward 结果：
+
+| Candidate | All delta | Canary delta | Avg scale | Selected | Gate |
+| --- | ---: | ---: | ---: | ---: | --- |
+| `static_optimal_or_doc_a_ctx12h_range_le350_scale025_downsize` | `+7.374277pp` | `+1.718344pp` | `0.958904` | `8/146` | rolling shadow pass |
+
+Stability audit 显示 `ctx12h_range_atr <= 3.40/3.45/3.50` 是同一收益平台，不是
+`3.50` 单点命中；`3.25..3.60` 区间内有 `8/19` 个阈值同时满足 all/canary/avg-scale/
+frozen-holdout 约束。Frozen train-window 诊断进一步显示：train `+8.291409pp`、
+holdout `+1.718344pp`、all `+10.009754pp`、holdout avg scale `0.956731`。因此它已从原始 OR 候选的
+`research_candidate_under_review` 提升为 `research_candidate_review_ready`。在完成人工 review、
+事件级审计和 live 可重建性确认前，仍不能直接进入 live 实现。
+
+2026-05-25 追加的 purged nested threshold selection 进一步降低了“事后固定 3.50”的过拟合担忧：
+每个 forward month 只允许使用更早月份训练，并空出 1 个 purge month；阈值选择不是取训练收益最高
+尖点，而是取训练窗内达到 best delta `95%` 的阈值平台中位数。该过程在 `28/40` 个 forward month
+可激活，自动选择的阈值分布为 `3.35, 3.45, 3.60, 3.70, 3.75, 3.80`，不是单点 `3.50`。结果：
+
+| Validation | All delta | Long delta | Canary delta | Avg scale | Selected |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| fixed `ctx12h_range_atr <= 3.50` rolling | `+7.374277pp` | `+5.655933pp` | `+1.718344pp` | `0.958904` | `8` |
+| purged nested plateau threshold | `+7.687331pp` | `+5.968986pp` | `+1.718344pp` | `0.953767` | `9` |
+
+这说明当前收益不是依赖 `3.50` 的单点调参；更合理的解释是存在一个中等 `ctx12h_range_atr`
+坏桶平台。不过 nested selector 仍共享同一条 OR 结构与 PP 规则，因此它只证明 range cap
+不敏感，不能证明整条 OR 规则已经可上线。
+
+2026-05-25 继续追加 selected-event reconstructability audit：
+
+- Script:
+  `research/entry_redesign/scripts/timing_probability_unified/t2_downsize_selected_event_reconstructability.py`
+- Output:
+  `research/entry_redesign/scripts/output/timing_probability_unified/t2_downsize_selected_event_reconstructability_20260525/`
+- Result:
+  `8/8` selected events 的 closed-bar context 可从 ETHUSDT 1s cache 重新聚合复算；
+  `8/8` 复算后的 `profit_protection` / branch / final downsize decision 与当前候选命中一致；
+  max feature abs diff 为 `4.4408920985e-16`。
+
+事件分支分布为：`static_optimal` 命中 `5` 次、`doc_rule_a` 命中 `2` 次、
+`static_optimal+doc_rule_a` 同时命中 `1` 次；所有 selected event 的 PP 均为 `False`。
+这说明候选依赖的 4h/12h closed-bar context 在研究数据路径上是 live-decision-time
+可重建的。剩余缺口是 intrabar touch 特征（`eff_300s`、`touch_extension_atr`）仍来自既有事件 ledger；
+进入任何 Go metadata wiring 前，还需要确认 live metadata 中已有同口径字段，或补 shadow-only
+telemetry 后再 review。
+
+2026-05-25 metadata readiness audit 结论：
+
+- Script:
+  `research/entry_redesign/scripts/timing_probability_unified/t2_downsize_live_metadata_readiness_audit.py`
+- Output:
+  `research/entry_redesign/scripts/output/timing_probability_unified/t2_downsize_live_metadata_readiness_20260525/`
+- Static code read:
+  `rf_probability`、`eff_300s`、`touch_extension_atr` 已在 advance-plan 路径可用；
+  `ctx12h_side_return_atr`、`ctx4h_range_atr`、`ctx12h_range_atr` 目前不是 Go live decision metadata 字段；
+  signalBarDecision 只保留 `current` / `prevBar2` 快照，未保留完整 12h closed-bar context。
+- Production read-only spot-check:
+  `bktrader-ctl order list --limit 20 --json` 中最近 ETH entry order 的
+  `intent.metadata.pretouchEvent` / `executionProposal.metadata.pretouchEvent`
+  均包含 `eff300s`、`touchExtensionAtr`、`speed300sAtr`、`preTouchSeconds`、`atr` 等字段；
+  未看到 4h/12h context 字段。
+
+2026-05-25 根据人工推进意见，下一步不再停留在 shadow-only telemetry，而是直接进入
+testnet shadow submitted quantity downsize：
+
+*   只在 `pretouchShadowMode=testnet_shadow_collect` 下计算并记录
+    `t2StaticDownsizeCandidate`。
+*   只有 `pretouchShadowT2StaticDownsize=true`、候选规则 selected，且既有 testnet risk-on guard
+    已允许提交 shadow quantity 时，才把 `submittedQuantityAfterShadow` 乘以 `0.25`。
+*   非 sandbox / guard 未通过 / mainnet 路径只记录 would-downsize 与 block reason，submitted
+    quantity 保持原 production sizing。


### PR DESCRIPTION
## 目的
实现 ETH pretouch T2 static downsize 候选的 testnet shadow 真实提交量降仓：在 `testnet_shadow_collect` 下复算 4h/12h closed-bar context，命中 `static_optimal_or_doc_a_ctx12h_range_le350_scale025_downsize` 且既有 sandbox risk-on guard 通过时，将 shadow submitted quantity 按默认 `0.25` 缩放。非 sandbox / guard 未通过只记录 candidate 与 block reason，不改变 production suggested quantity、dispatchMode 或 mainnet 行为。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [x] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
- [x] `dispatchMode` 默认值有否变化？没有变化。
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？没有。
- [x] DB migration 是否具备向下兼容幂等性？不涉及 DB migration。
- [x] 配置字段有没有无意被混改？仅新增 testnet shadow T2 static downsize 参数，并保留既有 sandbox/risk-on guard。

## 交易语义变更
- [x] 本次改动是否新增/修改了 `signalKind`？否。
- [x] 本次改动是否影响订单方向判断（`side` / `reduceOnly` / `closePosition`）？否。
- [x] 若涉及上述改动，`go test ./internal/domain/... -run TestClassifyOrderIntent` 是否通过？不涉及。
- [x] 若涉及交易链路语义（开仓/平仓/撤单/risk-exit），`go test ./internal/domain/... -run TestTradingReplayGoldenCases` 是否通过？不涉及。

## 验证方式与测试证据
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

已验证：
- `go test ./internal/service -run 'TestPretouchTimingEngine|TestPretouchShadow'`\n- `go test ./internal/service`\n- `go test ./...`\n- push 前仓库 pre-push harness：graphify rebuild、high risk defaults check、env safety check、backend checks 均通过\n\n## 备注\nPR 只包含本次 testnet shadow downsize 代码、对应测试、设计文档和探索主文档；未跟踪的 research sweep 脚本/输出未纳入。