### PR TITLE
[codex] add pretouch lead first-touch diagnostics

### DIFF
--- a/internal/service/strategy_engine_pretouch_timing.go
+++ b/internal/service/strategy_engine_pretouch_timing.go
@@ -92,6 +92,9 @@ type bkLiveEthPretouchTimingEngine struct {
 
 	leadDelayMu      sync.Mutex
 	leadDelayPending *pretouchLeadDelayPending
+
+	leadTouchMu        sync.Mutex
+	lastLeadFirstTouch pretouchLeadFirstTouchState
 }
 
 type pretouchLeadDelayPending struct {
@@ -105,6 +108,11 @@ type pretouchLeadDelayPending struct {
 	TargetATR      float64
 	ReferencePrice float64
 	TargetPrice    float64
+}
+
+type pretouchLeadFirstTouchState struct {
+	SignalBarKey string
+	Metadata     map[string]any
 }
 
 func newBkLiveEthPretouchTimingEngine(platform *Platform) *bkLiveEthPretouchTimingEngine {
@@ -253,6 +261,11 @@ func (e *bkLiveEthPretouchTimingEngine) EvaluateSignal(ctx StrategySignalEvaluat
 	result := e.detector.OnTick(tick)
 
 	if !result.Detected {
+		if strings.EqualFold(result.Reason, "already_touched_this_bar") {
+			if metadata := e.pretouchLeadAlreadyTouchedMetadata(ctx, currentBar); len(metadata) > 0 {
+				return StrategySignalDecision{Action: "wait", Reason: result.Reason, Metadata: metadata}, nil
+			}
+		}
 		if decision, handled := e.evaluateT3ShadowOverlay(ctx, tick, closedBars, currentBar, orderBookStats, result.Reason); handled {
 			return decision, nil
 		}
@@ -260,6 +273,7 @@ func (e *bkLiveEthPretouchTimingEngine) EvaluateSignal(ctx StrategySignalEvaluat
 	}
 
 	// --- Pretouch event detected! Do Go-native ML inference ---
+	signalBarTradeLimitKey := pretouchSignalBarTradeLimitKey(ctx.ExecutionContext.Symbol, "1h", currentBar)
 	logger.Info("pretouch event detected",
 		"event_id", result.Event.EventID,
 		"side", result.Event.Side,
@@ -274,12 +288,15 @@ func (e *bkLiveEthPretouchTimingEngine) EvaluateSignal(ctx StrategySignalEvaluat
 		logger.Warn("no model loaded, skipping event",
 			"event_id", result.Event.EventID,
 		)
+		firstTouch := e.recordPretouchLeadFirstTouch(result.Event, signalBarTradeLimitKey, "wait", "no_model_loaded", "", nil)
 		return StrategySignalDecision{
 			Action: "wait",
 			Reason: "no_model_loaded",
 			Metadata: map[string]any{
-				"pretouchEvent":      result.Event.EventID,
-				"detectedButSkipped": true,
+				"pretouchEvent":            result.Event.EventID,
+				"detectedButSkipped":       true,
+				"pretouchLeadFirstTouch":   firstTouch,
+				"pretouchLeadTouchOutcome": "no_model_loaded",
 			},
 		}, nil
 	}
@@ -320,20 +337,23 @@ func (e *bkLiveEthPretouchTimingEngine) EvaluateSignal(ctx StrategySignalEvaluat
 			"event_id", result.Event.EventID,
 			"probability", rfProb,
 		)
+		firstTouch := e.recordPretouchLeadFirstTouch(result.Event, signalBarTradeLimitKey, "wait", "timing_skip", leadModel.Version, nil)
 		return StrategySignalDecision{
 			Action: "wait",
 			Reason: "timing_skip",
 			Metadata: map[string]any{
-				"pretouchEvent": result.Event.EventID,
-				"timingRegime":  "skip",
-				"rfProbability": rfProb,
-				"modelVersion":  leadModel.Version,
+				"pretouchEvent":            result.Event.EventID,
+				"timingRegime":             "skip",
+				"rfProbability":            rfProb,
+				"modelVersion":             leadModel.Version,
+				"pretouchLeadFirstTouch":   firstTouch,
+				"pretouchLeadTouchOutcome": "timing_skip",
 			},
 		}, nil
 	}
 
 	if e.shouldArmPretouchLeadDelay(ctx, result.Event, timingRegime) {
-		return e.armPretouchLeadDelay(ctx, result.Event, leadModel.Version, currentBar), nil
+		return e.armPretouchLeadDelay(ctx, result.Event, leadModel.Version, currentBar, signalBarTradeLimitKey), nil
 	}
 
 	return e.buildPretouchLeadAdvanceDecision(ctx, result.Event, leadModel.Version, closedBars, currentBar, orderBookStats, triggerPrice, nil), nil
@@ -350,11 +370,14 @@ func (e *bkLiveEthPretouchTimingEngine) shouldArmPretouchLeadDelay(ctx StrategyS
 	return submitContext.liveExecution && submitContext.sandbox && strings.EqualFold(submitContext.executionMode, "rest")
 }
 
-func (e *bkLiveEthPretouchTimingEngine) armPretouchLeadDelay(ctx StrategySignalEvaluationContext, event domain.PretouchEvent, modelVersion string, currentBar *HourlyBar) StrategySignalDecision {
+func (e *bkLiveEthPretouchTimingEngine) armPretouchLeadDelay(ctx StrategySignalEvaluationContext, event domain.PretouchEvent, modelVersion string, currentBar *HourlyBar, signalBarKey string) StrategySignalDecision {
+	if signalBarKey == "" {
+		signalBarKey = pretouchSignalBarTradeLimitKey(ctx.ExecutionContext.Symbol, "1h", currentBar)
+	}
 	pending := pretouchLeadDelayPending{
 		Event:         event,
 		ModelVersion:  modelVersion,
-		SignalBarKey:  pretouchSignalBarTradeLimitKey(ctx.ExecutionContext.Symbol, "1h", currentBar),
+		SignalBarKey:  signalBarKey,
 		SelectedDelay: "pullback",
 		ArmedAt:       ctx.EventTime,
 		ReadyAt:       event.TouchTime.Add(5 * time.Second),
@@ -365,19 +388,23 @@ func (e *bkLiveEthPretouchTimingEngine) armPretouchLeadDelay(ctx StrategySignalE
 	e.leadDelayPending = &pending
 	e.leadDelayMu.Unlock()
 
+	delayMetadata := pending.metadata("armed")
+	firstTouch := e.recordPretouchLeadFirstTouch(event, signalBarKey, "wait", "pretouch_delay_policy_armed", modelVersion, delayMetadata)
 	return StrategySignalDecision{
 		Action: "wait",
 		Reason: "pretouch_delay_policy_armed",
 		Metadata: map[string]any{
-			"pretouchEvent":       event,
-			"timingRegime":        event.TimingRegime,
-			"rfProbability":       event.RFProbability,
-			"modelVersion":        modelVersion,
-			"selectedDelay":       pending.SelectedDelay,
-			"pretouchDelayPolicy": pending.metadata("armed"),
-			"signalSource":        "pretouch-timing-unified",
-			"decisionState":       "waiting",
-			"signalKind":          "entry-delay-watch",
+			"pretouchEvent":            event,
+			"timingRegime":             event.TimingRegime,
+			"rfProbability":            event.RFProbability,
+			"modelVersion":             modelVersion,
+			"selectedDelay":            pending.SelectedDelay,
+			"pretouchDelayPolicy":      delayMetadata,
+			"pretouchLeadFirstTouch":   firstTouch,
+			"pretouchLeadTouchOutcome": "pretouch_delay_policy_armed",
+			"signalSource":             "pretouch-timing-unified",
+			"decisionState":            "waiting",
+			"signalKind":               "entry-delay-watch",
 		},
 	}
 }
@@ -617,12 +644,93 @@ func (e *bkLiveEthPretouchTimingEngine) buildPretouchLeadAdvanceDecision(ctx Str
 		metadata["pretouchDelayPolicy"] = delayMetadata
 		metadata["selectedDelay"] = stringValue(delayMetadata["selectedDelay"])
 	}
+	firstTouchReason := fmt.Sprintf("pretouch_%s_%s", timingRegime, event.Side)
+	if delayMetadata != nil {
+		firstTouchReason = "pretouch_delay_policy_" + firstNonEmpty(stringValue(delayMetadata["status"]), "resolved")
+	}
+	firstTouch := e.recordPretouchLeadFirstTouch(event, signalBarTradeLimitKey, "advance-plan", firstTouchReason, modelVersion, delayMetadata)
+	metadata["pretouchLeadFirstTouch"] = firstTouch
+	metadata["pretouchLeadTouchOutcome"] = firstTouchReason
 
 	return StrategySignalDecision{
 		Action:   "advance-plan",
 		Reason:   fmt.Sprintf("pretouch_%s_%s", timingRegime, event.Side),
 		Metadata: metadata,
 	}
+}
+
+func (e *bkLiveEthPretouchTimingEngine) recordPretouchLeadFirstTouch(event domain.PretouchEvent, signalBarKey, action, reason, modelVersion string, delayMetadata map[string]any) map[string]any {
+	metadata := pretouchLeadFirstTouchMetadata(event, signalBarKey, action, reason, modelVersion, delayMetadata)
+	if e == nil || signalBarKey == "" {
+		return metadata
+	}
+	e.leadTouchMu.Lock()
+	e.lastLeadFirstTouch = pretouchLeadFirstTouchState{
+		SignalBarKey: signalBarKey,
+		Metadata:     cloneMetadata(metadata),
+	}
+	e.leadTouchMu.Unlock()
+	return metadata
+}
+
+func (e *bkLiveEthPretouchTimingEngine) pretouchLeadAlreadyTouchedMetadata(ctx StrategySignalEvaluationContext, currentBar *HourlyBar) map[string]any {
+	if e == nil {
+		return nil
+	}
+	signalBarKey := pretouchSignalBarTradeLimitKey(ctx.ExecutionContext.Symbol, "1h", currentBar)
+	e.leadTouchMu.Lock()
+	state := e.lastLeadFirstTouch
+	e.leadTouchMu.Unlock()
+	if signalBarKey == "" || state.SignalBarKey == "" || state.SignalBarKey != signalBarKey || len(state.Metadata) == 0 {
+		return nil
+	}
+	firstTouch := cloneMetadata(state.Metadata)
+	return map[string]any{
+		"decisionState":                 "rejected",
+		"signalKind":                    "entry-watch",
+		"signalSource":                  "pretouch-timing-unified",
+		"signalBarStateKey":             signalBarKey,
+		liveSignalBarTradeLimitKeyField: signalBarKey,
+		"pretouchLeadFirstTouch":        firstTouch,
+		"pretouchLeadTouchOutcome":      stringValue(firstTouch["outcomeReason"]),
+		"pretouchLeadAlreadyTouched":    true,
+		"t3OverlaySkippedReason":        "lead_already_touched_this_bar",
+		"t3OverlayRejected":             true,
+		"t3OverlayRejectReason":         "lead_already_touched_this_bar",
+		"t3OverlayRejectCategory":       "lead_already_touched_this_bar",
+	}
+}
+
+func pretouchLeadFirstTouchMetadata(event domain.PretouchEvent, signalBarKey, action, reason, modelVersion string, delayMetadata map[string]any) map[string]any {
+	metadata := map[string]any{
+		"eventId":           event.EventID,
+		"symbol":            event.Symbol,
+		"side":              event.Side,
+		"nextSide":          nextPretouchSide(event.Side),
+		"touchTime":         formatOptionalRFC3339(event.TouchTime),
+		"signalBarStart":    formatOptionalRFC3339(event.SignalBarStart),
+		"signalBarStateKey": signalBarKey,
+		"touchPrice":        event.TouchPrice,
+		"level":             event.Level,
+		"atr":               event.ATR,
+		"preTouchSeconds":   event.PreTouchSeconds,
+		"speed300sATR":      event.Speed300sATR,
+		"eff300s":           event.Eff300s,
+		"roundtripCostATR":  event.RoundtripCostATR,
+		"touchExtensionATR": event.TouchExtensionATR,
+		"timingRegime":      normalizePretouchTimingRegime(event.TimingRegime),
+		"rfProbability":     event.RFProbability,
+		"sizingMultiplier":  event.SizingMultiplier,
+		"costPenalty":       event.CostPenalty,
+		"finalPositionSize": event.FinalPositionSize,
+		"modelVersion":      modelVersion,
+		"outcomeAction":     action,
+		"outcomeReason":     reason,
+	}
+	if delayMetadata != nil {
+		metadata["pretouchDelayPolicy"] = cloneMetadata(delayMetadata)
+	}
+	return metadata
 }
 
 func nextPretouchSide(eventSide string) string {

--- a/internal/service/strategy_engine_pretouch_timing_test.go
+++ b/internal/service/strategy_engine_pretouch_timing_test.go
@@ -43,6 +43,13 @@ func TestPretouchTimingEngineAdvancePlanProducesLiveIntentMetadata(t *testing.T)
 	if got := parseFloatValue(decision.Metadata["suggestedQuantity"]); math.Abs(got-0.12) > 1e-9 {
 		t.Fatalf("expected suggested quantity 0.12, got %v", got)
 	}
+	firstTouch := mapValue(decision.Metadata["pretouchLeadFirstTouch"])
+	if got := stringValue(firstTouch["outcomeReason"]); got != "pretouch_fast_long" {
+		t.Fatalf("expected first touch outcome pretouch_fast_long, got %s in %#v", got, firstTouch)
+	}
+	if got := stringValue(firstTouch["signalBarStateKey"]); got != "ETHUSDT|1h|2026-05-15T12:00:00Z" {
+		t.Fatalf("expected first touch signal bar key, got %s in %#v", got, firstTouch)
+	}
 
 	intent := deriveLiveSignalIntent(decision, "ETHUSDT")
 	if intent == nil {
@@ -198,6 +205,43 @@ func TestPretouchTimingEngineArmsSlowPullbackDelayForSandboxShadow(t *testing.T)
 	}
 	if intent := deriveLiveSignalIntent(decision, "ETHUSDT"); intent != nil {
 		t.Fatalf("expected no live intent while slow delay is armed, got %#v", intent)
+	}
+	firstTouch := mapValue(decision.Metadata["pretouchLeadFirstTouch"])
+	if got := stringValue(firstTouch["outcomeReason"]); got != "pretouch_delay_policy_armed" {
+		t.Fatalf("expected first touch delay armed outcome, got %s in %#v", got, firstTouch)
+	}
+	if policy := mapValue(firstTouch["pretouchDelayPolicy"]); stringValue(policy["status"]) != "armed" {
+		t.Fatalf("expected first touch to carry armed delay policy, got %#v", firstTouch)
+	}
+}
+
+func TestPretouchTimingEngineReportsLeadFirstTouchOnAlreadyTouchedBar(t *testing.T) {
+	start := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
+	engine := testPretouchTimingEngine("fast", 0.75)
+
+	if decision, err := engine.EvaluateSignal(testPretouchSignalContext(start, 101)); err != nil || decision.Action != "wait" {
+		t.Fatalf("first evaluate failed decision=%#v err=%v", decision, err)
+	}
+	if decision, err := engine.EvaluateSignal(testPretouchSignalContext(start.Add(60*time.Second), 105.1)); err != nil || decision.Action != "advance-plan" {
+		t.Fatalf("expected first touch advance-plan, decision=%#v err=%v", decision, err)
+	}
+
+	decision, err := engine.EvaluateSignal(testPretouchSignalContext(start.Add(90*time.Second), 105.2))
+	if err != nil {
+		t.Fatalf("already touched evaluate failed: %v", err)
+	}
+	if decision.Action != "wait" || decision.Reason != "already_touched_this_bar" {
+		t.Fatalf("expected already_touched_this_bar wait, got %#v", decision)
+	}
+	firstTouch := mapValue(decision.Metadata["pretouchLeadFirstTouch"])
+	if got := stringValue(firstTouch["outcomeReason"]); got != "pretouch_fast_long" {
+		t.Fatalf("expected first touch outcome in already touched metadata, got %s in %#v", got, decision.Metadata)
+	}
+	if got := stringValue(decision.Metadata["t3OverlaySkippedReason"]); got != "lead_already_touched_this_bar" {
+		t.Fatalf("expected T3 skipped reason for already touched lead, got %s in %#v", got, decision.Metadata)
+	}
+	if intent := deriveLiveSignalIntent(decision, "ETHUSDT"); intent != nil {
+		t.Fatalf("expected already touched wait not to produce intent, got %#v", intent)
 	}
 }
 
@@ -1576,6 +1620,10 @@ func TestPretouchTimingEngineSkipsWhenModelMissing(t *testing.T) {
 	if decision.Action != "wait" || decision.Reason != "no_model_loaded" {
 		t.Fatalf("expected no_model_loaded wait, got %#v", decision)
 	}
+	firstTouch := mapValue(decision.Metadata["pretouchLeadFirstTouch"])
+	if got := stringValue(firstTouch["outcomeReason"]); got != "no_model_loaded" {
+		t.Fatalf("expected first touch no_model_loaded outcome, got %s in %#v", got, firstTouch)
+	}
 }
 
 func TestPretouchTimingEngineSkipsUnknownTimingRegime(t *testing.T) {
@@ -1589,6 +1637,10 @@ func TestPretouchTimingEngineSkipsUnknownTimingRegime(t *testing.T) {
 	}
 	if decision.Action != "wait" || decision.Reason != "timing_skip" {
 		t.Fatalf("expected timing_skip wait, got %#v", decision)
+	}
+	firstTouch := mapValue(decision.Metadata["pretouchLeadFirstTouch"])
+	if got := stringValue(firstTouch["outcomeReason"]); got != "timing_skip" {
+		t.Fatalf("expected first touch timing_skip outcome, got %s in %#v", got, firstTouch)
 	}
 }
 


### PR DESCRIPTION
## 目的
补齐 ETH pretouch lead 首次 touch 的生产诊断。

线上看到 `already_touched_this_bar` 时，之前只能知道同一根 bar 已经被 lead detector 消费过，但看不到第一次 touch 的最终结果：是 `timing_skip`、`pretouch_delay_policy_armed`、`advance-plan`，还是 `no_model_loaded`。这会导致排查 “这根 bar 明明 touch 了为什么没开仓” 时只能猜。

本 PR 不改变开仓/下单判定，只补 metadata：
- 首次 lead touch 后记录 `pretouchLeadFirstTouch`，包含 eventId、side、level、touchPrice、preTouchSeconds、speed/eff、timingRegime、rfProbability、modelVersion、outcomeAction、outcomeReason、delay policy 等
- `no_model_loaded`、`timing_skip`、`pretouch_delay_policy_armed`、`advance-plan` 都会带同一套 first-touch outcome
- 后续同 bar 返回 `already_touched_this_bar` 时，回显首次 outcome，并标记 `t3OverlaySkippedReason=lead_already_touched_this_bar`

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [x] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [ ] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
- [x] `dispatchMode` 默认值无变化
- [x] 不存在直接调用 `mainnet` 凭证或路由地址的硬编码
- [x] 无 DB migration
- [x] 配置字段没有混改；仅新增策略决策 metadata

## 交易语义变更
- [x] 本次改动不新增/修改 `signalKind`
- [x] 本次改动不影响订单方向判断（`side` / `reduceOnly` / `closePosition`）
- [ ] `go test ./internal/domain/... -run TestClassifyOrderIntent` 不适用
- [ ] `go test ./internal/domain/... -run TestTradingReplayGoldenCases` 不适用

## 验证方式与测试证据
- [x] `go test ./internal/service -run 'TestPretouchTimingEngine(AdvancePlanProducesLiveIntentMetadata|ArmsSlowPullbackDelayForSandboxShadow|ReportsLeadFirstTouchOnAlreadyTouchedBar|SkipsWhenModelMissing|SkipsUnknownTimingRegime|ReportsT3Overlay(NoLevelTouch|SpeedReject)Metadata|LogsT3OverlayDetectorMissOncePerSignalBar)'`\n- [x] `go test ./internal/service`\n- [x] `git diff --check`