### PR TITLE
[codex] Fix pretouch breakout tolerance semantics

### DIFF
--- a/docs/eth-pretouch-timing-live-design.md
+++ b/docs/eth-pretouch-timing-live-design.md
@@ -417,7 +417,7 @@ research 增强一次性接进 Go live。提交版本的边界如下：
 | 模块 | 提交版本状态 | 说明 |
 | --- | --- | --- |
 | `breakout_shape_tolerance_bps` | **已接入当前 ETH pretouch live** | `PretouchEventDetector` 使用 `StructureToleranceBps` 判断 `prev_high_2` / `prev_low_2` 是否 ready；默认来自 `defaultT2BreakoutShapeToleranceBps=0.5`，session 参数可覆盖非负值。 |
-| Breakout 容差语义 | **不是放宽 near-equal** | 当前 `0.5` bps 是 restrictive 分离度：long 需要 `prev_high_2 > prev_high_1 * (1 + 0.5/10000)`，short 需要 `prev_low_2 < prev_low_1 * (1 - 0.5/10000)`。这轮 research 证明不能直接把 near-equal/slack 结构推成 live 默认。 |
+| Breakout 容差语义 | **near-equal shape tolerance** | 当前 `0.5` bps 是 original_t2 结构容差：long 需要 `prev_high_2 >= prev_high_1 * (1 - 0.5/10000)`，short 需要 `prev_low_2 <= prev_low_1 * (1 + 0.5/10000)`；breakout level 仍锁定 `prev_high_2` / `prev_low_2`，不额外放宽触价门槛。 |
 | T3 结构 / `t3_swing` | **已接入 testnet shadow event source** | Go live engine 在 original_t2 未触发时检测 T3 swing：long 需 `prev_high_3 > prev_high_2 && prev_high_3 > prev_high_1 && prev_high_1 > prev_high_2`，short 对称；仅在 `testnet_shadow_collect` 下启用，不改变 production lead。 |
 | `2.0x T3 overlay` | **已接入 testnet shadow 真实 entry proposal** | T3 overlay 使用 `pretouchShadowOverlayBaseShare=0.40`、`pretouchShadowOverlayScale=2.0`，默认 base quantity `0.100` 时 initial overlay order 为 `0.080` ETH；仅当 live 语义、`sandbox=true`、`executionMode=rest`、speed/depth/spread guard 通过时生成 `entry-t3-overlay` proposal。scale/share 和最终 submitted quantity 均有硬上限。 |
 | T3 RF/cost quality sizing | **已接入 testnet shadow artifact + absolute quantity band** | `data/pretouch_t3_overlay_rf_model.json` 使用 T3 专用 RF 估计事件胜率，再把 overlay 直接映射到 `0.20..0.40` ETH absolute quantity band；默认 `0.080` ETH fixed overlay 等价于 `2.5..5.0x` quality multiplier。模型缺失或 feature build failed 时默认阻断 overlay submit 并写 `model_missing` / `feature_build_failed` metadata，避免污染 q020/q040 candidate 样本；只有显式 `pretouchShadowOverlayQualityFallbackSubmit=true` 才允许 fixed overlay fallback submit。 |
@@ -432,7 +432,7 @@ research 增强一次性接进 Go live。提交版本的边界如下：
 | --- | --- |
 | Symbol / timeframe | `ETHUSDT` / `1h` |
 | Event source | Lead 仍为 production-aligned `pretouch_small_pullback_rf_q50_speed300_ge_q10_touch30m_eff300le1`；overlay 仅为 testnet shadow `t3_swing` |
-| Breakout shape | Lead 继续使用当前 live `breakout_shape_tolerance_bps=0.5` restrictive 结构；T3 overlay 使用严格三根 bar swing 结构，不放宽 near-equal tolerance |
+| Breakout shape | Lead 使用 live `breakout_shape_tolerance_bps=0.5` near-equal original_t2 结构容差；T3 overlay 使用严格三根 bar swing 结构，不放宽 near-equal tolerance |
 | Pretouch window | Lead 与 overlay 均默认 `pre_touch_seconds <= 1800` |
 | Quality gates | Lead: `eff_300s <= 1.0`、`speed_300s_atr >= 0.228106`、`cost_q50 <= 0.116865` 后按 `pretouchCostQ50Penalty=0.50` 惩罚；T3 overlay: `abs(speed_300s_atr) >= 0.35`、`eff_300s <= 1.0` |
 | Model | Lead 使用 `data/pretouch_model.json` / `20260515_v1` 的 Go-native DT3 + RF；T3 overlay 使用 `data/pretouch_t3_overlay_rf_model.json` / `20260520_t3_overlay_rf_cost_v1` 只做 quality sizing，不做 timing skip。 |
@@ -781,15 +781,15 @@ PYTHONPATH=research:research/entry_redesign/scripts \
 
 ## Breakout 结构展开基准
 
-当前生产的 `breakout_shape_tolerance_bps=0.5` 不是“放宽触发容差”，而是要求 `prev_high_2` /
-`prev_low_2` 相对上一根 closed bar 有额外分离度：
+当前生产的 `breakout_shape_tolerance_bps=0.5` 是 original_t2 结构容差，不是更高的开仓门槛。它只允许
+`prev_high_2` / `prev_low_2` 与上一根 closed bar 在 0.5bps 内近似持平；breakout level 仍锁定
+`prev_high_2` / `prev_low_2`，当前价格必须真实触达该 level：
 
-- Long ready: `prev_high_2 > prev_high_1 * (1 + tolerance_bps / 10000)`
-- Short ready: `prev_low_2 < prev_low_1 * (1 - tolerance_bps / 10000)`
+- Long ready: `prev_high_2 >= prev_high_1 * (1 - tolerance_bps / 10000)`
+- Short ready: `prev_low_2 <= prev_low_1 * (1 + tolerance_bps / 10000)`
 
-因此它比原始 `original_t2` 严格比较更窄。后续如果要捕获 near-equal 结构，例如相邻两根 bar 的
-high/low 近乎持平但当前 bar 已经触达 `prev_high_2` / `prev_low_2`，必须在当前 lead 上展开，而不是切回
-`local_context_event_execution` 或旧 V6 口径。
+2026-05-25 生产排查发现 live `PretouchEventDetector` 曾把该容差反向实现成 restrictive separation；
+修复后它与 `strategy_registry.go` / replay 里的 T2 helper 语义保持一致。
 
 建议 research 展开顺序：
 

--- a/internal/service/pretouch_event_detector.go
+++ b/internal/service/pretouch_event_detector.go
@@ -511,16 +511,22 @@ func pretouchLongStructureReady(prevHigh2, prevHigh1, toleranceBps float64) bool
 	if prevHigh2 <= 0 || prevHigh1 <= 0 {
 		return false
 	}
-	// A zero tolerance keeps the original_t2 structure strictly above/below
-	// the previous bar; positive tolerance requires additional separation.
-	return prevHigh2 > prevHigh1*(1+toleranceBps/10000.0)
+	toleranceBps = sanitizeBreakoutShapeToleranceBps(toleranceBps)
+	if toleranceBps <= 0 {
+		return prevHigh2 > prevHigh1
+	}
+	return prevHigh2 >= prevHigh1*(1-toleranceBps/10000.0)
 }
 
 func pretouchShortStructureReady(prevLow2, prevLow1, toleranceBps float64) bool {
 	if prevLow2 <= 0 || prevLow1 <= 0 {
 		return false
 	}
-	return prevLow2 < prevLow1*(1-toleranceBps/10000.0)
+	toleranceBps = sanitizeBreakoutShapeToleranceBps(toleranceBps)
+	if toleranceBps <= 0 {
+		return prevLow2 < prevLow1
+	}
+	return prevLow2 <= prevLow1*(1+toleranceBps/10000.0)
 }
 
 func pretouchT3LongStructureReady(prevHigh3, prevHigh2, prevHigh1 float64) bool {

--- a/internal/service/pretouch_event_detector_test.go
+++ b/internal/service/pretouch_event_detector_test.go
@@ -55,6 +55,32 @@ func TestPretouchEventDetectorDetectsLongAndUsesBookCost(t *testing.T) {
 	}
 }
 
+func TestPretouchEventDetectorAllowsNearEqualLongBreakoutWithinTolerance(t *testing.T) {
+	start := time.Date(2026, 5, 25, 14, 0, 0, 0, time.UTC)
+	config := DefaultPretouchDetectorConfig()
+	config.StructureToleranceBps = 0.5
+	config.MinSpeed300sATR = 0.0
+	detector := NewPretouchEventDetector("ETHUSDT", config)
+	closedBars := pretouchDetectorClosedBars(start)
+	closedBars[len(closedBars)-2] = HourlyBar{OpenTime: start.Add(-2 * time.Hour), Open: 2113.88, High: 2118.26, Low: 2111.51, Close: 2116.33}
+	closedBars[len(closedBars)-1] = HourlyBar{OpenTime: start.Add(-1 * time.Hour), Open: 2116.33, High: 2118.33, Low: 2113.74, Close: 2115.50}
+	detector.SyncBars(closedBars, &HourlyBar{
+		OpenTime: start,
+		Open:     2115.50,
+		High:     2115.50,
+		Low:      2115.50,
+		Close:    2115.50,
+	})
+
+	result := detector.OnTick(TickData{Time: start.Add(60 * time.Second), Price: 2127.69})
+	if !result.Detected {
+		t.Fatalf("expected near-equal long breakout within 0.5 bps tolerance, got reason=%s", result.Reason)
+	}
+	if result.Event.Side != "long" || result.Event.Level != 2118.26 {
+		t.Fatalf("expected long breakout at prev_high_2, got side=%s level=%v", result.Event.Side, result.Event.Level)
+	}
+}
+
 func TestPretouchEventDetectorSyncBarsSortsClosedHistory(t *testing.T) {
 	start := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
 	bars := pretouchDetectorClosedBars(start)


### PR DESCRIPTION
## 目的
修复 ETH pretouch live detector 对 `breakout_shape_tolerance_bps` 的语义实现：该参数应允许 original_t2 的 `prev_high_2` / `prev_low_2` 在容差内近似持平，而不是要求额外分离度。

Root cause：`strategy_registry.go` / replay helper 已使用 near-equal tolerance 语义，但 `PretouchEventDetector` 独立实现时把 0.5bps 写成 restrictive separation，导致 live tick 已触达 breakout level 时仍在 detector 层返回 `no_level_touch`，后续 RF/sizing/intent 不会执行。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [x] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) - 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？- 无
- [x] DB migration 是否具备向下兼容幂等性？- 不涉及
- [x] 配置字段有没有无意被混改？- 仅修正既有 `breakout_shape_tolerance_bps` detector 语义

## 交易语义变更
- [ ] 本次改动是否新增/修改了 `signalKind`？若是，需同步更新 Golden Case
- [ ] 本次改动是否影响订单方向判断（`side` / `reduceOnly` / `closePosition`）？
- [ ] 若涉及上述改动，`go test ./internal/domain/... -run TestClassifyOrderIntent` 是否通过？
- [ ] 若涉及交易链路语义（开仓/平仓/撤单/risk-exit），`go test ./internal/domain/... -run TestTradingReplayGoldenCases` 是否通过？

说明：本 PR 会影响 pretouch entry event 是否能进入 intent 生成，但不修改 `signalKind`、订单方向、`reduceOnly`、dispatchMode 或执行策略。

## 验证方式与测试证据
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

本地验证：

```bash
git diff --check
go test ./internal/service -run 'TestPretouchEventDetector|TestEvaluateSignalBarGateAllowsT2BreakoutTolerance|TestResolveReplayInitialBreakoutAllowsOriginalT2Tolerance|TestNormalizeLiveSessionOverrides'
go test ./internal/service
```

新增回归覆盖了 2026-05-25 生产排查形态：`12:00 high=2118.26`、`13:00 high=2118.33` 在 0.5bps 容差内应允许 long shape，且 `14:00 high=2127.69` 真实触达 `prev_high_2` level。
