### PR TITLE
[codex] Fix T3 overlay intrabar breakout detection

### DIFF
--- a/internal/service/pretouch_event_detector.go
+++ b/internal/service/pretouch_event_detector.go
@@ -390,20 +390,30 @@ func (d *PretouchEventDetector) OnTickT3Overlay(tick TickData) PretouchDetection
 
 	var side string
 	var level float64
+	var touchPrice float64
 	longReady := pretouchT3LongStructureReady(prevBar3.High, prevBar2.High, prevBar1.High)
 	shortReady := pretouchT3ShortStructureReady(prevBar3.Low, prevBar2.Low, prevBar1.Low)
 	if tick.Price >= prevBar3.High && longReady {
 		side = "long"
 		level = prevBar3.High
+		touchPrice = tick.Price
+	} else if d.currentBar.High >= prevBar3.High && longReady {
+		side = "long"
+		level = prevBar3.High
+		touchPrice = d.currentBar.High
 	} else if tick.Price <= prevBar3.Low && shortReady {
 		side = "short"
 		level = prevBar3.Low
+		touchPrice = tick.Price
+	} else if d.currentBar.Low <= prevBar3.Low && shortReady {
+		side = "short"
+		level = prevBar3.Low
+		touchPrice = d.currentBar.Low
 	} else {
 		return PretouchDetectionResult{Reason: "t3_no_level_touch"}
 	}
 
 	touchTime := tick.Time
-	touchPrice := tick.Price
 	signalBarStart := d.currentBar.OpenTime
 	diagnostics := map[string]any{
 		"shape":                  "t3_swing",

--- a/internal/service/pretouch_event_detector_test.go
+++ b/internal/service/pretouch_event_detector_test.go
@@ -108,6 +108,59 @@ func TestPretouchEventDetectorSyncBarsSortsClosedHistory(t *testing.T) {
 	}
 }
 
+func TestPretouchEventDetectorT3OverlayDetectsIntrabarExtremeTouch(t *testing.T) {
+	start := time.Date(2026, 5, 27, 6, 0, 0, 0, time.UTC)
+	config := DefaultPretouchDetectorConfig()
+	config.MinSpeed300sATR = 0
+	detector := NewPretouchEventDetector("ETHUSDT", config)
+	closedBars := []HourlyBar{
+		{OpenTime: start.Add(-6 * time.Hour), Open: 100, High: 106, Low: 94, Close: 100},
+		{OpenTime: start.Add(-5 * time.Hour), Open: 100, High: 106, Low: 94, Close: 100},
+		{OpenTime: start.Add(-4 * time.Hour), Open: 100, High: 106, Low: 94, Close: 100},
+		{OpenTime: start.Add(-3 * time.Hour), Open: 100, High: 105, Low: 95, Close: 100},
+		{OpenTime: start.Add(-2 * time.Hour), Open: 100, High: 99, Low: 92, Close: 96},
+		{OpenTime: start.Add(-1 * time.Hour), Open: 96, High: 104, Low: 95, Close: 103},
+	}
+	detector.SyncBars(closedBars, &HourlyBar{
+		OpenTime: start,
+		Open:     103,
+		High:     103,
+		Low:      103,
+		Close:    103,
+	})
+
+	first := detector.OnTickT3Overlay(TickData{Time: start.Add(10 * time.Second), Price: 103})
+	if first.Detected {
+		t.Fatalf("first non-touch tick should not detect: %#v", first)
+	}
+
+	detector.SyncBars(closedBars, &HourlyBar{
+		OpenTime: start,
+		Open:     103,
+		High:     105.2,
+		Low:      102.5,
+		Close:    103.5,
+	})
+	result := detector.OnTickT3Overlay(TickData{Time: start.Add(60 * time.Second), Price: 103.5})
+	if !result.Detected {
+		t.Fatalf("expected T3 overlay detection from current bar high, got reason=%s diagnostics=%#v", result.Reason, result.Diagnostics)
+	}
+	if result.Event.Side != "long" {
+		t.Fatalf("expected long T3 overlay, got %s", result.Event.Side)
+	}
+	if result.Event.Level != 105 {
+		t.Fatalf("expected T3 level 105, got %v", result.Event.Level)
+	}
+	if result.Event.TouchPrice != 105.2 {
+		t.Fatalf("expected current bar high as touch price, got %v", result.Event.TouchPrice)
+	}
+
+	again := detector.OnTickT3Overlay(TickData{Time: start.Add(90 * time.Second), Price: 106})
+	if again.Detected || again.Reason != "t3_already_touched_this_bar" {
+		t.Fatalf("expected same-bar T3 dedupe, got detected=%v reason=%s", again.Detected, again.Reason)
+	}
+}
+
 func TestPretouchEventDetectorRejectsInsufficientHistory(t *testing.T) {
 	start := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
 	detector := NewPretouchEventDetector("ETHUSDT", DefaultPretouchDetectorConfig())

--- a/internal/service/strategy_engine_pretouch_timing_test.go
+++ b/internal/service/strategy_engine_pretouch_timing_test.go
@@ -688,6 +688,45 @@ func TestPretouchTimingEngineSubmitsT3OverlayForSandboxShadow(t *testing.T) {
 	}
 }
 
+func TestPretouchTimingEngineSubmitsT3OverlayFromSignalBarHighTouch(t *testing.T) {
+	start := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
+	engine := testPretouchTimingEngine("fast", 0.75)
+	ctx := testPretouchT3OverlaySignalContext(start, 100.0)
+	enablePretouchRiskOnShadow(&ctx, true)
+
+	if decision, err := engine.EvaluateSignal(ctx); err != nil {
+		t.Fatalf("first evaluate failed: %v", err)
+	} else if decision.Action != "wait" {
+		t.Fatalf("expected first tick to wait, got %#v", decision)
+	}
+
+	ctx = testPretouchT3OverlaySignalContext(start.Add(60*time.Second), 103.5)
+	enablePretouchRiskOnShadow(&ctx, true)
+	setPretouchOrderBook(&ctx, 103.49, 103.50)
+	bars := ctx.SourceStates["binance-kline|signal|ETHUSDT|1h"].(map[string]any)["bars"].([]any)
+	current := bars[len(bars)-1].(map[string]any)
+	current["high"] = 106.2
+	current["close"] = 103.5
+
+	decision, err := engine.EvaluateSignal(ctx)
+	if err != nil {
+		t.Fatalf("evaluate failed: %v", err)
+	}
+	if decision.Action != "advance-plan" {
+		t.Fatalf("expected T3 overlay advance-plan from signal bar high touch, got action=%s reason=%s metadata=%#v", decision.Action, decision.Reason, decision.Metadata)
+	}
+	event, ok := decision.Metadata["pretouchEvent"].(domain.PretouchEvent)
+	if !ok {
+		t.Fatalf("expected pretouchEvent metadata, got %#v", decision.Metadata["pretouchEvent"])
+	}
+	if event.Side != "long" || event.Level != 106 {
+		t.Fatalf("expected long T3 event at level 106, got %#v", event)
+	}
+	if event.TouchPrice != 106.2 {
+		t.Fatalf("expected signal bar high as T3 touch price, got %v", event.TouchPrice)
+	}
+}
+
 func TestPretouchT3DeterministicStopGateSelectsHardStopProfile(t *testing.T) {
 	event := domain.PretouchEvent{
 		EventID:           "ETHUSDT_t3_20260515_120500_long",


### PR DESCRIPTION
## 目的
修复 ETH pretouch T3 overlay 在当前 1h bar 已经通过 kline high/low 触达 T3 swing level，但触发策略评估的 trade tick 已经回落到 level 内侧时，仍返回 `wait/no_level_touch` 的漏识别问题。

生产现象：

- 当前 bar 的 `current.high` 已高于 T3 long level。
- `prev3.high > prev1.high > prev2.high`，T3 long 结构成立。
- 但 latest decision 仍是 `wait/no_level_touch`，且 `breakoutHistory` 没记录当前 bar。

代码原因是 T3 overlay detector 只用当前 `tick.Price` 判断触价；`signal_bar` 更新只刷新 bar state，不触发 live 策略评估，而 trade tick fanout 又有节流，所以越过 level 的瞬时 tick 可能没进入 `EvaluateSignal`。后续策略虽然能看到 current bar high 已越过 level，但 detector 不用这个 high 补判。

本 PR 只收窄修复 T3 overlay detector：

- 仍优先使用真实 trade tick 触价。
- 当当前 signal bar 的 high/low 已越过 T3 swing level 时，用该 intrabar extreme 作为 T3 touch price。
- 保留同一 signal bar 只触发一次的 dedupe。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [x] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) - 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？- 无
- [x] DB migration 是否具备向下兼容幂等性？- 无 migration
- [x] 配置字段有没有无意被混改？- 无配置字段改动

## 交易语义变更
- [x] 本次改动是否新增/修改了 `signalKind`？若是，需同步更新 Golden Case - 否，仍是 `entry-t3-overlay`
- [x] 本次改动是否影响订单方向判断（`side` / `reduceOnly` / `closePosition`）？- 影响 T3 overlay touch 识别来源，不改 side/reduceOnly/closePosition 映射
- [x] 若涉及上述改动，`go test ./internal/domain/... -run TestClassifyOrderIntent` 是否通过？- 不涉及 domain intent classifier
- [x] 若涉及交易链路语义（开仓/平仓/撤单/risk-exit），`go test ./internal/domain/... -run TestTradingReplayGoldenCases` 是否通过？- 不涉及 domain golden replay

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

已验证：

- `go test ./internal/service -run 'TestPretouchEventDetectorT3OverlayDetectsIntrabarExtremeTouch|TestPretouchTimingEngineSubmitsT3OverlayForSandboxShadow|TestPretouchTimingEngineSubmitsT3OverlayFromSignalBarHighTouch|TestPretouchTimingEngineLogsT3OverlayDetectorMissOncePerSignalBar' -count=1`
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
- `bash scripts/check_high_risk_defaults.sh`
