### PR TITLE
[codex] Default ETH pretouch T3 overlay to relaxed structure

### DIFF
--- a/internal/service/pretouch_event_detector.go
+++ b/internal/service/pretouch_event_detector.go
@@ -38,7 +38,7 @@ func DefaultPretouchDetectorConfig() PretouchDetectorConfig {
 		CostQ50Threshold:      0.116865,
 		CostQ50Penalty:        0.50,
 		StructureToleranceBps: defaultT2BreakoutShapeToleranceBps,
-		T3StructureMode:       "strict_current",
+		T3StructureMode:       "prev3_dominates",
 		BaseShare:             0.80,
 	}
 }

--- a/internal/service/pretouch_event_detector_test.go
+++ b/internal/service/pretouch_event_detector_test.go
@@ -158,6 +158,7 @@ func TestPretouchEventDetectorT3OverlayDetectsIntrabarExtremeTouch(t *testing.T)
 	start := time.Date(2026, 5, 27, 6, 0, 0, 0, time.UTC)
 	config := DefaultPretouchDetectorConfig()
 	config.MinSpeed300sATR = 0
+	config.T3StructureMode = "strict_current"
 	detector := NewPretouchEventDetector("ETHUSDT", config)
 	closedBars := []HourlyBar{
 		{OpenTime: start.Add(-6 * time.Hour), Open: 100, High: 106, Low: 94, Close: 100},
@@ -210,6 +211,13 @@ func TestPretouchEventDetectorT3OverlayDetectsIntrabarExtremeTouch(t *testing.T)
 	again := detector.OnTickT3Overlay(TickData{Time: start.Add(90 * time.Second), Price: 106})
 	if again.Detected || again.Reason != "t3_already_touched_this_bar" {
 		t.Fatalf("expected same-bar T3 dedupe, got detected=%v reason=%s", again.Detected, again.Reason)
+	}
+}
+
+func TestDefaultPretouchDetectorConfigUsesRelaxedT3Structure(t *testing.T) {
+	config := DefaultPretouchDetectorConfig()
+	if got := normalizePretouchT3StructureMode(config.T3StructureMode); got != "prev3_dominates" {
+		t.Fatalf("expected default T3 structure mode prev3_dominates, got %s", got)
 	}
 }
 

--- a/internal/service/strategy_engine_pretouch_timing_test.go
+++ b/internal/service/strategy_engine_pretouch_timing_test.go
@@ -693,7 +693,6 @@ func TestPretouchTimingEngineSubmitsRelaxedT3OverlayWithStrictComparisonTelemetr
 	engine := testPretouchTimingEngine("fast", 0.75)
 	ctx := testPretouchT3OverlaySignalContext(start, 100.0)
 	enablePretouchRiskOnShadow(&ctx, true)
-	ctx.ExecutionContext.Parameters[pretouchShadowT3StructureModeParam] = "prev3_dominates"
 	ctx.ExecutionContext.Parameters["pretouchSpeedThreshold"] = 100.0
 	bars := ctx.SourceStates["binance-kline|signal|ETHUSDT|1h"].(map[string]any)["bars"].([]any)
 	bars[len(bars)-3].(map[string]any)["high"] = 104.0
@@ -707,7 +706,6 @@ func TestPretouchTimingEngineSubmitsRelaxedT3OverlayWithStrictComparisonTelemetr
 
 	ctx = testPretouchT3OverlaySignalContext(start.Add(60*time.Second), 106.1)
 	enablePretouchRiskOnShadow(&ctx, true)
-	ctx.ExecutionContext.Parameters[pretouchShadowT3StructureModeParam] = "prev3_dominates"
 	ctx.ExecutionContext.Parameters["pretouchSpeedThreshold"] = 100.0
 	bars = ctx.SourceStates["binance-kline|signal|ETHUSDT|1h"].(map[string]any)["bars"].([]any)
 	bars[len(bars)-3].(map[string]any)["high"] = 104.0


### PR DESCRIPTION
## 目的
让 ETH pretouch T3 overlay 在 session 参数缺失时也默认使用当前 research lead 的 relaxed `prev3_dominates` 结构，避免老 session/老 strategy version 因未写 `pretouchShadowT3StructureMode` 而回落到旧 `strict_current`。

Root cause：`origin/main` 已支持 `pretouchShadowT3StructureMode=prev3_dominates`，模板也会写入该参数；但 `DefaultPretouchDetectorConfig()` 的 fallback 仍是 `strict_current`。生产当前 strategy version 参数里没有 `pretouchShadowT3StructureMode`，所以 T3 detector 会按旧 strict 规则判断，偏离 2026-05-29 relaxed T3 research lead。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [x] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) - 无变化。
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？- 无。
- [x] DB migration 是否具备向下兼容幂等性？- 无 DB migration。
- [x] 配置字段有没有无意被混改？- 只改 T3 detector fallback，从 strict_current 改为 prev3_dominates；显式传 strict_current 的测试/参数仍保留 strict 行为。

## 交易语义变更
- [ ] 本次改动是否新增/修改了 `signalKind`？若是，需同步更新 Golden Case
- [x] 本次改动是否影响订单方向判断（`side` / `reduceOnly` / `closePosition`）？- 可能影响 T3 overlay event 是否被识别，但不改变方向映射、reduceOnly 或 exit 逻辑。
- [ ] 若涉及上述改动，`go test ./internal/domain/... -run TestClassifyOrderIntent` 是否通过？
- [ ] 若涉及交易链路语义（开仓/平仓/撤单/risk-exit），`go test ./internal/domain/... -run TestTradingReplayGoldenCases` 是否通过？

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

已验证：

```bash
go test ./internal/service -run 'Test(DefaultPretouchDetectorConfigUsesRelaxedT3Structure|PretouchEventDetectorT3Overlay|PretouchTimingEngineSubmitsRelaxedT3OverlayWithStrictComparisonTelemetry)'\ngo test ./internal/service\ngit diff --check\n```\n\n新增/更新覆盖：\n\n- `TestDefaultPretouchDetectorConfigUsesRelaxedT3Structure` 锁定默认 fallback 为 `prev3_dominates`。\n- `TestPretouchTimingEngineSubmitsRelaxedT3OverlayWithStrictComparisonTelemetry` 去掉显式参数，覆盖 session 参数缺失时仍按 relaxed T3 overlay 提交。\n- 旧 strict detector 测试显式设置 `strict_current`，证明兼容路径仍可用。\n\nAgent: Codex assisted with production diagnosis, patching, and validation.\n