### PR TITLE
[codex] Align ETH pretouch live with research lead

### DIFF
--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -2330,13 +2330,26 @@ func applyLaunchTemplateContext(state map[string]any, context liveLaunchTemplate
 
 func applyLaunchTemplateBaselineState(state map[string]any) map[string]any {
 	if !liveIntradayResearchBaselineStateMatchesTemplate(state) {
-		return state
+		return applyEthPretouchResearchLeadTemplateState(state)
 	}
 	normalized := cloneMetadata(state)
 	for key, value := range liveIntradayResearchBaselineOverrides(stringValue(normalized["strategyEngine"])) {
 		normalized[key] = value
 	}
 	normalized["launchTemplateBaseline"] = "intraday-research"
+	return normalized
+}
+
+func applyEthPretouchResearchLeadTemplateState(state map[string]any) map[string]any {
+	if !ethPretouchResearchLeadStateMatchesTemplate(state) {
+		return state
+	}
+	normalized := cloneMetadata(state)
+	normalized["positionSizingMode"] = "intent_quantity"
+	normalized["dir2_zero_initial"] = false
+	normalized["zero_initial_mode"] = strategyZeroInitialModePosition
+	normalized["launchTemplateBaseline"] = "eth-pretouch-research-lead"
+	delete(normalized, livePendingZeroInitialWindowStateKey)
 	return normalized
 }
 
@@ -2363,6 +2376,24 @@ func liveIntradayResearchBaselineStateMatchesTemplate(state map[string]any) bool
 	default:
 		return false
 	}
+}
+
+func ethPretouchResearchLeadStateMatchesTemplate(state map[string]any) bool {
+	key := strings.ToLower(strings.TrimSpace(stringValue(state["launchTemplateKey"])))
+	if key != "binance-testnet-eth-pretouch-timing" {
+		return false
+	}
+	symbol := NormalizeSymbol(firstNonEmpty(
+		stringValue(state["launchTemplateSymbol"]),
+		stringValue(state["symbol"]),
+		stringValue(state["lastSymbol"]),
+	))
+	timeframe := normalizeSignalBarInterval(firstNonEmpty(
+		stringValue(state["launchTemplateTimeframe"]),
+		stringValue(state["signalTimeframe"]),
+		stringValue(state["timeframe"]),
+	))
+	return symbol == "ETHUSDT" && timeframe == "1h"
 }
 
 func (p *Platform) updateSignalRuntimeLaunchTemplateContext(sessionID string, context liveLaunchTemplateContext) (domain.SignalRuntimeSession, error) {

--- a/internal/service/live_launch_flow_template_test.go
+++ b/internal/service/live_launch_flow_template_test.go
@@ -358,6 +358,48 @@ func TestLaunchTemplateBaselineRequiresMatchingScope(t *testing.T) {
 	}
 }
 
+func TestETHPretouchTemplateSyncAlignsResearchLeadState(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+	session, err := platform.CreateLiveSession("", "live-main", "strategy-bk-eth-pretouch-timing", map[string]any{
+		"symbol":          "ETHUSDT",
+		"signalTimeframe": "1h",
+	})
+	if err != nil {
+		t.Fatalf("create pretouch live session failed: %v", err)
+	}
+	state := cloneMetadata(session.State)
+	state["launchTemplateKey"] = "binance-testnet-eth-pretouch-timing"
+	state["launchTemplateName"] = "Binance Testnet ETHUSDT Pretouch Timing"
+	state[livePendingZeroInitialWindowStateKey] = map[string]any{
+		"side":                "SELL",
+		"plannedReentryPrice": 2025.34,
+	}
+	session, err = platform.store.UpdateLiveSessionState(session.ID, state)
+	if err != nil {
+		t.Fatalf("seed pretouch template state failed: %v", err)
+	}
+
+	synced, err := platform.syncLiveSessionRuntime(session)
+	if err != nil {
+		t.Fatalf("sync live session runtime failed: %v", err)
+	}
+	if boolValue(synced.State["dir2_zero_initial"]) {
+		t.Fatalf("expected ETH pretouch research lead to disable dir2 zero-initial reentry")
+	}
+	if got := stringValue(synced.State["zero_initial_mode"]); got != strategyZeroInitialModePosition {
+		t.Fatalf("expected ETH pretouch zero_initial_mode=%s, got %s", strategyZeroInitialModePosition, got)
+	}
+	if got := stringValue(synced.State["positionSizingMode"]); got != "intent_quantity" {
+		t.Fatalf("expected ETH pretouch positionSizingMode=intent_quantity, got %s", got)
+	}
+	if _, ok := synced.State[livePendingZeroInitialWindowStateKey]; ok {
+		t.Fatalf("expected stale zero-initial window to be cleared for ETH pretouch research lead")
+	}
+	if got := stringValue(synced.State["launchTemplateBaseline"]); got != "eth-pretouch-research-lead" {
+		t.Fatalf("expected ETH pretouch research lead marker, got %s", got)
+	}
+}
+
 func TestSyncSignalRuntimeSessionPlanRefreshesStateWithoutStartingRuntime(t *testing.T) {
 	platform := NewPlatform(memory.NewStore())
 

--- a/internal/service/live_launch_templates.go
+++ b/internal/service/live_launch_templates.go
@@ -324,6 +324,8 @@ func buildEthPretouchTimingTemplate(strategyID, strategyName, strategyVersionID 
 		"max_hold_hours":   2.0,
 		// Sizing
 		"positionSizingMode":        "intent_quantity",
+		"dir2_zero_initial":         false,
+		"zero_initial_mode":         strategyZeroInitialModePosition,
 		"defaultOrderQuantity":      0.100,
 		"pretouchBaseOrderQuantity": 0.100,
 		"pretouchBaseShare":         0.80,
@@ -460,6 +462,7 @@ func buildEthPretouchTimingTemplate(strategyID, strategyName, strategyVersionID 
 			"live-runner/monolith 默认启动 pretouch model scheduler：artifact hot reload 每 30s 检查一次，T2/T3 retrain 默认每日尝试；新模型校验通过后原子替换，已运行 session 下一次 EvaluateSignal 自动读取新模型。",
 			"Lead 模型不可用或校验失败时 lead 事件自动 skip；T3 quality 模型不可用或 feature build failed 时默认阻断 overlay submit，只有显式 pretouchShadowOverlayQualityFallbackSubmit=true 才允许 fixed overlay fallback。",
 			"positionSizingMode=intent_quantity；testnet direct 在 sandbox=true、executionMode=rest、depth/spread guard 通过时，真实 lead entry 数量按 RF/cost 映射到 0.20-0.40 ETH 提交；默认不启用 T2 static downsize。",
+			"ETH pretouch research lead 使用触达后的 direct lead entry；显式关闭 dir2 zero-initial reentry window，避免继承 BTC intraday reentry baseline。",
 			"T3 overlay 只在 testnet direct、t3_swing 触达、speed_abs>=0.35 且 sandbox/rest/depth guard 通过时生成真实 entry proposal；RF/cost quality 将 overlay 数量映射到 0.20-0.40 ETH，非 sandbox 或显式关闭时只记录阻断原因。",
 			"T3 deterministic stop gate 命中的 overlay position 使用 hard_stop_atr=3.0 且只延迟 trailing 更新 4740s；hard stop 从开仓后立即有效，未命中继续走 PR447 lifecycle baseline。",
 			"该模板暂列默认推荐项；dispatchMode 由前端提交时显式注入，默认选择 auto-dispatch，可在前端切回 manual-review。",

--- a/internal/service/live_launch_templates_test.go
+++ b/internal/service/live_launch_templates_test.go
@@ -170,6 +170,12 @@ func TestLiveLaunchTemplatesExposeBinanceTestnetVariants(t *testing.T) {
 			if got := stringValue(item.LaunchPayload.LiveSessionOverrides["positionSizingMode"]); got != "intent_quantity" {
 				t.Fatalf("expected pretouch template positionSizingMode=intent_quantity, got %s", got)
 			}
+			if boolValue(item.LaunchPayload.LiveSessionOverrides["dir2_zero_initial"]) {
+				t.Fatalf("expected pretouch template to disable dir2 zero-initial reentry window")
+			}
+			if got := stringValue(item.LaunchPayload.LiveSessionOverrides["zero_initial_mode"]); got != strategyZeroInitialModePosition {
+				t.Fatalf("expected pretouch template zero_initial_mode=%s, got %s", strategyZeroInitialModePosition, got)
+			}
 			if item.DefaultDispatchMode != "auto-dispatch" {
 				t.Fatalf("expected pretouch template default dispatchMode auto-dispatch, got %s", item.DefaultDispatchMode)
 			}

--- a/internal/store/memory/store.go
+++ b/internal/store/memory/store.go
@@ -273,6 +273,8 @@ func NewStore() *Store {
 			"signalTimeframe":                              "1h",
 			"executionDataSource":                          "tick",
 			"positionSizingMode":                           "intent_quantity",
+			"dir2_zero_initial":                            false,
+			"zero_initial_mode":                            "position",
 			"defaultOrderQuantity":                         0.100,
 			"pretouchBaseOrderQuantity":                    0.100,
 			"pretouchBaseShare":                            0.80,


### PR DESCRIPTION
## 目的
让 ETH pretouch live/testnet template 对齐当前 research lead：lead 触达后走 direct lead entry + intent quantity / 0.20..0.40 ETH shadow sizing，而不是继承 BTC intraday 的 `dir2_zero_initial=true` / `reentry_window` baseline。

Root cause：ETH pretouch template 和 seed strategy 没有显式写 `dir2_zero_initial` / `zero_initial_mode`，live runtime sync 会通过全局 research baseline 默认把 initial entry 包成 zero-initial reentry window，导致 production 里 breakout 后进入 `pendingZeroInitialWindow`，等待反抽 `plannedReentryPrice`，偏离当前 ETH pretouch research lead。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [x] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) - 无变化，仍由模板/前端显式选择；本 PR 不写死 dispatchMode。
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？- 无。
- [x] DB migration 是否具备向下兼容幂等性？- 无 DB migration。
- [x] 配置字段有没有无意被混改？- 仅 ETH pretouch template/seed/sync 明确写入 `dir2_zero_initial=false`、`zero_initial_mode=position`。

## 交易语义变更
- [ ] 本次改动是否新增/修改了 `signalKind`？若是，需同步更新 Golden Case
- [x] 本次改动是否影响订单方向判断（`side` / `reduceOnly` / `closePosition`）？- 不改方向判断；只避免 ETH pretouch initial entry 被 zero-initial window 接管。
- [ ] 若涉及上述改动，`go test ./internal/domain/... -run TestClassifyOrderIntent` 是否通过？
- [ ] 若涉及交易链路语义（开仓/平仓/撤单/risk-exit），`go test ./internal/domain/... -run TestTradingReplayGoldenCases` 是否通过？

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

已验证：

```bash
go test ./internal/service
go test ./internal/store/...
go test ./...
go build ./cmd/platform-api
go build ./cmd/db-migrate
git diff --check
```

新增/更新覆盖：

- `TestLiveLaunchTemplatesExposeBinanceTestnetVariants` 断言 ETH pretouch template 显式禁用 zero-initial reentry window。
- `TestETHPretouchTemplateSyncAlignsResearchLeadState` 覆盖已有 ETH pretouch template session 在 runtime sync 时被标记为 `eth-pretouch-research-lead`，并清理 stale `pendingZeroInitialWindow`。

Agent: Codex assisted with diagnosis, patching, and validation.
