### PR TITLE
[codex] fix pretouch T3 structure mode visibility

### DIFF
--- a/internal/http/live.go
+++ b/internal/http/live.go
@@ -83,6 +83,7 @@ func registerLiveRoutes(mux *http.ServeMux, platform *service.Platform, cfg conf
 				FreshnessOverrideTradeTickFreshnessSecs   any    `json:"freshnessOverrideTradeTickFreshnessSeconds"`
 				FreshnessOverrideOrderBookFreshnessSecs   any    `json:"freshnessOverrideOrderBookFreshnessSeconds"`
 				FreshnessOverrideRuntimeQuietSecs         any    `json:"freshnessOverrideRuntimeQuietSeconds"`
+				PretouchShadowT3StructureMode             string `json:"pretouchShadowT3StructureMode"`
 			}
 			if err := decodeJSON(r, &payload); err != nil {
 				writeError(w, http.StatusBadRequest, err.Error())
@@ -230,6 +231,9 @@ func registerLiveRoutes(mux *http.ServeMux, platform *service.Platform, cfg conf
 			}
 			if payload.DispatchCooldownSec > 0 {
 				overrides["dispatchCooldownSeconds"] = payload.DispatchCooldownSec
+			}
+			if payload.PretouchShadowT3StructureMode != "" {
+				overrides["pretouchShadowT3StructureMode"] = payload.PretouchShadowT3StructureMode
 			}
 
 			// 处理新鲜度覆盖

--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -173,7 +173,14 @@ const (
 )
 
 func (p *Platform) ListLiveSessions() ([]domain.LiveSession, error) {
-	return p.store.ListLiveSessions()
+	items, err := p.store.ListLiveSessions()
+	if err != nil {
+		return nil, err
+	}
+	for i := range items {
+		items[i] = p.withEffectiveLiveSessionParameterState(items[i])
+	}
+	return items, nil
 }
 
 // ListLiveSessionsSummary 返回剥离了重状态 (sourceStates, signalBarStates) 的简要会话列表
@@ -184,7 +191,7 @@ func (p *Platform) ListLiveSessionsSummary() ([]domain.LiveSession, error) {
 	}
 	stripped := make([]domain.LiveSession, len(items))
 	for i, item := range items {
-		newItem := item
+		newItem := p.withEffectiveLiveSessionParameterState(item)
 		newItem.State = stripHeavyState(item.State)
 		stripped[i] = newItem
 	}
@@ -4316,6 +4323,7 @@ func (p *Platform) evaluateLiveSignalDecision(session domain.LiveSession, summar
 		nextPlannedRole,
 		nextPlannedReason,
 	)
+	updatedState = applyEffectiveLiveSessionParameterState(updatedState, executionContext.Parameters)
 	liveAccountBinding := map[string]any{}
 	if account, accountErr := p.store.GetAccount(session.AccountID); accountErr == nil {
 		liveAccountBinding = cloneMetadata(resolveLiveBinding(account))
@@ -5467,6 +5475,7 @@ func (p *Platform) resolveLiveSessionParameters(session domain.LiveSession, vers
 		"pretouchShadowOverlayQualityMaxQuantity",
 		"pretouchShadowOverlayQualityCostThresholdATR",
 		"pretouchShadowOverlaySpeedThreshold",
+		pretouchShadowT3StructureModeParam,
 		"pretouchShadowOverlayMaxPreTouchSec",
 		"pretouchShadowOverlayMaxEff300s",
 		pretouchShadowT3StopGateEnabledParam,
@@ -5495,7 +5504,52 @@ func (p *Platform) resolveLiveSessionParameters(session domain.LiveSession, vers
 	}
 	parameters = applyCanonicalLiveSignalScope(parameters, resolveStrategySignalBindings(parameters))
 	parameters = applyLiveSafeStopDefaults(parameters)
+	parameters = applyPretouchEffectiveParameterDefaults(parameters, version)
 	return NormalizeBacktestParameters(parameters)
+}
+
+func applyPretouchEffectiveParameterDefaults(parameters map[string]any, version domain.StrategyVersion) map[string]any {
+	normalized := cloneMetadata(parameters)
+	if normalized == nil {
+		normalized = map[string]any{}
+	}
+	engineKey := normalizeStrategyEngineKey(stringValue(normalized["strategyEngine"]))
+	if version.StrategyID == bkLiveEthPretouchTimingStrategyID || engineKey == bkLiveEthPretouchTimingEngineKey {
+		mode := normalizePretouchT3StructureMode(firstNonEmpty(
+			stringValue(normalized[pretouchShadowT3StructureModeParam]),
+			defaultPretouchShadowT3StructureMode,
+		))
+		normalized[pretouchShadowT3StructureModeParam] = mode
+	}
+	return normalized
+}
+
+func applyEffectiveLiveSessionParameterState(state map[string]any, parameters map[string]any) map[string]any {
+	updated := cloneMetadata(state)
+	if updated == nil {
+		updated = map[string]any{}
+	}
+	engineKey := normalizeStrategyEngineKey(stringValue(parameters["strategyEngine"]))
+	if engineKey == bkLiveEthPretouchTimingEngineKey {
+		updated[pretouchShadowT3StructureModeParam] = normalizePretouchT3StructureMode(firstNonEmpty(
+			stringValue(parameters[pretouchShadowT3StructureModeParam]),
+			defaultPretouchShadowT3StructureMode,
+		))
+	}
+	return updated
+}
+
+func (p *Platform) withEffectiveLiveSessionParameterState(session domain.LiveSession) domain.LiveSession {
+	version, err := p.resolveCurrentStrategyVersion(session.StrategyID)
+	if err != nil {
+		return session
+	}
+	parameters, err := p.resolveLiveSessionParameters(session, version)
+	if err != nil {
+		return session
+	}
+	session.State = applyEffectiveLiveSessionParameterState(session.State, parameters)
+	return session
 }
 
 func liveExecutionParameterOverrideKeys() []string {
@@ -6090,6 +6144,9 @@ func normalizeLiveSessionOverrides(overrides map[string]any) map[string]any {
 		if value := strings.TrimSpace(stringValue(overrides[key])); value != "" {
 			normalized[key] = value
 		}
+	}
+	if value := strings.TrimSpace(stringValue(overrides[pretouchShadowT3StructureModeParam])); value != "" {
+		normalized[pretouchShadowT3StructureModeParam] = normalizePretouchT3StructureMode(value)
 	}
 	for _, key := range []string{
 		"pretouchBaseOrderQuantity",

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -1872,6 +1872,46 @@ func TestResolveLiveSessionParametersDefaultsMissingStopsToTrailingForLive(t *te
 	}
 }
 
+func TestResolveLiveSessionParametersDefaultsPretouchT3StructureMode(t *testing.T) {
+	platform := NewPlatform(memory.NewStore())
+
+	if _, err := platform.store.UpdateStrategyParameters(bkLiveEthPretouchTimingStrategyID, map[string]any{
+		"strategyEngine":      bkLiveEthPretouchTimingEngineKey,
+		"symbol":              "ETHUSDT",
+		"signalTimeframe":     "1h",
+		"executionDataSource": "tick",
+	}); err != nil {
+		t.Fatalf("update pretouch strategy parameters failed: %v", err)
+	}
+	session, err := platform.CreateLiveSession("", "live-main", bkLiveEthPretouchTimingStrategyID, nil)
+	if err != nil {
+		t.Fatalf("create live session failed: %v", err)
+	}
+	if _, ok := session.State[pretouchShadowT3StructureModeParam]; ok {
+		t.Fatalf("expected raw session state to omit %s before enrichment", pretouchShadowT3StructureModeParam)
+	}
+
+	version, err := platform.resolveCurrentStrategyVersion(session.StrategyID)
+	if err != nil {
+		t.Fatalf("resolve strategy version failed: %v", err)
+	}
+	parameters, err := platform.resolveLiveSessionParameters(session, version)
+	if err != nil {
+		t.Fatalf("resolve live session parameters failed: %v", err)
+	}
+	if got := stringValue(parameters[pretouchShadowT3StructureModeParam]); got != defaultPretouchShadowT3StructureMode {
+		t.Fatalf("expected %s=%s, got %s", pretouchShadowT3StructureModeParam, defaultPretouchShadowT3StructureMode, got)
+	}
+
+	enriched, err := platform.GetLiveSession(session.ID)
+	if err != nil {
+		t.Fatalf("get live session failed: %v", err)
+	}
+	if got := stringValue(enriched.State[pretouchShadowT3StructureModeParam]); got != defaultPretouchShadowT3StructureMode {
+		t.Fatalf("expected enriched session %s=%s, got %s in %#v", pretouchShadowT3StructureModeParam, defaultPretouchShadowT3StructureMode, got, enriched.State)
+	}
+}
+
 func TestApplyLiveSafeStopDefaultsSkipsLegacyTrailingDefaultsForV4ExitContract(t *testing.T) {
 	parameters := applyLiveSafeStopDefaults(map[string]any{
 		"initial_stop_atr": 0.45,
@@ -4879,6 +4919,7 @@ func TestNormalizeLiveSessionOverridesIncludesPretouchExitContract(t *testing.T)
 func TestNormalizeLiveSessionOverridesIncludesPretouchT3StopGateContract(t *testing.T) {
 	overrides := normalizeLiveSessionOverrides(map[string]any{
 		pretouchShadowT3StopGateEnabledParam:                   true,
+		pretouchShadowT3StructureModeParam:                     "prev3_dominates",
 		pretouchShadowT3StopGateMinAbsSpeed300sATRParam:        0.65,
 		pretouchShadowT3StopGateMinEff300sParam:                0.85,
 		pretouchShadowT3StopGateMinPreTouchSecondsParam:        250.0,
@@ -4889,6 +4930,9 @@ func TestNormalizeLiveSessionOverridesIncludesPretouchT3StopGateContract(t *test
 	})
 	if !boolValue(overrides[pretouchShadowT3StopGateEnabledParam]) {
 		t.Fatalf("expected %s=true, got %#v", pretouchShadowT3StopGateEnabledParam, overrides)
+	}
+	if got := stringValue(overrides[pretouchShadowT3StructureModeParam]); got != defaultPretouchShadowT3StructureMode {
+		t.Fatalf("expected %s=%s, got %s in %#v", pretouchShadowT3StructureModeParam, defaultPretouchShadowT3StructureMode, got, overrides)
 	}
 	for key, want := range map[string]float64{
 		pretouchShadowT3StopGateMinAbsSpeed300sATRParam:        0.65,

--- a/internal/service/pretouch_event_detector.go
+++ b/internal/service/pretouch_event_detector.go
@@ -410,6 +410,30 @@ func (d *PretouchEventDetector) OnTickT3Overlay(tick TickData) PretouchDetection
 	shortRelaxedReady := pretouchT3ShortStructureReadyPrev3Dominates(prevBar3.Low, prevBar2.Low, prevBar1.Low)
 	longReady := pretouchT3LongStructureReady(prevBar3.High, prevBar2.High, prevBar1.High, structureMode)
 	shortReady := pretouchT3ShortStructureReady(prevBar3.Low, prevBar2.Low, prevBar1.Low, structureMode)
+	baseDiagnostics := map[string]any{
+		"shape":               "t3_swing",
+		"atr":                 atr,
+		"signalBarStart":      formatOptionalRFC3339(d.currentBar.OpenTime),
+		"tickTime":            formatOptionalRFC3339(tick.Time),
+		"current":             pretouchBarSnapshot(d.currentBar),
+		"prevBar1":            pretouchBarSnapshot(&prevBar1),
+		"prevBar2":            pretouchBarSnapshot(&prevBar2),
+		"prevBar3":            pretouchBarSnapshot(&prevBar3),
+		"structureMode":       structureMode,
+		"longLevel":           prevBar3.High,
+		"shortLevel":          prevBar3.Low,
+		"longStructureReady":  longReady,
+		"shortStructureReady": shortReady,
+		"longStrictReady":     longStrictReady,
+		"shortStrictReady":    shortStrictReady,
+		"longRelaxedReady":    longRelaxedReady,
+		"shortRelaxedReady":   shortRelaxedReady,
+		"longPriceTouched":    tick.Price >= prevBar3.High || d.currentBar.High >= prevBar3.High,
+		"shortPriceTouched":   tick.Price <= prevBar3.Low || d.currentBar.Low <= prevBar3.Low,
+		"tickPrice":           tick.Price,
+		"currentHigh":         d.currentBar.High,
+		"currentLow":          d.currentBar.Low,
+	}
 	if tick.Price >= prevBar3.High && longReady {
 		side = "long"
 		level = prevBar3.High
@@ -427,12 +451,21 @@ func (d *PretouchEventDetector) OnTickT3Overlay(tick TickData) PretouchDetection
 		level = prevBar3.Low
 		touchPrice = d.currentBar.Low
 	} else {
-		return PretouchDetectionResult{Reason: "t3_no_level_touch"}
+		return PretouchDetectionResult{
+			Reason:      "t3_no_level_touch",
+			Diagnostics: baseDiagnostics,
+		}
 	}
 
 	touchTime := tick.Time
 	signalBarStart := d.currentBar.OpenTime
-	diagnostics := map[string]any{
+	diagnostics := cloneMetadata(baseDiagnostics)
+	diagnostics["side"] = side
+	diagnostics["level"] = level
+	diagnostics["touchPrice"] = touchPrice
+	diagnostics["strictWouldTrigger"] = (side == "long" && longStrictReady) || (side == "short" && shortStrictReady)
+	diagnostics["relaxedWouldTrigger"] = (side == "long" && longRelaxedReady) || (side == "short" && shortRelaxedReady)
+	for key, value := range map[string]any{
 		"shape":                  "t3_swing",
 		"side":                   side,
 		"level":                  level,
@@ -457,6 +490,8 @@ func (d *PretouchEventDetector) OnTickT3Overlay(tick TickData) PretouchDetection
 		"minAbsSpeed300sATR":     d.config.MinSpeed300sATR,
 		"maxEff300s":             d.config.MaxEff300s,
 		"roundtripCostThreshold": d.config.CostQ50Threshold,
+	} {
+		diagnostics[key] = value
 	}
 	preTouchSeconds := touchTime.Sub(signalBarStart).Seconds()
 	diagnostics["preTouchSeconds"] = preTouchSeconds

--- a/internal/service/strategy.go
+++ b/internal/service/strategy.go
@@ -290,7 +290,11 @@ func (p *Platform) ListStrategySignalBindings(strategyID string) ([]domain.Accou
 }
 
 func (p *Platform) GetLiveSession(sessionID string) (domain.LiveSession, error) {
-	return p.store.GetLiveSession(sessionID)
+	session, err := p.store.GetLiveSession(sessionID)
+	if err != nil {
+		return domain.LiveSession{}, err
+	}
+	return p.withEffectiveLiveSessionParameterState(session), nil
 }
 
 // ListAccounts 获取所有账户列表。

--- a/internal/service/strategy_engine_pretouch_timing.go
+++ b/internal/service/strategy_engine_pretouch_timing.go
@@ -878,7 +878,7 @@ func (e *bkLiveEthPretouchTimingEngine) shouldLogT3ShadowOverlayMiss(key string)
 
 func pretouchT3OverlayMissLoggable(reason string) bool {
 	switch pretouchT3OverlayMissReasonCategory(reason) {
-	case "t3_pre_touch_seconds", "t3_speed_300s", "t3_eff_300s":
+	case "t3_no_level_touch", "t3_pre_touch_seconds", "t3_speed_300s", "t3_eff_300s":
 		return true
 	default:
 		return false

--- a/internal/service/strategy_engine_pretouch_timing_test.go
+++ b/internal/service/strategy_engine_pretouch_timing_test.go
@@ -830,6 +830,44 @@ func TestPretouchTimingEngineReportsT3OverlaySpeedRejectMetadata(t *testing.T) {
 	}
 }
 
+func TestPretouchTimingEngineReportsT3OverlayNoLevelTouchMetadata(t *testing.T) {
+	start := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
+	engine := testPretouchTimingEngine("fast", 0.75)
+	ctx := testPretouchT3OverlaySignalContext(start, 100.0)
+	enablePretouchRiskOnShadow(&ctx, true)
+	setPretouchOrderBook(&ctx, 99.99, 100.0)
+
+	decision, err := engine.EvaluateSignal(ctx)
+	if err != nil {
+		t.Fatalf("evaluate failed: %v", err)
+	}
+	if decision.Action != "wait" || decision.Reason != "no_level_touch" {
+		t.Fatalf("expected lead wait with T3 no-level metadata, got %#v", decision)
+	}
+	if !boolValue(decision.Metadata["t3OverlayRejected"]) {
+		t.Fatalf("expected t3OverlayRejected metadata, got %#v", decision.Metadata)
+	}
+	if got := stringValue(decision.Metadata["t3OverlayRejectCategory"]); got != "t3_no_level_touch" {
+		t.Fatalf("expected t3_no_level_touch reject category, got %s in %#v", got, decision.Metadata)
+	}
+	if got := parseFloatValue(decision.Metadata["t3OverlayLevel"]); got != 0 {
+		t.Fatalf("expected no selected touch level before price touch, got %v in %#v", got, decision.Metadata)
+	}
+	diagnostics := mapValue(decision.Metadata["t3OverlayDiagnostics"])
+	if diagnostics == nil {
+		t.Fatalf("expected T3 diagnostics metadata, got %#v", decision.Metadata)
+	}
+	if got := parseFloatValue(diagnostics["longLevel"]); math.Abs(got-106.0) > 1e-9 {
+		t.Fatalf("expected T3 long level 106, got %v in %#v", got, diagnostics)
+	}
+	if !boolValue(diagnostics["longStructureReady"]) || boolValue(diagnostics["longPriceTouched"]) {
+		t.Fatalf("expected long structure ready but not touched, got %#v", diagnostics)
+	}
+	if intent := deriveLiveSignalIntent(decision, "ETHUSDT"); intent != nil {
+		t.Fatalf("expected rejected T3 overlay wait not to produce intent, got %#v", intent)
+	}
+}
+
 func TestPretouchTimingEngineSubmitsLeadFromSignalBarHighTouch(t *testing.T) {
 	start := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
 	engine := testPretouchTimingEngine("fast", 0.75)
@@ -985,6 +1023,15 @@ func TestPretouchTimingEngineLogsT3OverlayDetectorMissOncePerSignalBar(t *testin
 	}
 	if decision.Action != "wait" || decision.Reason != "no_level_touch" {
 		t.Fatalf("expected lead wait/no_level_touch to remain unchanged, got %#v", decision)
+	}
+	if !boolValue(decision.Metadata["t3OverlayRejected"]) {
+		t.Fatalf("expected t3OverlayRejected metadata, got %#v", decision.Metadata)
+	}
+	if got := stringValue(decision.Metadata["t3OverlayRejectCategory"]); got != "t3_pre_touch_seconds" {
+		t.Fatalf("expected t3_pre_touch_seconds metadata, got %s in %#v", got, decision.Metadata)
+	}
+	if got := parseFloatValue(decision.Metadata["t3OverlayPreTouchSeconds"]); math.Abs(got-60.0) > 1e-9 {
+		t.Fatalf("expected pre-touch seconds 60, got %v in %#v", got, decision.Metadata)
 	}
 	output := logs.String()
 	if !strings.Contains(output, "pretouch T3 overlay rejected") {

--- a/internal/store/memory/store.go
+++ b/internal/store/memory/store.go
@@ -296,6 +296,7 @@ func NewStore() *Store {
 			"pretouchShadowOverlayQualityMaxQuantity":      0.40,
 			"pretouchShadowOverlayQualityCostThresholdATR": 0.10,
 			"pretouchShadowOverlaySpeedThreshold":          0.35,
+			"pretouchShadowT3StructureMode":                "prev3_dominates",
 			"pretouchShadowSubmitRiskOnQuantity":           true,
 			"pretouchShadowSubmitOverlayOrder":             true,
 			"pretouchShadowStrict10CalendarPct":            35.521555,

--- a/internal/store/memory/store_test.go
+++ b/internal/store/memory/store_test.go
@@ -7,6 +7,29 @@ import (
 	"github.com/wuyaocheng/bktrader/internal/domain"
 )
 
+func TestSeededPretouchStrategyIncludesT3StructureMode(t *testing.T) {
+	store := NewStore()
+
+	strategies, err := store.ListStrategies()
+	if err != nil {
+		t.Fatalf("list strategies failed: %v", err)
+	}
+	for _, strategy := range strategies {
+		if strategy["id"] != "strategy-bk-eth-pretouch-timing" {
+			continue
+		}
+		version, ok := strategy["currentVersion"].(domain.StrategyVersion)
+		if !ok {
+			t.Fatalf("expected currentVersion domain.StrategyVersion, got %#v", strategy["currentVersion"])
+		}
+		if got := version.Parameters["pretouchShadowT3StructureMode"]; got != "prev3_dominates" {
+			t.Fatalf("expected pretouchShadowT3StructureMode=prev3_dominates, got %#v", got)
+		}
+		return
+	}
+	t.Fatal("seeded pretouch timing strategy not found")
+}
+
 func TestSavePositionDeletesNonPositiveExistingPosition(t *testing.T) {
 	store := NewStore()
 


### PR DESCRIPTION
## 目的
修复 ETH pretouch T3 shadow 结构模式线上不可见/未显式生效的问题。之前 `pretouchShadowT3StructureMode=prev3_dominates` 只在模板/部分默认值链路里存在，已有 live session 和旧 strategy version 缺字段时，`live list --json` 仍会看到 `null`，也无法直接证明 T3 overlay 使用的是 relaxed `prev3_dominates` 结构。

本 PR 让该字段进入完整 live session 参数链路：
- seeded pretouch strategy 参数显式包含 `pretouchShadowT3StructureMode=prev3_dominates`
- live override 归一化和 `resolveLiveSessionParameters` 白名单保留该字段
- 对旧 session/旧 strategy version 缺字段时注入 effective 默认值
- `ListLiveSessions` / `GetLiveSession` 返回 state 时补齐 effective 字段，让 `bktrader-ctl live list --json` 能查到
- 策略评估写 state 时持久化该 effective 字段
- 补充 T3 overlay `t3_no_level_touch`/late miss 诊断，日志能看清 structureMode、strict/relaxed ready、level/touch 状态

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [x] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
- [x] `dispatchMode` 默认值无变化
- [x] 不存在直接调用 `mainnet` 凭证或路由地址的硬编码
- [x] 无 DB migration
- [x] 配置字段变更仅限 pretouch T3 structure mode 可见性/归一化

## 交易语义变更
- [x] 本次改动不新增/修改 `signalKind`
- [x] 本次改动不影响订单方向判断（`side` / `reduceOnly` / `closePosition`）
- [ ] `go test ./internal/domain/... -run TestClassifyOrderIntent` 不适用
- [ ] `go test ./internal/domain/... -run TestTradingReplayGoldenCases` 不适用

## 验证方式与测试证据
- [x] `go test ./internal/store/memory -run TestSeededPretouchStrategyIncludesT3StructureMode`
- [x] `go test ./internal/service -run 'TestResolveLiveSessionParametersDefaultsPretouchT3StructureMode|TestNormalizeLiveSessionOverridesIncludesPretouchT3StopGateContract|TestPretouchTimingEngineReportsT3Overlay(NoLevelTouch|SpeedReject)Metadata|TestPretouchTimingEngineLogsT3OverlayDetectorMissOncePerSignalBar'`\n- [x] `go test ./internal/http`\n- [x] `go test ./internal/store/memory`\n- [x] `go test ./internal/service`\n- [x] `git diff --check`