### PR TITLE
[codex] Add T3 overlay rejection diagnostics

### DIFF
--- a/internal/service/strategy_engine_pretouch_timing.go
+++ b/internal/service/strategy_engine_pretouch_timing.go
@@ -640,6 +640,13 @@ func (e *bkLiveEthPretouchTimingEngine) evaluateT3ShadowOverlay(ctx StrategySign
 	result := e.t3Detector.OnTickT3Overlay(tick)
 	if !result.Detected {
 		e.logT3ShadowOverlayMiss(ctx, tick, leadMissReason, result)
+		if metadata := pretouchT3OverlayRejectMetadata(leadMissReason, result); len(metadata) > 0 {
+			return StrategySignalDecision{
+				Action:   "wait",
+				Reason:   leadMissReason,
+				Metadata: metadata,
+			}, true
+		}
 		return StrategySignalDecision{}, false
 	}
 
@@ -785,8 +792,50 @@ func (e *bkLiveEthPretouchTimingEngine) logT3ShadowOverlayMiss(ctx StrategySigna
 		"t3_miss_category", category,
 		"event_time", formatOptionalRFC3339(ctx.EventTime),
 		"tick_price", tick.Price,
+		"t3_side", stringValue(diagnostics["side"]),
+		"t3_level", parseFloatValue(diagnostics["level"]),
+		"t3_touch_price", parseFloatValue(diagnostics["touchPrice"]),
+		"t3_signal_bar_start", stringValue(diagnostics["signalBarStart"]),
+		"t3_pre_touch_seconds", parseFloatValue(diagnostics["preTouchSeconds"]),
+		"t3_speed_300s_atr", parseFloatValue(diagnostics["speed300sATR"]),
+		"t3_min_abs_speed_300s_atr", parseFloatValue(diagnostics["minAbsSpeed300sATR"]),
+		"t3_eff_300s", parseFloatValue(diagnostics["eff300s"]),
+		"t3_max_eff_300s", parseFloatValue(diagnostics["maxEff300s"]),
+		"t3_touch_extension_atr", parseFloatValue(diagnostics["touchExtensionATR"]),
+		"t3_roundtrip_cost_atr", parseFloatValue(diagnostics["roundtripCostATR"]),
 		"diagnostics", diagnostics,
 	)
+}
+
+func pretouchT3OverlayRejectMetadata(leadMissReason string, result PretouchDetectionResult) map[string]any {
+	if len(result.Diagnostics) == 0 || !pretouchT3OverlayMissLoggable(result.Reason) {
+		return nil
+	}
+	diagnostics := cloneMetadata(result.Diagnostics)
+	category := pretouchT3OverlayMissReasonCategory(result.Reason)
+	return map[string]any{
+		"signalSource":                 "pretouch-t3-overlay-shadow",
+		"signalKind":                   "entry-t3-overlay-watch",
+		"decisionState":                "rejected",
+		"t3OverlayRejected":            true,
+		"t3OverlayLeadMissReason":      leadMissReason,
+		"t3OverlayRejectReason":        result.Reason,
+		"t3OverlayRejectCategory":      category,
+		"t3OverlaySide":                stringValue(diagnostics["side"]),
+		"t3OverlayLevel":               parseFloatValue(diagnostics["level"]),
+		"t3OverlayTouchPrice":          parseFloatValue(diagnostics["touchPrice"]),
+		"t3OverlaySignalBarStart":      stringValue(diagnostics["signalBarStart"]),
+		"t3OverlayPreTouchSeconds":     parseFloatValue(diagnostics["preTouchSeconds"]),
+		"t3OverlaySpeed300sATR":        parseFloatValue(diagnostics["speed300sATR"]),
+		"t3OverlayMinAbsSpeed300sATR":  parseFloatValue(diagnostics["minAbsSpeed300sATR"]),
+		"t3OverlayEff300s":             parseFloatValue(diagnostics["eff300s"]),
+		"t3OverlayMaxEff300s":          parseFloatValue(diagnostics["maxEff300s"]),
+		"t3OverlayTouchExtensionATR":   parseFloatValue(diagnostics["touchExtensionATR"]),
+		"t3OverlayRoundtripCostATR":    parseFloatValue(diagnostics["roundtripCostATR"]),
+		"t3OverlayLongStructureReady":  boolValue(diagnostics["longStructureReady"]),
+		"t3OverlayShortStructureReady": boolValue(diagnostics["shortStructureReady"]),
+		"t3OverlayDiagnostics":         diagnostics,
+	}
 }
 
 func (e *bkLiveEthPretouchTimingEngine) shouldLogT3ShadowOverlayMiss(key string) bool {

--- a/internal/service/strategy_engine_pretouch_timing_test.go
+++ b/internal/service/strategy_engine_pretouch_timing_test.go
@@ -727,6 +727,56 @@ func TestPretouchTimingEngineSubmitsT3OverlayFromSignalBarHighTouch(t *testing.T
 	}
 }
 
+func TestPretouchTimingEngineReportsT3OverlaySpeedRejectMetadata(t *testing.T) {
+	start := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
+	engine := testPretouchTimingEngine("fast", 0.75)
+	ctx := testPretouchT3OverlaySignalContext(start, 100.0)
+	enablePretouchRiskOnShadow(&ctx, true)
+
+	if decision, err := engine.EvaluateSignal(ctx); err != nil {
+		t.Fatalf("first evaluate failed: %v", err)
+	} else if decision.Action != "wait" {
+		t.Fatalf("expected first tick to wait, got %#v", decision)
+	}
+
+	ctx = testPretouchT3OverlaySignalContext(start.Add(60*time.Second), 106.1)
+	enablePretouchRiskOnShadow(&ctx, true)
+	ctx.ExecutionContext.Parameters["pretouchShadowOverlaySpeedThreshold"] = 10.0
+	setPretouchOrderBook(&ctx, 106.09, 106.10)
+
+	decision, err := engine.EvaluateSignal(ctx)
+	if err != nil {
+		t.Fatalf("evaluate failed: %v", err)
+	}
+	if decision.Action != "wait" || decision.Reason != "no_level_touch" {
+		t.Fatalf("expected lead wait with T3 reject metadata, got %#v", decision)
+	}
+	if !boolValue(decision.Metadata["t3OverlayRejected"]) {
+		t.Fatalf("expected t3OverlayRejected metadata, got %#v", decision.Metadata)
+	}
+	if got := stringValue(decision.Metadata["t3OverlayRejectCategory"]); got != "t3_speed_300s" {
+		t.Fatalf("expected t3_speed_300s reject category, got %s in %#v", got, decision.Metadata)
+	}
+	if got := stringValue(decision.Metadata["t3OverlaySide"]); got != "long" {
+		t.Fatalf("expected long T3 reject side, got %s in %#v", got, decision.Metadata)
+	}
+	if got := parseFloatValue(decision.Metadata["t3OverlayLevel"]); math.Abs(got-106.0) > 1e-9 {
+		t.Fatalf("expected T3 level 106, got %v in %#v", got, decision.Metadata)
+	}
+	if got := parseFloatValue(decision.Metadata["t3OverlayTouchPrice"]); math.Abs(got-106.1) > 1e-9 {
+		t.Fatalf("expected T3 touch price 106.1, got %v in %#v", got, decision.Metadata)
+	}
+	if got := parseFloatValue(decision.Metadata["t3OverlayMinAbsSpeed300sATR"]); math.Abs(got-10.0) > 1e-9 {
+		t.Fatalf("expected T3 speed threshold 10, got %v in %#v", got, decision.Metadata)
+	}
+	if diagnostics := mapValue(decision.Metadata["t3OverlayDiagnostics"]); diagnostics == nil {
+		t.Fatalf("expected T3 diagnostics metadata, got %#v", decision.Metadata)
+	}
+	if intent := deriveLiveSignalIntent(decision, "ETHUSDT"); intent != nil {
+		t.Fatalf("expected rejected T3 overlay wait not to produce intent, got %#v", intent)
+	}
+}
+
 func TestPretouchTimingEngineSubmitsLeadFromSignalBarHighTouch(t *testing.T) {
 	start := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
 	engine := testPretouchTimingEngine("fast", 0.75)


### PR DESCRIPTION
## 目的
补强 ETH pretouch T3 overlay 被拒绝时的生产可观测性。

这次生产现象是：价格已经触过 T3 突破价，但最终 live decision 仍显示 `wait/no_level_touch`。进一步查 `service.pretouch_timing` 才能看到真实原因是 `t3_speed_300s=0.1174 < 0.3500`。这个 PR 让后续类似情况在 decision metadata 和 system log 顶层字段里都能直接看到 T3 touch/reject 细节。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [x] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) - 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？- 无
- [x] DB migration 是否具备向下兼容幂等性？- 不涉及 DB migration
- [x] 配置字段有没有无意被混改？- 无配置字段变更

## 交易语义变更
- [ ] 本次改动是否新增/修改了 `signalKind`？若是，需同步更新 Golden Case
- [ ] 本次改动是否影响订单方向判断（`side` / `reduceOnly` / `closePosition`）？
- [ ] 若涉及上述改动，`go test ./internal/domain/... -run TestClassifyOrderIntent` 是否通过？
- [ ] 若涉及交易链路语义（开仓/平仓/撤单/risk-exit），`go test ./internal/domain/... -run TestTradingReplayGoldenCases` 是否通过？

说明：不改可执行 intent / 下单方向 / reduceOnly / dispatch。新增的是 rejected wait decision 的诊断 metadata，以及系统日志顶层字段。

## 改动内容
- T3 overlay 因 `t3_pre_touch_seconds` / `t3_speed_300s` / `t3_eff_300s` 被拒绝时，wait decision metadata 带上：
  - `t3OverlayRejected`
  - `t3OverlayRejectReason`
  - `t3OverlayRejectCategory`
  - side / level / touch price / speed / eff / pre-touch / structure ready / diagnostics
- `pretouch T3 overlay rejected` system log 增加顶层字段，方便 `bktrader-ctl logs system --component service.pretouch_timing --json` 直接读和过滤。
- 新增回归测试覆盖：T3 已触价但 speed gate 拒绝时，不产生 live intent，只产出 reject metadata。

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

已验证：
- `go test ./internal/service -run 'TestPretouchTimingEngineReportsT3OverlaySpeedRejectMetadata|TestPretouchTimingEngineSubmitsT3OverlayFromSignalBarHighTouch|TestPretouchTimingEngineSubmitsT3OverlayForSandboxShadow'`
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
- `bash scripts/check_high_risk_defaults.sh`
