### PR TITLE
Add pretouch lead miss diagnostics

### DIFF
--- a/cmd/bktrader-ctl/live.go
+++ b/cmd/bktrader-ctl/live.go
@@ -54,11 +54,24 @@ var liveGetCmd = &cobra.Command{
 	Short: "查看实盘会话详情 [IDEMPOTENT]",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		fields, _ := cmd.Flags().GetString("fields")
 		client := getClient()
-		resp, err := client.Request("GET", "/api/v1/live/sessions/"+url.PathEscape(args[0])+"/detail", nil)
+		resp, err := client.Request("GET", buildLiveSessionDetailPath(args[0], fields), nil)
 		handleResponse(resp, err)
 		return nil
 	},
+}
+
+const defaultLiveSessionDetailFields = "timeline,breakoutHistory,lastStrategyEvaluationSignalBarStates,lastStrategyEvaluationSourceStates,signalRuntimePlan,lastStrategyDecision,lastDispatchedIntent,lastExecutionDispatch,lastExecutionTelemetry"
+
+func buildLiveSessionDetailPath(sessionID, fields string) string {
+	resolvedFields := strings.TrimSpace(fields)
+	if resolvedFields == "" {
+		resolvedFields = defaultLiveSessionDetailFields
+	}
+	v := url.Values{}
+	v.Set("fields", resolvedFields)
+	return "/api/v1/live/sessions/" + url.PathEscape(sessionID) + "/detail?" + v.Encode()
 }
 
 var liveControlStatusCmd = &cobra.Command{
@@ -279,6 +292,7 @@ func init() {
 	liveTemplateCmd.AddCommand(liveTemplateListCmd)
 
 	liveListCmd.Flags().String("view", "", "视图类型 (e.g. summary)")
+	liveGetCmd.Flags().String("fields", "", "详情字段 CSV；默认包含 timeline/breakout/strategy/execution 诊断字段")
 	liveControlStatusCmd.Flags().Bool("only-pending", false, "只显示尚未收敛的控制请求")
 	liveControlStatusCmd.Flags().Bool("only-error", false, "只显示 actualStatus=ERROR 或存在控制错误的会话")
 	liveControlResetCmd.Flags().Bool("confirm", false, "确认执行控制状态重置")

--- a/cmd/bktrader-ctl/live_test.go
+++ b/cmd/bktrader-ctl/live_test.go
@@ -1,9 +1,38 @@
 package main
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
+
+func TestBuildLiveSessionDetailPathUsesDefaultFields(t *testing.T) {
+	path := buildLiveSessionDetailPath("live/session 1", "")
+	if !strings.HasPrefix(path, "/api/v1/live/sessions/live%2Fsession%201/detail?") {
+		t.Fatalf("expected escaped live session detail path, got %s", path)
+	}
+	for _, field := range []string{
+		"timeline",
+		"breakoutHistory",
+		"lastStrategyEvaluationSignalBarStates",
+		"lastStrategyDecision",
+		"lastExecutionDispatch",
+	} {
+		if !strings.Contains(path, field) {
+			t.Fatalf("expected default detail field %s in path %s", field, path)
+		}
+	}
+}
+
+func TestBuildLiveSessionDetailPathAllowsCustomFields(t *testing.T) {
+	path := buildLiveSessionDetailPath("live-1", "timeline,lastStrategyDecision")
+	if !strings.Contains(path, "fields=timeline%2ClastStrategyDecision") {
+		t.Fatalf("expected custom fields query, got %s", path)
+	}
+	if strings.Contains(path, "lastExecutionDispatch") {
+		t.Fatalf("expected custom fields to override defaults, got %s", path)
+	}
+}
 
 func TestBuildLiveSessionControlStatusPendingDuration(t *testing.T) {
 	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)

--- a/internal/service/live.go
+++ b/internal/service/live.go
@@ -4066,7 +4066,7 @@ func (p *Platform) evaluateLiveSessionOnSignal(session domain.LiveSession, runti
 	if !shouldAutoDispatchLiveIntent(updatedSession, dispatchIntent, eventTime) {
 		return nil
 	}
-	if _, err := p.dispatchLiveSessionIntent(updatedSession); err != nil {
+	if _, err := p.dispatchLiveSessionIntentWithProposalSnapshot(updatedSession, dispatchIntent); err != nil {
 		latestSession, latestErr := p.store.GetLiveSession(updatedSession.ID)
 		if latestErr == nil {
 			state = cloneMetadata(latestSession.State)

--- a/internal/service/live_execution.go
+++ b/internal/service/live_execution.go
@@ -942,6 +942,10 @@ func (p *Platform) recordLiveDispatchPreflightRejection(session domain.LiveSessi
 }
 
 func (p *Platform) dispatchLiveSessionIntent(session domain.LiveSession) (domain.Order, error) {
+	return p.dispatchLiveSessionIntentWithProposalSnapshot(session, nil)
+}
+
+func (p *Platform) dispatchLiveSessionIntentWithProposalSnapshot(session domain.LiveSession, proposalSnapshot map[string]any) (domain.Order, error) {
 	releaseDispatch := p.lockLiveSessionDispatch(session.ID)
 	defer releaseDispatch()
 	if latestSession, latestErr := p.store.GetLiveSession(session.ID); latestErr == nil {
@@ -960,6 +964,9 @@ func (p *Platform) dispatchLiveSessionIntent(session domain.LiveSession) (domain
 	}
 
 	proposalMap := cloneMetadata(mapValue(firstNonEmptyMapValue(session.State["lastExecutionProposal"], session.State["lastStrategyIntent"])))
+	if len(proposalMap) == 0 && len(proposalSnapshot) > 0 {
+		proposalMap = cloneMetadata(proposalSnapshot)
+	}
 	if len(proposalMap) == 0 {
 		return domain.Order{}, fmt.Errorf("live session %s has no execution proposal", session.ID)
 	}

--- a/internal/service/live_test.go
+++ b/internal/service/live_test.go
@@ -3841,6 +3841,93 @@ func TestDispatchLiveSessionIntentReloadsLatestStateBeforeDispatch(t *testing.T)
 	}
 }
 
+func TestAutoDispatchUsesEvaluationProposalSnapshotWhenLatestWaitClearsProposal(t *testing.T) {
+	platform, session, runtimeSessionID, _, _ := prepareLiveDecisionTelemetryFixture(t)
+	platform.registerLiveAdapter(testLiveAccountSyncAdapter{key: "test-auto-dispatch-snapshot"})
+
+	account, err := platform.store.GetAccount("live-main")
+	if err != nil {
+		t.Fatalf("get account failed: %v", err)
+	}
+	account.Status = "READY"
+	account.Metadata = cloneMetadata(account.Metadata)
+	account.Metadata["liveBinding"] = map[string]any{
+		"adapterKey":     "test-auto-dispatch-snapshot",
+		"connectionMode": "mock",
+		"executionMode":  "mock",
+	}
+	if _, err := platform.store.UpdateAccount(account); err != nil {
+		t.Fatalf("update account failed: %v", err)
+	}
+	freshAt := time.Now().UTC()
+	if err := platform.updateSignalRuntimeSessionState(runtimeSessionID, func(runtimeSession *domain.SignalRuntimeSession) {
+		runtimeSession.Status = "RUNNING"
+		state := cloneMetadata(runtimeSession.State)
+		state["lastEventAt"] = freshAt.Format(time.RFC3339Nano)
+		state["lastHeartbeatAt"] = freshAt.Format(time.RFC3339Nano)
+		sourceStates := cloneMetadata(mapValue(state["sourceStates"]))
+		for key, value := range sourceStates {
+			source := cloneMetadata(mapValue(value))
+			source["lastEventAt"] = freshAt.Format(time.RFC3339Nano)
+			sourceStates[key] = source
+		}
+		state["sourceStates"] = sourceStates
+		runtimeSession.State = state
+		runtimeSession.UpdatedAt = freshAt
+	}); err != nil {
+		t.Fatalf("refresh runtime state failed: %v", err)
+	}
+
+	proposal := executionProposalToMap(ExecutionProposal{
+		Action:            "entry",
+		Role:              "entry",
+		Reason:            "Pretouch-Timing",
+		Side:              "BUY",
+		Symbol:            "BTCUSDT",
+		Type:              "MARKET",
+		Quantity:          0.001,
+		PriceHint:         75600.0,
+		SignalKind:        "entry",
+		DecisionState:     "ready",
+		SignalBarStateKey: "BTCUSDT|1h|2026-06-03T05:00:00Z",
+		ExecutionStrategy: "book-aware-v1",
+		Status:            "dispatchable",
+		Metadata: map[string]any{
+			"executionDecision":             "direct-dispatch",
+			"executionMode":                 "live",
+			liveSignalBarTradeLimitKeyField: "BTCUSDT|1h|2026-06-03T05:00:00Z",
+		},
+	})
+	proposal = setExecutionProposalDecisionEventID(proposal, "strategy-decision-event-auto-dispatch-snapshot")
+
+	latestState := cloneMetadata(session.State)
+	delete(latestState, "lastExecutionProposal")
+	delete(latestState, "lastStrategyIntent")
+	latestState["lastStrategyDecision"] = map[string]any{
+		"action": "wait",
+		"reason": "already_touched_this_bar",
+	}
+	session, err = platform.store.UpdateLiveSessionState(session.ID, latestState)
+	if err != nil {
+		t.Fatalf("update latest session state failed: %v", err)
+	}
+
+	order, err := platform.dispatchLiveSessionIntentWithProposalSnapshot(session, proposal)
+	if err != nil {
+		t.Fatalf("expected auto dispatch snapshot to create order, got %v", err)
+	}
+	if order.ID == "" {
+		t.Fatalf("expected order id, got %+v", order)
+	}
+	updated, err := platform.store.GetLiveSession(session.ID)
+	if err != nil {
+		t.Fatalf("reload session failed: %v", err)
+	}
+	if got := stringValue(updated.State["lastDispatchedDecisionEventId"]); got != "strategy-decision-event-auto-dispatch-snapshot" {
+		t.Fatalf("expected dispatched decision event id from snapshot, got %s", got)
+	}
+}
+
 func TestValidateLiveDispatchIdempotencyRejectsPreviouslyDispatchedDecisionEvent(t *testing.T) {
 	state := map[string]any{
 		"lastDispatchedDecisionEventId": "strategy-decision-event-1",

--- a/internal/service/strategy_engine_pretouch_timing.go
+++ b/internal/service/strategy_engine_pretouch_timing.go
@@ -259,17 +259,27 @@ func (e *bkLiveEthPretouchTimingEngine) EvaluateSignal(ctx StrategySignalEvaluat
 
 	// Process tick through detector
 	result := e.detector.OnTick(tick)
+	leadMissDiagnostics := pretouchLeadMissDiagnostics(ctx, tick, closedBars, currentBar, config, result.Reason)
 
 	if !result.Detected {
 		if strings.EqualFold(result.Reason, "already_touched_this_bar") {
 			if metadata := e.pretouchLeadAlreadyTouchedMetadata(ctx, currentBar); len(metadata) > 0 {
+				if len(leadMissDiagnostics) > 0 {
+					metadata["pretouchLeadDiagnostics"] = leadMissDiagnostics
+				}
 				return StrategySignalDecision{Action: "wait", Reason: result.Reason, Metadata: metadata}, nil
 			}
 		}
-		if decision, handled := e.evaluateT3ShadowOverlay(ctx, tick, closedBars, currentBar, orderBookStats, result.Reason); handled {
+		if decision, handled := e.evaluateT3ShadowOverlay(ctx, tick, closedBars, currentBar, orderBookStats, result.Reason, leadMissDiagnostics); handled {
 			return decision, nil
 		}
-		return StrategySignalDecision{Action: "wait", Reason: result.Reason}, nil
+		metadata := map[string]any{}
+		if len(leadMissDiagnostics) > 0 {
+			metadata["pretouchLeadDiagnostics"] = leadMissDiagnostics
+			metadata["pretouchLeadRejectReason"] = result.Reason
+			metadata["pretouchLeadRejectCategory"] = pretouchLeadMissReasonCategory(result.Reason)
+		}
+		return StrategySignalDecision{Action: "wait", Reason: result.Reason, Metadata: metadata}, nil
 	}
 
 	// --- Pretouch event detected! Do Go-native ML inference ---
@@ -740,7 +750,7 @@ func nextPretouchSide(eventSide string) string {
 	return "BUY"
 }
 
-func (e *bkLiveEthPretouchTimingEngine) evaluateT3ShadowOverlay(ctx StrategySignalEvaluationContext, tick TickData, closedBars []HourlyBar, currentBar *HourlyBar, orderBookStats orderBookDecisionStats, leadMissReason string) (StrategySignalDecision, bool) {
+func (e *bkLiveEthPretouchTimingEngine) evaluateT3ShadowOverlay(ctx StrategySignalEvaluationContext, tick TickData, closedBars []HourlyBar, currentBar *HourlyBar, orderBookStats orderBookDecisionStats, leadMissReason string, leadDiagnostics map[string]any) (StrategySignalDecision, bool) {
 	if e.t3Detector == nil || !strings.EqualFold(stringValue(ctx.ExecutionContext.Parameters["pretouchShadowMode"]), pretouchShadowModeTestnetCollect) {
 		return StrategySignalDecision{}, false
 	}
@@ -750,7 +760,7 @@ func (e *bkLiveEthPretouchTimingEngine) evaluateT3ShadowOverlay(ctx StrategySign
 	result := e.t3Detector.OnTickT3Overlay(tick)
 	if !result.Detected {
 		e.logT3ShadowOverlayMiss(ctx, tick, leadMissReason, result)
-		if metadata := pretouchT3OverlayRejectMetadata(leadMissReason, result); len(metadata) > 0 {
+		if metadata := pretouchT3OverlayRejectMetadata(leadMissReason, result, leadDiagnostics); len(metadata) > 0 {
 			return StrategySignalDecision{
 				Action:   "wait",
 				Reason:   leadMissReason,
@@ -889,6 +899,54 @@ func (e *bkLiveEthPretouchTimingEngine) evaluateT3ShadowOverlay(ctx StrategySign
 	}, true
 }
 
+func pretouchLeadMissDiagnostics(ctx StrategySignalEvaluationContext, tick TickData, closedBars []HourlyBar, currentBar *HourlyBar, config PretouchDetectorConfig, reason string) map[string]any {
+	diagnostics := map[string]any{
+		"reason":         reason,
+		"rejectCategory": pretouchLeadMissReasonCategory(reason),
+		"shape":          "t2_prev2_breakout",
+		"tickTime":       formatOptionalRFC3339(tick.Time),
+		"tickPrice":      tick.Price,
+		"signalBarStart": formatOptionalRFC3339(ctx.EventTime.Truncate(time.Hour)),
+	}
+	if currentBar != nil {
+		diagnostics["current"] = pretouchBarSnapshot(currentBar)
+		diagnostics["signalBarStart"] = formatOptionalRFC3339(currentBar.OpenTime)
+		diagnostics["currentHigh"] = currentBar.High
+		diagnostics["currentLow"] = currentBar.Low
+	}
+	if len(closedBars) >= 1 {
+		prevBar1 := closedBars[len(closedBars)-1]
+		diagnostics["prevBar1"] = pretouchBarSnapshot(&prevBar1)
+	}
+	if len(closedBars) < 2 {
+		return diagnostics
+	}
+	prevBar1 := closedBars[len(closedBars)-1]
+	prevBar2 := closedBars[len(closedBars)-2]
+	diagnostics["prevBar2"] = pretouchBarSnapshot(&prevBar2)
+	longLevel := prevBar2.High
+	shortLevel := prevBar2.Low
+	longStructureReady := pretouchLongStructureReady(prevBar2.High, prevBar1.High, config.StructureToleranceBps)
+	shortStructureReady := pretouchShortStructureReady(prevBar2.Low, prevBar1.Low, config.StructureToleranceBps)
+	currentHigh := tick.Price
+	currentLow := tick.Price
+	if currentBar != nil {
+		currentHigh = currentBar.High
+		currentLow = currentBar.Low
+	}
+	longPriceTouched := currentHigh >= longLevel || tick.Price >= longLevel
+	shortPriceTouched := currentLow <= shortLevel || tick.Price <= shortLevel
+	diagnostics["longLevel"] = longLevel
+	diagnostics["shortLevel"] = shortLevel
+	diagnostics["longStructureReady"] = longStructureReady
+	diagnostics["shortStructureReady"] = shortStructureReady
+	diagnostics["longPriceTouched"] = longPriceTouched
+	diagnostics["shortPriceTouched"] = shortPriceTouched
+	diagnostics["longWouldTrigger"] = longStructureReady && longPriceTouched
+	diagnostics["shortWouldTrigger"] = shortStructureReady && shortPriceTouched
+	return diagnostics
+}
+
 func (e *bkLiveEthPretouchTimingEngine) logT3ShadowOverlayMiss(ctx StrategySignalEvaluationContext, tick TickData, leadMissReason string, result PretouchDetectionResult) {
 	if e == nil || e.platform == nil || !pretouchT3OverlayMissLoggable(result.Reason) {
 		return
@@ -933,16 +991,18 @@ func (e *bkLiveEthPretouchTimingEngine) logT3ShadowOverlayMiss(ctx StrategySigna
 	)
 }
 
-func pretouchT3OverlayRejectMetadata(leadMissReason string, result PretouchDetectionResult) map[string]any {
+func pretouchT3OverlayRejectMetadata(leadMissReason string, result PretouchDetectionResult, leadDiagnostics map[string]any) map[string]any {
 	if len(result.Diagnostics) == 0 || !pretouchT3OverlayMissLoggable(result.Reason) {
 		return nil
 	}
 	diagnostics := cloneMetadata(result.Diagnostics)
 	category := pretouchT3OverlayMissReasonCategory(result.Reason)
-	return map[string]any{
+	metadata := map[string]any{
 		"signalSource":                 "pretouch-t3-overlay-shadow",
 		"signalKind":                   "entry-t3-overlay-watch",
 		"decisionState":                "rejected",
+		"pretouchLeadRejectReason":     leadMissReason,
+		"pretouchLeadRejectCategory":   pretouchLeadMissReasonCategory(leadMissReason),
 		"t3OverlayRejected":            true,
 		"t3OverlayLeadMissReason":      leadMissReason,
 		"t3OverlayRejectReason":        result.Reason,
@@ -969,6 +1029,10 @@ func pretouchT3OverlayRejectMetadata(leadMissReason string, result PretouchDetec
 		"t3OverlayRelaxedWouldTrigger": boolValue(diagnostics["relaxedWouldTrigger"]),
 		"t3OverlayDiagnostics":         diagnostics,
 	}
+	if len(leadDiagnostics) > 0 {
+		metadata["pretouchLeadDiagnostics"] = cloneMetadata(leadDiagnostics)
+	}
+	return metadata
 }
 
 func (e *bkLiveEthPretouchTimingEngine) shouldLogT3ShadowOverlayMiss(key string) bool {
@@ -1002,6 +1066,20 @@ func pretouchT3OverlayMissReasonCategory(reason string) string {
 		return "t3_speed_300s"
 	case strings.HasPrefix(reason, "t3_eff_300s="):
 		return "t3_eff_300s"
+	default:
+		return reason
+	}
+}
+
+func pretouchLeadMissReasonCategory(reason string) string {
+	reason = strings.TrimSpace(reason)
+	switch {
+	case strings.HasPrefix(reason, "pre_touch_seconds="):
+		return "pre_touch_seconds"
+	case strings.HasPrefix(reason, "speed_300s="):
+		return "speed_300s"
+	case strings.HasPrefix(reason, "eff_300s="):
+		return "eff_300s"
 	default:
 		return reason
 	}

--- a/internal/service/strategy_engine_pretouch_timing_test.go
+++ b/internal/service/strategy_engine_pretouch_timing_test.go
@@ -897,6 +897,19 @@ func TestPretouchTimingEngineReportsT3OverlayNoLevelTouchMetadata(t *testing.T) 
 	if got := parseFloatValue(decision.Metadata["t3OverlayLevel"]); got != 0 {
 		t.Fatalf("expected no selected touch level before price touch, got %v in %#v", got, decision.Metadata)
 	}
+	if got := stringValue(decision.Metadata["pretouchLeadRejectReason"]); got != "no_level_touch" {
+		t.Fatalf("expected lead reject reason to be preserved, got %s in %#v", got, decision.Metadata)
+	}
+	leadDiagnostics := mapValue(decision.Metadata["pretouchLeadDiagnostics"])
+	if leadDiagnostics == nil {
+		t.Fatalf("expected lead diagnostics metadata, got %#v", decision.Metadata)
+	}
+	if got := parseFloatValue(leadDiagnostics["longLevel"]); math.Abs(got-103.0) > 1e-9 {
+		t.Fatalf("expected T2 long level 103, got %v in %#v", got, leadDiagnostics)
+	}
+	if boolValue(leadDiagnostics["longStructureReady"]) || boolValue(leadDiagnostics["longPriceTouched"]) {
+		t.Fatalf("expected T2 long structure and touch to be false, got %#v", leadDiagnostics)
+	}
 	diagnostics := mapValue(decision.Metadata["t3OverlayDiagnostics"])
 	if diagnostics == nil {
 		t.Fatalf("expected T3 diagnostics metadata, got %#v", decision.Metadata)


### PR DESCRIPTION
## 目的
修复 ETH pretouch 生产排查中发现的 auto-dispatch 竞态，并补齐 T2 lead miss 可见性。

生产 `2026-06-03T05:00:00Z` signal bar 的事实链路：
- `2026-06-03T05:04:10.257895Z` 产生 T2 lead `advance-plan / pretouch_fast_long`。
- strategy-decision event 中 `executionProposal.status=dispatchable`，BUY MARKET `0.39`，spread `2.96bps`，`executionDecision=direct-dispatch`。
- 但之后高频 tick 很快写入 `already_touched_this_bar` wait decision，清掉 `lastExecutionProposal`。
- auto-dispatch 调用 `dispatchLiveSessionIntent()` 时会重新读取 latest session；如果 latest 已被 wait 覆盖，就会看到 `has no execution proposal`，从而没有订单，且错误又可能被后续 wait 覆盖。

本 PR：
- auto-dispatch 路径携带本轮 evaluation 刚生成的 proposal snapshot，避免 latest wait 覆盖导致 dispatch 丢 proposal。
- 手动 dispatch 仍保持原有安全语义：继续重读最新 session，没有 proposal 就不下单。
- 当最终 visible decision 是 T3 overlay wait/reject 时，同时保留 `pretouchLeadDiagnostics`，能看到 T2 level、结构、触碰状态和 reject reason。
- 修复 `bktrader-ctl live get <sessionId>` 默认不带 `fields` 导致 detail API 400；默认返回 timeline/breakout/strategy/execution 诊断字段，仍支持 `--fields` 覆盖。

## 本次改动风险定级 (参照 agent-risk-model.md)
- [ ] **L0** - 低风险 (无逻辑、纯样式、研究脚本、文档)
- [ ] **L1** - 中风险 (新增无害接口、辅助工具扩容)
- [x] **L2** - 高风险 (执行面板改动、核心数据流替换、CI/部署调整) -> **需w/f双重Review**
- [ ] **L3** - 绝对极高等级 (涉及 dispatchMode / 实盘 Live / Mock出界) -> **极度敏感预警**

## AI Agent 参与声明
- [ ] 纯人工手打改动
- [x] 这段属于由 LLM/Agent 生成的代码，但我已经确切通读并检查了

## 风险点 checklist
_是否涉及默认行为、交易路径、部署流程、环境变量_
- [x] `dispatchMode` 默认值有否变化？(变化则不可轻率上 main) - 无变化
- [x] 存在直接调用 `mainnet` 凭证或路由地址的硬编码？- 无
- [x] DB migration 是否具备向下兼容幂等性？- 不涉及
- [x] 配置字段有没有无意被混改？- 无

## 交易语义变更
- [ ] 本次改动是否新增/修改了 `signalKind`？若是，需同步更新 Golden Case
- [x] 本次改动是否影响订单方向判断（`side` / `reduceOnly` / `closePosition`）？- 不改方向判断；仅让 auto-dispatch 使用本轮已验证 dispatchable 的 proposal snapshot，防止被后续 wait 覆盖。
- [ ] 若涉及上述改动，`go test ./internal/domain/... -run TestClassifyOrderIntent` 是否通过？
- [ ] 若涉及交易链路语义（开仓/平仓/撤单/risk-exit），`go test ./internal/domain/... -run TestTradingReplayGoldenCases` 是否通过？

不新增/修改 `signalKind`，不改 side/reduceOnly/closePosition 计算，不改默认交易参数。

## 验证方式与测试证据
- [x] 提供单元测试证明 / 或截图/控制台打印复制，作为实证证明此次不造成雪崩

本地验证：

```bash
go test ./internal/service -run 'TestDispatchLiveSessionIntentReloadsLatestStateBeforeDispatch|TestAutoDispatchUsesEvaluationProposalSnapshotWhenLatestWaitClearsProposal|TestValidateLiveDispatchIdempotencyRejectsPreviouslyDispatchedDecisionEvent'
go test ./internal/service -run 'TestPretouchTimingEngineReportsT3OverlayNoLevelTouchMetadata|TestPretouchTimingEngineReportsT3OverlaySpeedRejectMetadata|TestPretouchTimingEngineReturnsFirstTouchMetadataOnAlreadyTouched'
go test ./cmd/bktrader-ctl -run 'TestBuildLiveSessionDetailPath|TestBuildLiveSessionControlStatus'
go test ./cmd/bktrader-ctl
go test ./internal/service
git diff --check
```
