### PR TITLE
[codex] Fix pretouch live plan warm cache gate

### DIFF
--- a/internal/service/live_market_data.go
+++ b/internal/service/live_market_data.go
@@ -531,6 +531,13 @@ func (p *Platform) buildLiveExecutionPlanFromMarketData(
 		Semantics:           semantics,
 	}
 	cfg := buildStrategyReplayConfig(context)
+	switch normalized := normalizeStrategyEngineKey(engineKey); normalized {
+	case bkLiveEthPretouchTimingEngineKey:
+		// Pretouch timing is live-only: EvaluateSignal consumes real-time runtime
+		// source states and does not need a warmed offline execution plan.
+		return nil, nil
+	}
+
 	replayExecutionSource := cfg.ExecutionDataSource
 	if replayExecutionSource == "tick" {
 		// Live sessions still evaluate and trigger on real-time tick events, but the
@@ -565,10 +572,6 @@ func (p *Platform) buildLiveExecutionPlanFromMarketData(
 	switch normalized := normalizeStrategyEngineKey(engineKey); normalized {
 	case "bk-default", bkLiveIntrabarSMA5T2Only0p5BpsEngineKey, bkLiveIntrabarSMA5BaselinePlusT3EnhancedEngineKey:
 		result, err = runStrategyReplayOnMinuteBars(cfg, signals, minuteBars)
-	case bkLiveEthPretouchTimingEngineKey:
-		// Pretouch timing engine is a live-only engine and computes state dynamically in EvaluateSignal.
-		// It does not use or support offline batch replay for plan generation.
-		return nil, nil
 	default:
 		result, err = engine.Run(context)
 	}

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -1783,6 +1783,63 @@ func TestBuildLiveExecutionPlanFromMarketDataUsesLiveSnapshotForBaselinePlusT3En
 	}
 }
 
+func TestBuildLiveExecutionPlanFromMarketDataSkipsMarketSnapshotForPretouchTiming(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+
+	session, err := platform.CreateLiveSession("", "live-main", bkLiveEthPretouchTimingStrategyID, map[string]any{
+		"symbol":              "ETHUSDT",
+		"signalTimeframe":     "1h",
+		"executionDataSource": "tick",
+	})
+	if err != nil {
+		t.Fatalf("create live session failed: %v", err)
+	}
+
+	version, err := platform.resolveCurrentStrategyVersion(session.StrategyID)
+	if err != nil {
+		t.Fatalf("resolve strategy version failed: %v", err)
+	}
+	parameters, err := platform.resolveLiveSessionParameters(session, version)
+	if err != nil {
+		t.Fatalf("resolve live session parameters failed: %v", err)
+	}
+	engine, engineKey, err := platform.resolveStrategyEngine(version.ID, parameters)
+	if err != nil {
+		t.Fatalf("resolve strategy engine failed: %v", err)
+	}
+	if got := normalizeStrategyEngineKey(engineKey); got != bkLiveEthPretouchTimingEngineKey {
+		t.Fatalf("expected pretouch timing engine, got %s", got)
+	}
+
+	originalFetch := fetchLiveCandleRange
+	fetchCalls := 0
+	fetchLiveCandleRange = func(symbol, resolution string, from, to time.Time) ([]candleBar, error) {
+		fetchCalls++
+		return nil, fmt.Errorf("upstream unavailable")
+	}
+	t.Cleanup(func() {
+		fetchLiveCandleRange = originalFetch
+	})
+
+	plan, err := platform.buildLiveExecutionPlanFromMarketData(
+		session,
+		version,
+		engine,
+		engineKey,
+		parameters,
+		defaultExecutionSemantics(ExecutionModeLive, parameters),
+	)
+	if err != nil {
+		t.Fatalf("pretouch timing should not require warmed minute bars, got %v", err)
+	}
+	if plan != nil {
+		t.Fatalf("expected no offline plan for pretouch timing, got %#v", plan)
+	}
+	if fetchCalls != 0 {
+		t.Fatalf("expected pretouch timing plan setup to skip REST warm fetches, got %d calls", fetchCalls)
+	}
+}
+
 func TestResolveLiveSessionParametersDefaultsMissingStopsToTrailingForLive(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
 


### PR DESCRIPTION
## 目的
修复 ETH pretouch live session 在 Binance REST warm cache 失败时无法生成 decision 的问题。pretouch timing engine 是 live-only，策略评估依赖实时 runtime source states，不应在进入 EvaluateSignal 前被 warmed 1m execution plan gate 阻断。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [x] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) - 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？- 无
- [x] DB migration 是否具备向下兼容幂等性？- 不涉及
- [x] 配置字段有没有无意被混改？- 无

## 交易语义变更
- [x] 本次改动是否新增/修改了 `signalKind`？若是，需同步更新 Golden Case - 否
- [x] 本次改动是否影响订单方向判断（`side` / `reduceOnly` / `closePosition`）？- 否
- [ ] 若涉及上述改动，`go test ./internal/domain/... -run TestClassifyOrderIntent` 是否通过？- 不涉及
- [ ] 若涉及交易链路语义（开仓/平仓/撤单/risk-exit），`go test ./internal/domain/... -run TestTradingReplayGoldenCases` 是否通过？- 不涉及

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

验证：
- `go test ./internal/service -run 'TestBuildLiveExecutionPlanFromMarketData(SkipsMarketSnapshotForPretouchTiming|UsesLiveSnapshotForBaselinePlusT3Enhanced30m|UsesLiveSnapshotForEnhanced30m)'`
- `go test ./...`
- `go build ./cmd/platform-api`
- `go build ./cmd/db-migrate`
- `bash scripts/check_high_risk_defaults.sh`

Root cause:
`buildLiveExecutionPlanFromMarketData` converted tick execution to a warmed 1m replay source and required cached minute bars before checking the engine type. For `bk-live-eth-pretouch-timing`, that check is misplaced because the engine intentionally has no offline replay plan and computes decisions dynamically in `EvaluateSignal`. When REST warmup failed, live evaluation failed before `lastStrategyDecision` could be written.

Change:
- short-circuit pretouch timing before any market snapshot/minute-cache access
- add regression coverage proving pretouch plan setup skips REST warm fetches and does not fail when upstream warm data is unavailable
