### PR TITLE
[codex] Fix T2 intrabar breakout detection

### DIFF
--- a/internal/service/pretouch_event_detector.go
+++ b/internal/service/pretouch_event_detector.go
@@ -241,6 +241,7 @@ func (d *PretouchEventDetector) OnTick(tick TickData) PretouchDetectionResult {
 	// Check if tick touches a level
 	var side string
 	var level float64
+	var touchPrice float64
 
 	longReady := pretouchLongStructureReady(prevBar2.High, prevBar1.High, d.config.StructureToleranceBps)
 	shortReady := pretouchShortStructureReady(prevBar2.Low, prevBar1.Low, d.config.StructureToleranceBps)
@@ -249,10 +250,20 @@ func (d *PretouchEventDetector) OnTick(tick TickData) PretouchDetectionResult {
 		// Long breakout: current tick touches prev_high_2 for first time
 		side = "long"
 		level = longLevel
+		touchPrice = tick.Price
+	} else if d.currentBar.High >= longLevel && longReady {
+		side = "long"
+		level = longLevel
+		touchPrice = d.currentBar.High
 	} else if tick.Price <= shortLevel && shortReady {
 		// Short breakout: current tick touches prev_low_2 for first time
 		side = "short"
 		level = shortLevel
+		touchPrice = tick.Price
+	} else if d.currentBar.Low <= shortLevel && shortReady {
+		side = "short"
+		level = shortLevel
+		touchPrice = d.currentBar.Low
 	} else {
 		return PretouchDetectionResult{Reason: "no_level_touch"}
 	}
@@ -260,7 +271,6 @@ func (d *PretouchEventDetector) OnTick(tick TickData) PretouchDetectionResult {
 	// --- Compute pretouch features ---
 
 	touchTime := tick.Time
-	touchPrice := tick.Price
 	signalBarStart := d.currentBar.OpenTime
 
 	// pre_touch_seconds

--- a/internal/service/pretouch_event_detector_test.go
+++ b/internal/service/pretouch_event_detector_test.go
@@ -81,6 +81,52 @@ func TestPretouchEventDetectorAllowsNearEqualLongBreakoutWithinTolerance(t *test
 	}
 }
 
+func TestPretouchEventDetectorDetectsLeadIntrabarExtremeTouch(t *testing.T) {
+	start := time.Date(2026, 5, 27, 6, 0, 0, 0, time.UTC)
+	config := DefaultPretouchDetectorConfig()
+	config.MinSpeed300sATR = 0
+	detector := NewPretouchEventDetector("ETHUSDT", config)
+	closedBars := pretouchDetectorClosedBars(start)
+	detector.SyncBars(closedBars, &HourlyBar{
+		OpenTime: start,
+		Open:     100,
+		High:     100,
+		Low:      100,
+		Close:    100,
+	})
+
+	first := detector.OnTick(TickData{Time: start.Add(10 * time.Second), Price: 100})
+	if first.Detected {
+		t.Fatalf("first non-touch tick should not detect: %#v", first)
+	}
+
+	detector.SyncBars(closedBars, &HourlyBar{
+		OpenTime: start,
+		Open:     100,
+		High:     105.2,
+		Low:      99.5,
+		Close:    103.5,
+	})
+	result := detector.OnTick(TickData{Time: start.Add(60 * time.Second), Price: 103.5})
+	if !result.Detected {
+		t.Fatalf("expected lead detection from current bar high, got reason=%s", result.Reason)
+	}
+	if result.Event.Side != "long" {
+		t.Fatalf("expected long lead event, got %s", result.Event.Side)
+	}
+	if result.Event.Level != 105 {
+		t.Fatalf("expected T2 level 105, got %v", result.Event.Level)
+	}
+	if result.Event.TouchPrice != 105.2 {
+		t.Fatalf("expected current bar high as touch price, got %v", result.Event.TouchPrice)
+	}
+
+	again := detector.OnTick(TickData{Time: start.Add(90 * time.Second), Price: 106})
+	if again.Detected || again.Reason != "already_touched_this_bar" {
+		t.Fatalf("expected same-bar lead dedupe, got detected=%v reason=%s", again.Detected, again.Reason)
+	}
+}
+
 func TestPretouchEventDetectorSyncBarsSortsClosedHistory(t *testing.T) {
 	start := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
 	bars := pretouchDetectorClosedBars(start)

--- a/internal/service/strategy_engine_pretouch_timing_test.go
+++ b/internal/service/strategy_engine_pretouch_timing_test.go
@@ -727,6 +727,46 @@ func TestPretouchTimingEngineSubmitsT3OverlayFromSignalBarHighTouch(t *testing.T
 	}
 }
 
+func TestPretouchTimingEngineSubmitsLeadFromSignalBarHighTouch(t *testing.T) {
+	start := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
+	engine := testPretouchTimingEngine("fast", 0.75)
+	ctx := testPretouchSignalContext(start, 100.0)
+
+	if decision, err := engine.EvaluateSignal(ctx); err != nil {
+		t.Fatalf("first evaluate failed: %v", err)
+	} else if decision.Action != "wait" {
+		t.Fatalf("expected first tick to wait, got %#v", decision)
+	}
+
+	ctx = testPretouchSignalContext(start.Add(60*time.Second), 103.5)
+	setPretouchOrderBook(&ctx, 103.49, 103.50)
+	bars := ctx.SourceStates["binance-kline|signal|ETHUSDT|1h"].(map[string]any)["bars"].([]any)
+	current := bars[len(bars)-1].(map[string]any)
+	current["high"] = 105.2
+	current["close"] = 103.5
+
+	decision, err := engine.EvaluateSignal(ctx)
+	if err != nil {
+		t.Fatalf("evaluate failed: %v", err)
+	}
+	if decision.Action != "advance-plan" {
+		t.Fatalf("expected lead advance-plan from signal bar high touch, got action=%s reason=%s metadata=%#v", decision.Action, decision.Reason, decision.Metadata)
+	}
+	event, ok := decision.Metadata["pretouchEvent"].(domain.PretouchEvent)
+	if !ok {
+		t.Fatalf("expected pretouchEvent metadata, got %#v", decision.Metadata["pretouchEvent"])
+	}
+	if event.Side != "long" || event.Level != 105 {
+		t.Fatalf("expected long lead event at level 105, got %#v", event)
+	}
+	if event.TouchPrice != 105.2 {
+		t.Fatalf("expected signal bar high as lead touch price, got %v", event.TouchPrice)
+	}
+	if got := stringValue(decision.Metadata["signalKind"]); got != "entry" {
+		t.Fatalf("expected lead entry signal kind, got %s", got)
+	}
+}
+
 func TestPretouchT3DeterministicStopGateSelectsHardStopProfile(t *testing.T) {
 	event := domain.PretouchEvent{
 		EventID:           "ETHUSDT_t3_20260515_120500_long",


### PR DESCRIPTION
## 目的
补上 #456 同类问题在 T2 lead pretouch detector 上的修复：当当前 1h signal bar 的 high/low 已经越过 original_t2 breakout level，但进入策略评估的 trade tick 已经回落到 level 内侧时，T2 lead 不应继续 `wait/no_level_touch`。

代码原因和 #456 一致：live 策略评估由 `trade_tick` 触发，`signal_bar` 只刷新 bar state，不触发策略评估；如果越过 level 的瞬时 tick 没进入 `EvaluateSignal`，后续评估虽然能看到 current bar high/low 已越过 level，但 T2 detector 之前只看当前 `tick.Price`。

本 PR 对 T2 lead detector 做同类收敛：

- 仍优先使用真实 trade tick 作为 touch price。
- 如果 tick 未触达，但 current signal bar high/low 已触达 original_t2 level，则用 intrabar extreme 作为 touch price。
- 保留同一 signal bar 的 touched dedupe。
- 不改 T3 overlay 逻辑、不改 signalKind、不改 side/reduceOnly/closePosition 映射。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [x] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) - 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？- 无
- [x] DB migration 是否具备向下兼容幂等性？- 无 migration
- [x] 配置字段有没有无意被混改？- 无配置字段改动

## 交易语义变更
- [x] 本次改动是否新增/修改了 `signalKind`？若是，需同步更新 Golden Case - 否，lead 仍是 `entry`
- [x] 本次改动是否影响订单方向判断（`side` / `reduceOnly` / `closePosition`）？- 影响 T2 lead touch 识别来源，不改 side/reduceOnly/closePosition 映射
- [x] 若涉及上述改动，`go test ./internal/domain/... -run TestClassifyOrderIntent` 是否通过？- 不涉及 domain intent classifier
- [x] 若涉及交易链路语义（开仓/平仓/撤单/risk-exit），`go test ./internal/domain/... -run TestTradingReplayGoldenCases` 是否通过？- 不涉及 domain golden replay

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

已验证：

- `go test ./internal/service -run 'TestPretouchEventDetectorDetectsLeadIntrabarExtremeTouch|TestPretouchEventDetectorT3OverlayDetectsIntrabarExtremeTouch|TestPretouchTimingEngineSubmitsLeadFromSignalBarHighTouch|TestPretouchTimingEngineSubmitsT3OverlayFromSignalBarHighTouch|TestPretouchTimingEngineSubmitsT3OverlayForSandboxShadow' -count=1`
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
- `bash scripts/check_high_risk_defaults.sh`
