### PR TITLE
[codex] Add T3 production current-bar low regression

### DIFF
--- a/internal/service/pretouch_event_detector_test.go
+++ b/internal/service/pretouch_event_detector_test.go
@@ -261,6 +261,41 @@ func TestPretouchEventDetectorT3OverlayCanUseRelaxedPrev3DominatesStructure(t *t
 	}
 }
 
+func TestPretouchEventDetectorT3OverlayDetectsProductionCurrentBarLowTouch(t *testing.T) {
+	start := time.Date(2026, 6, 1, 5, 0, 0, 0, time.UTC)
+	config := DefaultPretouchDetectorConfig()
+	config.MinSpeed300sATR = 0
+	detector := NewPretouchEventDetector("ETHUSDT", config)
+	closedBars := []HourlyBar{
+		{OpenTime: time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC), Open: 2006.31, High: 2018.34, Low: 2005.83, Close: 2014.81},
+		{OpenTime: time.Date(2026, 6, 1, 1, 0, 0, 0, time.UTC), Open: 2014.81, High: 2014.97, Low: 1993.77, Close: 1994.01},
+		{OpenTime: time.Date(2026, 6, 1, 2, 0, 0, 0, time.UTC), Open: 1994.01, High: 2012.38, Low: 1993.45, Close: 2010.81},
+		{OpenTime: time.Date(2026, 6, 1, 3, 0, 0, 0, time.UTC), Open: 2010.85, High: 2016.74, Low: 2008.24, Close: 2008.75},
+		{OpenTime: time.Date(2026, 6, 1, 4, 0, 0, 0, time.UTC), Open: 2008.75, High: 2011.38, Low: 1994.03, Close: 1999.24},
+	}
+	detector.SyncBars(closedBars, &HourlyBar{
+		OpenTime: start,
+		Open:     1999.24,
+		High:     2000.25,
+		Low:      1993.45,
+		Close:    1994.11,
+	})
+
+	result := detector.OnTickT3Overlay(TickData{Time: start.Add(28*time.Minute + 46*time.Second), Price: 1994.11})
+	if !result.Detected {
+		t.Fatalf("expected production 2026-06-01 05:00 T3 short from current bar low, got reason=%s diagnostics=%#v", result.Reason, result.Diagnostics)
+	}
+	if result.Event.Side != "short" || result.Event.Level != 1993.45 {
+		t.Fatalf("expected short T3 at prev3 low 1993.45, got side=%s level=%v", result.Event.Side, result.Event.Level)
+	}
+	if result.Event.TouchPrice != 1993.45 {
+		t.Fatalf("expected current bar low touch price 1993.45, got %v", result.Event.TouchPrice)
+	}
+	if got := stringValue(result.Diagnostics["structureMode"]); got != "prev3_dominates" {
+		t.Fatalf("expected default relaxed structure mode, got %s in %#v", got, result.Diagnostics)
+	}
+}
+
 func TestPretouchEventDetectorRejectsInsufficientHistory(t *testing.T) {
 	start := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
 	detector := NewPretouchEventDetector("ETHUSDT", DefaultPretouchDetectorConfig())


### PR DESCRIPTION
## 目的
补一条 ETH pretouch T3 production 回归：2026-06-01 05:00 UTC 这根 1h bar 的 runtime `current.low` 已触达 prev3 low，但触发 tick 价格已经回抽到 level 上方时，T3 overlay 仍应按 current-bar low 识别 short breakout。

这次排查里，生产事件流在 2026-06-01T05:28:46Z 附近持续给出 `wait / no_level_touch`，但 payload 里的 runtime current low 已经到 `1993.45`。该 PR 不改交易逻辑，只把这个现场形态固化成测试，防止以后退回到只看 tick price 而忽略 current bar extreme。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [x] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档) - 仅新增测试
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) - 无变化。
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？- 无。
- [x] DB migration 是否具备向下兼容幂等性？- 无 DB migration。
- [x] 配置字段有没有无意被混改？- 无配置变更。

## 交易语义变更
- [ ] 本次改动是否新增/修改了 `signalKind`？若是，需同步更新 Golden Case
- [ ] 本次改动是否影响订单方向判断（`side` / `reduceOnly` / `closePosition`）？
- [ ] 若涉及上述改动，`go test ./internal/domain/... -run TestClassifyOrderIntent` 是否通过？
- [ ] 若涉及交易链路语义（开仓/平仓/撤单/risk-exit），`go test ./internal/domain/... -run TestTradingReplayGoldenCases` 是否通过？

## 验证方式与测试证据
_本地怎么测，测试环境怎么验_
- [ ] 无需跑后端或无需编译的文档性修改
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

已验证：

```bash
go test ./internal/service -run TestPretouchEventDetectorT3OverlayDetectsProductionCurrentBarLowTouch
go test ./internal/service
git diff --check
```

Agent: Codex assisted with production diagnosis, regression test, and validation.
